### PR TITLE
Provide an action the information about its origin

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
@@ -59,6 +59,23 @@ Then in an action you can get the arg like this:
 
 @[pass-arg-action-index](code/javaguide/http/JavaActionsComposition.java)
 
+## Debugging the action composition order
+
+To see in which order the actions of the action composition chain will be executed, please add the following to `logback.xml`:
+
+```
+<logger name="play.mvc.Action" level="DEBUG" />
+```
+
+You will now see the whole action composition chain with the according annotations (and their associated method/controller) in the logs:
+
+```
+[debug] play.mvc.Action - ### Start of action order
+[debug] play.mvc.Action - 1. ...
+[debug] play.mvc.Action - 2. ...
+[debug] play.mvc.Action - ### End of action order
+```
+
 ## Using Dependency Injection
 
 You can use [[runtime Dependency Injection|JavaDependencyInjection]] or [[compile-time Dependency Injection|JavaCompileTimeDependencyInjection]]together with action composition. 

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionActionCreator.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionActionCreator.java
@@ -19,7 +19,7 @@ public class ActionCompositionActionCreator implements ActionCreator {
             @Override
             public CompletionStage<Result> call(Http.Context ctx) {
                 return delegate.call(ctx).thenApply(result -> {
-                    String newContent = this.origin + "actioncreator" + Helpers.contentAsString(result);
+                    String newContent = "actioncreator" + Helpers.contentAsString(result);
                     return Results.ok(newContent);
                 });
             }

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionActionCreator.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionActionCreator.java
@@ -19,7 +19,7 @@ public class ActionCompositionActionCreator implements ActionCreator {
             @Override
             public CompletionStage<Result> call(Http.Context ctx) {
                 return delegate.call(ctx).thenApply(result -> {
-                    String newContent = "actioncreator" + Helpers.contentAsString(result);
+                    String newContent = this.origin + "actioncreator" + Helpers.contentAsString(result);
                     return Results.ok(newContent);
                 });
             }

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
@@ -23,7 +23,7 @@ public class ActionCompositionOrderTest {
         @Override
         public CompletionStage<Result> call(Http.Context ctx) {
             return delegate.call(ctx).thenApply(result -> {
-                String newContent = "controller" + Helpers.contentAsString(result);
+                String newContent = this.origin + "controller" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });
         }
@@ -38,7 +38,7 @@ public class ActionCompositionOrderTest {
         @Override
         public CompletionStage<Result> call(Http.Context ctx) {
             return delegate.call(ctx).thenApply(result -> {
-                String newContent = "action" + Helpers.contentAsString(result);
+                String newContent = this.origin + "action" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });
         }

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
@@ -23,7 +23,7 @@ public class ActionCompositionOrderTest {
         @Override
         public CompletionStage<Result> call(Http.Context ctx) {
             return delegate.call(ctx).thenApply(result -> {
-                String newContent = this.origin + "controller" + Helpers.contentAsString(result);
+                String newContent = this.annotatedElement.getClass().getName() + "controller" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });
         }
@@ -38,7 +38,7 @@ public class ActionCompositionOrderTest {
         @Override
         public CompletionStage<Result> call(Http.Context ctx) {
             return delegate.call(ctx).thenApply(result -> {
-                String newContent = this.origin + "action" + Helpers.contentAsString(result);
+                String newContent = this.annotatedElement.getClass().getName() + "action" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });
         }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -86,13 +86,13 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true")) { response =>
-      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontrollerACTION_ANNOTATIONaction")
+      response.body must beEqualTo("java.lang.Classcontrollerjava.lang.reflect.Methodaction")
     }
 
     "execute controller composition when action is not annotated" in makeRequest(new ComposedController {
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true")) { response =>
-      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontroller")
+      response.body must beEqualTo("java.lang.Classcontroller")
     }
   }
 
@@ -101,21 +101,21 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false")) { response =>
-      response.body must beEqualTo("ACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontroller")
+      response.body must beEqualTo("java.lang.reflect.Methodactionjava.lang.Classcontroller")
     }
 
     "execute action composition when controller is not annotated" in makeRequest(new MockController {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false")) { response =>
-      response.body must beEqualTo("ACTION_ANNOTATIONaction")
+      response.body must beEqualTo("java.lang.reflect.Methodaction")
     }
 
     "execute action composition first is the default" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }) { response =>
-      response.body must beEqualTo("ACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontroller")
+      response.body must beEqualTo("java.lang.reflect.Methodactionjava.lang.Classcontroller")
     }
   }
 
@@ -169,7 +169,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_CREATORactioncreatorACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontroller")
+      response.body must beEqualTo("actioncreatorjava.lang.reflect.Methodactionjava.lang.Classcontroller")
     }
 
     "execute request handler action first and controller composition before action composition" in makeRequest(new ComposedController {
@@ -179,7 +179,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_CREATORactioncreatorCONTROLLER_ANNOTATIONcontrollerACTION_ANNOTATIONaction")
+      response.body must beEqualTo("actioncreatorjava.lang.Classcontrollerjava.lang.reflect.Methodaction")
     }
 
     "execute request handler action first with only controller composition" in makeRequest(new ComposedController {
@@ -187,7 +187,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_CREATORactioncreatorCONTROLLER_ANNOTATIONcontroller")
+      response.body must beEqualTo("actioncreatorjava.lang.Classcontroller")
     }
 
     "execute request handler action first with only action composition" in makeRequest(new MockController {
@@ -196,7 +196,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_CREATORactioncreatorACTION_ANNOTATIONaction")
+      response.body must beEqualTo("actioncreatorjava.lang.reflect.Methodaction")
     }
   }
 
@@ -208,7 +208,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontrollerACTION_CREATORactioncreator")
+      response.body must beEqualTo("java.lang.reflect.Methodactionjava.lang.Classcontrolleractioncreator")
     }
 
     "execute request handler action last and controller composition before action composition" in makeRequest(new ComposedController {
@@ -218,7 +218,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontrollerACTION_ANNOTATIONactionACTION_CREATORactioncreator")
+      response.body must beEqualTo("java.lang.Classcontrollerjava.lang.reflect.Methodactionactioncreator")
     }
 
     "execute request handler action last with only controller composition" in makeRequest(new ComposedController {
@@ -226,7 +226,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontrollerACTION_CREATORactioncreator")
+      response.body must beEqualTo("java.lang.Classcontrolleractioncreator")
     }
 
     "execute request handler action last with only action composition" in makeRequest(new MockController {
@@ -235,7 +235,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_ANNOTATIONactionACTION_CREATORactioncreator")
+      response.body must beEqualTo("java.lang.reflect.Methodactionactioncreator")
     }
 
     "execute request handler action last is the default and controller composition before action composition" in makeRequest(new ComposedController {
@@ -244,7 +244,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontrollerACTION_ANNOTATIONactionACTION_CREATORactioncreator")
+      response.body must beEqualTo("java.lang.Classcontrollerjava.lang.reflect.Methodactionactioncreator")
     }
 
     "execute request handler action last is the default and action composition before controller composition" in makeRequest(new ComposedController {
@@ -253,7 +253,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontrollerACTION_CREATORactioncreator")
+      response.body must beEqualTo("java.lang.reflect.Methodactionjava.lang.Classcontrolleractioncreator")
     }
   }
 
@@ -263,7 +263,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_CREATORactioncreator")
+      response.body must beEqualTo("actioncreator")
     }
 
     "execute request handler action first without action composition" in makeRequest(new MockController {
@@ -271,7 +271,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("ACTION_CREATORactioncreator")
+      response.body must beEqualTo("actioncreator")
     }
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -86,13 +86,13 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true")) { response =>
-      response.body must beEqualTo("controlleraction")
+      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontrollerACTION_ANNOTATIONaction")
     }
 
     "execute controller composition when action is not annotated" in makeRequest(new ComposedController {
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true")) { response =>
-      response.body must beEqualTo("controller")
+      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontroller")
     }
   }
 
@@ -101,21 +101,21 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false")) { response =>
-      response.body must beEqualTo("actioncontroller")
+      response.body must beEqualTo("ACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontroller")
     }
 
     "execute action composition when controller is not annotated" in makeRequest(new MockController {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false")) { response =>
-      response.body must beEqualTo("action")
+      response.body must beEqualTo("ACTION_ANNOTATIONaction")
     }
 
     "execute action composition first is the default" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }) { response =>
-      response.body must beEqualTo("actioncontroller")
+      response.body must beEqualTo("ACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontroller")
     }
   }
 
@@ -169,7 +169,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actioncreatoractioncontroller")
+      response.body must beEqualTo("ACTION_CREATORactioncreatorACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontroller")
     }
 
     "execute request handler action first and controller composition before action composition" in makeRequest(new ComposedController {
@@ -179,7 +179,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actioncreatorcontrolleraction")
+      response.body must beEqualTo("ACTION_CREATORactioncreatorCONTROLLER_ANNOTATIONcontrollerACTION_ANNOTATIONaction")
     }
 
     "execute request handler action first with only controller composition" in makeRequest(new ComposedController {
@@ -187,7 +187,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actioncreatorcontroller")
+      response.body must beEqualTo("ACTION_CREATORactioncreatorCONTROLLER_ANNOTATIONcontroller")
     }
 
     "execute request handler action first with only action composition" in makeRequest(new MockController {
@@ -196,7 +196,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actioncreatoraction")
+      response.body must beEqualTo("ACTION_CREATORactioncreatorACTION_ANNOTATIONaction")
     }
   }
 
@@ -208,7 +208,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actioncontrolleractioncreator")
+      response.body must beEqualTo("ACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontrollerACTION_CREATORactioncreator")
     }
 
     "execute request handler action last and controller composition before action composition" in makeRequest(new ComposedController {
@@ -218,7 +218,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("controlleractionactioncreator")
+      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontrollerACTION_ANNOTATIONactionACTION_CREATORactioncreator")
     }
 
     "execute request handler action last with only controller composition" in makeRequest(new ComposedController {
@@ -226,7 +226,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("controlleractioncreator")
+      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontrollerACTION_CREATORactioncreator")
     }
 
     "execute request handler action last with only action composition" in makeRequest(new MockController {
@@ -235,7 +235,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actionactioncreator")
+      response.body must beEqualTo("ACTION_ANNOTATIONactionACTION_CREATORactioncreator")
     }
 
     "execute request handler action last is the default and controller composition before action composition" in makeRequest(new ComposedController {
@@ -244,7 +244,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("controlleractionactioncreator")
+      response.body must beEqualTo("CONTROLLER_ANNOTATIONcontrollerACTION_ANNOTATIONactionACTION_CREATORactioncreator")
     }
 
     "execute request handler action last is the default and action composition before controller composition" in makeRequest(new ComposedController {
@@ -253,7 +253,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actioncontrolleractioncreator")
+      response.body must beEqualTo("ACTION_ANNOTATIONactionCONTROLLER_ANNOTATIONcontrollerACTION_CREATORactioncreator")
     }
   }
 
@@ -263,7 +263,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actioncreator")
+      response.body must beEqualTo("ACTION_CREATORactioncreator")
     }
 
     "execute request handler action first without action composition" in makeRequest(new MockController {
@@ -271,7 +271,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }, Map(
       "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
       "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
-      response.body must beEqualTo("actioncreator")
+      response.body must beEqualTo("ACTION_CREATORactioncreator")
     }
   }
 

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -3,6 +3,7 @@
  */
 package play.mvc;
 
+import java.lang.reflect.AnnotatedElement;
 import java.util.concurrent.CompletionStage;
 
 import play.mvc.Http.Context;
@@ -20,7 +21,7 @@ public abstract class Action<T> extends Results {
     /**
      * Where an action was defined.
      */
-    public Origin origin;
+    public AnnotatedElement annotatedElement;
 
     /**
      * The precursor action.
@@ -50,12 +51,5 @@ public abstract class Action<T> extends Results {
      * A simple action with no configuration.
      */
     public static abstract class Simple extends Action<Void> {}
-
-    public static enum Origin {
-        ROOT, // The root action which starts the whole composition chain
-        ACTION_CREATOR, // The action created by the action creator
-        CONTROLLER_ANNOTATION, // Action composition annotation on controller class
-        ACTION_ANNOTATION // Action composition annotation on action method
-    }
 
 }

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -18,6 +18,11 @@ public abstract class Action<T> extends Results {
     public T configuration;
 
     /**
+     * Where an action was defined.
+     */
+    public Origin origin;
+
+    /**
      * The precursor action.
      *
      * If this action was called in a chain then this will contain the value of the action
@@ -45,5 +50,12 @@ public abstract class Action<T> extends Results {
      * A simple action with no configuration.
      */
     public static abstract class Simple extends Action<Void> {}
+
+    public static enum Origin {
+        ROOT, // The root action which starts the whole composition chain
+        ACTION_CREATOR, // The action created by the action creator
+        CONTROLLER_ANNOTATION, // Action composition annotation on controller class
+        ACTION_ANNOTATION // Action composition annotation on action method
+    }
 
 }


### PR DESCRIPTION
When using action composition in Play Java there is no way to find out if the current executed action annotation was defined on a controller class or on an action method.

For some use cases that would be a very valuable information. E.g. in https://github.com/schaloner/deadbolt-2-java/pull/50 we are working towards a solution where deadbolt-contraints defined on an action method can fallback to the constraints defined at controller level (if desired by the developer). Unfortunately such things are impossible right now since we don't have any clue where an action was defined.
With this pull request we now get a field `origin` which provides us an enum value with the origin:

```java
public class SomeAnnotationAction extends Action<SomeAnnotation> {
    @Override
    public CompletionStage<Result> call(final Context ctx) {
        this.origin; // can be:
        // * ROOT (The root action which starts the whole composition chain)
        // * ACTION_CREATOR (The action created by the action creator)
        // * CONTROLLER_ANNOTATION (Action composition annotation on controller class)
        // * ACTION_ANNOTATION (Action composition annotation on action method)
    }
}
```