### PR TITLE
HTTP/2 integration tests; update to Akka HTTP 10.0.10 (backport)

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -4,9 +4,10 @@
 import BuildSettings._
 import Dependencies._
 import Generators._
-import com.typesafe.tools.mima.plugin.MimaKeys.{ mimaPreviousArtifacts, mimaReportBinaryIssues }
+import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaReportBinaryIssues}
 import interplay.PlayBuildBase.autoImport._
 import sbt.Keys.parallelExecution
+import com.lightbend.sbt.javaagent.JavaAgent.JavaAgentKeys.javaAgents
 import sbt.ScriptedPlugin._
 import sbt._
 
@@ -57,7 +58,12 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "play")
     .settings(
       libraryDependencies ++= runtime(scalaVersion.value) ++ scalacheckDependencies,
 
-      sourceGenerators in Compile += Def.task(PlayVersion(version.value, scalaVersion.value, sbtVersion.value, (sourceManaged in Compile).value)).taskValue,
+      sourceGenerators in Compile += Def.task(PlayVersion(
+        version.value,
+        scalaVersion.value,
+        sbtVersion.value,
+        jettyAlpnAgent.revision,
+        (sourceManaged in Compile).value)).taskValue,
 
       sourceDirectories in(Compile, TwirlKeys.compileTemplates) := (unmanagedSourceDirectories in Compile).value,
       TwirlKeys.templateImports += "play.api.templates.PlayMagic._",
@@ -175,7 +181,12 @@ lazy val PlayGuiceProject = PlayCrossBuiltProject("Play-Guice", "play-guice")
 lazy val SbtPluginProject = PlaySbtPluginProject("SBT-Plugin", "sbt-plugin")
     .settings(
       libraryDependencies ++= sbtDependencies(sbtVersion.value, scalaVersion.value),
-      sourceGenerators in Compile += Def.task(PlayVersion(version.value, (scalaVersion in PlayProject).value, sbtVersion.value, (sourceManaged in Compile).value)).taskValue,
+      sourceGenerators in Compile += Def.task(PlayVersion(
+        version.value,
+        (scalaVersion in PlayProject).value,
+        sbtVersion.value,
+        jettyAlpnAgent.revision,
+        (sourceManaged in Compile).value)).taskValue,
 
       // This only publishes the sbt plugin projects on each scripted run.
       // The runtests script does a full publish before running tests.
@@ -231,10 +242,13 @@ lazy val PlayFiltersHelpersProject = PlayCrossBuiltProject("Filters-Helpers", "p
 
 // This project is just for testing Play, not really a public artifact
 lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Test", "play-integration-test")
+    .enablePlugins(JavaAgent)
     .settings(
-      libraryDependencies += h2database % Test,
+      libraryDependencies += okHttp % Test,
       parallelExecution in Test := false,
-      mimaPreviousArtifacts := Set.empty
+      mimaPreviousArtifacts := Set.empty,
+      fork in Test := true,
+      javaAgents += jettyAlpnAgent % "test"
     )
     .dependsOn(
       PlayProject % "test->test",
@@ -247,6 +261,7 @@ lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Te
     .dependsOn(PlayJavaProject)
     .dependsOn(PlayJavaFormsProject)
     .dependsOn(PlayAkkaHttpServerProject)
+    .dependsOn(PlayAkkaHttp2SupportProject)
     .dependsOn(PlayNettyServerProject)
 
 // This project is just for microbenchmarking Play. Not published.

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -194,7 +194,10 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.akkahttp.AkkaModelConversion.this"),
 
       // Added method to PlayBodyParsers, which is a Play API not meant to be extended by end users.
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.byteString")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.byteString"),
+
+      // Moved play[private] out of from companion object to allow it to access member variables
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.TestServer.start")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion = "2.5.4"
-  val akkaHttpVersion = "10.0.9"
+  val akkaHttpVersion = "10.0.10"
   val playJsonVersion = "2.6.3"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -50,6 +50,8 @@ object Dependencies {
   val acolyteVersion = "1.0.44-j7p"
   val acolyte = "org.eu.acolyte" % "jdbc-driver" % acolyteVersion
 
+  val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.6"
+
   val jjwt = "io.jsonwebtoken" % "jjwt" % "0.7.0"
 
   val jdbcDeps = Seq(
@@ -158,6 +160,8 @@ object Dependencies {
   ) ++ specsBuild.map(_ % Test)
 
   val nettyUtilsDependencies = slf4j
+
+  val okHttp = "com.squareup.okhttp3" % "okhttp" % "3.8.1"
 
   def routesCompilerDependencies(scalaVersion: String) = Seq(
     "commons-io" % "commons-io" % "2.5",

--- a/framework/project/Tasks.scala
+++ b/framework/project/Tasks.scala
@@ -8,7 +8,12 @@ import sbt.complete.Parsers
 
 object Generators {
   // Generates a scala file that contains the play version for use at runtime.
-  def PlayVersion(version: String, scalaVersion: String, sbtVersion: String, dir: File): Seq[File] = {
+  def PlayVersion(
+      version: String,
+      scalaVersion: String,
+      sbtVersion: String,
+      jettyAlpnAgentVersion: String,
+      dir: File): Seq[File] = {
     val file = dir / "PlayVersion.scala"
     val scalaSource =
         """|package play.core
@@ -17,8 +22,13 @@ object Generators {
            |  val current = "%s"
            |  val scalaVersion = "%s"
            |  val sbtVersion = "%s"
+           |  private[play] val jettyAlpnAgentVersion = "%s"
            |}
-           |""".stripMargin.format(version, scalaVersion, sbtVersion)
+           |""".stripMargin.format(
+              version,
+              scalaVersion,
+              sbtVersion,
+              jettyAlpnAgentVersion)
 
     if (!file.exists() || IO.read(file) != scalaSource) {
       IO.write(file, scalaSource)

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -6,6 +6,7 @@ val Versions = new {
   val sbtNativePackager = "1.2.0"
   val mima = "0.1.14"
   val sbtScalariform = "1.6.0"
+  val sbtJavaAgent = "0.1.3"
   val sbtJmh = "0.2.24"
   val sbtDoge = "0.1.5"
   val webjarsLocatorCore = "0.32"
@@ -27,6 +28,7 @@ addSbtPlugin("com.typesafe.play" % "interplay" % Versions.interplay)
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % Versions.sbtTwirl)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % Versions.mima)
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % Versions.sbtScalariform)
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % Versions.sbtJavaAgent)
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % Versions.sbtJmh)
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % Versions.sbtHeader)
 

--- a/framework/src/play-ahc-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/framework/src/play-ahc-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -62,7 +62,7 @@ trait WsTestClient {
    * @param port The port
    * @return The result of the block of code
    */
-  def withClient[T](block: WSClient => T)(implicit port: play.api.http.Port = new play.api.http.Port(-1), scheme: String = "http") = {
+  def withClient[T](block: WSClient => T)(implicit port: play.api.http.Port = new play.api.http.Port(-1), scheme: String = "http"): T = {
     val client = clientProducer(port.value, scheme)
     try {
       block(client)

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -91,17 +91,19 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
 
 }
 
+/** Run integration tests against a Netty server */
 trait NettyIntegrationSpecification extends ServerIntegrationSpecification {
   self: SpecificationLike =>
   // Provide a flag to disable Netty tests
   private val runTests: Boolean = (System.getProperty("run.netty.http.tests", "true") == "true")
   skipAllIf(!runTests)
 
-  override def integrationServerProvider: ServerProvider = NettyServer.provider
+  final override def integrationServerProvider: ServerProvider = NettyServer.provider
 }
 
+/** Run integration tests against an Akka HTTP server */
 trait AkkaHttpIntegrationSpecification extends ServerIntegrationSpecification {
   self: SpecificationLike =>
 
-  override def integrationServerProvider: ServerProvider = AkkaHttpServer.provider
+  final override def integrationServerProvider: ServerProvider = AkkaHttpServer.provider
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -11,10 +11,9 @@ import play.api.Mode
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{ EssentialAction, Results }
 import play.api.test._
-import play.it.{ NettyIntegrationSpecification, ServerIntegrationSpecification }
-import play.it.AkkaHttpIntegrationSpecification
 import play.api.libs.streams.Accumulator
 import play.core.server._
+import play.it.{ AkkaHttpIntegrationSpecification, NettyIntegrationSpecification, ServerIntegrationSpecification }
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits._

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
@@ -38,7 +38,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_== "a=1&b=1&b=2&b=3&b=4&b=5"
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
 
     "handle '/pat/resources/BodhiApplication?where={%22name%22:%22hsdashboard%22}' as a valid URI" in makeRequest(
@@ -46,7 +46,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_=== """/pat/resources/BodhiApplication?where={"name":"hsdashboard"}"""
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
 
     "handle '/dynatable/?queries%5Bsearch%5D=%7B%22condition%22%3A%22AND%22%2C%22rules%22%3A%5B%5D%7D&page=1&perPage=10&offset=0' as a URI" in makeRequest(
@@ -54,7 +54,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_=== """/dynatable/?queries[search]={"condition":"AND","rules":[]}&page=1&perPage=10&offset=0"""
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
 
     "handle '/foo%20bar.txt' as a URI" in makeRequest(
@@ -69,7 +69,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_=== """/?filter=a|,|b"""
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
 
     "handle '/?filter=a,b' as a URI" in makeRequest(
@@ -77,7 +77,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
     ) {
         case (endpoint, response) => {
           response.body.string must_=== """/?filter=a,b"""
-        }.pendingUntilHttp2Fixed(endpoint)
+        }
       }
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -32,9 +32,9 @@ class NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecificatio
 class AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpecification
 
 class NettyPingWebSocketOnlySpec extends PingWebSocketSpec with NettyIntegrationSpecification
-class AkkaHttpPingWebSocketOnlySpec extends PingWebSocketSpec with NettyIntegrationSpecification
+class AkkaHttpPingWebSocketOnlySpec extends PingWebSocketSpec with AkkaHttpIntegrationSpecification
 
-trait PingWebSocketSpec extends PlaySpecification with WsTestClient with NettyIntegrationSpecification with WebSocketSpecMethods {
+trait PingWebSocketSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification with WebSocketSpecMethods {
 
   sequential
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/ApplicationFactory.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/ApplicationFactory.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.test
+
+import play.api._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc._
+import play.api.routing.Router
+
+/**
+ * Creates an [[Application]]. Usually created by a helper in [[ApplicationFactories]].
+ */
+trait ApplicationFactory {
+  /** Creates an [[Application]]. */
+  def create(): Application
+}
+
+/**
+ * Mixin with helpers for creating [[ApplicationFactory]] objects.
+ */
+trait ApplicationFactories {
+  def withGuiceApp(builder: GuiceApplicationBuilder): ApplicationFactory = new ApplicationFactory {
+    override def create(): Application = builder.build()
+  }
+  def withComponents(components: => BuiltInComponents): ApplicationFactory = new ApplicationFactory {
+    override def create(): Application = components.application
+  }
+  def withRouter(createRouter: BuiltInComponents => Router): ApplicationFactory = withComponents {
+    val context = ApplicationLoader.createContext(
+      environment = Environment.simple(),
+      initialSettings = Map[String, AnyRef](Play.GlobalAppConfigKey -> java.lang.Boolean.FALSE)
+    )
+    new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+      override lazy val router: Router = createRouter(this)
+    }
+  }
+  def withAction(createAction: DefaultActionBuilder => Action[_]): ApplicationFactory = withRouter { components: BuiltInComponents =>
+    val action = createAction(components.Action)
+    Router.from { case _ => action }
+  }
+  def withResult(result: Result): ApplicationFactory = withAction { Action: DefaultActionBuilder =>
+    Action { result }
+  }
+}
+
+final object ApplicationFactory extends ApplicationFactories

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.test
+
+import org.specs2.execute.{ AsResult, PendingUntilFixed, Result, ResultExecution }
+import org.specs2.mutable.SpecificationLike
+import org.specs2.specification.core.Fragment
+import play.api.Configuration
+import play.core.server._
+
+/**
+ * Mixin class for integration tests that want to run over different
+ * backend servers and protocols.
+ *
+ * @see [[ServerEndpoints]]
+ */
+trait EndpointIntegrationSpecification
+    extends SpecificationLike with PendingUntilFixed
+    with ServerEndpoints with ApplicationFactories {
+
+  /**
+   * The list of server endpoints supported by this specification.
+   * @return
+   */
+  def allEndpointRecipes: Seq[ServerEndpointRecipe]
+
+  /**
+   * Implicit class that enhances [[ApplicationFactory]] with the [[withAllEndpoints()]] method.
+   */
+  implicit class ApplicationFactoryEndpointBaker(val appFactory: ApplicationFactory) {
+    /**
+     * Helper that creates a specs2 fragment for the server endpoints given in
+     * [[allEndpointRecipes]]. Each fragment creates an application, starts a server
+     * and runs the given block of code.
+     *
+     * {{{
+     * withResult(Results.Ok("Hello")) withAllEndpoints { endpoint: ServerEndpoint =>
+     *   val response = ... connect to endpoint.port ...
+     *   response.status must_== 200
+     * }
+     * }}}
+     */
+    def withAllEndpoints[A: AsResult](block: ServerEndpoint => A): Fragment = {
+      allEndpointRecipes.map { endpointRecipe: ServerEndpointRecipe =>
+        s"with ${endpointRecipe.description}" >> {
+          withEndpoint(endpointRecipe, appFactory)(block)
+        }
+      }.last
+    }
+  }
+
+  /**
+   * Implicit class that enhances code blocks with some `pendingUntilFixed`-style methods.
+   */
+  implicit class EndpointsPendingUntilFixed[T: AsResult](block: => T) {
+    /**
+     * Same as `pendingUntilFixed`, but only if a condition is met.
+     * Otherwise the test executes as normal.
+     */
+    private def conditionalPendingUntilFixed(pendingCondition: => Boolean): Result = {
+      if (pendingCondition) {
+        block.pendingUntilFixed
+      } else {
+        ResultExecution.execute(AsResult(block))
+      }
+    }
+
+    /**
+     * If this is an HTTP/2 endpoint then expect the test to fail, and mark it
+     * as *pending*. However, if the test passes, then this is a failure to
+     * indicate that the test is no longer pending a fix.
+     */
+    def pendingUntilHttp2Fixed(endpoint: ServerEndpoint): Result = {
+      conditionalPendingUntilFixed(endpoint.expectedHttpVersions.contains("2"))
+    }
+  }
+
+}
+
+/**
+ * Mixin for an integration test that wants to test against supported servers and protocols.
+ */
+trait AllEndpointsIntegrationSpecification extends EndpointIntegrationSpecification {
+  override val allEndpointRecipes: Seq[ServerEndpointRecipe] = {
+    def http2Conf(enabled: Boolean): Configuration = Configuration("play.server.akka.http2.enabled" -> enabled)
+    Seq(
+      new HttpServerEndpointRecipe("Netty HTTP/1.1 via HTTP", NettyServer.provider, Configuration.empty, Set("1.0", "1.1"), Option("netty")),
+      new HttpsServerEndpointRecipe("Netty HTTP/1.1 via HTTPS", NettyServer.provider, Configuration.empty, Set("1.0", "1.1"), Option("netty")),
+      new HttpServerEndpointRecipe("akka-http HTTP/1.1 via HTTP", AkkaHttpServer.provider, http2Conf(false), Set("1.0", "1.1"), None),
+      new HttpsServerEndpointRecipe("akka-http HTTP/1.1 via HTTPS", AkkaHttpServer.provider, http2Conf(false), Set("1.0", "1.1"), None),
+      new HttpsServerEndpointRecipe("akka-http HTTP/2 via HTTPS", AkkaHttpServer.provider, http2Conf(true), Set("1.0", "1.1", "2"), None)
+    )
+  }
+}
+

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.test
+
+import okhttp3.{ Protocol, Response }
+import play.api.mvc._
+import play.api.mvc.request.RequestAttrKey
+import play.api.test.PlaySpecification
+
+/**
+ * Tests that the [[EndpointIntegrationSpecification]] works properly.
+ */
+class EndpointIntegrationSpecificationSpec extends PlaySpecification with AllEndpointsIntegrationSpecification with OkHttpEndpointSupport {
+
+  "Endpoints" should {
+    "respond with the highest supported HTTP protocol" in {
+      withResult(Results.Ok("Hello")) withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
+        val response: Response = okEndpoint.makeRequest("/")
+        val protocol = response.protocol
+        if (okEndpoint.endpoint.expectedHttpVersions.contains("2")) {
+          protocol must_== Protocol.HTTP_2
+        } else if (okEndpoint.endpoint.expectedHttpVersions.contains("1.1")) {
+          protocol must_== Protocol.HTTP_1_1
+        } else {
+          ko("All endpoints should support at least HTTP/1.1")
+        }
+        response.body.string must_== "Hello"
+      }
+    }
+    "respond with the correct server attribute" in withAction { Action: DefaultActionBuilder =>
+      Action { request: Request[_] =>
+        Results.Ok(request.attrs.get(RequestAttrKey.Server).toString)
+      }
+    }.withAllOkHttpEndpoints { okHttpEndpoint: OkHttpEndpoint =>
+      val response: Response = okHttpEndpoint.makeRequest("/")
+      response.body.string must_== okHttpEndpoint.endpoint.expectedServerAttr.toString
+    }
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSpec.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.test
+
+import okhttp3.Response
+import play.api.mvc._
+import play.api.test.PlaySpecification
+
+/**
+ * Tests that [[OkHttpEndpointSupport]] works properly.
+ */
+class OkHttpEndpointSpec extends PlaySpecification with AllEndpointsIntegrationSpecification with OkHttpEndpointSupport {
+
+  "OkHttpEndpoint" should {
+    "make a request and get a response" in {
+      withResult(Results.Ok("Hello")) withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
+        val response: Response = okEndpoint.makeRequest("/")
+        response.body.string must_== "Hello"
+      }
+    }
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.test
+
+import okhttp3.{ OkHttpClient, Request, Response }
+import org.specs2.execute.AsResult
+import org.specs2.specification.core.Fragment
+import play.api.mvc.Call
+
+import scala.annotation.implicitNotFound
+
+/**
+ * Provides a similar interface to [[play.api.test.WsTestClient]], but
+ * uses OkHttp and connects to an integration test's [[ServerEndpoints.ServerEndpoint]]
+ * instead of to an arbitrary scheme and port.
+ */
+trait OkHttpEndpointSupport {
+  self: EndpointIntegrationSpecification =>
+
+  /** Describes an [[OkHttpClient] that is bound to a particular [[ServerEndpoint]]. */
+  trait OkHttpEndpoint {
+    /** The endpoint to connect to. */
+    def endpoint: ServerEndpoint
+    /** The client to connect with. */
+    def client: OkHttpClient
+    /**
+     * Make a request to the endpoint using the given path.
+     */
+    def makeRequest(path: String): Response = {
+      val request = new Request.Builder()
+        .url(s"${endpoint.scheme}://localhost:${endpoint.port}$path")
+        .build()
+      client.newCall(request).execute()
+    }
+  }
+
+  /**
+   * Takes a [[ServerEndpoint]], creates a matching [[OkHttpEndpoint]], calls
+   * a block of code on the client and then closes the client afterwards.
+   *
+   * Most users should use [[OkHttpApplicationFactory.withAllOkHttpEndpoints()]]
+   * instead of this method.
+   */
+  def withOkHttpEndpoint[A](endpoint: ServerEndpoint)(block: OkHttpEndpoint => A): A = {
+    val e = endpoint // Avoid a name clash
+    val serverClient = new OkHttpEndpoint {
+      override val endpoint = e
+      override val client: OkHttpClient = {
+        endpoint match {
+          case e: HttpsEndpoint =>
+            // Create a client that trusts the server's certificate
+            new OkHttpClient.Builder()
+              .sslSocketFactory(e.serverSsl.sslContext.getSocketFactory, e.serverSsl.trustManager)
+              .build()
+          case _ => new OkHttpClient()
+        }
+      }
+    }
+    block(serverClient)
+  }
+
+  /**
+   * Implicit class that enhances [[ApplicationFactory]] with the [[withAllOkHttpEndpoints()]] method.
+   */
+  implicit class OkHttpApplicationFactory(appFactory: ApplicationFactory) {
+    /**
+     * Helper that creates a specs2 fragment for the server endpoints given in
+     * [[allEndpointRecipes]]. Each fragment creates an application, starts a server,
+     * starts an [[OkHttpClient]] and runs the given block of code.
+     *
+     * {{{
+     * withResult(Results.Ok("Hello")) withAllOkHttpEndpoints {
+     *   okEndpoint: OkHttpEndpoint =>
+     *     val response = okEndpoint.makeRequest("/")
+     *     response.body.string must_== "Hello"
+     * }
+     * }}}
+     */
+    def withAllOkHttpEndpoints[A: AsResult](block: OkHttpEndpoint => A): Fragment =
+      appFactory.withAllEndpoints { endpoint: ServerEndpoint => withOkHttpEndpoint(endpoint)(block) }
+  }
+
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/ServerEndpoints.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/ServerEndpoints.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.test
+
+import java.security.KeyStore
+import javax.net.ssl._
+
+import play.api.test.PlayRunners
+import play.api.{ Application, Configuration, Mode }
+import play.core.ApplicationProvider
+import play.core.server.ssl.FakeKeyStore
+import play.core.server.{ ServerConfig, ServerProvider }
+import play.server.api.SSLEngineProvider
+
+trait ServerEndpoints {
+
+  /**
+   * Contains information about the port and protocol used to connect to the server.
+   * This class is used to abstract out the details of connecting to different backends
+   * and protocols. Most tests will operate the same no matter which endpoint they
+   * are connected to.
+   */
+  sealed trait ServerEndpoint {
+    def description: String
+    def scheme: String
+    def port: Int
+    def expectedHttpVersions: Set[String]
+    def expectedServerAttr: Option[String]
+    final override def toString = description
+  }
+  /** Represents an HTTP connection to a server. */
+  trait HttpEndpoint extends ServerEndpoint {
+    override final val scheme: String = "http"
+  }
+  /** Represents an HTTPS connection to a server. */
+  trait HttpsEndpoint extends ServerEndpoint {
+    override final val scheme: String = "https"
+    /** Information about the server's SSL setup. */
+    def serverSsl: ServerSSL
+  }
+
+  /** Contains information how SSL is configured for an [[HttpsEndpoint]]. */
+  case class ServerSSL(sslContext: SSLContext, trustManager: X509TrustManager)
+
+  /**
+   * A recipe for making a [[ServerEndpoint]]. Recipes are often used
+   * when describing which tests to run. The recipe can be used to start
+   * servers with the correct [[ServerEndpoint]]s.
+   *
+   * @see [[ServerEndpoints.withEndpoint()]]
+   */
+  trait ServerEndpointRecipe {
+    type EndpointType <: ServerEndpoint
+
+    /** A human-readable description of this endpoint. */
+    val description: String
+    /** The HTTP port to use when configuring the server. */
+    val configuredHttpPort: Option[Int]
+    /** The HTTPS port to use when configuring the server. */
+    val configuredHttpsPort: Option[Int]
+    /**
+     * Any extra configuration to use when configuring the server. This
+     * configuration will be applied last so it will override any existing
+     * configuration.
+     */
+    def serverConfiguration: Configuration
+    /** The provider used to create the server instance. */
+    def serverProvider: ServerProvider
+
+    /**
+     * Once a server has been started using this recipe, the running instance
+     * can be queried to create an endpoint. Usually this just involves asking
+     * the server what port it is using.
+     */
+    def createEndpointFromServer(runningTestServer: play.api.test.TestServer): EndpointType
+  }
+
+  /** Provides a recipe for making an [[HttpEndpoint]]. */
+  protected class HttpServerEndpointRecipe(
+      override val description: String,
+      override val serverProvider: ServerProvider,
+      extraServerConfiguration: Configuration = Configuration.empty,
+      expectedHttpVersions: Set[String],
+      expectedServerAttr: Option[String]
+  ) extends ServerEndpointRecipe {
+    recipe =>
+    override type EndpointType = HttpEndpoint
+    override val configuredHttpPort: Option[Int] = Some(0)
+    override val configuredHttpsPort: Option[Int] = None
+    override val serverConfiguration: Configuration = extraServerConfiguration
+    override def createEndpointFromServer(runningServer: play.api.test.TestServer): HttpEndpoint = {
+      new HttpEndpoint {
+        override def description: String = recipe.description
+        override def port: Int = runningServer.runningHttpPort.get
+        override def expectedHttpVersions: Set[String] = recipe.expectedHttpVersions
+        override def expectedServerAttr: Option[String] = recipe.expectedServerAttr
+      }
+    }
+    override def toString: String = s"HttpServerEndpointRecipe($description)"
+  }
+
+  /** Provides a recipe for making an [[HttpsEndpoint]]. */
+  protected class HttpsServerEndpointRecipe(
+      override val description: String,
+      override val serverProvider: ServerProvider,
+      extraServerConfiguration: Configuration = Configuration.empty,
+      expectedHttpVersions: Set[String],
+      expectedServerAttr: Option[String]
+  ) extends ServerEndpointRecipe {
+    recipe =>
+    override type EndpointType = HttpsEndpoint
+    override val configuredHttpPort: Option[Int] = None
+    override val configuredHttpsPort: Option[Int] = Some(0)
+    override def serverConfiguration: Configuration = Configuration(
+      "play.server.https.engineProvider" -> classOf[ServerEndpoints.SelfSignedSSLEngineProvider].getName
+    ) ++ extraServerConfiguration
+    override def createEndpointFromServer(runningServer: play.api.test.TestServer): HttpsEndpoint = {
+      new HttpsEndpoint {
+        override def description: String = recipe.description
+        override def port: Int = runningServer.runningHttpsPort.get
+        override def expectedHttpVersions: Set[String] = recipe.expectedHttpVersions
+        override def expectedServerAttr: Option[String] = recipe.expectedServerAttr
+        override val serverSsl: ServerSSL = ServerSSL(
+          ServerEndpoints.SelfSigned.sslContext,
+          ServerEndpoints.SelfSigned.trustManager
+        )
+      }
+    }
+    override def toString: String = s"HttpsServerEndpointRecipe($description)"
+  }
+
+  /**
+   * Starts a server by following a [[ServerEndpointRecipe]] and using the
+   * application provided by an [[ApplicationFactory]]. The server's endpoint
+   * is passed to the given `block` of code.
+   */
+  def withEndpoint[A](endpointRecipe: ServerEndpointRecipe, appFactory: ApplicationFactory)(block: ServerEndpoint => A): A = {
+    val application: Application = appFactory.create()
+
+    // Create a ServerConfig with dynamic ports and using a self-signed certificate
+    val serverConfig = {
+      val sc: ServerConfig = ServerConfig(
+        port = endpointRecipe.configuredHttpPort,
+        sslPort = endpointRecipe.configuredHttpsPort,
+        mode = Mode.Test,
+        rootDir = application.path
+      )
+      val patch = endpointRecipe.serverConfiguration
+      sc.copy(configuration = sc.configuration ++ patch)
+    }
+
+    // Initialize and start the TestServer
+    val testServer: play.api.test.TestServer = new play.api.test.TestServer(
+      serverConfig, application, Some(endpointRecipe.serverProvider)
+    )
+    val runners = new PlayRunners {} // We can't mix in PlayRunners because it pollutes the namespace
+    runners.running(testServer) {
+      val endpoint: ServerEndpoint = endpointRecipe.createEndpointFromServer(testServer)
+      block(endpoint)
+    }
+  }
+}
+
+object ServerEndpoints {
+
+  /**
+   * An SSLEngineProvider which simply references the values in the
+   * SelfSigned object.
+   */
+  private[test] class SelfSignedSSLEngineProvider(serverConfig: ServerConfig, appProvider: ApplicationProvider) extends SSLEngineProvider {
+    override lazy val createSSLEngine: SSLEngine = SelfSigned.sslContext.createSSLEngine()
+  }
+
+  /**
+   * Contains a statically initialized self-signed certificate.
+   */
+  private[test] object SelfSigned {
+
+    /**
+     * The SSLContext and TrustManager associated with the self-signed certificate.
+     */
+    lazy val (sslContext, trustManager): (SSLContext, X509TrustManager) = {
+      val keyStore: KeyStore = FakeKeyStore.generateKeyStore
+
+      val kmf: KeyManagerFactory = KeyManagerFactory.getInstance("SunX509")
+      kmf.init(keyStore, "".toCharArray)
+      val kms: Array[KeyManager] = kmf.getKeyManagers
+
+      val tmf: TrustManagerFactory = TrustManagerFactory
+        .getInstance(TrustManagerFactory.getDefaultAlgorithm())
+      tmf.init(keyStore)
+      val tms: Array[TrustManager] = tmf.getTrustManagers
+      val x509TrustManager: X509TrustManager = tms(0).asInstanceOf[X509TrustManager]
+
+      val sslContext: SSLContext = SSLContext.getInstance("TLS")
+      sslContext.init(kms, tms, null)
+
+      (sslContext, x509TrustManager)
+    }
+  }
+
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/WSEndpointSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/WSEndpointSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.test
+
+import play.api.libs.ws.WSResponse
+import play.api.mvc._
+import play.api.test.PlaySpecification
+
+/**
+ * Tests that [[OkHttpEndpointSupport]] works properly.
+ */
+class WSEndpointSpec extends PlaySpecification with AllEndpointsIntegrationSpecification with WSEndpointSupport {
+
+  "WSEndpoint" should {
+    "make a request and get a response" in {
+      withResult(Results.Ok("Hello")) withAllWSEndpoints { endpointClient: WSEndpoint =>
+        val response: WSResponse = endpointClient.makeRequest("/")
+        response.body must_== "Hello"
+      }
+    }
+    "support a WSTestClient-style API" in {
+      withResult(Results.Ok("Hello")) withAllWSEndpoints { implicit endpointClient: WSEndpoint =>
+        val response: WSResponse = await(wsUrl("/").get()) // Test for deprecated
+        response.body must_== "Hello"
+      }
+    }
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/WSEndpointSupport.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/WSEndpointSupport.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.test
+
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{ ActorSystem, Terminated }
+import akka.stream.ActorMaterializer
+import com.typesafe.sslconfig.ssl.{ SSLConfigSettings, SSLLooseConfig }
+import org.specs2.execute.AsResult
+import org.specs2.specification.core.Fragment
+import play.api.Configuration
+import play.api.libs.ws.ahc.{ AhcWSClient, AhcWSClientConfig }
+import play.api.libs.ws.{ WSClient, WSClientConfig, WSRequest, WSResponse }
+import play.api.mvc.Call
+import play.api.test.{ DefaultAwaitTimeout, FutureAwaits }
+
+import scala.annotation.implicitNotFound
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future }
+
+/**
+ * Provides a similar interface to [[play.api.test.WsTestClient]], but
+ * connects to an integration test's [[ServerEndpoints.ServerEndpoint]] instead of an
+ * arbitrary scheme and port.
+ */
+trait WSEndpointSupport {
+  self: EndpointIntegrationSpecification with FutureAwaits with DefaultAwaitTimeout =>
+
+  /** Describes a [[WSClient]] that is bound to a particular [[ServerEndpoint]]. */
+  @implicitNotFound("Use withAllWSEndpoints { implicit wsEndpoint: WSEndpoint => ... } to get a value")
+  trait WSEndpoint {
+    /** The endpoint to connect to. */
+    def endpoint: ServerEndpoint
+    /** The client to connect with. */
+    def client: WSClient
+    /**
+     * Build a request to the endpoint using the given path.
+     */
+    def buildRequest(path: String): WSRequest = {
+      client.url(s"${endpoint.scheme}://localhost:" + endpoint.port + path)
+    }
+    /**
+     * Make a request to the endpoint using the given path.
+     */
+    def makeRequest(path: String): WSResponse = {
+      await(buildRequest(path).get())
+    }
+  }
+
+  /**
+   * Build a request to the running server endpoint at the given path.
+   *
+   * This method is provided as a drop-in replacement for the methods in
+   * the [[play.api.test.WsTestClient]] class. However, you should use
+   * the methods on the [[WSEndpoint]] object directly, if possible.
+   */
+  @deprecated("Use WSEndpoint.buildRequest or .makeRequest instead", "2.6.4")
+  def wsUrl(path: String)(implicit endpointClient: WSEndpoint): WSRequest = {
+    endpointClient.buildRequest(path)
+  }
+  /**
+   * Build a request to the running server endpoint using the given call.
+   *
+   * This method is provided as a drop-in replacement for the methods in
+   * the [[play.api.test.WsTestClient]] class. However, you should use
+   * the methods on the [[WSEndpoint]] object directly, if possible.
+   */
+  @deprecated("Use WSEndpoint.buildRequest(call.url) or .makeRequest(call.url) instead", "2.6.4")
+  def wsCall(call: Call)(implicit endpointClient: WSEndpoint): WSRequest = {
+    endpointClient.buildRequest(call.url)
+  }
+
+  /**
+   * Get the client used to connect to the running server endpoint.
+   *
+   * This method is provided as a drop-in replacement for the methods in
+   * the [[play.api.test.WsTestClient]] class. However, you should use
+   * the methods on the [[WSEndpoint]] object directly, if possible.
+   */
+  @deprecated("Use WSEndpoint.client, .buildRequest() or .makeRequest() instead", "2.6.4")
+  def withClient[T](block: WSClient => T)(implicit endpointClient: WSEndpoint): T = block(endpointClient.client)
+
+  /**
+   * Takes a [[ServerEndpoint]], creates a matching [[WSEndpoint]], calls
+   * a block of code on the client and then closes the client afterwards.
+   *
+   * Most users should use [[WSApplicationFactory.withAllWSEndpoints()]]
+   * instead of this method.
+   */
+  def withWSEndpoint[A](endpoint: ServerEndpoint)(block: WSEndpoint => A): A = {
+    val e = endpoint // Avoid a name clash
+
+    val serverClient = new WSEndpoint with Closeable {
+      override val endpoint = e
+      private val actorSystem: ActorSystem = {
+        val actorConfig = Configuration(
+          "akka.loglevel" -> "WARNING"
+        )
+        ActorSystem("WSEndpointSupport", actorConfig.underlying)
+      }
+      override val client: WSClient = {
+        // Set up custom config to trust any SSL certificate. Unfortunately
+        // even though we have the certificate information already loaded
+        // we can't easily get it to our WSClient due to limitations in
+        // the ssl-config library.
+        val sslLooseConfig: SSLLooseConfig = SSLLooseConfig().withAcceptAnyCertificate(true)
+        val sslConfig: SSLConfigSettings = SSLConfigSettings().withLoose(sslLooseConfig)
+        val wsClientConfig: WSClientConfig = WSClientConfig(ssl = sslConfig)
+        val ahcWsClientConfig = AhcWSClientConfig(wsClientConfig = wsClientConfig, maxRequestRetry = 0)
+
+        implicit val materializer = ActorMaterializer(namePrefix = Some("WSEndpointSupport"))(actorSystem)
+        AhcWSClient(ahcWsClientConfig)
+      }
+      override def close(): Unit = {
+        client.close()
+        val terminated: Future[Terminated] = actorSystem.terminate()
+        Await.ready(terminated, Duration(20, TimeUnit.SECONDS))
+      }
+    }
+    try block(serverClient) finally serverClient.close()
+  }
+
+  /**
+   * Implicit class that enhances [[ApplicationFactory]] with the [[withAllWSEndpoints()]] method.
+   */
+  implicit class WSApplicationFactory(appFactory: ApplicationFactory) {
+    /**
+     * Helper that creates a specs2 fragment for the server endpoints given in
+     * [[allEndpointRecipes]]. Each fragment creates an application, starts a server,
+     * starts a [[WSClient]] and runs the given block of code.
+     *
+     * {{{
+     * withResult(Results.Ok("Hello")) withAllWSEndpoints {
+     *   wsEndpoint: WSEndpoint =>
+     *     val response = wsEndpoint.makeRequest("/")
+     *     response.body must_== "Hello"
+     * }
+     * }}}
+     */
+    def withAllWSEndpoints[A: AsResult](block: WSEndpoint => A): Fragment =
+      appFactory.withAllEndpoints { endpoint: ServerEndpoint => withWSEndpoint(endpoint)(block) }
+  }
+}

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -50,43 +50,60 @@ object FakeKeyStore {
   }
 
   def keyManagerFactory(appPath: File): KeyManagerFactory = {
-    val keyStore = KeyStore.getInstance("JKS")
     val keyStoreFile = new File(appPath, GeneratedKeyStore)
-    if (shouldGenerate(keyStoreFile)) {
-
+    val keyStore: KeyStore = if (shouldGenerate(keyStoreFile)) {
       logger.info("Generating HTTPS key pair in " + keyStoreFile.getAbsolutePath + " - this may take some time. If nothing happens, try moving the mouse/typing on the keyboard to generate some entropy.")
 
-      // Generate the key pair
-      val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
-      keyPairGenerator.initialize(2048) // 2048 is the NIST acceptable key length until 2030
-      val keyPair = keyPairGenerator.generateKeyPair()
-
-      // Generate a self signed certificate
-      val cert = createSelfSignedCertificate(keyPair)
-
-      // Create the key store, first set the store pass
-      keyStore.load(null, "".toCharArray)
-      keyStore.setKeyEntry("playgenerated", keyPair.getPrivate, "".toCharArray, Array(cert))
-      keyStore.setCertificateEntry("playgeneratedtrusted", cert)
+      val freshKeyStore: KeyStore = generateKeyStore
       val out = java.nio.file.Files.newOutputStream(keyStoreFile.toPath)
       try {
-        keyStore.store(out, "".toCharArray)
+        freshKeyStore.store(out, "".toCharArray)
       } finally {
         PlayIO.closeQuietly(out)
       }
+      freshKeyStore
     } else {
+      // Load a KeyStore from a file
+      val loadedKeystore: KeyStore = KeyStore.getInstance("JKS")
       val in = java.nio.file.Files.newInputStream(keyStoreFile.toPath)
       try {
-        keyStore.load(in, "".toCharArray)
+        loadedKeystore.load(in, "".toCharArray)
       } finally {
         PlayIO.closeQuietly(in)
       }
+      loadedKeystore
     }
 
     // Load the key and certificate into a key manager factory
     val kmf = KeyManagerFactory.getInstance("SunX509")
     kmf.init(keyStore, "".toCharArray)
     kmf
+  }
+
+  /**
+   * Generate a fresh KeyStore object in memory. This KeyStore
+   * is not saved to disk. If you want that, then call `keyManagerFactory`.
+   *
+   * This method has has `private[play]` access so it can be used for
+   * testing.
+   */
+  private[play] def generateKeyStore: KeyStore = {
+    // Create a new KeyStore
+    val keyStore: KeyStore = KeyStore.getInstance("JKS")
+
+    // Generate the key pair
+    val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
+    keyPairGenerator.initialize(2048) // 2048 is the NIST acceptable key length until 2030
+    val keyPair = keyPairGenerator.generateKeyPair()
+
+    // Generate a self signed certificate
+    val cert: X509Certificate = createSelfSignedCertificate(keyPair)
+
+    // Create the key store, first set the store pass
+    keyStore.load(null, "".toCharArray)
+    keyStore.setKeyEntry("playgenerated", keyPair.getPrivate, "".toCharArray, Array(cert))
+    keyStore.setCertificateEntry("playgeneratedtrusted", cert)
+    keyStore
   }
 
   def createSelfSignedCertificate(keyPair: KeyPair): X509Certificate = {

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
@@ -38,7 +38,7 @@ object ServerSSLEngine {
         createJavaSSLEngineProvider(s.asInstanceOf[Class[JavaSSLEngineProvider]], serverConfig, applicationProvider)
 
       case _ =>
-        throw new ClassCastException("Must define play.server.api.SSLEngineProvider or play.server.SSLEngineProvider as interface!")
+        throw new ClassCastException(s"Can't create SSLEngineProvider: ${providerClass} must implement either play.server.api.SSLEngineProvider or play.server.SSLEngineProvider.")
     }
   }
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -125,7 +125,7 @@ trait PlayRunners extends HttpVerbs {
    * The port to use for a test server. Defaults to 19001. May be configured using the system property
    * testserver.port
    */
-  lazy val testServerPort = Option(System.getProperty("testserver.port")).map(_.toInt).getOrElse(19001)
+  lazy val testServerPort: Int = Option(System.getProperty("testserver.port")).map(_.toInt).getOrElse(19001)
 
   /**
    * Constructs a in-memory (h2) database configuration to add to an Application.

--- a/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -21,6 +21,15 @@ case class TestServer(
     serverProvider: Option[ServerProvider]) {
 
   private var testServerProcess: TestServerProcess = _
+  private var testServer: Server = _
+
+  private def getTestServerIfRunning: Server = {
+    val s = testServer
+    if (s == null) {
+      throw new IllegalStateException("Test server not running")
+    }
+    s
+  }
 
   /**
    * Starts this server.
@@ -31,7 +40,17 @@ case class TestServer(
     }
 
     try {
-      testServerProcess = TestServer.start(serverProvider, config, application)
+      testServerProcess = new TestServerProcess
+      val resolvedServerProvider: ServerProvider = serverProvider.getOrElse {
+        ServerProvider.fromConfiguration(testServerProcess.classLoader, config.configuration)
+      }
+      Play.start(application)
+      testServer = resolvedServerProvider.createServer(config, application)
+      testServerProcess.addShutdownHook {
+        val ts = testServer
+        testServer = null // Clear field before stopping, in case an error occurs
+        ts.stop()
+      }
     } catch {
       case NonFatal(t) =>
         t.printStackTrace
@@ -44,16 +63,27 @@ case class TestServer(
    */
   def stop() {
     if (testServerProcess != null) {
-      val shuttingDownProcess = testServerProcess
-      testServerProcess = null
-      shuttingDownProcess.shutdown()
+      val p = testServerProcess
+      testServerProcess = null // Clear field before shutting, in case an error occurs
+      p.shutdown()
     }
   }
 
   /**
    * The port that the server is running on.
    */
+  @deprecated("Using runningHttpPort or runningHttpsPort instead", "2.6.4")
   def port: Int = config.port.getOrElse(throw new IllegalStateException("No HTTP port defined"))
+
+  /**
+   * The HTTP port that the server is running on.
+   */
+  def runningHttpPort: Option[Int] = getTestServerIfRunning.httpPort
+
+  /**
+   * The HTTPS port that the server is running on.
+   */
+  def runningHttpsPort: Option[Int] = getTestServerIfRunning.httpsPort
 }
 
 object TestServer {
@@ -74,26 +104,6 @@ object TestServer {
     ServerConfig(port = Some(port), sslPort = sslPort, mode = Mode.Test,
       rootDir = application.path), application, serverProvider
   )
-
-  /**
-   * Start a TestServer with the given config and application. To stop it,
-   * call `shutdown` on the returned TestServerProcess.
-   */
-  private[play] def start(
-    testServerProvider: Option[ServerProvider],
-    config: ServerConfig,
-    application: Application): TestServerProcess = {
-    val process = new TestServerProcess
-    val serverProvider: ServerProvider = {
-      testServerProvider
-    } getOrElse {
-      ServerProvider.fromConfiguration(process.classLoader, config.configuration)
-    }
-    Play.start(application)
-    val server = serverProvider.createServer(config, application)
-    process.addShutdownHook { server.stop() }
-    process
-  }
 
 }
 

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -180,7 +180,8 @@ case class Configuration(underlying: Config) {
   }
 
   /**
-   * Merge two configurations.
+   * Merge two configurations. The second configuration overrides the first configuration.
+   * This is the opposite direction of `Config`'s `withFallback` method.
    */
   def ++(other: Configuration): Configuration = {
     Configuration(other.underlying.withFallback(underlying))


### PR DESCRIPTION
Backports two commits from _master_ to _2.6.x_. These PRs add tests for HTTP/2 query string decoding and then update Akka HTTP to fix it.

You might want to not squash these commits to preserve their lovely commit messages. :)