### PR TITLE
Removes unnecessary actorsystem.terminate

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -335,8 +335,6 @@ class AkkaHttpServer(
       case NonFatal(e) => logger.error("Error while stopping logger", e)
     }
 
-    system.terminate()
-
     // Call provided hook
     // Do this last because the hooks were created before the server,
     // so the server might need them to run until the last moment.


### PR DESCRIPTION
## Purpose

IIUC, `AkkaHttpServer` doesn't need to stop the actorSystem it runs on. It is provided externally so I would expect the invoking code to manage the termination.

* In `ProdServerStart` the actorSystem used is the one from the `Application`. When `AkkaHttpServer` stops the application the actor system is terminated. In this case, the removed line is a noop.
* In `DevServerStart` the `ServerContext` has a custom `stopHook` that stops the actorSystem custom-created for the server. In this case, the removed line actually terminates the actor system and the custom `stopHook` becomes a noop.

