### PR TITLE
Update library dependencies to the latest version

### DIFF
--- a/documentation/manual/releases/release26/migration26/WSMigration26.md
+++ b/documentation/manual/releases/release26/migration26/WSMigration26.md
@@ -20,9 +20,9 @@ libraryDependencies += ehcache
 If you want to use it in a non Play project, it can be added to an SBT project with:
 
 ```scala
-libraryDependencies += "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.1"
-libraryDependencies += "com.typesafe.play" %% "play-ws-standalone-json" % "1.0.1"
-libraryDependencies += "com.typesafe.play" %% "play-ws-standalone-xml" % "1.0.1"
+libraryDependencies += "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.1.2"
+libraryDependencies += "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.2"
+libraryDependencies += "com.typesafe.play" %% "play-ws-standalone-xml" % "1.1.2"
 ```
 
 ## Package changes


### PR DESCRIPTION
Latest versions could be found in central maven repository: [com.typesafe.play/play-ahc-ws-standalone_2.12](https://mvnrepository.com/artifact/com.typesafe.play/play-ahc-ws-standalone_2.12)