### PR TITLE
make Routers composable

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -249,7 +249,10 @@ object BuildSettings {
 
       // Made InlineCache.cache private and changed the type (class is private[play])
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache_=")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache_="),
+      ProblemFilters.exclude[FinalMethodProblem]("play.api.inject.guice.FakeRoutes.handlerFor"),
+      ProblemFilters.exclude[FinalMethodProblem]("play.core.routing.GeneratedRouter.handlerFor"),
+      ProblemFilters.exclude[FinalMethodProblem]("play.api.routing.SimpleRouterImpl.handlerFor")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play/src/main/java/play/routing/Router.java
+++ b/framework/src/play/src/main/java/play/routing/Router.java
@@ -24,6 +24,10 @@ public interface Router {
 
     Router withPrefix(String prefix);
 
+    default Router orElse(Router router) {
+        return this.asScala().orElse(router.asScala()).asJava();
+    }
+
     default play.api.routing.Router asScala() {
         return SimpleRouter$.MODULE$.apply(new JavaPartialFunction<play.api.mvc.RequestHeader, Handler>() {
             @Override

--- a/framework/src/play/src/test/scala/play/api/routing/RouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/routing/RouterSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.routing
+
+import org.specs2.mutable.Specification
+import play.api.mvc.Handler
+import play.api.routing.Router.Routes
+import play.api.routing.sird._
+import play.core.test.FakeRequest
+
+class RouterSpec extends Specification {
+  "Routers" should {
+    object First extends Handler
+    object Second extends Handler
+    object Third extends Handler
+    val firstRouter = Router.from {
+      case GET(p"/oneRoute") => First
+    }
+    val secondRouter = Router.from {
+      case GET(p"/anotherRoute") => Second
+    }
+    val thirdRouter = Router.from {
+      case GET(p"/oneRoute") => Third // sic, same route as in firstRouter
+    }
+
+    "be composable" in {
+      "find handler from first router" in {
+        firstRouter.orElse(secondRouter).handlerFor(FakeRequest("GET", "/oneRoute")) must beSome(First)
+      }
+      "find handler from second router" in {
+        firstRouter.orElse(secondRouter).handlerFor(FakeRequest("GET", "/anotherRoute")) must beSome(Second)
+      }
+      "none when handler is not present in any of the routers" in {
+        firstRouter.orElse(secondRouter).handlerFor(FakeRequest("GET", "/noSuchRoute")) must beNone
+      }
+      "prefer first router if both match" in {
+        firstRouter.orElse(thirdRouter).handlerFor(FakeRequest("GET", "/oneRoute")) must beSome(First)
+      }
+      "withPrefix should be applied recursively" in {
+        val r1 = firstRouter.withPrefix("/stan")
+        val r2 = secondRouter.withPrefix("/kyle")
+        val r3 = r1.orElse(r2).withPrefix("/cartman")
+        r3.handlerFor(FakeRequest("GET", "/cartman/stan/oneRoute")) must beSome(First)
+        r3.handlerFor(FakeRequest("GET", "/cartman/kyle/anotherRoute")) must beSome(Second)
+      }
+      "documentation should be concatenated" in {
+        case class DocRouter(documentation: Seq[(String, String, String)]) extends Router {
+          def routes: Routes = PartialFunction.empty
+          def withPrefix(prefix: String): Router = this
+        }
+
+        val r1 = DocRouter(Seq(("Jesse", "Walter", "Skyler")))
+        val r2 = DocRouter(Seq(("Gus", "Tuco", "Lydia")))
+        r1.orElse(r2).documentation must beEqualTo(Seq(("Jesse", "Walter", "Skyler"), ("Gus", "Tuco", "Lydia")))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hey guys,

This is a small PR to make Router objects composable by adding an `append` method. Effectively this adds a `Monoid` instance for the `Router` type (I didn't want to make that explicit since the framework doesn't currently depend on any library that provides a `Monoid` typeclass, like `play-functional`, but that's essentially what it is). 

This is useful because then you can have traits that extend BuiltInComponents and add their own routes to whatever is already there using the stackable trait pattern. Example:
```
trait FooComponents extends BuiltInComponents {
  lazy val fooRouter = Router.from {
    // router definition here, e. g. using SIRD
  }
  abstract override def router: Router = fooRouter.append(super.router)
}
```
This really helps to create more modular applications, because you only need to mix an additional trait into your components cake and you automagically get the routes associated with that without having to touch the routes file at all. We have used this technique in our project and it works rather well, so I thought it might be useful to other people.
