### PR TITLE
Fix-issue-6412-playGenerateSecret to always output

### DIFF
--- a/framework/src/play-akka-http-server/src/test/resources/application.conf
+++ b/framework/src/play-akka-http-server/src/test/resources/application.conf
@@ -1,5 +1,5 @@
 play {
-  crypto.secret = rosebud
+  http.secret.key = rosebud
   
   akka {
 

--- a/framework/src/play-netty-server/src/test/resources/application.conf
+++ b/framework/src/play-netty-server/src/test/resources/application.conf
@@ -1,5 +1,5 @@
 play {
-  crypto.secret = rosebud
+  http.secret.key = rosebud
   
   akka {
 

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
@@ -22,7 +22,7 @@ object ApplicationSecretGenerator {
 
   def generateSecretTask = Def.task[String] {
     val secret = generateSecret
-    Keys.streams.value.log.info("Generated new secret: " + secret)
+    println("Generated new secret: " + secret)
     secret
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #6412

## Purpose

This alters the log-output from generateSecretTask, as playGenerateSecret should always display the secret even in the case of suppressed logging.
