### PR TITLE
Actually set the netty request tag

### DIFF
--- a/documentation/manual/working/commonGuide/server/NettyServer.md
+++ b/documentation/manual/working/commonGuide/server/NettyServer.md
@@ -25,11 +25,11 @@ run -Dplay.server.provider=play.core.server.NettyServerProvider
 
 ## Verifying that the Netty server is running
 
-When the Netty server is running it will tag all requests with a tag called `HTTP_SERVER` with a value of `netty`. The Netty backend will not have a value for this tag.
+When the Netty server is running it will tag all requests with a tag called `HTTP_SERVER` with a value of `netty`. The Akka HTTP backend will not have a value for this tag.
 
 ```scala
 Action { request =>
-  assert(request.tags.get("HTTP_SERVER") == Some("netty"))
+  assert(request.tags.get("HTTP_SERVER") == "netty")
   ...
 }
 ```

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -165,7 +165,7 @@ private[server] class NettyModelConversion(
       // Send an attribute so our tests can tell which kind of server we're using.
       // We only do this for the "non-default" engine, so we used to tag
       // akka-http explicitly, so that benchmarking isn't affected by this.
-      TypedMap(RequestAttrKey.Server -> "netty")
+      TypedMap(RequestAttrKey.Server -> "netty", RequestAttrKey.Tags -> Map("HTTP_SERVER" -> "netty"))
     )
   }
 


### PR DESCRIPTION
The Netty `HTTP_SERVER` request tag was never set.
Also the docs were buggy (the tags are a `<String, String>` map).

BTW: I know tags are deprecated, I will provide another pr for this.