### PR TITLE
Move WebCommands (e.g. evolutions) inside application code

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -227,7 +227,23 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.cache.ehcache.EhCacheComponents.actorSystem"),
 
       // Changed this private[play] type to a Lock to allow explicit locking
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.test.PlayRunners.mutex")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.test.PlayRunners.mutex"),
+
+      // Deprecate ApplicationProvider.handleWebCommands and pass BuildLink through ApplicationLoader.Context
+      ProblemFilters.exclude[FinalClassProblem]("play.api.OptionalSourceMapper"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.api.ApplicationLoader$Context$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.ApplicationLoader#Context.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.ApplicationLoader#Context.copy$default$4"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.ApplicationLoader#Context.copy$default$3"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.ApplicationLoader#Context.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServerComponents.sourceMapper"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServerComponents.webCommands"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.BuiltInComponents.play$api$BuiltInComponents$$defaultWebCommands"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.BuiltInComponents.play$api$BuiltInComponents$_setter_$play$api$BuiltInComponents$$defaultWebCommands_="),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.ApplicationLoader#Context.copy$default$2"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.ApplicationLoader#Context.copy$default$5"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServerComponents.sourceMapper"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServerComponents.webCommands")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -26,7 +26,7 @@ class DocServerStart {
 
     val components = {
       val environment = Environment(projectPath, this.getClass.getClassLoader, Mode.Test)
-      val context = ApplicationLoader.createContext(environment)
+      val context = ApplicationLoader.Context.create(environment)
       new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
         lazy val router = Router.empty
       }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -212,13 +212,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
 
   "The CSRF module" should {
     val environment = Environment(new java.io.File("."), getClass.getClassLoader, Mode.Test)
-    def fakeContext = Context(
-      environment,
-      None,
-      new DefaultWebCommands,
-      Configuration.load(environment),
-      new DefaultApplicationLifecycle()
-    )
+    def fakeContext = Context.create(environment)
     def loader = new GuiceApplicationLoader
     "allow injecting CSRF filters" in {
       implicit val app = loader.load(fakeContext)

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -105,7 +105,8 @@ final case class GuiceApplicationBuilder(
       .bindings(loadedModules: _*)
       .bindings(
         bind[ILoggerFactory] to loggerFactory,
-        bind[OptionalSourceMapper] to new OptionalSourceMapper(None),
+        bind[OptionalDevContext] to new OptionalDevContext(None),
+        bind[OptionalSourceMapper].toProvider[OptionalSourceMapperProvider],
         bind[WebCommands] to new DefaultWebCommands
       ).createModule()
   }

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -3,8 +3,8 @@
  */
 package play.api.inject.guice
 
-import play.api.{ Application, ApplicationLoader, OptionalSourceMapper }
-import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle, bind }
+import play.api._
+import play.api.inject.{ ApplicationLifecycle, bind }
 import play.core.WebCommands
 
 /**
@@ -49,8 +49,7 @@ object GuiceApplicationLoader {
    */
   def defaultOverrides(context: ApplicationLoader.Context): Seq[GuiceableModule] = {
     Seq(
-      bind[OptionalSourceMapper] to new OptionalSourceMapper(context.sourceMapper),
-      bind[WebCommands] to context.webCommands,
+      bind[OptionalDevContext] to new OptionalDevContext(context.devContext),
       bind[ApplicationLifecycle] to context.lifecycle)
   }
 }

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -61,14 +61,14 @@ class GuiceApplicationLoaderSpec extends Specification {
       var hooksCalled = false
       lifecycle.addStopHook(() => Future.successful(hooksCalled = true))
       val loader = new GuiceApplicationLoader()
-      val app = loader.load(ApplicationLoader.createContext(Environment.simple()).copy(lifecycle = lifecycle))
+      val app = loader.load(ApplicationLoader.Context.create(Environment.simple(), lifecycle = lifecycle))
       Await.ready(app.stop(), 5.minutes)
       hooksCalled must_== true
     }
 
   }
 
-  def fakeContext = ApplicationLoader.createContext(Environment.simple())
+  def fakeContext = ApplicationLoader.Context.create(Environment.simple())
   def fakeContextWithModule(module: Class[_ <: AbstractModule]) = {
     val f = fakeContext
     val c = f.initialConfiguration

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/FormActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/FormActionSpec.scala
@@ -32,7 +32,7 @@ class FormActionSpec extends PlaySpecification with WsTestClient {
   )
 
   def application: Application = {
-    val context = ApplicationLoader.createContext(Environment.simple())
+    val context = ApplicationLoader.Context.create(Environment.simple())
     new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
 
       import play.api.routing.sird.{ POST => SirdPost, _ }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -24,7 +24,7 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
     def withServer[T](errorHandler: HttpErrorHandler = DefaultHttpErrorHandler)(block: Port => T) = {
       val port = testServerPort
 
-      val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with HttpFiltersComponents {
+      val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple())) with HttpFiltersComponents {
         def router = {
           import sird._
           Router.from {

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -36,7 +36,7 @@ trait DefaultFiltersSpec extends FiltersSpec {
   // `withServer` method that allows filters to be constructed with a Materializer
   def withFlexibleServer[T](settings: Map[String, String], errorHandler: Option[HttpErrorHandler], makeFilters: Materializer => Seq[EssentialFilter])(block: WSClient => T) = {
 
-    val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(
+    val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(
       environment = Environment.simple(),
       initialSettings = settings
     )) with HttpFiltersComponents {

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/ApplicationFactory.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/ApplicationFactory.scala
@@ -29,7 +29,7 @@ trait ApplicationFactories {
   def withRouter(createRouter: BuiltInComponents => Router): ApplicationFactory =
     withConfigAndRouter(Map.empty)(createRouter)
   def withConfigAndRouter(extraConfig: Map[String, Any])(createRouter: BuiltInComponents => Router): ApplicationFactory = withComponents {
-    val context = ApplicationLoader.createContext(
+    val context = ApplicationLoader.Context.create(
       environment = Environment.simple(),
       initialSettings = Map[String, AnyRef](Play.GlobalAppConfigKey -> java.lang.Boolean.FALSE) ++ extraConfig.asInstanceOf[Map[String, AnyRef]]
     )

--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -324,7 +324,7 @@ object HttpBinApplication {
   }
 
   def app = {
-    new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with AhcWSComponents with NoHttpFiltersComponents {
+    new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple())) with AhcWSComponents with NoHttpFiltersComponents {
       override implicit lazy val Action = defaultActionBuilder
       def router = SimpleRouter(
         PartialFunction.empty

--- a/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
@@ -46,7 +46,7 @@ object ProdServerStart {
         // Start the application
         val application: Application = {
           val environment = Environment(config.rootDir, process.classLoader, Mode.Prod)
-          val context = ApplicationLoader.createContext(environment)
+          val context = ApplicationLoader.Context.create(environment)
           val loader = ApplicationLoader(context)
           loader.load(context)
         }

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -7,21 +7,17 @@ import java.util.function.{ Function => JFunction }
 
 import com.typesafe.config.ConfigFactory
 import play.api.ApplicationLoader.Context
-import play.api.http.{ DefaultHttpErrorHandler, Port }
-import play.api.routing.Router
-
-import scala.language.postfixOps
 import play.api._
-import play.api.mvc._
-import play.core.{ ApplicationProvider, DefaultWebCommands, SourceMapper, WebCommands }
+import play.api.http.{ DefaultHttpErrorHandler, Port }
 import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
+import play.api.mvc._
+import play.api.routing.Router
+import play.core._
 import play.routing.{ Router => JRouter }
-import play.{ ApplicationLoader => JApplicationLoader }
-import play.{ BuiltInComponents => JBuiltInComponents }
-import play.{ BuiltInComponentsFromContext => JBuiltInComponentsFromContext }
+import play.{ ApplicationLoader => JApplicationLoader, BuiltInComponents => JBuiltInComponents, BuiltInComponentsFromContext => JBuiltInComponentsFromContext }
 
-import scala.util.{ Failure, Success }
 import scala.concurrent.Future
+import scala.language.postfixOps
 
 trait WebSocketable {
   def getHeader(header: String): String
@@ -46,40 +42,20 @@ trait Server extends ReloadableServer {
    * - If an exception is thrown.
    */
   def getHandlerFor(request: RequestHeader): Either[Future[Result], (RequestHeader, Handler, Application)] = {
-
-    // Common code for handling an exception and returning an error result
-    def logExceptionAndGetResult(e: Throwable): Left[Future[Result], Nothing] = {
-      Left(DefaultHttpErrorHandler.onServerError(request, e))
-    }
-
     try {
-      applicationProvider.handleWebCommand(request) match {
-        case Some(result) =>
-          // The ApplicationProvider handled the result
-          Left(Future.successful(result))
-        case None =>
-          // The ApplicationProvider didn't handle the result, so try
-          // handling it with the Application
-          applicationProvider.get match {
-            case Success(application) =>
-              // We managed to get an Application, now make a fresh request
-              // using the Application's RequestFactory, then use the Application's
-              // logic to handle that request.
-              val factoryMadeHeader: RequestHeader = application.requestFactory.copyRequestHeader(request)
-              val (handlerHeader, handler) = application.requestHandler.handlerForRequest(factoryMadeHeader)
-              Right((handlerHeader, handler, application))
-            case Failure(e) =>
-              // The ApplicationProvider couldn't give us an application.
-              // This usually means there was a compile error or a problem
-              // starting the application.
-              logExceptionAndGetResult(e)
-          }
-      }
+      // Get the Application from the provider.
+      val application = applicationProvider.get.get
+      // We managed to get an Application, now make a fresh request
+      // using the Application's RequestFactory, then use the Application's
+      // logic to handle that request.
+      val factoryMadeHeader: RequestHeader = application.requestFactory.copyRequestHeader(request)
+      val (handlerHeader, handler) = application.requestHandler.handlerForRequest(factoryMadeHeader)
+      Right((handlerHeader, handler, application))
     } catch {
       case e: ThreadDeath => throw e
       case e: VirtualMachineError => throw e
       case e: Throwable =>
-        logExceptionAndGetResult(e)
+        Left(DefaultHttpErrorHandler.onServerError(request, e))
     }
   }
 
@@ -156,9 +132,10 @@ object Server {
    */
   def withRouter[T](config: ServerConfig = ServerConfig(port = Some(0), mode = Mode.Test))(routes: PartialFunction[RequestHeader, Handler])(block: Port => T)(implicit provider: ServerProvider): T = {
     val context = ApplicationLoader.Context(
-      Environment.simple(path = config.rootDir, mode = config.mode),
-      None, new DefaultWebCommands(), Configuration(ConfigFactory.load()),
-      new DefaultApplicationLifecycle
+      environment = Environment.simple(path = config.rootDir, mode = config.mode),
+      initialConfiguration = Configuration(ConfigFactory.load()),
+      lifecycle = new DefaultApplicationLifecycle,
+      devContext = None
     )
     val application = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
       def router = Router.from(routes)
@@ -180,13 +157,15 @@ object Server {
    * @return The result of the block of code.
    */
   def withRouterFromComponents[T](config: ServerConfig = ServerConfig(port = Some(0), mode = Mode.Test))(routes: BuiltInComponents => PartialFunction[RequestHeader, Handler])(block: Port => T)(implicit provider: ServerProvider): T = {
-    val application = new BuiltInComponentsFromContext(ApplicationLoader.Context(
-      Environment.simple(path = config.rootDir, mode = config.mode),
-      None, new DefaultWebCommands(), Configuration(ConfigFactory.load()),
-      new DefaultApplicationLifecycle
-    )) with NoHttpFiltersComponents { self: BuiltInComponents =>
+    val context: Context = ApplicationLoader.Context(
+      environment = Environment.simple(path = config.rootDir, mode = config.mode),
+      initialConfiguration = Configuration(ConfigFactory.load()),
+      lifecycle = new DefaultApplicationLifecycle,
+      devContext = None
+    )
+    val application = (new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents { self: BuiltInComponents =>
       def router = Router.from(routes(self))
-    }.application
+    }).application
     withApplication(application, config)(block)
   }
 
@@ -218,9 +197,10 @@ object Server {
    */
   def withApplicationFromContext[T](config: ServerConfig = ServerConfig(port = Some(0), mode = Mode.Test))(appProducer: ApplicationLoader.Context => Application)(block: Port => T)(implicit provider: ServerProvider): T = {
     val context: Context = ApplicationLoader.Context(
-      Environment.simple(path = config.rootDir, mode = config.mode),
-      None, new DefaultWebCommands(), Configuration(ConfigFactory.load()),
-      new DefaultApplicationLifecycle
+      environment = Environment.simple(path = config.rootDir, mode = config.mode),
+      initialConfiguration = Configuration(ConfigFactory.load()),
+      lifecycle = new DefaultApplicationLifecycle,
+      devContext = None
     )
     withApplication(appProducer(context), config)(block)
   }
@@ -237,8 +217,6 @@ trait ServerComponents {
   lazy val serverConfig: ServerConfig = ServerConfig()
 
   lazy val environment: Environment = Environment.simple(mode = serverConfig.mode)
-  lazy val sourceMapper: Option[SourceMapper] = None
-  lazy val webCommands: WebCommands = new DefaultWebCommands
   lazy val configuration: Configuration = Configuration(ConfigFactory.load())
   lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
 

--- a/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -22,7 +22,7 @@ import play.core.server.ServerProvider
  * @param applicationLoader The application loader to use
  * @param context The context supplied to the application loader
  */
-abstract class WithApplicationLoader(applicationLoader: ApplicationLoader = new GuiceApplicationLoader(), context: ApplicationLoader.Context = ApplicationLoader.createContext(new Environment(new java.io.File("."), ApplicationLoader.getClass.getClassLoader, Mode.Test))) extends Around with Scope {
+abstract class WithApplicationLoader(applicationLoader: ApplicationLoader = new GuiceApplicationLoader(), context: ApplicationLoader.Context = ApplicationLoader.Context.create(new Environment(new java.io.File("."), ApplicationLoader.getClass.getClassLoader, Mode.Test))) extends Around with Scope {
   implicit lazy val app = applicationLoader.load(context)
   def around[T: AsResult](t: => T): Result = {
     Helpers.running(app)(AsResult.effectively(t))

--- a/framework/src/play/src/main/java/play/ApplicationLoader.java
+++ b/framework/src/play/src/main/java/play/ApplicationLoader.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import com.typesafe.config.Config;
 import play.api.inject.DefaultApplicationLifecycle;
+import play.core.BuildLink;
 import play.core.SourceMapper;
 import play.core.DefaultWebCommands;
 import play.inject.ApplicationLifecycle;
@@ -89,11 +90,10 @@ public interface ApplicationLoader {
         public Context(Environment environment, Map<String, Object> initialSettings) {
             this.underlying = new play.api.ApplicationLoader.Context(
                     environment.asScala(),
-                    scala.Option.empty(),
-                    new play.core.DefaultWebCommands(),
                     play.api.Configuration.load(environment.asScala(),
                     play.libs.Scala.asScala(initialSettings)),
-                    new DefaultApplicationLifecycle());
+                    new DefaultApplicationLifecycle(),
+                    scala.Option.empty());
         }
 
         /**
@@ -176,10 +176,9 @@ public interface ApplicationLoader {
         public Context withEnvironment(Environment environment) {
             play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
                     environment.asScala(),
-                    underlying.sourceMapper(),
-                    underlying.webCommands(),
                     underlying.initialConfiguration(),
-                    new DefaultApplicationLifecycle());
+                    new DefaultApplicationLifecycle(),
+                    underlying.devContext());
             return new Context(scalaContext);
         }
 
@@ -193,10 +192,9 @@ public interface ApplicationLoader {
         public Context withConfiguration(Configuration initialConfiguration) {
             play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
                     underlying.environment(),
-                    underlying.sourceMapper(),
-                    underlying.webCommands(),
                     initialConfiguration.getWrappedConfiguration(),
-                    new DefaultApplicationLifecycle());
+                    new DefaultApplicationLifecycle(),
+                    underlying.devContext());
             return new Context(scalaContext);
         }
 
@@ -209,10 +207,9 @@ public interface ApplicationLoader {
         public Context withConfig(Config initialConfiguration) {
             play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
                     underlying.environment(),
-                    underlying.sourceMapper(),
-                    underlying.webCommands(),
                     new play.api.Configuration(initialConfiguration),
-                    new DefaultApplicationLifecycle());
+                    new DefaultApplicationLifecycle(),
+                    underlying.devContext());
             return new Context(scalaContext);
         }
 
@@ -268,12 +265,11 @@ public interface ApplicationLoader {
      * @return the created context
      */
     static Context create(Environment environment, Map<String, Object> initialSettings) {
-        play.api.ApplicationLoader.Context scalaContext = play.api.ApplicationLoader$.MODULE$.createContext(
+        play.api.ApplicationLoader.Context scalaContext = play.api.ApplicationLoader.Context$.MODULE$.create(
                 environment.asScala(),
                 Scala.asScala(initialSettings),
-                Scala.<SourceMapper>None(),
-                new DefaultWebCommands(),
-                new DefaultApplicationLifecycle());
+                new DefaultApplicationLifecycle(),
+                Scala.<play.api.ApplicationLoader.DevContext>None());
         return new Context(scalaContext);
     }
 

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -3,10 +3,13 @@
  */
 package play.api
 
-import play.core.{ DefaultWebCommands, SourceMapper, WebCommands }
-import play.utils.Reflect
+import javax.inject.{ Inject, Provider, Singleton }
+
+import play.api.ApplicationLoader.DevContext
 import play.api.inject.ApplicationLifecycle
 import play.api.mvc.{ ControllerComponents, DefaultControllerComponents }
+import play.core.{ BuildLink, SourceMapper, WebCommands }
+import play.utils.Reflect
 
 /**
  * Loads an application.  This is responsible for instantiating an application given a context.
@@ -53,13 +56,82 @@ object ApplicationLoader {
    * The context for loading an application.
    *
    * @param environment The environment
-   * @param sourceMapper An optional source mapper
-   * @param webCommands The web command handlers
    * @param initialConfiguration The initial configuration.  This configuration is not necessarily the same
    *                             configuration used by the application, as the ApplicationLoader may, through it's own
    *                             mechanisms, modify it or completely ignore it.
+   * @param lifecycle Used to register hooks that run when the application stops.
+   * @param devContext If an application is loaded in dev mode then this additional context is available.
    */
-  final case class Context(environment: Environment, sourceMapper: Option[SourceMapper], webCommands: WebCommands, initialConfiguration: Configuration, lifecycle: ApplicationLifecycle)
+  final case class Context(
+      environment: Environment,
+      initialConfiguration: Configuration,
+      lifecycle: ApplicationLifecycle,
+      devContext: Option[DevContext]
+  ) {
+    @deprecated("Use devContext.map(_.sourceMapper) instead", "2.7.0")
+    def sourceMapper: Option[SourceMapper] = devContext.map(_.sourceMapper)
+    @deprecated("WebCommands are no longer a property of ApplicationLoader.Context; they are available via injection or from the BuiltinComponents trait", "2.7.0")
+    def webCommands: WebCommands =
+      throw new UnsupportedOperationException("WebCommands are no longer a property of ApplicationLoader.Context; they are available via injection or from the BuiltinComponents trait")
+  }
+
+  /**
+   * If an application is loaded in dev mode then this additional context is available. It is available as a property
+   * in the `Context` object, from [[BuiltInComponents]] trait or injected via [[OptionalDevContext]].
+   *
+   * @param sourceMapper Information about the source files that were used to compile the application.
+   * @param buildLink An interface that can be used to interact with the build system.
+   */
+  final case class DevContext(
+    sourceMapper: SourceMapper,
+    buildLink: BuildLink
+  )
+
+  object Context {
+
+    /**
+     * Create an application loading context.
+     *
+     * Locates and loads the necessary configuration files for the application.
+     *
+     * @param environment The application environment.
+     * @param initialSettings The initial settings. These settings are merged with the settings from the loaded
+     *                        configuration files, and together form the initialConfiguration provided by the context.  It
+     *                        is intended for use in dev mode, to allow the build system to pass additional configuration
+     *                        into the application.
+     * @param lifecycle Used to register hooks that run when the application stops.
+     * @param devContext If an application is loaded in dev mode then this additional context can be provided.
+     */
+    def create(
+      environment: Environment,
+      initialSettings: Map[String, AnyRef] = Map.empty[String, AnyRef],
+      lifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle(),
+      devContext: Option[DevContext] = None) = {
+      Context(
+        environment = environment,
+        devContext = devContext,
+        lifecycle = lifecycle,
+        initialConfiguration = Configuration.load(environment, initialSettings)
+      )
+    }
+
+    @deprecated("Context properties have changed; use the default Context apply method or Context.create instead", "2.7.0")
+    def apply(
+      environment: Environment,
+      sourceMapper: Option[SourceMapper],
+      webCommands: WebCommands,
+      initialConfiguration: Configuration,
+      lifecycle: ApplicationLifecycle): Context = {
+      require(sourceMapper == None, "sourceMapper parameter is no longer supported by ApplicationLoader.Context; use devContext parameter instead")
+      require(webCommands == null, "webCommands parameter is no longer supported by ApplicationLoader.Context")
+      Context(
+        environment = environment,
+        devContext = None,
+        initialConfiguration = initialConfiguration,
+        lifecycle = lifecycle
+      )
+    }
+  }
 
   /**
    * Locate and instantiate the ApplicationLoader.
@@ -104,14 +176,20 @@ object ApplicationLoader {
    *                        into the application.
    * @param sourceMapper An optional source mapper.
    */
+  @deprecated("Context properties have changed; use the default Context apply method or Context.create instead", "2.7.0")
   def createContext(
     environment: Environment,
     initialSettings: Map[String, AnyRef] = Map.empty[String, AnyRef],
     sourceMapper: Option[SourceMapper] = None,
-    webCommands: WebCommands = new DefaultWebCommands,
+    webCommands: WebCommands = null,
     lifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle()) = {
-    val configuration = Configuration.load(environment, initialSettings)
-    Context(environment, sourceMapper, webCommands, configuration, lifecycle)
+    require(sourceMapper == None, "sourceMapper parameter is no longer supported by createContext; use create method's devContext parameter instead")
+    require(webCommands == null, "webCommands parameter is no longer supported by ApplicationLoader.Context")
+    Context.create(
+      environment = environment,
+      initialSettings = initialSettings,
+      lifecycle = lifecycle
+    )
   }
 
 }
@@ -120,14 +198,31 @@ object ApplicationLoader {
  * Helper that provides all the built in components dependencies from the application loader context
  */
 abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) extends BuiltInComponents {
-  lazy val environment = context.environment
-  lazy val sourceMapper = context.sourceMapper
-  lazy val webCommands = context.webCommands
-  lazy val applicationLifecycle: ApplicationLifecycle = context.lifecycle
-  def configuration = context.initialConfiguration
+  override def environment = context.environment
+  override def devContext = context.devContext
+  override def applicationLifecycle: ApplicationLifecycle = context.lifecycle
+  override def configuration = context.initialConfiguration
 
   lazy val controllerComponents: ControllerComponents = DefaultControllerComponents(
     defaultActionBuilder, playBodyParsers, messagesApi, langs, fileMimeTypes, executionContext
   )
 }
 
+/**
+ * Represents an `Option[DevContext]` so that it can be used for dependency
+ * injection. We can't easily use a plain `Option[DevContext]` since Java
+ * erases the type parameter of that type.
+ */
+final class OptionalDevContext(val devContext: Option[DevContext])
+
+/**
+ * Represents an `Option[SourceMapper]` so that it can be used for dependency
+ * injection. We can't easily use a plain `Option[SourceMapper]` since Java
+ * erases the type parameter of that type.
+ */
+final class OptionalSourceMapper(val sourceMapper: Option[SourceMapper])
+
+@Singleton
+final class OptionalSourceMapperProvider @Inject() (optDevContext: OptionalDevContext) extends Provider[OptionalSourceMapper] {
+  val get = new OptionalSourceMapper(optDevContext.devContext.map(_.sourceMapper))
+}

--- a/framework/src/play/src/main/scala/play/core/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/ApplicationProvider.scala
@@ -42,6 +42,7 @@ trait ApplicationProvider {
   /**
    * Handle a request directly, without using the application.
    */
+  @deprecated("This method is no longer called; WebCommands are now handled by the DefaultHttpRequestHandler", "2.7.0")
   def handleWebCommand(requestHeader: play.api.mvc.RequestHeader): Option[Result] = None
 }
 

--- a/framework/src/play/src/test/scala/play/api/BuiltInComponentsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/BuiltInComponentsSpec.scala
@@ -10,7 +10,6 @@ import org.specs2.mutable.Specification
 import play.api.inject.DefaultApplicationLifecycle
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
-import play.core.{ SourceMapper, WebCommands }
 
 class BuiltInComponentsSpec extends Specification {
   "BuiltinComponents" should {
@@ -21,8 +20,6 @@ class BuiltInComponentsSpec extends Specification {
         override def configuration: Configuration = Configuration.load(environment)
         override def applicationLifecycle: DefaultApplicationLifecycle = new DefaultApplicationLifecycle
         override def router: Router = ???
-        override def webCommands: WebCommands = ???
-        override def sourceMapper: Option[SourceMapper] = ???
         override def httpFilters: Seq[EssentialFilter] = ???
       }
       components.environment.classLoader must_== classLoader

--- a/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -146,7 +146,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
     }
 
     "works when using compile time dependency injection" in {
-      val context = ApplicationLoader.createContext(
+      val context = ApplicationLoader.Context.create(
         new Environment(new File("."), ApplicationLoader.getClass.getClassLoader, Mode.Test))
       val appLoader = new ApplicationLoader {
         def load(context: Context) = {

--- a/framework/src/play/src/test/scala/play/core/test/package.scala
+++ b/framework/src/play/src/test/scala/play/core/test/package.scala
@@ -11,7 +11,7 @@ package object test {
    * Run the given block of code with an application.
    */
   def withApplication[T](block: => T): T = {
-    val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with NoHttpFiltersComponents {
+    val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple())) with NoHttpFiltersComponents {
       def router = play.api.routing.Router.empty
     }.application
     Play.start(app)
@@ -23,7 +23,7 @@ package object test {
   }
 
   def withApplication[T](block: Application => T): T = {
-    val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with NoHttpFiltersComponents {
+    val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple())) with NoHttpFiltersComponents {
       def router = play.api.routing.Router.empty
     }.application
     Play.start(app)


### PR DESCRIPTION
WebCommands let the application add code that (a) runs before any other code in the application and (b) hook into the dev mode build to do things like restart the application.

As far as I know WebCommands is only used by Play's Evolutions code.

This change simplifies the WebCommands implementation by injecting the BuildLink into the application so that the DefaultHttpRequestHandler can manage WebCommand execution without needing to interact with as much code in DevServerStart.

BuildLink and SourceMapper are provided in a new DevContext object that encapsulates the interface between a Play application and the dev mode container. In the future we can simplify the DevContext interface further, e.g. remove the dependency on BuildLink and just supply the minimum that we need to support evolutions (i.e. a hook to reload).

Another thing we can consider in the future is removing WebCommands (which depend on BuildLink) and replacing them with a more general way of intercepting requests. That should be pretty easy to do.