### PR TITLE
Use ActionBuilder.ignoringBody instead of Action for TODO

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -35,7 +35,7 @@ trait ControllerHelpers extends Results with HttpProtocol with Status with Heade
    *   def action(query: String) = TODO
    * }}}
    */
-  lazy val TODO: Action[AnyContent] = Action {
+  lazy val TODO: Action[AnyContent] = ActionBuilder.ignoringBody {
     NotImplemented[Html](views.html.defaultpages.todo())
   }
 }


### PR DESCRIPTION
I noticed that the global `Action` was being used here. Probably the result of the various refactorings that went on in this file. `ActionBuilder.ignoringBody` is a special internal helper that simply ignores the body and uses the trampoline execution context.