### PR TITLE
Removes double indirection

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -201,7 +201,7 @@ object PlayRun extends PlayRunCompat {
   val playStartCommand = Command.args("start", "<port>") { (state: State, args: Seq[String]) =>
     state.log.warn("The start command is deprecated, and will be removed in a future version of Play.")
     state.log.warn("To run Play in production mode, run 'stage' instead, and then execute the generated start script in target/universal/stage/bin.")
-    state.log.warn("To test your application using production mode, run 'testProd' instead.")
+    state.log.warn("To test your application using production mode, run 'runProd' instead.")
 
     testProd(state, args)
   }


### PR DESCRIPTION
In the deprecation message for `start`, there's a recommendation to run `testProd` which is deprecated too.
The deprecation message for `testProd` recommends using `runProd`.

This change updates the deprecation message of `start` to avoid the double indirection and instruct users to go straight to `runProd`.
