### PR TITLE
Fixes issue-7892 with consolidated test

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -65,5 +65,16 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
       )
       response.body.left.toOption must beSome("https://bar.com")
     }
+
+    "pass http header common tests" in withServer((Action, _) => Action { rh =>
+      val akkaHeaders = rh.headers
+      (new HttpHeaderSpec).commonTests(akkaHeaders)
+      Results.Ok(akkaHeaders.getAll("a").mkString(","))
+    }) { port =>
+      val Seq(response) = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map("a" -> "a1", "a" -> "a2", "b" -> "b1", "b" -> "b2", "B" -> "b3", "c" -> "c1"), "")
+      )
+      response.body.left.toOption must beSome("a2")
+    }
   }
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/HttpHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/HttpHeaderSpec.scala
@@ -4,15 +4,15 @@
 package play.api.mvc
 
 import org.specs2.mutable._
-
 import play.core.test._
 
-class HttpSpec extends Specification {
+class HttpHeaderSpec extends Specification {
   "HTTP" title
 
-  val headers = Headers("a" -> "a1", "a" -> "a2", "b" -> "b1", "b" -> "b2", "B" -> "b3", "c" -> "c1")
+  "Headers should" in { commonTests(Headers("a" -> "a1", "a" -> "a2", "b" -> "b1", "b" -> "b2", "B" -> "b3", "c" -> "c1")) }
 
-  "Headers" should {
+  def commonTests(headers: Headers) = {
+
     "return its headers as a sequence of name-value pairs" in {
       // Wrap sequence in a new Headers object so we can compare with Headers.equals
       new Headers(headers.headers) must_== headers


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #7892

## Purpose

Makes the tests under HttpSpec common to both AkkaRequestHeader and NettyRequestHeader specifications.
