### PR TITLE
Add GzipConfig.compressionLevel

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -248,6 +248,7 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.streams.GzipFlow.gzip"),
 
       // Pass a default server header to netty
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.this"),

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -243,6 +243,12 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServerComponents.sourceMapper"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServerComponents.webCommands"),
 
+      // Add compressionLevel to GzipFilter
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilter.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.apply"),
+
       // Pass a default server header to netty
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler.this"),

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -194,6 +194,9 @@ play.filters {
         # Compress all responses except the ones whose content type is in this list.
         blackList = []
     }
+
+    # The compression level to use, integer, -1 to 9, inclusive. See java.util.zip.Deflater.
+    compressionLevel = -1
   }
 
   # Configuration for redirection to HTTPS and Strict-Transport-Security

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -4,6 +4,7 @@
 package play.filters.gzip
 
 import java.util.function.BiFunction
+import java.util.zip.Deflater
 import javax.inject.{ Inject, Provider, Singleton }
 
 import akka.stream.scaladsl._
@@ -44,8 +45,9 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
   import play.api.http.HeaderNames._
 
   def this(bufferSize: Int = 8192, chunkedThreshold: Int = 102400,
-    shouldGzip: (RequestHeader, Result) => Boolean = (_, _) => true)(implicit mat: Materializer) =
-    this(GzipFilterConfig(bufferSize, chunkedThreshold, shouldGzip))
+    shouldGzip: (RequestHeader, Result) => Boolean = (_, _) => true,
+    compressionLevel: Int = Deflater.DEFAULT_COMPRESSION)(implicit mat: Materializer) =
+    this(GzipFilterConfig(bufferSize, chunkedThreshold, shouldGzip, compressionLevel))
 
   def apply(next: EssentialAction) = new EssentialAction {
     implicit val ec = mat.executionContext
@@ -57,6 +59,8 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
       }
     }
   }
+
+  private def createGzipFlow: Flow[ByteString, ByteString, _] = GzipFlow.gzip(config.bufferSize, config.compressionLevel)
 
   private def handleResult(request: RequestHeader, result: Result): Future[Result] = {
     implicit val ec = mat.executionContext
@@ -80,14 +84,14 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
         case HttpEntity.Streamed(data, _, contentType) if request.version == HttpProtocol.HTTP_1_0 =>
           // It's above the chunked threshold, but we can't chunk it because we're using HTTP 1.0.
           // Instead, we use a close delimited body (ie, regular body with no content length)
-          val gzipped = data via GzipFlow.gzip(config.bufferSize)
+          val gzipped = data via createGzipFlow
           Future.successful(
             result.copy(header = header, body = HttpEntity.Streamed(gzipped, None, contentType))
           )
 
         case HttpEntity.Streamed(data, _, contentType) =>
           // It's above the chunked threshold, compress through the gzip flow, and send as chunked
-          val gzipped = data via GzipFlow.gzip(config.bufferSize) map (d => HttpChunk.Chunk(d))
+          val gzipped = data via createGzipFlow map (d => HttpChunk.Chunk(d))
           Future.successful(
             result.copy(header = header, body = HttpEntity.Chunked(gzipped, contentType))
           )
@@ -111,7 +115,7 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
             // Broadcast the stream through two separate flows, one that collects chunks and turns them into
             // ByteStrings, sends those ByteStrings through the Gzip flow, and then turns them back into chunks,
             // the other that just allows the last chunk through. Then concat those two flows together.
-            broadcast.out(0) ~> extractChunks ~> GzipFlow.gzip(config.bufferSize) ~> createChunks ~> concat.in(0)
+            broadcast.out(0) ~> extractChunks ~> createGzipFlow ~> createChunks ~> concat.in(0)
             broadcast.out(1) ~> filterLastChunk ~> concat.in(1)
 
             new FlowShape(broadcast.in, concat.out)
@@ -127,7 +131,7 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
   }
 
   private def compressStrictEntity(source: Source[ByteString, Any], contentType: Option[String])(implicit ec: ExecutionContext) = {
-    val compressed = source.via(GzipFlow.gzip(config.bufferSize)).runFold(ByteString.empty)(_ ++ _)
+    val compressed = source.via(createGzipFlow).runFold(ByteString.empty)(_ ++ _)
     compressed.map(data => HttpEntity.Strict(data, contentType))
   }
 
@@ -182,7 +186,8 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
 case class GzipFilterConfig(
     bufferSize: Int = 8192,
     chunkedThreshold: Int = 102400,
-    shouldGzip: (RequestHeader, Result) => Boolean = (_, _) => true) {
+    shouldGzip: (RequestHeader, Result) => Boolean = (_, _) => true,
+    compressionLevel: Int = Deflater.DEFAULT_COMPRESSION) {
 
   // alternate constructor and builder methods for Java
   def this() = this(shouldGzip = (_, _) => true)
@@ -266,7 +271,8 @@ object GzipFilterConfig {
             case Some(MediaType.parse(outgoing)) => whiteList.exists(mask => matches(outgoing, mask))
             case _ => false // Fail closed (to not gziping), since whitelists are intentionally strict.
           }
-        }
+        },
+      compressionLevel = config.get[Int]("compressionLevel")
     )
   }
 }

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
@@ -3,6 +3,8 @@
  */
 package play.api.libs.streams
 
+import java.util.zip.Deflater
+
 import akka.stream.scaladsl.{ Compression, Flow }
 import akka.stream.stage._
 import akka.stream._
@@ -18,8 +20,8 @@ object GzipFlow {
   /**
    * Create a Gzip Flow with the given buffer size.
    */
-  def gzip(bufferSize: Int = 512): Flow[ByteString, ByteString, _] = {
-    Flow[ByteString].via(new Chunker(bufferSize)).via(Compression.gzip)
+  def gzip(bufferSize: Int = 512, compressionLevel: Int = Deflater.DEFAULT_COMPRESSION): Flow[ByteString, ByteString, _] = {
+    Flow[ByteString].via(new Chunker(bufferSize)).via(Compression.gzip(compressionLevel))
   }
 
   // http://doc.akka.io/docs/akka/2.4.14/scala/stream/stream-cookbook.html#Chunking_up_a_stream_of_ByteStrings_into_limited_size_ByteStrings


### PR DESCRIPTION
Allow user to specify the compression level to use for the underlying Deflater instance, and switch the default compression level from Deflater.BEST_COMPRESSION to Deflater.DEFAULT_COMPRESSION.

Mailing list discussion: https://groups.google.com/d/topic/play-framework/xjgcXPsRvyo/discussion

In a not very scientific microbenchmark where I compress a 600kb webpage 100x for each compression level I got the following (on the second run so things have had a chance to JIT): 

[info] application - Level 1: 619,883 -> 111,773, 18.03130590772775%, nanos: 531,628,867, 11177300
[info] application - Level 2: 619,883 -> 87,209, 14.068622627173193%, nanos: 549,247,847, 8720900
[info] application - Level 3: 619,883 -> 94,679, 15.27368874448888%, nanos: 731,691,153, 9467900
[info] application - Level 4: 619,883 -> 84,454, 13.624183918578183%, nanos: 804,356,176, 8445400
[info] application - Level 5: 619,883 -> 81,712, 13.181842379932988%, nanos: 1,152,557,312, 8171200
[info] application - Level 6: 619,883 -> 57,972, 9.352087410043508%, nanos: 1,826,056,529, 5797200
[info] application - Level 7: 619,883 -> 58,539, 9.443556284008434%, nanos: 2,679,872,317, 5853900
[info] application - Level 8: 619,883 -> 56,608, 9.132045886078503%, nanos: 8,115,200,116, 5660800
[info] application - Level 9: 619,883 -> 56,413, 9.100588336831306%, nanos: 11,152,594,021, 5641300

Deflater.DEFAULT_COMPRESSION = -1 but corresponds to 6 in actual usage. 
