### PR TITLE
Using an java8 optional as parameter can enhance readability in contr…

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.routes
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.routes
@@ -31,7 +31,7 @@ GET   /:page                controllers.Application.show(page)
 # The version parameter is optional. E.g. /api/list-all?version=3.0
 GET   /api/list-all         controllers.Api.list(version ?= null)
 # or
-GET   /api/list-all         controllers.Api.list(version: java.util.Optional[String])
+GET   /api/list-all         controllers.Api.listOpt(version: java.util.Optional[String])
 # #optional
 
 # #nocsrf

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.routes
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.routes
@@ -30,7 +30,7 @@ GET   /:page                controllers.Application.show(page)
 # #optional
 # The version parameter is optional. E.g. /api/list-all?version=3.0
 GET   /api/list-all         controllers.Api.list(version ?= null)
-or
+# or
 GET   /api/list-all         controllers.Api.list(version: java.util.Optional[String])
 # #optional
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.routes
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.routes
@@ -30,6 +30,8 @@ GET   /:page                controllers.Application.show(page)
 # #optional
 # The version parameter is optional. E.g. /api/list-all?version=3.0
 GET   /api/list-all         controllers.Api.list(version ?= null)
+or
+GET   /api/list-all         controllers.Api.list(version: java.util.Optional[String])
 # #optional
 
 # #nocsrf

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/routing/controllers/Api.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/routing/controllers/Api.java
@@ -3,12 +3,18 @@
  */
 package javaguide.http.routing.controllers;
 
+import java.util.Optional;
+
 import play.mvc.Controller;
 import play.mvc.Result;
 
 public class Api extends Controller {
     public Result list(String version) {
         return ok("version " + version);
+    }
+
+    public Result listOpt(Optional<String> version) {
+        return ok("version " + version.orElse("unknown"));
     }
 
     public Result newThing() {


### PR DESCRIPTION
Using an java8 optional as parameter can enhance readability in controllers and code quality.
And it's closer to the scala version.

In controller, we could use the optional to check if the query param is present.
```java
public Result index(Optional<String> version) {
  if (version.isPresent()) {
    // request contains version
  } else {
    // no version
  }
}
```

What do you think ?

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Only documentations, no fix

## Purpose

What does this PR do?

Enhance documentation about optional parameters in routes.

## Background Context

Why did you take this approach?

We're doing a coding dojo with colleagues to try play 2. We wanted to use optional parameters but didn't like to use null as default value. We wanted to use optional as we were in java but didn't find an example in the documentation. So I decided to suggest this pull request.

## References

Are there any relevant issues / PRs / mailing lists discussions?
None as far as I know.