### PR TITLE
Always add Vary header in CORSHeader

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -39,7 +39,7 @@ private[cors] trait AbstractCORSPolicy {
   }
 
   protected def filterRequest(next: EssentialAction, request: RequestHeader): Accumulator[ByteString, Result] = {
-    (request.headers.get(HeaderNames.ORIGIN), request.method) match {
+    val resultAcc = (request.headers.get(HeaderNames.ORIGIN), request.method) match {
       case (None, _) =>
         /* http://www.w3.org/TR/cors/#resource-requests
          * § 6.1.1
@@ -74,6 +74,19 @@ private[cors] trait AbstractCORSPolicy {
         // unrecognized method so invalid request
         handleInvalidCORSRequest(request)
     }
+
+    /* http://www.w3.org/TR/cors/#resource-implementation
+     * § 6.4
+     * Resources that wish to enable themselves to be shared with multiple Origins but do
+     * not respond uniformly with "*" must in practice generate the Access-Control-Allow-Origin
+     * header dynamically in response to every request they wish to allow. As a consequence,
+     * authors of such resources should send a Vary: Origin HTTP header or provide other
+     * appropriate control directives to prevent caching of such responses, which may be
+     * inaccurate if re-used across-origins.
+     */
+    resultAcc.map { result =>
+      result.withHeaders(result.header.varyWith(HeaderNames.ORIGIN))
+    }(play.core.Execution.trampoline)
   }
 
   /* Handles a CORS request
@@ -131,16 +144,6 @@ private[cors] trait AbstractCORSPolicy {
        */
       headerBuilder += ACCESS_CONTROL_ALLOW_CREDENTIALS -> "true"
       headerBuilder += ACCESS_CONTROL_ALLOW_ORIGIN -> origin
-      /* http://www.w3.org/TR/cors/#resource-implementation
-       * § 6.4
-       * Resources that wish to enable themselves to be shared with multiple Origins but do
-       * not respond uniformly with "*" must in practice generate the Access-Control-Allow-Origin
-       * header dynamically in response to every request they wish to allow. As a consequence,
-       * authors of such resources should send a Vary: Origin HTTP header or provide other
-       * appropriate control directives to prevent caching of such responses, which may be
-       * inaccurate if re-used across-origins.
-       */
-      headerBuilder += result.header.varyWith(ORIGIN)
     } else {
       /* Otherwise, add a single Access-Control-Allow-Origin header,
        * with either the value of the Origin header or the string "*" as value.
@@ -149,10 +152,6 @@ private[cors] trait AbstractCORSPolicy {
         headerBuilder += ACCESS_CONTROL_ALLOW_ORIGIN -> "*"
       } else {
         headerBuilder += ACCESS_CONTROL_ALLOW_ORIGIN -> origin
-        /* http://www.w3.org/TR/cors/#resource-implementation
-         * § 6.4
-         */
-        headerBuilder += result.header.varyWith(ORIGIN)
       }
     }
 
@@ -169,8 +168,10 @@ private[cors] trait AbstractCORSPolicy {
   }
 
   private def handlePreFlightCORSRequest(request: RequestHeader): Accumulator[ByteString, Result] = {
+    import HeaderNames._
+
     val origin = {
-      val originOpt = request.headers.get(HeaderNames.ORIGIN)
+      val originOpt = request.headers.get(ORIGIN)
       assume(originOpt.isDefined, "The presence of the ORIGIN header should guaranteed at this point.")
       originOpt.get
     }
@@ -184,7 +185,7 @@ private[cors] trait AbstractCORSPolicy {
     if (!corsConfig.allowedOrigins(origin)) {
       handleInvalidCORSRequest(request)
     } else {
-      request.headers.get(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD) match {
+      request.headers.get(ACCESS_CONTROL_REQUEST_METHOD) match {
         case None =>
           /* http://www.w3.org/TR/cors/#resource-preflight-requests
            * § 6.2.3
@@ -214,7 +215,7 @@ private[cors] trait AbstractCORSPolicy {
              * let header field-names be the empty list.
              */
             val accessControlRequestHeaders: List[String] = {
-              request.headers.get(HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS) match {
+              request.headers.get(ACCESS_CONTROL_REQUEST_HEADERS) match {
                 case None => List.empty[String]
                 case Some(headerVal) =>
                   headerVal.trim.split(',').map(_.trim.toLowerCase(java.util.Locale.ENGLISH))(collection.breakOut)
@@ -241,31 +242,16 @@ private[cors] trait AbstractCORSPolicy {
                  * with the value of the Origin header as value, and add a single
                  * Access-Control-Allow-Credentials header with the case-sensitive string "true" as value.
                  */
-                headerBuilder += HeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS -> "true"
-                headerBuilder += HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN -> origin
-
-                /* http://www.w3.org/TR/cors/#resource-implementation
-                 * § 6.4
-                 * Resources that wish to enable themselves to be shared with multiple Origins but do
-                 * not respond uniformly with "*" must in practice generate the Access-Control-Allow-Origin
-                 * header dynamically in response to every request they wish to allow. As a consequence,
-                 * authors of such resources should send a Vary: Origin HTTP header or provide other
-                 * appropriate control directives to prevent caching of such responses, which may be
-                 * inaccurate if re-used across-origins.
-                 */
-                headerBuilder += HeaderNames.VARY -> HeaderNames.ORIGIN
+                headerBuilder += ACCESS_CONTROL_ALLOW_CREDENTIALS -> "true"
+                headerBuilder += ACCESS_CONTROL_ALLOW_ORIGIN -> origin
               } else {
                 /* Otherwise, add a single Access-Control-Allow-Origin header,
                  * with either the value of the Origin header or the string "*" as value.
                  */
                 if (corsConfig.anyOriginAllowed) {
-                  headerBuilder += HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN -> "*"
+                  headerBuilder += ACCESS_CONTROL_ALLOW_ORIGIN -> "*"
                 } else {
-                  headerBuilder += HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN -> origin
-                  /* http://www.w3.org/TR/cors/#resource-implementation
-                   * § 6.4
-                   */
-                  headerBuilder += HeaderNames.VARY -> HeaderNames.ORIGIN
+                  headerBuilder += ACCESS_CONTROL_ALLOW_ORIGIN -> origin
                 }
               }
 
@@ -275,7 +261,7 @@ private[cors] trait AbstractCORSPolicy {
                * of seconds the user agent is allowed to cache the result of the request.
                */
               if (corsConfig.preflightMaxAge.toSeconds > 0) {
-                headerBuilder += HeaderNames.ACCESS_CONTROL_MAX_AGE -> corsConfig.preflightMaxAge.toSeconds.toString
+                headerBuilder += ACCESS_CONTROL_MAX_AGE -> corsConfig.preflightMaxAge.toSeconds.toString
               }
 
               /* http://www.w3.org/TR/cors/#resource-preflight-requests
@@ -287,7 +273,7 @@ private[cors] trait AbstractCORSPolicy {
                * Note: Since the list of methods can be unbounded, simply returning the method
                * indicated by Access-Control-Request-Method (if supported) can be enough.
                */
-              headerBuilder += HeaderNames.ACCESS_CONTROL_ALLOW_METHODS -> accessControlRequestMethod
+              headerBuilder += ACCESS_CONTROL_ALLOW_METHODS -> accessControlRequestMethod
 
               /* http://www.w3.org/TR/cors/#resource-preflight-requests
                * § 6.2.9
@@ -302,7 +288,7 @@ private[cors] trait AbstractCORSPolicy {
                * headers from Access-Control-Allow-Headers can be enough.
                */
               if (accessControlRequestHeaders.nonEmpty) {
-                headerBuilder += HeaderNames.ACCESS_CONTROL_ALLOW_HEADERS -> accessControlRequestHeaders.mkString(",")
+                headerBuilder += ACCESS_CONTROL_ALLOW_HEADERS -> accessControlRequestHeaders.mkString(",")
               }
 
               Accumulator.done(Results.Ok.withHeaders(headerBuilder.result(): _*))

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
@@ -43,6 +43,7 @@ trait CORSCommonSpec extends PlaySpecification {
         )).get
 
         status(result) must_== OK
+        header(VARY, result) must beSome(ORIGIN)
         mustBeNoAccessControlResponseHeaders(result)
       }
       "without a port number" in withApplication() { app =>
@@ -52,6 +53,7 @@ trait CORSCommonSpec extends PlaySpecification {
         )).get
 
         status(result) must_== OK
+        header(VARY, result) must beSome(ORIGIN)
         mustBeNoAccessControlResponseHeaders(result)
       }
     }
@@ -67,6 +69,7 @@ trait CORSCommonSpec extends PlaySpecification {
         )).get
 
         status(result) must_== OK
+        header(VARY, result) must beSome(ORIGIN)
         mustBeNoAccessControlResponseHeaders(result)
       }
       "forbidden" in withApplication(conf = serveForbidden) { app =>
@@ -75,6 +78,7 @@ trait CORSCommonSpec extends PlaySpecification {
         )).get
 
         status(result) must_== OK
+        header(VARY, result) must beSome(ORIGIN)
         mustBeNoAccessControlResponseHeaders(result)
       }
     }
@@ -87,6 +91,7 @@ trait CORSCommonSpec extends PlaySpecification {
 
       status(result) must_== OK
       header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("http://www.example.com")
+      header(VARY, result) must beSome(ORIGIN)
     }
 
     "not consider different ports to be the same origin" in withApplication() { app =>
@@ -97,6 +102,7 @@ trait CORSCommonSpec extends PlaySpecification {
 
       status(result) must_== OK
       header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("http://www.example.com:9000")
+      header(VARY, result) must beSome(ORIGIN)
     }
 
     "not consider different protocols to be the same origin" in withApplication() { app =>
@@ -107,6 +113,7 @@ trait CORSCommonSpec extends PlaySpecification {
 
       status(result) must_== OK
       header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("https://www.example.com:9000")
+      header(VARY, result) must beSome(ORIGIN)
     }
 
     "forbid an empty origin header" in withApplication() { app =>


### PR DESCRIPTION
This is a follow up to #7851.

The current behaviour of the CORSFilter is only to serve the Vary:Origin header when CORS headers are served. This means a non-CORS request will not be served the Vary header. So a cache might store a response for a same-origin request and serve it to a user expecting CORS headers, thus breaking CORS.