### PR TITLE
Fix wording in 2.6 ScalaActionsComposition documentation

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/ScalaActionsComposition.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaActionsComposition.md
@@ -96,7 +96,7 @@ First of all, we'll create a request object that adds an `Item` to our `UserRequ
 
 @[request-with-item](code/ScalaActionsComposition.scala)
 
-Now we'll create an action refiner that looks up that item and returns `Either` an error (`Left`) or a new `ItemRequest` (`Right`).  Note that this action refiner is defined inside a method that takes the id of the item:
+Now we'll create an action refiner that looks up that item and returns `Either` a new `ItemRequest` (`Left`) or an error (`Right`).  Note that this action refiner is defined inside a method that takes the id of the item:
 
 @[item-action-builder](code/ScalaActionsComposition.scala)
 


### PR DESCRIPTION
Description of `Either` for code sample shown below was flipped
```
def ItemAction(itemId: String)(implicit ec: ExecutionContext) = new ActionRefiner[UserRequest, ItemRequest] {
  def executionContext = ec
  def refine[A](input: UserRequest[A]) = Future.successful {
    ItemDao.findById(itemId)
      .map(new ItemRequest(_, input))
      .toRight(NotFound)
  }
}

