### PR TITLE
Fix-issue-7669-AkkaRequestTimeoutSpec is flaky

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaRequestTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaRequestTimeoutSpec.scala
@@ -56,7 +56,7 @@ class AkkaRequestTimeoutSpec extends PlaySpecification with AkkaHttpIntegrationS
 
     "support sub-second timeouts" in withServer(300.millis)(EssentialAction { req =>
       Accumulator(Sink.ignore).map { _ =>
-        Thread.sleep(400L)
+        Thread.sleep(1400L)
         Results.Ok
       }
     }) { port =>


### PR DESCRIPTION
Fixes #7669  

##Purpose
Here the purpose is to avoid exception caused because of the less difference in server timeout (300 ms) and the sleep value (400 ms). The problem is solved by increasing the thread sleep time from 400ms to 1400ms.

