### PR TITLE
[2.6.x] Provide an action the information about its precursor (#7965)

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -24,7 +24,18 @@ public abstract class Action<T> extends Results {
     public AnnotatedElement annotatedElement;
 
     /**
+     * The precursor action.
+     *
+     * If this action was called in a chain then this will contain the value of the action
+     * that is called before this action. If no action was called first, then this value will be null.
+     */
+    public Action<?> precursor;
+
+    /**
      * The wrapped action.
+     *
+     * If this action was called in a chain then this will contain the value of the action
+     * that is called after this action. If there is no action left to be called, then this value will be null.
      */
     public Action<?> delegate;
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -91,6 +91,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
     val endOfChainAction = if (config.executeActionCreatorActionFirst) {
       rootAction
     } else {
+      rootAction.precursor = baseAction
       baseAction.delegate = rootAction
       baseAction
     }
@@ -99,12 +100,14 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
       case (delegate, (annotation, actionClass, annotatedElement)) =>
         val action = handlerComponents.getAction(actionClass).asInstanceOf[play.mvc.Action[Object]]
         action.configuration = annotation
+        delegate.precursor = action
         action.delegate = delegate
         action.annotatedElement = annotatedElement
         action
     }
 
     val firstAction = if (config.executeActionCreatorActionFirst) {
+      firstUserDeclaredAction.precursor = baseAction
       baseAction.delegate = firstUserDeclaredAction
       baseAction
     } else {


### PR DESCRIPTION
Backports #7965
We do need this in the next 2.6.x release since it *is* useful for us right *now*.