### PR TITLE
Fix documentation issue for WS SSL

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/WsSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/WsSSL.md
@@ -10,21 +10,21 @@ unlimited strength java cryptography extension.  You can download the policy fil
 
 ## Table of Contents
 
-The Play WS configuration is based on [Typesafe SSLConfig](https://typesafehub.github.io/ssl-config).  For convenience, a table of contents to SSLConfig is provided:
+The Play WS configuration is based on [Typesafe SSLConfig](https://lightbend.github.io/ssl-config).  For convenience, a table of contents to SSLConfig is provided:
 
-- [Quick Start to WS SSL](https://typesafehub.github.io/ssl-config/WSQuickStart.html)
-- [Generating X.509 Certificates](https://typesafehub.github.io/ssl-config/CertificateGeneration.html)
-- [Configuring Trust Stores and Key Stores](https://typesafehub.github.io/ssl-config/KeyStores.html)
-- [Configuring Protocols](https://typesafehub.github.io/ssl-config/Protocols.html)
-- [Configuring Cipher Suites](https://typesafehub.github.io/ssl-config/CipherSuites.html)
-- [Configuring Certificate Validation](https://typesafehub.github.io/ssl-config/CertificateValidation.html)
-- [Configuring Certificate Revocation](https://typesafehub.github.io/ssl-config/CertificateRevocation.html)
-- [Configuring Hostname Verification](https://typesafehub.github.io/ssl-config/HostnameVerification.html)
-- [Example Configurations](https://typesafehub.github.io/ssl-config/ExampleSSLConfig.html)
-- [Using the Default SSLContext](https://typesafehub.github.io/ssl-config/DefaultContext.html)
-- [Debugging SSL Connections](https://typesafehub.github.io/ssl-config/DebuggingSSL.html)
-- [Loose Options](https://typesafehub.github.io/ssl-config/LooseSSL.html)
-- [Testing SSL](https://typesafehub.github.io/ssl-config/TestingSSL.html)
+- [Quick Start to WS SSL](https://lightbend.github.io/ssl-config/WSQuickStart.html)
+- [Generating X.509 Certificates](https://lightbend.github.io/ssl-config/CertificateGeneration.html)
+- [Configuring Trust Stores and Key Stores](https://lightbend.github.io/ssl-config/KeyStores.html)
+- [Configuring Protocols](https://lightbend.github.io/ssl-config/Protocols.html)
+- [Configuring Cipher Suites](https://lightbend.github.io/ssl-config/CipherSuites.html)
+- [Configuring Certificate Validation](https://lightbend.github.io/ssl-config/CertificateValidation.html)
+- [Configuring Certificate Revocation](https://lightbend.github.io/ssl-config/CertificateRevocation.html)
+- [Configuring Hostname Verification](https://lightbend.github.io/ssl-config/HostnameVerification.html)
+- [Example Configurations](https://lightbend.github.io/ssl-config/ExampleSSLConfig.html)
+- [Using the Default SSLContext](https://lightbend.github.io/ssl-config/DefaultContext.html)
+- [Debugging SSL Connections](https://lightbend.github.io/ssl-config/DebuggingSSL.html)
+- [Loose Options](https://lightbend.github.io/ssl-config/LooseSSL.html)
+- [Testing SSL](https://lightbend.github.io/ssl-config/TestingSSL.html)
 
 ## Further Reading
 


### PR DESCRIPTION
## Fixes 

Fixes #7962 

## Purpose

Fixes the bug  in documentation that is caused by migration from typesafehub to lightbend.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

