### PR TITLE
Create minimal sbt plugin for Play services

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -12,20 +12,34 @@ import sbt.Keys._
 import sbt._
 
 /**
- * Base plugin for Play projects. Declares common settings for both Java and Scala based Play projects.
+ * Base plugin for all Play services (web apps or microservices).
+ *
+ * Declares common settings for both Java and Scala based Play projects.
  */
-object Play extends AutoPlugin {
+object PlayService extends AutoPlugin {
 
-  override def requires = SbtTwirl && SbtJsTask && RoutesCompiler && JavaServerAppPackaging
+  override def requires = JavaServerAppPackaging
 
   val autoImport = PlayImport
 
-  override def projectSettings =
-    PlaySettings.defaultSettings ++
-      Seq(
-        scalacOptions ++= Seq("-deprecation", "-unchecked", "-encoding", "utf8"),
-        javacOptions in Compile ++= Seq("-encoding", "utf8", "-g")
-      )
+  override def projectSettings = PlaySettings.serviceSettings
+}
+
+@deprecated("Use PlayWeb instead for a web project.", "2.7.0")
+object Play extends AutoPlugin {
+  override def requires = JavaServerAppPackaging && SbtTwirl && SbtJsTask && RoutesCompiler
+  val autoImport = PlayImport
+  override def projectSettings = PlaySettings.defaultSettings
+}
+
+/**
+ * Base plugin for Play web projects.
+ *
+ * Declares common settings for both Java and Scala based web projects, as well as sbt-web and assets settings.
+ */
+object PlayWeb extends AutoPlugin {
+  override def requires = PlayService && SbtTwirl && SbtJsTask && RoutesCompiler
+  override def projectSettings = PlaySettings.webSettings
 }
 
 /**
@@ -39,7 +53,7 @@ object Play extends AutoPlugin {
  * }}}
  */
 object PlayMinimalJava extends AutoPlugin {
-  override def requires = Play
+  override def requires = PlayWeb
   override def projectSettings =
     PlaySettings.minimalJavaSettings ++
       Seq(libraryDependencies += PlayImport.javaCore)
@@ -56,7 +70,7 @@ object PlayMinimalJava extends AutoPlugin {
  * }}}
  */
 object PlayJava extends AutoPlugin {
-  override def requires = Play
+  override def requires = PlayWeb
   override def projectSettings =
     PlaySettings.defaultJavaSettings ++
       Seq(libraryDependencies += PlayImport.javaForms)
@@ -70,7 +84,7 @@ object PlayJava extends AutoPlugin {
  * }}}
  */
 object PlayScala extends AutoPlugin {
-  override def requires = Play
+  override def requires = PlayWeb
   override def projectSettings =
     PlaySettings.defaultScalaSettings
 }
@@ -79,7 +93,7 @@ object PlayScala extends AutoPlugin {
  * This plugin enables the Play netty http server
  */
 object PlayNettyServer extends AutoPlugin {
-  override def requires = Play
+  override def requires = PlayService
 
   override def projectSettings = Seq(
     libraryDependencies ++= {
@@ -96,7 +110,7 @@ object PlayNettyServer extends AutoPlugin {
  * This plugin enables the Play akka http server
  */
 object PlayAkkaHttpServer extends AutoPlugin {
-  override def requires = Play
+  override def requires = PlayService
   override def trigger = allRequirements
 
   override def projectSettings = Seq(

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayFilters.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayFilters.scala
@@ -16,7 +16,7 @@ import sbt._
  * }}}
  */
 object PlayFilters extends AutoPlugin {
-  override def requires = Play
+  override def requires = PlayWeb
   override def trigger = allRequirements
 
   override def projectSettings =

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayLayoutPlugin.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayLayoutPlugin.scala
@@ -9,11 +9,16 @@ import play.twirl.sbt.Import.TwirlKeys
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
 
+/**
+ * Play layout plugin to switch to the traditional Play web app layout instead of the standard Maven layout.
+ *
+ * This is enabled automatically with the PlayWeb plugin (as an AutoPlugin) but not with the PlayService plugin.
+ */
 object PlayLayoutPlugin extends AutoPlugin {
 
-  override def requires = Play
+  override def requires = PlayWeb
 
-  override def trigger = AllRequirements
+  override def trigger = allRequirements
 
   override def projectSettings = Seq(
     target := baseDirectory.value / "target",

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayLogback.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayLogback.scala
@@ -10,7 +10,7 @@ import sbt._
  * This plugin enables Play Logback
  */
 object PlayLogback extends AutoPlugin {
-  override def requires = Play
+  override def requires = PlayService
 
   // add this plugin automatically if Play is added.
   override def trigger = AllRequirements

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -50,8 +50,11 @@ object PlaySettings extends PlaySettingsCompat {
     Classpaths.managedJars(config, (classpathTypes in config).value, update.value)
   }
 
-  lazy val defaultSettings = Seq[Setting[_]](
-    TwirlKeys.constructorAnnotations += "@javax.inject.Inject()",
+  // Settings for a Play service (not a web project)
+  lazy val serviceSettings = Seq[Setting[_]](
+
+    scalacOptions ++= Seq("-deprecation", "-unchecked", "-encoding", "utf8"),
+    javacOptions in Compile ++= Seq("-encoding", "utf8", "-g"),
 
     playPlugin := false,
 
@@ -97,6 +100,10 @@ object PlaySettings extends PlaySettingsCompat {
       Seq(playStartCommand, playRunProdCommand, playTestProdCommand, playStopProdCommand, h2Command)
     },
 
+    // Assets classloader (used by PlayRun.playDefaultRunTask)
+    PlayInternalKeys.playAllAssets := Seq.empty,
+    PlayRun.playAssetsClassLoaderSetting,
+
     // THE `in Compile` IS IMPORTANT!
     Keys.run in Compile := PlayRun.playDefaultRunTask.evaluated,
     mainClass in (Compile, Keys.run) := Some("play.core.server.DevServerStart"),
@@ -128,13 +135,6 @@ object PlaySettings extends PlaySettingsCompat {
 
     ivyLoggingLevel := UpdateLogging.DownloadOnly,
 
-    RoutesKeys.routesImport ++= Seq("controllers.Assets.Asset"),
-
-    sources in (Compile, RoutesKeys.routes) ++= {
-      val dirs = (unmanagedResourceDirectories in Compile).value
-      (dirs * "routes").get ++ (dirs * "*.routes").get
-    },
-
     playMonitoredFiles := PlayCommands.playMonitoredFilesTask.value,
 
     fileWatchService := FileWatchService.defaultWatchService(target.value, getPoolInterval(pollInterval.value).toMillis.toInt, sLog.value),
@@ -147,35 +147,6 @@ object PlaySettings extends PlaySettingsCompat {
     playRunHooks := Nil,
 
     playInteractionMode := PlayConsoleInteractionMode,
-
-    // sbt-web
-    jsFilter in Assets := new PatternFilter("""[^_].*\.js""".r.pattern),
-
-    WebKeys.stagingDirectory := WebKeys.stagingDirectory.value / "public",
-
-    playAssetsWithCompilation := {
-      val ignore = ((assets in Assets)?).value
-      getPlayAssetsWithCompilation((compile in Compile).value)
-    },
-
-    // Assets for run mode
-    PlayRun.playPrefixAndAssetsSetting,
-    PlayRun.playAllAssetsSetting,
-    PlayRun.playAssetsClassLoaderSetting,
-    assetsPrefix := "public/",
-
-    // Assets for distribution
-    WebKeys.packagePrefix in Assets := assetsPrefix.value,
-    playPackageAssets := (packageBin in Assets).value,
-    scriptClasspathOrdering += {
-      val (id, art) = (projectID.value, (artifact in (Assets, packageBin)).value)
-      val jarName = JavaAppPackaging.makeJarName(id.organization, id.name, id.revision, art.name, Some("assets"))
-      playPackageAssets.value -> ("lib/" + jarName)
-    },
-
-    // Assets for testing
-    public in TestAssets := (public in TestAssets).value / assetsPrefix.value,
-    fullClasspath in Test += Attributed.blank((assets in TestAssets).value.getParentFile),
 
     // Settings
 
@@ -252,9 +223,52 @@ object PlaySettings extends PlaySettingsCompat {
     bashScriptExtraDefines += "addJava \"-Duser.dir=$(realpath \"$(cd \"${app_home}/..\"; pwd -P)\"  $(is_cygwin && echo \"fix\"))\"\n",
 
     generateSecret := ApplicationSecretGenerator.generateSecretTask.value,
-    updateSecret := ApplicationSecretGenerator.updateSecretTask.value
+    updateSecret := ApplicationSecretGenerator.updateSecretTask.value,
+
+    // by default, compile any routes files in the root named "routes" or "*.routes"
+    sources in (Compile, RoutesKeys.routes) ++= {
+      val dirs = (unmanagedResourceDirectories in Compile).value
+      (dirs * "routes").get ++ (dirs * "*.routes").get
+    }
 
   ) ++ inConfig(Compile)(externalizedSettings)
+
+  @deprecated("Use webSettings instead for a web project, serviceSettings for a Play service", "2.7.0")
+  lazy val defaultSettings = webSettings
+
+  lazy val webSettings = Seq[Setting[_]](
+    TwirlKeys.constructorAnnotations += "@javax.inject.Inject()",
+
+    RoutesKeys.routesImport ++= Seq("controllers.Assets.Asset"),
+
+    // sbt-web
+    jsFilter in Assets := new PatternFilter("""[^_].*\.js""".r.pattern),
+
+    WebKeys.stagingDirectory := WebKeys.stagingDirectory.value / "public",
+
+    playAssetsWithCompilation := {
+      val ignore = ((assets in Assets)?).value
+      getPlayAssetsWithCompilation((compile in Compile).value)
+    },
+
+    // Assets for run mode
+    PlayRun.playPrefixAndAssetsSetting,
+    PlayRun.playAllAssetsSetting,
+    assetsPrefix := "public/",
+
+    // Assets for distribution
+    WebKeys.packagePrefix in Assets := assetsPrefix.value,
+    playPackageAssets := (packageBin in Assets).value,
+    scriptClasspathOrdering += {
+      val (id, art) = (projectID.value, (artifact in (Assets, packageBin)).value)
+      val jarName = JavaAppPackaging.makeJarName(id.organization, id.name, id.revision, art.name, Some("assets"))
+      playPackageAssets.value -> ("lib/" + jarName)
+    },
+
+    // Assets for testing
+    public in TestAssets := (public in TestAssets).value / assetsPrefix.value,
+    fullClasspath in Test += Attributed.blank((assets in TestAssets).value.getParentFile)
+  )
 
   /**
    * Settings for creating a jar that excludes externalized resources

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -61,7 +61,8 @@ object PlayRun extends PlayRunCompat {
     runHooks: TaskKey[Seq[play.sbt.PlayRunHook]],
     dependencyClasspath: TaskKey[Classpath],
     reloaderClasspath: TaskKey[Classpath],
-    assetsClassLoader: TaskKey[ClassLoader => ClassLoader]): Def.Initialize[InputTask[Unit]] = Def.inputTask {
+    assetsClassLoader: TaskKey[ClassLoader => ClassLoader]
+  ): Def.Initialize[InputTask[Unit]] = Def.inputTask {
 
     val args = Def.spaceDelimited().parsed
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/README
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/README
@@ -1,0 +1,4 @@
+This is your new Play application
+=====================================
+
+This file will be packaged with your application, when using `play dist`.

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/build.sbt
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+//
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayService)
+  .enablePlugins(RoutesCompiler)
+  .enablePlugins(MediatorWorkaroundPlugin)
+  .settings(
+    libraryDependencies += guice,
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4"),
+
+    InputKey[Unit]("verifyResourceContains") := {
+      val args = Def.spaceDelimited("<path> <status> <words> ...").parsed
+      val path = args.head
+      val status = args.tail.head.toInt
+      val assertions = args.tail.tail
+      DevModeBuild.verifyResourceContains(path, status, assertions, 0)
+    }
+  )

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/project/Build.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+import play.dev.filewatch.FileWatchService
+import play.sbt.run.toLoggerProxy
+import sbt._
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.util.Properties
+
+object DevModeBuild {
+
+  def jdk7WatchService = Def.setting {
+    FileWatchService.jdk7(Keys.sLog.value)
+  }
+
+  def jnotifyWatchService = Def.setting {
+    FileWatchService.jnotify(Keys.target.value)
+  }
+
+  // Using 30 max attempts so that we can give more chances to
+  // the file watcher service. This is relevant when using the
+  // default JDK watch service which does uses polling.
+  val MaxAttempts = 30
+  val WaitTime = 500l
+
+  val ConnectTimeout = 10000
+  val ReadTimeout = 10000
+
+  @tailrec
+  def verifyResourceContains(path: String, status: Int, assertions: Seq[String], attempts: Int): Unit = {
+    println(s"Attempt $attempts at $path")
+    val messages = ListBuffer.empty[String]
+    try {
+      val url = new java.net.URL("http://localhost:9000" + path)
+      val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]
+      conn.setConnectTimeout(ConnectTimeout)
+      conn.setReadTimeout(ReadTimeout)
+
+      if (status == conn.getResponseCode) {
+        messages += s"Resource at $path returned $status as expected"
+      } else {
+        throw new RuntimeException(s"Resource at $path returned ${conn.getResponseCode} instead of $status")
+      }
+
+      val is = if (conn.getResponseCode >= 400) {
+        conn.getErrorStream
+      } else {
+        conn.getInputStream
+      }
+
+      // The input stream may be null if there's no body
+      val contents = if (is != null) {
+        val c = IO.readStream(is)
+        is.close()
+        c
+      } else ""
+      conn.disconnect()
+
+      assertions.foreach { assertion =>
+        if (contents.contains(assertion)) {
+          messages += s"Resource at $path contained $assertion"
+        } else {
+          throw new RuntimeException(s"Resource at $path didn't contain '$assertion':\n$contents")
+        }
+      }
+
+      messages.foreach(println)
+    } catch {
+      case e: Exception =>
+        println(s"Got exception: $e")
+        if (attempts < MaxAttempts) {
+          Thread.sleep(WaitTime)
+          verifyResourceContains(path, status, assertions, attempts + 1)
+        } else {
+          messages.foreach(println)
+          println(s"After $attempts attempts:")
+          throw e
+        }
+    }
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+
+unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "project" / s"scala-sbt-${sbtBinaryVersion.value}"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/resources/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.http.secret.key=";1[WE]JmK;XMCxV=S2P6kYl?A<^YcKYW3aui[SmusaQlkjq97A`M8l_S:iV?OmDh"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/resources/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/resources/routes
@@ -1,0 +1,3 @@
+## Routes file
+
+GET /   controllers.HomeController.index

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/scala/controllers/HomeController.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/scala/controllers/HomeController.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import javax.inject.Inject
+
+import play.api.mvc._
+
+/**
+ * A very small controller that renders a home page.
+ */
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def index = Action { implicit request =>
+    Ok("Hello, this is Play!")
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/test
@@ -1,0 +1,8 @@
+# Build the distribution and ensure that the files we expect are indeed there
+> stage
+$ exists target/universal/stage/README
+$ exists target/universal/stage/bin/root
+
+> runProd --no-exit-sbt
+> verifyResourceContains / 200 Hello
+> stopProd --no-exit-sbt

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/README
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/README
@@ -1,0 +1,4 @@
+This is your new Play application
+=====================================
+
+This file will be packaged with your application, when using `play dist`.

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/build.sbt
@@ -1,0 +1,19 @@
+//
+// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+//
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayService)
+  .enablePlugins(MediatorWorkaroundPlugin)
+  .settings(
+    libraryDependencies += guice,
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4"),
+
+    InputKey[Unit]("verifyResourceContains") := {
+      val args = Def.spaceDelimited("<path> <status> <words> ...").parsed
+      val path = args.head
+      val status = args.tail.head.toInt
+      val assertions = args.tail.tail
+      DevModeBuild.verifyResourceContains(path, status, assertions, 0)
+    }
+  )

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/project/Build.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+import play.dev.filewatch.FileWatchService
+import play.sbt.run.toLoggerProxy
+import sbt._
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.util.Properties
+
+object DevModeBuild {
+
+  def jdk7WatchService = Def.setting {
+    FileWatchService.jdk7(Keys.sLog.value)
+  }
+
+  def jnotifyWatchService = Def.setting {
+    FileWatchService.jnotify(Keys.target.value)
+  }
+
+  // Using 30 max attempts so that we can give more chances to
+  // the file watcher service. This is relevant when using the
+  // default JDK watch service which does uses polling.
+  val MaxAttempts = 30
+  val WaitTime = 500l
+
+  val ConnectTimeout = 10000
+  val ReadTimeout = 10000
+
+  @tailrec
+  def verifyResourceContains(path: String, status: Int, assertions: Seq[String], attempts: Int): Unit = {
+    println(s"Attempt $attempts at $path")
+    val messages = ListBuffer.empty[String]
+    try {
+      val url = new java.net.URL("http://localhost:9000" + path)
+      val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]
+      conn.setConnectTimeout(ConnectTimeout)
+      conn.setReadTimeout(ReadTimeout)
+
+      if (status == conn.getResponseCode) {
+        messages += s"Resource at $path returned $status as expected"
+      } else {
+        throw new RuntimeException(s"Resource at $path returned ${conn.getResponseCode} instead of $status")
+      }
+
+      val is = if (conn.getResponseCode >= 400) {
+        conn.getErrorStream
+      } else {
+        conn.getInputStream
+      }
+
+      // The input stream may be null if there's no body
+      val contents = if (is != null) {
+        val c = IO.readStream(is)
+        is.close()
+        c
+      } else ""
+      conn.disconnect()
+
+      assertions.foreach { assertion =>
+        if (contents.contains(assertion)) {
+          messages += s"Resource at $path contained $assertion"
+        } else {
+          throw new RuntimeException(s"Resource at $path didn't contain '$assertion':\n$contents")
+        }
+      }
+
+      messages.foreach(println)
+    } catch {
+      case e: Exception =>
+        println(s"Got exception: $e")
+        if (attempts < MaxAttempts) {
+          Thread.sleep(WaitTime)
+          verifyResourceContains(path, status, assertions, attempts + 1)
+        } else {
+          messages.foreach(println)
+          println(s"After $attempts attempts:")
+          throw e
+        }
+    }
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+
+unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "project" / s"scala-sbt-${sbtBinaryVersion.value}"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/resources/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.http.secret.key=";1[WE]JmK;XMCxV=S2P6kYl?A<^YcKYW3aui[SmusaQlkjq97A`M8l_S:iV?OmDh"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/scala/controllers/HomeController.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/scala/controllers/HomeController.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import javax.inject.Inject
+
+import play.api.mvc._
+
+/**
+ * A very small controller that renders a home page.
+ */
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def index = Action { implicit request =>
+    Ok("Hello, this is Play!")
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/scala/router/Routes.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/scala/router/Routes.scala
@@ -1,0 +1,14 @@
+package router
+
+import javax.inject.Inject
+
+import play.api.mvc._
+import play.api.routing.Router
+import play.api.routing.SimpleRouter
+import play.api.routing.sird._
+
+class Routes @Inject()(controller: controllers.HomeController) extends SimpleRouter {
+  override def routes: Router.Routes = {
+    case GET(p"/") => controller.index
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/test
@@ -1,0 +1,8 @@
+# Build the distribution and ensure that the files we expect are indeed there
+> stage
+$ exists target/universal/stage/README
+$ exists target/universal/stage/bin/root
+
+> runProd --no-exit-sbt
+> verifyResourceContains / 200 Hello
+> stopProd --no-exit-sbt


### PR DESCRIPTION
Fixes #7991.

Splits the current `Play` plugin into a `PlayService` and `PlayWeb` plugin.

`PlayService` uses the standard maven layout and doesn't automatically add template support, sbt-web, or routes file support. Support for routes can be easily added using the `RoutesCompiler` sbt plugin. The old Play layout can be added by adding `PlayLayoutPlugin`.

Eventually the `PlayService` plugin could also be the base plugin for Lagom services.