### PR TITLE
Change Cache expire arg default value to Duration.Undefined (#6660)

### DIFF
--- a/framework/src/play-cache/src/main/scala/play/api/cache/AsyncCacheApi.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/AsyncCacheApi.scala
@@ -26,7 +26,7 @@ trait AsyncCacheApi {
    * @param value Item value.
    * @param expiration Expiration time.
    */
-  def set(key: String, value: Any, expiration: Duration = Duration.Inf): Future[Done]
+  def set(key: String, value: Any, expiration: Duration = Duration.Undefined): Future[Done]
 
   /**
    * Remove a value from the cache
@@ -40,7 +40,7 @@ trait AsyncCacheApi {
    * @param expiration expiration period in seconds.
    * @param orElse The default function to invoke if the value was not found in cache.
    */
-  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration = Duration.Inf)(orElse: => Future[A]): Future[A]
+  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration = Duration.Undefined)(orElse: => Future[A]): Future[A]
 
   /**
    * Retrieve a value from the cache for the given type

--- a/framework/src/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala
@@ -21,7 +21,7 @@ trait SyncCacheApi {
    * @param value Item value.
    * @param expiration Expiration time.
    */
-  def set(key: String, value: Any, expiration: Duration = Duration.Inf): Unit
+  def set(key: String, value: Any, expiration: Duration = Duration.Undefined): Unit
 
   /**
    * Remove a value from the cache
@@ -35,7 +35,7 @@ trait SyncCacheApi {
    * @param expiration expiration period in seconds.
    * @param orElse The default function to invoke if the value was not found in cache.
    */
-  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration = Duration.Inf)(orElse: => A): A
+  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration = Duration.Undefined)(orElse: => A): A
 
   /**
    * Retrieve a value from the cache for the given type
@@ -59,7 +59,7 @@ trait CacheApi {
    * @param value Item value.
    * @param expiration Expiration time.
    */
-  def set(key: String, value: Any, expiration: Duration = Duration.Inf): Unit
+  def set(key: String, value: Any, expiration: Duration = Duration.Undefined): Unit
 
   /**
    * Remove a value from the cache
@@ -73,7 +73,7 @@ trait CacheApi {
    * @param expiration expiration period in seconds.
    * @param orElse The default function to invoke if the value was not found in cache.
    */
-  def getOrElse[A: ClassTag](key: String, expiration: Duration = Duration.Inf)(orElse: => A): A
+  def getOrElse[A: ClassTag](key: String, expiration: Duration = Duration.Undefined)(orElse: => A): A
 
   /**
    * Retrieve a value from the cache for the given type

--- a/framework/src/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/framework/src/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -179,7 +179,7 @@ class SyncEhCacheApi @Inject() (private[ehcache] val cache: Ehcache) extends Syn
   override def set(key: String, value: Any, expiration: Duration): Unit = {
     val element = new Element(key, value)
     expiration match {
-      case infinite: Duration.Infinite => element.setEternal(true)
+      case infinite: Duration.Infinite if infinite != Duration.Undefined => element.setEternal(true)
       case finite: FiniteDuration =>
         val seconds = finite.toSeconds
         if (seconds <= 0) {


### PR DESCRIPTION
Fixes #6660
Now, if you want to put an element with the infinite exp time, you should pass Duration.Inf value to cache set method.
If no expire value is specified for the cache set method, the default lifespan values will be used from cache config.