### PR TITLE
Updated scalariform plugin; some code reformatted

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -13,8 +13,7 @@ import de.heikoseeberger.sbtheader.HeaderKey._
 import de.heikoseeberger.sbtheader.HeaderPattern
 
 import scalariform.formatter.preferences._
-import com.typesafe.sbt.SbtScalariform.scalariformSettings
-import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+import com.typesafe.sbt.SbtScalariform.autoImport._
 import bintray.BintrayPlugin.autoImport._
 import interplay._
 import interplay.Omnidoc.autoImport._
@@ -74,13 +73,14 @@ object BuildSettings {
    */
   def playCommonSettings: Seq[Setting[_]] = {
 
-    scalariformSettings ++ fileHeaderSettings ++ Seq(
-      ScalariformKeys.preferences := ScalariformKeys.preferences.value
+    fileHeaderSettings ++ Seq(
+      scalariformAutoformat := true,
+      scalariformPreferences := scalariformPreferences.value
           .setPreference(SpacesAroundMultiImports, true)
           .setPreference(SpaceInsideParentheses, false)
           .setPreference(DanglingCloseParenthesis, Preserve)
           .setPreference(PreserveSpaceBeforeArguments, true)
-          .setPreference(DoubleIndentClassDeclaration, true)
+          .setPreference(DoubleIndentConstructorArguments, true)
     ) ++ Seq(
       homepage := Some(url("https://playframework.com")),
       ivyLoggingLevel := UpdateLogging.DownloadOnly,

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -7,7 +7,7 @@ val Versions = new {
   // documentation/manual/working/commonGuide/production/Deploying.md
   val sbtNativePackager = "1.3.2"
   val mima = "0.1.18"
-  val sbtScalariform = "1.6.0"
+  val sbtScalariform = "1.8.2"
   val sbtJavaAgent = "0.1.4"
   val sbtJmh = "0.2.27"
   val sbtDoge = "0.1.5"

--- a/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSModule.scala
+++ b/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSModule.scala
@@ -176,11 +176,11 @@ class OptionalAhcHttpCacheProvider @Inject() (
   }
 
   case class AhcHttpCacheConfiguration(
-    enabled: Boolean,
-    cacheName: String,
-    heuristicsEnabled: Boolean,
-    cacheManagerURI: String,
-    cachingProviderName: String)
+      enabled: Boolean,
+      cacheName: String,
+      heuristicsEnabled: Boolean,
+      cacheManagerURI: String,
+      cachingProviderName: String)
 
   object AhcHttpCacheParser {
     // For the sake of compatibility, parse both cacheManagerResource and cacheManagerURI, use cacheManagerURI first.
@@ -214,7 +214,7 @@ class OptionalAhcHttpCacheProvider @Inject() (
  */
 @Singleton
 class AhcWSClientProvider @Inject() (asyncHttpClient: AsyncHttpClient)(implicit materializer: Materializer)
-    extends Provider[WSClient] {
+  extends Provider[WSClient] {
 
   lazy val get: WSClient = {
     new AhcWSClient(new StandaloneAhcWSClient(asyncHttpClient))

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -158,8 +158,8 @@ class AkkaHttpServer(
    * Values that are cached based on the current application.
    */
   private case class ReloadCacheValues(
-    resultUtils: ServerResultUtils,
-    modelConversion: AkkaModelConversion
+      resultUtils: ServerResultUtils,
+      modelConversion: AkkaModelConversion
   )
 
   /**

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
@@ -35,12 +35,12 @@ object PlayDocsValidation extends PlayDocsValidationCompat {
    * This is the main markdown report for validating markdown docs.
    */
   case class MarkdownRefReport(
-    markdownFiles: Seq[File],
-    wikiLinks: Seq[LinkRef],
-    resourceLinks: Seq[LinkRef],
-    codeSamples: Seq[CodeSampleRef],
-    relativeLinks: Seq[LinkRef],
-    externalLinks: Seq[LinkRef])
+      markdownFiles: Seq[File],
+      wikiLinks: Seq[LinkRef],
+      resourceLinks: Seq[LinkRef],
+      codeSamples: Seq[CodeSampleRef],
+      relativeLinks: Seq[LinkRef],
+      externalLinks: Seq[LinkRef])
 
   case class LinkRef(link: String, file: File, position: Int)
   case class CodeSampleRef(source: String, segment: String, file: File, sourcePosition: Int, segmentPosition: Int)
@@ -65,20 +65,20 @@ object PlayDocsValidation extends PlayDocsValidationCompat {
   }
   case class FileWithCodeSamples(name: String, source: String, codeSamples: Seq[CodeSample])
   case class CodeSample(source: String, segment: String,
-    sourcePosition: Int, segmentPosition: Int)
+      sourcePosition: Int, segmentPosition: Int)
 
   case class TranslationReport(
-    missingFiles: Seq[String],
-    introducedFiles: Seq[String],
-    changedPathFiles: Seq[(String, String)],
-    codeSampleIssues: Seq[TranslationCodeSamples],
-    okFiles: Seq[String],
-    total: Int)
+      missingFiles: Seq[String],
+      introducedFiles: Seq[String],
+      changedPathFiles: Seq[(String, String)],
+      codeSampleIssues: Seq[TranslationCodeSamples],
+      okFiles: Seq[String],
+      total: Int)
   case class TranslationCodeSamples(
-    name: String,
-    missingCodeSamples: Seq[CodeSample],
-    introducedCodeSamples: Seq[CodeSample],
-    totalCodeSamples: Int)
+      name: String,
+      missingCodeSamples: Seq[CodeSample],
+      introducedCodeSamples: Seq[CodeSample],
+      totalCodeSamples: Int)
 
   /**
    * Configuration for validation.

--- a/framework/src/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/framework/src/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -140,7 +140,7 @@ private[play] class NamedAsyncCacheApiProvider(key: BindingKey[Ehcache]) extends
 }
 
 private[play] class NamedSyncCacheApiProvider(key: BindingKey[AsyncCacheApi])
-    extends Provider[SyncCacheApi with CacheApi] {
+  extends Provider[SyncCacheApi with CacheApi] {
   @Inject private var injector: Injector = _
 
   // TODO: remove "with CacheApi" hacks for 2.7.0
@@ -160,7 +160,7 @@ private[play] class NamedJavaAsyncCacheApiProvider(key: BindingKey[AsyncCacheApi
 }
 
 private[play] class NamedJavaSyncCacheApiProvider(key: BindingKey[AsyncCacheApi])
-    extends Provider[JavaSyncCacheApi with JavaCacheApi] {
+  extends Provider[JavaSyncCacheApi with JavaCacheApi] {
   @Inject private var injector: Injector = _
   lazy val get: JavaSyncCacheApi with JavaCacheApi =
     new SyncCacheApiAdapter(injector.instanceOf(key).sync)

--- a/framework/src/play-ehcache/src/test/scala/play/api/cache/ehcache/EhCacheApiSpec.scala
+++ b/framework/src/play-ehcache/src/test/scala/play/api/cache/ehcache/EhCacheApiSpec.scala
@@ -37,9 +37,9 @@ class EhCacheApiSpec extends PlaySpecification {
       _.overrides(
         bind[CacheManager].toProvider[CustomCacheManagerProvider]
       ).configure(
-        "play.cache.createBoundCaches" -> false,
-        "play.cache.bindCaches" -> Seq("custom")
-      )
+          "play.cache.createBoundCaches" -> false,
+          "play.cache.bindCaches" -> Seq("custom")
+        )
     ) {
       app.injector.instanceOf[NamedCacheController]
     }
@@ -91,6 +91,6 @@ class CustomCacheManagerProvider @Inject() (cacheManagerProvider: CacheManagerPr
 }
 
 class NamedCacheController @Inject() (
-  @NamedCache("custom") val cache: SyncCacheApi,
-  @NamedCache("custom") val asyncCache: AsyncCacheApi
+    @NamedCache("custom") val cache: SyncCacheApi,
+    @NamedCache("custom") val asyncCache: AsyncCacheApi
 )

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/HttpFiltersComponents.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/HttpFiltersComponents.scala
@@ -20,9 +20,9 @@ import play.filters.hosts.AllowedHostsComponents
  * }}}
  */
 trait HttpFiltersComponents
-    extends CSRFComponents
-    with SecurityHeadersComponents
-    with AllowedHostsComponents {
+  extends CSRFComponents
+  with SecurityHeadersComponents
+  with AllowedHostsComponents {
 
   def httpFilters: Seq[EssentialFilter] = Seq(csrfFilter, securityHeadersFilter, allowedHostsFilter)
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -249,24 +249,24 @@ object GzipFilterConfig {
       chunkedThreshold = config.get[ConfigMemorySize]("chunkedThreshold").toBytes.toInt,
       shouldGzip = (_, res) =>
 
-      if (whiteList.isEmpty) {
+        if (whiteList.isEmpty) {
 
-        if (blackList.isEmpty) {
-          true // default case, both whitelist and blacklist are empty so we gzip it.
+          if (blackList.isEmpty) {
+            true // default case, both whitelist and blacklist are empty so we gzip it.
+          } else {
+            // The blacklist is defined, so we gzip the result if it's not blacklisted.
+            res.body.contentType match {
+              case Some(MediaType.parse(outgoing)) => blackList.forall(mask => !matches(outgoing, mask))
+              case _ => true // Fail open (to gziping), since blacklists have a tendency to fail open.
+            }
+          }
         } else {
-          // The blacklist is defined, so we gzip the result if it's not blacklisted.
+          // The whitelist is defined. We gzip the result IFF there is a matching whitelist entry.
           res.body.contentType match {
-            case Some(MediaType.parse(outgoing)) => blackList.forall(mask => !matches(outgoing, mask))
-            case _ => true // Fail open (to gziping), since blacklists have a tendency to fail open.
+            case Some(MediaType.parse(outgoing)) => whiteList.exists(mask => matches(outgoing, mask))
+            case _ => false // Fail closed (to not gziping), since whitelists are intentionally strict.
           }
         }
-      } else {
-        // The whitelist is defined. We gzip the result IFF there is a matching whitelist entry.
-        res.body.contentType match {
-          case Some(MediaType.parse(outgoing)) => whiteList.exists(mask => matches(outgoing, mask))
-          case _ => false // Fail closed (to not gziping), since whitelists are intentionally strict.
-        }
-      }
     )
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -17,7 +17,7 @@ import play.core.j.{ JavaContextComponents, JavaHttpErrorHandlerAdapter }
  * A filter that denies requests by hosts that do not match a configured list of allowed hosts.
  */
 case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandler: HttpErrorHandler)
-    extends EssentialFilter {
+  extends EssentialFilter {
 
   private val logger = Logger(this.getClass)
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -77,7 +77,7 @@ private object RedirectHttpsKeys {
 
 @Singleton
 class RedirectHttpsConfigurationProvider @Inject() (c: Configuration, e: Environment)
-    extends Provider[RedirectHttpsConfiguration] {
+  extends Provider[RedirectHttpsConfiguration] {
   import RedirectHttpsKeys._
 
   private val logger = Logger(getClass)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -82,68 +82,68 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       """
         |play.filters.hosts.allowed = ["example.com", "example.net"]
       """.stripMargin) { app =>
-      status(request(app, "example.com")) must_== OK
-      status(request(app, "EXAMPLE.net")) must_== OK
-      status(request(app, "example.org")) must_== BAD_REQUEST
-      status(request(app, "foo.example.com")) must_== BAD_REQUEST
-    }
+        status(request(app, "example.com")) must_== OK
+        status(request(app, "EXAMPLE.net")) must_== OK
+        status(request(app, "example.org")) must_== BAD_REQUEST
+        status(request(app, "foo.example.com")) must_== BAD_REQUEST
+      }
 
     "allow defining host suffixes in configuration" in withApplication(
       okWithHost,
       """
         |play.filters.hosts.allowed = [".example.com"]
       """.stripMargin) { app =>
-      status(request(app, "foo.example.com")) must_== OK
-      status(request(app, "example.com")) must_== OK
-    }
+        status(request(app, "foo.example.com")) must_== OK
+        status(request(app, "example.com")) must_== OK
+      }
 
     "support FQDN format for hosts" in withApplication(
       okWithHost,
       """
         |play.filters.hosts.allowed = [".example.com", "example.net"]
       """.stripMargin) { app =>
-      status(request(app, "foo.example.com.")) must_== OK
-      status(request(app, "example.net.")) must_== OK
-    }
+        status(request(app, "foo.example.com.")) must_== OK
+        status(request(app, "example.net.")) must_== OK
+      }
 
     "support allowing empty hosts" in withApplication(
       okWithHost,
       """
         |play.filters.hosts.allowed = [".example.com", ""]
       """.stripMargin) { app =>
-      status(request(app, "")) must_== OK
-      status(request(app, "example.net")) must_== BAD_REQUEST
-      status(route(app, FakeRequest().withHeaders(HeaderNames.HOST -> "")).get) must_== OK
-    }
+        status(request(app, "")) must_== OK
+        status(request(app, "example.net")) must_== BAD_REQUEST
+        status(route(app, FakeRequest().withHeaders(HeaderNames.HOST -> "")).get) must_== OK
+      }
 
     "support host headers with ports" in withApplication(
       okWithHost,
       """
         |play.filters.hosts.allowed = ["example.com"]
       """.stripMargin) { app =>
-      status(request(app, "example.com:80")) must_== OK
-      status(request(app, "google.com:80")) must_== BAD_REQUEST
-    }
+        status(request(app, "example.com:80")) must_== OK
+        status(request(app, "google.com:80")) must_== BAD_REQUEST
+      }
 
     "restrict host headers based on port" in withApplication(
       okWithHost,
       """
         |play.filters.hosts.allowed = [".example.com:8080"]
       """.stripMargin) { app =>
-      status(request(app, "example.com:80")) must_== BAD_REQUEST
-      status(request(app, "www.example.com:8080")) must_== OK
-      status(request(app, "example.com:8080")) must_== OK
-    }
+        status(request(app, "example.com:80")) must_== BAD_REQUEST
+        status(request(app, "www.example.com:8080")) must_== OK
+        status(request(app, "example.com:8080")) must_== OK
+      }
 
     "support matching all hosts" in withApplication(
       okWithHost,
       """
         |play.filters.hosts.allowed = ["."]
       """.stripMargin) { app =>
-      status(request(app, "example.net")) must_== OK
-      status(request(app, "amazon.com")) must_== OK
-      status(request(app, "")) must_== OK
-    }
+        status(request(app, "example.net")) must_== OK
+        status(request(app, "amazon.com")) must_== OK
+        status(request(app, "")) must_== OK
+      }
 
     // See http://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html
 
@@ -152,28 +152,28 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       """
         |play.filters.hosts.allowed = [".mozilla.org"]
       """.stripMargin) { app =>
-      status(request(app, "addons.mozilla.org:@passwordreset.net")) must_== BAD_REQUEST
-      status(request(app, "addons.mozilla.org: www.securepasswordreset.com")) must_== BAD_REQUEST
-    }
+        status(request(app, "addons.mozilla.org:@passwordreset.net")) must_== BAD_REQUEST
+        status(request(app, "addons.mozilla.org: www.securepasswordreset.com")) must_== BAD_REQUEST
+      }
 
     "validate hosts in absolute URIs" in withApplication(
       okWithHost,
       """
         |play.filters.hosts.allowed = [".mozilla.org"]
       """.stripMargin) { app =>
-      status(request(app, "www.securepasswordreset.com", "https://addons.mozilla.org/en-US/firefox/users/pwreset")) must_== OK
-      status(request(app, "addons.mozilla.org", "https://www.securepasswordreset.com/en-US/firefox/users/pwreset")) must_== BAD_REQUEST
-    }
+        status(request(app, "www.securepasswordreset.com", "https://addons.mozilla.org/en-US/firefox/users/pwreset")) must_== OK
+        status(request(app, "addons.mozilla.org", "https://www.securepasswordreset.com/en-US/firefox/users/pwreset")) must_== BAD_REQUEST
+      }
 
     "not allow bypassing with X-Forwarded-Host header" in withServer(
       okWithHost,
       """
         |play.filters.hosts.allowed = ["localhost"]
       """.stripMargin) { ws =>
-      val wsRequest = ws.url(s"http://localhost:$TestServerPort").addHttpHeaders(X_FORWARDED_HOST -> "evil.com").get()
-      val wsResponse = Await.result(wsRequest, 5.seconds)
-      wsResponse.status must_== OK
-      wsResponse.body must_== s"localhost:$TestServerPort"
-    }
+        val wsRequest = ws.url(s"http://localhost:$TestServerPort").addHttpHeaders(X_FORWARDED_HOST -> "evil.com").get()
+        val wsResponse = Await.result(wsRequest, 5.seconds)
+        wsResponse.status must_== OK
+        wsResponse.body must_== s"localhost:$TestServerPort"
+      }
   }
 }

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -19,15 +19,15 @@ import scala.runtime.AbstractPartialFunction
  * A builder for creating Applications using Guice.
  */
 final case class GuiceApplicationBuilder(
-  environment: Environment = Environment.simple(),
-  configuration: Configuration = Configuration.empty,
-  modules: Seq[GuiceableModule] = Seq.empty,
-  overrides: Seq[GuiceableModule] = Seq.empty,
-  disabled: Seq[Class[_]] = Seq.empty,
-  binderOptions: Set[BinderOption] = BinderOption.defaults,
-  eagerly: Boolean = false,
-  loadConfiguration: Environment => Configuration = Configuration.load,
-  loadModules: (Environment, Configuration) => Seq[GuiceableModule] = GuiceableModule.loadModules) extends GuiceBuilder[GuiceApplicationBuilder](
+    environment: Environment = Environment.simple(),
+    configuration: Configuration = Configuration.empty,
+    modules: Seq[GuiceableModule] = Seq.empty,
+    overrides: Seq[GuiceableModule] = Seq.empty,
+    disabled: Seq[Class[_]] = Seq.empty,
+    binderOptions: Set[BinderOption] = BinderOption.defaults,
+    eagerly: Boolean = false,
+    loadConfiguration: Environment => Configuration = Configuration.load,
+    loadModules: (Environment, Configuration) => Seq[GuiceableModule] = GuiceableModule.loadModules) extends GuiceBuilder[GuiceApplicationBuilder](
   environment, configuration, modules, overrides, disabled, binderOptions, eagerly
 ) {
 

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -230,13 +230,13 @@ abstract class GuiceBuilder[Self] protected (
  * Default empty builder for creating Guice-backed Injectors.
  */
 final class GuiceInjectorBuilder(
-  environment: Environment = Environment.simple(),
-  configuration: Configuration = Configuration.empty,
-  modules: Seq[GuiceableModule] = Seq.empty,
-  overrides: Seq[GuiceableModule] = Seq.empty,
-  disabled: Seq[Class[_]] = Seq.empty,
-  binderOptions: Set[BinderOption] = BinderOption.defaults,
-  eagerly: Boolean = false) extends GuiceBuilder[GuiceInjectorBuilder](
+    environment: Environment = Environment.simple(),
+    configuration: Configuration = Configuration.empty,
+    modules: Seq[GuiceableModule] = Seq.empty,
+    overrides: Seq[GuiceableModule] = Seq.empty,
+    disabled: Seq[Class[_]] = Seq.empty,
+    binderOptions: Set[BinderOption] = BinderOption.defaults,
+    eagerly: Boolean = false) extends GuiceBuilder[GuiceInjectorBuilder](
   environment, configuration, modules, overrides, disabled, binderOptions, eagerly
 ) {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -83,11 +83,11 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
    * Override the standard WithServer class.
    */
   abstract class WithServer(
-    app: play.api.Application = GuiceApplicationBuilder().build(),
-    port: Int = play.api.test.Helpers.testServerPort)
-      extends play.api.test.WithServer(
-        app, port, serverProvider = Some(integrationServerProvider)
-      )
+      app: play.api.Application = GuiceApplicationBuilder().build(),
+      port: Int = play.api.test.Helpers.testServerPort)
+    extends play.api.test.WithServer(
+      app, port, serverProvider = Some(integrationServerProvider)
+    )
 
 }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -21,7 +21,7 @@ class AkkaHttpServerIntegrationSpecificationSpec extends ServerIntegrationSpecif
  * server backends, works properly.
  */
 trait ServerIntegrationSpecificationSpec extends PlaySpecification
-    with WsTestClient with ServerIntegrationSpecification {
+  with WsTestClient with ServerIntegrationSpecification {
 
   def expectedServerTag: Option[String]
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/FormActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/FormActionSpec.scala
@@ -18,9 +18,9 @@ import play.api.routing.Router
 class FormActionSpec extends PlaySpecification with WsTestClient {
 
   case class User(
-    name: String,
-    email: String,
-    age: Int
+      name: String,
+      email: String,
+      age: Int
   )
 
   val userForm = Form(

--- a/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -91,14 +91,14 @@ class SecuritySpec extends PlaySpecification {
 case class User(name: String)
 
 class AuthMessagesRequest[A](
-  val user: User,
-  messagesApi: MessagesApi,
-  request: Request[A]) extends MessagesRequest[A](request, messagesApi)
+    val user: User,
+    messagesApi: MessagesApi,
+    request: Request[A]) extends MessagesRequest[A](request, messagesApi)
 
 class UserAuthenticatedBuilder(parser: BodyParser[AnyContent])(implicit ec: ExecutionContext)
-    extends AuthenticatedBuilder[User]({ req: RequestHeader =>
-      req.session.get("user").map(User)
-    }, parser) {
+  extends AuthenticatedBuilder[User]({ req: RequestHeader =>
+    req.session.get("user").map(User)
+  }, parser) {
   @Inject()
   def this(parser: BodyParsers.Default)(implicit ec: ExecutionContext) = {
     this(parser: BodyParser[AnyContent])
@@ -106,10 +106,10 @@ class UserAuthenticatedBuilder(parser: BodyParser[AnyContent])(implicit ec: Exec
 }
 
 class AuthenticatedActionBuilder(
-  val parser: BodyParser[AnyContent],
-  messagesApi: MessagesApi,
-  builder: AuthenticatedBuilder[User])(implicit val executionContext: ExecutionContext)
-    extends ActionBuilder[AuthMessagesRequest, AnyContent] {
+    val parser: BodyParser[AnyContent],
+    messagesApi: MessagesApi,
+    builder: AuthenticatedBuilder[User])(implicit val executionContext: ExecutionContext)
+  extends ActionBuilder[AuthMessagesRequest, AnyContent] {
 
   type ResultBlock[A] = (AuthMessagesRequest[A]) => Future[Result]
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -281,7 +281,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
  *             trailers
  */
 case class BasicResponse(version: String, status: Int, reasonPhrase: String, headers: Map[String, String],
-  body: Either[String, (Seq[String], Map[String, String])])
+    body: Either[String, (Seq[String], Map[String, String])])
 
 /**
  * A basic request

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -18,7 +18,7 @@ import play.it.test.{ ApplicationFactories, ApplicationFactory, EndpointIntegrat
 import scala.collection.JavaConverters
 
 class FlashCookieSpec extends PlaySpecification
-    with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
+  with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
 
   /** Makes an app that we use while we're testing */
   def withFlashCookieApp(additionalConfiguration: Map[String, Any] = Map.empty): ApplicationFactory = {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
@@ -8,7 +8,7 @@ import play.api.test._
 import play.it.test.{ ApplicationFactories, ApplicationFactory, EndpointIntegrationSpecification, OkHttpEndpointSupport }
 
 class FormFieldOrderSpec extends PlaySpecification
-    with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
+  with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
 
   "Form URL Decoding " should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -194,43 +194,43 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
     "close the connection when the connection close header is present" in withServer(
       Results.Ok
     ) { port =>
-      BasicHttpClient.makeRequests(port, checkClosed = true)(
-        BasicRequest("GET", "/", "HTTP/1.1", Map("Connection" -> "close"), "")
-      )(0).status must_== 200
-    }
+        BasicHttpClient.makeRequests(port, checkClosed = true)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map("Connection" -> "close"), "")
+        )(0).status must_== 200
+      }
 
     "close the connection when the connection when protocol is HTTP 1.0" in withServer(
       Results.Ok
     ) { port =>
-      BasicHttpClient.makeRequests(port, checkClosed = true)(
-        BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
-      )(0).status must_== 200
-    }
+        BasicHttpClient.makeRequests(port, checkClosed = true)(
+          BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
+        )(0).status must_== 200
+      }
 
     "honour the keep alive header for HTTP 1.0" in withServer(
       Results.Ok
     ) { port =>
-      val responses = BasicHttpClient.makeRequests(port)(
-        BasicRequest("GET", "/", "HTTP/1.0", Map("Connection" -> "keep-alive"), ""),
-        BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
-      )
-      responses(0).status must_== 200
-      responses(0).headers.get(CONNECTION) must beSome.like {
-        case s => s.toLowerCase(ENGLISH) must_== "keep-alive"
+        val responses = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.0", Map("Connection" -> "keep-alive"), ""),
+          BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
+        )
+        responses(0).status must_== 200
+        responses(0).headers.get(CONNECTION) must beSome.like {
+          case s => s.toLowerCase(ENGLISH) must_== "keep-alive"
+        }
+        responses(1).status must_== 200
       }
-      responses(1).status must_== 200
-    }
 
     "keep alive HTTP 1.1 connections" in withServer(
       Results.Ok
     ) { port =>
-      val responses = BasicHttpClient.makeRequests(port)(
-        BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
-        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
-      )
-      responses(0).status must_== 200
-      responses(1).status must_== 200
-    }
+        val responses = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )
+        responses(0).status must_== 200
+        responses(1).status must_== 200
+      }
 
     "close chunked connections when requested" in withServer(
       Results.Ok.chunked(Source(List("a", "b", "c")))
@@ -285,13 +285,13 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
     "Strip malformed cookies" in withServer(
       Results.Ok
     ) { port =>
-      val response = BasicHttpClient.makeRequests(port)(
-        BasicRequest("GET", "/", "HTTP/1.1", Map("Cookie" -> """£"""), "")
-      )(0)
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map("Cookie" -> """£"""), "")
+        )(0)
 
-      response.status must_== 200
-      response.body must beLeft
-    }
+        response.status must_== 200
+        response.body must beLeft
+      }
 
     "reject HTTP 1.0 requests for chunked results" in withServer(
       Results.Ok.chunked(Source(List("a", "b", "c"))),
@@ -329,19 +329,19 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       Results.Ok
     ) { port =>
 
-      forall(List(
-        "aaa" -> "bbb\fccc",
-        "ddd" -> "eee\u000bfff"
-      )) { header =>
+        forall(List(
+          "aaa" -> "bbb\fccc",
+          "ddd" -> "eee\u000bfff"
+        )) { header =>
 
-        val response = BasicHttpClient.makeRequests(port)(
-          BasicRequest("GET", "/", "HTTP/1.1", Map(header), "")
-        ).head
+          val response = BasicHttpClient.makeRequests(port)(
+            BasicRequest("GET", "/", "HTTP/1.1", Map(header), "")
+          ).head
 
-        response.status must_== 400
-        response.body must beLeft
+          response.status must_== 400
+          response.body must beLeft
+        }
       }
-    }
 
     "support UTF-8 encoded filenames in Content-Disposition headers" in {
       val tempFile: Path = JFiles.createTempFile("ScalaResultsHandlingSpec", "txt")
@@ -442,42 +442,42 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
     "not have a message body, nor Content-Length, when a 100 response is returned" in withServer(
       Results.Continue
     ) { port =>
-      val response = BasicHttpClient.makeRequests(port)(
-        BasicRequest("POST", "/", "HTTP/1.1", Map(), "")
-      ).head
-      response.body must beLeft("")
-      response.headers.get(CONTENT_LENGTH) must beNone
-    }
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("POST", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
 
     "not have a message body, nor Content-Length, when a 101 response is returned" in withServer(
       Results.SwitchingProtocols
     ) { port =>
-      val response = BasicHttpClient.makeRequests(port)(
-        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
-      ).head
-      response.body must beLeft("")
-      response.headers.get(CONTENT_LENGTH) must beNone
-    }
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
 
     "not have a message body, nor Content-Length, when a 204 response is returned" in withServer(
       Results.NoContent
     ) { port =>
-      val response = BasicHttpClient.makeRequests(port)(
-        BasicRequest("PUT", "/", "HTTP/1.1", Map(), "")
-      ).head
-      response.body must beLeft("")
-      response.headers.get(CONTENT_LENGTH) must beNone
-    }
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("PUT", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
 
     "not have a message body, nor Content-Length, when a 304 response is returned" in withServer(
       Results.NotModified
     ) { port =>
-      val response = BasicHttpClient.makeRequests(port)(
-        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
-      ).head
-      response.body must beLeft("")
-      response.headers.get(CONTENT_LENGTH) must beNone
-    }
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
 
     "not have a message body, nor Content-Length, even when a 100 response with an explicit Content-Length is returned" in withServer(
       Results.Continue.withHeaders("Content-Length" -> "0")

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -76,10 +76,10 @@ trait PingWebSocketSpec extends PlaySpecification with WsTestClient with ServerI
 }
 
 trait WebSocketSpec extends PlaySpecification
-    with WsTestClient
-    with ServerIntegrationSpecification
-    with WebSocketSpecMethods
-    with PingWebSocketSpec {
+  with WsTestClient
+  with ServerIntegrationSpecification
+  with WebSocketSpecMethods
+  with PingWebSocketSpec {
 
   /*
    * This is the flakiest part of the test suite -- the CI server will timeout websockets

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -16,8 +16,8 @@ import play.core.server._
  * @see [[ServerEndpoint]]
  */
 trait EndpointIntegrationSpecification
-    extends SpecLike with PendingUntilFixed
-    with ApplicationFactories {
+  extends SpecLike with PendingUntilFixed
+  with ApplicationFactories {
 
   /**
    * Implicit class that enhances [[ApplicationFactory]] with the [[withAllEndpoints()]] method.

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -44,7 +44,7 @@ class RuntimeDependencyInjectionFormSpec extends FormSpec {
 class CompileTimeDependencyInjectionFormSpec extends FormSpec {
 
   class MyComponents(context: ApplicationLoader.Context, extraConfig: Map[String, Any] = Map.empty) extends BuiltInComponentsFromContext(context)
-      with FormFactoryComponents {
+    with FormFactoryComponents {
     override def router(): Router = Router.empty()
 
     override def httpFilters(): java.util.List[EssentialFilter] = java.util.Collections.emptyList()

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -244,13 +244,13 @@ trait EvolutionsConfig {
  * Default evolutions datasource configuration.
  */
 case class DefaultEvolutionsDatasourceConfig(
-  enabled: Boolean,
-  schema: String,
-  autocommit: Boolean,
-  useLocks: Boolean,
-  autoApply: Boolean,
-  autoApplyDowns: Boolean,
-  skipApplyDownsOnly: Boolean) extends EvolutionsDatasourceConfig
+    enabled: Boolean,
+    schema: String,
+    autocommit: Boolean,
+    useLocks: Boolean,
+    autoApply: Boolean,
+    autoApplyDowns: Boolean,
+    skipApplyDownsOnly: Boolean) extends EvolutionsDatasourceConfig
 
 /**
  * Default evolutions configuration.

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -191,7 +191,7 @@ abstract class DefaultDatabase(val name: String, configuration: Config, environm
  * Default implementation of the database API using a connection pool.
  */
 class PooledDatabase(name: String, configuration: Config, environment: Environment, pool: ConnectionPool)
-    extends DefaultDatabase(name, configuration, environment) {
+  extends DefaultDatabase(name, configuration, environment) {
 
   def this(name: String, configuration: Configuration) = this(name, configuration.underlying, Environment.simple(), new HikariCPConnectionPool(Environment.simple()))
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -45,8 +45,8 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
    * Values that are cached based on the current application.
    */
   private case class ReloadCacheValues(
-    resultUtils: ServerResultUtils,
-    modelConversion: NettyModelConversion
+      resultUtils: ServerResultUtils,
+      modelConversion: NettyModelConversion
   )
 
   /**

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
@@ -37,11 +37,11 @@ object ServerProvider {
    * This function can be used to close resources that are provided to the server.
    */
   final case class Context(
-    config: ServerConfig,
-    appProvider: ApplicationProvider,
-    actorSystem: ActorSystem,
-    materializer: Materializer,
-    stopHook: () => Future[_])
+      config: ServerConfig,
+      appProvider: ApplicationProvider,
+      actorSystem: ActorSystem,
+      materializer: Materializer,
+      stopHook: () => Future[_])
 
   /**
    * Load a server provider from the configuration and classloader.

--- a/framework/src/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
@@ -13,14 +13,14 @@ import play.api.http.{ HeaderNames, HttpProtocol, HttpVerbs, Status }
  * methods.  It also mixes in the Play test helpers and types for convenience.
  */
 trait PlaySpecification extends SpecificationLike
-    with PlayRunners
-    with HeaderNames
-    with Status
-    with HttpProtocol
-    with DefaultAwaitTimeout
-    with ResultExtractors
-    with Writeables
-    with RouteInvokers
-    with FutureAwaits
-    with HttpVerbs {
+  with PlayRunners
+  with HeaderNames
+  with Status
+  with HttpProtocol
+  with DefaultAwaitTimeout
+  with ResultExtractors
+  with Writeables
+  with RouteInvokers
+  with FutureAwaits
+  with HttpVerbs {
 }

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -222,7 +222,7 @@ private class StrictAccumulator[-E, +A](handler: Option[E] => Future[A], val toS
 }
 
 private class FlattenedAccumulator[-E, +A](future: Future[Accumulator[E, A]])(implicit materializer: Materializer)
-    extends SinkAccumulator[E, A](Accumulator.futureToSink(future)) {
+  extends SinkAccumulator[E, A](Accumulator.futureToSink(future)) {
 
   override def run(source: Source[E, _])(implicit materializer: Materializer): Future[A] = {
     future.flatMap(_.run(source))(materializer.executionContext)

--- a/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -137,6 +137,6 @@ private[play] class TestServerProcess extends ServerProcess {
 }
 
 private[play] case class TestServerExitException(
-  message: String,
-  cause: Option[Throwable] = None,
-  returnCode: Int = -1) extends Exception(s"Exit with $message, $cause, $returnCode", cause.orNull)
+    message: String,
+    cause: Option[Throwable] = None,
+    returnCode: Int = -1) extends Exception(s"Exit with $message, $cause, $returnCode", cause.orNull)

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -83,8 +83,8 @@ object ApplicationLoader {
    * @param buildLink An interface that can be used to interact with the build system.
    */
   final case class DevContext(
-    sourceMapper: SourceMapper,
-    buildLink: BuildLink
+      sourceMapper: SourceMapper,
+      buildLink: BuildLink
   )
 
   object Context {
@@ -145,23 +145,23 @@ object ApplicationLoader {
     Reflect.configuredClass[ApplicationLoader, play.ApplicationLoader, NoApplicationLoader](
       context.environment, context.initialConfiguration, LoaderKey, classOf[NoApplicationLoader].getName
     ) match {
-      case None =>
-        loaderNotFound()
-      case Some(Left(scalaClass)) =>
-        scalaClass.newInstance
-      case Some(Right(javaClass)) =>
-        val javaApplicationLoader: play.ApplicationLoader = javaClass.newInstance
-        // Create an adapter from a Java to a Scala ApplicationLoader. This class is
-        // effectively anonymous, but let's give it a name to make debugging easier.
-        class JavaApplicationLoaderAdapter extends ApplicationLoader {
-          override def load(context: ApplicationLoader.Context): Application = {
-            val javaContext = new play.ApplicationLoader.Context(context)
-            val javaApplication = javaApplicationLoader.load(javaContext)
-            javaApplication.asScala()
+        case None =>
+          loaderNotFound()
+        case Some(Left(scalaClass)) =>
+          scalaClass.newInstance
+        case Some(Right(javaClass)) =>
+          val javaApplicationLoader: play.ApplicationLoader = javaClass.newInstance
+          // Create an adapter from a Java to a Scala ApplicationLoader. This class is
+          // effectively anonymous, but let's give it a name to make debugging easier.
+          class JavaApplicationLoaderAdapter extends ApplicationLoader {
+            override def load(context: ApplicationLoader.Context): Application = {
+              val javaContext = new play.ApplicationLoader.Context(context)
+              val javaApplication = javaApplicationLoader.load(javaContext)
+              javaApplication.asScala()
+            }
           }
-        }
-        new JavaApplicationLoaderAdapter
-    }
+          new JavaApplicationLoaderAdapter
+      }
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -30,7 +30,7 @@ import scala.concurrent.{ ExecutionContext, Future }
  *
  */
 class ExternalAssets @Inject() (environment: Environment)(implicit ec: ExecutionContext, fileMimeTypes: FileMimeTypes)
-    extends ControllerHelpers {
+  extends ControllerHelpers {
 
   val AbsolutePath = """^(/|[a-zA-Z]:\\).*""".r
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -23,14 +23,14 @@ import scala.concurrent.duration._
  * @param fileMimeTypes The fileMimeTypes configuration
  */
 case class HttpConfiguration(
-  context: String = "/",
-  parser: ParserConfiguration = ParserConfiguration(),
-  actionComposition: ActionCompositionConfiguration = ActionCompositionConfiguration(),
-  cookies: CookiesConfiguration = CookiesConfiguration(),
-  session: SessionConfiguration = SessionConfiguration(),
-  flash: FlashConfiguration = FlashConfiguration(),
-  fileMimeTypes: FileMimeTypesConfiguration = FileMimeTypesConfiguration(),
-  secret: SecretConfiguration = SecretConfiguration())
+    context: String = "/",
+    parser: ParserConfiguration = ParserConfiguration(),
+    actionComposition: ActionCompositionConfiguration = ActionCompositionConfiguration(),
+    cookies: CookiesConfiguration = CookiesConfiguration(),
+    session: SessionConfiguration = SessionConfiguration(),
+    flash: FlashConfiguration = FlashConfiguration(),
+    fileMimeTypes: FileMimeTypesConfiguration = FileMimeTypesConfiguration(),
+    secret: SecretConfiguration = SecretConfiguration())
 
 /**
  * The application secret. Must be set. A value of "changeme" will cause the application to fail to start in
@@ -89,14 +89,14 @@ case class CookiesConfiguration(strict: Boolean = true) {
  * @param jwt        The JWT specific information
  */
 case class SessionConfiguration(
-  cookieName: String = "PLAY_SESSION",
-  secure: Boolean = false,
-  maxAge: Option[FiniteDuration] = None,
-  httpOnly: Boolean = true,
-  domain: Option[String] = None,
-  path: String = "/",
-  sameSite: Option[SameSite] = Some(SameSite.Lax),
-  jwt: JWTConfiguration = JWTConfiguration()
+    cookieName: String = "PLAY_SESSION",
+    secure: Boolean = false,
+    maxAge: Option[FiniteDuration] = None,
+    httpOnly: Boolean = true,
+    domain: Option[String] = None,
+    path: String = "/",
+    sameSite: Option[SameSite] = Some(SameSite.Lax),
+    jwt: JWTConfiguration = JWTConfiguration()
 )
 
 /**
@@ -111,13 +111,13 @@ case class SessionConfiguration(
  * @param jwt        The JWT specific information
  */
 case class FlashConfiguration(
-  cookieName: String = "PLAY_FLASH",
-  secure: Boolean = false,
-  httpOnly: Boolean = true,
-  domain: Option[String] = None,
-  path: String = "/",
-  sameSite: Option[SameSite] = Some(SameSite.Lax),
-  jwt: JWTConfiguration = JWTConfiguration()
+    cookieName: String = "PLAY_FLASH",
+    secure: Boolean = false,
+    httpOnly: Boolean = true,
+    domain: Option[String] = None,
+    path: String = "/",
+    sameSite: Option[SameSite] = Some(SameSite.Lax),
+    jwt: JWTConfiguration = JWTConfiguration()
 )
 
 /**
@@ -127,8 +127,8 @@ case class FlashConfiguration(
  * @param maxDiskBuffer   The maximum size that a request body should be buffered on disk.
  */
 case class ParserConfiguration(
-  maxMemoryBuffer: Int = 102400,
-  maxDiskBuffer: Long = 10485760)
+    maxMemoryBuffer: Int = 102400,
+    maxDiskBuffer: Long = 10485760)
 
 /**
  * Configuration for action composition.
@@ -138,8 +138,8 @@ case class ParserConfiguration(
  *                                        executed before the action composition ones.
  */
 case class ActionCompositionConfiguration(
-  controllerAnnotationsFirst: Boolean = false,
-  executeActionCreatorActionFirst: Boolean = false)
+    controllerAnnotationsFirst: Boolean = false,
+    executeActionCreatorActionFirst: Boolean = false)
 
 /**
  * Configuration for file MIME types, mapping from extension to content type.
@@ -329,10 +329,10 @@ object HttpConfiguration {
  * @param dataClaim The claim key corresponding to the data map passed in by the user
  */
 case class JWTConfiguration(
-  signatureAlgorithm: String = "HS256",
-  expiresAfter: Option[FiniteDuration] = None,
-  clockSkew: FiniteDuration = 30.seconds,
-  dataClaim: String = "data"
+    signatureAlgorithm: String = "HS256",
+    expiresAfter: Option[FiniteDuration] = None,
+    clockSkew: FiniteDuration = 30.seconds,
+    dataClaim: String = "data"
 )
 
 object JWTConfigurationParser {

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -262,14 +262,14 @@ class DefaultHttpRequestHandler(
  * the base class for your custom [[HttpRequestHandler]].
  */
 class JavaCompatibleHttpRequestHandler(
-  webCommands: WebCommands,
-  optDevContext: Option[DevContext],
-  router: Router,
-  errorHandler: HttpErrorHandler,
-  configuration: HttpConfiguration,
-  filters: Seq[EssentialFilter],
-  handlerComponents: JavaHandlerComponents)
-    extends DefaultHttpRequestHandler(webCommands, optDevContext, router, errorHandler, configuration, filters) {
+    webCommands: WebCommands,
+    optDevContext: Option[DevContext],
+    router: Router,
+    errorHandler: HttpErrorHandler,
+    configuration: HttpConfiguration,
+    filters: Seq[EssentialFilter],
+    handlerComponents: JavaHandlerComponents)
+  extends DefaultHttpRequestHandler(webCommands, optDevContext, router, errorHandler, configuration, filters) {
 
   @Inject
   def this(

--- a/framework/src/play/src/main/scala/play/api/http/Writeable.scala
+++ b/framework/src/play/src/main/scala/play/api/http/Writeable.scala
@@ -151,11 +151,11 @@ trait DefaultWriteables extends LowPriorityWriteables {
 
     Writeable[MultipartFormData[A]](
       transform = { form: MultipartFormData[A] =>
-      formatDataParts(form.dataParts) ++ form.files.flatMap { file =>
-        val fileBytes = aWriteable.transform(file)
-        filePartHeader(file) ++ fileBytes ++ codec.encode("\r\n")
-      } ++ codec.encode(s"--$boundary--")
-    },
+        formatDataParts(form.dataParts) ++ form.files.flatMap { file =>
+          val fileBytes = aWriteable.transform(file)
+          filePartHeader(file) ++ fileBytes ++ codec.encode("\r\n")
+        } ++ codec.encode(s"--$boundary--")
+      },
       contentType = Some(s"multipart/form-data; boundary=$boundary")
     )
   }

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -512,11 +512,11 @@ class DefaultMessagesApi @Inject() (
 
 @Singleton
 class DefaultMessagesApiProvider @Inject() (
-  environment: Environment,
-  config: Configuration,
-  langs: Langs,
-  httpConfiguration: HttpConfiguration)
-    extends Provider[MessagesApi] {
+    environment: Environment,
+    config: Configuration,
+    langs: Langs,
+    httpConfiguration: HttpConfiguration)
+  extends Provider[MessagesApi] {
 
   override lazy val get: MessagesApi = {
     new DefaultMessagesApi(

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -140,9 +140,9 @@ object Files {
    */
   @Singleton
   class DefaultTemporaryFileCreator @Inject() (
-    applicationLifecycle: ApplicationLifecycle,
-    temporaryFileReaper: TemporaryFileReaper)
-      extends TemporaryFileCreator {
+      applicationLifecycle: ApplicationLifecycle,
+      temporaryFileReaper: TemporaryFileReaper)
+    extends TemporaryFileCreator {
 
     private val logger = play.api.Logger(this.getClass)
     private val frq = new FinalizableReferenceQueue()
@@ -231,9 +231,9 @@ object Files {
 
   @Singleton
   class DefaultTemporaryFileReaper @Inject() (
-    actorSystem: ActorSystem,
-    config: TemporaryFileReaperConfiguration)
-      extends TemporaryFileReaper {
+      actorSystem: ActorSystem,
+      config: TemporaryFileReaperConfiguration)
+    extends TemporaryFileReaper {
 
     private val logger = play.api.Logger(this.getClass)
     private val blockingDispatcherName = "play.akka.blockingIoDispatcher"
@@ -314,10 +314,10 @@ object Files {
    * @param interval the duration after the initial run during which the reaper will scan for files it can remove.  Default 5 minutes.
    */
   case class TemporaryFileReaperConfiguration(
-    enabled: Boolean = false,
-    olderThan: FiniteDuration = 5.minutes,
-    initialDelay: FiniteDuration = 5.minutes,
-    interval: FiniteDuration = 5.minutes)
+      enabled: Boolean = false,
+      olderThan: FiniteDuration = 5.minutes,
+      initialDelay: FiniteDuration = 5.minutes,
+      interval: FiniteDuration = 5.minutes)
 
   object TemporaryFileReaperConfiguration {
     def fromConfiguration(config: Configuration): TemporaryFileReaperConfiguration = {

--- a/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedKey.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedKey.scala
@@ -29,7 +29,7 @@ final class TypedKey[A] private (val displayName: Option[String]) {
    * @param value The value to bind.
    * @return An entry binding this key to a value of the right type.
    */
-  def -> (value: A): TypedEntry[A] = bindValue(value)
+  def ->(value: A): TypedEntry[A] = bindValue(value)
 
   override def toString: String = displayName.getOrElse(super.toString)
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -478,12 +478,12 @@ object DefaultActionBuilder {
 }
 
 class ActionBuilderImpl[B](val parser: BodyParser[B])(implicit val executionContext: ExecutionContext)
-    extends ActionBuilder[Request, B] {
+  extends ActionBuilder[Request, B] {
   def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request)
 }
 
 class DefaultActionBuilderImpl(parser: BodyParser[AnyContent])(implicit ec: ExecutionContext)
-    extends ActionBuilderImpl(parser) with DefaultActionBuilder {
+  extends ActionBuilderImpl(parser) with DefaultActionBuilder {
   @Inject
   def this(parser: BodyParsers.Default)(implicit ec: ExecutionContext) = this(parser: BodyParser[AnyContent])
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -318,7 +318,7 @@ object QueryStringBindable {
    * @tparam A the type being parsed
    */
   class Parsing[A](parse: String => A, serialize: A => String, error: (String, Exception) => String)
-      extends QueryStringBindable[A] {
+    extends QueryStringBindable[A] {
 
     def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { p =>
       try {
@@ -567,7 +567,7 @@ object PathBindable {
    * @tparam A the type being parsed
    */
   class Parsing[A](parse: String => A, serialize: A => String, error: (String, Exception) => String)
-      extends PathBindable[A] {
+    extends PathBindable[A] {
 
     // added for bincompat
     @deprecated("Use constructor without codec", "2.6.2")

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -403,10 +403,10 @@ trait BodyParserUtils {
 }
 
 class DefaultPlayBodyParsers @Inject() (
-  val config: ParserConfiguration,
-  val errorHandler: HttpErrorHandler,
-  val materializer: Materializer,
-  val temporaryFileCreator: TemporaryFileCreator) extends PlayBodyParsers
+    val config: ParserConfiguration,
+    val errorHandler: HttpErrorHandler,
+    val materializer: Materializer,
+    val temporaryFileCreator: TemporaryFileCreator) extends PlayBodyParsers
 
 object PlayBodyParsers {
   /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -210,13 +210,13 @@ trait ControllerComponents {
 }
 
 case class DefaultControllerComponents @Inject() (
-  actionBuilder: DefaultActionBuilder,
-  parsers: PlayBodyParsers,
-  messagesApi: MessagesApi,
-  langs: Langs,
-  fileMimeTypes: FileMimeTypes,
-  executionContext: scala.concurrent.ExecutionContext)
-    extends ControllerComponents
+    actionBuilder: DefaultActionBuilder,
+    parsers: PlayBodyParsers,
+    messagesApi: MessagesApi,
+    langs: Langs,
+    fileMimeTypes: FileMimeTypes,
+    executionContext: scala.concurrent.ExecutionContext)
+  extends ControllerComponents
 
 /**
  * Implements deprecated controller functionality. We recommend moving away from this and using one of the classes or

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -322,7 +322,7 @@ trait CookieHeaderEncoding {
  * The default implementation of `CookieHeaders`.
  */
 class DefaultCookieHeaderEncoding @Inject() (
-  override protected val config: CookiesConfiguration = CookiesConfiguration()) extends CookieHeaderEncoding
+    override protected val config: CookiesConfiguration = CookiesConfiguration()) extends CookieHeaderEncoding
 
 /**
  * Utilities for merging individual cookie values in HTTP cookie headers.
@@ -762,13 +762,13 @@ trait FallbackCookieDataCodec extends CookieDataCodec {
 }
 
 case class DefaultUrlEncodedCookieDataCodec(
-  isSigned: Boolean,
-  cookieSigner: CookieSigner
+    isSigned: Boolean,
+    cookieSigner: CookieSigner
 ) extends UrlEncodedCookieDataCodec
 
 case class DefaultJWTCookieDataCodec @Inject() (
-  secretConfiguration: SecretConfiguration,
-  jwtConfiguration: JWTConfiguration
+    secretConfiguration: SecretConfiguration,
+    jwtConfiguration: JWTConfiguration
 ) extends JWTCookieDataCodec
 
 /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -89,10 +89,10 @@ trait FlashCookieBaker extends CookieBaker[Flash] with CookieDataCodec {
 }
 
 class DefaultFlashCookieBaker @Inject() (
-  val config: FlashConfiguration,
-  val secretConfiguration: SecretConfiguration,
-  val cookieSigner: CookieSigner)
-    extends FlashCookieBaker with FallbackCookieDataCodec {
+    val config: FlashConfiguration,
+    val secretConfiguration: SecretConfiguration,
+    val cookieSigner: CookieSigner)
+  extends FlashCookieBaker with FallbackCookieDataCodec {
 
   def this() = this(FlashConfiguration(), SecretConfiguration(), new CookieSignerProvider(SecretConfiguration()).get)
 
@@ -101,10 +101,10 @@ class DefaultFlashCookieBaker @Inject() (
 }
 
 class LegacyFlashCookieBaker @Inject() (
-  val config: FlashConfiguration,
-  val secretConfiguration: SecretConfiguration,
-  val cookieSigner: CookieSigner)
-    extends FlashCookieBaker with UrlEncodedCookieDataCodec {
+    val config: FlashConfiguration,
+    val secretConfiguration: SecretConfiguration,
+    val cookieSigner: CookieSigner)
+  extends FlashCookieBaker with UrlEncodedCookieDataCodec {
   def this() = this(FlashConfiguration(), SecretConfiguration(), new CookieSignerProvider(SecretConfiguration()).get)
 }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/MessagesRequest.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/MessagesRequest.scala
@@ -64,7 +64,7 @@ class MessagesRequest[A](request: Request[A], val messagesApi: MessagesApi) exte
 trait MessagesActionBuilder extends ActionBuilder[MessagesRequest, AnyContent]
 
 class MessagesActionBuilderImpl[B](val parser: BodyParser[B], messagesApi: MessagesApi)(implicit val executionContext: ExecutionContext)
-    extends ActionBuilder[MessagesRequest, B] {
+  extends ActionBuilder[MessagesRequest, B] {
 
   def invokeBlock[A](request: Request[A], block: (MessagesRequest[A]) => Future[Result]): Future[Result] = {
     block(new MessagesRequest[A](request, messagesApi))
@@ -72,7 +72,7 @@ class MessagesActionBuilderImpl[B](val parser: BodyParser[B], messagesApi: Messa
 }
 
 class DefaultMessagesActionBuilderImpl(parser: BodyParser[AnyContent], messagesApi: MessagesApi)(implicit ec: ExecutionContext)
-    extends MessagesActionBuilderImpl(parser, messagesApi) with MessagesActionBuilder {
+  extends MessagesActionBuilderImpl(parser, messagesApi) with MessagesActionBuilder {
   @Inject
   def this(parser: BodyParsers.Default, messagesApi: MessagesApi)(implicit ec: ExecutionContext) = {
     this(parser: BodyParser[AnyContent], messagesApi)
@@ -87,13 +87,13 @@ trait MessagesControllerComponents extends ControllerComponents {
 }
 
 case class DefaultMessagesControllerComponents @Inject() (
-  messagesActionBuilder: MessagesActionBuilder,
-  actionBuilder: DefaultActionBuilder,
-  parsers: PlayBodyParsers,
-  messagesApi: MessagesApi,
-  langs: Langs,
-  fileMimeTypes: FileMimeTypes,
-  executionContext: scala.concurrent.ExecutionContext
+    messagesActionBuilder: MessagesActionBuilder,
+    actionBuilder: DefaultActionBuilder,
+    parsers: PlayBodyParsers,
+    messagesApi: MessagesApi,
+    langs: Langs,
+    fileMimeTypes: FileMimeTypes,
+    executionContext: scala.concurrent.ExecutionContext
 ) extends MessagesControllerComponents
 
 /**
@@ -125,5 +125,5 @@ trait MessagesBaseController extends BaseControllerHelpers {
  * }}}
  */
 abstract class MessagesAbstractController @Inject() (
-  protected val controllerComponents: MessagesControllerComponents
+    protected val controllerComponents: MessagesControllerComponents
 ) extends MessagesBaseController

--- a/framework/src/play/src/main/scala/play/api/mvc/Request.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Request.scala
@@ -73,10 +73,10 @@ object Request {
  * @tparam A The type of the body content.
  */
 private[play] class RequestImpl[+A](
-  override val connection: RemoteConnection,
-  override val method: String,
-  override val target: RequestTarget,
-  override val version: String,
-  override val headers: Headers,
-  override val attrs: TypedMap,
-  override val body: A) extends Request[A]
+    override val connection: RemoteConnection,
+    override val method: String,
+    override val target: RequestTarget,
+    override val version: String,
+    override val headers: Headers,
+    override val attrs: TypedMap,
+    override val body: A) extends Request[A]

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -366,9 +366,9 @@ object RequestHeader {
  * A standard implementation of a RequestHeader.
  */
 private[play] class RequestHeaderImpl(
-  override val connection: RemoteConnection,
-  override val method: String,
-  override val target: RequestTarget,
-  override val version: String,
-  override val headers: Headers,
-  override val attrs: TypedMap) extends RequestHeader
+    override val connection: RemoteConnection,
+    override val method: String,
+    override val target: RequestTarget,
+    override val version: String,
+    override val headers: Headers,
+    override val attrs: TypedMap) extends RequestHeader

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -93,10 +93,10 @@ trait SessionCookieBaker extends CookieBaker[Session] with CookieDataCodec {
  * A session cookie that reads in both signed and JWT cookies, and writes out JWT cookies.
  */
 class DefaultSessionCookieBaker @Inject() (
-  val config: SessionConfiguration,
-  val secretConfiguration: SecretConfiguration,
-  cookieSigner: CookieSigner)
-    extends SessionCookieBaker with FallbackCookieDataCodec {
+    val config: SessionConfiguration,
+    val secretConfiguration: SecretConfiguration,
+    cookieSigner: CookieSigner)
+  extends SessionCookieBaker with FallbackCookieDataCodec {
 
   override val jwtCodec: JWTCookieDataCodec = DefaultJWTCookieDataCodec(secretConfiguration, config.jwt)
   override val signedCodec: UrlEncodedCookieDataCodec = DefaultUrlEncodedCookieDataCodec(isSigned, cookieSigner)

--- a/framework/src/play/src/main/scala/play/api/routing/HandlerDef.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/HandlerDef.scala
@@ -8,13 +8,13 @@ package play.api.routing
  * with reflection.
  */
 case class HandlerDef(
-  classLoader: ClassLoader,
-  routerPackage: String,
-  controller: String,
-  method: String,
-  parameterTypes: Seq[Class[_]],
-  verb: String,
-  path: String,
-  comments: String = "",
-  modifiers: Seq[String] = Seq.empty
+    classLoader: ClassLoader,
+    routerPackage: String,
+    controller: String,
+    method: String,
+    parameterTypes: Seq[Class[_]],
+    verb: String,
+    path: String,
+    comments: String = "",
+    modifiers: Seq[String] = Seq.empty
 ) extends play.routing.HandlerDef

--- a/framework/src/play/src/main/scala/play/core/hidden/ObjectMappings.scala
+++ b/framework/src/play/src/main/scala/play/core/hidden/ObjectMappings.scala
@@ -54,7 +54,7 @@ class ObjectMapping$times[R, $aParams](apply: Function$times[$aParams, R], unapp
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
-  def withPrefix(prefix: String): ObjectMapping$times[R, $aParams] = addPrefix(prefix).map(newKey => 
+  def withPrefix(prefix: String): ObjectMapping$times[R, $aParams] = addPrefix(prefix).map(newKey =>
     new ObjectMapping$times(apply, unapply, ${g("f%", ", ")}, newKey, constraints)
   ).getOrElse(this)
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -58,7 +58,7 @@ class JavaActionAnnotations(val controller: Class[_], val method: java.lang.refl
  * An action that's handling Java requests
  */
 abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
-    extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
+  extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
 
   private val logger = Logger(classOf[JAction[_]])
 
@@ -163,10 +163,10 @@ trait JavaContextComponents {
  * The components necessary to handle a play.mvc.Http.Context object.
  */
 class DefaultJavaContextComponents @Inject() (
-  val messagesApi: JMessagesApi,
-  val langs: JLangs,
-  val fileMimeTypes: FileMimeTypes,
-  val httpConfiguration: HttpConfiguration
+    val messagesApi: JMessagesApi,
+    val langs: JLangs,
+    val fileMimeTypes: FileMimeTypes,
+    val httpConfiguration: HttpConfiguration
 ) extends JavaContextComponents
 
 trait JavaHandlerComponents {

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -130,14 +130,14 @@ object Multipart {
   }
 
   case class FileInfo(
-    /** Name of the part in HTTP request (e.g. field name) */
-    partName: String,
+      /** Name of the part in HTTP request (e.g. field name) */
+      partName: String,
 
-    /** Name of the file */
-    fileName: String,
+      /** Name of the file */
+      fileName: String,
 
-    /** Type of content (e.g. "application/pdf"), or `None` if unspecified. */
-    contentType: Option[String])
+      /** Type of content (e.g. "application/pdf"), or `None` if unspecified. */
+      contentType: Option[String])
 
   private[play] object FileInfoMatcher {
 
@@ -240,7 +240,7 @@ object Multipart {
    * see: http://tools.ietf.org/html/rfc2046#section-5.1.1
    */
   private final class BodyPartParser(boundary: String, maxMemoryBufferSize: Int, maxHeaderSize: Int)
-      extends GraphStage[FlowShape[ByteString, RawPart]] {
+    extends GraphStage[FlowShape[ByteString, RawPart]] {
 
     require(boundary.nonEmpty, "'boundary' parameter of multipart Content-Type must be non-empty")
     require(boundary.charAt(boundary.length - 1) != ' ', "'boundary' parameter of multipart Content-Type must not end with a space char")

--- a/framework/src/play/src/test/scala/play/utils/UriEncodingSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/UriEncodingSpec.scala
@@ -162,7 +162,7 @@ RFC 3986 - Uniform Resource Identifier (URI): Generic Syntax
    differ only in the case of hexadecimal digits used in percent-encoded
    octets, they are equivalent.  For consistency, URI producers and
    normalizers should use uppercase hexadecimal digits for all percent-
-   encodings.    
+   encodings.
 */
     "percent-encode to triplets with upper-case hex" in {
       encodingFor("\u0000", "ISO-8859-1") must_== PercentEncoded("%00")

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
@@ -21,7 +21,7 @@ sealed trait Rule extends Positional
  * @param comments The comments above the route
  */
 case class Route(verb: HttpVerb, path: PathPattern, call: HandlerCall,
-  comments: Seq[Comment] = Seq.empty, modifiers: Seq[Modifier] = Seq.empty) extends Rule
+    comments: Seq[Comment] = Seq.empty, modifiers: Seq[Modifier] = Seq.empty) extends Rule
 
 /**
  * An include for another router

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -291,8 +291,8 @@ object Reloader {
     lazy val delegatingLoader: ClassLoader = new DelegatingClassLoader(
       parentClassLoader,
       Build.sharedClasses, buildLoader, new ApplicationClassLoaderProvider {
-      def get: ClassLoader = { applicationLoader }
-    })
+        def get: ClassLoader = { applicationLoader }
+      })
 
     lazy val applicationLoader = new NamedURLClassLoader("DependencyClassLoader", urls(dependencyClasspath),
       delegatingLoader)


### PR DESCRIPTION
Updated the sbt-scalariform plugin to the latest version. This will
allow us to upgrade the Play build to sbt 1.0. Unfortunately scalariform
has deprecated/removed one of its settings so we cannot retain the
previous formatting rules. I changed the rules in order to produce
the minimum amount of formatting changes. Nonetheless, about 3,500
lines of code have been changed. :(

This change is separated out from the main sbt 1 upgrade work because
the diff is so heavy and we don't want noisy code formatting changes to
be part of the sbt 1 upgrade commit.