### PR TITLE
async-http-client 2.0.24 -> 2.0.35

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -299,7 +299,7 @@ object Dependencies {
     ) ++ specsBuild.map(_ % Test)
 
 
-  val asyncHttpClientVersion = "2.0.24"
+  val asyncHttpClientVersion = "2.0.35"
   val playWsDeps = Seq(
     guava,
     "org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion,


### PR DESCRIPTION
async-http-client 2.0.35 addresses a security vulnerability in async-http-client.
