### PR TITLE
Remove deprecated global state from specs

### DIFF
--- a/framework/src/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/framework/src/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -354,7 +354,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
     import java.io._
     import java.util.zip._
 
-    lazy val Action = new ActionBuilder.IgnoringBody()(_root_.controllers.Execution.trampoline)
+    lazy val Action = ActionBuilder.ignoringBody
 
     val routes: Application => PartialFunction[(String, String), Handler] = {
       app =>
@@ -383,7 +383,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
   "support gziped encoding" in new WithServer(gzipFakeApp) {
     val client = app.injector.instanceOf[WSClient]
     val req = client.url("http://localhost:" + port + "/").get()
-    val rep = Await.result(req, 1 second)
+    val rep = Await.result(req, 1.second)
     rep.body must ===("gziped response")
   }
 

--- a/framework/src/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/framework/src/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -15,7 +15,7 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.oauth.{ ConsumerKey, OAuthCalculator, RequestToken }
 import play.api.libs.ws._
-import play.api.mvc.{ Action, DefaultActionBuilder, Handler, Results }
+import play.api.mvc._
 import play.api.test.{ DefaultAwaitTimeout, FutureAwaits, Helpers, WithServer }
 import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
 import play.shaded.ahc.org.asynchttpclient.Realm.AuthScheme
@@ -73,7 +73,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
       val client = mock[StandaloneAhcWSClient]
       import scala.collection.JavaConverters._
       val req: AHCRequest = makeAhcRequest("http://playframework.com/")
-        .withHeaders("key" -> "value1", "key" -> "value2").asInstanceOf[AhcWSRequest]
+        .addHttpHeaders("key" -> "value1", "key" -> "value2").asInstanceOf[AhcWSRequest]
         .underlying.buildRequest()
       req.getHeaders.getAll("key").asScala must containTheSameElementsAs(Seq("value1", "value2"))
     }
@@ -90,7 +90,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
   "not make Content-Type header if there is Content-Type in headers already" in {
     import scala.collection.JavaConverters._
     val req: AHCRequest = makeAhcRequest("http://playframework.com/")
-      .withHeaders("content-type" -> "fake/contenttype; charset=utf-8")
+      .addHttpHeaders("content-type" -> "fake/contenttype; charset=utf-8")
       .withBody(<aaa>value1</aaa>)
       .asInstanceOf[AhcWSRequest].underlying
       .buildRequest()
@@ -174,7 +174,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
     val calc = OAuthCalculator(consumerKey, requestToken)
     val req: AHCRequest = makeAhcRequest("http://playframework.com/")
       .withBody(Map("param1" -> Seq("value1")))
-      .withHeaders("Content-Length" -> "9001") // add a meaningless content length here...
+      .addHttpHeaders("Content-Length" -> "9001") // add a meaningless content length here...
       .asInstanceOf[AhcWSRequest].underlying
       .buildRequest()
 
@@ -193,7 +193,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
     val calc = OAuthCalculator(consumerKey, requestToken)
     val req: AHCRequest = makeAhcRequest("http://playframework.com/")
       .withBody(Map("param1" -> Seq("value1")))
-      .withHeaders("Content-Length" -> "9001") // add a meaningless content length here...
+      .addHttpHeaders("Content-Length" -> "9001") // add a meaningless content length here...
       .sign(calc) // this is signed, so content length is no longer valid per #5221
       .asInstanceOf[AhcWSRequest].underlying
       .buildRequest()
@@ -207,7 +207,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
   "Verify Content-Type header is passed through correctly" in {
     import scala.collection.JavaConverters._
     val req: AHCRequest = makeAhcRequest("http://playframework.com/")
-      .withHeaders("Content-Type" -> "text/plain; charset=US-ASCII")
+      .addHttpHeaders("Content-Type" -> "text/plain; charset=US-ASCII")
       .withBody("HELLO WORLD")
       .asInstanceOf[AhcWSRequest].underlying
       .buildRequest()
@@ -216,7 +216,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
 
   "POST binary data as is" in {
     val binData = ByteString((0 to 511).map(_.toByte).toArray)
-    val req: AHCRequest = makeAhcRequest("http://playframework.com/").withHeaders("Content-Type" -> "application/x-custom-bin-data").withBody(binData)
+    val req: AHCRequest = makeAhcRequest("http://playframework.com/").addHttpHeaders("Content-Type" -> "application/x-custom-bin-data").withBody(binData)
       .asInstanceOf[AhcWSRequest].underlying
       .buildRequest()
 
@@ -354,6 +354,8 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
     import java.io._
     import java.util.zip._
 
+    lazy val Action = new ActionBuilder.IgnoringBody()(_root_.controllers.Execution.trampoline)
+
     val routes: Application => PartialFunction[(String, String), Handler] = {
       app =>
         {
@@ -460,7 +462,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv) extends Specification with Mockito wi
       ahcHeaders.add("Bar", "baz")
       ahcResponse.getHeaders returns ahcHeaders
       val response = makeAhcResponse(ahcResponse)
-      val headers = response.allHeaders
+      val headers = response.headers
       headers must beEqualTo(Map("Foo" -> Seq("bar", "baz"), "Bar" -> Seq("baz")))
       headers.contains("foo") must beTrue
       headers.contains("Foo") must beTrue

--- a/framework/src/play-ahc-ws/src/test/scala/play/libs/ws/WSSpec.scala
+++ b/framework/src/play-ahc-ws/src/test/scala/play/libs/ws/WSSpec.scala
@@ -3,35 +3,49 @@
  */
 package play.libs.ws
 
-import play.api.inject.guice.GuiceApplicationBuilder
+import akka.stream.Materializer
 import play.api.mvc.Results._
-import play.api.mvc.{ Action, Result }
+import play.api.mvc._
 import play.api.test._
+import play.core.server.Server
+import play.libs.ws.ahc.AhcWSClient
+import play.shaded.ahc.org.asynchttpclient.AsyncHttpClient
 
-class WSSpec extends PlaySpecification {
+class WSSpec extends PlaySpecification with WsTestClient {
 
   sequential
 
   "WS.url().post(InputStream)" should {
 
-    val uploadApp = GuiceApplicationBuilder().routes {
-      case ("POST", "/") =>
-        Action { request =>
-          request.body.asRaw.fold[Result](BadRequest) { raw =>
-            val size = raw.size
-            Ok(s"size=$size")
+    "uploads the stream" in {
+
+      var mat: Materializer = NoMaterializer
+
+      Server.withRouterFromComponents() { components =>
+
+        mat = components.materializer
+
+        import components.{ defaultActionBuilder => Action }
+        import play.api.routing.sird.{ POST => SirdPost, _ }
+        {
+          case SirdPost(p"/") => Action { req: Request[AnyContent] =>
+            req.body.asRaw.fold[Result](BadRequest) { raw =>
+              val size = raw.size
+              Ok(s"size=$size")
+            }
           }
         }
-    }.build()
+      } { implicit port =>
+        withClient { ws =>
+          val javaWs = new AhcWSClient(ws.underlying[AsyncHttpClient], mat)
+          val input = this.getClass.getClassLoader.getResourceAsStream("play/libs/ws/play_full_color.png")
+          val rep = javaWs.url(s"http://localhost:$port/").post(input).toCompletableFuture.get()
 
-    "uploads the stream" in new WithServer(app = uploadApp, port = 3333) {
-      val wsClient = app.injector.instanceOf(classOf[WSClient])
+          rep.getStatus must ===(200)
+          rep.getBody must ===("size=20039")
+        }
+      }
 
-      val input = this.getClass.getClassLoader.getResourceAsStream("play/libs/ws/play_full_color.png")
-      val rep = wsClient.url("http://localhost:3333").post(input).toCompletableFuture.get()
-
-      rep.getStatus must ===(200)
-      rep.getBody must ===("size=20039")
     }
   }
 

--- a/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -7,10 +7,9 @@ import play.core.server._
 import play.api.routing.sird._
 import play.api.mvc._
 
-import akka._
-import akka.http._
-
 object AkkaTestServer extends App {
+
+  lazy val Action = new ActionBuilder.IgnoringBody()(_root_.controllers.Execution.trampoline)
 
   val port: Int = 9000
   val server = AkkaHttpServer.fromRouter(ServerConfig(

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -59,7 +59,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 
             // Also add it to the response
             if (config.cookieName().isDefined()) {
-                scala.Option<String> domain = Session.domain();
+                scala.Option<String> domain = sessionConfiguration.domain();
                 Http.Cookie cookie = new Http.Cookie(
                     config.cookieName().get(), newToken.value(), null, sessionConfiguration.path(),
                     domain.isDefined() ? domain.get() : null, config.secureCookie(), config.httpOnlyCookie(), null);

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -100,7 +100,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
 
         if (CSRF.getToken(request).isEmpty()) {
             if (config.cookieName().isDefined()) {
-                Option<String> domain = Session.domain();
+                Option<String> domain = sessionConfiguration.domain();
                 ctx.response().discardCookie(config.cookieName().get(), sessionConfiguration.path(),
                         domain.isDefined() ? domain.get() : null, config.secureCookie());
             } else {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -39,7 +39,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
       buildCsrfAddToken()(_.put(""))(_.status must_== NOT_FOUND)
     }
     "not add a token to GET requests that don't accept HTML" in {
-      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/json").get())(_.status must_== NOT_FOUND)
+      buildCsrfAddToken()(_.addHttpHeaders(ACCEPT -> "application/json").get())(_.status must_== NOT_FOUND)
     }
     "not add a token to responses that set cache headers" in {
       buildCsrfAddResponseHeaders(CACHE_CONTROL -> "public, max-age=3600")(_.get())(_.cookies must be empty)
@@ -48,16 +48,16 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
       buildCsrfAddResponseHeaders(CACHE_CONTROL -> "no-cache")(_.get())(_.cookies must not be empty)
     }
     "add a token to GET requests that accept HTML" in {
-      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "text/html").get())(_.status must_== OK)
+      buildCsrfAddToken()(_.addHttpHeaders(ACCEPT -> "text/html").get())(_.status must_== OK)
     }
     "add a token to GET requests that accept XHTML" in {
-      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/xhtml+xml").get())(_.status must_== OK)
+      buildCsrfAddToken()(_.addHttpHeaders(ACCEPT -> "application/xhtml+xml").get())(_.status must_== OK)
     }
     "not add a token to HEAD requests that don't accept HTML" in {
-      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/json").head())(_.status must_== NOT_FOUND)
+      buildCsrfAddToken()(_.addHttpHeaders(ACCEPT -> "application/json").head())(_.status must_== NOT_FOUND)
     }
     "add a token to HEAD requests that accept HTML" in {
-      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "text/html").head())(_.status must_== OK)
+      buildCsrfAddToken()(_.addHttpHeaders(ACCEPT -> "text/html").head())(_.status must_== OK)
     }
 
     // extra conditions for doing a check
@@ -75,27 +75,27 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
     }
 
     "not add a token when responding to GET requests that accept HTML and don't get the token" in {
-      buildCsrfAddTokenNoRender(false)(_.withHeaders(ACCEPT -> "text/html").get())(_.cookies must be empty)
+      buildCsrfAddTokenNoRender(false)(_.addHttpHeaders(ACCEPT -> "text/html").get())(_.cookies must be empty)
     }
     "not add a token when responding to GET requests that accept XHTML and don't get the token" in {
-      buildCsrfAddTokenNoRender(false)(_.withHeaders(ACCEPT -> "application/xhtml+xml").get())(_.cookies must be empty)
+      buildCsrfAddTokenNoRender(false)(_.addHttpHeaders(ACCEPT -> "application/xhtml+xml").get())(_.cookies must be empty)
     }
     "add a token when responding to GET requests that don't get the token, if using non-HTTPOnly session cookie" in {
       buildCsrfAddTokenNoRender(
         false,
         "play.filters.csrf.cookie.name" -> null,
         "play.http.session.httpOnly" -> "false"
-      )(_.withHeaders(ACCEPT -> "text/html").get())(_.cookies must not be empty)
+      )(_.addHttpHeaders(ACCEPT -> "text/html").get())(_.cookies must not be empty)
     }
     "add a token when responding to GET requests that don't get the token, if using non-HTTPOnly cookie" in {
       buildCsrfAddTokenNoRender(
         false,
         "play.filters.csrf.cookie.name" -> "csrf",
         "play.filters.csrf.cookie.httpOnly" -> "false"
-      )(_.withHeaders(ACCEPT -> "text/html").get())(_.cookies must not be empty)
+      )(_.addHttpHeaders(ACCEPT -> "text/html").get())(_.cookies must not be empty)
     }
     "add a token when responding to GET requests that don't get the token, if response is streamed" in {
-      buildCsrfAddTokenNoRender(true)(_.withHeaders(ACCEPT -> "text/html").get())(_.cookies must not be empty)
+      buildCsrfAddTokenNoRender(true)(_.addHttpHeaders(ACCEPT -> "text/html").get())(_.cookies must not be empty)
     }
 
     // other
@@ -181,7 +181,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
       val token = signedTokenProvider.generateToken
       val ws = inject[WSClient]
       val response = await(ws.url("http://localhost:" + port).withSession(TokenName -> token)
-        .withHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")
+        .addHttpHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")
         .post(
           Seq(
             // Ensure token is first so that it makes it into the buffered part

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -5,9 +5,9 @@ package play.filters.csrf
 
 import java.util.concurrent.CompletableFuture
 
-import play.api.{ Application }
+import play.api.Application
 import play.api.libs.ws._
-import play.api.mvc.Session
+import play.api.mvc.{ DefaultSessionCookieBaker, SessionCookieBaker }
 import play.core.j.{ JavaAction, JavaActionAnnotations, JavaContextComponents, JavaHandlerComponents }
 import play.core.routing.HandlerInvokerFactory
 import play.mvc.Http.{ Context, RequestHeader }
@@ -70,7 +70,7 @@ class JavaCSRFActionSpec extends CSRFCommonSpecs {
   "The Java CSRF filter support" should {
     "allow adding things to the session when a token is also added to the session" in {
       buildCsrfWithSession()(_.get()) { response =>
-        val session = response.cookie(Session.COOKIE_NAME).map(_.value).map(Session.decode)
+        val session = response.cookie(sessionCookieBaker.COOKIE_NAME).map(_.value).map(sessionCookieBaker.decode)
         session must beSome.which { s =>
           s.get(TokenName) must beSome[String]
           s.get("hello") must beSome("world")

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -170,7 +170,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       """
         |play.filters.hosts.allowed = ["localhost"]
       """.stripMargin) { ws =>
-      val wsRequest = ws.url(s"http://localhost:$TestServerPort").withHeaders(X_FORWARDED_HOST -> "evil.com").get()
+      val wsRequest = ws.url(s"http://localhost:$TestServerPort").addHttpHeaders(X_FORWARDED_HOST -> "evil.com").get()
       val wsResponse = Await.result(wsRequest, 1.second)
       wsResponse.status must_== OK
       wsResponse.body must_== s"localhost:$TestServerPort"

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -6,14 +6,13 @@ package play.it
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Results._
 import play.api.mvc._
+import play.api.mvc.request.RequestAttrKey
 import play.api.test._
 
 class NettyServerIntegrationSpecificationSpec extends ServerIntegrationSpecificationSpec with NettyIntegrationSpecification {
-  override def isAkkaHttpServer = false
   override def expectedServerTag = Some("netty")
 }
 class AkkaHttpServerIntegrationSpecificationSpec extends ServerIntegrationSpecificationSpec with AkkaHttpIntegrationSpecification {
-  override def isAkkaHttpServer = true
   override def expectedServerTag = None
 }
 
@@ -24,15 +23,13 @@ class AkkaHttpServerIntegrationSpecificationSpec extends ServerIntegrationSpecif
 trait ServerIntegrationSpecificationSpec extends PlaySpecification
     with WsTestClient with ServerIntegrationSpecification {
 
-  def isAkkaHttpServer: Boolean
-
   def expectedServerTag: Option[String]
 
   "ServerIntegrationSpecification" should {
 
     val httpServerTagRoutes: PartialFunction[(String, String), Handler] = {
-      case ("GET", "/httpServerTag") => ActionBuilder.ignoringBody { implicit request =>
-        val httpServer = request.tags.get("HTTP_SERVER")
+      case ("GET", "/httpServerTag") => ActionBuilder.ignoringBody { implicit request: RequestHeader =>
+        val httpServer = request.attrs.get(RequestAttrKey.Server)
         Ok(httpServer.toString)
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -52,9 +52,11 @@ class SecuritySpec extends PlaySpecification {
   }
 
   def TestAction(implicit app: Application) =
-    AuthenticatedBuilder(app.injector.instanceOf[BodyParsers.Default])(app.materializer.executionContext)
+    AuthenticatedBuilder(getUserInfoFromRequest, app.injector.instanceOf[BodyParsers.Default])(app.materializer.executionContext)
 
-  def getUserFromRequest(req: RequestHeader) = req.session.get("user") map (User(_))
+  def getUserInfoFromRequest(req: RequestHeader) = req.session.get("username")
+
+  def getUserFromRequest(req: RequestHeader) = req.session.get("user").map(User)
 
   class AuthenticatedDbRequest[A](val user: User, val conn: Connection, request: Request[A]) extends WrappedRequest[A](request)
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
@@ -53,7 +53,7 @@ trait FormFieldOrderSpec extends PlaySpecification with ServerIntegrationSpecifi
 
       val ws = app.injector.instanceOf[WSClient]
       val future: Future[WSResponse] = ws.url("http://localhost:" + port + "/").
-        withHeaders("Content-Type" -> contentType).
+        addHttpHeaders("Content-Type" -> contentType).
         withRequestTimeout(10000.millis).post(urlEncoded)
 
       val response = await(future)

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -369,6 +369,9 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
 
     "split Set-Cookie headers" in {
       import play.api.mvc.Cookie
+
+      lazy val cookieHeaderEncoding = new DefaultCookieHeaderEncoding()
+
       val aCookie = Cookie("a", "1")
       val bCookie = Cookie("b", "2")
       val cCookie = Cookie("c", "3")
@@ -378,7 +381,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         response.headers.get(SET_COOKIE) must beSome.like {
           case rawCookieHeaders =>
             val decodedCookieHeaders: Set[Set[Cookie]] = rawCookieHeaders.map { headerValue =>
-              Cookies.decodeSetCookieHeader(headerValue).to[Set]
+              cookieHeaderEncoding.decodeSetCookieHeader(headerValue).to[Set]
             }.to[Set]
             decodedCookieHeaders must_== (Set(Set(aCookie), Set(bCookie), Set(cCookie)))
         }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -6,6 +6,7 @@ package play.it.http.parsing
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import play.api.Application
 import play.api.mvc._
 import play.api.test._
 
@@ -13,10 +14,12 @@ class DefaultBodyParserSpec extends PlaySpecification {
 
   "The default body parser" should {
 
-    def parse(method: String, contentType: Option[String], body: ByteString)(implicit mat: Materializer) = {
+    implicit def defaultBodyParser(implicit app: Application) = app.injector.instanceOf[PlayBodyParsers].default
+
+    def parse(method: String, contentType: Option[String], body: ByteString)(implicit mat: Materializer, defaultBodyParser: BodyParser[AnyContent]) = {
       val request = FakeRequest(method, "/x").withHeaders(
         contentType.map(CONTENT_TYPE -> _).toSeq :+ (CONTENT_LENGTH -> body.length.toString): _*)
-      await(BodyParsers.parse.default(request).run(Source.single(body)))
+      await(defaultBodyParser(request).run(Source.single(body)))
     }
 
     "parse text bodies for DELETE requests" in new WithApplication() {
@@ -50,7 +53,7 @@ class DefaultBodyParserSpec extends PlaySpecification {
     }
 
     "parse unknown empty bodies as empty for PUT requests" in new WithApplication() {
-      parse("PUT", None, ByteString.empty) must_== Right(AnyContentAsEmpty)
+      parse("PUT", None, ByteString.empty) must beRight(AnyContentAsEmpty)
     }
 
     "parse unknown bodies as raw for PUT requests" in new WithApplication() {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
@@ -6,17 +6,21 @@ package play.it.http.parsing
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import play.api.Application
 import play.api.test._
-import play.api.mvc.BodyParsers
+import play.api.mvc.{ BodyParser, PlayBodyParsers }
 
 class EmptyBodyParserSpec extends PlaySpecification {
 
   "The empty body parser" should {
 
-    def parse(bytes: ByteString, contentType: Option[String], encoding: String)(implicit mat: Materializer) = {
+    implicit def emptyBodyParser(implicit app: Application) = app.injector.instanceOf[PlayBodyParsers].empty
+
+    def parse(bytes: ByteString, contentType: Option[String], encoding: String)(implicit mat: Materializer, bodyParser: BodyParser[Unit]) = {
       await(
-        BodyParsers.parse.empty(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
-          .run(Source.single(bytes))
+        bodyParser(
+          FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
+        ).run(Source.single(bytes))
       )
     }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
@@ -75,7 +75,7 @@ class JsonBodyParserSpec extends PlaySpecification {
     "validate json content using .validate" in new WithApplication() {
       import scala.concurrent.ExecutionContext.Implicits.global
 
-      implicit val fooParser: BodyParser[Foo] = jsonBodyParser.validate {
+      val fooParser: BodyParser[Foo] = jsonBodyParser.validate {
         _.validate[Foo].asEither.left.map(e => BadRequest(JsError.toJson(e)))
       }
       parse("""{"a":1,"b":"bar"}""", Some("application/json"), "utf-8")(app.materializer, fooParser) must beRight

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
@@ -6,9 +6,10 @@ package play.it.http.parsing
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import play.api.libs.json.{ Json, JsError }
+import play.api.Application
+import play.api.libs.json.{ JsError, JsValue, Json }
 import play.api.mvc.Results.BadRequest
-import play.api.mvc.{ BodyParser, BodyParsers }
+import play.api.mvc.{ BodyParser, PlayBodyParsers }
 import play.api.test._
 
 class JsonBodyParserSpec extends PlaySpecification {
@@ -16,9 +17,13 @@ class JsonBodyParserSpec extends PlaySpecification {
   private case class Foo(a: Int, b: String)
   private implicit val fooFormat = Json.format[Foo]
 
+  implicit def tolerantJsonBodyParser(implicit app: Application) = app.injector.instanceOf[PlayBodyParsers].tolerantJson
+
+  def jsonBodyParser(implicit app: Application) = app.injector.instanceOf[PlayBodyParsers].json
+
   "The JSON body parser" should {
 
-    def parse[A](json: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[A] = BodyParsers.parse.tolerantJson)(implicit mat: Materializer) = {
+    def parse[A](json: String, contentType: Option[String], encoding: String)(implicit mat: Materializer, bodyParser: BodyParser[A]) = {
       await(
         bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
           .run(Source.single(ByteString(json.getBytes(encoding))))
@@ -50,41 +55,44 @@ class JsonBodyParserSpec extends PlaySpecification {
     }
 
     "accept all common json content types" in new WithApplication() {
-      parse("""{"foo":"bar"}""", Some("application/json"), "utf-8", BodyParsers.parse.json) must beRight.like {
+      parse("""{"foo":"bar"}""", Some("application/json"), "utf-8") must beRight.like {
         case json => (json \ "foo").as[String] must_== "bar"
       }
-      parse("""{"foo":"bar"}""", Some("text/json"), "utf-8", BodyParsers.parse.json) must beRight.like {
+      parse("""{"foo":"bar"}""", Some("text/json"), "utf-8") must beRight.like {
         case json => (json \ "foo").as[String] must_== "bar"
       }
     }
 
     "reject non json content types" in new WithApplication() {
-      parse("""{"foo":"bar"}""", Some("application/xml"), "utf-8", BodyParsers.parse.json) must beLeft
-      parse("""{"foo":"bar"}""", None, "utf-8", BodyParsers.parse.json) must beLeft
+      parse("""{"foo":"bar"}""", Some("application/xml"), "utf-8")(app.materializer, jsonBodyParser) must beLeft
+      parse("""{"foo":"bar"}""", None, "utf-8")(app.materializer, jsonBodyParser) must beLeft
     }
 
     "gracefully handle invalid json" in new WithApplication() {
-      parse("""{"foo:}""", Some("application/json"), "utf-8", BodyParsers.parse.json) must beLeft
+      parse("""{"foo:}""", Some("application/json"), "utf-8") must beLeft
     }
 
     "validate json content using .validate" in new WithApplication() {
       import scala.concurrent.ExecutionContext.Implicits.global
 
-      val fooParser = BodyParsers.parse.json.validate {
+      implicit val fooParser: BodyParser[Foo] = jsonBodyParser.validate {
         _.validate[Foo].asEither.left.map(e => BadRequest(JsError.toJson(e)))
       }
-      parse("""{"a":1,"b":"bar"}""", Some("application/json"), "utf-8", fooParser) must beRight
-      parse("""{"foo":"bar"}""", Some("application/json"), "utf-8", fooParser) must beLeft
-      parse("""{"a":1}""", Some("application/json"), "utf-8", fooParser) must beLeft
+      parse("""{"a":1,"b":"bar"}""", Some("application/json"), "utf-8")(app.materializer, fooParser) must beRight
+      parse("""{"foo":"bar"}""", Some("application/json"), "utf-8")(app.materializer, fooParser) must beLeft
+      parse("""{"a":1}""", Some("application/json"), "utf-8")(app.materializer, fooParser) must beLeft
     }
 
     "validate json content using implicit reads" in new WithApplication() {
-      parse("""{"a":1,"b":"bar"}""", Some("application/json"), "utf-8", BodyParsers.parse.json[Foo]) must beRight.like {
+
+      val parser = app.injector.instanceOf[PlayBodyParsers].json[Foo]
+
+      parse("""{"a":1,"b":"bar"}""", Some("application/json"), "utf-8")(app.materializer, parser) must beRight.like {
         case foo => foo must_== Foo(1, "bar")
       }
-      parse("""{"foo":"bar"}""", Some("application/json"), "utf-8", BodyParsers.parse.json[Foo]) must beLeft
-      parse("""{"a":1}""", Some("application/json"), "utf-8", BodyParsers.parse.json[Foo]) must beLeft
-      parse("""{"foo:}""", Some("application/json"), "utf-8", BodyParsers.parse.json[Foo]) must beLeft
+      parse("""{"foo":"bar"}""", Some("application/json"), "utf-8")(app.materializer, parser) must beLeft
+      parse("""{"a":1}""", Some("application/json"), "utf-8")(app.materializer, parser) must beLeft
+      parse("""{"foo:}""", Some("application/json"), "utf-8")(app.materializer, parser) must beLeft
     }
 
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -443,7 +443,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   def allowRejectingTheWebSocketWithAResult(webSocket: Application => Int => Handler) = {
     withServer(app => webSocket(app)(FORBIDDEN)) { implicit app =>
       val ws = app.injector.instanceOf[WSClient]
-      await(ws.url(s"http://localhost:$testServerPort/stream").withHeaders(
+      await(ws.url(s"http://localhost:$testServerPort/stream").addHttpHeaders(
         "Upgrade" -> "websocket",
         "Connection" -> "upgrade",
         "Sec-WebSocket-Version" -> "13",

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -3,8 +3,9 @@
  */
 package play.it.i18n
 
+import controllers.Execution
 import play.api.test.{ PlaySpecification, WithApplication }
-import play.api.mvc.ControllerHelpers
+import play.api.mvc.{ ActionBuilder, ControllerHelpers }
 import play.api.i18n._
 
 class MessagesSpec extends PlaySpecification with ControllerHelpers {
@@ -12,6 +13,8 @@ class MessagesSpec extends PlaySpecification with ControllerHelpers {
   sequential
 
   implicit val lang = Lang("en-US")
+
+  lazy val Action = new ActionBuilder.IgnoringBody()(Execution.trampoline)
 
   "Messages" should {
     "provide default messages" in new WithApplication(_.requireExplicitBindings()) {

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/ScalaWSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/ScalaWSSpec.scala
@@ -70,7 +70,7 @@ trait ScalaWSSpec extends PlaySpecification with ServerIntegrationSpecification 
 
     "streaming a request body with manual content length" in withHeaderCheck { ws =>
       val source = Source.single(ByteString("abc"))
-      val res = ws.url("/post").withMethod("POST").withHeaders(CONTENT_LENGTH -> "3").withBody(source).execute()
+      val res = ws.url("/post").withMethod("POST").addHttpHeaders(CONTENT_LENGTH -> "3").withBody(source).execute()
       val body = await(res).body
 
       body must_== s"Content-Length: 3; Transfer-Encoding: -1"
@@ -109,7 +109,7 @@ trait ScalaWSSpec extends PlaySpecification with ServerIntegrationSpecification 
       }
 
       "with query string" in withServer { ws =>
-        ws.url("/").withQueryString("lorem" -> "ipsum").
+        ws.url("/").withQueryStringParameters("lorem" -> "ipsum").
           sign(calc) aka "signed request" must not(throwA[Exception])
       }
     }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -162,10 +162,10 @@ private[server] class NettyModelConversion(
       target,
       request.protocolVersion.text(),
       headers,
-      // Send a tag so our tests can tell which kind of server we're using.
+      // Send an attribute so our tests can tell which kind of server we're using.
       // We only do this for the "non-default" engine, so we used to tag
       // akka-http explicitly, so that benchmarking isn't affected by this.
-      TypedMap(RequestAttrKey.Tags -> Map("HTTP_SERVER" -> "netty"))
+      TypedMap(RequestAttrKey.Server -> "netty")
     )
   }
 

--- a/framework/src/play-netty-server/src/test/scala/play/NettyTestServer.scala
+++ b/framework/src/play-netty-server/src/test/scala/play/NettyTestServer.scala
@@ -9,6 +9,8 @@ import play.api.mvc._
 
 object NettyTestServer extends App {
 
+  lazy val Action = new ActionBuilder.IgnoringBody()(_root_.controllers.Execution.trampoline)
+
   val port: Int = 8000
   val server = NettyServer.fromRouter(ServerConfig(
     port = Some(port),

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -202,7 +202,7 @@ object Server {
    *
    * {{{
    *   Server.withApplicationFromContext(ServerConfig(mode = Mode.Prod, port = Some(0))) { context =>
-   *     new BuiltInComponentsFromContext(context) with AssetsComponents {
+   *     new BuiltInComponentsFromContext(context) with AssetsComponents with play.filters.HttpFiltersComponents {
    *      override def router: Router = Router.from {
    *        case req => assets.versioned("/testassets", req.path)
    *      }

--- a/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -19,7 +19,7 @@ import scala.language.reflectiveCalls
 class HelpersSpec extends Specification {
 
   val ctrl = new ControllerHelpers {
-    private val Action = ActionBuilder.ignoringBody
+    lazy val Action: ActionBuilder[Request, AnyContent] = ActionBuilder.ignoringBody
     def abcAction: EssentialAction = Action {
       Ok("abc").as("text/plain")
     }

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -123,8 +123,8 @@ abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) 
   lazy val environment = context.environment
   lazy val sourceMapper = context.sourceMapper
   lazy val webCommands = context.webCommands
-  lazy val configuration = context.initialConfiguration
   lazy val applicationLifecycle: ApplicationLifecycle = context.lifecycle
+  def configuration = context.initialConfiguration
 
   lazy val controllerComponents: ControllerComponents = DefaultControllerComponents(
     defaultActionBuilder, playBodyParsers, messagesApi, langs, fileMimeTypes, executionContext

--- a/framework/src/play/src/main/scala/play/api/mvc/request/RequestAttrKey.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/request/RequestAttrKey.scala
@@ -40,4 +40,9 @@ object RequestAttrKey {
    */
   @deprecated("Use attributes instead of tags", "2.6.0")
   val Tags = TypedKey[Map[String, String]]("Tags")
+
+  /**
+   * The key for the request attribute storing the server name.
+   */
+  val Server = TypedKey[String]("Server-Name")
 }

--- a/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -80,16 +80,16 @@ class ConfigurationSpec extends Specification {
     }
 
     "make all get accessible using scala" in {
-      exampleConfig.getBooleanSeq("blah.0").get must ===(Seq(true, false, true))
-      exampleConfig.getIntSeq("blah.1").get must ===(Seq(1, 2, 3))
-      exampleConfig.getDoubleSeq("blah.2").get must ===(Seq(1.1, 2.2, 3.3))
-      exampleConfig.getLongSeq("blah.3").get must ===(Seq(1L, 2L, 3L))
-      exampleConfig.getStringSeq("blah.4").get must contain(exactly("one", "two", "three"))
+      exampleConfig.get[Seq[Boolean]]("blah.0") must ===(Seq(true, false, true))
+      exampleConfig.get[Seq[Int]]("blah.1") must ===(Seq(1, 2, 3))
+      exampleConfig.get[Seq[Double]]("blah.2") must ===(Seq(1.1, 2.2, 3.3))
+      exampleConfig.get[Seq[Long]]("blah.3") must ===(Seq(1L, 2L, 3L))
+      exampleConfig.get[Seq[String]]("blah.4") must contain(exactly("one", "two", "three"))
     }
 
     "handle invalid and null configuration values" in {
-      exampleConfig.getBooleanSeq("foo.bar1").get must throwA[PlayException]
-      exampleConfig.getBoolean("foo.bar3") must throwA[PlayException]
+      exampleConfig.get[Seq[Boolean]]("foo.bar1") must throwA[com.typesafe.config.ConfigException]
+      exampleConfig.get[Boolean]("foo.bar3") must throwA[com.typesafe.config.ConfigException]
     }
 
     "throw serializable exceptions" in {
@@ -110,7 +110,7 @@ class ConfigurationSpec extends Specification {
       );
       {
         try {
-          conf.getStringList("item")
+          conf.get[Seq[String]]("item")
         } catch {
           case NonFatal(e) => copyViaSerialize(e)
         }

--- a/framework/src/play/src/test/scala/play/api/libs/CometSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/CometSpec.scala
@@ -20,6 +20,8 @@ class CometSpec extends Specification {
 
   class MockController(val materializer: Materializer, action: ActionBuilder[Request, AnyContent]) extends ControllerHelpers {
 
+    val Action = action
+
     //#comet-string
     def cometString = action {
       implicit val m = materializer

--- a/framework/src/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
@@ -6,8 +6,6 @@ package play.api.mvc
 import org.specs2.mutable._
 import java.net.URLEncoder
 
-import play.api.http.HttpConfiguration
-
 class FlashCookieSpec extends Specification {
 
   def oldEncoder(data: Map[String, String]): String = {
@@ -17,80 +15,82 @@ class FlashCookieSpec extends Specification {
     )
   }
 
+  def flash: FlashCookieBaker = new DefaultFlashCookieBaker()
+
   "Flash cookies" should {
     "bake in a header and value" in {
-      val es = Flash.encode(Map("a" -> "b"))
-      val m = Flash.decode(es)
+      val es = flash.encode(Map("a" -> "b"))
+      val m = flash.decode(es)
       m.size must_== 1
       m("a") must_== "b"
     }
     "bake in multiple headers and values" in {
-      val es = Flash.encode(Map("a" -> "b", "c" -> "d"))
-      val m = Flash.decode(es)
+      val es = flash.encode(Map("a" -> "b", "c" -> "d"))
+      val m = flash.decode(es)
       m.size must_== 2
       m("a") must_== "b"
       m("c") must_== "d"
     }
     "bake in a header an empty value" in {
-      val es = Flash.encode(Map("a" -> ""))
-      val m = Flash.decode(es)
+      val es = flash.encode(Map("a" -> ""))
+      val m = flash.decode(es)
       m.size must_== 1
       m("a") must_== ""
     }
     "bake in a header a Unicode value" in {
-      val es = Flash.encode(Map("a" -> "\u0000"))
-      val m = Flash.decode(es)
+      val es = flash.encode(Map("a" -> "\u0000"))
+      val m = flash.decode(es)
       m.size must_== 1
       m("a") must_== "\u0000"
     }
     "bake in an empty map" in {
-      val es = Flash.encode(Map.empty)
-      val m = Flash.decode(es)
+      val es = flash.encode(Map.empty)
+      val m = flash.decode(es)
       m.size must_== 0
     }
     "encode values such that no extra keys can be created" in {
-      val es = Flash.encode(Map("a" -> "b&c=d"))
-      val m = Flash.decode(es)
+      val es = flash.encode(Map("a" -> "b&c=d"))
+      val m = flash.decode(es)
       m.size must_== 1
       m("a") must_== "b&c=d"
     }
     "specifically exclude control chars" in {
       for (i <- 0 until 32) {
         val s = Character.toChars(i).toString
-        val es = Flash.encode(Map("a" -> s))
+        val es = flash.encode(Map("a" -> s))
         es must not contain s
 
-        val m = Flash.decode(es)
+        val m = flash.decode(es)
         m.size must_== 1
         m("a") must_== s
       }
       success
     }
     "specifically exclude special cookie chars" in {
-      val es = Flash.encode(Map("a" -> " \",;\\"))
+      val es = flash.encode(Map("a" -> " \",;\\"))
       es must not contain " "
       es must not contain "\""
       es must not contain ","
       es must not contain ";"
       es must not contain "\\"
 
-      val m = Flash.decode(es)
+      val m = flash.decode(es)
       m.size must_== 1
       m("a") must_== " \",;\\"
     }
     "decode values of the previously supported format" in {
       val es = oldEncoder(Map("a" -> "b", "c" -> "d"))
-      val m = Flash.decode(es)
+      val m = flash.decode(es)
       m.size must_== 0
     }
     "decode values of the previously supported format with the new delimiters in them" in {
       val es = oldEncoder(Map("a" -> "b&="))
-      val m = Flash.decode(es)
+      val m = flash.decode(es)
       m.size must_== 0
     }
     "decode values with gibberish in them" in {
       val es = "asfjdlkasjdflk"
-      val m = Flash.decode(es)
+      val m = flash.decode(es)
       m.size must_== 0
     }
     "put disallows null values" in {
@@ -98,7 +98,7 @@ class FlashCookieSpec extends Specification {
       c + (("x", null)) must throwA(new IllegalArgumentException("requirement failed: Cookie values cannot be null"))
     }
     "be insecure by default" in {
-      Flash.encodeAsCookie(Flash()).secure must beFalse
+      flash.encodeAsCookie(Flash()).secure must beFalse
     }
   }
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
@@ -101,12 +101,15 @@ class HttpSpec extends Specification {
   }
 
   "Cookies" should {
+
+    lazy val cookieHeaderEncoding = new DefaultCookieHeaderEncoding()
+
     "merge two cookies" in withApplication {
       val cookies = Seq(
         Cookie("foo", "bar"),
         Cookie("bar", "qux"))
 
-      Cookies.mergeSetCookieHeader("", cookies) must ===("foo=bar; Path=/; HTTPOnly;;bar=qux; Path=/; HTTPOnly")
+      cookieHeaderEncoding.mergeSetCookieHeader("", cookies) must ===("foo=bar; Path=/; HTTPOnly;;bar=qux; Path=/; HTTPOnly")
     }
     "merge and remove duplicates" in withApplication {
       val cookies = Seq(
@@ -119,7 +122,7 @@ class HttpSpec extends Specification {
         Cookie("foo", "bar", path = "/blah"),
         Cookie("foo", "baz", path = "/blah"))
 
-      Cookies.mergeSetCookieHeader("", cookies) must ===(
+      cookieHeaderEncoding.mergeSetCookieHeader("", cookies) must ===(
         "foo=baz; Path=/; Domain=FoO; HTTPOnly" + ";;" + // Cookie("foo", "baz", domain=Some("FoO"))
           "foo=baz; Path=/" + ";;" + // Cookie("foo", "baz", httpOnly=false)
           "foo=baz; Path=/blah; HTTPOnly" // Cookie("foo", "baz", path="/blah")

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -91,16 +91,16 @@ class ResultsSpec extends Specification {
     }
 
     "support cookies helper" in withApplication {
-      val setCookieHeader = Cookies.encodeSetCookieHeader(Seq(Cookie("session", "items"), Cookie("preferences", "blue")))
+      val setCookieHeader = cookieHeaderEncoding.encodeSetCookieHeader(Seq(Cookie("session", "items"), Cookie("preferences", "blue")))
 
-      val decodedCookies = Cookies.decodeSetCookieHeader(setCookieHeader).map(c => c.name -> c).toMap
+      val decodedCookies = cookieHeaderEncoding.decodeSetCookieHeader(setCookieHeader).map(c => c.name -> c).toMap
       decodedCookies.size must be_==(2)
       decodedCookies("session").value must be_==("items")
       decodedCookies("preferences").value must be_==("blue")
 
-      val newCookieHeader = Cookies.mergeSetCookieHeader(setCookieHeader, Seq(Cookie("lang", "fr"), Cookie("session", "items2")))
+      val newCookieHeader = cookieHeaderEncoding.mergeSetCookieHeader(setCookieHeader, Seq(Cookie("lang", "fr"), Cookie("session", "items2")))
 
-      val newDecodedCookies = Cookies.decodeSetCookieHeader(newCookieHeader).map(c => c.name -> c).toMap
+      val newDecodedCookies = cookieHeaderEncoding.decodeSetCookieHeader(newCookieHeader).map(c => c.name -> c).toMap
       newDecodedCookies.size must be_==(3)
       newDecodedCookies("session").value must be_==("items2")
       newDecodedCookies("preferences").value must be_==("blue")
@@ -113,7 +113,7 @@ class ResultsSpec extends Specification {
           .discardingCookies(DiscardingCookie("logged"))
       }
 
-      val setCookies = Cookies.decodeSetCookieHeader(headers("Set-Cookie")).map(c => c.name -> c).toMap
+      val setCookies = cookieHeaderEncoding.decodeSetCookieHeader(headers("Set-Cookie")).map(c => c.name -> c).toMap
       setCookies must haveSize(4)
       setCookies("session").value must be_==("items2")
       setCookies("session").maxAge must beNone
@@ -143,7 +143,7 @@ class ResultsSpec extends Specification {
         cookies2: List[Cookie],
         expected: Option[Set[Cookie]]) = {
         val result = bake { Ok("hello").withCookies(cookies1: _*).withCookies(cookies2: _*) }
-        result.header.headers.get("Set-Cookie").map(Cookies.decodeSetCookieHeader(_).to[Set]) must_== expected
+        result.header.headers.get("Set-Cookie").map(cookieHeaderEncoding.decodeSetCookieHeader(_).to[Set]) must_== expected
       }
       val preferencesCookie = Cookie("preferences", "blue")
       val sessionCookie = Cookie("session", "items")
@@ -175,18 +175,18 @@ class ResultsSpec extends Specification {
 
     "support clearing a language cookie using clearingLang" in withApplication { app: Application =>
       implicit val messagesApi = app.injector.instanceOf[MessagesApi]
-      val cookie = Cookies.decodeSetCookieHeader(bake(Ok.clearingLang).header.headers("Set-Cookie")).head
+      val cookie = cookieHeaderEncoding.decodeSetCookieHeader(bake(Ok.clearingLang).header.headers("Set-Cookie")).head
       cookie.name must_== Play.langCookieName
       cookie.value must_== ""
     }
 
     "allow discarding a cookie by deprecated names method" in withApplication {
-      Cookies.decodeSetCookieHeader(bake(Ok.discardingCookies(DiscardingCookie("blah"))).header.headers("Set-Cookie")).head.name must_== "blah"
+      cookieHeaderEncoding.decodeSetCookieHeader(bake(Ok.discardingCookies(DiscardingCookie("blah"))).header.headers("Set-Cookie")).head.name must_== "blah"
     }
 
     "allow discarding multiple cookies by deprecated names method" in withApplication {
       val baked = bake { Ok.discardingCookies(DiscardingCookie("foo"), DiscardingCookie("bar")) }
-      val cookies = Cookies.decodeSetCookieHeader(baked.header.headers("Set-Cookie")).map(_.name)
+      val cookies = cookieHeaderEncoding.decodeSetCookieHeader(baked.header.headers("Set-Cookie")).map(_.name)
       cookies must containTheSameElementsAs(Seq("foo", "bar"))
     }
 


### PR DESCRIPTION
## Purpose

Removes uses of deprecated APIs that are still accessing global state. While this is only specs code, it is better that we can have the non-deprecated access better tested.