### PR TITLE
Get clientCertificateChain information for Akka HTTP server

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -53,6 +53,14 @@ play {
       # Play uses the concept of a `BodyParser` to enforce this limit, so we override it to infinite.
       max-content-length = infinite
 
+      # Enables/disables inclusion of an Tls-Session-Info header in parsed
+      # messages over Tls transports (i.e., HttpRequest on server side and
+      # HttpResponse on client side).
+      #
+      # See Akka HTTP `akka.http.server.parsing.tls-session-info-header` for
+      # more information about how this works.
+      tls-session-info-header = on
+
     }
   }
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -76,6 +76,7 @@ class AkkaHttpServer(
 
     val parserSettings = ParserSettings(initialConfig)
       .withMaxContentLength(getPossiblyInfiniteBytes(akkaServerConfig.underlying, "max-content-length"))
+      .withIncludeTlsSessionInfoHeader(akkaServerConfig.get[Boolean]("tls-session-info-header"))
 
     val initialSettings = ServerSettings(initialConfig)
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -4,7 +4,9 @@
 package play.core.server.akkahttp
 
 import java.net.{ InetAddress, InetSocketAddress, URI }
+import java.security.cert.X509Certificate
 import java.util.Locale
+import javax.net.ssl.SSLPeerUnverifiedException
 
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
@@ -97,8 +99,18 @@ private[server] class AkkaModelConversion(
         new RemoteConnection {
           override def remoteAddress: InetAddress = remoteAddressArg.getAddress
           override def secure: Boolean = secureProtocol
-          // TODO - Akka does not yet expose the SSLEngine used for the request
-          override lazy val clientCertificateChain = None
+          override def clientCertificateChain: Option[Seq[X509Certificate]] = {
+            try {
+              request.header[`Tls-Session-Info`].map { tslSessionInfo =>
+                tslSessionInfo
+                  .getSession
+                  .getPeerCertificates
+                  .collect { case x509: X509Certificate => x509 }
+              }
+            } catch {
+              case _: SSLPeerUnverifiedException => None
+            }
+          }
         },
         headers),
       request.method.name,

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -101,8 +101,8 @@ private[server] class AkkaModelConversion(
           override def secure: Boolean = secureProtocol
           override def clientCertificateChain: Option[Seq[X509Certificate]] = {
             try {
-              request.header[`Tls-Session-Info`].map { tslSessionInfo =>
-                tslSessionInfo
+              request.header[`Tls-Session-Info`].map { tlsSessionInfo =>
+                tlsSessionInfo
                   .getSession
                   .getPeerCertificates
                   .collect { case x509: X509Certificate => x509 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/routing/ServerSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/routing/ServerSpec.scala
@@ -17,12 +17,22 @@ import play.server.Server
 import play.{ Mode => JavaMode }
 import scala.compat.java8.FunctionConverters._
 
-class ServerSpec extends Specification with BeforeAll {
+class AkkaHTTPServerSpec extends ServerSpec {
+  override def serverProvider: String = "play.core.server.AkkaHttpServerProvider"
+}
+
+class NettyServerSpec extends ServerSpec {
+  override def serverProvider: String = "play.core.server.NettyServerProvider"
+}
+
+trait ServerSpec extends Specification with BeforeAll {
 
   sequential
 
+  def serverProvider: String
+
   override def beforeAll(): Unit = {
-    System.setProperty("play.server.provider", "play.core.server.NettyServerProvider")
+    System.setProperty("play.server.provider", serverProvider)
   }
 
   private def withServer[T](server: Server)(block: Server => T): T = {


### PR DESCRIPTION
## Purpose

Fix TODO task for Akka HTTP Server: Get `clientCertificateChain` information when it is available.

## References

See https://github.com/akka/akka-http/issues/1104.
