### PR TITLE
Update to play-file-watch 1.1.5

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -173,7 +173,7 @@ object Dependencies {
   }
 
   def playFileWatch(sbtVersion: String): ModuleID = CrossVersion.binarySbtVersion(sbtVersion) match {
-    case "1.0" => "com.lightbend.play" %% "play-file-watch" % "1.1.3"
+    case "1.0" => "com.lightbend.play" %% "play-file-watch" % "1.1.5"
     case "0.13" => "com.lightbend.play" %% "play-file-watch" % "1.0.0"
   }
 


### PR DESCRIPTION
This version uses a version of directory-watcher that also has debug logging and logging of exceptions, which should make it easier to track down bugs in the future.