### PR TITLE
Fix play.api.Configuration.getOptional

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -231,7 +231,11 @@ case class Configuration(underlying: Config) {
    * usage. Instead you should define all config keys in a reference.conf file.
    */
   def getOptional[A](path: String)(implicit loader: ConfigLoader[A]): Option[A] = {
-    readValue(path, get[A](path))
+    try {
+      if (underlying.hasPath(path)) Some(get[A](path)) else None
+    } catch {
+      case NonFatal(e) => throw reportError(path, e.getMessage, Some(e))
+    }
   }
 
   /**

--- a/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -54,7 +54,7 @@ class ConfigurationSpec extends Specification {
 
     }
 
-    "support getting optional values" in {
+    "support getting optional values via get[Option[...]]" in {
       "when null" in {
         config("foo.bar" -> null).get[Option[String]]("foo.bar") must beNone
       }
@@ -63,6 +63,17 @@ class ConfigurationSpec extends Specification {
       }
       "when undefined" in {
         config().get[Option[String]]("foo.bar") must throwA[ConfigException.Missing]
+      }
+    }
+    "support getting optional values via getOptional" in {
+      "when null" in {
+        config("foo.bar" -> null).getOptional[String]("foo.bar") must beNone
+      }
+      "when set" in {
+        config("foo.bar" -> "bar").getOptional[String]("foo.bar") must beSome("bar")
+      }
+      "when undefined" in {
+        config().getOptional[String]("foo.bar") must beNone
       }
     }
     "support getting prototyped seqs" in {


### PR DESCRIPTION
`.get[Option[String]]("some.key")` and `.getOptional[String]("some.key")` should have the same behaviour, however that isn't the case. Right now when calling `.getOptional[String]("some.key")` and `some.key = null` we get an exception where I would expect to get `None` instead:
```
[info] Caused by: com.typesafe.config.ConfigException$Null: reference.conf @ /reference.conf: 41: Configuration key 'some.key' is set to null but expected STRING
[info] 	at com.typesafe.config.impl.SimpleConfig.throwIfNull(SimpleConfig.java:142)
[info] 	at com.typesafe.config.impl.SimpleConfig.find(SimpleConfig.java:188)
[info] 	at com.typesafe.config.impl.SimpleConfig.find(SimpleConfig.java:193)
[info] 	at com.typesafe.config.impl.SimpleConfig.getString(SimpleConfig.java:250)
[info] 	at play.api.ConfigLoader$.$anonfun$stringLoader$2(Configuration.scala:1027)
[info] 	at play.api.ConfigLoader$$anon$3.load(Configuration.scala:1022)
[info] 	at play.api.Configuration.get(Configuration.scala:215)
[info] 	at play.api.Configuration.$anonfun$getOptional$1(Configuration.scala:234)
[info] 	at play.api.Configuration.readValue(Configuration.scala:199)
[info] 	at play.api.Configuration.getOptional(Configuration.scala:234)
```
`getOptional` has to use `hasPath` and not `hasPathOrNull` (see the `readValue` method).

Note: `readValue` can be removed later anyway (together with the deprecated methods which use it).