### PR TITLE
Fixes #7936 Check failure when writing an uploaded file

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -51,7 +51,7 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "play")
     .enablePlugins(SbtTwirl)
     .settings(
       libraryDependencies ++= runtime(scalaVersion.value) ++ scalacheckDependencies ++ cookieEncodingDependencies :+
-        ephemeralfs % Test,
+        jimfs % Test,
 
       sourceGenerators in Compile += Def.task(PlayVersion(
         version.value,

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -50,7 +50,8 @@ lazy val PlayJodaFormsProject = PlayCrossBuiltProject("Play-Joda-Forms", "play-j
 lazy val PlayProject = PlayCrossBuiltProject("Play", "play")
     .enablePlugins(SbtTwirl)
     .settings(
-      libraryDependencies ++= runtime(scalaVersion.value) ++ scalacheckDependencies ++ cookieEncodingDependencies,
+      libraryDependencies ++= runtime(scalaVersion.value) ++ scalacheckDependencies ++ cookieEncodingDependencies :+
+        "com.github.sbridges" % "ephemeralfs" % "1.0.1.0" % Test,
 
       sourceGenerators in Compile += Def.task(PlayVersion(
         version.value,

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -51,7 +51,7 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "play")
     .enablePlugins(SbtTwirl)
     .settings(
       libraryDependencies ++= runtime(scalaVersion.value) ++ scalacheckDependencies ++ cookieEncodingDependencies :+
-        "com.github.sbridges" % "ephemeralfs" % "1.0.1.0" % Test,
+        ephemeralfs % Test,
 
       sourceGenerators in Compile += Def.task(PlayVersion(
         version.value,

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -161,7 +161,7 @@ object Dependencies {
 
   val cookieEncodingDependencies = slf4j
 
-  val ephemeralfs = "com.github.sbridges" % "ephemeralfs" % "1.0.1.0"
+  val jimfs = "com.google.jimfs" % "jimfs" % "1.1"
 
   val okHttp = "com.squareup.okhttp3" % "okhttp" % "3.9.0"
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -161,6 +161,8 @@ object Dependencies {
 
   val cookieEncodingDependencies = slf4j
 
+  val ephemeralfs = "com.github.sbridges" % "ephemeralfs" % "1.0.1.0"
+
   val okHttp = "com.squareup.okhttp3" % "okhttp" % "3.9.0"
 
   def routesCompilerDependencies(scalaVersion: String) = Seq(

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -123,9 +123,9 @@ object Multipart {
   def handleFilePartAsTemporaryFile(temporaryFileCreator: TemporaryFileCreator): FilePartHandler[TemporaryFile] = {
     case FileInfo(partName, filename, contentType) =>
       val tempFile = temporaryFileCreator.create("multipartBody", "asTemporaryFile")
-      Accumulator(FileIO.toPath(tempFile.path)).map {
-        case IOResult(_, Success(_)) => FilePart(partName, filename, contentType, tempFile)
-        case IOResult(_, Failure(error)) => throw error
+      Accumulator(FileIO.toPath(tempFile.path)).mapFuture {
+        case IOResult(_, Failure(error)) => Future.failed(error)
+        case _                           => Future.successful(FilePart(partName, filename, contentType, tempFile))
       }
   }
 

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -114,9 +114,7 @@ object Multipart {
 
       }
 
-      multipartAccumulator.through(handleFileParts).recoverWith {
-        case t => errorHandler.onServerError(request, t).map(Left(_))
-      }
+      multipartAccumulator.through(handleFileParts)
     }.apply(request)
   }
 
@@ -125,10 +123,9 @@ object Multipart {
   def handleFilePartAsTemporaryFile(temporaryFileCreator: TemporaryFileCreator): FilePartHandler[TemporaryFile] = {
     case FileInfo(partName, filename, contentType) =>
       val tempFile = temporaryFileCreator.create("multipartBody", "asTemporaryFile")
-
       Accumulator(FileIO.toPath(tempFile.path)).mapFuture {
         case IOResult(_, Failure(error)) => Future.failed(error)
-        case _ => Future.successful(FilePart(partName, filename, contentType, tempFile))
+        case _                           => Future.successful(FilePart(partName, filename, contentType, tempFile))
       }
   }
 

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -7,10 +7,11 @@ import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 import scala.collection.breakOut
 import scala.concurrent.Future
+import scala.util.{ Failure, Success }
 
 import akka.stream.Materializer
 import akka.stream.scaladsl._
-import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import akka.stream.{ Attributes, FlowShape, Inlet, IOResult, Outlet }
 import akka.stream.stage._
 import akka.util.ByteString
 
@@ -122,8 +123,9 @@ object Multipart {
   def handleFilePartAsTemporaryFile(temporaryFileCreator: TemporaryFileCreator): FilePartHandler[TemporaryFile] = {
     case FileInfo(partName, filename, contentType) =>
       val tempFile = temporaryFileCreator.create("multipartBody", "asTemporaryFile")
-      Accumulator(FileIO.toPath(tempFile.path)).map { _ =>
-        FilePart(partName, filename, contentType, tempFile)
+      Accumulator(FileIO.toPath(tempFile.path)).map {
+        case IOResult(_, Success(_)) => FilePart(partName, filename, contentType, tempFile)
+        case IOResult(_, Failure(error)) => throw error
       }
   }
 

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -125,7 +125,7 @@ object Multipart {
       val tempFile = temporaryFileCreator.create("multipartBody", "asTemporaryFile")
       Accumulator(FileIO.toPath(tempFile.path)).mapFuture {
         case IOResult(_, Failure(error)) => Future.failed(error)
-        case _                           => Future.successful(FilePart(partName, filename, contentType, tempFile))
+        case _ => Future.successful(FilePart(partName, filename, contentType, tempFile))
       }
   }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/InMemoryTemporaryFileCreator.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/InMemoryTemporaryFileCreator.scala
@@ -1,0 +1,31 @@
+package play.api.mvc
+
+import java.io.File
+import java.nio.file.{ FileSystem, Path, Files => JFiles }
+
+import com.github.sbridges.ephemeralfs.EphemeralFsFileSystemBuilder
+import play.api.libs.Files.{ TemporaryFile, TemporaryFileCreator }
+
+import scala.util.Try
+
+class InMemoryTemporaryFile(val path: Path, val temporaryFileCreator: TemporaryFileCreator) extends TemporaryFile {
+  def file: File = path.toFile
+}
+
+class InMemoryTemporaryFileCreator(totalSpace: Long) extends TemporaryFileCreator {
+  val fs: FileSystem = EphemeralFsFileSystemBuilder
+    .unixFs()
+    .setTotalSpace(totalSpace)
+    .build()
+  private val playTempFolder: Path = fs.getPath("/tmp")
+
+  def create(prefix: String = "", suffix: String = ""): TemporaryFile = {
+    JFiles.createDirectories(playTempFolder)
+    val tempFile = JFiles.createTempFile(playTempFolder, prefix, suffix)
+    new InMemoryTemporaryFile(tempFile, this)
+  }
+
+  def create(path: Path): TemporaryFile = new InMemoryTemporaryFile(path, this)
+
+  def delete(file: TemporaryFile): Try[Boolean] = Try(JFiles.deleteIfExists(file.path))
+}

--- a/framework/src/play/src/test/scala/play/api/mvc/InMemoryTemporaryFileCreator.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/InMemoryTemporaryFileCreator.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api.mvc
 
 import java.io.File

--- a/framework/src/play/src/test/scala/play/api/mvc/InMemoryTemporaryFileCreator.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/InMemoryTemporaryFileCreator.scala
@@ -6,7 +6,7 @@ package play.api.mvc
 import java.io.File
 import java.nio.file.{ FileSystem, Path, Files => JFiles }
 
-import com.github.sbridges.ephemeralfs.EphemeralFsFileSystemBuilder
+import com.google.common.jimfs.{ Configuration, Jimfs }
 import play.api.libs.Files.{ TemporaryFile, TemporaryFileCreator }
 
 import scala.util.Try
@@ -16,10 +16,11 @@ class InMemoryTemporaryFile(val path: Path, val temporaryFileCreator: TemporaryF
 }
 
 class InMemoryTemporaryFileCreator(totalSpace: Long) extends TemporaryFileCreator {
-  val fs: FileSystem = EphemeralFsFileSystemBuilder
-    .unixFs()
-    .setTotalSpace(totalSpace)
+  private val fsConfig: Configuration = Configuration.unix
+    .toBuilder
+    .setMaxSize(totalSpace)
     .build()
+  private val fs: FileSystem = Jimfs.newFileSystem(fsConfig)
   private val playTempFolder: Path = fs.getPath("/tmp")
 
   def create(prefix: String = "", suffix: String = ""): TemporaryFile = {

--- a/framework/src/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
@@ -21,7 +21,7 @@ import scala.util.Random
 
 class MultipartBodyParserSpec extends Specification {
 
-  "Multipar body parser" should {
+  "Multipart body parser" should {
     implicit val system = ActorSystem()
     implicit val executionContext = system.dispatcher
     implicit val materializer = ActorMaterializer()

--- a/framework/src/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
@@ -4,20 +4,16 @@
 package play.api.mvc
 
 import java.io.IOException
-import java.nio.file.{ Files, Paths }
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{ FileIO, Source }
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.specs2.mutable.Specification
-import play.api.http.{ HttpEntity, HttpErrorHandler }
 import play.core.test.{ FakeHeaders, FakeRequest }
 
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import scala.util.Random
 
 class MultipartBodyParserSpec extends Specification {
 

--- a/framework/src/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
@@ -1,0 +1,77 @@
+package play.api.mvc
+
+import java.io.IOException
+import java.nio.file.{ Files, Paths }
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ FileIO, Source }
+import akka.util.ByteString
+import org.specs2.mutable.Specification
+import play.api.http.{ HttpEntity, HttpErrorHandler }
+import play.core.test.{ FakeHeaders, FakeRequest }
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.Duration
+import scala.util.Random
+
+class MultipartBodyParserSpec extends Specification {
+
+  "Multipar body parser" should {
+    implicit val system = ActorSystem()
+    implicit val executionContext = system.dispatcher
+    implicit val materializer = ActorMaterializer()
+
+    class CustomHttpErrorHandler extends HttpErrorHandler {
+      def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = ???
+      def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+        val responseHeader = new ResponseHeader(status = 500, reasonPhrase = Some(exception.getMessage))
+        Future.successful(Result(header = responseHeader, body = HttpEntity.NoEntity))
+      }
+    }
+
+    val playBodyParsers = PlayBodyParsers(
+      tfc = new InMemoryTemporaryFileCreator(10),
+      eh = new CustomHttpErrorHandler)
+
+    "return an error if temporary file creation fails" in {
+
+      val fileSize = 100
+      val boundary = "-----------------------------14568445977970839651285587160"
+      val header =
+        s"--$boundary\r\n" +
+          "Content-Disposition: form-data; name=\"uploadedfile\"; filename=\"uploadedfile.txt\"\r\n" +
+          "Content-Type: application/octet-stream\r\n" +
+          "\r\n"
+      val content = Array.ofDim[Byte](fileSize)
+      val footer =
+        "\r\n" +
+          "\r\n" +
+          s"--$boundary--\r\n"
+
+      val body = Source(
+        ByteString(header) ::
+          ByteString(content) ::
+          ByteString(footer) ::
+          Nil)
+
+      val bodySize = header.length + fileSize + footer.length
+
+      val request = FakeRequest(
+        method = "POST",
+        uri = "/x",
+        headers = FakeHeaders(Seq(
+          "Content-Type" -> s"multipart/form-data; boundary=$boundary",
+          "Content-Length" -> bodySize.toString)),
+        body = body)
+
+      val response = playBodyParsers.multipartFormData.apply(request).run(body)
+      Await.result(response, Duration.Inf) must beLeft.like {
+        case result =>
+          result.header.status must_=== 500
+          result.header.reasonPhrase must beSome("Out of disk space")
+      }
+    }
+  }
+}

--- a/framework/src/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api.mvc
 
 import java.io.IOException


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [X] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [X] Have you added tests for any changed functionality?

# Helpful things

Fixes #7936 

## Purpose

The PR check IOResult provided by FileIO.toPath when a temporary file is created.
If file creation fails, the error is reported to error handler.