### PR TITLE
Switch Action and parse in BuiltInComponents to protected

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
@@ -15,7 +15,7 @@ import play.it.test._
 class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
 
   private def makeRequest[T: AsResult](path: String)(block: (ServerEndpoint, okhttp3.Response) => T): Fragment = withRouter { components: BuiltInComponents =>
-    import components.Action
+    import components.{ defaultActionBuilder => Action }
     import sird.UrlContext
     Router.from {
       case sird.GET(p"/path") => Action { request: Request[_] => Results.Ok(request.queryString) }

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/ApplicationFactory.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/ApplicationFactory.scala
@@ -36,7 +36,7 @@ trait ApplicationFactories {
     }
   }
   def withAction(createAction: DefaultActionBuilder => Action[_]): ApplicationFactory = withRouter { components: BuiltInComponents =>
-    val action = createAction(components.Action)
+    val action = createAction(components.defaultActionBuilder)
     Router.from { case _ => action }
   }
   def withResult(result: Result): ApplicationFactory = withAction { Action: DefaultActionBuilder =>

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -263,16 +263,6 @@ trait BuiltInComponents extends I18nComponents {
   def router: Router
 
   /**
-   * Alias method to [[defaultActionBuilder]]. This just helps to keep the idiom of using `Action`
-   * when creating `Router`s using the built in components.
-   *
-   * @return the default action builder.
-   */
-  def Action: DefaultActionBuilder = defaultActionBuilder
-
-  def parse = playBodyParsers
-
-  /**
    * The runtime [[Injector]] instance provided to the [[DefaultApplication]]. This injector is set up to allow
    * existing (deprecated) legacy APIs to function. It is not set up to support injecting arbitrary Play components.
    */
@@ -347,6 +337,22 @@ trait BuiltInComponents extends I18nComponents {
   lazy val fileMimeTypes: FileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes).get
 
   lazy val javaContextComponents: JavaContextComponents = JavaHelpers.createContextComponents(messagesApi, langs, fileMimeTypes, httpConfiguration)
+
+  // NOTE: the following helpers are declared as protected since they are only meant to be used inside BuiltInComponents
+  // This also makes them not conflict with other methods of the same type when used with Macwire.
+
+  /**
+   * Alias method to [[defaultActionBuilder]]. This just helps to keep the idiom of using `Action`
+   * when creating `Router`s using the built in components.
+   *
+   * @return the default action builder.
+   */
+  protected def Action: DefaultActionBuilder = defaultActionBuilder
+
+  /**
+   * Alias method to [[playBodyParsers]].
+   */
+  protected def parse: PlayBodyParsers = playBodyParsers
 }
 
 /**


### PR DESCRIPTION
If these methods are public, they make it difficult to use Macwire with Play, as reported here: https://stackoverflow.com/questions/46092028/macwire-found-multiple-values-of-type

Given that the purpose (as I understand it) is to allow idiomatic usage within `BuiltInComponents`, I think it makes sense to make the methods `protected` here, which would make them no longer a candidate for injection (see https://github.com/adamw/macwire/issues/77).

This still preserves binary compatibility, but would break source compatibility for anyone calling `Action` instead of `defaultActionBuilder` from outside the components class.