### PR TITLE
Easy way to set server-header when using Netty

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -243,7 +243,11 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.ApplicationLoader#Context.copy$default$2"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.ApplicationLoader#Context.copy$default$5"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServerComponents.sourceMapper"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServerComponents.webCommands")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServerComponents.webCommands"),
+
+      // Pass a default server header to netty
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler.this")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -36,9 +36,9 @@ play {
 
       # The default value of the `Server` header to produce if no
       # explicit `Server`-header was included in a response.
-      # If this value is the empty string and no header was included in
+      # If this value is null and no header was included in
       # the request, no `Server` header will be rendered at all.
-      server-header = ""
+      server-header = null
 
       # Configures the processing mode when encountering illegal characters in
       # header value of response.

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -39,6 +39,7 @@ play {
       # If this value is null and no header was included in
       # the request, no `Server` header will be rendered at all.
       server-header = null
+      server-header = ${?play.server.server-header}
 
       # Configures the processing mode when encountering illegal characters in
       # header value of response.

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -95,7 +95,7 @@ class AkkaHttpServer(
       .withRemoteAddressHeader(true)
       // Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
       .withTransparentHeadRequests(akkaServerConfig.get[Boolean]("transparent-head-requests"))
-      .withServerHeader(akkaServerConfig.getOptional[String]("server-header").map(headers.Server(_)))
+      .withServerHeader(akkaServerConfig.get[Option[String]]("server-header").collect { case s if s.nonEmpty => headers.Server(s) })
       .withDefaultHostHeader(headers.Host(akkaServerConfig.get[String]("default-host-header")))
       .withParserSettings(parserSettings)
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -95,7 +95,7 @@ class AkkaHttpServer(
       .withRemoteAddressHeader(true)
       // Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
       .withTransparentHeadRequests(akkaServerConfig.get[Boolean]("transparent-head-requests"))
-      .withServerHeader(akkaServerConfig.getOptional[String]("server-header").filterNot(_ == "").map(headers.Server(_)))
+      .withServerHeader(akkaServerConfig.getOptional[String]("server-header").map(headers.Server(_)))
       .withDefaultHostHeader(headers.Host(akkaServerConfig.get[String]("default-host-header")))
       .withParserSettings(parserSettings)
 

--- a/framework/src/play-microbenchmark/src/test/scala/play/core/server/netty/NettyHelpers.scala
+++ b/framework/src/play-microbenchmark/src/test/scala/play/core/server/netty/NettyHelpers.scala
@@ -26,7 +26,8 @@ object NettyHelpers {
     )
     new NettyModelConversion(
       serverResultUtils,
-      new ForwardedHeaderHandler(ForwardedHeaderHandler.ForwardedHeaderHandlerConfig(None))
+      new ForwardedHeaderHandler(ForwardedHeaderHandler.ForwardedHeaderHandlerConfig(None)),
+      None
     )
   }
 

--- a/framework/src/play-netty-server/src/main/resources/reference.conf
+++ b/framework/src/play-netty-server/src/main/resources/reference.conf
@@ -6,8 +6,8 @@ play.server {
   netty {
 
     # The default value of the `Server` header to produce if no explicit `Server`-header was included in a response.
-    # If this value is the empty string and no header was included in the request, no `Server` header will be rendered at all.
-    server-header = ""
+    # If this value is the null and no header was included in the request, no `Server` header will be rendered at all.
+    server-header = null
 
     # The number of event loop threads. 0 means let Netty decide, which by default will select 2 times the number of
     # available processors.

--- a/framework/src/play-netty-server/src/main/resources/reference.conf
+++ b/framework/src/play-netty-server/src/main/resources/reference.conf
@@ -5,6 +5,10 @@ play.server {
 
   netty {
 
+    # The default value of the `Server` header to produce if no explicit `Server`-header was included in a response.
+    # If this value is the empty string and no header was included in the request, no `Server` header will be rendered at all.
+    server-header = ""
+
     # The number of event loop threads. 0 means let Netty decide, which by default will select 2 times the number of
     # available processors.
     eventLoopThreads = 0

--- a/framework/src/play-netty-server/src/main/resources/reference.conf
+++ b/framework/src/play-netty-server/src/main/resources/reference.conf
@@ -8,6 +8,7 @@ play.server {
     # The default value of the `Server` header to produce if no explicit `Server`-header was included in a response.
     # If this value is the null and no header was included in the request, no `Server` header will be rendered at all.
     server-header = null
+    server-header = ${?play.server.server-header}
 
     # The number of event loop threads. 0 means let Netty decide, which by default will select 2 times the number of
     # available processors.

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -49,7 +49,7 @@ class NettyServer(
 
   private val serverConfig = config.configuration.get[Configuration]("play.server")
   private val nettyConfig = serverConfig.get[Configuration]("netty")
-  private val serverHeader = nettyConfig.getOptional[String]("server-header")
+  private val serverHeader = nettyConfig.get[Option[String]]("server-header").collect { case s if s.nonEmpty => s }
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize = nettyConfig.get[Int]("maxHeaderSize")
   private val maxChunkSize = nettyConfig.get[Int]("maxChunkSize")

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -49,7 +49,7 @@ class NettyServer(
 
   private val serverConfig = config.configuration.get[Configuration]("play.server")
   private val nettyConfig = serverConfig.get[Configuration]("netty")
-  private val serverHeader = nettyConfig.getOptional[String]("server-header").filterNot(_ == "")
+  private val serverHeader = nettyConfig.getOptional[String]("server-header")
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize = nettyConfig.get[Int]("maxHeaderSize")
   private val maxChunkSize = nettyConfig.get[Int]("maxChunkSize")

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -49,6 +49,7 @@ class NettyServer(
 
   private val serverConfig = config.configuration.get[Configuration]("play.server")
   private val nettyConfig = serverConfig.get[Configuration]("netty")
+  private val serverHeader = nettyConfig.getOptional[String]("server-header").filterNot(_ == "")
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize = nettyConfig.get[Int]("maxHeaderSize")
   private val maxChunkSize = nettyConfig.get[Int]("maxChunkSize")
@@ -143,7 +144,7 @@ class NettyServer(
   /**
    * Create a new PlayRequestHandler.
    */
-  protected[this] def newRequestHandler(): ChannelInboundHandler = new PlayRequestHandler(this)
+  protected[this] def newRequestHandler(): ChannelInboundHandler = new PlayRequestHandler(this, serverHeader)
 
   /**
    * Create a sink for the incoming connection channels.

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -31,7 +31,8 @@ import scala.util.{ Failure, Try }
 
 private[server] class NettyModelConversion(
     resultUtils: ServerResultUtils,
-    forwardedHeaderHandler: ForwardedHeaderHandler) {
+    forwardedHeaderHandler: ForwardedHeaderHandler,
+    serverHeader: Option[String]) {
 
   private val logger = Logger(classOf[NettyModelConversion])
 
@@ -268,12 +269,17 @@ private[server] class NettyModelConversion(
         response.headers().add(DATE, dateHeader)
       }
 
+      if (!response.headers().contains(SERVER)) {
+        serverHeader.foreach(response.headers().add(SERVER, _))
+      }
+
       Future.successful(response)
     } {
       // Fallback response
       val response = new DefaultFullHttpResponse(httpVersion, HttpResponseStatus.INTERNAL_SERVER_ERROR, Unpooled.EMPTY_BUFFER)
       HttpUtil.setContentLength(response, 0)
       response.headers().add(DATE, dateHeader)
+      serverHeader.foreach(response.headers().add(SERVER, _))
       response.headers().add(CONNECTION, "close")
       response
     }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -28,7 +28,7 @@ private object PlayRequestHandler {
   private val logger: Logger = Logger(classOf[PlayRequestHandler])
 }
 
-private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelInboundHandlerAdapter {
+private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader: Option[String]) extends ChannelInboundHandlerAdapter {
 
   import PlayRequestHandler._
 
@@ -56,7 +56,7 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
     override protected def reloadValue(tryApp: Try[Application]): ReloadCacheValues = {
       val serverResultUtils = reloadServerResultUtils(tryApp)
       val forwardedHeaderHandler = reloadForwardedHeaderHandler(tryApp)
-      val modelConversion = new NettyModelConversion(serverResultUtils, forwardedHeaderHandler)
+      val modelConversion = new NettyModelConversion(serverResultUtils, forwardedHeaderHandler, serverHeader)
       ReloadCacheValues(
         resultUtils = serverResultUtils,
         modelConversion = modelConversion


### PR DESCRIPTION
For akka-http we [already have](https://github.com/playframework/playframework/blob/2.6.7/framework/src/play-akka-http-server/src/main/resources/reference.conf#L37-L41) this setting:
```
play.server.akka.server-header = ...
```
which is implemented [here](https://github.com/playframework/playframework/blob/2.6.7/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala#L98).

This pull request now adds the same feature for the Netty backend:
```
play.server.netty.server-header = ...
```

Please backport this to 2.6 because I need this to get the TechEmpower benchmarks working with the netty backend. All the Play benchmarks (which all use akka-http now) just set the `server-header` config, which allowed me to get rid of filters and action compositions which were needed just to set that header.