### PR TITLE
Fix TODO in BodyParser documentation -- Wrap source body within StreamedBody

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -113,8 +113,7 @@ import org.specs2.execute.AsResult
           def forward(request: WSRequest): BodyParser[WSResponse] = BodyParser { req =>
             Accumulator.source[ByteString].mapFuture { source =>
               request
-                // TODO: stream body when support is implemented
-                // .withBody(source)
+                .withBody(StreamedBody(source))
                 .execute()
                 .map(Right.apply)
             }


### PR DESCRIPTION
The solution is documented here: https://www.playframework.com/documentation/2.5.x/ScalaWS#Streaming-data

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
  --> The JavaDoc doesn't have this TODO
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

TODO in ScalaBodyParsers documentation, https://www.playframework.com/documentation/2.5.x/ScalaBodyParsers#Directing-the-body-elsewhere

## Purpose

## Background Context

## References
