### PR TITLE
Remove code to handle old Java versions

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
@@ -10,7 +10,6 @@ import java.math.BigInteger
 import java.util.Date
 import sun.security.util.ObjectIdentifier
 import java.time.{ Duration, Instant }
-import scala.util.Properties.isJavaAtLeast
 
 /**
  * Used for testing only.  This relies on internal sun.security packages, so cannot be used in OpenJDK.
@@ -73,14 +72,10 @@ object CertificateGenerator {
     val sn: BigInteger = new BigInteger(64, new SecureRandom)
     val owner: X500Name = new X500Name(dn)
 
-    // Note: CertificateSubjectName and CertificateIssuerName are removed in Java 8
-    // and when setting the subject or issuer just the X500Name should be used.
-    val justName = isJavaAtLeast("1.8")
-
     info.set(X509CertInfo.VALIDITY, interval)
     info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(sn))
-    info.set(X509CertInfo.SUBJECT, if (justName) owner else new CertificateSubjectName(owner))
-    info.set(X509CertInfo.ISSUER, if (justName) owner else new CertificateIssuerName(owner))
+    info.set(X509CertInfo.SUBJECT, owner)
+    info.set(X509CertInfo.ISSUER, owner)
     info.set(X509CertInfo.KEY, new CertificateX509Key(pair.getPublic))
     info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3))
 

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -11,7 +11,6 @@ import java.math.BigInteger
 import java.security.cert.X509Certificate
 import java.io.File
 import javax.net.ssl.KeyManagerFactory
-import scala.util.Properties.isJavaAtLeast
 import play.utils.PlayIO
 import java.security.interfaces.RSAPublicKey
 
@@ -104,12 +103,9 @@ object FakeKeyStore {
     certInfo.set(X509CertInfo.VALIDITY, validity)
 
     // Subject and issuer
-    // Note: CertificateSubjectName and CertificateIssuerName are removed in Java 8
-    // and when setting the subject or issuer just the X500Name should be used.
     val owner = new X500Name(DnName)
-    val justName = isJavaAtLeast("1.8")
-    certInfo.set(X509CertInfo.SUBJECT, if (justName) owner else new CertificateSubjectName(owner))
-    certInfo.set(X509CertInfo.ISSUER, if (justName) owner else new CertificateIssuerName(owner))
+    certInfo.set(X509CertInfo.SUBJECT, owner)
+    certInfo.set(X509CertInfo.ISSUER, owner)
 
     // Key and algorithm
     certInfo.set(X509CertInfo.KEY, new CertificateX509Key(keyPair.getPublic))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
@@ -12,12 +12,7 @@ import scala.util.Properties
 object DevModeBuild {
 
   def jdk7WatchService = Def.setting {
-    if (Properties.isJavaAtLeast("1.7")) {
-      FileWatchService.jdk7(Keys.sLog.value)
-    } else {
-      println("Not testing JDK7 watch service because we're not on JDK7")
-      FileWatchService.sbt(Keys.pollInterval.value)
-    }
+    FileWatchService.jdk7(Keys.sLog.value)
   }
 
   def jnotifyWatchService = Def.setting {


### PR DESCRIPTION
Those checks are no longer needed 'cause Play now requires Java >= 8

Tries to fix #7697. I guess this will do it, but I'm still running the build.
