### PR TITLE
make it possible to disable the assets jar

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -106,6 +106,7 @@ object PlayImport extends PlayImportCompat {
     val updateSecret = TaskKey[File]("playUpdateSecret", "Update the application conf to generate an application secret", KeyRanks.BTask)
 
     val assetsPrefix = SettingKey[String]("assetsPrefix")
+    val generateAssetsJar = TaskKey[Boolean]("generateAssetsJar")
     val playPackageAssets = TaskKey[File]("playPackageAssets")
 
     val playMonitoredFiles = TaskKey[Seq[File]]("playMonitoredFiles")

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -58,6 +58,7 @@ object PlaySettings extends PlaySettingsCompat {
 
     playPlugin := false,
 
+    generateAssetsJar := true,
     externalizeResources := true,
 
     includeDocumentationInBinary := true,
@@ -263,11 +264,21 @@ object PlaySettings extends PlaySettingsCompat {
     // Assets for distribution
     WebKeys.packagePrefix in Assets := assetsPrefix.value,
     playPackageAssets := (packageBin in Assets).value,
-    scriptClasspathOrdering += {
-      val (id, art) = (projectID.value, (artifact in (Assets, packageBin)).value)
-      val jarName = JavaAppPackaging.makeJarName(id.organization, id.name, id.revision, art.name, Some("assets"))
-      playPackageAssets.value -> ("lib/" + jarName)
-    },
+    scriptClasspathOrdering := Def.taskDyn {
+      val oldValue = scriptClasspathOrdering.value
+      // only create a assets-jar if the task is active
+      // this actually disables calling playPackageAssets, which in turn would call packageBin in Assets
+      // without these calls no assets jar will be created
+      if (generateAssetsJar.value) {
+        Def.task {
+          val (id, art) = (projectID.value, (artifact in (Assets, packageBin)).value)
+          val jarName = JavaAppPackaging.makeJarName(id.organization, id.name, id.revision, art.name, Some("assets"))
+          oldValue :+ playPackageAssets.value -> ("lib/" + jarName)
+        }
+      } else {
+        Def.task(oldValue)
+      }
+    }.value,
 
     // Assets for testing
     public in TestAssets := (public in TestAssets).value / assetsPrefix.value,

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/app/assets/main.less
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/app/assets/main.less
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+h2 {
+  color: red;
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/app/assets/main.less
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/app/assets/main.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 h2 {
   color: red;

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+// Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
 //
 
 import java.net.URLClassLoader

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
@@ -1,0 +1,18 @@
+//
+// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+//
+
+import java.net.URLClassLoader
+import com.typesafe.sbt.packager.Keys.executableScriptName
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala)
+  .enablePlugins(MediatorWorkaroundPlugin)
+  .settings(
+    name := "assets-sample",
+    version := "1.0-SNAPSHOT",
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.3"),
+    includeFilter in (Assets, LessKeys.less) := "*.less",
+    excludeFilter in (Assets, LessKeys.less) := "_*.less",
+    generateAssetsJar := false
+  )

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
@@ -14,5 +14,5 @@ lazy val root = (project in file("."))
     scalaVersion := sys.props.get("scala.version").getOrElse("2.12.3"),
     includeFilter in (Assets, LessKeys.less) := "*.less",
     excludeFilter in (Assets, LessKeys.less) := "_*.less",
-    generateAssetsJar := false
+    PlayKeys.generateAssetsJar := false
   )

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/project/plugins.sbt
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+// Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
 //
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/test
@@ -1,0 +1,3 @@
+# Check that no assets jar will be created
+> stage
+-$ exists target/universal/stage/lib/assets-sample.assets-sample-1.0-SNAPSHOT-assets.jar


### PR DESCRIPTION
Currently this adds a way to disable `-assets.jar` by setting `playAssetsJar := false`.
At the moment I do not use anything from `sbt-web` Thus I either get a [Empty Assets Jar](https://github.com/playframework/playframework/issues/7570) or I actually get my assets packaged into the application jar and the assets jar.

Basically this allows to disable the assets.jar completly and disable the `packageBin in Assets` task.
This allows better packaging assets that come from other sources, like a npm project, etc.

This somewhat fixes #7570 (not automatically tough).
