### PR TITLE
Change how we call Futures in EhCacheApi

### DIFF
--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -83,6 +83,25 @@ Now to access these different caches, when you inject them, use the [NamedCache]
 
 @[qualified](code/javaguide/cache/qualified/Application.java)
 
+## Setting the execution context
+
+By default all the get, set, remove,... operations on the Ehcache are done within Play's default execution context.
+Usually that configuration should be enough for most use cases because it is assumed that accessing the cache is a very fast operation, so usually no thread gets blocked by it.
+However depending on how EhCache was configured (e.g. by [not storing elements in memory](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html) these operations might get slow and therefore might block Play's default threads.
+For such a case you can provide a different execution context and set it via `play.cache.dispatcher` so the EhCache plugin makes use of it:
+
+```
+play.cache.dispatcher = "contexts.blockingCacheDispatcher"
+
+contexts {
+  blockingCacheDispatcher {
+    fork-join-executor {
+      parallelism-factor = 3.0
+    }
+  }
+}
+```
+
 ## Caching HTTP responses
 
 You can easily create a smart cached action using standard `Action` composition.

--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -86,7 +86,7 @@ Now to access these different caches, when you inject them, use the [NamedCache]
 ## Setting the execution context
 
 By default, all Ehcache operations are blocking, and async implementations will block threads in the default execution context.
-Usually that configuration is okay if you are using Play's default configuration, which only stores elements in memory, since reads should be relatively fast.
+Usually this is okay if you are using Play's default configuration, which only stores elements in memory since reads should be relatively fast.
 However, depending on how EhCache was configured and [where the data is stored](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html), this blocking I/O might be too costly.
 For such a case you can configure a different [Akka dispatcher](http://doc.akka.io/docs/akka/current/scala/dispatchers.html#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the EhCache plugin makes use of it:
 

--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -85,10 +85,10 @@ Now to access these different caches, when you inject them, use the [NamedCache]
 
 ## Setting the execution context
 
-By default all the get, set, remove,... operations on the Ehcache are done within Play's default execution context.
-Usually that configuration should be enough for most use cases because it is assumed that accessing the cache is a very fast operation, so usually no thread gets blocked by it.
-However depending on how EhCache was configured (e.g. by [not storing elements in memory](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html) these operations might get slow and therefore might block Play's default threads.
-For such a case you can provide a different execution context and set it via `play.cache.dispatcher` so the EhCache plugin makes use of it:
+By default, all Ehcache operations are blocking, and async implementations will block threads in the default execution context.
+Usually that configuration is okay if you are using Play's default configuration, which only stores elements in memory, since reads should be relatively fast.
+However, depending on how EhCache was configured and [where the data is stored](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html), this blocking I/O might be too costly.
+For such a case you can configure a different [Akka dispatcher](http://doc.akka.io/docs/akka/current/scala/dispatchers.html#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the EhCache plugin makes use of it:
 
 ```
 play.cache.dispatcher = "contexts.blockingCacheDispatcher"

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -85,6 +85,25 @@ Now to access these different caches, when you inject them, use the [NamedCache]
 
 @[qualified](code/ScalaCache.scala)
 
+## Setting the execution context
+
+By default all the get, set, remove,... operations on the Ehcache are done within Play's default execution context.
+Usually that configuration should be enough for most use cases because it is assumed that accessing the cache is a very fast operation, so usually no thread gets blocked by it.
+However depending on how EhCache was configured (e.g. by [not storing elements in memory](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html) these operations might get slow and therefore might block Play's default threads.
+For such a case you can provide a different execution context and set it via `play.cache.dispatcher` so the EhCache plugin makes use of it:
+
+```
+play.cache.dispatcher = "contexts.blockingCacheDispatcher"
+
+contexts {
+  blockingCacheDispatcher {
+    fork-join-executor {
+      parallelism-factor = 3.0
+    }
+  }
+}
+```
+
 ## Caching HTTP responses
 
 You can easily create smart cached actions using standard Action composition.

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -88,7 +88,7 @@ Now to access these different caches, when you inject them, use the [NamedCache]
 ## Setting the execution context
 
 By default, all Ehcache operations are blocking, and async implementations will block threads in the default execution context.
-Usually that configuration is okay if you are using Play's default configuration, which only stores elements in memory, since reads should be relatively fast.
+Usually this is okay if you are using Play's default configuration, which only stores elements in memory since reads should be relatively fast.
 However, depending on how EhCache was configured and [where the data is stored](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html), this blocking I/O might be too costly.
 For such a case you can configure a different [Akka dispatcher](http://doc.akka.io/docs/akka/current/scala/dispatchers.html#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the EhCache plugin makes use of it:
 

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -87,10 +87,10 @@ Now to access these different caches, when you inject them, use the [NamedCache]
 
 ## Setting the execution context
 
-By default all the get, set, remove,... operations on the Ehcache are done within Play's default execution context.
-Usually that configuration should be enough for most use cases because it is assumed that accessing the cache is a very fast operation, so usually no thread gets blocked by it.
-However depending on how EhCache was configured (e.g. by [not storing elements in memory](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html) these operations might get slow and therefore might block Play's default threads.
-For such a case you can provide a different execution context and set it via `play.cache.dispatcher` so the EhCache plugin makes use of it:
+By default, all Ehcache operations are blocking, and async implementations will block threads in the default execution context.
+Usually that configuration is okay if you are using Play's default configuration, which only stores elements in memory, since reads should be relatively fast.
+However, depending on how EhCache was configured and [where the data is stored](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html), this blocking I/O might be too costly.
+For such a case you can configure a different [Akka dispatcher](http://doc.akka.io/docs/akka/current/scala/dispatchers.html#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the EhCache plugin makes use of it:
 
 ```
 play.cache.dispatcher = "contexts.blockingCacheDispatcher"

--- a/framework/src/play-ehcache/src/main/resources/reference.conf
+++ b/framework/src/play-ehcache/src/main/resources/reference.conf
@@ -14,6 +14,8 @@ play {
     createBoundCaches = true
     # The name of the default cache to use in ehcache
     defaultCache = "play"
+    # The dispatcher used for get, set, remove,...  operations on the cache. By default Play's default dispatcher is used.
+    dispatcher = null
   }
 
 }

--- a/framework/src/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/framework/src/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -128,9 +128,10 @@ private[play] object NamedEhCacheProvider {
 
 private[play] class NamedAsyncCacheApiProvider(key: BindingKey[Ehcache]) extends Provider[AsyncCacheApi] {
   @Inject private var injector: Injector = _
+  @Inject private var defaultEc: ExecutionContext = _
   @Inject private var config: Configuration = _
   @Inject private var actorSystem: ActorSystem = _
-  private lazy val ec: ExecutionContext = config.get[Option[String]]("play.cache.dispatcher").map(actorSystem.dispatchers.lookup(_)).getOrElse(injector.instanceOf[ExecutionContext])
+  private lazy val ec: ExecutionContext = config.get[Option[String]]("play.cache.dispatcher").map(actorSystem.dispatchers.lookup(_)).getOrElse(defaultEc)
   lazy val get: AsyncCacheApi =
     new EhCacheApi(injector.instanceOf(key))(ec)
 }

--- a/framework/src/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/framework/src/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -176,18 +176,18 @@ class EhCacheApi @Inject() (private[ehcache] val cache: Ehcache)(implicit contex
           element.setTimeToLive(seconds.toInt)
         }
     }
-    Future.successful {
+    Future {
       cache.put(element)
       Done
     }
   }
 
-  def get[T](key: String)(implicit ct: ClassTag[T]): Future[Option[T]] = {
+  def get[T](key: String)(implicit ct: ClassTag[T]): Future[Option[T]] = Future {
     val result = Option(cache.get(key)).map(_.getObjectValue).filter { v =>
       Primitives.wrap(ct.runtimeClass).isInstance(v) ||
         ct == ClassTag.Nothing || (ct == ClassTag.Unit && v == ((): Unit))
     }.asInstanceOf[Option[T]]
-    Future.successful(result)
+    result
   }
 
   def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] = {
@@ -197,7 +197,7 @@ class EhCacheApi @Inject() (private[ehcache] val cache: Ehcache)(implicit contex
     }
   }
 
-  def remove(key: String): Future[Done] = Future.successful {
+  def remove(key: String): Future[Done] = Future {
     cache.remove(key)
     Done
   }

--- a/framework/src/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/framework/src/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -86,6 +86,7 @@ class CachedSpec extends PlaySpecification {
       val result1 = action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       invoked.get() must_== 1
+      Thread.sleep(1000) // give ehcache time to set the value because that happens asynchronously
       val result2 = action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
 


### PR DESCRIPTION
Calling `Future.successful` just returns an already finished `Future` but doesn't process it's body asynchronous. So we are actually blocking. Only `removeAll` did it the non-blocking way right now.

Or do I understand something wrong here?

