### PR TITLE
Fixes #7863: Support both cacheManagerResource and cacheManagerURI properties of AhcHttpCacheConfiguration, use cacheManagerURI first.

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/WsCache.md
+++ b/documentation/manual/working/commonGuide/configuration/WsCache.md
@@ -35,10 +35,10 @@ Cache size is limited by the underlying cache implementation.  Play WS will crea
 
 > **NOTE**: If you do not limit the HTTP cache or expire elements in the cache, then you may cause the JVM to run out of memory.
 
-In ehcache, you can specify an existing cache by specifying [CacheManager](https://static.javadoc.io/javax.cache/cache-api/1.0.0/javax/cache/CacheManager.html) URI explicitly, which is used in `cachingProvider.getCacheManager(uri, environment.classLoader)`:
+In ehcache, you can specify an existing cache by specifying [CacheManager](https://static.javadoc.io/javax.cache/cache-api/1.0.0/javax/cache/CacheManager.html) resource explicitly, which is used in `cachingProvider.getCacheManager(uri, environment.classLoader)`:
 
 ```
-play.ws.cache.cacheManagerURI="file:./conf/ehcache-play-ws-cache.xml"
+play.ws.cache.cacheManagerResource="ehcache-play-ws-cache.xml"
 ```
 
 and then adding a cache such as following into the `conf` directory:
@@ -56,6 +56,8 @@ and then adding a cache such as following into the `conf` directory:
 
 </ehcache>
 ```
+
+> **NOTE**: `play.ws.cache.cacheManagerURI` is deprecated, use `play.ws.cache.cacheManagerResource` with a path on the classpath instead.
 
 ## Debugging the Cache
 

--- a/framework/src/play-ahc-ws/src/main/resources/reference.conf
+++ b/framework/src/play-ahc-ws/src/main/resources/reference.conf
@@ -21,9 +21,13 @@ play.ws.cache {
   # A specific caching provider name (e.g. if both ehcache and caffeine are set)
   cachingProviderName = ""
 
-  # The cache manager URI to use, i.e.
-  # cacheManagerURI = "file:./conf/ehcache-play-ws-cache.xml"
-  # Or caffeine:
-  # cacheManagerURI = "file:./conf/application.conf"
-  cacheManagerURI = ""
+  # The CacheManager resource to use. For example:
+  #
+  # cacheManagerResource = "ehcache-play-ws-cache.xml"
+  #
+  # If null, will use the ehcache default URI.
+  cacheManagerResource = null
+
+  # The CacheManager URI to use. If non-null, this is used instead of cacheManagerResource.
+  cacheManagerURI = null
 }

--- a/framework/src/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
+++ b/framework/src/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
@@ -31,7 +31,7 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
       val settings = Map(
         "play.ws.cache.enabled" -> "true",
         "play.ws.cache.cachingProviderName" -> classOf[JCacheCachingProvider].getName,
-        "play.ws.cache.cacheManagerURI" -> env.classLoader.getResource("ehcache-play-ws-cache.xml").toURI.toString
+        "play.ws.cache.cacheManagerResource" -> "ehcache-play-ws-cache.xml"
       )
       Configuration.load(env, settings)
     }).build()) {
@@ -46,7 +46,7 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
       val settings = Map(
         "play.ws.cache.enabled" -> "true",
         "play.ws.cache.cachingProviderName" -> classOf[CaffeineCachingProvider].getName,
-        "play.ws.cache.cacheManagerURI" -> "caffeine.conf"
+        "play.ws.cache.cacheManagerResource" -> "caffeine.conf"
       )
       Configuration.load(env, settings)
     }).build()) {


### PR DESCRIPTION
Fixes #7863
We currently configure the value of  play.ws.cache.cacheManagerURI using file URI scheme. If configured with a absolute file path, it's ok.  However, if configured with a relative file path, the real file path 
 depends on the current working directory.  For example:
```
play.ws {
   cache.enabled = true
   cache.cacheManagerURI="file:./conf/ehcache-play-ws-cache.xml"
}
```
While running in dev mode,  it's ok, because the real file path is:
```
PROJECT_ROOT/./conf/ehcache-play-ws-cache.xml
```
But in prod mode,  the real file path depends on where you start the project. For example, we start it under the PROJECT_ROOT/bin directory, the real file path will be:
```
PROJECT_ROOT/bin/./conf/ehcache-play-ws-cache.xml
```
So FileNotFoundException will be thrown.

This PR resolves this problem by supporting both cacheManagerResource and cacheManagerURI, use cacheManagerURI first. Treat cacheManagerResource as a resource on the classpath and convert it to an URI(thanks for the suggestions from gmethvin & richdougherty). `cacheManagerURI` property is still supported, but should be deprecated later.