### PR TITLE
Add imports to PlayImport

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -100,7 +100,7 @@ object PlayNettyServer extends AutoPlugin {
       if (PlayKeys.playPlugin.value) {
         Nil
       } else {
-        Seq("com.typesafe.play" %% "play-netty-server" % play.core.PlayVersion.current)
+        Seq(PlayImport.nettyServer)
       }
     }
   )
@@ -114,7 +114,7 @@ object PlayAkkaHttpServer extends AutoPlugin {
   override def trigger = allRequirements
 
   override def projectSettings = Seq(
-    libraryDependencies += "com.typesafe.play" %% "play-akka-http-server" % play.core.PlayVersion.current
+    libraryDependencies += PlayImport.akkaHttpServer
   )
 }
 

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -22,6 +22,14 @@ object PlayImport extends PlayImportCompat {
     throw new ComponentExternalisedException
   }
 
+  val playCore = component("play")
+
+  val nettyServer = component("play-netty-server")
+
+  val akkaHttpServer = component("play-akka-http-server")
+
+  val logback = component("play-logback")
+
   val evolutions = component("play-jdbc-evolutions")
 
   val jdbc = component("play-jdbc")

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayLogback.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayLogback.scala
@@ -17,7 +17,7 @@ object PlayLogback extends AutoPlugin {
 
   override def projectSettings = Seq(
     libraryDependencies ++= {
-      Seq("com.typesafe.play" %% "play-logback" % play.core.PlayVersion.current)
+      Seq(PlayImport.logback)
     }
   )
 }


### PR DESCRIPTION
This makes it easier to build minimal projects without using the Play plugin.

I also added the `playCore` import for the `play` library. This is useful when building libraries based on Play where you don't want to use the Play plugin.