### PR TITLE
Update play-ws to version 1.0.2

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -265,7 +265,7 @@ object Dependencies {
   ) ++ jcacheApi
 
   val caffeineVersion = "2.5.3"
-  val playWsStandaloneVersion = "1.0.1"
+  val playWsStandaloneVersion = "1.0.4"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-xml" % playWsStandaloneVersion,


### PR DESCRIPTION
Version 1.0.2 has no API changes. See https://github.com/playframework/play-ws/pull/174 for more information.
