### PR TITLE
[2.6.x]: Configure JPA at "jpa"; make this configurable (backport)

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -42,10 +42,10 @@ Here is a sample configuration file to use with Hibernate:
 </persistence>
 ```
 
-Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by the `play.jpa.default` property in your `conf/application.conf`.
+Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by setting the `jpa.default` property in your `conf/application.conf`.
 
 ```
-play.jpa.default=defaultPersistenceUnit
+jpa.default=defaultPersistenceUnit
 ```
 
 ## Deploying Play with JPA

--- a/framework/src/play-java-jpa/src/main/resources/reference.conf
+++ b/framework/src/play-java-jpa/src/main/resources/reference.conf
@@ -4,10 +4,9 @@ play {
   }
 
   jpa {
-    # Reference persistence units here as defined in persistence.xml
-    # default = defaultPersistenceUnit
+    # The name of the configuration item from which to read JPA config.
+    # So, if set to "jpa", means that "jpa.default" is where the configuration
+    # for the database named "default" is found.
+    config = "jpa"
   }
 }
-
-# The jpa key will be deprecated in Play 2.7.0. Please use play.jpa instead.
-# jpa {}

--- a/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
+++ b/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
@@ -3,12 +3,6 @@
  */
 package play.db.jpa;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.persistence.EntityManager;
-
-import com.google.common.collect.Sets;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Rule;
@@ -18,10 +12,14 @@ import play.db.Database;
 import play.db.Databases;
 import play.db.jpa.DefaultJPAConfig.JPAConfigProvider;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
+import javax.persistence.EntityManager;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 public class JPAApiTest {
@@ -29,48 +27,61 @@ public class JPAApiTest {
     @Rule
     public TestDatabase db = new TestDatabase();
 
+    private Set<String> getConfiguredPersistenceUnitNames(String configString) {
+        Config overrides = ConfigFactory.parseString(configString);
+        Config config = overrides.withFallback(ConfigFactory.load());
+        return new JPAConfigProvider(config).get().persistenceUnits().stream()
+                .map(unit -> unit.unitName).collect(Collectors.toSet());
+    }
+
+
     @Test
     public void shouldWorkWithEmptyConfiguration() {
-        Config config = ConfigFactory.load();
-        assertThat(new JPAConfigProvider(config).get().persistenceUnits(), notNullValue());
+        String configString = "";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(Collections.emptySet()));
     }
 
     @Test
-    public void shouldWorkWithLegacyConfiguration() {
-        Config overrides = ConfigFactory.parseString("jpa.default = defaultPersistenceUnit");
-        Config config = overrides.withFallback(ConfigFactory.load());
-        Set<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
-            .map(unit -> unit.unitName).collect(Collectors.toSet());
-        assertThat(unitNames, equalTo(Sets.newHashSet("defaultPersistenceUnit")));
+    public void shouldWorkWithSingleValue() {
+        String configString = "jpa.default = defaultPersistenceUnit";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(new HashSet(Arrays.asList("defaultPersistenceUnit"))));
     }
 
     @Test
-    public void shouldWorkWithPlayConfiguration() {
-        Config overrides = ConfigFactory.parseString("play.jpa.default = defaultPersistenceUnit");
-        Config config = overrides.withFallback(ConfigFactory.load());
-        Set<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
-            .map(unit -> unit.unitName).collect(Collectors.toSet());
-        assertThat(unitNames, equalTo(Sets.newHashSet("defaultPersistenceUnit")));
+    public void shouldWorkWithMultipleValues() {
+        String configString =
+                "jpa.default = defaultPersistenceUnit\n" +
+                "jpa.number2 = number2Unit";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(new HashSet(Arrays.asList("defaultPersistenceUnit", "number2Unit"))));
     }
 
     @Test
-    public void shouldWorkWithMultipleConfiguration() {
-        Config overrides = ConfigFactory.parseString(
-            "play.jpa.one = pu1\njpa.two = pu2");
-        Config config = overrides.withFallback(ConfigFactory.load());
-        Set<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
-            .map(unit -> unit.unitName).collect(Collectors.toSet());
-        assertThat(unitNames, equalTo(Sets.newHashSet("pu1", "pu2")));
+    public void shouldWorkWithEmptyConfigurationAtConfiguredLocation() {
+        String configString = "play.jpa.config = myconfig.jpa";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(Collections.emptySet()));
     }
 
     @Test
-    public void shouldWorkWithMultipleOverlappingConfiguration() {
-        Config overrides = ConfigFactory.parseString(
-            "play.jpa.one = pu1\njpa.one = pu2");
-        Config config = overrides.withFallback(ConfigFactory.load());
-        Set<String> unitNames = new JPAConfigProvider(config).get().persistenceUnits().stream()
-            .map(unit -> unit.unitName).collect(Collectors.toSet());
-        assertThat(unitNames, equalTo(Sets.newHashSet("pu2")));
+    public void shouldWorkWithSingleValueAtConfiguredLocation() {
+        String configString =
+                "play.jpa.config = myconfig.jpa\n" +
+                "myconfig.jpa.default = defaultPersistenceUnit";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(new HashSet(Arrays.asList("defaultPersistenceUnit"))));
+    }
+
+    @Test
+    public void shouldWorkWithMultipleValuesAtConfiguredLocation() {
+        String configString =
+                "play.jpa.config = myconfig.jpa\n" +
+                "myconfig.jpa.default = defaultPersistenceUnit\n" +
+                "myconfig.jpa.number2 = number2Unit";
+        Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
+        assertThat(unitNames, equalTo(new HashSet(Arrays.asList("defaultPersistenceUnit", "number2Unit"))));
     }
 
     @Test


### PR DESCRIPTION
This is a backport of #7711 to the 2.6.x branch.

This restores the previous default JPA location back
from "play.jpa" to "jpa", but makes the location
configurable. This means that users won't have to
change their JPA configuration when they update
Play versions.

The configuration location is at "play.jpa.config",
which is similar to "play.db.config". This config
location is advanced usage and I've followed the
lead of "play.db.config" and not documented this
anywhere except in reference.conf.

For reference, the previous behavior was introduced
very recently in PRs #7681 and #7698.