### PR TITLE
Disable Akka-CS's JVM shutdown hook [2.6.x]

### DIFF
--- a/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
+++ b/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
@@ -124,3 +124,23 @@ play.akka.actor-system = "custom-name"
 A common use case within Akka is to have some computation performed concurrently without needing the extra utility of an Actor. If you find yourself creating a pool of Actors for the sole reason of performing a calculation in parallel, there is an easier (and faster) way:
 
 @[async](code/javaguide/akka/async/Application.java)
+
+## Akka Coordinated Shutdown
+
+Play terminates the built-in Akka actor system using Akka's [Coordinated Shutdown](https://doc.akka.io/docs/akka/current/actors.html?language=java#coordinated-shutdown). By default Play will run the Coordinated Shutdown using only the last phase where the actor system is terminated. You can override that settings using:
+
+```
+# Runs Akka CoordinatedShutdown for Play's actor system
+# from phase "service-stop". See Akka docs on Coordinated 
+# Shutdown for other phase names. In Play, this defaults 
+# to "actor-system-terminate"
+play.akka.run-cs-from-phase = "service-stop" 
+```
+
+If you are using extra actor systems in your Play Application and tests, make sure they are all terminated and feel free to migrate your termination code from the traditional `actorSystem.terminate()` to the new [Coordinated Shutdown](https://doc.akka.io/docs/akka/current/actors.html?language=java#coordinated-shutdown)
+
+## Akka Cluster
+
+You can make your Play application join an existing [Akka Cluster](https://doc.akka.io/docs/akka/snapshot/cluster-usage.html). In that case it is recommended that you leave the cluster gracefully. Play ships with Akka's Coordinated Shutdown since Play 2.6 which can take care of that graceful leave but it is disabled. 
+
+If you are joining an Akka Cluster with your Play application and you already have custom Cluster Leave code it is recommended that you replace it and enable Akka's handling using `play.akka.run-cs-from-phase` described above and set it to run from, at least, `before-cluster-shutdown` phase. See [Akka docs](https://doc.akka.io/docs/akka/current/actors.html?language=java#coordinated-shutdown) for more details.

--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -41,4 +41,42 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
+  # CoordinatedShutdown is an extension introduced in Akka 2.5 that will
+  # perform registered tasks in the order that is defined by the phases.
+  # This setup extends Akka's default phases with Play-specific ones.
+  coordinated-shutdown {
+
+    # Terminate the ActorSystem in the last phase actor-system-terminate.
+    terminate-actor-system = on
+
+    # Exit the JVM (System.exit(0)) in the last phase actor-system-terminate
+    # if this is set to 'on'. It is done after termination of the
+    # ActorSystem if terminate-actor-system=on, otherwise it is done
+    # immediately when the last phase is reached.
+    # This is disabled by default since it falls on Play's responsibilities
+    # to exit the JVM.
+    exit-jvm = off
+
+    # Run the coordinated shutdown when the JVM process exits, e.g.
+    # via kill SIGTERM signal.
+    # Play takes care of registering a shutdownHook already.
+    run-by-jvm-shutdown-hook = off
+
+    phases {
+      actor-system-terminate {
+        timeout = ${play.akka.shutdown-timeout}
+        depends-on = [before-actor-system-terminate]
+      }
+    }
+  }
+
+  cluster {
+
+    # Run the coordinated shutdown when the cluster is shutdown for other
+    # reasons than when leaving, e.g. when downing. This will terminate
+    # the ActorSystem when the cluster extension is shutdown.
+    run-coordinated-shutdown-when-down = on
+
+  }
+
 }

--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -75,7 +75,7 @@ akka {
     # Run the coordinated shutdown when the cluster is shutdown for other
     # reasons than when leaving, e.g. when downing. This will terminate
     # the ActorSystem when the cluster extension is shutdown.
-    run-coordinated-shutdown-when-down = on
+    run-coordinated-shutdown-when-down = off
 
   }
 

--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -62,12 +62,6 @@ akka {
     # Play takes care of registering a shutdownHook already.
     run-by-jvm-shutdown-hook = off
 
-    phases {
-      actor-system-terminate {
-        timeout = ${play.akka.shutdown-timeout}
-        depends-on = [before-actor-system-terminate]
-      }
-    }
   }
 
   cluster {

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -873,6 +873,46 @@ play {
 
       # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
       http.server.transparent-head-requests = false
+
+      # CoordinatedShutdown is an extension introduced in Akka 2.5 that will
+      # perform registered tasks in the order that is defined by the phases.
+      # This setup extends Akka's default phases with Play-specific ones.
+      coordinated-shutdown {
+
+        # Terminate the ActorSystem in the last phase actor-system-terminate.
+        terminate-actor-system = on
+
+        # Exit the JVM (System.exit(0)) in the last phase actor-system-terminate
+        # if this is set to 'on'. It is done after termination of the
+        # ActorSystem if terminate-actor-system=on, otherwise it is done
+        # immediately when the last phase is reached.
+        # This is disabled by default since it falls on Play's responsibilities
+        # to exit the JVM.
+        exit-jvm = off
+
+        # Run the coordinated shutdown when the JVM process exits, e.g.
+        # via kill SIGTERM signal.
+        # Play takes care of registering a shutdownHook already.
+        run-by-jvm-shutdown-hook = off
+
+
+        phases {
+          actor-system-terminate {
+            timeout = ${play.akka.shutdown-timeout}
+            depends-on = [before-actor-system-terminate]
+          }
+        }
+      }
+
+      cluster {
+
+        # Run the coordinated shutdown when the cluster is shutdown for other
+        # reasons than when leaving, e.g. when downing. This will terminate
+        # the ActorSystem when the cluster extension is shutdown.
+        run-coordinated-shutdown-when-down = on
+
+      }
+
     }
   }
 

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -909,7 +909,7 @@ play {
         # Run the coordinated shutdown when the cluster is shutdown for other
         # reasons than when leaving, e.g. when downing. This will terminate
         # the ActorSystem when the cluster extension is shutdown.
-        run-coordinated-shutdown-when-down = on
+        run-coordinated-shutdown-when-down = off
 
       }
 

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -914,6 +914,12 @@ play {
       }
 
     }
+
+    # When Play is shutting down an ActorSystem it will use Akka's CoordinatedShutdown. Instead of running all
+    # phases you can choose what phase to run. The dafault is to only stop the actor system but Akka cluster
+    # users may opt in and replace their current code with the cluster shutdown phases provided by Akka CS.
+    # See https://doc.akka.io/docs/akka/current/actors.html?language=scala#coordinated-shutdown
+    run-cs-from-phase = "actor-system-terminate"
   }
 
   #Assets configuration

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -895,13 +895,6 @@ play {
         # Play takes care of registering a shutdownHook already.
         run-by-jvm-shutdown-hook = off
 
-
-        phases {
-          actor-system-terminate {
-            timeout = ${play.akka.shutdown-timeout}
-            depends-on = [before-actor-system-terminate]
-          }
-        }
       }
 
       cluster {

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -138,7 +138,6 @@ object ActorSystemProvider {
     val system = ActorSystem(name, akkaConfig, classLoader)
     logger.debug(s"Starting application default Akka system: $name")
 
-
     val stopHook = { () =>
       val akkaRunCSFromPhase = config.get[String]("play.akka.run-cs-from-phase")
       logger.debug(s"Shutdown application default Akka system: $name")

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -146,7 +146,7 @@ object ActorSystemProvider {
       // Play's "play.akka.shutdown-timeout" is used to configure the timeout of
       // the 'actor-system-terminate' phase of Akka's CoordinatedShutdown
       // in reference-overrides.conf
-      CoordinatedShutdown(system).run()
+      CoordinatedShutdown(system).run(Some(CoordinatedShutdown.PhaseActorSystemTerminate))
     }
 
     (system, stopHook)

--- a/framework/src/play/src/test/resources/application-infinite-timeout.conf
+++ b/framework/src/play/src/test/resources/application-infinite-timeout.conf
@@ -1,0 +1,1 @@
+play.akka.shutdown-timeout = null

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -3,12 +3,14 @@
  */
 package play.api.libs.concurrent
 
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
-import akka.actor.CoordinatedShutdown
-import com.typesafe.config.ConfigValueFactory
+import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.specs2.mutable.Specification
+import play.api.libs.concurrent.ActorSystemProvider.StopHook
 import play.api.{ Configuration, Environment }
 
 import scala.concurrent.duration.Duration
@@ -16,15 +18,52 @@ import scala.concurrent.{ Await, Future, Promise }
 import scala.util.Success
 
 class ActorSystemProviderSpec extends Specification {
+
+  val akkaMaxDelayInSec = 2147483
   val fiveSec = Duration(5, "seconds")
   val oneSec = Duration(100, "milliseconds")
+  val mustRunPhase = CoordinatedShutdown.PhaseServiceStop
+  val mustNotRunPhase = CoordinatedShutdown.PhaseBeforeServiceUnbind
+
+  val akkaTimeoutKey = "akka.coordinated-shutdown.phases.actor-system-terminate.timeout"
+  val playTimeoutKey = "play.akka.shutdown-timeout"
 
   "ActorSystemProvider" should {
 
-    "run the CoordinatedShutdown from the configured phase system when the stopHook is run" in {
+    "use Play's 'play.akka.shutdown-timeout' if defined " in {
+      withOverridenTimeout {
+        _.withValue(playTimeoutKey, ConfigValueFactory.fromAnyRef("12 s"))
+      } { actorSystem =>
+        actorSystem.settings.config.getDuration(akkaTimeoutKey).getSeconds must equalTo(12)
+      }
+    }
 
-      val mustRunPhase = CoordinatedShutdown.PhaseServiceStop
-      val mustNotRunPhase = CoordinatedShutdown.PhaseBeforeServiceUnbind
+    "use an infinite timeout if usingg Play's 'play.akka.shutdown-timeout = null' " in {
+      withOverridenTimeout {
+        _.withFallback(ConfigFactory.parseResources("src/test/resources/application-infinite-timeout.conf"))
+      } { actorSystem =>
+        actorSystem.settings.config.getDuration(akkaTimeoutKey).getSeconds must equalTo(akkaMaxDelayInSec)
+      }
+    }
+
+    "use Play's 'Duration.Inf' when no 'play.akka.shutdown-timeout' is defined and user overwrites Akka's default" in {
+      withOverridenTimeout {
+        _.withValue(akkaTimeoutKey, ConfigValueFactory.fromAnyRef("21 s"))
+      } { actorSystem =>
+        actorSystem.settings.config.getDuration(akkaTimeoutKey).getSeconds must equalTo(akkaMaxDelayInSec)
+      }
+    }
+
+    "use infinite when 'play.akka.shutdown-timeout = null' and user overwrites Akka's default" in {
+      withOverridenTimeout {
+        _.withFallback(ConfigFactory.parseResources("src/test/resources/application-infinite-timeout.conf"))
+          .withValue(akkaTimeoutKey, ConfigValueFactory.fromAnyRef("17 s"))
+      } { actorSystem =>
+        actorSystem.settings.config.getDuration(akkaTimeoutKey).getSeconds must equalTo(akkaMaxDelayInSec)
+      }
+    }
+
+    "run the CoordinatedShutdown from the configured phase system when the stopHook is run" in {
 
       val config = Configuration
         .load(Environment.simple())
@@ -67,6 +106,23 @@ class ActorSystemProviderSpec extends Specification {
       isRun.get() must equalTo(false)
     }
 
+  }
+
+  private def withOverridenTimeout[T](reconfigure: Config => Config)(block: ActorSystem => T): T = {
+    val config: Config = reconfigure(Configuration
+      .load(Environment.simple())
+      .underlying
+      .withoutPath(playTimeoutKey)
+    )
+    val (actorSystem, stopHook) = ActorSystemProvider.start(
+      this.getClass.getClassLoader,
+      Configuration(config)
+    )
+    try {
+      block(actorSystem)
+    } finally {
+      CoordinatedShutdown(actorSystem).run()
+    }
   }
 
 }

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -1,0 +1,69 @@
+package play.api.libs.concurrent
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.Done
+import akka.actor.CoordinatedShutdown
+import com.typesafe.config.ConfigValueFactory
+import org.specs2.mutable.Specification
+import play.api.{ Configuration, Environment }
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future, Promise }
+import scala.util.Success
+
+class ActorSystemProviderSpec extends Specification {
+  val fiveSec = Duration(5, "seconds")
+  val oneSec = Duration(100, "milliseconds")
+
+  "ActorSystemProvider" should {
+
+    "run the CoordinatedShutdown from the configured phase system when the stopHook is run" in {
+
+      val mustRunPhase = CoordinatedShutdown.PhaseServiceStop
+      val mustNotRunPhase = CoordinatedShutdown.PhaseBeforeServiceUnbind
+
+      val config = Configuration
+        .load(Environment.simple())
+        .underlying
+        .withValue(
+          "play.akka.run-cs-from-phase",
+          ConfigValueFactory.fromAnyRef(mustRunPhase))
+
+      val (actorSystem, stopHook) = ActorSystemProvider.start(
+        this.getClass.getClassLoader,
+        Configuration(config)
+      )
+
+      val promise = Promise[Done]()
+      val terminated = promise.future
+      val isRun = new AtomicBoolean(false)
+
+      CoordinatedShutdown(actorSystem).addTask(mustRunPhase, "termination-promise") {
+        () =>
+          promise.complete(Success(Done))
+          Future.successful(Done)
+      }
+      CoordinatedShutdown(actorSystem).addTask(mustNotRunPhase, "is-ignored-promise") {
+        () =>
+          isRun.set(true)
+          Future.successful(Done)
+      }
+
+      try {
+        Await.result(terminated, oneSec)
+        failure
+      } catch {
+        case _: Throwable =>
+      }
+
+      import scala.concurrent.ExecutionContext.Implicits.global
+      val completeShutdown = stopHook().flatMap(_ => terminated)
+
+      Await.result(completeShutdown, fiveSec) must equalTo(Done)
+      isRun.get() must equalTo(false)
+    }
+
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api.libs.concurrent
 
 import java.util.concurrent.atomic.AtomicBoolean


### PR DESCRIPTION
Since Akka 2.5 there's a JVM shutdown hook enabled by default. That competes with Play's shutdown hook when stopping the process.

This PR also replaces `ActorSystemProvider`'s stopHook to use Akka's CS instead of an explicit `actorSystem.terminate()`. The code only runs last phases of CS (not clustering shutdown) as it is not Play's responsibility to setup a hypothetical Akka cluster. Users of Akka cluster within Play already have to handle shutdown themselves.