### PR TITLE
Nicer syntax for router.withPrefix

### DIFF
--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -27,11 +27,20 @@ trait Router {
   def documentation: Seq[(String, String, String)]
 
   /**
-   * Get a router that routes requests to `s"$prefix/$path"` in the same way this router routes requests to `path`.
+   * Get a new router that routes requests to `s"$prefix/$path"` in the same way this router routes requests to `path`.
    *
    * @return the prefixed router
    */
   def withPrefix(prefix: String): Router
+
+  /**
+   * An alternative syntax for `withPrefix`. For example:
+   *
+   * {{{
+   *   val router = "/bar" /: barRouter
+   * }}}
+   */
+  final def /:(prefix: String): Router = withPrefix(prefix)
 
   /**
    * A lifted version of the routes partial function.

--- a/framework/src/play/src/test/scala/play/core/routing/RouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/routing/RouterSpec.scala
@@ -105,8 +105,7 @@ class RouterSpec extends Specification {
 
     "add prefix multiple times" in {
       import play.api.http.HttpVerbs._
-      val v1Router = router.withPrefix("/v1")
-      val apiV1Router = v1Router.withPrefix("/api/")
+      val apiV1Router = "/api" /: "v1" /: router
       apiV1Router.handlerFor(FakeRequest(GET, "/")) must beNone
       apiV1Router.handlerFor(FakeRequest(GET, "/api/")) must beNone
       apiV1Router.handlerFor(FakeRequest(GET, "/api/v1/")) must beSome(Root)


### PR DESCRIPTION
This introduces a `/:` alias for `withPrefix` in the `Router`. In other words this code:
```scala
val router = "/api" /: apiRouter
```
can be used instead of 
```scala
val router = apiRouter.withPrefix("/api")
```
It will also work nicely with the `orElse` method introduced in #8012:

```scala
val router = ("/api" /: apiRouter) orElse ("/frontend" /: frontendRouter)
```
or even
```scala
val router = Seq(
  "/api/v1" /: v1Router,
  "/api/v2" /: v2Router,
  "/app" /: appRouter
) reduce (_ orElse _)
```