### PR TITLE
Allow dollar sign in message key (for inner classes)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -132,7 +132,7 @@ object Messages extends MessagesImplicits {
     val ignoreWhiteSpace = opt(whiteSpace)
     val blankLine = ignoreWhiteSpace <~ newLine ^^ { case _ => Comment("") }
     val comment = """^#.*""".r ^^ { case s => Comment(s) }
-    val messageKey = namedError("""^[a-zA-Z0-9_.-]+""".r, "Message key expected")
+    val messageKey = namedError("""^[a-zA-Z0-9$_.-]+""".r, "Message key expected")
     val messagePattern = namedError(
       rep(
         ("""\""" ^^ (_ => "")) ~> ( // Ignore the leading \

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -102,6 +102,7 @@ class MessagesSpec extends Specification {
 # this is a comment
 simplekey=value
 key.with.dots=value
+key.with.dollar$sign=value
 multiline.unix=line1\
 line2
 multiline.dos=line1\
@@ -121,6 +122,7 @@ backslash.dummy=\a\b\c\e\f
 
       messages("simplekey") must ===("value")
       messages("key.with.dots") must ===("value")
+      messages("key.with.dollar$sign") must ===("value")
       messages("multiline.unix") must ===("line1line2")
       messages("multiline.dos") must ===("line1line2")
       messages("multiline.inline") must ===("line1\nline2")


### PR DESCRIPTION
When using [custom data binders](https://www.playframework.com/documentation/2.6.x/JavaForms#Register-a-custom-DataBinder)

> When the binding fails an array of errors keys is created, the first one defined in the messages file will be used. This array will generally contain:
> `["error.invalid.<fieldName>", "error.invalid.<type>", "error.invalid"]`

The  the [libphonenumber](https://github.com/googlei18n/libphonenumber) library e.g. provides a `Phonenumber.PhoneNumber` type which is a [nested class](https://static.javadoc.io/com.googlecode.libphonenumber/libphonenumber/8.8.0/index.html?com/google/i18n/phonenumbers/Phonenumber.PhoneNumber.html).

To provide an custom error message when binding the `PhoneNumber` type fails we would have to add following message key the the message file:
```
error.invalid.com.google.i18n.phonenumbers.Phonenumber$PhoneNumber=Invalid phone number
```

Unfortunately right now dollar signs are not allowed in a message key so parsing such a message key/file fails with an exception.


