### PR TITLE
Fix links to chaining implicits documentation

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -242,7 +242,7 @@ import play.api._
 logger.info("some info message")(MarkerContext(someMarker))
 ```
 
-This opens the door for implicit markers to be passed for logging in several statements, which makes adding context to logging much easier without resorting to MDC.  For example, using [Logstash Logback Encoder](https://github.com/logstash/logstash-logback-encoder#loggingevent_custom_event) and an [implicit conversion chain](http://docs.scala-lang.org/tutorials/FAQ/chaining-implicits), request information can be encoded into logging statements automatically:
+This opens the door for implicit markers to be passed for logging in several statements, which makes adding context to logging much easier without resorting to MDC.  For example, using [Logstash Logback Encoder](https://github.com/logstash/logstash-logback-encoder#loggingevent_custom_event) and an [implicit conversion chain](http://docs.scala-lang.org/tutorials/FAQ/chaining-implicits.html), request information can be encoded into logging statements automatically:
 
 @[logging-request-context-trait](../../working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala)
 

--- a/documentation/manual/working/scalaGuide/main/logging/ScalaLogging.md
+++ b/documentation/manual/working/scalaGuide/main/logging/ScalaLogging.md
@@ -99,7 +99,7 @@ For convenience, there is an implicit conversion available from a `Marker` to a 
 
 @[logging-log-info-with-implicit-conversion](code/ScalaLoggingSpec.scala)
 
-Markers can be extremely useful, because they can carry contextual information across threads where MDC may not be available, by using a MarkerContext as an implicit parameter to methods to provide a logging context.  For example, using [Logstash Logback Encoder](https://github.com/logstash/logstash-logback-encoder#loggingevent_custom_event) and an [implicit conversion chain](http://docs.scala-lang.org/tutorials/FAQ/chaining-implicits), request information can be encoded into logging statements automatically:
+Markers can be extremely useful, because they can carry contextual information across threads where MDC may not be available, by using a MarkerContext as an implicit parameter to methods to provide a logging context.  For example, using [Logstash Logback Encoder](https://github.com/logstash/logstash-logback-encoder#loggingevent_custom_event) and an [implicit conversion chain](http://docs.scala-lang.org/tutorials/FAQ/chaining-implicits.html), request information can be encoded into logging statements automatically:
 
 @[logging-request-context-trait](code/ScalaLoggingSpec.scala)
 

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -264,7 +264,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
 trait RequestMarkerContext {
 
   // Adding 'implicit request' enables implicit conversion chaining
-  // See http://docs.scala-lang.org/tutorials/FAQ/chaining-implicits
+  // See http://docs.scala-lang.org/tutorials/FAQ/chaining-implicits.html
   implicit def requestHeaderToMarkerContext(implicit request: RequestHeader): MarkerContext = {
     import net.logstash.logback.marker.LogstashMarker
     import net.logstash.logback.marker.Markers._


### PR DESCRIPTION
It looks like the link to the chaining implicits documentation has been changed from http://docs.scala-lang.org/tutorials/FAQ/chaining-implicits to http://docs.scala-lang.org/tutorials/FAQ/chaining-implicits.html
