### PR TITLE
CustomExecutionContext implementations should be singletons

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -559,6 +559,10 @@ database.dispatcher {
 To define a custom execution context, subclass [`CustomExecutionContext`](api/scala/play/api/libs/concurrent/CustomExecutionContext.html) with the dispatcher name:
 
 ```scala
+import akka.actor.ActorSystem
+import play.api.libs.concurrent.CustomExecutionContext
+import javax.inject.{ Inject, Singleton }
+
 @Singleton
 class DatabaseExecutionContext @Inject()(system: ActorSystem)
    extends CustomExecutionContext(system, "database.dispatcher")
@@ -579,11 +583,14 @@ To define a custom execution context, subclass [`CustomExecutionContext`](api/ja
 ```java
 import akka.actor.ActorSystem;
 import play.libs.concurrent.CustomExecutionContext;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class DatabaseExecutionContext
         extends CustomExecutionContext {
 
-    @javax.inject.Inject
+    @Inject
     public DatabaseExecutionContext(ActorSystem actorSystem) {
         // uses a custom thread pool defined in application.conf
         super(actorSystem, "database.dispatcher");

--- a/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/TasksCustomExecutionContext.java
+++ b/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/TasksCustomExecutionContext.java
@@ -10,8 +10,10 @@ import play.libs.concurrent.CustomExecutionContext;
 import scala.concurrent.duration.Duration;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.concurrent.TimeUnit;
 
+@Singleton
 public class TasksCustomExecutionContext extends CustomExecutionContext {
 
     @Inject

--- a/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/TasksCustomExecutionContext.scala
+++ b/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/TasksCustomExecutionContext.scala
@@ -7,11 +7,12 @@ package scalaguide.scheduling
 import scala.concurrent.duration._
 
 //#custom-task-execution-context
-import javax.inject.Inject
+import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
 import play.api.libs.concurrent.CustomExecutionContext
 
+@Singleton
 class TasksCustomExecutionContext @Inject() (actorSystem: ActorSystem)
   extends CustomExecutionContext(actorSystem, "tasks-dispatcher")
 //#custom-task-execution-context

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/MyExecutionContext.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/MyExecutionContext.java
@@ -7,8 +7,10 @@ import akka.actor.ActorSystem;
 import play.libs.concurrent.CustomExecutionContext;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 //#custom-execution-context
+@Singleton
 public class MyExecutionContext extends CustomExecutionContext {
 
     @Inject

--- a/documentation/manual/working/javaGuide/main/sql/code/DatabaseExecutionContext.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/DatabaseExecutionContext.java
@@ -5,10 +5,13 @@ package javaguide.sql;
 
 import akka.actor.ActorSystem;
 import play.libs.concurrent.CustomExecutionContext;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class DatabaseExecutionContext extends CustomExecutionContext {
 
-    @javax.inject.Inject
+    @Inject
     public DatabaseExecutionContext(ActorSystem actorSystem) {
         // uses a custom thread pool defined in application.conf
         super(actorSystem, "database.dispatcher");

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -3,7 +3,7 @@
  */
 package scalaguide.async.scalaasync
 
-import javax.inject.Inject
+import javax.inject.{ Inject, Singleton }
 
 import scala.concurrent._
 import akka.actor._
@@ -40,6 +40,7 @@ import play.api.libs.concurrent.CustomExecutionContext
 
 trait MyExecutionContext extends ExecutionContext
 
+@Singleton
 class MyExecutionContextImpl @Inject()(system: ActorSystem)
   extends CustomExecutionContext(system, "my.executor") with MyExecutionContext
 

--- a/framework/src/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
@@ -15,8 +15,10 @@ import scala.concurrent.ExecutionContextExecutor;
  *
  * <pre>
  * {@code
+ * @Singleton
  * class MyCustomExecutionContext extends CustomExecutionContext {
  *   // Dependency inject the actorsystem from elsewhere
+ *   @Inject
  *   public MyCustomExecutionContext(ActorSystem actorSystem) {
  *     super(actorSystem, "full.path.to.my-custom-executor");
  *   }
@@ -24,9 +26,28 @@ import scala.concurrent.ExecutionContextExecutor;
  * }
  * </pre>
  *
- * Then use your custom execution context where you have blocking
+ * and then bind it in dependency injection:
+ *
+ * <pre>
+ * {@code
+ * bind(DatabaseExecutionContext.class).toSelf().eagerly()
+ * }
+ * </pre>
+ *
+ * Then inject and use your custom execution context where you have blocking
  * operations that require processing outside of Play's main rendering
  * thread.
+ *
+ * <pre>
+ * {@code
+ * public class DatabaseService {
+ *   @Inject
+ *   public DatabaseService(DatabaseExecutionContext executionContext) {
+ *     ...
+ *   }
+ * }
+ * }
+ * </pre>
  *
  * @see <a href="http://doc.akka.io/docs/akka/2.5/java/dispatchers.html">Dispatchers</a>
  * @see <a href="https://www.playframework.com/documentation/latest/ThreadPools">Thread Pools</a>

--- a/framework/src/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
@@ -14,24 +14,24 @@ import scala.concurrent.ExecutionContextExecutor;
  * the full path to the Akka dispatcher.
  *
  * <pre>
- * {@code
- * @Singleton
+ * <code>
+ * {@literal @}Singleton
  * class MyCustomExecutionContext extends CustomExecutionContext {
  *   // Dependency inject the actorsystem from elsewhere
- *   @Inject
+ *   {@literal @}Inject
  *   public MyCustomExecutionContext(ActorSystem actorSystem) {
  *     super(actorSystem, "full.path.to.my-custom-executor");
  *   }
  * }
- * }
+ * </code>
  * </pre>
  *
  * and then bind it in dependency injection:
  *
  * <pre>
- * {@code
+ * <code>
  * bind(DatabaseExecutionContext.class).toSelf().eagerly()
- * }
+ * </code>
  * </pre>
  *
  * Then inject and use your custom execution context where you have blocking
@@ -39,14 +39,14 @@ import scala.concurrent.ExecutionContextExecutor;
  * thread.
  *
  * <pre>
- * {@code
+ * <code>
  * public class DatabaseService {
- *   @Inject
+ *   {@literal @}Inject
  *   public DatabaseService(DatabaseExecutionContext executionContext) {
  *     ...
  *   }
  * }
- * }
+ * </code>
  * </pre>
  *
  * @see <a href="http://doc.akka.io/docs/akka/2.5/java/dispatchers.html">Dispatchers</a>


### PR DESCRIPTION
I think all of the `CustomExecutionContext` implementations should actually be singletons.
The only place in the docs right now where that's the case is the `"Defining a CustomExecutionContext in Scala"` section in the 2.6 release highlights [here](https://www.playframework.com/documentation/2.6.x/Highlights26#Defining-a-CustomExecutionContext-in-Scala). Everywhere else in the docs it seems this was forgotten (even just a few lines below in the `"...in Java"` section).

I also think all the 2.6 examples should make use of the `CustomExecutionContext` now. E.g.  the `DatabaseExecutionContext` in the `play-java-jpa-example` repo still [just implements a `ExecutionContextExecutor`](https://github.com/playframework/play-java-jpa-example/blob/494c73c0b6360991f4cdb4c5c1819a416b191160/app/models/DatabaseExecutionContext.java#L12). I haven't checked, but maybe for other example projects that's also the case. (/cc @wsargent)