### PR TITLE
Update play-file-watch to 1.1.3

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -173,7 +173,7 @@ object Dependencies {
   }
 
   def playFileWatch(sbtVersion: String): ModuleID = CrossVersion.binarySbtVersion(sbtVersion) match {
-    case "1.0" => "com.lightbend.play" %% "play-file-watch" % "1.1.2"
+    case "1.0" => "com.lightbend.play" %% "play-file-watch" % "1.1.3"
     case "0.13" => "com.lightbend.play" %% "play-file-watch" % "1.0.0"
   }
 


### PR DESCRIPTION
This fixes a bug that would crash the watcher if a file is created and deleted before the watcher gets a chance to process the creation event.