### PR TITLE
Decode empty cookies without an exception

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -500,12 +500,17 @@ trait UrlEncodedCookieDataCodec extends CookieDataCodec {
    */
   def decode(data: String): Map[String, String] = {
 
-    def urldecode(data: String) = {
-      data
-        .split("&")
-        .map(_.split("=", 2))
-        .map(p => URLDecoder.decode(p(0), "UTF-8") -> URLDecoder.decode(p(1), "UTF-8"))
-        .toMap
+    def urldecode(data: String): Map[String, String] = {
+      // In some cases we've seen clients ignore the Max-Age and Expires on a cookie, and fail to properly clear the
+      // cookie. This can cause the client to send an empty cookie back to us after we've attempted to clear it. So
+      // just decode empty cookies to an empty map. See https://github.com/playframework/playframework/issues/7680.
+      if (data.nonEmpty) {
+        data
+          .split("&")
+          .map(_.split("=", 2))
+          .map(p => URLDecoder.decode(p(0), "UTF-8") -> URLDecoder.decode(p(1), "UTF-8"))
+          .toMap
+      } else Map.empty
     }
 
     // Do not change this unless you understand the security issues behind timing attacks.

--- a/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -187,6 +187,11 @@ class CookiesSpec extends Specification {
       codec.decode(jwtValue) must contain("hello" -> "world")
     }
 
+    "decode empty string to map" in {
+      val jwtValue = ""
+      codec.decode(jwtValue) must beEmpty
+    }
+
     "encode and decode in a round trip" in {
       val jwtValue = codec.encode(Map("hello" -> "world"))
       codec.decode(jwtValue) must contain("hello" -> "world")
@@ -279,6 +284,10 @@ class CookiesSpec extends Specification {
     "decode a JWT cookie encoding" in {
       val signedEncoding = "eyJhbGciOiJIUzI1NiJ9.eyJuYmYiOjAsImlhdCI6MCwiZGF0YSI6eyJoZWxsbyI6IndvcmxkIn19.SoN8DSDXnFSK0oZXs6hsP4y_8MQqiWQAPJYiTNfAErM"
       sessionCookieBaker.decode(signedEncoding) must contain("hello" -> "world")
+    }
+
+    "decode an empty cookie" in {
+      sessionCookieBaker.decode("") must beEmpty
     }
 
     "decode an empty legacy session" in {


### PR DESCRIPTION
This change makes sure we can decode an empty cookie. We just decode to an empty map.