### PR TITLE
Update play-file-watch to 1.1.2

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -176,7 +176,7 @@ object Dependencies {
   }
 
   val runSupportDependencies = Seq(
-    "com.lightbend.play" %% "play-file-watch" % "1.0.0"
+    "com.lightbend.play" %% "play-file-watch" % "1.1.2"
   ) ++ specsBuild.map(_ % Test)
 
   // use partial version so that non-standard scala binary versions from dbuild also work

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -10,8 +10,8 @@ scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.12.2")
 
 PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode
 
-// Start by using the sbt watcher
-PlayKeys.fileWatchService := play.dev.filewatch.FileWatchService.sbt(pollInterval.value)
+// Start by using the polling watcher
+PlayKeys.fileWatchService := play.dev.filewatch.FileWatchService.polling(pollInterval.value)
 
 TaskKey[Unit]("resetReloads") := {
   (target.value / "reload.log").delete()

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
@@ -32,7 +32,7 @@ object DevModeBuild {
       val url = new java.net.URL("http://localhost:9000" + path)
       val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]
       conn.setConnectTimeout(ConnectTimeout)
-      conn.setReadTimeout(ReadTimeout)      
+      conn.setReadTimeout(ReadTimeout)
 
       if (status == conn.getResponseCode) {
         messages += s"Resource at $path returned $status as expected"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/plugins.sbt
@@ -5,3 +5,6 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")
+
+// We need this to test JNotify
+libraryDependencies += "com.lightbend.play" % "jnotify" % "0.94-play-2"


### PR DESCRIPTION
We don't need to backport this necessarily; just checking to see if tests pass.