### PR TITLE
[2.6.x]: Improve JPA configuration

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -42,10 +42,10 @@ Here is a sample configuration file to use with Hibernate:
 </persistence>
 ```
 
-Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by the `jpa.default` property in your `conf/application.conf`.
+Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by the `play.jpa.default` property in your `conf/application.conf`.
 
 ```
-jpa.default=defaultPersistenceUnit
+play.jpa.default=defaultPersistenceUnit
 ```
 
 ## Deploying Play with JPA

--- a/framework/src/play-java-jpa/src/main/resources/reference.conf
+++ b/framework/src/play-java-jpa/src/main/resources/reference.conf
@@ -2,4 +2,12 @@ play {
   modules {
     enabled += "play.db.jpa.JPAModule"
   }
+
+  jpa {
+    # Reference persistence units here as defined in persistence.xml
+    # default = defaultPersistenceUnit
+  }
 }
+
+# The jpa key will be deprecated in Play 2.7.0. Please use play.jpa instead.
+# jpa {}

--- a/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
+++ b/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
@@ -3,22 +3,75 @@
  */
 package play.db.jpa;
 
-import org.junit.Rule;
-import org.junit.rules.ExternalResource;
-import play.db.Database;
-import play.db.Databases;
-
-import org.junit.Test;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import com.google.common.collect.Sets;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import play.db.Database;
+import play.db.Databases;
+import play.db.jpa.DefaultJPAConfig.JPAConfigProvider;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 public class JPAApiTest {
 
     @Rule
     public TestDatabase db = new TestDatabase();
+
+    @Test
+    public void shouldWorkWithEmptyConfiguration() {
+        Config config = ConfigFactory.load();
+        assertThat(new JPAConfigProvider(config).get().persistenceUnits(), notNullValue());
+    }
+
+    @Test
+    public void shouldWorkWithLegacyConfiguration() {
+        Config overrides = ConfigFactory.parseString("jpa.default = defaultPersistenceUnit");
+        Config config = overrides.withFallback(ConfigFactory.load());
+        Set<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
+            .map(unit -> unit.unitName).collect(Collectors.toSet());
+        assertThat(unitNames, equalTo(Sets.newHashSet("defaultPersistenceUnit")));
+    }
+
+    @Test
+    public void shouldWorkWithPlayConfiguration() {
+        Config overrides = ConfigFactory.parseString("play.jpa.default = defaultPersistenceUnit");
+        Config config = overrides.withFallback(ConfigFactory.load());
+        Set<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
+            .map(unit -> unit.unitName).collect(Collectors.toSet());
+        assertThat(unitNames, equalTo(Sets.newHashSet("defaultPersistenceUnit")));
+    }
+
+    @Test
+    public void shouldWorkWithMultipleConfiguration() {
+        Config overrides = ConfigFactory.parseString(
+            "play.jpa.one = pu1\njpa.two = pu2");
+        Config config = overrides.withFallback(ConfigFactory.load());
+        Set<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
+            .map(unit -> unit.unitName).collect(Collectors.toSet());
+        assertThat(unitNames, equalTo(Sets.newHashSet("pu1", "pu2")));
+    }
+
+    @Test
+    public void shouldWorkWithMultipleOverlappingConfiguration() {
+        Config overrides = ConfigFactory.parseString(
+            "play.jpa.one = pu1\njpa.one = pu2");
+        Config config = overrides.withFallback(ConfigFactory.load());
+        Set<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
+            .map(unit -> unit.unitName).collect(Collectors.toSet());
+        assertThat(unitNames, equalTo(Sets.newHashSet("pu2")));
+    }
 
     @Test
     public void shouldBeAbleToGetAnEntityManagerWithAGivenName() {


### PR DESCRIPTION
Backport of #7691. Supports both `play.jpa` and `jpa` configuration but will warn if both are used.