### PR TITLE
Improve JPA configuration

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -42,10 +42,10 @@ Here is a sample configuration file to use with Hibernate:
 </persistence>
 ```
 
-Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by the `jpa.default` property in your `conf/application.conf`.
+Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by the `play.jpa.default` property in your `conf/application.conf`.
 
 ```
-jpa.default=defaultPersistenceUnit
+play.jpa.default=defaultPersistenceUnit
 ```
 
 ## Deploying Play with JPA

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
@@ -3,6 +3,7 @@
  */
 package play.db.jpa;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
@@ -10,9 +11,10 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import com.typesafe.config.Config;
-
 import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
+import play.api.ConfigLoader$;
+import play.libs.Scala;
 
 /**
  * Default JPA configuration.
@@ -41,13 +43,12 @@ public class DefaultJPAConfig implements JPAConfig {
         @Inject
         public JPAConfigProvider(Config configuration) {
             ImmutableSet.Builder<JPAConfig.PersistenceUnit> persistenceUnits = new ImmutableSet.Builder<JPAConfig.PersistenceUnit>();
-            Config jpa = configuration.getConfig("jpa");
-            if (jpa != null) {
-                jpa.entrySet().forEach(entry -> {
-                    String key = entry.getKey();
-                    persistenceUnits.add(new JPAConfig.PersistenceUnit(key, jpa.getString(key)));
-                });
-            }
+            Config jpa = new play.api.Configuration(configuration).getDeprecated(
+                "play.jpa", Scala.asScala(Arrays.asList("jpa")), ConfigLoader$.MODULE$.configLoader());
+            jpa.entrySet().forEach(entry -> {
+                String key = entry.getKey();
+                persistenceUnits.add(new JPAConfig.PersistenceUnit(key, jpa.getString(key)));
+            });
             jpaConfig = new DefaultJPAConfig(persistenceUnits.build());
         }
 

--- a/framework/src/play-java-jpa/src/main/resources/reference.conf
+++ b/framework/src/play-java-jpa/src/main/resources/reference.conf
@@ -2,4 +2,12 @@ play {
   modules {
     enabled += "play.db.jpa.JPAModule"
   }
+
+  jpa {
+    # Reference persistence units here as defined in persistence.xml
+    # default = defaultPersistenceUnit
+  }
 }
+
+# Deprecated; Use play.jpa instead
+# jpa {}


### PR DESCRIPTION
 - Fix issue of `jpa` key not existing as reported here: https://groups.google.com/forum/#!topic/play-framework/LSqKKEyv8BQ
 - Deprecate root `jpa` key in favor of `play.jpa`
 - Add JPA config keys to `reference.conf` with a short description of how they are used
