### PR TITLE
Appends filters to play.filters.enabled in reference.conf

### DIFF
--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -10,11 +10,9 @@ play.modules {
 play.filters {
 
   # Default list of enabled filters, configured by play.api.http.EnabledFilters
-  enabled = [
-    play.filters.csrf.CSRFFilter,
-    play.filters.headers.SecurityHeadersFilter,
-    play.filters.hosts.AllowedHostsFilter
-  ]
+  enabled += play.filters.csrf.CSRFFilter
+  enabled += play.filters.headers.SecurityHeadersFilter
+  enabled += play.filters.hosts.AllowedHostsFilter
 
   # CSRF config
   csrf {


### PR DESCRIPTION
Fixes #7823

Appends values to `play.filters.enabled` instead of assigning an array. Necessary so other libraries can also append values to this config within their `reference.conf` without getting overwritten.

It's just the same like we handle `play.modules.enabled`:

https://github.com/playframework/playframework/blob/3c6ca710a192725ec59d965ad9635c62dd1adecf/framework/src/play/src/main/resources/reference.conf#L813-L819

