### PR TITLE
[WIP] Replaces Play's shutdown hook with Akka's CoordinatedShutdown

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -4,14 +4,19 @@
 package play.core.server
 
 import java.io._
-import akka.actor.ActorSystem
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.Done
+import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.actor.CoordinatedShutdown._
 import akka.stream.ActorMaterializer
 import play.api._
 import play.api.mvc._
 import play.core._
 import play.utils.Threads
+
 import scala.collection.JavaConverters._
-import scala.concurrent.{ Future, Await }
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
@@ -93,6 +98,8 @@ object DevServerStart {
         println(play.utils.Colors.magenta("--- (Running the application, auto-reloading is enabled) ---"))
         println()
 
+        val unexpectedApplicationShutdown = new AtomicBoolean(true)
+
         // Create reloadable ApplicationProvider
         val appProvider = new ApplicationProvider {
           // Use a stamped lock over a synchronized block so we can better control concurrency and avoid
@@ -141,7 +148,8 @@ object DevServerStart {
               val reloadable = this
 
               // First, stop the old application if it exists
-              lastState.foreach(Play.stop)
+              unexpectedApplicationShutdown.set(false)
+              lastState.foreach(app => Await.result(CoordinatedShutdown(app.actorSystem).run(), 10.minutes))
 
               // Basically no matter if the last state was a Success, we need to
               // call all remaining hooks
@@ -170,7 +178,26 @@ object DevServerStart {
                   devContext = Some(ApplicationLoader.DevContext(sourceMapper, buildLink))
                 )
                 val loader = ApplicationLoader(context)
-                loader.load(context)
+                val app = loader.load(context)
+
+                // The new incarnation of Application may be shutdown in a controlled way (via reload)
+                // or it may be shutdown by an external trigger of CoordinatedShutdown. Unless explicitly
+                // specified we assume the shutdown was external (aka unexpected)
+                unexpectedApplicationShutdown.set(true)
+                CoordinatedShutdown(app.actorSystem).addTask(PlayCoordinatedShutdown.PhaseApplicationStopHooks, "dev-application-stop-hooks") {
+                  () =>
+                    Play.stop(app)
+                    // because anyone has access to shutting down the application via invoking
+                    // CoordinatedShutdown.run(), we track if the shutdown was controlled or unexpected. When it's
+                    // unexpected we tell the buildLink to force a reload. When it's expected the buildLink should
+                    // not be notified because it is either a reload or on system termination.
+                    if (unexpectedApplicationShutdown.get()) {
+                      buildLink.forceReload()
+                    }
+                    Future.successful(Done)
+                }
+
+                app
               }
 
               Play.start(newApplication)
@@ -209,16 +236,29 @@ object DevServerStart {
         // then both the dev mode and the application actor system will attempt to open that remote port, and one of
         // them will fail.
         val devModeAkkaConfig = serverConfig.configuration.underlying.getConfig("play.akka.dev-mode")
-        val actorSystem = ActorSystem("play-dev-mode", devModeAkkaConfig)
+        val serverActorSystem = ActorSystem("play-dev-mode", devModeAkkaConfig)
 
-        val serverContext = ServerProvider.Context(serverConfig, appProvider, actorSystem,
-          ActorMaterializer()(actorSystem), () => {
-            actorSystem.terminate()
-            Await.result(actorSystem.whenTerminated, Duration.Inf)
-            Future.successful(())
-          })
+        val serverContext = ServerProvider.Context(serverConfig, appProvider, serverActorSystem,
+          ActorMaterializer()(serverActorSystem),
+          () => Future.successful(()))
+
+        CoordinatedShutdown(serverActorSystem).addTask(PhaseActorSystemTerminate, "devmode-server-actor-system-shutdown") {
+          () =>
+            appProvider.current.map {
+              app =>
+                unexpectedApplicationShutdown.set(false)
+                CoordinatedShutdown(app.actorSystem).run()
+            }.getOrElse(Future.successful(Done))
+        }
+
         val serverProvider = ServerProvider.fromConfiguration(classLoader, serverConfig.configuration)
-        serverProvider.createServer(serverContext)
+
+        new ReloadableServer {
+          val delegate: ReloadableServer = serverProvider.createServer(serverContext)
+          override def stop() = CoordinatedShutdown(serverActorSystem).run()
+          override def reload() = delegate.reload()
+          override def mainAddress() = delegate.mainAddress()
+        }
       } catch {
         case e: ExceptionInInitializerError => throw e.getCause
       }

--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -149,7 +149,7 @@ object DevServerStart {
 
               // First, stop the old application if it exists
               unexpectedApplicationShutdown.set(false)
-              lastState.foreach(app => Await.result(CoordinatedShutdown(app.actorSystem).run(), 10.minutes))
+              lastState.foreach(Play.stop)
 
               // Basically no matter if the last state was a Success, we need to
               // call all remaining hooks
@@ -242,7 +242,7 @@ object DevServerStart {
           ActorMaterializer()(serverActorSystem),
           () => Future.successful(()))
 
-        CoordinatedShutdown(serverActorSystem).addTask(PhaseActorSystemTerminate, "devmode-server-actor-system-shutdown") {
+        CoordinatedShutdown(serverActorSystem).addTask(PlayCoordinatedShutdown.PhaseApplicationStopHooks, "devmode-server-actor-system-shutdown") {
           () =>
             appProvider.current.map {
               app =>

--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -41,4 +41,61 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
+  # CoordinatedShutdown is an extension introduced in Akka 2.5 that will
+  # perform registered tasks in the order that is defined by the phases.
+  # This setup extends Akka's default phases with Play-specific ones.
+  coordinated-shutdown {
+
+    # Terminate the ActorSystem in the last phase actor-system-terminate.
+    terminate-actor-system = on
+
+    # Exit the JVM (System.exit(0)) in the last phase actor-system-terminate
+    # if this is set to 'on'. It is done after termination of the
+    # ActorSystem if terminate-actor-system=on, otherwise it is done
+    # immediately when the last phase is reached.
+    exit-jvm = off
+
+    # Run the coordinated shutdown when the JVM process exits, e.g.
+    # via kill SIGTERM signal (SIGINT ctrl-c doesn't work).
+    run-by-jvm-shutdown-hook = on
+
+    #//#coordinated-shutdown-phases-play-overrides
+    phases {
+
+      # application-stop-hooks phase will run the stop hooks registered
+      # in Play's ApplicationLifecycle. Stop hooks in ApplicationLifecycle
+      # are run in reverse order than they where registered.
+      # Other tasks registered in this phase directly will run in parallel
+      # to Play's stop hooks.
+      # This phase depends on Akka's default 'service-stop'
+      application-stop-hooks {
+        depends-on = [service-stop]
+      }
+
+      # Once the service and the application are stopped Play needs to run
+      # server cleanup code.
+      play-server-stop {
+        depends-on = [application-stop-hooks]
+      }
+
+      # Once the server cleanup completes the server is considered stopped.
+      # In this phase it's possible to include custom server hooks to run after
+      # server is shutdown.
+      after-play-server-stop {
+        depends-on = [play-server-stop]
+      }
+
+      # This overrides Akka's default 'before-cluster-shutdown' in order to
+      # add 'application-stop-hooks' and 'after-server-stop' in the
+      # default graph of shutdown phases.
+      # Note this defaults run the complete play Server shutdown before
+      # shutting down the Akka cluster, the actor system or exiting the JVM.
+      before-cluster-shutdown {
+        depends-on = [service-stop, after-play-server-stop]
+      }
+
+    }
+    #//#coordinated-shutdown-phases-play-overrides
+  }
+
 }

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -873,6 +873,33 @@ play {
 
       # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
       http.server.transparent-head-requests = false
+
+      akka.coordinated-shutdown {
+        # Terminate the ActorSystem in the last phase actor-system-terminate.
+        terminate-actor-system = on
+
+        # Don't exit the JVM when running in dev-mode
+        exit-jvm = off
+
+        # On JVM shutdown the CoordinatedShutdown for the server actorsystem must be triggered and that shutdown
+        # will take care of invoking the Application's CoordinatedShutdown (if any).
+        run-by-jvm-shutdown-hook = on
+
+        phases {
+          application-stop-hooks {
+            depends-on = [service-stop]
+          }
+          play-server-stop {
+            depends-on = [application-stop-hooks]
+          }
+          after-play-server-stop {
+            depends-on = [play-server-stop]
+          }
+          before-cluster-shutdown {
+            depends-on = [service-stop, after-play-server-stop]
+          }
+        }
+      }
     }
   }
 

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -898,6 +898,10 @@ play {
           before-cluster-shutdown {
             depends-on = [service-stop, after-play-server-stop]
           }
+          actor-system-terminate {
+            timeout = ${play.akka.shutdown-timeout}
+            depends-on = [before-actor-system-terminate]
+          }
         }
       }
     }

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -6,7 +6,8 @@ package play.api
 import java.io._
 import javax.inject.{ Inject, Singleton }
 
-import akka.actor.ActorSystem
+import akka.Done
+import akka.actor.{ ActorSystem, CoordinatedShutdown }
 import akka.stream.{ ActorMaterializer, Materializer }
 import play.api.ApplicationLoader.DevContext
 import play.api.http._
@@ -199,6 +200,13 @@ trait Application {
   lazy val globalApplicationEnabled: Boolean = {
     configuration.getOptional[Boolean](Play.GlobalAppConfigKey).getOrElse(true)
   }
+
+  // Stop the application
+  CoordinatedShutdown(actorSystem).addTask(PlayCoordinatedShutdown.PhaseApplicationStopHooks, "play-application-stop") { () =>
+    stop()
+    Future.successful(Done)
+  }
+
 }
 
 object Application {

--- a/framework/src/play/src/main/scala/play/api/PlayCoordinatedShutdown.scala
+++ b/framework/src/play/src/main/scala/play/api/PlayCoordinatedShutdown.scala
@@ -1,0 +1,31 @@
+package play.api
+
+/**
+ * Extends Akka's CoordinatedShutdown with Play specific phases.
+ */
+object PlayCoordinatedShutdown {
+
+  /**
+   * The phase Play will use to run all stop hooks registered
+   * in the ApplicationLifecycle. Akka's Coordinated Shutdown
+   * delegates the execution to Play so stop hooks are granted to
+   * run in reverse order they where registered.
+   * By default Akka's CoordinatedShutdown runs all tasks on the
+   * same phase in parallel so Akka doesn't grant ordering within
+   * a phase.
+   */
+  val PhaseApplicationStopHooks = "application-stop-hooks"
+
+  /**
+   * Play Server needs to run some cleanup once the Application is
+   * shutdown. This phase is the final step to completely close the
+   * play server.
+   */
+  val PhasePlayServerStop = "play-server-stop"
+
+  /**
+   * This phase allows registering stop hooks that will run once
+   * the Play server is completely stopped.
+   */
+  val PhaseAfterPlayServerStop = "after-play-server-stop"
+}

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -140,24 +140,8 @@ object ActorSystemProvider {
     val system = ActorSystem(name, akkaConfig, classLoader)
     logger.debug(s"Starting application default Akka system: $name")
 
+    // The actor system is no longer terminated during Play's ApplicationLifecycle stop sequence.
     val stopHook = { () =>
-      logger.debug(s"Shutdown application default Akka system: $name")
-      system.terminate()
-
-      config.get[Duration]("play.akka.shutdown-timeout") match {
-        case timeout: FiniteDuration =>
-          try {
-            Await.result(system.whenTerminated, timeout)
-          } catch {
-            case te: TimeoutException =>
-              // oh well.  We tried to be nice.
-              logger.info(s"Could not shutdown the Akka system in $timeout milliseconds.  Giving up.")
-          }
-        case _ =>
-          // wait until it is shutdown
-          Await.result(system.whenTerminated, Duration.Inf)
-      }
-
       Future.successful(())
     }
 


### PR DESCRIPTION
This PR is a first step to widely use Akka's CoordinatedShutdown across Play. 

In this PR:

 - [X] ProdServerStart replaces the JVM shutdown Hook
 - [X] DevServerStart uses separate CoordinatedShutdown for the server and the application actor systems.
 - [X] DevServerStart registers a hook to detect if the application actor system was closed behind the scenes and forces a reload when that happens.
 - [X] replaces the code in {AkkaHttp,Netty}Server with a noop and uses CS on those two classes to register the appropriate shutdown tasks.
 - [ ] unit tests
 - [ ] scripted tests
 - [X] manual tests :-P
 - [ ] remove dead code. I could use some indications here. Also, see my comments below wrt refactoring code out of the `{Netty,AkkaHttp}Server` classes.
 - [x] link `play.akka.shutdown-timeout` with CS's `timeouts` and add a deprecation warning.

I don't think documentation in the user guide or migration are required at the moment since users are not supposed to register their tasks on the `CoordinatedShutdown` yet. This PR is only a first step.