### PR TITLE
Consistency update for JavaFileUpload.md

### DIFF
--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import play.mvc.Http;
-import play.mvc.Http.MultipartFormData;
 import play.mvc.Http.MultipartFormData.FilePart;
 import play.mvc.Result;
 import play.test.WithApplication;
@@ -49,8 +48,8 @@ public class JavaFileUpload extends WithApplication {
     static class SyncUpload extends Controller {
         //#syncUpload
         public Result upload() {
-            MultipartFormData<File> body = request().body().asMultipartFormData();
-            FilePart<File> picture = body.getFile("picture");
+            Http.MultipartFormData<File> body = request().body().asMultipartFormData();
+            Http.MultipartFormData.FilePart<File> picture = body.getFile("picture");
             if (picture != null) {
                 String fileName = picture.getFilename();
                 String contentType = picture.getContentType();


### PR DESCRIPTION
This makes the first example in [JavaFileUpload.md](https://www.playframework.com/documentation/2.6.x/JavaFileUpload) consistent with the second one (the test) regarding the usage of MultipartFormData.

I've also been trying to follow these docs to learn Play. At some point somewhere, I've come to start using this for my controller boilerplate:

    package controllers;

    import play.mvc.*;

    import views.html.*;

    public class MyController extends Controller {

        public Result myAction() {
            return ok("change me");
        }

    }

(I think this comes from `play-java-starter-example`, but I'm not really sure)

By using Http explicitly (in `Http.MultipartFormData<File> body`), I am able to continue using this boilerplate combined with a simple text editor. I don't need to resort to some fancy IDE or anything.