### PR TITLE
Wait for cache.set in Cached

### DIFF
--- a/framework/src/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/framework/src/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -33,7 +33,6 @@ class CachedSpec extends PlaySpecification {
       val result1 = controller.action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       controller.invoked.get() must_== 1
-      Thread.sleep(1000) // give cache time to set the value because that happens asynchronously
       val result2 = controller.action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
       controller.invoked.get() must_== 1
@@ -50,7 +49,6 @@ class CachedSpec extends PlaySpecification {
       val result1 = controller.action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       controller.invoked.get() must_== 1
-      Thread.sleep(1000) // give cache time to set the value because that happens asynchronously
       val result2 = controller.action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
       controller.invoked.get() must_== 1
@@ -88,7 +86,6 @@ class CachedSpec extends PlaySpecification {
       val result1 = action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       invoked.get() must_== 1
-      Thread.sleep(1000) // give ehcache time to set the value because that happens asynchronously
       val result2 = action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
 
@@ -108,7 +105,6 @@ class CachedSpec extends PlaySpecification {
       val result1 = action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       invoked.get() must_== 1
-      Thread.sleep(1000) // give cache time to set the value because that happens asynchronously
       val result2 = action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
 


### PR DESCRIPTION
As you can see in the snippet below, the [current implementation of `Cached`](https://github.com/playframework/playframework/blob/a9525c22d8bd271425c8781f07e193824f7f1612/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala#L211) does not wait for `cache.set` to complete before returning the result of the `Action`. 

```scala
cache.set(etagKey, etag, duration)
cache.set(resultKey, new SerializableResult(resultWithHeaders), duration)
resultWithHeaders
```

As I described [in the mailing list](https://groups.google.com/forum/#!topic/play-framework/9XzMWKTKUfg) this can lead to undesired behavior.

> So let's say we have the following endpoints:
>
> - Endpoint A: Its response is cached
> - Endpoint B: When called it invalidates the cached response of endpoint A
>
> And I also have the following flow:
>
> - Endpoint A is called
> - on any subsequent calls to endpoint A the cached response is returned
> -  except if in the meantime endpoint B is called, then the cached response of A is no longer valid
>
> Note that endpoint B uses values returned from endpoint A so it's only possible to call B after A has returned successfully.
>
> In order for this flow to work it is necessary that the value is in the cache before endpoint A returns, so that endpoint B can invalidate it.
>
> With the current implementation the following is possible:
>
> -  Endpoint A returns before it's response is done being cached
> - then endpoint B is called, again before caching of the previous response is done (so invalidation doesn't really work here)
> - caching finally completes
> -  calls to endpoint A return the invalid cached response
