### PR TITLE
Documentation: use PlayBodyParsers instead BodyParsers.parse

### DIFF
--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
@@ -104,7 +104,7 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
       contentAsString(result) === """{"status":"OK","message":"Place 'Nuthanger Farm' saved."}"""
     }
 
-    "allow handling JSON with BodyParser" in {
+    "allow handling JSON with BodyParser" in new WithApplication() with Injecting {
 
       import play.api.libs.json._
       import play.api.libs.functional.syntax._
@@ -119,8 +119,10 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
         (JsPath \ "location").read[Location]
       )(Place.apply _)
 
+      val parse = inject[PlayBodyParsers]
+
       //#handle-json-bodyparser
-      def savePlace = Action(BodyParsers.parse.json) { request =>
+      def savePlace = Action(parse.json) { request =>
         val placeResult = request.body.validate[Place]
         placeResult.fold(
           errors => {
@@ -151,8 +153,10 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
       contentAsString(result) === """{"status":"OK","message":"Place 'Nuthanger Farm' saved."}"""
     }
 
-    "allow concise handling JSON with BodyParser" in {
+    "allow concise handling JSON with BodyParser" in new WithApplication() with Injecting {
       import scala.concurrent.ExecutionContext.Implicits.global
+
+      val parse = inject[PlayBodyParsers]
 
       //#handle-json-bodyparser-concise
       import play.api.libs.json._
@@ -171,7 +175,7 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
 
       // This helper parses and validates JSON using the implicit `placeReads`
       // above, returning errors if the parsed json fails validation.
-      def validateJson[A : Reads] = BodyParsers.parse.json.validate(
+      def validateJson[A : Reads] = parse.json.validate(
         _.validate[A].asEither.left.map(e => BadRequest(JsError.toJson(e)))
       )
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes
Fixed example code in documentation.

## Purpose
In this article, because it is assumed all codes are written in the controller class that extends `AbstructController`, `PlayBodyParsers` should be used instead of `BodyParsers.parse`


## Background Context

Play 2.6 Migration Guide.

## References
