### PR TITLE
Support null and infinite when configuring timeouts

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -62,8 +62,8 @@ class AkkaHttpServer(
 
   private def getPossiblyInfiniteBytes(config: Config, path: String): Long = {
     config.getString(path) match {
-      case "infinite" ⇒ Long.MaxValue
-      case x ⇒ config.getBytes(path)
+      case "infinite" => Long.MaxValue
+      case x => config.getBytes(path)
     }
   }
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -179,13 +179,9 @@ class NettyServer(
         pipeline.addLast("logging", new LoggingHandler(LogLevel.DEBUG))
       }
 
-      val idleTimeout = if (secure) {
-        serverConfig.get[Duration]("https.idleTimeout")
-      } else {
-        serverConfig.get[Duration]("http.idleTimeout")
-      }
+      val idleTimeout = serverConfig.get[Duration](if (secure) "https.idleTimeout" else "http.idleTimeout")
       idleTimeout match {
-        case Duration.Inf => // Do nothing
+        case Duration.Inf => // Do nothing, in other words, don't set any timeout.
         case Duration(timeout, timeUnit) =>
           logger.trace(s"using idle timeout of $timeout $timeUnit on port $port")
           // only timeout if both reader and writer have been idle for the specified time

--- a/framework/src/play-server/src/main/resources/reference.conf
+++ b/framework/src/play-server/src/main/resources/reference.conf
@@ -19,7 +19,9 @@ play {
       address = ${?http.address}
 
       # The idle timeout for an open connection after which it will be closed
-      # Set to null to disable the timeout
+      # Set to null or "infinite" to disable the timeout, but notice that this
+      # is not encouraged since timeout are important mechanisms to protect your
+      # servers from malicious attacks or programming mistakes.
       idleTimeout = 75 seconds
     }
 
@@ -34,7 +36,9 @@ play {
       address = ${?https.address}
 
       # The idle timeout for an open connection after which it will be closed
-      # Set to null to disable the timeout
+      # Set to null or "infinite" to disable the timeout, but notice that this
+      # is not encouraged since timeout are important mechanisms to protect your
+      # servers from malicious attacks or programming mistakes.
       idleTimeout = ${play.server.http.idleTimeout}
 
       # The SSL engine provider

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -1034,7 +1034,9 @@ object ConfigLoader {
     ConfigLoader(_.getBooleanList).map(_.asScala.map(_.booleanValue))
 
   implicit val durationLoader: ConfigLoader[Duration] = ConfigLoader { config => path =>
-    if (!config.getIsNull(path)) config.getDuration(path).toNanos.nanos else Duration.Inf
+    if (config.getIsNull(path)) Duration.Inf
+    else if (config.getString(path) == "infinite") Duration.Inf
+    else config.getDuration(path).toNanos.nanos
   }
 
   // Note: this does not support null values but it added for convenience

--- a/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -34,6 +34,26 @@ class ConfigurationSpec extends Specification {
 
   "Configuration" should {
 
+    import scala.concurrent.duration._
+    "support getting durations" in {
+
+      "simple duration" in {
+        val conf = config("my.duration" -> "10s")
+        conf.get[Duration]("my.duration") must beEqualTo(10.seconds)
+      }
+
+      "handle 'infinite' as Duration.Inf" in {
+        val conf = config("my.duration" -> "infinite")
+        conf.get[Duration]("my.duration") must beEqualTo(Duration.Inf)
+      }
+
+      "handle null as Duration.Inf" in {
+        val conf = config("my.duration" -> null)
+        conf.get[Duration]("my.duration") must beEqualTo(Duration.Inf)
+      }
+
+    }
+
     "support getting optional values" in {
       "when null" in {
         config("foo.bar" -> null).get[Option[String]]("foo.bar") must beNone


### PR DESCRIPTION
## Fixes

Fixes #7752

## Purpose

"null" and "infinite" as possible values when configuring server `idleTimeout`.