### PR TITLE
Make constraint annotations @Repeatable

### DIFF
--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -1,0 +1,26 @@
+# What's new in Play 2.7
+
+This page highlights the new features of Play 2.7. If you want to learn about the changes you need to make when you migrate to Play 2.7, check out the [[Play 2.7 Migration Guide|Migration27]].
+
+## Constraint annotations offered for Play Java are now @Repeatable
+
+All of the constraint annotations defined by `play.data.validation.Constraints` are now `@Repeatable`. This lets you, for example, reuse the same annotation on the same element several times but each time with different `groups`. For some constraints however it makes sense to let them repeat itself anyway, like `@ValidateWith`:
+
+```java
+@Validate(groups={GroupA.class})
+@Validate(groups={GroupB.class})
+public class MyForm {
+
+    @ValidateWith(MyValidator.class)
+    @ValidateWith(MyOtherValidator.class)
+    @Pattern(value="[a-k]", message="Should be a - k")
+    @Pattern(value="[c-v]", message="Should be c - v")
+    @MinLength(value=4, groups={GroupA.class})
+    @MinLength(value=7, groups={GroupB.class})
+    private String name;
+
+    //...
+}
+```
+
+You can of course also make your own custom constraints `@Repeatable` as well and Play will automatically recognise that.

--- a/documentation/manual/releases/release27/index.toc
+++ b/documentation/manual/releases/release27/index.toc
@@ -1,0 +1,2 @@
+Highlights27:What's new?
+!migration27:Migration Guides

--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -37,7 +37,7 @@ You can define additional constraints that will be checked during the binding ph
 
 @[user](code/javaguide/forms/u2/User.java)
 
-> **Tip:** The `play.data.validation.Constraints` class contains several built-in validation annotations.
+> **Tip:** The `play.data.validation.Constraints` class contains several built-in validation annotations. All of these constraint annotations are defined as `@Repeatable`. This lets you, for example, reuse the same annotation on the same element several times but each time with different `groups`. For some constraints however it makes sense to let them repeat itself anyway, like `@ValidateWith` for example.
 
 In the [Advanced validation](#advanced-validation) section further below you will learn how to handle concerns like cross field validation, partial form validation or how to make use of injected components (e.g. to access a database) during validation.
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDB.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDB.java
@@ -9,6 +9,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 
 import javax.validation.Constraint;
@@ -16,10 +17,20 @@ import javax.validation.Payload;
 
 @Target({TYPE, ANNOTATION_TYPE})
 @Retention(RUNTIME)
+@Repeatable(ValidateWithDB.List.class)
 @Constraint(validatedBy = ValidateWithDBValidator.class)
 public @interface ValidateWithDB {
     String message() default "error.invalid";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
+
+    /**
+     * Defines several {@code @ValidateWithDB} annotations on the same element.
+     */
+    @Target({TYPE, ANNOTATION_TYPE})
+    @Retention(RUNTIME)
+    public @interface List {
+        ValidateWithDB[] value();
+    }
 }
 //#annotation

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBValidator.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBValidator.java
@@ -4,8 +4,6 @@
 package javaguide.forms.customconstraint;
 
 //#constraint
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.validation.ConstraintValidatorContext;
 

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -23,6 +23,7 @@ import play.data.validation.Constraints.Validatable;
 import play.data.validation.ValidationError;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
+import play.libs.AnnotationUtils;
 import play.mvc.Http;
 import play.mvc.Http.HttpVerbs;
 
@@ -1029,7 +1030,7 @@ public class Form<T> {
                             continue;
                         }
                         // getDeclaredAnnotations also looks for private fields; also it provides the annotations in a guaranteed order
-                        orderedAnnotations = field.getDeclaredAnnotations();
+                        orderedAnnotations = AnnotationUtils.unwrapContainerAnnotations(field.getDeclaredAnnotations());
                         break;
                     }
                     constraints = Constraints.displayableConstraint(

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -109,11 +109,21 @@ public class Constraints {
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = RequiredValidator.class)
+    @Repeatable(play.data.validation.Constraints.Required.List.class)
     @play.data.Form.Display(name="constraint.required")
     public @interface Required {
         String message() default RequiredValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
+
+        /**
+         * Defines several {@code @Required} annotations on the same element.
+         */
+        @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+        @Retention(RUNTIME)
+        public @interface List {
+            Required[] value();
+        }
     }
 
     /**
@@ -163,12 +173,22 @@ public class Constraints {
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = MinValidator.class)
+    @Repeatable(play.data.validation.Constraints.Min.List.class)
     @play.data.Form.Display(name="constraint.min", attributes={"value"})
     public @interface Min {
         String message() default MinValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         long value();
+
+        /**
+         * Defines several {@code @Min} annotations on the same element.
+         */
+        @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+        @Retention(RUNTIME)
+        public @interface List {
+            Min[] value();
+        }
     }
 
     /**
@@ -221,12 +241,22 @@ public class Constraints {
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = MaxValidator.class)
+    @Repeatable(play.data.validation.Constraints.Max.List.class)
     @play.data.Form.Display(name="constraint.max", attributes={"value"})
     public @interface Max {
         String message() default MaxValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         long value();
+
+        /**
+         * Defines several {@code @Max} annotations on the same element.
+         */
+        @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+        @Retention(RUNTIME)
+        public @interface List {
+            Max[] value();
+        }
     }
 
     /**
@@ -279,12 +309,22 @@ public class Constraints {
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = MinLengthValidator.class)
+    @Repeatable(play.data.validation.Constraints.MinLength.List.class)
     @play.data.Form.Display(name="constraint.minLength", attributes={"value"})
     public @interface MinLength {
         String message() default MinLengthValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         long value();
+
+        /**
+         * Defines several {@code @MinLength} annotations on the same element.
+         */
+        @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+        @Retention(RUNTIME)
+        public @interface List {
+            MinLength[] value();
+        }
     }
 
     /**
@@ -336,12 +376,22 @@ public class Constraints {
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = MaxLengthValidator.class)
+    @Repeatable(play.data.validation.Constraints.MaxLength.List.class)
     @play.data.Form.Display(name="constraint.maxLength", attributes={"value"})
     public @interface MaxLength {
         String message() default MaxLengthValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         long value();
+
+        /**
+         * Defines several {@code @MaxLength} annotations on the same element.
+         */
+        @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+        @Retention(RUNTIME)
+        public @interface List {
+            MaxLength[] value();
+        }
     }
 
     /**
@@ -393,11 +443,21 @@ public class Constraints {
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = EmailValidator.class)
+    @Repeatable(play.data.validation.Constraints.Email.List.class)
     @play.data.Form.Display(name="constraint.email", attributes={})
     public @interface Email {
         String message() default EmailValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
+
+        /**
+         * Defines several {@code @Email} annotations on the same element.
+         */
+        @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+        @Retention(RUNTIME)
+        public @interface List {
+            Email[] value();
+        }
     }
 
     /**
@@ -447,12 +507,22 @@ public class Constraints {
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = PatternValidator.class)
+    @Repeatable(play.data.validation.Constraints.Pattern.List.class)
     @play.data.Form.Display(name="constraint.pattern", attributes={"value"})
     public @interface Pattern {
         String message() default PatternValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         String value();
+
+        /**
+         * Defines several {@code @Pattern} annotations on the same element.
+         */
+        @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+        @Retention(RUNTIME)
+        public @interface List {
+            Pattern[] value();
+        }
     }
 
     /**
@@ -507,12 +577,22 @@ public class Constraints {
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = ValidateWithValidator.class)
+    @Repeatable(play.data.validation.Constraints.ValidateWith.List.class)
     @play.data.Form.Display(name="constraint.validatewith", attributes={})
     public @interface ValidateWith {
         String message() default ValidateWithValidator.defaultMessage;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         Class<? extends Validator> value();
+
+        /**
+         * Defines several {@code @ValidateWith} annotations on the same element.
+         */
+        @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+        @Retention(RUNTIME)
+        public @interface List {
+            ValidateWith[] value();
+        }
     }
 
     /**
@@ -569,10 +649,20 @@ public class Constraints {
     @Target({TYPE, ANNOTATION_TYPE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = ValidateValidator.class)
+    @Repeatable(play.data.validation.Constraints.Validate.List.class)
     public @interface Validate {
         String message() default "error.invalid";
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
+
+        /**
+         * Defines several {@code @Validate} annotations on the same element.
+         */
+        @Target({TYPE, ANNOTATION_TYPE})
+        @Retention(RUNTIME)
+        public @interface List {
+            Validate[] value();
+        }
     }
 
     public interface Validatable<T> {

--- a/framework/src/play-java-forms/src/test/java/play/data/GreenValidator.java
+++ b/framework/src/play-java-forms/src/test/java/play/data/GreenValidator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.data;
+
+
+import play.data.validation.Constraints;
+import play.libs.F;
+
+
+public class GreenValidator extends Constraints.Validator<String> {
+
+    public boolean isValid(String value) {
+        return "green".equals(value);
+    }
+
+    public F.Tuple<String, Object[]> getErrorMessageKey() {
+        return F.Tuple("notgreen", new Object[] {});
+    }
+}

--- a/framework/src/play-java-forms/src/test/java/play/data/RepeatableConstraintsForm.java
+++ b/framework/src/play-java-forms/src/test/java/play/data/RepeatableConstraintsForm.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.data;
+
+import play.data.validation.Constraints.Pattern;
+import play.data.validation.Constraints.ValidateWith;
+
+public class RepeatableConstraintsForm {
+
+    @ValidateWith(BlueValidator.class)
+    @ValidateWith(GreenValidator.class)
+    @Pattern(value="[a-c]", message="Should be a - c")
+    @Pattern(value="[c-h]", message="Should be c - h")
+    private String name;
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/framework/src/play-java-forms/src/test/java/play/data/validation/TestConstraints.java
+++ b/framework/src/play-java-forms/src/test/java/play/data/validation/TestConstraints.java
@@ -3,12 +3,11 @@
  */
 package play.data.validation;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
 import static play.libs.F.Tuple;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 import java.util.regex.Pattern;
 
 import javax.inject.Inject;
@@ -31,12 +30,22 @@ public class TestConstraints {
     @Target({FIELD})
     @Retention(RUNTIME)
     @Constraint(validatedBy = I18NConstraintValidator.class)
+    @Repeatable(play.data.validation.TestConstraints.I18Constraint.List.class)
     @play.data.Form.Display(name="constraint.i18nconstraint", attributes={"value"})
     public static @interface I18Constraint {
         String message() default I18NConstraintValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         String value();
+
+        /**
+         * Defines several {@code @I18Constraint} annotations on the same element.
+         */
+        @Target({FIELD})
+        @Retention(RUNTIME)
+        public @interface List {
+            I18Constraint[] value();
+        }
     }
 
     /**
@@ -80,12 +89,22 @@ public class TestConstraints {
     @Target({FIELD})
     @Retention(RUNTIME)
     @Constraint(validatedBy = AnotherI18NConstraintValidator.class)
+    @Repeatable(play.data.validation.TestConstraints.AnotherI18NConstraint.List.class)
     @play.data.Form.Display(name="constraint.anotheri18nconstraint", attributes={"value"})
     public static @interface AnotherI18NConstraint {
         String message() default AnotherI18NConstraintValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         String value();
+
+        /**
+         * Defines several {@code @AnotherI18NConstraint} annotations on the same element.
+         */
+        @Target({FIELD})
+        @Retention(RUNTIME)
+        public @interface List {
+            AnotherI18NConstraint[] value();
+        }
     }
 
     /**

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -402,6 +402,11 @@ trait FormSpec extends Specification {
 
     "support @repeatable constraints" in {
       val form = formFactory.form(classOf[RepeatableConstraintsForm]).bind(Map("name" -> "xyz").asJava)
+      form.field("name").constraints().size() must beEqualTo(4)
+      form.field("name").constraints().get(0)._1 must beEqualTo("constraint.validatewith")
+      form.field("name").constraints().get(1)._1 must beEqualTo("constraint.validatewith")
+      form.field("name").constraints().get(2)._1 must beEqualTo("constraint.pattern")
+      form.field("name").constraints().get(3)._1 must beEqualTo("constraint.pattern")
       form.hasErrors must beEqualTo(true)
       form.hasGlobalErrors() must beEqualTo(false)
       form.allErrors().size() must beEqualTo(4)

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -400,6 +400,20 @@ trait FormSpec extends Specification {
       optForm.get().getOptional.get must beEqualTo("Microsoft Corporation")
     }
 
+    "support @repeatable constraints" in {
+      val form = formFactory.form(classOf[RepeatableConstraintsForm]).bind(Map("name" -> "xyz").asJava)
+      form.hasErrors must beEqualTo(true)
+      form.hasGlobalErrors() must beEqualTo(false)
+      form.allErrors().size() must beEqualTo(4)
+      form.errors("name").size() must beEqualTo(4)
+      val nameErrorMessages = form.errors("name").asScala.flatMap(_.messages().asScala)
+      nameErrorMessages.size must beEqualTo(4)
+      nameErrorMessages must contain("Should be a - c")
+      nameErrorMessages must contain("Should be c - h")
+      nameErrorMessages must contain("notgreen")
+      nameErrorMessages must contain("notblue")
+    }
+
     "work with the @repeat helper" in {
       val form = formFactory.form(classOf[JavaForm])
 

--- a/framework/src/play/src/main/java/play/libs/AnnotationUtils.java
+++ b/framework/src/play/src/main/java/play/libs/AnnotationUtils.java
@@ -27,9 +27,9 @@ public class AnnotationUtils {
      */
     public static <A extends Annotation> Annotation[] unwrapContainerAnnotations(final A[] annotations) {
         final List<Annotation> unwrappedAnnotations = new LinkedList<>();
-        for(final Annotation maybeContainerAnnotation : annotations) {
+        for (final Annotation maybeContainerAnnotation : annotations) {
             final List<Annotation> indirectlyPresentAnnotations = getIndirectlyPresentAnnotations(maybeContainerAnnotation);
-            if(!indirectlyPresentAnnotations.isEmpty()) {
+            if (!indirectlyPresentAnnotations.isEmpty()) {
                 unwrappedAnnotations.addAll(indirectlyPresentAnnotations);
             } else {
                 unwrappedAnnotations.add(maybeContainerAnnotation); // was not a container annotation
@@ -52,7 +52,7 @@ public class AnnotationUtils {
             final Object o = method.invoke(maybeContainerAnnotation);
             if (Annotation[].class.isAssignableFrom(o.getClass())) {
                 final Annotation[] indirectAnnotations = (Annotation[])o;
-                if(indirectAnnotations.length > 0 && indirectAnnotations[0].annotationType().isAnnotationPresent(Repeatable.class)) {
+                if (indirectAnnotations.length > 0 && indirectAnnotations[0].annotationType().isAnnotationPresent(Repeatable.class)) {
                     return Arrays.asList(indirectAnnotations);
                 }
             }

--- a/framework/src/play/src/main/java/play/libs/AnnotationUtils.java
+++ b/framework/src/play/src/main/java/play/libs/AnnotationUtils.java
@@ -18,9 +18,9 @@ public class AnnotationUtils {
 
     /**
      * Returns a new array whose entries do not contain container annotations anymore but the indirectly present annotations a container annotation
-     * was wrapping instead.
+     * was wrapping instead. Annotations inside the given array which are not container annotations will be returned untouched.
      * 
-     * @param annotations An array of annotations to unwrap.
+     * @param annotations An array of annotations to unwrap. Can contain both container and non container annotations.
      * @return A new array without container annotations but the container annotations' indirectly defined annotations.
      */
     public static <A extends Annotation> Annotation[] unwrapContainerAnnotations(final A[] annotations) {
@@ -47,9 +47,6 @@ public class AnnotationUtils {
     public static <A extends Annotation> List<Annotation> getIndirectlyPresentAnnotations(final A annotation) {
         try {
             final Method method = annotation.getClass().getMethod("value");
-            if (!method.isAccessible()) {
-                method.setAccessible(true);
-            }
             final Object o = method.invoke(annotation);
             if (Annotation[].class.isAssignableFrom(o.getClass())) {
                 return Arrays.asList((Annotation[])o);

--- a/framework/src/play/src/main/java/play/libs/AnnotationUtils.java
+++ b/framework/src/play/src/main/java/play/libs/AnnotationUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Annotation utilities.
+ */
+public class AnnotationUtils {
+
+    /**
+     * Returns a new array whose entries do not contain container annotations anymore but the indirectly present annotations a container annotation
+     * was wrapping instead.
+     * 
+     * @param annotations An array of annotations to unwrap.
+     * @return A new array without container annotations but the container annotations' indirectly defined annotations.
+     */
+    public static <A extends Annotation> Annotation[] unwrapContainerAnnotations(final A[] annotations) {
+        final List<Annotation> returnAnnotations = new ArrayList<>();
+        for(final Annotation a : annotations) {
+            final List<Annotation> indirectlyPresentAnnotations = getIndirectlyPresentAnnotations(a);
+            if(!indirectlyPresentAnnotations.isEmpty()) {
+                returnAnnotations.addAll(indirectlyPresentAnnotations);
+            } else {
+                returnAnnotations.add(a);
+            }
+        }
+        return returnAnnotations.toArray(new Annotation[returnAnnotations.size()]);
+    }
+
+    /**
+     * If the given annotation's {@code value()} method is an {@code Annotation[]} array the annotations of that array will be returned.
+     * If the annotation does not have a {@code value()} method or the return type of the {@code value()} method is not an {@code Annotation[]} array
+     * an empty list will be returned instead.
+     * 
+     * @param annotation The annotation which {@code value()} method will be checked for other annotations 
+     * @return The annotations defined by the {@code value()} method or an empty list.
+     */
+    public static <A extends Annotation> List<Annotation> getIndirectlyPresentAnnotations(final A annotation) {
+        try {
+            final Method method = annotation.getClass().getMethod("value");
+            if (!method.isAccessible()) {
+                method.setAccessible(true);
+            }
+            final Object o = method.invoke(annotation);
+            if (Annotation[].class.isAssignableFrom(o.getClass())) {
+                return Arrays.asList((Annotation[])o);
+            }
+        } catch (final NoSuchMethodException e) {
+            // That's ok, this just wasn't a container annotation -> continue
+        } catch (final SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new IllegalStateException(e);
+        }
+        return Collections.emptyList();
+    }
+}

--- a/framework/src/play/src/main/java/play/libs/AnnotationUtils.java
+++ b/framework/src/play/src/main/java/play/libs/AnnotationUtils.java
@@ -43,7 +43,7 @@ public class AnnotationUtils {
      * {@code Annotation[]} array are annotated with the {@link Repeatable} annotation the annotations of that array will be returned.
      * If the passed annotation does not have a {@code value()} method or the above criteria are not met an empty list will be returned instead.
      * 
-     * @param annotation The annotation which {@code value()} method will be checked for other annotations
+     * @param maybeContainerAnnotation The annotation which {@code value()} method will be checked for other annotations
      * @return The annotations defined by the {@code value()} method or an empty list.
      */
     public static <A extends Annotation> List<Annotation> getIndirectlyPresentAnnotations(final A maybeContainerAnnotation) {


### PR DESCRIPTION
In `master` branch we upgraded to Hibernate Validator 6 which [made all it's constraint annotations `@Repeatable`](https://github.com/hibernate/hibernate-validator/pull/493). This PR does the same for the constraint annotations play-java offers.

This allows a user to e.g. apply multiple `@ValidateWith`, etc. on the same element or use groups to choose when a certain constraint annotation should be used, even when an other group needs the same constraint annotation on the same element. Very nice actually, makes the form validation much more flexible...
```
@Validate(groups={GroupA.class})
@Validate(groups={GroupB.class})
public class MyForm {

    @ValidateWith(MyValidator.class)
    @ValidateWith(MyOtherValidator.class)
    @Pattern(value="[a-k]", message="Should be a - k")
    @Pattern(value="[c-v]", message="Should be c - v")
    @MinLength(value=4, groups={GroupA.class})
    @MinLength(value=7, groups={GroupB.class})
    private String name;

    //...
}
```