### PR TITLE
Suppress unused arguments warning in generated routes code

### DIFF
--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -86,7 +86,7 @@ case include @ Include(path, router) => {
   }
   case route: Route => {
     @markLines(route)
-    case @(routeIdentifier(route, index))(params) =>
+    case @(routeIdentifier(route, index))(params@@_) =>
       call@(routeBinding(route)) @ob @localNames(route)
         @(invokerIdentifier(route, index)).call(@injectedControllerMethodCall(route, dep.ident, x => safeKeyword(x.name)))
       @cb

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/forwardsRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/forwardsRouter.scala.twirl
@@ -85,7 +85,7 @@ case (include @ Include(path, router), index) => {
   }
   case (route: Route, index) => {
     @markLines(route)
-    case @(routeIdentifier(route, index))(params) =>
+    case @(routeIdentifier(route, index))(params@@_) =>
       call@(routeBinding(route)) @ob @localNames(route)
         @(invokerIdentifier(route, index)).call(@controllerMethodCall(route, x => safeKeyword(x.name)))
       @cb


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #7519 

## Purpose

The routes compiler generates code with an unused argument `params` for controllers that do not take any parameters. This leads to the following warning when compiling using Scala 2.6.x when the option `-Ywarn-unused` is set:

`pattern var params in method applyOrElse is never used; 'params@_' suppresses this warning`

This PR suppresses the warning by changing the argument `params` to `params@_`

## References

See the discussion in #7519 for more details
