### PR TITLE
Use statically compiled regexes where possible.

### DIFF
--- a/framework/src/play-exceptions/src/main/java/play/api/PlayException.java
+++ b/framework/src/play-exceptions/src/main/java/play/api/PlayException.java
@@ -3,14 +3,18 @@
  */
 package play.api;
 
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 
 /**
  * Helper for `PlayException`.
  */
 public class PlayException extends UsefulException {
+
+    /** Statically compiled Pattern for splitting lines. */
+    private static final Pattern SPLIT_LINES = Pattern.compile("\\r?\\n");
 
     private final AtomicLong generator = new AtomicLong(System.currentTimeMillis());
 
@@ -89,7 +93,8 @@ public class PlayException extends UsefulException {
                 if(input() == null || line() == null) {
                     return null;
                 }
-                String[] lines = input().split("\\r?\\n");
+
+                String[] lines = SPLIT_LINES.split(input(), 0);
                 int firstLine = Math.max(0, line() - 1 - border);
                 int lastLine = Math.min(lines.length - 1, line() - 1 + border);
                 List<String> focusOn = new ArrayList<String>();

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -26,6 +27,9 @@ import static play.mvc.Http.Session;
  * Any action result.
  */
 public class Result {
+
+    /** Statically compiled pattern for extracting the charset from a Result.  */
+    private static final Pattern SPLIT_CHARSET = Pattern.compile("(?i);\\s*charset=");
 
     private final ResponseHeader header;
     private final HttpEntity body;
@@ -229,7 +233,7 @@ public class Result {
      */
     public Optional<String> charset() {
         return body.contentType().flatMap(h -> {
-            String[] parts = h.split("(?i);\\s*charset=", 2);
+            String[] parts = SPLIT_CHARSET.split(h, 2);
             if (parts.length > 1) {
                 String charset = parts[1];
                 return Optional.of(charset.trim());


### PR DESCRIPTION
This PR isn't related to any issue, it's just something I wanted to do, don't let reviewing this take time away from your actual work. It's just refactoring regexes into statically compiled versions.

Which means the JVM will not have to compile them again every time they're used. It compiles them once and then uses the object this created.

Also, I saw this one case of a few lines of code just being inside brackets for no apparent reason, so I removed that.

All other changes was Intellij cleaning up whitespace and imports, I can revert that if so desired.

Also a backport can be provided to 2.6.x if wanted.