### PR TITLE
Make timeout use seconds instead of milliseconds in Java SyncCacheApi

### DIFF
--- a/framework/src/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
+++ b/framework/src/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
@@ -33,7 +33,7 @@ public class SyncCacheApiAdapter implements SyncCacheApi, CacheApi {
 
   @Override
   public <T> T getOrElseUpdate(String key, Callable<T> block, int expiration) {
-    return scalaApi.getOrElseUpdate(key, msDuration(expiration), Scala.asScala(block), Scala.classTag());
+    return scalaApi.getOrElseUpdate(key, intToDuration(expiration), Scala.asScala(block), Scala.classTag());
   }
 
   @Override
@@ -53,7 +53,7 @@ public class SyncCacheApiAdapter implements SyncCacheApi, CacheApi {
 
   @Override
   public void set(String key, Object value, int expiration) {
-    scalaApi.set(key, value, msDuration(expiration));
+    scalaApi.set(key, value, intToDuration(expiration));
   }
 
   @Override
@@ -66,7 +66,7 @@ public class SyncCacheApiAdapter implements SyncCacheApi, CacheApi {
     scalaApi.remove(key);
   }
 
-  private Duration msDuration(int millis) {
-    return Duration.apply(millis, TimeUnit.MILLISECONDS);
+  private Duration intToDuration(int seconds) {
+    return seconds == 0 ? Duration.Inf() : Duration.apply(seconds, TimeUnit.SECONDS);
   }
 }

--- a/framework/src/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/framework/src/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -30,6 +30,13 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
       Thread.sleep(2.seconds.toMillis)
       cacheApi.get[String]("foo").toScala must beNull.await
     }
+    "set cache values with an expiration time" in new WithApplication {
+      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+      Await.result(cacheApi.set("foo", "bar", 10 /* seconds */ ).toScala, 1.second)
+
+      Thread.sleep(2.seconds.toMillis)
+      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+    }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -88,6 +95,13 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
       Thread.sleep(2.seconds.toMillis)
       cacheApi.get[String]("foo") must beNull
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+      cacheApi.set("foo", "bar", 10 /* seconds */ )
+
+      Thread.sleep(2.seconds.toMillis)
+      cacheApi.get[String]("foo") must beEqualTo("bar")
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {


### PR DESCRIPTION
Fixes #7834