### PR TITLE
Update sbt native packager to 1.3.1

### DIFF
--- a/documentation/manual/working/commonGuide/production/Deploying.md
+++ b/documentation/manual/working/commonGuide/production/Deploying.md
@@ -85,7 +85,7 @@ For builds with sub-projects, the statement above has to be applied to all sub-p
 
 ## The Native Packager
 
-Play uses the [SBT Native Packager plugin](http://www.scala-sbt.org/sbt-native-packager/). The native packager plugin declares the `dist` task to create a zip file. Invoking the `dist` task is directly equivalent to invoking the following:
+Play uses the [SBT Native Packager plugin](https://sbt-native-packager.readthedocs.io/en/v1.3.1/). The native packager plugin declares the `dist` task to create a zip file. Invoking the `dist` task is directly equivalent to invoking the following:
 
 ```bash
 [my-first-app] $ universal:packageBin
@@ -100,16 +100,16 @@ Many other types of archive can be generated including:
 * Debian packages
 * System V / init.d and Upstart services in RPM/Debian packages
 
-Please consult the [documentation](http://sbt-native-packager.readthedocs.io/en/v1.2.0/) on the native packager plugin for more information.
+Please consult the [documentation](https://sbt-native-packager.readthedocs.io/en/v1.3.1/) on the native packager plugin for more information.
 
 ### Build a server distribution
 
 The sbt-native-packager plugins provides a number archetypes.  The one that Play uses by default is called the Java server archetype, which enables the following features:
 
 * System V or Upstart startup scripts
-* [Default folders](http://sbt-native-packager.readthedocs.io/en/v1.2.0/archetypes/java_server/index.html#default-mappings)
+* [Default folders](https://sbt-native-packager.readthedocs.io/en/v1.3.1/archetypes/java_server/index.html#default-mappings)
 
-A full documentation can be found in the [documentation](http://sbt-native-packager.readthedocs.io/en/v1.2.0/archetypes/java_server/index.html).
+More information can be found in the [Java Server Application Archetype documentation](https://sbt-native-packager.readthedocs.io/en/v1.3.1/archetypes/java_server/index.html).
 
 #### Minimal Debian settings
 
@@ -152,7 +152,7 @@ s"-Dpidfile.path=/var/run/${packageName.value}/play.pid",
 # Add all other startup settings here, too
 ```
 
-Please see the sbt-native-packager [page on Play](http://sbt-native-packager.readthedocs.io/en/v1.2.0/recipes/play.html) for more details.
+Please see the sbt-native-packager [page on Play](https://sbt-native-packager.readthedocs.io/en/v1.3.1/recipes/play.html) for more details.
 
 To prevent Play from creating a PID just set the property to `/dev/null`:
 
@@ -160,7 +160,7 @@ To prevent Play from creating a PID just set the property to `/dev/null`:
 -Dpidfile.path=/dev/null
 ```
 
-For a full list of replacements take a closer look at the [customize java server documentation](http://sbt-native-packager.readthedocs.io/en/v1.2.0/archetypes/java_server/customize.html) and [customize java app documentation](http://sbt-native-packager.readthedocs.io/en/v1.2.0/archetypes/java_app/customize.html).
+For a full list of replacements take a closer look at the [customize java server documentation](https://sbt-native-packager.readthedocs.io/en/v1.3.1/archetypes/java_server/customize.html) and [customize java app documentation](https://sbt-native-packager.readthedocs.io/en/v1.3.1/archetypes/java_app/customize.html).
 
 ## Publishing to a Maven (or Ivy) repository
 

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -3,7 +3,7 @@
 enablePlugins(BuildInfoPlugin)
 
 val Versions = new {
-  val sbtNativePackager = "1.2.2"
+  val sbtNativePackager = "1.3.1"
   val mima = "0.1.18"
   val sbtScalariform = "1.6.0"
   val sbtJavaAgent = "0.1.4"

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -3,6 +3,8 @@
 enablePlugins(BuildInfoPlugin)
 
 val Versions = new {
+  // when updating sbtNativePackager version, be sure to also update the documentation links in
+  // documentation/manual/working/commonGuide/production/Deploying.md
   val sbtNativePackager = "1.3.1"
   val mima = "0.1.18"
   val sbtScalariform = "1.6.0"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -25,7 +25,7 @@ checkStartScript := {
   }
   val contents = IO.read(startScript)
   val lines = IO.readLines(startScript)
-  if (!contents.contains( """app_mainclass=("play.core.server.ProdServerStart")""")) {
+  if (!contents.contains( "app_mainclass=(play.core.server.ProdServerStart)")) {
     startScriptError(contents, "Cannot find the declaration of the main class in the script")
   }
   val appClasspath = lines.find(_ startsWith "declare -r app_classpath")


### PR DESCRIPTION
This includes improved support for building Docker images in [version 1.3.0](https://github.com/sbt/sbt-native-packager/releases/tag/v1.3.0).

Specifically, it uses a new Docker feature to copy files and `chown` them in a single layer. Previously it did this in two separate `Dockerfile` steps, effectively doubling the size of Docker images it built.

Would like if this can be backported to Play 2.6.x.