### PR TITLE
Upgrade Spring dependency

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -73,7 +73,7 @@ object Dependencies {
     case _ => Nil
   }
 
-  val springFrameworkVersion = "4.3.11.RELEASE"
+  val springFrameworkVersion = "5.0.1.RELEASE"
 
   val javaDeps = Seq(
     scalaJava8Compat,
@@ -104,6 +104,7 @@ object Dependencies {
 
     ("org.springframework" % "spring-core" % springFrameworkVersion)
       .exclude("org.springframework", "spring-asm")
+      .exclude("org.springframework", "spring-jcl")
       .exclude("commons-logging", "commons-logging"),
 
     ("org.springframework" % "spring-beans" % springFrameworkVersion)


### PR DESCRIPTION
A new lib would be fetched - the "Spring Commons Logging Bridge": `spring-jcl`. However I think we don't need that one. See: 
https://github.com/spring-projects/spring-framework/tree/v5.0.1.RELEASE/spring-jcl
https://github.com/spring-projects/spring-framework/blob/v5.0.1.RELEASE/spring-jcl/spring-jcl.gradle
https://github.com/spring-projects/spring-framework/blob/v5.0.1.RELEASE/spring-jcl/src/main/java/org/apache/commons/logging/package-info.java#L2-L23