### PR TITLE
Use constant to refer to javascript mime type

### DIFF
--- a/framework/src/play-java/src/main/java/play/libs/Jsonp.java
+++ b/framework/src/play-java/src/main/java/play/libs/Jsonp.java
@@ -4,6 +4,7 @@
 package play.libs;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import play.mvc.Http.MimeTypes;
 import play.twirl.api.Content;
 
 /**
@@ -42,7 +43,7 @@ public class Jsonp implements Content {
 
     @Override
     public String contentType() {
-        return "text/javascript";
+        return MimeTypes.JAVASCRIPT;
     }
 
     private final String padding;


### PR DESCRIPTION
`text/javascript` is deprecated in favor of `application/javascript`