### PR TITLE
Update to Akka HTTP 10.0.10

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion = "2.5.4"
-  val akkaHttpVersion = "10.0.9"
+  val akkaHttpVersion = "10.0.10"
   val playJsonVersion = "2.6.3"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
@@ -38,7 +38,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_== "a=1&b=1&b=2&b=3&b=4&b=5"
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
 
     "handle '/pat/resources/BodhiApplication?where={%22name%22:%22hsdashboard%22}' as a valid URI" in makeRequest(
@@ -46,7 +46,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_=== """/pat/resources/BodhiApplication?where={"name":"hsdashboard"}"""
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
 
     "handle '/dynatable/?queries%5Bsearch%5D=%7B%22condition%22%3A%22AND%22%2C%22rules%22%3A%5B%5D%7D&page=1&perPage=10&offset=0' as a URI" in makeRequest(
@@ -54,7 +54,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_=== """/dynatable/?queries[search]={"condition":"AND","rules":[]}&page=1&perPage=10&offset=0"""
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
 
     "handle '/foo%20bar.txt' as a URI" in makeRequest(
@@ -69,7 +69,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_=== """/?filter=a|,|b"""
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
 
     "handle '/?filter=a,b' as a URI" in makeRequest(
@@ -77,7 +77,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_=== """/?filter=a,b"""
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
   }
 


### PR DESCRIPTION
Fixes #7596.

This update fixes several HTTP/2 related issues. As well as parsing query strings there is now handling for Cookie headers that have been split during [HTTP/2 encoding](https://tools.ietf.org/html/rfc7540#section-8.1.2.5).