### PR TITLE
Remove linebreaks from cookie message

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -607,8 +607,8 @@ trait JWTCookieDataCodec extends CookieDataCodec {
         val devLogger = logger.forMode(Mode.Dev)
         devLogger.info(
           "The JWT signature in the cookie does not match the locally computed signature with the server. "
-          + "This usually indicates the browser has a leftover cookie from another Play application, so clearing " 
-          + "cookies may resolve this error message.")
+            + "This usually indicates the browser has a leftover cookie from another Play application, so clearing "
+            + "cookies may resolve this error message.")
         Map.empty
 
       case NonFatal(e) =>

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -606,9 +606,9 @@ trait JWTCookieDataCodec extends CookieDataCodec {
         logger.warn(s"decode: cookie has invalid signature! message = ${e.getMessage}")(SecurityMarkerContext)
         val devLogger = logger.forMode(Mode.Dev)
         devLogger.info(
-          s"""The JWT signature in the cookie does not match the locally computed signature with the server.
-             |This usually indicates the browser has a leftover cookie from another Play application,
-             |so clearing cookies may resolve this error message.""".stripMargin)
+          "The JWT signature in the cookie does not match the locally computed signature with the server. "
+          + "This usually indicates the browser has a leftover cookie from another Play application, so clearing " 
+          + "cookies may resolve this error message.")
         Map.empty
 
       case NonFatal(e) =>


### PR DESCRIPTION
## Purpose

Removes line breaks from JWT message.

Before, the error message was as follows:

```
[info] p.a.m.DefaultJWTCookieDataCodec - The JWT signature in the cookie does not match the locally computed signature with the server.
This usually indicates the browser has a leftover cookie from another Play application,
so clearing cookies may resolve this error message.
```

which is difficult to read and unnecessary.