### PR TITLE
Play-JDBC-Evolutions - SQL92-style comment syntax support

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -14,3 +14,7 @@ If you have a in your logback.xml referencing the `application` logger, you may 
 Each logger should have a unique name matching the name of the class it is in. In this way, you can configure a different log level for each class. You can also set the log level for a given package. E.g. to set the log level for all of Play's internal classes to the info level, you can set:
 
     <logger name="play" level="INFO" />
+
+### Evolutions comment syntax changes
+
+Play Evolutions now properly supports SQL92 comment syntax. This means you can write evolutions using `--` at the beginning of a line instead of `#` wherever you choose. Newly generated evolutions using the Evolutions API will now also use SQL92-style comment syntax in all areas. Documentation has also been updated accordingly to prefer the SQL92 style, though the older comment style is still fully supported.

--- a/documentation/manual/working/commonGuide/database/Evolutions.md
+++ b/documentation/manual/working/commonGuide/database/Evolutions.md
@@ -31,10 +31,10 @@ The first script is named `1.sql`, the second script `2.sql`, and so on…
 
 Each script contains two parts:
 
-- The **Ups** part the describe the required transformations.
-- The **Downs** part that describe how to revert them.
+- The **Ups** part that describes the required transformations.
+- The **Downs** part that describes how to revert them.
 
-For example, take a look at this first evolution script that bootstrap a basic application:
+For example, take a look at this first evolution script that bootstraps a basic application:
 
 ```
 -- Users schema
@@ -55,7 +55,7 @@ CREATE TABLE User (
 DROP TABLE User;
 ```
 
-As you see you have to delimit the both Ups and Downs section by using comments in your SQL script. Both SQL92 (`--`) and MySQL (`#`) comment styles are supported, but this guide will use SQL92 to prevent confusion.
+The **Ups** and **Downs** parts are delimited by using a standard, single-line SQL comment in your script containing either `!Ups` or `!Downs`, respectively. Both SQL92 (`--`) and MySQL (`#`) comment styles are supported, but we recommend using SQL92 syntax because it is supported by more databases.
 
 > Play splits your `.sql` files into a series of semicolon-delimited statements before executing them one-by-one against the database. So if you need to use a semicolon *within* a statement, escape it by entering `;;` instead of `;`. For example, `INSERT INTO punctuation(name, character) VALUES ('semicolon', ';;');`.
 

--- a/documentation/manual/working/commonGuide/database/Evolutions.md
+++ b/documentation/manual/working/commonGuide/database/Evolutions.md
@@ -37,9 +37,9 @@ Each script contains two parts:
 For example, take a look at this first evolution script that bootstrap a basic application:
 
 ```
-# Users schema
+-- Users schema
 
-# --- !Ups
+-- !Ups
 
 CREATE TABLE User (
     id bigint(20) NOT NULL AUTO_INCREMENT,
@@ -50,12 +50,12 @@ CREATE TABLE User (
     PRIMARY KEY (id)
 );
 
-# --- !Downs
+-- !Downs
 
 DROP TABLE User;
 ```
 
-As you see you have to delimit the both Ups and Downs section by using comments in your SQL script.
+As you see you have to delimit the both Ups and Downs section by using comments in your SQL script. Both SQL92 (`--`) and MySQL (`#`) comment styles are supported, but this guide will use SQL92 to prevent confusion.
 
 > Play splits your `.sql` files into a series of semicolon-delimited statements before executing them one-by-one against the database. So if you need to use a semicolon *within* a statement, escape it by entering `;;` instead of `;`. For example, `INSERT INTO punctuation(name, character) VALUES ('semicolon', ';;');`.
 
@@ -85,9 +85,9 @@ For example, to enable `autoApply` for all evolutions, you might set `play.evolu
 Now let’s imagine that we have two developers working on this project. Developer A will work on a feature that requires a new database table. So he will create the following `2.sql` evolution script:
 
 ```
-# Add Post
+-- Add Post
 
-# --- !Ups
+-- !Ups
 CREATE TABLE Post (
     id bigint(20) NOT NULL AUTO_INCREMENT,
     title varchar(255) NOT NULL,
@@ -98,7 +98,7 @@ CREATE TABLE Post (
     PRIMARY KEY (id)
 );
 
-# --- !Downs
+-- !Downs
 DROP TABLE Post;
 ```
 
@@ -107,12 +107,12 @@ Play will apply this evolution script to Developer A’s database.
 On the other hand, developer B will work on a feature that requires altering the User table. So he will also create the following `2.sql` evolution script:
 
 ```
-# Update User
+-- Update User
 
-# --- !Ups
+-- !Ups
 ALTER TABLE User ADD age INT;
 
-# --- !Downs
+-- !Downs
 ALTER TABLE User DROP age;
 ```
 
@@ -128,9 +128,9 @@ Each developer has created a `2.sql` evolution script. So developer A needs to m
 
 ```
 <<<<<<< HEAD
-# Add Post
+-- Add Post
 
-# --- !Ups
+-- !Ups
 CREATE TABLE Post (
     id bigint(20) NOT NULL AUTO_INCREMENT,
     title varchar(255) NOT NULL,
@@ -141,15 +141,15 @@ CREATE TABLE Post (
     PRIMARY KEY (id)
 );
 
-# --- !Downs
+-- !Downs
 DROP TABLE Post;
 =======
-# Update User
+-- Update User
 
-# --- !Ups
+-- !Ups
 ALTER TABLE User ADD age INT;
 
-# --- !Downs
+-- !Downs
 ALTER TABLE User DROP age;
 >>>>>>> devB
 ```
@@ -157,9 +157,9 @@ ALTER TABLE User DROP age;
 The merge is really easy to do:
 
 ```
-# Add Post and update User
+-- Add Post and update User
 
-# --- !Ups
+-- !Ups
 ALTER TABLE User ADD age INT;
 
 CREATE TABLE Post (
@@ -172,7 +172,7 @@ CREATE TABLE Post (
     PRIMARY KEY (id)
 );
 
-# --- !Downs
+-- !Downs
 ALTER TABLE User DROP age;
 
 DROP TABLE Post;
@@ -189,12 +189,12 @@ Sometimes you will make a mistake in your evolution scripts, and they will fail.
 For example, the Ups script of this evolution has an error:
 
 ```
-# Add another column to User
+-- Add another column to User
 
-# --- !Ups
+-- !Ups
 ALTER TABLE Userxxx ADD company varchar(255);
 
-# --- !Downs
+-- !Downs
 ALTER TABLE User DROP company;
 ```
 
@@ -213,12 +213,12 @@ ALTER TABLE User ADD company varchar(255);
 But because your evolution script has errors, you probably want to fix it. So you modify the `3.sql` script:
 
 ```
-# Add another column to User
+-- Add another column to User
 
-# --- !Ups
+-- !Ups
 ALTER TABLE User ADD company varchar(255);
 
-# --- !Downs
+-- !Downs
 ALTER TABLE User DROP company;
 ```
 

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -124,12 +124,12 @@ object Evolutions {
     Files.createDirectory(environment.getFile(directoryName(db)).toPath)
     writeFileIfChanged(
       evolutions,
-      """|# --- %s
+      """|-- %s
          |
-         |# --- !Ups
+         |-- !Ups
          |%s
          |
-         |# --- !Downs
+         |-- !Downs
          |%s
          |
          |""".stripMargin.format(comment, ups, downs))
@@ -155,12 +155,12 @@ object Evolutions {
    */
   def toHumanReadableScript(scripts: Seq[Script]): String = {
     val txt = scripts.map {
-      case UpScript(ev) => "# --- Rev:" + ev.revision + ",Ups - " + ev.hash.take(7) + "\n" + ev.sql_up + "\n"
-      case DownScript(ev) => "# --- Rev:" + ev.revision + ",Downs - " + ev.hash.take(7) + "\n" + ev.sql_down + "\n"
+      case UpScript(ev) => "-- Rev:" + ev.revision + ",Ups - " + ev.hash.take(7) + "\n" + ev.sql_up + "\n"
+      case DownScript(ev) => "-- Rev:" + ev.revision + ",Downs - " + ev.hash.take(7) + "\n" + ev.sql_down + "\n"
     }.mkString("\n")
 
     val hasDownWarning =
-      "# !!! WARNING! This script contains DOWNS evolutions that are likely destructive\n\n"
+      "-- !!! WARNING! This script contains DOWNS evolutions that are likely destructive\n\n"
 
     if (scripts.exists(_.isInstanceOf[DownScript])) hasDownWarning + txt else txt
   }

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -225,7 +225,7 @@ class DatabaseEvolutions(database: Database, schema: String = "") {
 
           connection.rollback()
 
-          val humanScript = "# --- Rev:" + lastScript.evolution.revision + "," + (if (lastScript.isInstanceOf[UpScript]) "Ups" else "Downs") + " - " + lastScript.evolution.hash + "\n\n" + (if (lastScript.isInstanceOf[UpScript]) lastScript.evolution.sql_up else lastScript.evolution.sql_down)
+          val humanScript = "-- Rev:" + lastScript.evolution.revision + "," + (if (lastScript.isInstanceOf[UpScript]) "Ups" else "Downs") + " - " + lastScript.evolution.hash + "\n\n" + (if (lastScript.isInstanceOf[UpScript]) lastScript.evolution.sql_up else lastScript.evolution.sql_down)
 
           throw InconsistentDatabase(database.name, humanScript, message, lastScript.evolution.revision, autocommit)
         } else {
@@ -280,7 +280,7 @@ class DatabaseEvolutions(database: Database, schema: String = "") {
 
             logger.error(error)
 
-            val humanScript = "# --- Rev:" + revision + "," + (if (state == "applying_up") "Ups" else "Downs") + " - " + hash + "\n\n" + script
+            val humanScript = "-- Rev:" + revision + "," + (if (state == "applying_up") "Ups" else "Downs") + " - " + hash + "\n\n" + script
 
             throw InconsistentDatabase(database.name, humanScript, error, revision, autocommit)
           }

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -440,22 +440,22 @@ abstract class ResourceEvolutionsReader extends EvolutionsReader {
 
   def evolutions(db: String): Seq[Evolution] = {
 
-    val upsMarker = """^#.*!Ups.*$""".r
-    val downsMarker = """^#.*!Downs.*$""".r
+    val upsMarker = """^(#|--).*!Ups.*$""".r
+    val downsMarker = """^(#|--).*!Downs.*$""".r
 
     val UPS = "UPS"
     val DOWNS = "DOWNS"
     val UNKNOWN = "UNKNOWN"
 
     val mapUpsAndDowns: PartialFunction[String, String] = {
-      case upsMarker() => UPS
-      case downsMarker() => DOWNS
+      case upsMarker(_) => UPS
+      case downsMarker(_) => DOWNS
       case _ => UNKNOWN
     }
 
     val isMarker: PartialFunction[String, Boolean] = {
-      case upsMarker() => true
-      case downsMarker() => true
+      case upsMarker(_) => true
+      case downsMarker(_) => true
       case _ => false
     }
 

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/commentsyntax/1.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/commentsyntax/1.sql
@@ -1,0 +1,7 @@
+# --- MySQL-style comment syntax
+
+# --- !Ups
+select 1;
+
+# --- !Downs
+select 2;

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/commentsyntax/2.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/commentsyntax/2.sql
@@ -1,0 +1,7 @@
+-- SQL92-style comment syntax
+
+-- !Ups
+select 3;
+
+-- !Downs
+select 4;

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/commentsyntax/3.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/commentsyntax/3.sql
@@ -1,0 +1,7 @@
+# --- Multi-style comment syntax, with arbitrary text
+
+# CompletelyArbitraryText !Ups
+select 5;
+
+-- CompletelyArbitraryText !Downs
+select 6;

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
@@ -31,7 +31,7 @@ class EvolutionsReaderSpec extends Specification {
       reader.evolutions("commentsyntax") must_== Seq(
         Evolution(1, "select 1;", "select 2;"), // 1.sql should have MySQL-style comments
         Evolution(2, "select 3;", "select 4;"), // 2.sql should have SQL92-style comments
-        Evolution(3, "select 5;", "select 6;")  // 3.sql mixes styles with arbitrary text
+        Evolution(3, "select 5;", "select 6;") // 3.sql mixes styles with arbitrary text
       )
     }
 

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
@@ -4,6 +4,7 @@
 package play.api.db.evolutions
 
 import java.io.File
+
 import org.specs2.mutable.Specification
 import play.api.{ Environment, Mode }
 
@@ -20,6 +21,17 @@ class EvolutionsReaderSpec extends Specification {
         Evolution(2, "insert into test (id, name) values (1, 'alice');\ninsert into test (id, name) values (2, 'bob');", "delete from test;"),
         Evolution(3, "insert into test (id, name) values (3, 'charlie');\ninsert into test (id, name) values (4, 'dave');", ""),
         Evolution(4, "", "")
+      )
+    }
+
+    "read evolution files with different comment syntax" in {
+      val environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
+      val reader = new EnvironmentEvolutionsReader(environment)
+
+      reader.evolutions("commentsyntax") must_== Seq(
+        Evolution(1, "select 1;", "select 2;"), // 1.sql should have MySQL-style comments
+        Evolution(2, "select 3;", "select 4;"), // 2.sql should have SQL92-style comments
+        Evolution(3, "select 5;", "select 6;")  // 3.sql mixes styles with arbitrary text
       )
     }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

* Enables support for SQL92-style comments in Play Evolutions scripts in addition to the older MySQL style
* Replaces the older MySQL-style comments in play-jdbc-evolutions with SQL92-style comments (for generated Evolutions, etc.)
* Includes a new test for recognizing files in both MySQL and SQL92 comment syntax.
* Updates documentation to feature the new default style

## Background Context

MySQL-style comments can cause syntax errors in linting tools and IDEs when using another database's SQL dialect. By conforming to SQL92-style comment syntax everywhere, there will be less confusion and enable more flexibility in evolutions.

## References

[Mailing list thread](https://groups.google.com/forum/#!topic/play-framework-dev/knKA5aGbFq8)