### PR TITLE
Support evolutions scripts prefixed with zeros (01.sql, 001.sql, etc.)

### DIFF
--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -102,10 +102,14 @@ object Evolutions {
    */
   def fileName(db: String, revision: Int): String = s"${directoryName(db)}/${revision}.sql"
 
+  def fileName(db: String, revision: String): String = s"${directoryName(db)}/${revision}.sql"
+
   /**
    * Default evolution resource name.
    */
   def resourceName(db: String, revision: Int): String = s"evolutions/${db}/${revision}.sql"
+
+  def resourceName(db: String, revision: String): String = s"evolutions/${db}/${revision}.sql"
 
   /**
    * Apply pending evolutions for the given database.

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -492,8 +492,10 @@ abstract class ResourceEvolutionsReader extends EvolutionsReader {
 class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends ResourceEvolutionsReader {
 
   def loadResource(db: String, revision: Int) = {
-    environment.getExistingFile(Evolutions.fileName(db, revision)).map(f => java.nio.file.Files.newInputStream(f.toPath)).orElse {
-      environment.resourceAsStream(Evolutions.resourceName(db, revision))
+    val revisionPadded = List.tabulate(15)(s"${revision}".reverse.padTo(_, "0").reverse.mkString).distinct // 1, 01, 001, ... 000000000001
+
+    revisionPadded.flatMap(revision => environment.getExistingFile(Evolutions.fileName(db, revision))).find(_ != None).map(f => java.nio.file.Files.newInputStream(f.toPath)).orElse {
+      revisionPadded.flatMap(revision => environment.resource(Evolutions.resourceName(db, revision))).find(_ != None).map(_.openStream())
     }
   }
 }

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/001.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/001.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+create table do_not_create_that_table (id bigint not null, name varchar(255));
+
+# --- !Downs
+
+drop table if exists do_not_create_that_table;

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/0010.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/0010.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (99, 'Isabella');
+
+# --- !Downs
+
+delete from test where name = 'Isabella';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/002.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/002.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (96, 'Benjamin');
+
+# --- !Downs
+
+delete from test where name = 'Benjamin';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/005.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/005.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (95, 'Charlotte');
+
+# --- !Downs
+
+delete from test where name = 'Charlotte';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/01.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/01.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (98, 'James');
+
+# --- !Downs
+
+delete from test where name = 'James';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/010.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/010.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (11, 'Mason');
+
+# --- !Downs
+
+delete from test where name = 'Mason';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/0100.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/0100.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (94, 'Jacob');
+
+# --- !Downs
+
+delete from test where name = 'Jacob';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/02.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/02.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (97, 'Mia');
+
+# --- !Downs
+
+delete from test where name = 'Mia';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/05.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/05.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (6, 'Noah');
+
+# --- !Downs
+
+delete from test where name = 'Noah';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/4.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/4.sql
@@ -1,1 +1,7 @@
+# --- !Ups
+
+insert into test (id, name) values (5, 'Emma');
+
 # --- !Downs
+
+delete from test where name = 'Emma';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/6.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/6.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (7, 'Olivia');
+
+# --- !Downs
+
+delete from test where name = 'Olivia';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/7.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/7.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (8, 'Liam');
+
+# --- !Downs
+
+delete from test where name = 'Liam';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/8.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/8.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (9, 'William');
+
+# --- !Downs
+
+delete from test where name = 'William';

--- a/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/9.sql
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/evolutions/test/9.sql
@@ -1,0 +1,9 @@
+# --- Test data set
+
+# --- !Ups
+
+insert into test (id, name) values (10, 'Sophia');
+
+# --- !Downs
+
+delete from test where name = 'Sophia';

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
@@ -12,7 +12,8 @@ class EvolutionsReaderSpec extends Specification {
 
   "EnvironmentEvolutionsReader" should {
 
-    "read evolution files from classpath" in {
+    "read evolution files from classpath" in withLogbackCapturingAppender {
+      val appender = LogbackCapturingAppender[DefaultEvolutionsApi]
       val environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
       val reader = new EnvironmentEvolutionsReader(environment)
 
@@ -20,7 +21,22 @@ class EvolutionsReaderSpec extends Specification {
         Evolution(1, "create table test (id bigint not null, name varchar(255));", "drop table if exists test;"),
         Evolution(2, "insert into test (id, name) values (1, 'alice');\ninsert into test (id, name) values (2, 'bob');", "delete from test;"),
         Evolution(3, "insert into test (id, name) values (3, 'charlie');\ninsert into test (id, name) values (4, 'dave');", ""),
-        Evolution(4, "", "")
+        Evolution(4, "insert into test (id, name) values (5, 'Emma');", "delete from test where name = 'Emma';"),
+        Evolution(5, "insert into test (id, name) values (6, 'Noah');", "delete from test where name = 'Noah';"),
+        Evolution(6, "insert into test (id, name) values (7, 'Olivia');", "delete from test where name = 'Olivia';"),
+        Evolution(7, "insert into test (id, name) values (8, 'Liam');", "delete from test where name = 'Liam';"),
+        Evolution(8, "insert into test (id, name) values (9, 'William');", "delete from test where name = 'William';"),
+        Evolution(9, "insert into test (id, name) values (10, 'Sophia');", "delete from test where name = 'Sophia';"),
+        Evolution(10, "insert into test (id, name) values (11, 'Mason');", "delete from test where name = 'Mason';")
+      // revision file 100 will not even run because revision 11 - 99 do not exist
+      )
+      appender.events.map(_.getMessage) must_== Seq(
+        "Ignoring evolution script 01.sql, using 1.sql instead already",
+        "Ignoring evolution script 001.sql, using 1.sql instead already",
+        "Ignoring evolution script 02.sql, using 2.sql instead already",
+        "Ignoring evolution script 002.sql, using 2.sql instead already",
+        "Ignoring evolution script 005.sql, using 05.sql instead already",
+        "Ignoring evolution script 0010.sql, using 010.sql instead already"
       )
     }
 
@@ -35,5 +51,11 @@ class EvolutionsReaderSpec extends Specification {
       )
     }
 
+  }
+
+  private def withLogbackCapturingAppender[T](block: => T): T = {
+    val result = block
+    LogbackCapturingAppender.detachAll()
+    result
   }
 }

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/LogbackCapturingAppender.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/LogbackCapturingAppender.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.db.evolutions
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{ Level, Logger => LogbackLogger }
+import ch.qos.logback.core.AppenderBase
+import org.slf4j.{ Logger => Slf4jLogger, LoggerFactory }
+import scala.reflect.ClassTag
+
+import scala.collection.mutable
+
+class LogbackCapturingAppender private (slf4jLogger: Slf4jLogger) extends AppenderBase[ILoggingEvent] {
+
+  private val _logger: LogbackLogger = {
+    val logger = slf4jLogger.asInstanceOf[LogbackLogger]
+    logger.setLevel(Level.ALL)
+    logger.addAppender(this)
+    logger
+  }
+
+  private val _events: mutable.ArrayBuffer[ILoggingEvent] = new mutable.ArrayBuffer
+
+  /**
+   * Start the appender
+   */
+  start()
+
+  /**
+   * Returns the list of all captured logging events
+   */
+  def events: Seq[ILoggingEvent] = _events.toSeq
+
+  protected def append(event: ILoggingEvent): Unit = synchronized {
+    _events += event
+  }
+
+  private def detach(): Unit = {
+    _logger.detachAppender(this)
+    _events.clear()
+  }
+}
+
+object LogbackCapturingAppender {
+  private[this] val _appenders: mutable.ArrayBuffer[LogbackCapturingAppender] = new mutable.ArrayBuffer
+
+  def apply[T](implicit ct: ClassTag[T]): LogbackCapturingAppender =
+    attachForLogger(LoggerFactory.getLogger(ct.runtimeClass))
+
+  /**
+   * Get a capturing appender for the given logger
+   */
+  def attachForLogger(playLogger: play.api.Logger): LogbackCapturingAppender = attachForLogger(playLogger.logger)
+
+  /**
+   * Get a capturing appender for the given logger
+   */
+  def attachForLogger(slf4jLogger: Slf4jLogger): LogbackCapturingAppender = {
+    val appender = new LogbackCapturingAppender(slf4jLogger)
+    _appenders += appender
+    appender
+  }
+
+  /**
+   * Detach all the appenders we attached
+   */
+  def detachAll(): Unit = {
+    _appenders foreach (_.detach())
+    _appenders.clear()
+  }
+}


### PR DESCRIPTION
Fixes #7976

The order of precedence which file is chosen is `1.sql` if it exists, otherwise `01.sql` if it exists, otherwise `001.sql` and so on - until `000000000001.sql`.

Can be backported because it's backwards compatible.