### PR TITLE
Provide an action the information about its precursor

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -18,6 +18,11 @@ public abstract class Action<T> extends Results {
     public T configuration;
 
     /**
+     * The precursor action.
+     */
+    public Action<?> precursor;
+
+    /**
      * The wrapped action.
      */
     public Action<?> delegate;

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -19,11 +19,17 @@ public abstract class Action<T> extends Results {
 
     /**
      * The precursor action.
+     *
+     * If this action was called in a chain then this will contain the value of the action
+     * that is called before this action. If no action was called first, then this value will be null.
      */
     public Action<?> precursor;
 
     /**
      * The wrapped action.
+     *
+     * If this action was called in a chain then this will contain the value of the action
+     * that is called after this action. If there is no action left to be called, then this value will be null.
      */
     public Action<?> delegate;
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -86,6 +86,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
       rootAction
     } else {
       baseAction.delegate = rootAction
+      rootAction.precursor = baseAction
       baseAction
     }
 
@@ -94,11 +95,13 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
         val action = handlerComponents.getAction(actionClass).asInstanceOf[play.mvc.Action[Object]]
         action.configuration = annotation
         action.delegate = delegate
+        delegate.precursor = action
         action
     }
 
     val finalAction = if (config.executeActionCreatorActionFirst) {
       baseAction.delegate = finalUserDeclaredAction
+      finalUserDeclaredAction.precursor = baseAction
       baseAction
     } else {
       finalUserDeclaredAction

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -85,8 +85,8 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
     val endOfChainAction = if (config.executeActionCreatorActionFirst) {
       rootAction
     } else {
-      baseAction.delegate = rootAction
       rootAction.precursor = baseAction
+      baseAction.delegate = rootAction
       baseAction
     }
 
@@ -94,14 +94,14 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
       case (delegate, (annotation, actionClass)) =>
         val action = handlerComponents.getAction(actionClass).asInstanceOf[play.mvc.Action[Object]]
         action.configuration = annotation
-        action.delegate = delegate
         delegate.precursor = action
+        action.delegate = delegate
         action
     }
 
     val finalAction = if (config.executeActionCreatorActionFirst) {
-      baseAction.delegate = finalUserDeclaredAction
       finalUserDeclaredAction.precursor = baseAction
+      baseAction.delegate = finalUserDeclaredAction
       baseAction
     } else {
       finalUserDeclaredAction


### PR DESCRIPTION
Follow up on #7964

As opposite to `delegate` it would be a valuable information to also have the `precursor` of an action in the Java action composition chain. (That makes the composition chain kind of like a double linked list).

That - with #7964 (for some cases) - would allow us to travel forth and backwards in the composition chain and look up things like "are there any (more) actions defined on an action/controller via an annotation are coming/have been processed already?" or "I am to last/first action method of a specific type?" and much much more.