### PR TITLE
asScala/asJava for TypedMap and TypedKey + docs update

### DIFF
--- a/documentation/manual/working/commonGuide/server/NettyServer.md
+++ b/documentation/manual/working/commonGuide/server/NettyServer.md
@@ -25,14 +25,13 @@ run -Dplay.server.provider=play.core.server.NettyServerProvider
 
 ## Verifying that the Netty server is running
 
-When the Netty server is running it will tag all requests with a tag called `HTTP_SERVER` with a value of `netty`. The Akka HTTP backend will not have a value for this tag.
+When the Netty server is running the request attribute `RequestAttrKey.Server` with the value `netty` will be set for all requests. The Akka HTTP backend will not set a value for this request attribute.
 
-```scala
-Action { request =>
-  assert(request.tags.get("HTTP_SERVER") == "netty")
-  ...
-}
-```
+Scala
+: @[server-request-attribute](code/SomeScalaController.scala)
+
+Java
+: @[server-request-attribute](code/SomeJavaController.java)
 
 ## Configuring Netty
 

--- a/documentation/manual/working/commonGuide/server/code/SomeJavaController.java
+++ b/documentation/manual/working/commonGuide/server/code/SomeJavaController.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+import play.mvc.Controller;
+import play.mvc.Result;
+import java.util.Optional;
+//#server-request-attribute
+import play.api.mvc.request.RequestAttrKey;
+
+public class SomeJavaController extends Controller {
+
+  public Result index() {
+    assert(request().attrs().getOptional(RequestAttrKey.Server().asJava()).equals(Optional.of("netty")));
+    // ...
+    //###skip: 1
+    return ok("");
+  }
+
+}
+//#server-request-attribute

--- a/documentation/manual/working/commonGuide/server/code/SomeScalaController.scala
+++ b/documentation/manual/working/commonGuide/server/code/SomeScalaController.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+import javax.inject._
+import play.api.mvc._
+//#server-request-attribute
+import play.api.mvc.request.RequestAttrKey
+
+class SomeScalaController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def index = Action { request =>
+    assert(request.attrs.get(RequestAttrKey.Server) == Option("netty"))
+    // ...
+    //###skip: 1
+    Ok("")
+  }
+
+}
+//#server-request-attribute

--- a/framework/src/play/src/main/java/play/libs/typedmap/TypedKey.java
+++ b/framework/src/play/src/main/java/play/libs/typedmap/TypedKey.java
@@ -20,8 +20,18 @@ public final class TypedKey<A> {
 
     /**
      * @return the underlying Scala TypedKey which this instance wraps.
+     *
+     * @deprecated As of release 2.6.8. Use {@link #asScala()}
      */
+    @Deprecated
     public play.api.libs.typedmap.TypedKey<A> underlying() {
+        return underlying;
+    }
+
+    /**
+     * @return the underlying Scala TypedKey which this instance wraps.
+     */
+    public play.api.libs.typedmap.TypedKey<A> asScala() {
         return underlying;
     }
 

--- a/framework/src/play/src/main/java/play/libs/typedmap/TypedMap.java
+++ b/framework/src/play/src/main/java/play/libs/typedmap/TypedMap.java
@@ -31,8 +31,18 @@ public final class TypedMap {
 
     /**
      * @return the underlying Scala TypedMap which this instance wraps.
+     *
+     * @deprecated As of release 2.6.8. Use {@link #asScala()}
      */
+    @Deprecated
     public play.api.libs.typedmap.TypedMap underlying() {
+        return underlying;
+    }
+
+    /**
+     * @return the underlying Scala TypedMap which this instance wraps.
+     */
+    public play.api.libs.typedmap.TypedMap asScala() {
         return underlying;
     }
 
@@ -45,7 +55,7 @@ public final class TypedMap {
      * @throws java.util.NoSuchElementException If the value isn't present in the map.
      */
     public <A> A get(TypedKey<A> key) {
-        return underlying.apply(key.underlying());
+        return underlying.apply(key.asScala());
     }
 
     /**
@@ -56,7 +66,7 @@ public final class TypedMap {
      * @return An <code>Optional</code>, with the value present if it is in the map.
      */
     public <A> Optional<A> getOptional(TypedKey<A> key) {
-        return OptionConverters.toJava(underlying.get(key.underlying()));
+        return OptionConverters.toJava(underlying.get(key.asScala()));
     }
 
     /**
@@ -66,7 +76,7 @@ public final class TypedMap {
      * @return True if the value is present, false otherwise.
      */
     public boolean containsKey(TypedKey<?> key) {
-        return underlying.contains(key.underlying());
+        return underlying.contains(key.asScala());
     }
 
     /**
@@ -78,7 +88,7 @@ public final class TypedMap {
      * @return A new instance of the map with the new entry added.
      */
     public <A> TypedMap put(TypedKey<A> key, A value) {
-        return new TypedMap(underlying.updated(key.underlying(), value));
+        return new TypedMap(underlying.updated(key.asScala(), value));
     }
 
     /**
@@ -90,7 +100,7 @@ public final class TypedMap {
     public TypedMap putAll(TypedEntry<?>... entries) {
         play.api.libs.typedmap.TypedMap newUnderlying = underlying;
         for (TypedEntry<?> e : entries) {
-            newUnderlying = newUnderlying.updated(((TypedKey<Object>) e.key()).underlying(), e.value());
+            newUnderlying = newUnderlying.updated(((TypedKey<Object>) e.key()).asScala(), e.value());
         }
         return new TypedMap(newUnderlying);
     }

--- a/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedKey.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedKey.scala
@@ -32,6 +32,11 @@ final class TypedKey[A] private (val displayName: Option[String]) {
   def -> (value: A): TypedEntry[A] = bindValue(value)
 
   override def toString: String = displayName.getOrElse(super.toString)
+
+  /**
+   * @return The Java version for this key.
+   */
+  def asJava: play.libs.typedmap.TypedKey[A] = new play.libs.typedmap.TypedKey[A](this)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -63,6 +63,11 @@ trait TypedMap {
    * @return A new instance of the map with the new entries added.
    */
   def +(entries: TypedEntry[_]*): TypedMap
+
+  /**
+   * @return The Java version for this map.
+   */
+  def asJava: play.libs.typedmap.TypedMap = new play.libs.typedmap.TypedMap(this)
 }
 
 object TypedMap {


### PR DESCRIPTION
Don't use tags in the documentation, it's deprecated. Use request attributes instead.