### PR TITLE
Java Form.errorsAsJson should use last item of messages array

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -722,7 +722,9 @@ public class Form<T> {
             if (error != null) {
                 final List<String> messages = new ArrayList<>();
                 if (messagesApi != null && lang != null) {
-                    messages.add(messagesApi.get(lang, error.messages(), translateMsgArg(error.arguments(), messagesApi, lang)));
+                    final List<String> reversedMessages = new ArrayList(error.messages());
+                    Collections.reverse(reversedMessages);
+                    messages.add(messagesApi.get(lang, reversedMessages, translateMsgArg(error.arguments(), messagesApi, lang)));
                 } else {
                     messages.add(error.message());
                 }

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -134,10 +134,13 @@ public class HttpFormsTest {
             Context ctx = new Context(rb, contextComponents(app));
             Context.current.set(ctx);
 
+            List<String> msgs = new ArrayList<>();
+            msgs.add("error.generalcustomerror");
+            msgs.add("error.custom");
             List<Object> args = new ArrayList<>();
             args.add("error.customarg");
             List<ValidationError> errors = new ArrayList<>();
-            errors.add(new ValidationError("foo", "error.custom", args));
+            errors.add(new ValidationError("foo", msgs, args));
             Form<Money> form = new Form<>(null, Money.class, new HashMap<>(), errors, Optional.empty(), messagesApi, formatters, validator);
 
             assertThat(form.errorsAsJson().get("foo").toString()).isEqualTo("[\"It looks like something was not correct\"]");

--- a/framework/src/play/src/test/resources/messages
+++ b/framework/src/play/src/test/resources/messages
@@ -1,6 +1,8 @@
 error.custom=This is a {0}
 error.customarg=custom error
 
+error.generalcustomerror=Some general custom error message
+
 constraint.custom=I am a {0}
 constraint.customarg=custom constraint
 


### PR DESCRIPTION
Fixes #7756

If the [`messages` list](https://github.com/playframework/playframework/blob/2.6.3/framework/src/play-java-forms/src/main/java/play/data/validation/ValidationError.java#L17) inside a Java `ValidationError` contains multiple items, by default the [last item of that list](https://github.com/playframework/playframework/blob/2.6.3/framework/src/play-java-forms/src/main/java/play/data/validation/ValidationError.java#L71) will be shown when calling `error.message()` - so more general errors are stored in the "top" of the list and more "specific" errors at the end (that's how the error messages [get stored](https://github.com/playframework/playframework/blob/2.6.3/framework/src/play-java-forms/src/main/java/play/data/Form.java#L447-L457) when there are any binding failures).

The `errorsAsJson` method however didn't follow that rule yet - it just used the first item of the list which meant we always got the `error.invalid` message, no matter if we defined more specific error message keys for binding failures.

BTW: The `errorsAsJson` method of a Scala form already follows that rules. It [calls `e.message`](https://github.com/playframework/playframework/blob/2.6.3/framework/src/play/src/main/scala/play/api/data/Form.scala#L236-L237) which also [returns the last element](https://github.com/playframework/playframework/blob/2.6.3/framework/src/play/src/main/scala/play/api/data/validation/Validation.scala#L253) of the message list.
So we just fix the Java version and bring it on par with the Scala one.