### PR TITLE
Remove useless semicolon from ScalaErrorHandling.scala

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -50,7 +50,7 @@ import play.api.http.HttpErrorHandler
 import play.api.mvc._
 import play.api.mvc.Results._
 import scala.concurrent._
-import javax.inject.Singleton;
+import javax.inject.Singleton
 
 @Singleton
 class ErrorHandler extends HttpErrorHandler {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

The ScalaErrorHandling.scala file contains a useless semicolon while importing a package.

## Purpose

Update the documentation to remove the useless semicolon.


