### PR TITLE
Fix Map ConfigLoader for keys containing dots or special characters

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 
 import com.typesafe.config._
 import com.typesafe.config.impl.ConfigImpl
+import play.twirl.api.utils.StringEscapeUtils
 import play.utils.PlayIO
 
 import scala.collection.JavaConverters._
@@ -1091,7 +1092,9 @@ object ConfigLoader {
       val conf = obj.toConfig
 
       obj.keySet().asScala.map { key =>
-        key -> valueLoader.load(conf, key)
+        // quote and escape the key in case it contains dots or special characters
+        val path = "\"" + StringEscapeUtils.escapeEcmaScript(key) + "\""
+        key -> valueLoader.load(conf, path)
       }(scala.collection.breakOut)
     }
   }


### PR DESCRIPTION
Before we were using `valueLoader.load(conf, key)` for each key in the map, but `ConfigLoader` accepts a path, not a key. So if you have a key like "foo.bar" in your map, it will assume that's actually a path with two components. By escaping and quoting we can make sure our key is actually treated as a key.