### PR TITLE
Keep headers when Content-Encoding set

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -53,7 +53,7 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       val bodyString = "Hello World"
 
       // Compress the bytes
-      var output = new Array[Byte](100)
+      val output = new Array[Byte](100)
       val compressor = new Deflater()
       compressor.setInput(bodyString.getBytes("UTF-8"))
       compressor.finish()


### PR DESCRIPTION
Fixes #7911.

The code now filters out the Content-Encoding header instead of all the other headers when decoding the request content.