### PR TITLE
Don't aggregate play-microbenchmark

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -249,7 +249,8 @@ lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Te
     .dependsOn(PlayAkkaHttpServerProject)
     .dependsOn(PlayNettyServerProject)
 
-// This project is just for microbenchmarking Play, not really a public artifact
+// This project is just for microbenchmarking Play. Not published.
+// NOTE: this project depends on JMH, which is GPLv2.
 lazy val PlayMicrobenchmarkProject = PlayCrossBuiltProject("Play-Microbenchmark", "play-microbenchmark")
     .enablePlugins(JmhPlugin)
     .settings(
@@ -331,7 +332,6 @@ lazy val publishedProjects = Seq[ProjectReference](
   PlayDocsProject,
   PlayFiltersHelpersProject,
   PlayIntegrationTestProject,
-  PlayMicrobenchmarkProject,
   PlayDocsSbtPlugin,
   StreamsProject
 )


### PR DESCRIPTION
`play-microbenchmark` isn't meant to be published since it's not a publicly supported module and is only used internally by Play Framework for testing. It also need not be included in the whitesource check for this reason.