### PR TITLE
Configure JPA at "jpa"; make this configurable

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -42,10 +42,10 @@ Here is a sample configuration file to use with Hibernate:
 </persistence>
 ```
 
-Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by the `play.jpa.default` property in your `conf/application.conf`.
+Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by setting the `jpa.default` property in your `conf/application.conf`.
 
 ```
-play.jpa.default=defaultPersistenceUnit
+jpa.default=defaultPersistenceUnit
 ```
 
 ## Deploying Play with JPA

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
@@ -3,18 +3,14 @@
  */
 package play.db.jpa;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
+import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-
-import com.google.common.collect.ImmutableSet;
-import com.typesafe.config.Config;
-import play.api.ConfigLoader$;
-import play.libs.Scala;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Default JPA configuration.
@@ -42,13 +38,18 @@ public class DefaultJPAConfig implements JPAConfig {
 
         @Inject
         public JPAConfigProvider(Config configuration) {
+            String jpaKey = configuration.getString("play.jpa.config");
+
             ImmutableSet.Builder<JPAConfig.PersistenceUnit> persistenceUnits = new ImmutableSet.Builder<JPAConfig.PersistenceUnit>();
-            Config jpa = new play.api.Configuration(configuration).getDeprecated(
-                "play.jpa", Scala.asScala(Arrays.asList("jpa")), ConfigLoader$.MODULE$.configLoader());
-            jpa.entrySet().forEach(entry -> {
-                String key = entry.getKey();
-                persistenceUnits.add(new JPAConfig.PersistenceUnit(key, jpa.getString(key)));
-            });
+
+            if (configuration.hasPath(jpaKey)) {
+                Config jpa = configuration.getConfig(jpaKey);
+                jpa.entrySet().forEach(entry -> {
+                    String key = entry.getKey();
+                    persistenceUnits.add(new JPAConfig.PersistenceUnit(key, jpa.getString(key)));
+                });
+            }
+
             jpaConfig = new DefaultJPAConfig(persistenceUnits.build());
         }
 

--- a/framework/src/play-java-jpa/src/main/resources/reference.conf
+++ b/framework/src/play-java-jpa/src/main/resources/reference.conf
@@ -4,10 +4,9 @@ play {
   }
 
   jpa {
-    # Reference persistence units here as defined in persistence.xml
-    # default = defaultPersistenceUnit
+    # The name of the configuration item from which to read JPA config.
+    # So, if set to "jpa", means that "jpa.default" is where the configuration
+    # for the database named "default" is found.
+    config = "jpa"
   }
 }
-
-# Deprecated; Use play.jpa instead
-# jpa {}

--- a/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
+++ b/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
@@ -3,52 +3,85 @@
  */
 package play.db.jpa;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import play.db.Database;
 import play.db.Databases;
-
-import org.junit.Test;
 import play.db.jpa.DefaultJPAConfig.JPAConfigProvider;
 
 import javax.persistence.EntityManager;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class JPAApiTest {
 
     @Rule
     public TestDatabase db = new TestDatabase();
 
+    private Set<String> getConfiguredPersistenceUnitNames(String configString) {
+        Config overrides = ConfigFactory.parseString(configString);
+        Config config = overrides.withFallback(ConfigFactory.load());
+        return new JPAConfigProvider(config).get().persistenceUnits().stream()
+                .map(unit -> unit.unitName).collect(Collectors.toSet());
+    }
+
+
     @Test
     public void shouldWorkWithEmptyConfiguration() {
-        Config config = ConfigFactory.load();
-        assertThat(new JPAConfigProvider(config).get().persistenceUnits(), notNullValue());
+        String configString = "";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(Collections.emptySet()));
     }
 
     @Test
-    public void shouldWorkWithLegacyConfiguration() {
-        Config overrides = ConfigFactory.parseString("jpa.default = defaultPersistenceUnit");
-        Config config = overrides.withFallback(ConfigFactory.load());
-        List<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
-            .map(unit -> unit.unitName).collect(Collectors.toList());
-        assertThat(unitNames, equalTo(Arrays.asList("defaultPersistenceUnit")));
+    public void shouldWorkWithSingleValue() {
+        String configString = "jpa.default = defaultPersistenceUnit";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(new HashSet(Arrays.asList("defaultPersistenceUnit"))));
     }
 
     @Test
-    public void shouldWorkWithPlayConfiguration() {
-        Config overrides = ConfigFactory.parseString("play.jpa.default = defaultPersistenceUnit");
-        Config config = overrides.withFallback(ConfigFactory.load());
-        List<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
-            .map(unit -> unit.unitName).collect(Collectors.toList());
-        assertThat(unitNames, equalTo(Arrays.asList("defaultPersistenceUnit")));
+    public void shouldWorkWithMultipleValues() {
+        String configString =
+                "jpa.default = defaultPersistenceUnit\n" +
+                "jpa.number2 = number2Unit";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(new HashSet(Arrays.asList("defaultPersistenceUnit", "number2Unit"))));
+    }
+
+    @Test
+    public void shouldWorkWithEmptyConfigurationAtConfiguredLocation() {
+        String configString = "play.jpa.config = myconfig.jpa";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(Collections.emptySet()));
+    }
+
+    @Test
+    public void shouldWorkWithSingleValueAtConfiguredLocation() {
+        String configString =
+                "play.jpa.config = myconfig.jpa\n" +
+                "myconfig.jpa.default = defaultPersistenceUnit";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(new HashSet(Arrays.asList("defaultPersistenceUnit"))));
+    }
+
+    @Test
+    public void shouldWorkWithMultipleValuesAtConfiguredLocation() {
+        String configString =
+                "play.jpa.config = myconfig.jpa\n" +
+                "myconfig.jpa.default = defaultPersistenceUnit\n" +
+                "myconfig.jpa.number2 = number2Unit";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(new HashSet(Arrays.asList("defaultPersistenceUnit", "number2Unit"))));
     }
 
     @Test


### PR DESCRIPTION
This restores the previous default JPA location back
from "play.jpa" to "jpa", but makes the location
configurable. This means that users won't have to
change their JPA configuration when they update
Play versions.

The configuration location is at "play.jpa.config",
which is similar to "play.db.config". This config
location is advanced usage and I've followed the
lead of "play.db.config" and not documented this
anywhere except in reference.conf.

For reference, the previous behavior was introduced
very recently in PRs #7681 and #7698.