### PR TITLE
Prevent compiler for issuing an unused warning for ReverseRouteContext

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -231,7 +231,7 @@ package object templates {
     if (fixedParams.isEmpty) {
       ""
     } else {
-      "implicit val _rrc = new play.core.routing.ReverseRouteContext(Map(%s))".format(fixedParams.mkString(", "))
+      "implicit lazy val _rrc = new play.core.routing.ReverseRouteContext(Map(%s)); _rrc".format(fixedParams.mkString(", "))
     }
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [X] Have you added copyright headers to new files?
* [X] Have you checked that both Scala and Java APIs are updated?
* [X] Have you updated the documentation for both Scala and Java sections?
* [X] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes some of #6302

## Purpose

This PR changes the reverse routes generator so that `ReverseRouteContext` is only introduced for routes that for `Asset`s. Currently, a `ReverseRouteContext` is introduced for any route with fixed parameters, which causes Scala to issue warnings when the project is compiled with `-Ywarn-unused`

## Background Context

The only of `ReverseRouteContext` I could find was to implicitly convert it into a `PathBindable[Asset]`, so this PR modifies it to fit that use case.

## References

Related issue: #6302 