### PR TITLE
Create Akka and Netty servers from built in components (backport)

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
@@ -28,11 +28,13 @@ public class JavaEmbeddingPlay {
     @Test
     public void simple() throws Exception {
         //#simple
-        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
+        Server server = Server.forRouter((components) ->
+            RoutingDsl.fromComponents(components)
                 .GET("/hello/:to").routeTo(to ->
-                        ok("Hello " + to)
+                    ok("Hello " + to)
                 )
-                .build());
+                .build()
+        );
         //#simple
 
         try {
@@ -58,9 +60,10 @@ public class JavaEmbeddingPlay {
     @Test
     public void config() throws Exception {
         //#config
-        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
+        Server server = Server.forRouter((components) ->
+            RoutingDsl.fromComponents(components)
                 .GET("/hello/:to").routeTo(to ->
-                        ok("Hello " + to)
+                    ok("Hello " + to)
                 )
                 .build()
         );

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayAkkaHttp.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayAkkaHttp.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
 #  Embedding an Akka Http server in your application
 
-Play Akka HTTP server is also configurable as a embedded Play server. The simplest way to start an Play Akka HTTP Server is to use the [`AkkaHttpServer`](api/scala/play/core/server/AkkaHttpServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
+Play Akka HTTP server is also configurable as a embedded Play server. The simplest way to start an Play Akka HTTP Server is to use the [`AkkaHttpServer`](api/scala/play/core/server/AkkaHttpServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouterWithComponents` method:
 
 @[simple-akka-http](code/ScalaAkkaEmbeddingPlay.scala)
 

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
@@ -3,7 +3,7 @@
 
 While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.
 
-The simplest way to start an embedded Play server is to use the [`NettyServer`](api/scala/play/core/server/NettyServer$.html) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
+The simplest way to start an embedded Play server is to use the [`NettyServer`](api/scala/play/core/server/NettyServer$.html) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouterWithComponents` method:
 
 @[simple](code/ScalaNettyEmbeddingPlay.scala)
 

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
@@ -17,9 +17,13 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
       import play.api.routing.sird._
       import play.core.server.AkkaHttpServer
 
-      val server = AkkaHttpServer.fromRouter() {
-        case GET(p"/hello/$to") => Action {
-          Results.Ok(s"Hello $to")
+      val server = AkkaHttpServer.fromRouterWithComponents() { components =>
+        import Results._
+        import components.{ defaultActionBuilder => Action }
+        {
+          case GET(p"/hello/$to") => Action {
+            Ok(s"Hello $to")
+          }
         }
       }
 
@@ -39,12 +43,16 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
       import play.api.routing.sird._
       import play.core.server.{AkkaHttpServer, _}
 
-      val server = AkkaHttpServer.fromRouter(ServerConfig(
+      val server = AkkaHttpServer.fromRouterWithComponents(ServerConfig(
         port = Some(19000),
         address = "127.0.0.1"
-      )) {
-        case GET(p"/hello/$to") => Action {
-          Results.Ok(s"Hello $to")
+      )) { components =>
+        import Results._
+        import components.{ defaultActionBuilder => Action }
+        {
+          case GET(p"/hello/$to") => Action {
+            Ok(s"Hello $to")
+          }
         }
       }
       //#config-akka-http
@@ -69,18 +77,20 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
 
       val components = new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
 
-        lazy val Action = defaultActionBuilder
-
-        lazy val router = Router.from {
+        override lazy val router: Router = Router.from {
           case GET(p"/hello/$to") => Action {
             Results.Ok(s"Hello $to")
           }
         }
 
-        override lazy val httpErrorHandler = new DefaultHttpErrorHandler(environment,
-          configuration, sourceMapper, Some(router)) {
+        override lazy val httpErrorHandler = new DefaultHttpErrorHandler(
+          environment,
+          configuration,
+          sourceMapper,
+          Some(router)
+        ) {
 
-          override protected def onNotFound(request: RequestHeader, message: String) = {
+          override protected def onNotFound(request: RequestHeader, message: String): Future[Result] = {
             Future.successful(Results.NotFound("Nothing was found!"))
           }
         }

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -45,11 +45,12 @@ class GitHubClientSpec extends Specification {
   "GitHubClient" should {
     "get all repositories" in {
 
-      Server.withRouterFromComponents() { cs =>
-        import cs.{ defaultActionBuilder => Action }
+      Server.withRouterFromComponents() { components =>
+        import Results._
+        import components.{ defaultActionBuilder => Action }
         {
           case GET(p"/repositories") => Action {
-            Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+            Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
           }
         }
       } { implicit port =>
@@ -88,11 +89,12 @@ class ScalaTestingWebServiceClients extends Specification {
       import play.api.routing.sird._
       import play.core.server.Server
 
-      Server.withRouterFromComponents() { cs => 
-        import cs.{ defaultActionBuilder => Action }
+      Server.withRouterFromComponents() { components =>
+        import Results._
+        import components.{ defaultActionBuilder => Action }
         {
           case GET(p"/repositories") => Action {
-            Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+            Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
           }
         }
       } { implicit port =>
@@ -112,7 +114,7 @@ class ScalaTestingWebServiceClients extends Specification {
         new BuiltInComponentsFromContext(context) with HttpFiltersComponents {
           override def router: Router = Router.from {
             case GET(p"/repositories") =>
-              this.defaultActionBuilder { req =>
+              Action { req =>
                 Results.Ok.sendResource("github/repositories.json")(fileMimeTypes)
               }
           }
@@ -137,7 +139,7 @@ class ScalaTestingWebServiceClients extends Specification {
           new BuiltInComponentsFromContext(context) with HttpFiltersComponents{
             override def router: Router = Router.from {
               case GET(p"/repositories") =>
-                this.defaultActionBuilder { req =>
+                Action { req =>
                   Results.Ok.sendResource("github/repositories.json")(fileMimeTypes)
                 }
             }

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -4,8 +4,7 @@
 import BuildSettings._
 import Dependencies._
 import Generators._
-import com.typesafe.tools.mima.plugin.MimaKeys.{ mimaPreviousArtifacts, mimaReportBinaryIssues, mimaBinaryIssueFilters }
-import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.plugin.MimaKeys.{ mimaPreviousArtifacts, mimaReportBinaryIssues }
 import interplay.PlayBuildBase.autoImport._
 import sbt.Keys.parallelExecution
 import sbt.ScriptedPlugin._

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -194,11 +194,7 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.akkahttp.AkkaModelConversion.this"),
 
       // Added method to PlayBodyParsers, which is a Play API not meant to be extended by end users.
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.byteString"),
-
-      // Refactoring to unify AkkaHttpServer and NettyServer fromRouter methods
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.NettyServer.fromRouter"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.AkkaHttpServer.fromRouter")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.byteString")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-import com.typesafe.sbt.SbtScalariform._
-
 import sbt.ScriptedPlugin._
 import sbt._
 import Keys.{version, _}
@@ -196,7 +194,11 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.akkahttp.AkkaModelConversion.this"),
 
       // Added method to PlayBodyParsers, which is a Play API not meant to be extended by end users.
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.byteString")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.byteString"),
+
+      // Refactoring to unify AkkaHttpServer and NettyServer fromRouter methods
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.NettyServer.fromRouter"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.AkkaHttpServer.fromRouter")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -424,6 +424,11 @@ object AkkaHttpServer extends ServerFromRouter {
       application.materializer, () => Future.successful(()))
   }
 
+  // Preserve binary compatibility on the 2.6.x branch by casting the return type
+  override def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): AkkaHttpServer = {
+    super.fromRouter(config)(routes).asInstanceOf[AkkaHttpServer]
+  }
+
   override protected def createServerFromRouter(serverConf: ServerConfig = ServerConfig())(routes: ServerComponents with BuiltInComponents => Router): Server = {
     new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
       override lazy val serverConfig: ServerConfig = serverConf

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -18,17 +18,16 @@ import akka.http.scaladsl.{ ConnectionContext, Http }
 import akka.stream.Materializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
-import com.typesafe.config.{ Config, ConfigFactory, ConfigMemorySize }
+import com.typesafe.config.{ Config, ConfigMemorySize }
 import play.api._
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
-import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
 import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder }
 import play.core.server.common.{ ReloadCache, ServerResultUtils }
 import play.core.server.ssl.ServerSSLEngine
-import play.core.{ ApplicationProvider, DefaultWebCommands, SourceMapper, WebCommands }
+import play.core.ApplicationProvider
 import play.server.SSLEngineProvider
 
 import scala.concurrent.duration._
@@ -53,7 +52,7 @@ class AkkaHttpServer(
   private val serverConfig = config.configuration.get[Configuration]("play.server")
   private val akkaServerConfig = config.configuration.get[Configuration]("play.server.akka")
 
-  def mode = config.mode
+  override def mode: Mode = config.mode
 
   // Remember that some user config may not be available in development mode due to its unusual ClassLoader.
   implicit private val system: ActorSystem = actorSystem
@@ -348,9 +347,9 @@ class AkkaHttpServer(
     httpServerBinding.orElse(httpsServerBinding).map(_.localAddress).get
   }
 
-  def httpPort = httpServerBinding.map(_.localAddress.getPort)
+  override def httpPort: Option[Int] = httpServerBinding.map(_.localAddress.getPort)
 
-  def httpsPort = httpsServerBinding.map(_.localAddress.getPort)
+  override def httpsPort: Option[Int] = httpsServerBinding.map(_.localAddress.getPort)
 
   /**
    * There is a mismatch between the Play SSL API and the Akka IO SSL API, Akka IO takes an SSL context, and
@@ -377,7 +376,34 @@ class AkkaHttpServer(
   }
 }
 
-object AkkaHttpServer {
+/**
+ * Creates an AkkaHttpServer from the given router:
+ *
+ * {{{
+ *   val server = AkkaHttpServer.fromRouter(ServerConfig(port = Some(9002))) {
+ *     case GET(p"/") => Action {
+ *       Results.Ok("Hello")
+ *     }
+ *   }
+ * }}}
+ *
+ * Or from a given router using [[BuiltInComponents]]:
+ *
+ * {{{
+ *   val server = AkkaHttpServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components =>
+ *     import play.api.mvc.Results._
+ *     import components.{ defaultActionBuilder => Action }
+ *     {
+ *       case GET(p"/") => Action {
+ *         Ok("Hello")
+ *       }
+ *     }
+ *   }
+ * }}}
+ *
+ * Use this together with <a href="https://www.playframework.com/documentation/2.6.x/ScalaSirdRouter">Sird Router</a>.
+ */
+object AkkaHttpServer extends ServerFromRouter {
 
   private val logger = Logger(classOf[AkkaHttpServer])
 
@@ -398,10 +424,10 @@ object AkkaHttpServer {
       application.materializer, () => Future.successful(()))
   }
 
-  def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): AkkaHttpServer = {
+  override protected def createServerFromRouter(serverConf: ServerConfig = ServerConfig())(routes: ServerComponents with BuiltInComponents => Router): Server = {
     new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
-      override lazy val serverConfig: ServerConfig = config
-      lazy val router: Router = Router.from(routes)
+      override lazy val serverConfig: ServerConfig = serverConf
+      override def router: Router = routes(this)
     }.server
   }
 }
@@ -415,8 +441,10 @@ class AkkaHttpServerProvider extends ServerProvider {
       context.stopHook)
 }
 
-trait AkkaHttpServerComponents {
-  lazy val serverConfig: ServerConfig = ServerConfig()
+/**
+ * Components for building a simple Akka HTTP Server.
+ */
+trait AkkaHttpServerComponents extends ServerComponents {
   lazy val server: AkkaHttpServer = {
     // Start the application first
     Play.start(application)
@@ -424,16 +452,5 @@ trait AkkaHttpServerComponents {
       application.materializer, serverStopHook)
   }
 
-  lazy val environment: Environment = Environment.simple(mode = serverConfig.mode)
-  lazy val sourceMapper: Option[SourceMapper] = None
-  lazy val webCommands: WebCommands = new DefaultWebCommands
-  lazy val configuration: Configuration = Configuration(ConfigFactory.load())
-  lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-
   def application: Application
-
-  /**
-   * Called when Server.stop is called.
-   */
-  def serverStopHook: () => Future[Unit] = () => Future.successful(())
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -25,7 +25,6 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
       val port = testServerPort
 
       val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with HttpFiltersComponents {
-        def Action = defaultActionBuilder
         def router = {
           import sird._
           Router.from {

--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -325,7 +325,7 @@ object HttpBinApplication {
 
   def app = {
     new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with AhcWSComponents with NoHttpFiltersComponents {
-      implicit lazy val Action = defaultActionBuilder
+      override implicit lazy val Action = defaultActionBuilder
       def router = SimpleRouter(
         PartialFunction.empty
           .orElse(getIp)

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -3,14 +3,13 @@
  */
 package play.core.server
 
-import java.io.IOException
 import java.net.InetSocketAddress
 
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.{ Sink, Source }
-import com.typesafe.config.{ Config, ConfigFactory, ConfigValue }
+import com.typesafe.config.{ Config, ConfigValue }
 import com.typesafe.netty.HandlerPublisher
 import com.typesafe.netty.http.HttpStreamsServerHandler
 import io.netty.bootstrap.Bootstrap
@@ -24,8 +23,6 @@ import io.netty.handler.logging.{ LogLevel, LoggingHandler }
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.timeout.IdleStateHandler
 import play.api._
-import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
-import play.api.mvc.{ Handler, RequestHeader }
 import play.api.routing.Router
 import play.core._
 import play.core.server.netty._
@@ -65,7 +62,7 @@ class NettyServer(
 
   import NettyServer._
 
-  def mode = config.mode
+  override def mode: Mode = config.mode
 
   /**
    * The event loop
@@ -209,17 +206,6 @@ class NettyServer(
     }
   }
 
-  private def handleSubscriberError(error: Throwable): Unit = {
-    error match {
-      // IO exceptions happen all the time, it usually just means that the client has closed the connection before fully
-      // sending/receiving the response.
-      case e: IOException =>
-        logger.trace("Benign IO exception caught in Netty", e)
-      case e =>
-        logger.error("Exception caught in Netty", e)
-    }
-  }
-
   // Maybe the HTTP server channel
   private val httpChannel = config.port.map(bindChannel(_, secure = false))
 
@@ -271,13 +257,13 @@ class NettyServer(
     Await.result(stopHook(), Duration.Inf)
   }
 
-  override lazy val mainAddress = {
+  override lazy val mainAddress: InetSocketAddress = {
     (httpChannel orElse httpsChannel).get.localAddress().asInstanceOf[InetSocketAddress]
   }
 
-  def httpPort = httpChannel map (_.localAddress().asInstanceOf[InetSocketAddress].getPort)
+  override def httpPort: Option[Int] = httpChannel map (_.localAddress().asInstanceOf[InetSocketAddress].getPort)
 
-  def httpsPort = httpsChannel map (_.localAddress().asInstanceOf[InetSocketAddress].getPort)
+  override def httpsPort: Option[Int] = httpsChannel map (_.localAddress().asInstanceOf[InetSocketAddress].getPort)
 }
 
 /**
@@ -295,9 +281,33 @@ class NettyServerProvider extends ServerProvider {
 }
 
 /**
- * Bootstraps Play application with a NettyServer backend.
+ * Create a Netty server from the given router and server config:
+ *
+ * {{{
+ *   val server = Netty.fromRouter(ServerConfig(port = Some(9002))) {
+ *     case GET(p"/") => Action {
+ *       Results.Ok("Hello")
+ *     }
+ *   }
+ * }}}
+ *
+ * Or from a given router using [[BuiltInComponents]]:
+ *
+ * {{{
+ *   val server = NettyServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components =>
+ *     import play.api.mvc.Results._
+ *     import components.{ defaultActionBuilder => Action }
+ *     {
+ *       case GET(p"/") => Action {
+ *         Ok("Hello")
+ *       }
+ *     }
+ *   }
+ * }}}
+ *
+ * Use this together with <a href="https://www.playframework.com/documentation/latest/ScalaSirdRouter">Sird Router</a>.
  */
-object NettyServer {
+object NettyServer extends ServerFromRouter {
 
   private val logger = Logger(this.getClass)
 
@@ -320,13 +330,10 @@ object NettyServer {
       application.materializer)
   }
 
-  /**
-   * Create a Netty server from the given router and server config.
-   */
-  def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): NettyServer = {
+  override protected def createServerFromRouter(serverConf: ServerConfig)(routes: ServerComponents with BuiltInComponents => Router): Server = {
     new NettyServerComponents with BuiltInComponents with NoHttpFiltersComponents {
-      override lazy val serverConfig = config
-      lazy val router = Router.from(routes)
+      override lazy val serverConfig: ServerConfig = serverConf
+      override def router: Router = routes(this)
     }.server
   }
 }
@@ -334,8 +341,7 @@ object NettyServer {
 /**
  * Cake for building a simple Netty server.
  */
-trait NettyServerComponents {
-  lazy val serverConfig: ServerConfig = ServerConfig()
+trait NettyServerComponents extends ServerComponents {
   lazy val server: NettyServer = {
     // Start the application first
     Play.start(application)
@@ -343,16 +349,5 @@ trait NettyServerComponents {
       application.materializer)
   }
 
-  lazy val environment: Environment = Environment.simple(mode = serverConfig.mode)
-  lazy val sourceMapper: Option[SourceMapper] = None
-  lazy val webCommands: WebCommands = new DefaultWebCommands
-  lazy val configuration: Configuration = Configuration(ConfigFactory.load())
-  lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-
   def application: Application
-
-  /**
-   * Called when Server.stop is called.
-   */
-  def serverStopHook: () => Future[Unit] = () => Future.successful(())
 }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -23,6 +23,7 @@ import io.netty.handler.logging.{ LogLevel, LoggingHandler }
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.timeout.IdleStateHandler
 import play.api._
+import play.api.mvc.{ Handler, RequestHeader }
 import play.api.routing.Router
 import play.core._
 import play.core.server.netty._
@@ -328,6 +329,11 @@ object NettyServer extends ServerFromRouter {
   def fromApplication(application: Application, config: ServerConfig = ServerConfig()): NettyServer = {
     new NettyServer(config, ApplicationProvider(application), () => Future.successful(()), application.actorSystem)(
       application.materializer)
+  }
+
+  // Preserve binary compatibility on the 2.6.x branch by casting the return type
+  override def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): NettyServer = {
+    super.fromRouter(config)(routes).asInstanceOf[NettyServer]
   }
 
   override protected def createServerFromRouter(serverConf: ServerConfig)(routes: ServerComponents with BuiltInComponents => Router): Server = {

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -13,9 +13,8 @@ import play.api.routing.Router
 import scala.language.postfixOps
 import play.api._
 import play.api.mvc._
-import play.core.{ ApplicationProvider, DefaultWebCommands }
-import play.api.inject.DefaultApplicationLifecycle
-
+import play.core.{ ApplicationProvider, DefaultWebCommands, SourceMapper, WebCommands }
+import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.routing.{ Router => JRouter }
 import play.{ ApplicationLoader => JApplicationLoader }
 import play.{ BuiltInComponents => JBuiltInComponents }
@@ -226,6 +225,54 @@ object Server {
     withApplication(appProducer(context), config)(block)
   }
 
+}
+
+/**
+ * Components to create a Server instance.
+ */
+trait ServerComponents {
+
+  def server: Server
+
+  lazy val serverConfig: ServerConfig = ServerConfig()
+
+  lazy val environment: Environment = Environment.simple(mode = serverConfig.mode)
+  lazy val sourceMapper: Option[SourceMapper] = None
+  lazy val webCommands: WebCommands = new DefaultWebCommands
+  lazy val configuration: Configuration = Configuration(ConfigFactory.load())
+  lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
+
+  def serverStopHook: () => Future[Unit] = () => Future.successful(())
+}
+
+/**
+ * Define how to create a Server from a Router.
+ */
+private[server] trait ServerFromRouter {
+
+  protected def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents with BuiltInComponents => Router): Server
+
+  /**
+   * Creates a [[Server]] from the given router.
+   *
+   * @param config the server configuration
+   * @param routes the routes definitions
+   * @return an AkkaHttpServer instance
+   */
+  def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): Server = {
+    createServerFromRouter(config) { _ => Router.from(routes) }
+  }
+
+  /**
+   * Creates a [[Server]] from the given router, using [[ServerComponents]].
+   *
+   * @param config the server configuration
+   * @param routes the routes definitions
+   * @return an AkkaHttpServer instance
+   */
+  def fromRouterWithComponents(config: ServerConfig = ServerConfig())(routes: BuiltInComponents => PartialFunction[RequestHeader, Handler]): Server = {
+    createServerFromRouter(config)(components => Router.from(routes(components)))
+  }
 }
 
 private[play] object JavaServerHelper {

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -263,6 +263,16 @@ trait BuiltInComponents extends I18nComponents {
   def router: Router
 
   /**
+   * Alias method to [[defaultActionBuilder]]. This just helps to keep the idiom of using `Action`
+   * when creating `Router`s using the built in components.
+   *
+   * @return the default action builder.
+   */
+  def Action: DefaultActionBuilder = defaultActionBuilder
+
+  def parse = playBodyParsers
+
+  /**
    * The runtime [[Injector]] instance provided to the [[DefaultApplication]]. This injector is set up to allow
    * existing (deprecated) legacy APIs to function. It is not set up to support injecting arbitrary Play components.
    */


### PR DESCRIPTION
This is a backport of #7520 with [an additional change](https://github.com/playframework/playframework/pull/7520#discussion_r129967680) to preserve binary compatibility.