### PR TITLE
Make RequestBodyHandlingSpec faster

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -98,8 +98,8 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       Results.Ok(rh.body.asText.getOrElse(""))
     }) { port =>
       // big body that should not crash akka and netty
-      val body = "Hello World" * 1024 * 1024
-      val responses = BasicHttpClient.makeRequests(port, trickleFeed = Some(100L))(
+      val body = "Hello World" * (1024 * 1024)
+      val responses = BasicHttpClient.makeRequests(port, trickleFeed = Some(1))(
         BasicRequest("POST", "/", "HTTP/1.1", Map("Content-Length" -> body.length.toString), body)
       )
       responses.length must_== 1


### PR DESCRIPTION
Running time on my machine was 2.5 minutes, which for both Akka HTTP and Netty tests added 5 minutes to the test suite running time. This reduces the time down to 5-20 seconds. The trickle delay should still work well enough to test the body handling code properly.