### PR TITLE
Add more reasonable FutureOps.withDelay

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Futures.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Futures.scala
@@ -183,9 +183,21 @@ trait LowPriorityFuturesImplicits {
      *
      * @param duration the duration after which the future should be executed.
      * @param futures the implicit Futures.
-     * @return the future that completes first, either the failed future, or the operation.
+     * @return the future delayed by the specified duration.
      */
+    @deprecated("Use future.withDelay(duration) or futures.delayed(duration)(future)", "2.6.6")
     def withDelay[A](duration: FiniteDuration)(future: Future[A])(implicit futures: Futures): Future[A] = {
+      futures.delayed(duration)(future)
+    }
+
+    /**
+     * Creates a future which will be executed after the given delay.
+     *
+     * @param duration the duration after which the future should be executed.
+     * @param futures the implicit Futures.
+     * @return the future delayed by the specified duration.
+     */
+    def withDelay(duration: FiniteDuration)(implicit futures: Futures): Future[T] = {
       futures.delayed(duration)(future)
     }
   }


### PR DESCRIPTION
https://github.com/playframework/playframework/blob/56456b8e76729a82374e441931f2ad674256aba3/framework/src/play/src/main/scala/play/api/libs/concurrent/Futures.scala#L188

The `withDelay` method above, that enriches a `Future`, as defined now, it accepts an additional `Future` as a parameter instead of using the `Future` that is being enriched.

Such a method doesn't make much sense, I think it should be deprecated and removed in the future.
 
In this PR I add a new `withDelay` method (not to break backwards compatibility) that accepts only the desired duration as an explicit parameter. So, someone can do the following:
```scala
someFuture.withDelay(2 seconds)
```