### PR TITLE
Fix Akka HTTP headers handling

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http
+
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc._
+import play.api.test._
+import play.api.{ Configuration, Mode }
+import play.core.server.ServerConfig
+import play.it._
+
+class NettyRequestHeadersSpec extends RequestHeadersSpec with NettyIntegrationSpecification
+class AkkaHttpRequestHeadersSpec extends RequestHeadersSpec with AkkaHttpIntegrationSpecification
+
+trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecification {
+
+  sequential
+
+  "Play request header handling" should {
+
+    def withServerAndConfig[T](configuration: (String, Any)*)(action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
+      val port = testServerPort
+
+      val serverConfig: ServerConfig = {
+        val c = ServerConfig(port = Some(testServerPort), mode = Mode.Test)
+        c.copy(configuration = c.configuration ++ Configuration(configuration: _*))
+      }
+      running(play.api.test.TestServer(serverConfig, GuiceApplicationBuilder().appRoutes { app =>
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        val parse = app.injector.instanceOf[PlayBodyParsers]
+        ({ case _ => action(Action, parse) })
+      }.build(), Some(integrationServerProvider))) {
+        block(port)
+      }
+    }
+
+    def withServer[T](action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
+      withServerAndConfig()(action)(block)
+    }
+
+    "get request headers properly" in withServer((Action, _) => Action { rh =>
+      Results.Ok(rh.headers.getAll("Origin").mkString(","))
+    }) { port =>
+      val Seq(response) = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map("origin" -> "http://foo"), "")
+      )
+      response.body.left.toOption must beSome("http://foo")
+    }
+
+    "remove request headers properly" in withServer((Action, _) => Action { rh =>
+      Results.Ok(rh.headers.remove("ORIGIN").getAll("Origin").mkString(","))
+    }) { port =>
+      val Seq(response) = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map("origin" -> "http://foo"), "")
+      )
+      response.body.left.toOption must beSome("")
+    }
+
+    "replace request headers properly" in withServer((Action, _) => Action { rh =>
+      Results.Ok(rh.headers.replace("Origin" -> "https://bar.com").getAll("Origin").mkString(","))
+    }) { port =>
+      val Seq(response) = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map("origin" -> "http://foo"), "")
+      )
+      response.body.left.toOption must beSome("https://bar.com")
+    }
+  }
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
@@ -47,17 +47,12 @@ class Headers(protected var _headers: Seq[(String, String)]) {
   /**
    * Append the given headers
    */
-  def add(headers: (String, String)*) = new Headers(this.headers ++ headers)
+  def add(headers: (String, String)*): Headers = new Headers(this.headers ++ headers)
 
   /**
    * Retrieves the first header value which is associated with the given key.
    */
   def apply(key: String): String = get(key).getOrElse(scala.sys.error("Header doesn't exist"))
-
-  override def equals(that: Any) = that match {
-    case other: Headers => toMap == other.toMap
-    case _ => false
-  }
 
   /**
    * Optionally returns the first header value associated with a key.
@@ -69,13 +64,6 @@ class Headers(protected var _headers: Seq[(String, String)]) {
    */
   def getAll(key: String): Seq[String] = toMap.getOrElse(key, Nil)
 
-  override def hashCode = {
-    toMap.map {
-      case (name, value) =>
-        name.toLowerCase(Locale.ENGLISH) -> value
-    }.hashCode()
-  }
-
   /**
    * Retrieve all header keys
    */
@@ -84,7 +72,7 @@ class Headers(protected var _headers: Seq[(String, String)]) {
   /**
    * Remove any headers with the given keys
    */
-  def remove(keys: String*) = {
+  def remove(keys: String*): Headers = {
     val keySet = TreeSet(keys: _*)(CaseInsensitiveOrdered)
     new Headers(headers.filterNot { case (name, _) => keySet(name) })
   }
@@ -92,7 +80,7 @@ class Headers(protected var _headers: Seq[(String, String)]) {
   /**
    * Append the given headers, replacing any existing headers having the same keys
    */
-  def replace(headers: (String, String)*) = remove(headers.map(_._1): _*).add(headers: _*)
+  def replace(headers: (String, String)*): Headers = remove(headers.map(_._1): _*).add(headers: _*)
 
   /**
    * Transform the Headers to a Map
@@ -114,9 +102,23 @@ class Headers(protected var _headers: Seq[(String, String)]) {
    */
   lazy val toSimpleMap: Map[String, String] = toMap.mapValues(_.headOption.getOrElse(""))
 
-  override def toString = headers.toString()
-
   lazy val asJava: play.mvc.Http.Headers = new play.mvc.Http.Headers(this.toMap.mapValues(_.asJava).asJava)
+
+  /**
+   * A headers map with all keys normalized to lowercase
+   */
+  private lazy val lowercaseMap: Map[String, Set[String]] = toMap.map {
+    case (name, value) => name.toLowerCase(Locale.ENGLISH) -> value
+  }.mapValues(_.toSet)
+
+  override def equals(that: Any): Boolean = that match {
+    case other: Headers => lowercaseMap == other.lowercaseMap
+    case _ => false
+  }
+
+  override def hashCode: Int = lowercaseMap.hashCode()
+
+  override def toString: String = headers.toString()
 
 }
 


### PR DESCRIPTION
This fixes the behavior of `request.headers.remove` and `request.headers.replace` when dealing with headers of a different case. Previously, `remove` and `replace` would not remove or replace a header if the case differed, while `get` and `getAll` would work regardless of case.