### PR TITLE
Introduce externalizeResourcesExcludes

### DIFF
--- a/documentation/manual/working/commonGuide/build/SBTCookbook.md
+++ b/documentation/manual/working/commonGuide/build/SBTCookbook.md
@@ -46,6 +46,23 @@ For example you can add the `pictures` folder to be included as an additional as
 
 This will allow you to use `routes.Assets.at` with this folder.
 
+## Configure externalized resources
+
+Since Play 2.4 the content of the `conf` directory is added to the classpath by default.
+When [[packaging a Play application for production|Deploying]] that `conf` folder (or it's content) can exist in two places:
+Either the `conf` folder will *not* be packaged into a `jar` file (together with the rest of the application) but instead stays *outside* that `jar` file on the file system. Therefore the content of that `conf` folder (e.g. `application.conf`) can be edited and by restarting the application any changes will be picked up immediately - there is no need to repackage and redeploy an application. This is the default.
+Or Play can be configured to always put the content of the `conf` folder *inside* the application `jar` file. This can be done by setting
+```
+PlayKeys.externalizeResources := false
+```
+in `build.sbt`. Sometimes this behaviour is needed for cases where a library requires (some) resources of the `conf` folder and the application class files to live inside the *same* `jar` file in order to work correctly.
+
+Since Play 2.7 another configuration key exists that allows you to exclude specific resources so they won't be externalized, even though when `PlayKeys.externalizeResources := true`:
+```
+PlayKeys.externalizeResourcesExcludes += "folder-inside-conf/file.xml"
+```
+Thanks to this configuration key you don't have to put all the files of the `conf` folder into the `jar` file anymore when that is needed only for some specific files.
+
 ## Disable documentation
 
 To speed up compilation you can disable documentation generation:

--- a/documentation/manual/working/commonGuide/build/SBTCookbook.md
+++ b/documentation/manual/working/commonGuide/build/SBTCookbook.md
@@ -59,7 +59,7 @@ in `build.sbt`. Sometimes this behaviour is needed for cases where a library req
 
 Since Play 2.7 another configuration key exists that allows you to exclude specific resources so they won't be externalized, even though when `PlayKeys.externalizeResources := true`:
 ```
-PlayKeys.externalizeResourcesExcludes += "folder-inside-conf/file.xml"
+PlayKeys.externalizeResourcesExcludes += baseDirectory.value / "conf" / "somefolder" / "somefile.xml"
 ```
 Thanks to this configuration key you don't have to put all the files of the `conf` folder into the `jar` file anymore when that is needed only for some specific files.
 

--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -54,7 +54,9 @@ Running Play in development mode while using JPA will work fine, but in order to
 
 @[jpa-externalize-resources](code/jpa.sbt)
 
-> **Note:** Since Play 2.4 the contents of the `conf` directory are added to the classpath by default. This option will disable that behavior and allow a JPA application to be deployed. The content of conf directory will still be available in the classpath due to it being included in the application's jar file.
+> **Note:** More information on how to configure externalized resources can be found [[here|SBTCookbook#Configure-externalized-resources]].
+The above settings makes sure the `persistence.xml` file will always stay *inside* the generated application `jar` file.
+This is a requirement by the [JPA specification](http://download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf). According to it the `persistence.xml` file has to be in the *same* `jar` file where its persistence-units' entities live, otherwise these entities won't be availabe for the persistence-units. (You could, however, explicitly add a `jar` file containing entities via `<jar-file>xxx.jar</jar-file>` to a persistence-unit - but that doesn't work well with Play as it would fail with a `FileNotFoundException` in development mode because there is no `jar` file that will be generated in that mode. Further that wouldn't work well in production mode too because when deploying an application, the name of the generated application `jar` file changes with each new release as the current version of the application gets appended to it.)
 
 ## Using `play.db.jpa.JPAApi`
 

--- a/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
+++ b/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
@@ -10,5 +10,5 @@ libraryDependencies ++= Seq(
 //#jpa-sbt-dependencies
 
 //#jpa-externalize-resources
-PlayKeys.externalizeResources := false
+PlayKeys.externalizeResourcesExcludes += "META-INF/persistence.xml"
 //#jpa-externalize-resources

--- a/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
+++ b/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
@@ -10,5 +10,5 @@ libraryDependencies ++= Seq(
 //#jpa-sbt-dependencies
 
 //#jpa-externalize-resources
-PlayKeys.externalizeResourcesExcludes += "META-INF/persistence.xml"
+PlayKeys.externalizeResourcesExcludes += baseDirectory.value / "conf" / "META-INF" / "persistence.xml"
 //#jpa-externalize-resources

--- a/framework/src/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlaySettingsCompat.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlaySettingsCompat.scala
@@ -25,7 +25,7 @@ private[sbt] trait PlaySettingsCompat {
 
   def getPlayAssetsWithCompilation(compileValue: Analysis): Analysis = compileValue
 
-  def getPlayExternalizedResources(rdirs: Seq[File], unmanagedResourcesValue: Seq[File]): Seq[(File, String)] = {
-    (unmanagedResourcesValue --- rdirs) pair (relativeTo(rdirs) | flat)
+  def getPlayExternalizedResources(rdirs: Seq[File], unmanagedResourcesValue: Seq[File], externalizeResourcesExcludes: Seq[String]): Seq[(File, String)] = {
+    (unmanagedResourcesValue --- rdirs) pair (relativeTo(rdirs) | flat) filterNot (r => externalizeResourcesExcludes.map(_.toLowerCase).contains(r._2.toLowerCase))
   }
 }

--- a/framework/src/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlaySettingsCompat.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlaySettingsCompat.scala
@@ -25,7 +25,7 @@ private[sbt] trait PlaySettingsCompat {
 
   def getPlayAssetsWithCompilation(compileValue: Analysis): Analysis = compileValue
 
-  def getPlayExternalizedResources(rdirs: Seq[File], unmanagedResourcesValue: Seq[File], externalizeResourcesExcludes: Seq[String]): Seq[(File, String)] = {
-    (unmanagedResourcesValue --- rdirs) pair (relativeTo(rdirs) | flat) filterNot (r => externalizeResourcesExcludes.map(_.toLowerCase).contains(r._2.toLowerCase))
+  def getPlayExternalizedResources(rdirs: Seq[File], unmanagedResourcesValue: Seq[File], externalizeResourcesExcludes: Seq[File]): Seq[(File, String)] = {
+    (unmanagedResourcesValue --- rdirs --- externalizeResourcesExcludes) pair (relativeTo(rdirs) | flat)
   }
 }

--- a/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/PlaySettingsCompat.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/PlaySettingsCompat.scala
@@ -25,8 +25,8 @@ private[sbt] trait PlaySettingsCompat {
     compileValue.asInstanceOf[sbt.internal.inc.Analysis]
   }
 
-  def getPlayExternalizedResources(rdirs: Seq[File], unmanagedResourcesValue: Seq[File], externalizeResourcesExcludes: Seq[String]): Seq[(File, String)] = {
-    (unmanagedResourcesValue --- rdirs) pair (relativeTo(rdirs) | flat) filterNot (r => externalizeResourcesExcludes.map(_.toLowerCase).contains(r._2.toLowerCase))
+  def getPlayExternalizedResources(rdirs: Seq[File], unmanagedResourcesValue: Seq[File], externalizeResourcesExcludes: Seq[File]): Seq[(File, String)] = {
+    (unmanagedResourcesValue --- rdirs --- externalizeResourcesExcludes) pair (relativeTo(rdirs) | flat)
   }
 
 }

--- a/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/PlaySettingsCompat.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/PlaySettingsCompat.scala
@@ -25,8 +25,8 @@ private[sbt] trait PlaySettingsCompat {
     compileValue.asInstanceOf[sbt.internal.inc.Analysis]
   }
 
-  def getPlayExternalizedResources(rdirs: Seq[File], unmanagedResourcesValue: Seq[File]): Seq[(File, String)] = {
-    (unmanagedResourcesValue --- rdirs) pair (relativeTo(rdirs) | flat)
+  def getPlayExternalizedResources(rdirs: Seq[File], unmanagedResourcesValue: Seq[File], externalizeResourcesExcludes: Seq[String]): Seq[(File, String)] = {
+    (unmanagedResourcesValue --- rdirs) pair (relativeTo(rdirs) | flat) filterNot (r => externalizeResourcesExcludes.map(_.toLowerCase).contains(r._2.toLowerCase))
   }
 
 }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -83,7 +83,7 @@ object PlayImport extends PlayImportCompat {
 
     val externalizeResources = SettingKey[Boolean]("playExternalizeResources", "Whether resources should be externalized into the conf directory when Play is packaged as a distribution.")
     val playExternalizedResources = TaskKey[Seq[(File, String)]]("playExternalizedResources", "The resources to externalize")
-    val externalizeResourcesExcludes = SettingKey[Seq[(String)]]("externalizeResourcesExcludes", "Resources that should not be externalized but stay in the generated jar")
+    val externalizeResourcesExcludes = SettingKey[Seq[String]]("externalizeResourcesExcludes", "Resources that should not be externalized but stay in the generated jar")
     val playJarSansExternalized = TaskKey[File]("playJarSansExternalized", "Creates a jar file that has all the externalized resources excluded")
 
     val playOmnidoc = SettingKey[Boolean]("playOmnidoc", "Determines whether to use the aggregated Play documentation")

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -83,6 +83,7 @@ object PlayImport extends PlayImportCompat {
 
     val externalizeResources = SettingKey[Boolean]("playExternalizeResources", "Whether resources should be externalized into the conf directory when Play is packaged as a distribution.")
     val playExternalizedResources = TaskKey[Seq[(File, String)]]("playExternalizedResources", "The resources to externalize")
+    val externalizeResourcesExcludes = SettingKey[Seq[(String)]]("externalizeResourcesExcludes", "Resources that should not be externalized but stay in the generated jar")
     val playJarSansExternalized = TaskKey[File]("playJarSansExternalized", "Creates a jar file that has all the externalized resources excluded")
 
     val playOmnidoc = SettingKey[Boolean]("playOmnidoc", "Determines whether to use the aggregated Play documentation")

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -83,7 +83,7 @@ object PlayImport extends PlayImportCompat {
 
     val externalizeResources = SettingKey[Boolean]("playExternalizeResources", "Whether resources should be externalized into the conf directory when Play is packaged as a distribution.")
     val playExternalizedResources = TaskKey[Seq[(File, String)]]("playExternalizedResources", "The resources to externalize")
-    val externalizeResourcesExcludes = SettingKey[Seq[String]]("externalizeResourcesExcludes", "Resources that should not be externalized but stay in the generated jar")
+    val externalizeResourcesExcludes = SettingKey[Seq[File]]("externalizeResourcesExcludes", "Resources that should not be externalized but stay in the generated jar")
     val playJarSansExternalized = TaskKey[File]("playJarSansExternalized", "Creates a jar file that has all the externalized resources excluded")
 
     val playOmnidoc = SettingKey[Boolean]("playOmnidoc", "Determines whether to use the aggregated Play documentation")

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -57,6 +57,8 @@ object PlaySettings extends PlaySettingsCompat {
 
     externalizeResources := true,
 
+    externalizeResourcesExcludes := Nil,
+
     includeDocumentationInBinary := true,
 
     javacOptions in (Compile, doc) := List("-encoding", "utf8"),
@@ -263,7 +265,8 @@ object PlaySettings extends PlaySettingsCompat {
     Defaults.packageTaskSettings(playJarSansExternalized, mappings in playJarSansExternalized) ++ Seq(
       playExternalizedResources := getPlayExternalizedResources(
         unmanagedResourceDirectories.value,
-        unmanagedResources.value
+        unmanagedResources.value,
+        externalizeResourcesExcludes.value
       ),
       mappings in playJarSansExternalized := {
         // packageBin mappings have all the copied resources from the classes directory

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
@@ -1,6 +1,6 @@
 # Build the distribution and ensure that the files we expect are indeed there
 # Note: externalizeResources is true by default
-> set PlayKeys.externalizeResourcesExcludes += '"MEtA-InF/peRsisTence.xml"'
+> set PlayKeys.externalizeResourcesExcludes += baseDirectory.value / '"conf"' / '"META-INF"' / '"persistence.xml"'
 > stage
 $ exists target/universal/stage/README
 $ exists target/universal/stage/SomeFile.txt

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
@@ -1,4 +1,6 @@
 # Build the distribution and ensure that the files we expect are indeed there
+# Note: externalizeResources is true by default
+> set PlayKeys.externalizeResourcesExcludes += '"MEtA-InF/peRsisTence.xml"'
 > stage
 $ exists target/universal/stage/README
 $ exists target/universal/stage/SomeFile.txt
@@ -8,6 +10,7 @@ $ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT-sans-ex
 
 > checkStartScript
 $ exists target/universal/stage/conf/application.conf
+-$ exists target/universal/stage/conf/META-INF/persistence.xml
 $ exists target/universal/stage/lib
 $ exists target/universal/stage/share/doc/api
 
@@ -27,6 +30,8 @@ $ copy-file conf/alternate.conf target/universal/stage/conf/application.conf
 > set PlayKeys.externalizeResources := false
 > stage
 -$ exists target/dist/conf/application.conf
+-$ exists target/universal/stage/conf/application.conf
+-$ exists target/universal/stage/conf/META-INF/persistence.xml
 -$ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT-sans-externalized.jar
 $ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT.jar
 > checkStartScript no-conf


### PR DESCRIPTION
Introduces `PlayKeys.externalizeResourcesExcludes` which allows us/you to exclude selected resources from being externalized even though when `PlayKeys.externalizeResources := true` (which is the default).

This is especially useful for JPA because the `META-INF/persistence.xml` file has to be in the *same* jar file where its persistence-unit(s) entities live, otherwise these entities won't be availabe for the persistence-unit(s) - even when that jar containing the entities is on the classpath. (You could, however, add the jar via `<jar-file>xxx.jar</jar-file>` to  a persistence-unit, according to the [JPA specification](http://download.oracle.com/otn-pub/jcp/persistence-2_1-fr-eval-spec/JavaPersistence.pdf) - but that doesn't work well with play because that would fail with a `FileNotFoundException` in dev mode as there is no jar that will be generated and for staging the file name of the generated app jar changes which each new release because the version is appended to it).

We can set `PlayKeys.externalizeResourcesExcludes += "META-INF/persistence.xml"` by default as soon as someone adds `javaJpa` to the `libraryDependencies`. That would allow us the remove [the section in the docs](https://www.playframework.com/documentation/2.6.7/JavaJPA#Deploying-Play-with-JPA) where we tell people to set `PlayKeys.externalizeResources := false` to make JPA work with Play. So JPA in Play would "just work" now (and people would still be able to edit the the `conf/application.conf` file, etc. in staging and just restart the app with no need to re-package the whole app like that's the case for play-jpa apps right now.)

BTW: I am not aware other libraries that require a config or similiar to live in the same jar with other required classes, however the setting introduced with this pr would allow us to easily add other excluded resources in the future if needed.