### PR TITLE
Add the security header names to HeaderNames object(s) (backport)

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -191,6 +191,18 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.common.ServerResultUtils.cookieHeaderEncoding"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.common.ServerResultUtils.flashBaker"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.common.ServerResultUtils.this"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.CONTENT_SECURITY_POLICY"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$CONTENT_SECURITY_POLICY_="),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$X_XSS_PROTECTION_="),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.X_XSS_PROTECTION"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$REFERRER_POLICY_="),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.REFERRER_POLICY"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.X_CONTENT_TYPE_OPTIONS"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$X_CONTENT_TYPE_OPTIONS_="),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.X_PERMITTED_CROSS_DOMAIN_POLICIES"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$X_PERMITTED_CROSS_DOMAIN_POLICIES_="),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.X_FRAME_OPTIONS"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$X_FRAME_OPTIONS_="),
 
       // private
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.akkahttp.AkkaModelConversion.this"),

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -6,6 +6,7 @@ package play.filters.headers
 import javax.inject.{ Inject, Provider, Singleton }
 
 import play.api.Configuration
+import play.api.http.HeaderNames
 import play.api.inject._
 import play.api.mvc._
 
@@ -34,12 +35,12 @@ import play.api.mvc._
  * @see <a href="https://www.w3.org/TR/referrer-policy/">Referrer Policy</a>
  */
 object SecurityHeadersFilter {
-  val X_FRAME_OPTIONS_HEADER = "X-Frame-Options"
-  val X_XSS_PROTECTION_HEADER = "X-XSS-Protection"
-  val X_CONTENT_TYPE_OPTIONS_HEADER = "X-Content-Type-Options"
-  val X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER = "X-Permitted-Cross-Domain-Policies"
-  val CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy"
-  val REFERRER_POLICY = "Referrer-Policy"
+  val X_FRAME_OPTIONS_HEADER = HeaderNames.X_FRAME_OPTIONS
+  val X_XSS_PROTECTION_HEADER = HeaderNames.X_XSS_PROTECTION
+  val X_CONTENT_TYPE_OPTIONS_HEADER = HeaderNames.X_CONTENT_TYPE_OPTIONS
+  val X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER = HeaderNames.X_PERMITTED_CROSS_DOMAIN_POLICIES
+  val CONTENT_SECURITY_POLICY_HEADER = HeaderNames.CONTENT_SECURITY_POLICY
+  val REFERRER_POLICY = HeaderNames.REFERRER_POLICY
 
   /**
    * Convenience method for creating a SecurityHeadersFilter that reads settings from application.conf.  Generally speaking,

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2499,6 +2499,7 @@ public class Http {
         String IF_RANGE = "If-Range";
         String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
         String LAST_MODIFIED = "Last-Modified";
+        String LINK = "Link";
         String LOCATION = "Location";
         String MAX_FORWARDS = "Max-Forwards";
         String PRAGMA = "Pragma";
@@ -2533,6 +2534,13 @@ public class Http {
         String X_FORWARDED_PORT = "X-Forwarded-Port";
         String X_FORWARDED_PROTO = "X-Forwarded-Proto";
         String X_REQUESTED_WITH = "X-Requested-With";
+        String STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
+        String X_FRAME_OPTIONS = "X-Frame-Options";
+        String X_XSS_PROTECTION = "X-XSS-Protection";
+        String X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+        String X_PERMITTED_CROSS_DOMAIN_POLICIES = "X-Permitted-Cross-Domain-Policies";
+        String CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+        String REFERRER_POLICY = "Referrer-Policy";
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -325,6 +325,13 @@ trait HeaderNames {
   val ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers"
 
   val STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security"
+
+  val X_FRAME_OPTIONS = "X-Frame-Options"
+  val X_XSS_PROTECTION = "X-XSS-Protection"
+  val X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options"
+  val X_PERMITTED_CROSS_DOMAIN_POLICIES = "X-Permitted-Cross-Domain-Policies"
+  val CONTENT_SECURITY_POLICY = "Content-Security-Policy"
+  val REFERRER_POLICY = "Referrer-Policy"
 }
 
 /**


### PR DESCRIPTION
Backport of @mkurz's #7580 to the _2.6.x_ branch.

* Add security header names to HeaderNames object(s)
* Removed _HEADER suffix
* Add MIMA rules