### PR TITLE
Removes a superflous match that contains unreachable code.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -99,10 +99,7 @@ object Filter {
  * Compose the action and the Filters to create a new Action
  */
 object Filters {
-  def apply(h: EssentialAction, filters: EssentialFilter*) = h match {
-    case a: EssentialAction => FilterChain(a, filters.toList)
-    case h => h
-  }
+  def apply(h: EssentialAction, filters: EssentialFilter*): EssentialAction = FilterChain(h, filters.toList)
 }
 
 /**


### PR DESCRIPTION
I noticed this when tracing through some filter construction logic, and figured I might as well submit a patch. The match here is superfluous because `h` is, by definition, always of the type `EssentialAction`.

I also added the explicit return type, because IntelliJ nagged me to.

If this sort of thing is too small to open PRs over, feel free to just close it. 😃 