### PR TITLE
Fix #8023 - Don't ignore exceptions thrown during JPA rollback

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -151,9 +151,11 @@ public class DefaultJPAApi implements JPAApi {
             return result;
 
         } catch (Throwable t) {
-            if (tx != null && tx.isActive()) {
+            if (tx != null) {
                 try {
-                    tx.rollback();
+                    if (tx.isActive()) {
+                        tx.rollback();
+                    }
                 } catch (Exception e) {
                     logger.error("Could not rollback transaction", e);
                 }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -154,7 +154,7 @@ public class DefaultJPAApi implements JPAApi {
             if (tx != null && tx.isActive()) {
                 try {
                     tx.rollback();
-                } catch (PersistenceException e) {
+                } catch (Exception e) {
                     logger.error("Could not rollback transaction", e);
                 }
             }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -3,7 +3,8 @@
  */
 package play.db.jpa;
 
-import play.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.db.DBApi;
 import play.inject.ApplicationLifecycle;
 
@@ -22,7 +23,7 @@ import javax.persistence.*;
  */
 public class DefaultJPAApi implements JPAApi {
 
-    private static final Logger.ALogger logger = Logger.of(DefaultJPAApi.class);
+    private static final Logger logger = LoggerFactory.getLogger(DefaultJPAApi.class);
 
     private final JPAConfig jpaConfig;
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
  * N/A
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
  * N/A
* [ ] Have you added tests for any changed functionality?
  * I didn't not change any functionality, I'll be happy to improve the exception management tests if you think it's worth it.

# Helpful things

## Fixes

Fixes #8023

## Purpose

Check that the transaction is active before to roll it back and add logging if any exception is encountered during the rollback.

## Background Context

I started to look at #8023 and followed the advises. I looked at the JPA documentation in order to choose a better exception type to catch

## References

[JPA EntityTransaction documentation](https://docs.oracle.com/javaee/6/api/javax/persistence/EntityTransaction.html#rollback())
