### PR TITLE
[2.6.x backport] Upgrade to SBT 0.13.16

### DIFF
--- a/documentation/manual/hacking/Translations.md
+++ b/documentation/manual/hacking/Translations.md
@@ -39,7 +39,7 @@ translation-project
 `build.properties` should contain the SBT version, ie:
 
 ```
-sbt.version=0.13.15
+sbt.version=0.13.16
 ```
 
 `plugins.sbt` should include the Play docs sbt plugin, ie:

--- a/documentation/project/build.properties
+++ b/documentation/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -177,7 +177,7 @@ object Dependencies {
 
   // use partial version so that non-standard scala binary versions from dbuild also work
   def sbtIO(sbtVersion: String, scalaVersion: String): ModuleID = CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, major)) if major >= 11 => "org.scala-sbt" %% "io" % "0.13.15" % "provided"
+    case Some((2, major)) if major >= 11 => "org.scala-sbt" %% "io" % "0.13.16" % "provided"
     case _ => "org.scala-sbt" % "io" % sbtVersion % "provided"
   }
 

--- a/framework/project/build.properties
+++ b/framework/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/project/build.properties
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/project/build.properties
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
Backporting https://github.com/playframework/playframework/pull/7794 is the first step of supporting SBT 1.0. We'll need to build with SBT 0.13.16 in order to cross-build the Play plugins to work with SBT 1.0