### PR TITLE
Bumps AkkaHttp version

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion = "2.5.7"
-  val akkaHttpVersion = "10.0.10"
+  val akkaHttpVersion = "10.0.11"
   val playJsonVersion = "2.6.7"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"


### PR DESCRIPTION
This change upgrades Akka HTTP to [recently release](https://doc.akka.io/docs/akka-http/current/scala/http/release-notes.html) 10.0.11 which is necessary to complete https://github.com/lagom/lagom/pull/1054.

#fixes #7995