### PR TITLE
Remove jnotify from direct dependencies

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -181,8 +181,6 @@ object Dependencies {
     case _ => "org.scala-sbt" % "io" % sbtVersion % "provided"
   }
 
-  val jnotify = "net.contentobjects.jnotify" % "jnotify" % "0.94-play-1"
-
   val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
 
   def sbtDependencies(sbtVersion: String, scalaVersion: String) = {
@@ -191,8 +189,6 @@ object Dependencies {
     Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion % "provided",
       typesafeConfig,
-
-      jnotify,
       slf4jSimple,
 
       sbtDep("com.typesafe.sbt" % "sbt-twirl" % BuildInfo.sbtTwirlVersion),


### PR DESCRIPTION
We already get jnotify from play-file-watch so I don't think we need it here. It's confusing since it's a different version from the play-file-watch one.