### PR TITLE
Preserve request body when using RoutingDsl

### DIFF
--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -122,8 +122,7 @@ public class RoutingDsl {
 
     @Inject
     public RoutingDsl(PlayBodyParsers bodyParsers, JavaContextComponents contextComponents) {
-        this.bodyParser = bodyParsers.defaultBodyParser();
-        this.contextComponents = contextComponents;
+        this(bodyParsers.defaultBodyParser(), contextComponents);
     }
 
     public static RoutingDsl fromComponents(BuiltInComponents components) {

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -903,7 +903,10 @@ public class Http {
         /**
          * Constructor only based on a header.
          * @param header the header from a request
+         *
+         * @deprecated Since 2.7.0. Use {@link #RequestImpl(play.api.mvc.Request)} instead.
          */
+        @Deprecated
         public RequestImpl(play.api.mvc.RequestHeader header) {
             super(header.withBody(null));
         }


### PR DESCRIPTION
## Fixes

Fixes #7682.

## Purpose

Preserve the request body when using `RoutingDsl`. See #7682 for discussion.