### PR TITLE
Fixes #7659:  The session module doesn't work after LegacyCookiesModule is enabled.

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -190,6 +190,10 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.core.ObjectMapperComponents.applicationLifecycle"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServerComponents.applicationLifecycle"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.core.server.NettyServerComponents.applicationLifecycle"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.common.ServerResultUtils.sessionBaker"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.common.ServerResultUtils.cookieHeaderEncoding"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.common.ServerResultUtils.flashBaker"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.common.ServerResultUtils.this"),
 
       // private
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.akkahttp.AkkaModelConversion.this"),

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -93,6 +93,26 @@ class ScalaResultsSpec extends PlaySpecification {
     }
   }
 
+  "support legacy cookie bakers" in {
+    "legacy session baker should work normally" in withLegacyCookiesModule { implicit app =>
+      sessionBaker must beAnInstanceOf[LegacySessionCookieBaker]
+
+      val data = Map("user" -> "kiki", "langs" -> "fr:en:de")
+      val encodedSession = sessionBaker.encode(data)
+      val decodedSession = sessionBaker.decode(encodedSession)
+      decodedSession must_== Map("user" -> "kiki", "langs" -> "fr:en:de")
+    }
+
+    "legacy flash baker should work normally" in withLegacyCookiesModule { implicit app =>
+      flashBaker must beAnInstanceOf[LegacyFlashCookieBaker]
+
+      val data = Map("message" -> "success")
+      val encodedSession = flashBaker.encode(data)
+      val decodedSession = flashBaker.decode(encodedSession)
+      decodedSession must_== Map("message" -> "success")
+    }
+  }
+
   def withApplication[T](config: (String, Any)*)(block: Application => T): T = running(
     _.configure(Map(config: _*) + ("play.http.secret.key" -> "foo"))
   )(block)
@@ -109,4 +129,9 @@ class ScalaResultsSpec extends PlaySpecification {
       "play.http.flash.path" -> path
     )(block)
   }
+
+  def withLegacyCookiesModule[T](block: Application => T) = withApplication(
+    "play.modules.disabled" -> Seq("play.api.mvc.CookiesModule"),
+    "play.modules.enabled" -> Seq("play.api.i18n.I18nModule", "play.api.inject.BuiltinModule", "play.api.mvc.LegacyCookiesModule")
+  )(block)
 }

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -17,13 +17,11 @@ import play.api.mvc.request.RequestAttrKey
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-private[play] final class ServerResultUtils(httpConfiguration: HttpConfiguration) {
-
-  private val cookieSigner = new CookieSignerProvider(httpConfiguration.secret).get
-
-  val cookieHeaderEncoding: CookieHeaderEncoding = new DefaultCookieHeaderEncoding(httpConfiguration.cookies)
-  val sessionBaker: SessionCookieBaker = new DefaultSessionCookieBaker(httpConfiguration.session, httpConfiguration.secret, cookieSigner)
-  val flashBaker: FlashCookieBaker = new DefaultFlashCookieBaker(httpConfiguration.flash, httpConfiguration.secret, cookieSigner)
+private[play] final class ServerResultUtils(
+    httpConfiguration: HttpConfiguration,
+    sessionBaker: SessionCookieBaker,
+    flashBaker: FlashCookieBaker,
+    cookieHeaderEncoding: CookieHeaderEncoding) {
 
   private val logger = Logger(getClass)
 

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -9,6 +9,7 @@ import akka.util.ByteString
 import org.specs2.mutable.Specification
 import play.api.http.Status._
 import play.api.http._
+import play.api.libs.crypto.CookieSignerProvider
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -24,7 +25,15 @@ class ServerResultUtilsSpec extends Specification {
     override def jwtConfiguration = JWTConfiguration()
     override def secretConfiguration = SecretConfiguration()
   }
-  val resultUtils = new ServerResultUtils(HttpConfiguration())
+  val resultUtils = {
+    val httpConfig = HttpConfiguration()
+    new ServerResultUtils(
+      httpConfig,
+      new DefaultSessionCookieBaker(httpConfig.session, httpConfig.secret, new CookieSignerProvider(httpConfig.secret).get),
+      new DefaultFlashCookieBaker(httpConfig.flash, httpConfig.secret, new CookieSignerProvider(httpConfig.secret).get),
+      new DefaultCookieHeaderEncoding(httpConfig.cookies)
+    )
+  }
 
   private def cookieRequestHeader(cookie: Option[(String, String)]): RequestHeader = {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(

--- a/framework/src/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
@@ -87,9 +87,9 @@ object RequestFactory {
  * - flash cookie
  */
 class DefaultRequestFactory @Inject() (
-    cookieHeaderEncoding: CookieHeaderEncoding,
-    sessionBaker: SessionCookieBaker,
-    flashBaker: FlashCookieBaker) extends RequestFactory {
+    val cookieHeaderEncoding: CookieHeaderEncoding,
+    val sessionBaker: SessionCookieBaker,
+    val flashBaker: FlashCookieBaker) extends RequestFactory {
 
   def this(config: HttpConfiguration) = this(
     new DefaultCookieHeaderEncoding(config.cookies),


### PR DESCRIPTION
Obtain the CookieBakers from application.requestFactory for ServerResultUtils.

Fixes #7659.