### PR TITLE
Java cache api should return Optional (like the scala api)

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -133,6 +133,22 @@ Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]]
 
 > **Important**: When upgrading to Play 2.7 you will not see any compiler warnings indicating that you have to migrate your `validate` methods (because Play executed them via reflection).
 
+## The Java Cache API `get` method has been deprecated in favor of `getOptional`
+
+The `getOptional` methods of the Java `cacheApi` return their results wrapped in an `Optional`.
+
+Changes in `play.cache.SyncCacheApi`:
+
+| **deprecated method**                      | **new method**
+|------------------------------------------|----------------------------------------------------
+| `<T> T get(String key)`                  | `<T> Optional<T> getOptional(String key)`
+
+Changes in `play.cache.AsyncCacheApi`:
+
+| **deprecated method**                      | **new method**
+|------------------------------------------|----------------------------------------------------
+| `<T> CompletionStage<T> get(String key)` | `<T> CompletionStage<Optional<T>> getOptional(String key)`
+
 ## SecurityHeadersFilter's contentSecurityPolicy deprecated for CSPFilter
 
 The [[SecurityHeaders filter|SecurityHeaders]] has a `contentSecurityPolicy` property: this is deprecated in 2.7.0.  `contentSecurityPolicy` has been changed from `default-src 'self'` to `null` -- the default setting of `null` means that a `Content-Security-Policy` header will not be added to HTTP responses from the SecurityHeaders filter.  Please use the new [[CSPFilter]] to enable CSP functionality.

--- a/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/JavaCache.java
+++ b/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/JavaCache.java
@@ -20,6 +20,7 @@ import java.lang.Throwable;
 import java.util.Collections;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
+import java.util.Optional;
 
 import static javaguide.testhelpers.MockJavaActionHelper.call;
 import static org.hamcrest.CoreMatchers.*;
@@ -62,9 +63,9 @@ public class JavaCache extends WithApplication {
         block(result);
         }
         //#get
-        CompletionStage<News> news = cache.get("item.key");
+        CompletionStage<Optional<News>> news = cache.getOptional("item.key");
         //#get
-        assertThat(block(news), equalTo(frontPageNews));
+        assertThat(block(news).get(), equalTo(frontPageNews));
         //#get-or-else
         CompletionStage<News> maybeCached = cache.getOrElseUpdate("item.key", this::lookUpFrontPageNews);
         //#get-or-else
@@ -79,7 +80,7 @@ public class JavaCache extends WithApplication {
         //#removeAll
         block(result);
         }
-        assertThat(cache.sync().get("item.key"), nullValue());
+        assertThat(cache.sync().getOptional("item.key"), equalTo(Optional.empty()));
     }
 
     private CompletionStage<News> lookUpFrontPageNews() {
@@ -105,7 +106,7 @@ public class JavaCache extends WithApplication {
         AsyncCacheApi cache = app.injector().instanceOf(AsyncCacheApi.class);
 
         assertThat(contentAsString(call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)), equalTo("Hello world"));
-        assertThat(cache.sync().get("homePage"), notNullValue());
+        assertThat(cache.sync().getOptional("homePage").get(), notNullValue());
         cache.sync().set("homePage", Results.ok("something else"));
         assertThat(contentAsString(call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)), equalTo("something else"));
     }

--- a/documentation/manual/working/javaGuide/main/cache/code/javaguide/ehcache/JavaEhCache.java
+++ b/documentation/manual/working/javaGuide/main/cache/code/javaguide/ehcache/JavaEhCache.java
@@ -20,6 +20,7 @@ import java.lang.Throwable;
 import java.util.Collections;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
+import java.util.Optional;
 
 import static javaguide.testhelpers.MockJavaActionHelper.call;
 import static org.hamcrest.CoreMatchers.*;
@@ -62,9 +63,9 @@ public class JavaEhCache extends WithApplication {
         block(result);
         }
         //#get
-        CompletionStage<News> news = cache.get("item.key");
+        CompletionStage<Optional<News>> news = cache.getOptional("item.key");
         //#get
-        assertThat(block(news), equalTo(frontPageNews));
+        assertThat(block(news).get(), equalTo(frontPageNews));
         //#get-or-else
         CompletionStage<News> maybeCached = cache.getOrElseUpdate("item.key", this::lookUpFrontPageNews);
         //#get-or-else
@@ -79,7 +80,7 @@ public class JavaEhCache extends WithApplication {
         //#removeAll
         block(result);
         }
-        assertThat(cache.sync().get("item.key"), nullValue());
+        assertThat(cache.sync().getOptional("item.key"), equalTo(Optional.empty()));
     }
 
     private CompletionStage<News> lookUpFrontPageNews() {
@@ -105,7 +106,7 @@ public class JavaEhCache extends WithApplication {
         AsyncCacheApi cache = app.injector().instanceOf(AsyncCacheApi.class);
 
         assertThat(contentAsString(call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)), equalTo("Hello world"));
-        assertThat(cache.sync().get("homePage"), notNullValue());
+        assertThat(cache.sync().getOptional("homePage").get(), notNullValue());
         cache.set("homePage", Results.ok("something else"));
         assertThat(contentAsString(call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)), equalTo("something else"));
     }

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -541,7 +541,11 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.api.PlayConfig"),
 
       // Add play.Application environmnent() method
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.Application.environment")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.Application.environment"),
+
+      // Added getOptional to Java (async)cacheApi
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.AsyncCacheApi.getOptional"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.SyncCacheApi.getOptional")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-cache/src/main/java/play/cache/AsyncCacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/AsyncCacheApi.java
@@ -6,6 +6,7 @@ package play.cache;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
+import java.util.Optional;
 
 import akka.Done;
 
@@ -27,8 +28,20 @@ public interface AsyncCacheApi {
      * @param <T> the type of the stored object
      * @param key the key to look up
      * @return a CompletionStage containing the value
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #getOptional(String)} instead.
      */
+    @Deprecated
     <T> CompletionStage<T> get(String key);
+
+    /**
+     * Retrieves an object by key.
+     *
+     * @param <T> the type of the stored object
+     * @param key the key to look up
+     * @return a CompletionStage containing the value wrapped in an Optional
+     */
+    <T> CompletionStage<Optional<T>> getOptional(String key);
 
     /**
      * Retrieve a value from the cache, or set it from a default Callable function.

--- a/framework/src/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
@@ -7,6 +7,7 @@ package play.cache;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -15,6 +16,7 @@ import akka.Done;
 import play.libs.Scala;
 import scala.concurrent.duration.Duration;
 
+import scala.compat.java8.OptionConverters;
 import static scala.compat.java8.FutureConverters.toJava;
 
 /**
@@ -35,8 +37,13 @@ public class DefaultAsyncCacheApi implements AsyncCacheApi {
         return new SyncCacheApiAdapter(asyncCacheApi.sync());
     }
 
+	@Deprecated
     public <T> CompletionStage<T> get(String key) {
         return toJava(asyncCacheApi.get(key, Scala.<T>classTag())).thenApply(Scala::orNull);
+    }
+
+    public <T> CompletionStage<Optional<T>> getOptional(String key) {
+        return toJava(asyncCacheApi.get(key, Scala.<T>classTag())).thenApply(OptionConverters::toJava);
     }
 
     public <T> CompletionStage<T> getOrElseUpdate(String key, Callable<CompletionStage<T>> block, int expiration) {

--- a/framework/src/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
@@ -37,36 +37,44 @@ public class DefaultAsyncCacheApi implements AsyncCacheApi {
         return new SyncCacheApiAdapter(asyncCacheApi.sync());
     }
 
-	@Deprecated
+    @Override
+    @Deprecated
     public <T> CompletionStage<T> get(String key) {
         return toJava(asyncCacheApi.get(key, Scala.<T>classTag())).thenApply(Scala::orNull);
     }
 
+    @Override
     public <T> CompletionStage<Optional<T>> getOptional(String key) {
         return toJava(asyncCacheApi.get(key, Scala.<T>classTag())).thenApply(OptionConverters::toJava);
     }
 
+    @Override
     public <T> CompletionStage<T> getOrElseUpdate(String key, Callable<CompletionStage<T>> block, int expiration) {
         return toJava(
             asyncCacheApi.getOrElseUpdate(key, intToDuration(expiration), Scala.asScalaWithFuture(block), Scala.<T>classTag()));
     }
 
+    @Override
     public <T> CompletionStage<T> getOrElseUpdate(String key, Callable<CompletionStage<T>> block) {
         return toJava(asyncCacheApi.getOrElseUpdate(key, Duration.Inf(), Scala.asScalaWithFuture(block), Scala.<T>classTag()));
     }
 
+    @Override
     public CompletionStage<Done> set(String key, Object value, int expiration) {
         return toJava(asyncCacheApi.set(key, value, intToDuration(expiration)));
     }
 
+    @Override
     public CompletionStage<Done> set(String key, Object value) {
         return toJava(asyncCacheApi.set(key, value, Duration.Inf()));
     }
 
+    @Override
     public CompletionStage<Done> remove(String key) {
         return toJava(asyncCacheApi.remove(key));
     }
 
+    @Override
     public CompletionStage<Done> removeAll() {
         return toJava(asyncCacheApi.removeAll());
     }

--- a/framework/src/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -32,8 +33,14 @@ public class DefaultSyncCacheApi implements SyncCacheApi {
     }
 
     @Override
+    @Deprecated
     public <T> T get(String key) {
         return blocking(cacheApi.get(key));
+    }
+
+    @Override
+    public <T> Optional<T> getOptional(String key) {
+        return blocking(cacheApi.getOptional(key));
     }
 
     @Override

--- a/framework/src/play-cache/src/main/java/play/cache/SyncCacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/SyncCacheApi.java
@@ -5,6 +5,7 @@
 package play.cache;
 
 import java.util.concurrent.Callable;
+import java.util.Optional;
 
 /**
  * A synchronous API to access a Cache.
@@ -16,8 +17,20 @@ public interface SyncCacheApi {
      * @param <T> the type of the stored object
      * @param key the key to look up
      * @return the object or null
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #getOptional(String)} instead.
      */
+    @Deprecated
     <T> T get(String key);
+
+    /**
+     * Retrieves an object by key.
+     *
+     * @param <T> the type of the stored object
+     * @param key the key to look up
+     * @return the object wrapped in an Optional
+     */
+    <T> Optional<T> getOptional(String key);
 
     /**
      * Retrieve a value from the cache, or set it from a default Callable function.

--- a/framework/src/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
+++ b/framework/src/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
@@ -6,10 +6,13 @@ package play.cache;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
 import scala.concurrent.duration.Duration;
 
 import play.libs.Scala;
+
+import static scala.compat.java8.OptionConverters.toJava;
 
 /**
  * Adapts a Scala SyncCacheApi to a Java SyncCacheApi
@@ -23,6 +26,7 @@ public class SyncCacheApiAdapter implements SyncCacheApi {
   }
 
   @Override
+  @Deprecated
   public <T> T get(String key) {
     scala.Option<T> opt = scalaApi.get(key, Scala.classTag());
     if (opt.isDefined()) {
@@ -30,6 +34,11 @@ public class SyncCacheApiAdapter implements SyncCacheApi {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public <T> Optional<T> getOptional(String key) {
+    return toJava(scalaApi.get(key, Scala.classTag()));
   }
 
   @Override

--- a/framework/src/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/framework/src/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -5,6 +5,7 @@
 package play.api.cache
 
 import java.util.concurrent.{ Callable, CompletableFuture, CompletionStage }
+import java.util.Optional
 
 import akka.util.Timeout
 
@@ -27,25 +28,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar", 1 /* second */ ).toScala)
 
-      after2sec { cacheApi.get[String]("foo").toScala must beNull.await }
+      after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await }
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar", 10 /* seconds */ ).toScala)
 
-      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo("bar").await }
+      after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         await(cacheApi.set("foo", "bar").toScala)
-        cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+        cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -54,7 +55,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
         }).toScala
 
         future must beEqualTo("bar").await
-        cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+        cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -64,25 +65,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
         future must beEqualTo("bar").await
 
-        after2sec { cacheApi.get[String]("foo").toScala must beNull.await }
+        after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
 
       await(cacheApi.remove("foo").toScala)
-      cacheApi.get[String]("foo").toScala must beNull.await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await
     }
 
     "remove all values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
 
       await(cacheApi.removeAll().toScala)
-      cacheApi.get[String]("foo").toScala must beNull.await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await
     }
   }
 
@@ -90,25 +91,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar")
-      cacheApi.get[String]("foo") must beEqualTo("bar")
+      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar", 1 /* second */ )
 
-      cacheApi.get[String]("foo") must beNull.eventually(3, 2.seconds)
+      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty()).eventually(3, 2.seconds)
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar", 10 /* seconds */ )
 
-      after2sec { cacheApi.get[String]("foo") must beEqualTo("bar") }
+      after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar")) }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
         cacheApi.set("foo", "bar")
-        cacheApi.get[String]("foo") must beEqualTo("bar")
+        cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
@@ -117,7 +118,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
         })
 
         value must beEqualTo("bar")
-        cacheApi.get[String]("foo") must beEqualTo("bar")
+        cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
@@ -127,16 +128,16 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
         future must beEqualTo("bar")
 
-        after2sec { cacheApi.get[String]("foo") must beNull }
+        after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty()) }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar")
-      cacheApi.get[String]("foo") must beEqualTo("bar")
+      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
 
       cacheApi.remove("foo")
-      cacheApi.get[String]("foo") must beNull
+      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty())
     }
   }
 }

--- a/framework/src/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/framework/src/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -5,6 +5,7 @@
 package play.api.cache
 
 import java.util.concurrent.{ Callable, CompletableFuture, CompletionStage }
+import java.util.Optional
 
 import akka.util.Timeout
 
@@ -27,25 +28,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar", 1 /* second */ ).toScala)
 
-      after2sec { cacheApi.get[String]("foo").toScala must beNull.await }
+      after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await }
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar", 10 /* seconds */ ).toScala)
 
-      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo("bar").await }
+      after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         await(cacheApi.set("foo", "bar").toScala)
-        cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+        cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -54,7 +55,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
         }).toScala
 
         future must beEqualTo("bar").await
-        cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+        cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -64,25 +65,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
         future must beEqualTo("bar").await
 
-        after2sec { cacheApi.get[String]("foo").toScala must beNull.await }
+        after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
 
       await(cacheApi.remove("foo").toScala)
-      cacheApi.get[String]("foo").toScala must beNull.await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await
     }
 
     "remove all values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
 
       await(cacheApi.removeAll().toScala)
-      cacheApi.get[String]("foo").toScala must beNull.await
+      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await
     }
   }
 
@@ -90,25 +91,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar")
-      cacheApi.get[String]("foo") must beEqualTo("bar")
+      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar", 1 /* second */ )
 
-      after2sec { cacheApi.get[String]("foo") must beNull }
+      after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty()) }
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar", 10 /* seconds */ )
 
-      after2sec { cacheApi.get[String]("foo") must beEqualTo("bar") }
+      after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar")) }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
         cacheApi.set("foo", "bar")
-        cacheApi.get[String]("foo") must beEqualTo("bar")
+        cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
@@ -117,7 +118,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
         })
 
         value must beEqualTo("bar")
-        cacheApi.get[String]("foo") must beEqualTo("bar")
+        cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
@@ -127,16 +128,16 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
         future must beEqualTo("bar")
 
-        after2sec { cacheApi.get[String]("foo") must beNull }
+        after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty()) }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar")
-      cacheApi.get[String]("foo") must beEqualTo("bar")
+      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
 
       cacheApi.remove("foo")
-      cacheApi.get[String]("foo") must beNull
+      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty())
     }
   }
 }


### PR DESCRIPTION
I will finish this PR after #7611 has been merged which removes deprecated `play.cache.CacheApi`.

The PR changes the return type of the Java...
* ... `SyncCacheApi` `<T> T get(String key)` to `<T> Optional<T> get(String key)`
* ... `AsyncCacheApi` `<T> CompletionStage<T> get(String key)` to `<T> CompletionStage<Optional<T>> get(String key)`

The Scala api also returns `Option`, see [here](https://github.com/playframework/playframework/blob/2.6.6/framework/src/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala#L46) and [here](https://github.com/playframework/playframework/blob/2.6.6/framework/src/play-cache/src/main/scala/play/api/cache/AsyncCacheApi.scala#L51).