### PR TITLE
Remove wrong comment in docs

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/code/JavaJdbcConnection.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaJdbcConnection.java
@@ -12,7 +12,6 @@ import play.mvc.Controller;
 import play.db.NamedDatabase;
 import play.db.Database;
 
-// inject "orders" database instead of "default"
 class JavaJdbcConnection {
     private Database db;
     private DatabaseExecutionContext executionContext;


### PR DESCRIPTION
Probably a copy&paste issue from [another](https://github.com/playframework/playframework/blob/2.6.3/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java#L13) example [above](https://www.playframework.com/documentation/2.6.x/JavaDatabase#Accessing-the-JDBC-datasource) this one.