### PR TITLE
Update FlashCookieSpec to test HTTP/2

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -55,15 +55,14 @@ class FlashCookieSpec extends PlaySpecification
     def withAllCookieEndpoints[A: AsResult](block: CookieEndpoint => A): Fragment = {
       appFactory.withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
         block(new CookieEndpoint {
+          import JavaConverters._
           def call(path: String, cookies: List[okhttp3.Cookie]): (okhttp3.Response, List[okhttp3.Cookie]) = {
             var responseCookies: List[okhttp3.Cookie] = null
             val cookieJar = new CookieJar {
-              override def loadForRequest(url: HttpUrl): util.List[okhttp3.Cookie] = {
-                JavaConverters.seqAsJavaList(cookies)
-              }
+              override def loadForRequest(url: HttpUrl): util.List[okhttp3.Cookie] = cookies.asJava
               override def saveFromResponse(url: HttpUrl, cookies: util.List[okhttp3.Cookie]): Unit = {
                 assert(responseCookies == null, "This CookieJar only handles a single response")
-                responseCookies = JavaConverters.collectionAsScalaIterable(cookies).toList
+                responseCookies = cookies.asScala.toList
               }
             }
             val client = okEndpoint.clientBuilder.followRedirects(false).cookieJar(cookieJar).build()

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -3,137 +3,174 @@
  */
 package play.it.http
 
-import com.typesafe.config.ConfigFactory
-import play.api.http.{ FlashConfiguration, SecretConfiguration }
-import play.api.libs.crypto.CookieSignerProvider
-import play.api.{ BuiltInComponentsFromContext, Configuration, NoHttpFiltersComponents }
-import play.api.test._
-import play.api.mvc._
+import java.util
+
+import okhttp3.{ CookieJar, HttpUrl }
+import okhttp3.internal.http.HttpDate
+import org.specs2.execute.AsResult
+import org.specs2.specification.core.Fragment
 import play.api.mvc.Results._
-import play.api.libs.ws.{ DefaultWSCookie, WSClient, WSCookie, WSResponse }
+import play.api.mvc._
 import play.api.routing.Router
-import play.core.server.Server
-import play.it._
+import play.api.test._
+import play.it.test.{ ApplicationFactories, ApplicationFactory, EndpointIntegrationSpecification, OkHttpEndpointSupport }
 
-class NettyFlashCookieSpec extends FlashCookieSpec with NettyIntegrationSpecification
-class AkkaHttpFlashCookieSpec extends FlashCookieSpec with AkkaHttpIntegrationSpecification
+import scala.collection.JavaConverters
 
-trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecification with WsTestClient {
+class FlashCookieSpec extends PlaySpecification
+    with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
 
-  sequential
-
-  def withClientAndServer[T](additionalConfiguration: Map[String, String] = Map.empty)(block: WSClient => T) = {
-    Server.withApplicationFromContext() { context =>
-      new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
-
-        import play.api.routing.sird.{ GET => SirdGet, _ }
-        import scala.collection.JavaConverters._
-
-        override def configuration: Configuration = super.configuration ++ new Configuration(ConfigFactory.parseMap(additionalConfiguration.asJava))
-
-        override def router: Router = Router.from {
-          case SirdGet(p"/flash") => defaultActionBuilder {
-            Redirect("/landing").flashing(
-              "success" -> "found"
-            )
-          }
-          case SirdGet(p"/set-cookie") => defaultActionBuilder {
-            Ok.withCookies(Cookie("some-cookie", "some-value"))
-          }
-          case SirdGet(p"/landing") => defaultActionBuilder {
-            Ok("ok")
-          }
+  /** Makes an app that we use while we're testing */
+  def withFlashCookieApp(additionalConfiguration: Map[String, Any] = Map.empty): ApplicationFactory = {
+    withConfigAndRouter(additionalConfiguration) { components =>
+      import play.api.routing.sird.{ GET => SirdGet, _ }
+      Router.from {
+        case SirdGet(p"/flash") => components.defaultActionBuilder {
+          Redirect("/landing").flashing(
+            "success" -> "found"
+          )
         }
-      }.application
-    } { implicit port =>
-      withClient(block)
+        case SirdGet(p"/set-cookie") => components.defaultActionBuilder {
+          Ok.withCookies(Cookie("some-cookie", "some-value"))
+        }
+        case SirdGet(p"/landing") => components.defaultActionBuilder {
+          Ok("ok")
+        }
+      }
     }
+  }
+
+  /**
+   * Handles the details of calling a [[ServerEndpoint]] with a cookie and
+   * receiving the response and its cookies.
+   */
+  trait CookieEndpoint {
+    def call(path: String, cookies: List[okhttp3.Cookie]): (okhttp3.Response, List[okhttp3.Cookie])
+  }
+
+  /**
+   * Helper to add the `withAllCookieEndpoints` method to an `ApplicationFactory`.
+   */
+  implicit class CookieEndpointBaker(val appFactory: ApplicationFactory) {
+    def withAllCookieEndpoints[A: AsResult](block: CookieEndpoint => A): Fragment = {
+      appFactory.withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
+        block(new CookieEndpoint {
+          def call(path: String, cookies: List[okhttp3.Cookie]): (okhttp3.Response, List[okhttp3.Cookie]) = {
+            var responseCookies: List[okhttp3.Cookie] = null
+            val cookieJar = new CookieJar {
+              override def loadForRequest(url: HttpUrl): util.List[okhttp3.Cookie] = {
+                JavaConverters.seqAsJavaList(cookies)
+              }
+              override def saveFromResponse(url: HttpUrl, cookies: util.List[okhttp3.Cookie]): Unit = {
+                assert(responseCookies == null, "This CookieJar only handles a single response")
+                responseCookies = JavaConverters.collectionAsScalaIterable(cookies).toList
+              }
+            }
+            val client = okEndpoint.clientBuilder.followRedirects(false).cookieJar(cookieJar).build()
+            val request = new okhttp3.Request.Builder().url(okEndpoint.endpoint.pathUrl(path)).build()
+            val response = client.newCall(request).execute()
+            val siteUrl = okhttp3.HttpUrl.parse(okEndpoint.endpoint.pathUrl("/"))
+            assert(responseCookies != null, "The CookieJar should have received a response by now")
+            (response, responseCookies)
+          }
+        })
+      }
+    }
+
   }
 
   lazy val flashCookieBaker: FlashCookieBaker = new DefaultFlashCookieBaker()
 
-  def readFlashCookie(response: WSResponse): Option[WSCookie] =
-    response.cookie(flashCookieBaker.COOKIE_NAME)
+  /** Represents a session cookie in OkHttp */
+  val SessionExpiry = HttpDate.MAX_DATE
+  /** Represents any expired cookie in OkHttp */
+  val PastExpiry = Long.MinValue
 
   "the flash cookie" should {
-    "can be set for one request" in withClientAndServer() { ws =>
-      val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
-      response.status must equalTo(SEE_OTHER)
-      val flashCookie = readFlashCookie(response)
-      flashCookie must beSome.like {
-        case cookie =>
-          cookie.maxAge must beNone
-      }
-    }
 
-    "be removed after a redirect" in withClientAndServer() { ws =>
-      val response = await(ws.url("/flash").get())
-      response.status must equalTo(OK)
-      val flashCookie = readFlashCookie(response)
-      flashCookie must beSome.like {
+    "be set for first request and removed on next request" in withFlashCookieApp().withAllCookieEndpoints { fcep: CookieEndpoint =>
+      // Make a request that returns a flash cookie
+      val (response1, cookies1) = fcep.call("/flash", Nil)
+      response1.code must equalTo(SEE_OTHER)
+      val flashCookie1 = cookies1.find(_.name == flashCookieBaker.COOKIE_NAME)
+      flashCookie1 must beSome.like {
+        case cookie =>
+          cookie.expiresAt must ===(SessionExpiry)
+      }
+
+      // Send back the flash cookie
+      val redirectLocation = response1.header("Location")
+      val (response2, cookies2) = fcep.call(redirectLocation, List(flashCookie1.get))
+
+      // The returned flash cookie should now be cleared
+      val flashCookie2 = cookies2.find(_.name == flashCookieBaker.COOKIE_NAME)
+      flashCookie2 must beSome.like {
         case cookie =>
           cookie.value must ===("")
-          cookie.maxAge must beSome(0L)
+          cookie.expiresAt must ===(PastExpiry)
       }
     }
 
-    "allow the setting of additional cookies when cleaned up" in withClientAndServer() { ws =>
-      val response = await(ws.url("/flash").withFollowRedirects(false).get())
-      val Some(flashCookie) = readFlashCookie(response)
-      val response2 = await(ws.url("/set-cookie")
-        .addCookies(DefaultWSCookie(flashCookie.name, flashCookie.value))
-        .get())
-
-      readFlashCookie(response2) must beSome.like {
-        case cookie => cookie.value must ===("")
-      }
-      response2.cookie("some-cookie") must beSome.like {
+    "allow the setting of additional cookies when cleaned up" in withFlashCookieApp().withAllCookieEndpoints { fcep: CookieEndpoint =>
+      // Get a flash cookie
+      val (response1, cookies1) = fcep.call("/flash", Nil)
+      response1.code must equalTo(SEE_OTHER)
+      val flashCookie1 = cookies1.find(_.name == flashCookieBaker.COOKIE_NAME).get
+      // Send request with flash cookie
+      val (response2, cookies2) = fcep.call("/set-cookie", List(flashCookie1))
+      val flashCookie2 = cookies2.find(_.name == flashCookieBaker.COOKIE_NAME)
+      // Flash cookie should be cleared
+      flashCookie2 must beSome.like {
         case cookie =>
-          cookie.value must ===("some-value")
+          cookie.value must ===("")
+          cookie.expiresAt must ===(PastExpiry)
+      }
+      // Another cookie should be set
+      val someCookie2 = cookies2.find(_.name == "some-cookie")
+      someCookie2 must beSome.like {
+        case cookie => cookie.value must ===("some-value")
       }
 
     }
 
     "honor the configuration for play.http.flash.sameSite" in {
-      "configured to null" in withClientAndServer(Map("play.http.flash.sameSite" -> null)) { ws =>
-        val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
-        response.status must equalTo(SEE_OTHER)
-        response.header(SET_COOKIE) must beSome.which(!_.contains("SameSite"))
+
+      "by not sending SameSite when configured to null" in withFlashCookieApp(Map("play.http.flash.sameSite" -> null)).withAllCookieEndpoints { fcep: CookieEndpoint =>
+        val (response, cookies) = fcep.call("/flash", Nil)
+        response.code must equalTo(SEE_OTHER)
+        response.header(SET_COOKIE) must not contain ("SameSite")
       }
 
-      "configured to lax" in withClientAndServer(Map("play.http.flash.sameSite" -> "lax")) { ws =>
-        val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
-        response.status must equalTo(SEE_OTHER)
-        response.header(SET_COOKIE) must beSome.which(_.contains("SameSite=Lax"))
+      "by sending SameSite=Lax when configured with 'lax'" in withFlashCookieApp(Map("play.http.flash.sameSite" -> "lax")).withAllCookieEndpoints { fcep: CookieEndpoint =>
+        val (response, cookies) = fcep.call("/flash", Nil)
+        response.code must equalTo(SEE_OTHER)
+        response.header(SET_COOKIE) must contain("SameSite=Lax")
       }
 
-      "configured to strict" in withClientAndServer(Map("play.http.flash.sameSite" -> "strict")) { ws =>
-        val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
-        response.status must equalTo(SEE_OTHER)
-        response.header(SET_COOKIE) must beSome.which(_.contains("SameSite=Strict"))
+      "by sending SameSite=Strict when configured with 'strict'" in withFlashCookieApp(Map("play.http.flash.sameSite" -> "lax")).withAllCookieEndpoints { fcep: CookieEndpoint =>
+        val (response, cookies) = fcep.call("/flash", Nil)
+        response.code must equalTo(SEE_OTHER)
+        response.header(SET_COOKIE) must contain("SameSite=Lax")
       }
+
     }
 
     "honor configuration for flash.secure" in {
-      "configured to true" in Helpers.running(_.configure("play.http.flash.secure" -> true)) { _ =>
-        val secretConfig = SecretConfiguration()
-        val fcb: FlashCookieBaker = new DefaultFlashCookieBaker(
-          FlashConfiguration(secure = true),
-          secretConfig,
-          new CookieSignerProvider(secretConfig).get
-        )
-        fcb.encodeAsCookie(Flash()).secure must beTrue
+
+      "by making cookies secure when set to true" in withFlashCookieApp(Map("play.http.flash.secure" -> true)).withAllCookieEndpoints { fcep: CookieEndpoint =>
+        val (response, cookies) = fcep.call("/flash", Nil)
+        response.code must equalTo(SEE_OTHER)
+        val cookie = cookies.find(_.name == flashCookieBaker.COOKIE_NAME)
+        cookie must beSome.which(_.secure)
       }
 
-      "configured to false" in Helpers.running(_.configure("play.http.flash.secure" -> false)) { _ =>
-        val secretConfig = SecretConfiguration()
-        val fcb: FlashCookieBaker = new DefaultFlashCookieBaker(
-          FlashConfiguration(secure = false),
-          secretConfig,
-          new CookieSignerProvider(secretConfig).get
-        )
-        fcb.encodeAsCookie(Flash()).secure must beFalse
+      "by not making cookies secure when set to false" in withFlashCookieApp(Map("play.http.flash.secure" -> false)).withAllCookieEndpoints { fcep: CookieEndpoint =>
+        val (response, cookies) = fcep.call("/flash", Nil)
+        response.code must equalTo(SEE_OTHER)
+        val cookie = cookies.find(_.name == flashCookieBaker.COOKIE_NAME)
+        cookie must beSome.which(!_.secure)
       }
+
     }
 
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
@@ -12,7 +12,7 @@ import play.api.routing.sird
 import play.api.test.PlaySpecification
 import play.it.test._
 
-class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
+class UriHandlingSpec extends PlaySpecification with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
 
   private def makeRequest[T: AsResult](path: String)(block: (ServerEndpoint, okhttp3.Response) => T): Fragment = withRouter { components: BuiltInComponents =>
     import components.{ defaultActionBuilder => Action }
@@ -22,7 +22,7 @@ class UriHandlingSpec extends PlaySpecification with AllEndpointsIntegrationSpec
       case _ => Action { request: Request[_] => Results.Ok(request.path + queryToString(request.queryString)) }
     }
   }.withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
-    val response: okhttp3.Response = okEndpoint.makeRequest(path)
+    val response: okhttp3.Response = okEndpoint.call(path)
     block(okEndpoint.endpoint, response)
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/ApplicationFactory.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/ApplicationFactory.scala
@@ -26,10 +26,12 @@ trait ApplicationFactories {
   def withComponents(components: => BuiltInComponents): ApplicationFactory = new ApplicationFactory {
     override def create(): Application = components.application
   }
-  def withRouter(createRouter: BuiltInComponents => Router): ApplicationFactory = withComponents {
+  def withRouter(createRouter: BuiltInComponents => Router): ApplicationFactory =
+    withConfigAndRouter(Map.empty)(createRouter)
+  def withConfigAndRouter(extraConfig: Map[String, Any])(createRouter: BuiltInComponents => Router): ApplicationFactory = withComponents {
     val context = ApplicationLoader.createContext(
       environment = Environment.simple(),
-      initialSettings = Map[String, AnyRef](Play.GlobalAppConfigKey -> java.lang.Boolean.FALSE)
+      initialSettings = Map[String, AnyRef](Play.GlobalAppConfigKey -> java.lang.Boolean.FALSE) ++ extraConfig.asInstanceOf[Map[String, AnyRef]]
     )
     new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
       override lazy val router: Router = createRouter(this)

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -19,19 +19,32 @@ trait EndpointIntegrationSpecification
     extends SpecLike with PendingUntilFixed
     with ServerEndpoints with ApplicationFactories {
 
+  private def http2Conf(enabled: Boolean): Configuration = Configuration("play.server.akka.http2.enabled" -> enabled)
+
+  private val Netty11Plaintext = new HttpServerEndpointRecipe("Netty HTTP/1.1 (plaintext)", NettyServer.provider, Configuration.empty, Set("1.0", "1.1"), Option("netty"))
+  private val Netty11Encrypted = new HttpsServerEndpointRecipe("Netty HTTP/1.1 (encrypted)", NettyServer.provider, Configuration.empty, Set("1.0", "1.1"), Option("netty"))
+  private val AkkaHttp11Plaintext = new HttpServerEndpointRecipe("Akka HTTP HTTP/1.1 (plaintext)", AkkaHttpServer.provider, http2Conf(false), Set("1.0", "1.1"), None)
+  private val AkkaHttp11Encrypted = new HttpsServerEndpointRecipe("Akka HTTP HTTP/1.1 (encrypted)", AkkaHttpServer.provider, http2Conf(false), Set("1.0", "1.1"), None)
+  private val AkkaHttp20Encrypted = new HttpsServerEndpointRecipe("Akka HTTP HTTP/2 (encrypted)", AkkaHttpServer.provider, http2Conf(true), Set("1.0", "1.1", "2"), None)
+
   /**
    * The list of server endpoints supported by this specification.
-   * @return
    */
-  def allEndpointRecipes: Seq[ServerEndpointRecipe]
+  private val allEndpointRecipes: Seq[ServerEndpointRecipe] = Seq(
+    Netty11Plaintext,
+    Netty11Encrypted,
+    AkkaHttp11Plaintext,
+    AkkaHttp11Encrypted,
+    AkkaHttp20Encrypted
+  )
 
   /**
    * Implicit class that enhances [[ApplicationFactory]] with the [[withAllEndpoints()]] method.
    */
   implicit class ApplicationFactoryEndpointBaker(val appFactory: ApplicationFactory) {
     /**
-     * Helper that creates a specs2 fragment for the server endpoints given in
-     * [[allEndpointRecipes]]. Each fragment creates an application, starts a server
+     * Helper that creates a specs2 fragment for the given server endpoints.
+     * Each fragment creates an application, starts a server
      * and runs the given block of code.
      *
      * {{{
@@ -41,13 +54,28 @@ trait EndpointIntegrationSpecification
      * }
      * }}}
      */
-    def withAllEndpoints[A: AsResult](block: ServerEndpoint => A): Fragment = {
-      allEndpointRecipes.map { endpointRecipe: ServerEndpointRecipe =>
+    def withEndpoints[A: AsResult](endpoints: Seq[ServerEndpointRecipe])(block: ServerEndpoint => A): Fragment = {
+      endpoints.map { endpointRecipe: ServerEndpointRecipe =>
         s"with ${endpointRecipe.description}" >> {
           withEndpoint(endpointRecipe, appFactory)(block)
         }
       }.last
     }
+
+    /**
+     * Helper that creates a specs2 fragment for all the server endpoints supported
+     * by Play. Each fragment creates an application, starts a server
+     * and runs the given block of code.
+     *
+     * {{{
+     * withResult(Results.Ok("Hello")) withAllEndpoints { endpoint: ServerEndpoint =>
+     *   val response = ... connect to endpoint.port ...
+     *   response.status must_== 200
+     * }
+     * }}}
+     */
+    def withAllEndpoints[A: AsResult](block: ServerEndpoint => A): Fragment =
+      withEndpoints(allEndpointRecipes)(block)
   }
 
   /**
@@ -77,20 +105,3 @@ trait EndpointIntegrationSpecification
   }
 
 }
-
-/**
- * Mixin for an integration test that wants to test against supported servers and protocols.
- */
-trait AllEndpointsIntegrationSpecification extends EndpointIntegrationSpecification {
-  override val allEndpointRecipes: Seq[ServerEndpointRecipe] = {
-    def http2Conf(enabled: Boolean): Configuration = Configuration("play.server.akka.http2.enabled" -> enabled)
-    Seq(
-      new HttpServerEndpointRecipe("Netty HTTP/1.1 via HTTP", NettyServer.provider, Configuration.empty, Set("1.0", "1.1"), Option("netty")),
-      new HttpsServerEndpointRecipe("Netty HTTP/1.1 via HTTPS", NettyServer.provider, Configuration.empty, Set("1.0", "1.1"), Option("netty")),
-      new HttpServerEndpointRecipe("akka-http HTTP/1.1 via HTTP", AkkaHttpServer.provider, http2Conf(false), Set("1.0", "1.1"), None),
-      new HttpsServerEndpointRecipe("akka-http HTTP/1.1 via HTTPS", AkkaHttpServer.provider, http2Conf(false), Set("1.0", "1.1"), None),
-      new HttpsServerEndpointRecipe("akka-http HTTP/2 via HTTPS", AkkaHttpServer.provider, http2Conf(true), Set("1.0", "1.1", "2"), None)
-    )
-  }
-}
-

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
@@ -11,12 +11,12 @@ import play.api.test.PlaySpecification
 /**
  * Tests that the [[EndpointIntegrationSpecification]] works properly.
  */
-class EndpointIntegrationSpecificationSpec extends PlaySpecification with AllEndpointsIntegrationSpecification with OkHttpEndpointSupport {
+class EndpointIntegrationSpecificationSpec extends PlaySpecification with EndpointIntegrationSpecification with OkHttpEndpointSupport {
 
   "Endpoints" should {
     "respond with the highest supported HTTP protocol" in {
       withResult(Results.Ok("Hello")) withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
-        val response: Response = okEndpoint.makeRequest("/")
+        val response: Response = okEndpoint.call("/")
         val protocol = response.protocol
         if (okEndpoint.endpoint.expectedHttpVersions.contains("2")) {
           protocol must_== Protocol.HTTP_2
@@ -33,7 +33,7 @@ class EndpointIntegrationSpecificationSpec extends PlaySpecification with AllEnd
         Results.Ok(request.attrs.get(RequestAttrKey.Server).toString)
       }
     }.withAllOkHttpEndpoints { okHttpEndpoint: OkHttpEndpoint =>
-      val response: Response = okHttpEndpoint.makeRequest("/")
+      val response: Response = okHttpEndpoint.call("/")
       response.body.string must_== okHttpEndpoint.endpoint.expectedServerAttr.toString
     }
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSpec.scala
@@ -10,12 +10,12 @@ import play.api.test.PlaySpecification
 /**
  * Tests that [[OkHttpEndpointSupport]] works properly.
  */
-class OkHttpEndpointSpec extends PlaySpecification with AllEndpointsIntegrationSpecification with OkHttpEndpointSupport {
+class OkHttpEndpointSpec extends PlaySpecification with EndpointIntegrationSpecification with OkHttpEndpointSupport {
 
   "OkHttpEndpoint" should {
     "make a request and get a response" in {
       withResult(Results.Ok("Hello")) withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
-        val response: Response = okEndpoint.makeRequest("/")
+        val response: Response = okEndpoint.call("/")
         response.body.string must_== "Hello"
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/ServerEndpoints.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/ServerEndpoints.scala
@@ -28,6 +28,11 @@ trait ServerEndpoints {
     def expectedHttpVersions: Set[String]
     def expectedServerAttr: Option[String]
     final override def toString = description
+
+    /**
+     * Given a path create the URL to access that path at this endpoint.
+     */
+    final def pathUrl(path: String): String = s"$scheme://localhost:$port$path"
   }
   /** Represents an HTTP connection to a server. */
   trait HttpEndpoint extends ServerEndpoint {

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/WSEndpointSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/WSEndpointSpec.scala
@@ -10,7 +10,7 @@ import play.api.test.PlaySpecification
 /**
  * Tests that [[OkHttpEndpointSupport]] works properly.
  */
-class WSEndpointSpec extends PlaySpecification with AllEndpointsIntegrationSpecification with WSEndpointSupport {
+class WSEndpointSpec extends PlaySpecification with EndpointIntegrationSpecification with WSEndpointSupport {
 
   "WSEndpoint" should {
     "make a request and get a response" in {


### PR DESCRIPTION
Another test changed to use HTTP/2. Includes some minor refactoring to the endpoint testing code.