### PR TITLE
Method being passed along to an execute method is being ignored

### DIFF
--- a/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -7,14 +7,21 @@ import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.w3c.dom.Document;
-import play.libs.ws.*;
+import play.libs.ws.BodyWritable;
+import play.libs.ws.DefaultWSCookie;
 import play.libs.ws.StandaloneWSRequest;
 import play.libs.ws.StandaloneWSResponse;
+import play.libs.ws.WSAuthScheme;
+import play.libs.ws.WSBodyWritables;
+import play.libs.ws.WSCookie;
+import play.libs.ws.WSRequest;
+import play.libs.ws.WSRequestFilter;
+import play.libs.ws.WSResponse;
+import play.libs.ws.WSSignatureCalculator;
 import play.mvc.Http;
 
 import java.io.File;
 import java.io.InputStream;
-import java.lang.annotation.Documented;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -172,7 +179,7 @@ public class AhcWSRequest implements WSRequest {
 
     @Override
     public CompletionStage<WSResponse> execute(String method) {
-        return request.execute().thenApply(responseFunction);
+        return request.setMethod(method).execute().thenApply(responseFunction);
     }
 
     @Override

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
@@ -53,6 +53,15 @@ trait JavaWSSpec extends PlaySpecification with ServerIntegrationSpecification w
       (rep.getStatus() aka "status" must_== 200) and (rep.asJson().path("origin").textValue must not beNull)
     }
 
+    "make DELETE Requests" in withServer { ws =>
+      val request: WSRequest = ws.url("/delete")
+      val futureResponse: CompletionStage[WSResponse] = request.execute("DELETE")
+      val future = futureResponse.toCompletableFuture
+      val rep: WSResponse = future.get(10, TimeUnit.SECONDS)
+
+      (rep.getStatus() aka "status" must_== 200) and (rep.asJson().path("origin").textValue must not beNull)
+    }
+
     "use queryString in url" in withServer { ws =>
       val rep = ws.url("/get?foo=bar").get().toCompletableFuture.get(10, TimeUnit.SECONDS)
 


### PR DESCRIPTION
EDIT: I sqaushed everything into 1 commit.

While doing a migration, I noticed that the `request.execute(String method)` call was ignoring the actual method.

Sure, there's a `setMethod(String method)` call that does it, but providing a method that accepts a method String and then doesn't use it at all is just plain incorrect.

So this is a quick fix for that. I don't know if this fix is prefered or if it's encouraged people use only `setMethod(String method)` and thus the `execute(String method)` call should be removed?

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you added tests for any changed functionality?

# Helpful things
I checked the Scala file, that seems to have been correct already:

https://github.com/playframework/playframework/blob/3c6ca710a192725ec59d965ad9635c62dd1adecf/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala#L255-L257

## Fixes

Fixes #7745

## Purpose

Fix a bug in the AhcWsRequest Java code.

## Background Context

It seemed simple enough to do it like this.
