### PR TITLE
Fixing example value for maxMemoryBuffer on 2.6.x documentation

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
@@ -60,7 +60,7 @@ Most of the built in body parsers buffer the body in memory, and some buffer it 
 
 The memory buffer limit is configured using `play.http.parser.maxMemoryBuffer`, and defaults to 100KB, while the disk buffer limit is configured using `play.http.parser.maxDiskBuffer`, and defaults to 10MB.  These can both be configured in `application.conf`, for example, to increase the memory buffer limit to 256KB:
 
-    play.http.parser.maxMemoryBuffer = 256kb
+    play.http.parser.maxMemoryBuffer = 256K
 
 You can also limit the amount of memory used on a per action basis by writing a custom body parser, see [below](#Writing-a-custom-max-length-body-parser) for details.
 


### PR DESCRIPTION
Switching to 'K' instead of 'kb'. Using 'kb' causes the app to crash.