### PR TITLE
Allow hyphens in /@evolutions/... url

### DIFF
--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -357,8 +357,8 @@ class DynamicEvolutions {
 @Singleton
 class EvolutionsWebCommands @Inject() (evolutions: EvolutionsApi, reader: EvolutionsReader, config: EvolutionsConfig) extends HandleWebCommandSupport {
   def handleWebCommand(request: play.api.mvc.RequestHeader, buildLink: play.core.BuildLink, path: java.io.File): Option[play.api.mvc.Result] = {
-    val applyEvolutions = """/@evolutions/apply/([a-zA-Z0-9_]+)""".r
-    val resolveEvolutions = """/@evolutions/resolve/([a-zA-Z0-9_]+)/([0-9]+)""".r
+    val applyEvolutions = """/@evolutions/apply/([a-zA-Z0-9_-]+)""".r
+    val resolveEvolutions = """/@evolutions/resolve/([a-zA-Z0-9_-]+)/([0-9]+)""".r
 
     lazy val redirectUrl = request.queryString.get("redirect").filterNot(_.isEmpty).map(_.head).getOrElse("/")
 


### PR DESCRIPTION
In dev mode it's not possible to apply evolutions *via browser* which have a config key that contains hyphens:
```
db {
    my-awesome-database {
        // db config...
    }
    prod-db-1 {
        // db config...
    }
    prod-db-2 {
        // db config...
    }
}

// even more config:
play.evolutions.db {
    my-awesome-database {
        enabled = false
        // ...
    }
    prod-db-1 {
        enabled = true
        // ...
    }
    prod-db-2 {
        enabled = false
        // ...
    }
}
```

Sure I could use underscores but for me it seems a bit weird that in all our config keys we can (and do) use hyphens but only the database config part forces us to use underscores or camelCase. And that's just because the url regex in dev mode doesn't allow it. Applying evolutions using system properties (in dev or prod mode) isn't a problem at all, so it's really just the regex restriction.

Please backport, thanks!