### PR TITLE
Improve Heroku deploying docs (deploying project that depends on Java 9)

### DIFF
--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -124,12 +124,12 @@ $ heroku open
 
 ## Deploying Java 9 application
 
-Heroku uses OpenJDK 8 to run play application by default. It can not automatically determine if another version is needed, so deploying application that uses Java will lead to compilation error on server. If you use newer version, you should declare it in `system.properties` file. 
+Heroku uses OpenJDK 8 to run Java applications by default. It cannot automatically determine if another version is needed, so deploying a Java 9 applicaiton will lead to a compilation error on the server. If you use a newer version than Java 8, you should declare it in your system.properties file in the project root directory:
 ```txt
 java.runtime.version=9
 ```
-This file should be located in project root directory to be processed by Heroku.
-For more information about specifying java version, [see heroku instructions](https://devcenter.heroku.com/articles/java-support#specifying-a-java-version).
+
+See the [heroku documentation](https://devcenter.heroku.com/articles/java-support#specifying-a-java-version) for more details.
 
 ## Deploying with the sbt-heroku plugin
 

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -124,7 +124,7 @@ $ heroku open
 
 ## Deploying Java 9 application
 
-Heroku uses OpenJDK 8 to run Java applications by default. It cannot automatically determine if another version is needed, so deploying a Java 9 applicaiton will lead to a compilation error on the server. If you use a newer version than Java 8, you should declare it in your system.properties file in the project root directory:
+Heroku uses OpenJDK 8 to run Java applications by default. It cannot automatically determine if another version is needed, so deploying a Java 9 application will lead to a compilation error on the server. If you use a newer version than Java 8, you should declare it in your `system.properties` file in the project root directory:
 ```txt
 java.runtime.version=9
 ```

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -122,6 +122,14 @@ Looks good. We can now visit the app by running:
 $ heroku open
 ```
 
+## Deploying Java 9 application
+
+Heroku uses OpenJDK 8 to run play application by default. It can not automatically determine if another version is needed, so deploying application that uses Java will lead to compilation error on server. If you use newer version, you should declare it in `system.properties` file. 
+```txt
+java.runtime.version=9
+```
+This file should be located in project root directory to be processed by Heroku.
+
 ## Deploying with the sbt-heroku plugin
 
 The Heroku sbt plugin utilizes an API to provide direct deployment of prepackaged standalone web applications to Heroku. This may be a preferred approach for applications that take a long time to compile, or that need to be deployed from a Continuous Integration server such as Travis CI or Jenkins.

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -129,7 +129,7 @@ Heroku uses OpenJDK 8 to run play application by default. It can not automatical
 java.runtime.version=9
 ```
 This file should be located in project root directory to be processed by Heroku.
-For more information about specifying java version, [see](https://devcenter.heroku.com/articles/java-support#specifying-a-java-version).
+For more information about specifying java version, [see heroku instructions](https://devcenter.heroku.com/articles/java-support#specifying-a-java-version).
 
 ## Deploying with the sbt-heroku plugin
 

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -129,6 +129,7 @@ Heroku uses OpenJDK 8 to run play application by default. It can not automatical
 java.runtime.version=9
 ```
 This file should be located in project root directory to be processed by Heroku.
+For more information about specifying java version, [see](https://devcenter.heroku.com/articles/java-support#specifying-a-java-version).
 
 ## Deploying with the sbt-heroku plugin
 


### PR DESCRIPTION
## Purpose

This docs improvement aims to save time of developers that are using Heroku to host their apps on and have possible troubles with migrating to Java 9 according to the fact that Heroku uses OpenJdk 8 by default.
