### PR TITLE
makes it possible to have implicit PathBindable's for AnyVal

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -558,6 +558,9 @@ object QueryStringBindable {
  */
 object PathBindable {
 
+  import play.api.mvc.macros.BinderMacros
+  import scala.language.experimental.macros
+
   /**
    * A helper class for creating PathBindables to map the value of a path pattern/segment
    *
@@ -671,6 +674,11 @@ object PathBindable {
   ) {
     override def javascriptUnbind = """function(k,v){return !!v}"""
   }
+
+  /**
+   * Path binder for AnyVal
+   */
+  implicit def anyValPathBindable[T <: AnyVal]: PathBindable[T] = macro BinderMacros.anyValPathBindable[T]
 
   /**
    * Path binder for Java Boolean.

--- a/framework/src/play/src/main/scala/play/api/mvc/macros/BinderMacros.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/macros/BinderMacros.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.mvc.macros
+
+import scala.reflect.macros.blackbox.{ Context => MacroContext }
+
+class BinderMacros(val c: MacroContext) {
+
+  import c.universe._
+
+  def anyValPathBindable[T](implicit t: WeakTypeTag[T]): Tree = {
+    withAnyValParam(t.tpe) { param =>
+      // currently we do not need to invoke `import _root_.play.api.mvc.PathBindable._`
+      // since we are in the same package
+      q"""
+         new _root_.play.api.mvc.PathBindable[${t.tpe}] {
+           private val binder = _root_.scala.Predef.implicitly[_root_.play.api.mvc.PathBindable[${param.typeSignature}]]
+           override def bind(key: String, value: String): Either[String, ${t.tpe}] = {
+             binder.bind(key, value).right.map((p: ${param.typeSignature}) => new ${t.tpe}(p))
+           }
+
+           override def unbind(key: String, value: ${t.tpe}): String = {
+             binder.unbind(key, value.${param.name.toTermName})
+           }
+
+         }
+       """
+    }.getOrElse(fail("PathBindable", t.tpe))
+  }
+
+  private def fail(enc: String, t: Type) = {
+    c.abort(c.enclosingPosition, s"could not find the implicit $enc for AnyVal Type $t")
+  }
+
+  private def withAnyValParam[R](tpe: Type)(f: Symbol => R): Option[R] = {
+    tpe.baseType(c.symbolOf[AnyVal]) match {
+      case NoType => None
+      case _ =>
+        primaryConstructor(tpe).map(_.paramLists.flatten).collect {
+          case param :: Nil => f(param)
+        }
+    }
+  }
+
+  private def primaryConstructor(t: Type) = {
+    t.members.collectFirst {
+      case m: MethodSymbol if m.isPrimaryConstructor => m.typeSignature.asSeenFrom(t, t.typeSymbol)
+    }
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -6,6 +6,9 @@ package play.api.mvc
 import java.util.UUID
 import org.specs2.mutable._
 
+case class Demo(value: Long) extends AnyVal
+case class Hase(x: String) extends AnyVal
+
 class BindersSpec extends Specification {
 
   val uuid = UUID.randomUUID
@@ -128,6 +131,15 @@ class BindersSpec extends Specification {
     }
     "Fail on empty" in {
       subject.bind("key", "") must be_==(Left("Cannot parse parameter key with value '' as Char: key must be exactly one digit in length."))
+    }
+  }
+
+  "AnyVal PathBindable" should {
+    "Bind Long String as Demo" in {
+      implicitly[PathBindable[Demo]].bind("key", "10") must equalTo(Right(Demo(10L)))
+    }
+    "Unbind Hase as String" in {
+      implicitly[PathBindable[Hase]].unbind("key", Hase("Disney_Land")) must equalTo("Disney_Land")
     }
   }
 


### PR DESCRIPTION
currently it is very repetitive to generate PathBindable's for every AnyVal
so I created a small (understandable) macro that will implicitly
generate the AnyVal PathBindable's whenever needed

I will try to make it possible for QueryBindable's, too. (after the pr is merged)

(this PR can probably be backported)