### PR TITLE
Fixes resource leakage in DefaultTemporaryFileReaper

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -275,18 +275,26 @@ object Files {
         playTempFolder.map { f =>
           import scala.compat.java8.StreamConverters._
 
-          val reaped = JFiles.list(f)
+          val directoryStream = JFiles.list(f)
             .filter(new Predicate[Path]() {
               override def test(p: Path): Boolean = {
                 val lastModifiedTime = JFiles.getLastModifiedTime(p).toInstant
                 lastModifiedTime.isBefore(secondsAgo)
               }
-            }).toScala[List]
+            })
 
-          reaped.foreach { p =>
-            delete(p)
+          try {
+            val reaped = directoryStream.toScala[List]
+
+            reaped.foreach { p =>
+              delete(p)
+            }
+
+            reaped
+          } finally {
+            directoryStream.close()
           }
-          reaped
+
         }.getOrElse(Seq.empty)
       }(blockingExecutionContext)
     }

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -276,20 +276,16 @@ object Files {
           import scala.compat.java8.StreamConverters._
 
           val directoryStream = JFiles.list(f)
-            .filter(new Predicate[Path]() {
+
+          try {
+            val reaped = directoryStream.filter(new Predicate[Path]() {
               override def test(p: Path): Boolean = {
                 val lastModifiedTime = JFiles.getLastModifiedTime(p).toInstant
                 lastModifiedTime.isBefore(secondsAgo)
               }
-            })
+            }).toScala[List]
 
-          try {
-            val reaped = directoryStream.toScala[List]
-
-            reaped.foreach { p =>
-              delete(p)
-            }
-
+            reaped.foreach(delete)
             reaped
           } finally {
             directoryStream.close()


### PR DESCRIPTION
Fixes #7667

As noted already, this is not easy to unit test without adding further abstractions. Ideas and feedback how to properly test it is welcome.