### PR TITLE
Merge Vary header properly in CORSFilter

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -62,7 +62,7 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
     implicit val ec = mat.executionContext
     if (shouldCompress(result) && config.shouldGzip(request, result)) {
 
-      val header = result.header.copy(headers = setupHeader(result.header.headers))
+      val header = result.header.copy(headers = setupHeader(result.header))
 
       result.body match {
 
@@ -166,19 +166,8 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
    */
   private def isNotAlreadyCompressed(header: ResponseHeader) = header.headers.get(CONTENT_ENCODING).isEmpty
 
-  private def setupHeader(header: Map[String, String]): Map[String, String] = {
-    header + (CONTENT_ENCODING -> "gzip") + addToVaryHeader(header, VARY, ACCEPT_ENCODING)
-  }
-
-  /**
-   * There may be an existing Vary value, which we must add to (comma separated)
-   */
-  private def addToVaryHeader(existingHeaders: Map[String, String], headerName: String, headerValue: String): (String, String) = {
-    existingHeaders.get(headerName) match {
-      case None => (headerName, headerValue)
-      case Some(existing) if existing.split(",").exists(_.trim.equalsIgnoreCase(headerValue)) => (headerName, existing)
-      case Some(existing) => (headerName, s"$existing,$headerValue")
-    }
+  private def setupHeader(rh: ResponseHeader): Map[String, String] = {
+    rh.headers + (CONTENT_ENCODING -> "gzip") + rh.varyWith(ACCEPT_ENCODING)
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Render.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Render.scala
@@ -39,7 +39,7 @@ trait Rendering {
       val result =
         if (request.acceptedTypes.isEmpty) _render(Seq(new MediaRange("*", "*", Nil, None, Nil)))
         else _render(request.acceptedTypes)
-      result.withHeaders(VARY -> ACCEPT)
+      result.withHeaders(result.header.varyWith(ACCEPT))
     }
 
     /**
@@ -70,7 +70,7 @@ trait Rendering {
       val result =
         if (request.acceptedTypes.isEmpty) _render(Seq(new MediaRange("*", "*", Nil, None, Nil)))
         else _render(request.acceptedTypes)
-      result.map(_.withHeaders(VARY -> ACCEPT))
+      result.map(r => r.withHeaders(r.header.varyWith(ACCEPT)))
     }
   }
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -53,7 +53,25 @@ final class ResponseHeader(val status: Int, _headers: Map[String, String] = Map.
   def asJava: play.mvc.ResponseHeader = {
     new play.mvc.ResponseHeader(status, headers.asJava, reasonPhrase.orNull)
   }
+
+  /**
+   * INTERNAL API
+   *
+   * Appends to the comma-separated `Vary` header of this request
+   */
+  private[play] def varyWith(headerValues: String*): (String, String) = {
+    val newValue = headers.get(VARY) match {
+      case Some(existing) if existing.nonEmpty =>
+        val existingSet: Set[String] = existing.split(",").map(_.trim.toLowerCase)(collection.breakOut)
+        val newValuesToAdd = headerValues.filterNot(v => existingSet.contains(v.trim.toLowerCase))
+        s"$existing${newValuesToAdd.map(v => s",$v").mkString}"
+      case _ =>
+        headerValues.mkString(",")
+    }
+    VARY -> newValue
+  }
 }
+
 object ResponseHeader {
   val basicDateFormatPattern = "EEE, dd MMM yyyy HH:mm:ss"
   val httpDateFormat: DateTimeFormatter =


### PR DESCRIPTION
Extracts the logic used in GzipFilter to merge the header and uses it in CORSFilter also.

Fixes #7850 