### PR TITLE
WIP: adds a stop method to ProdServerStart

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
@@ -17,12 +17,23 @@ import scala.util.control.NonFatal
  */
 object ProdServerStart {
 
+  private var server: ReloadableServer = _
+
   /**
    * Start a prod mode server from the command line.
    */
   def main(args: Array[String]) {
     val process = new RealServerProcess(args)
-    start(process)
+    server = start(process)
+  }
+
+  /**
+   * Stop method for Daemon Managers
+   */
+  def stop(args: Array[String]): Unit = {
+    if (server != null) {
+      server.stop()
+    }
   }
 
   /**


### PR DESCRIPTION
currently this is useful when using a service manager
like procrun (https://commons.apache.org/proper/commons-daemon/procrun.html)

This is WIP, since I want to add documentation on how to run Play! on Windows. And make a simple procrun configuration that makes it possible.