### PR TITLE
[2.6.x]: Use a Java BodyParser in RoutingDsl

### DIFF
--- a/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/FiltersTest.java
+++ b/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/FiltersTest.java
@@ -21,7 +21,7 @@ public class FiltersTest extends WithApplication {
 
     @Test
     public void testRequestBuilder() {
-        Router router = new RoutingDsl(instanceOf(PlayBodyParsers.class), instanceOf(JavaContextComponents.class))
+        Router router = new RoutingDsl(instanceOf(play.mvc.BodyParser.Default.class), instanceOf(JavaContextComponents.class))
                 .GET("/xx/Kiwi").routeTo(() -> Results.ok("success"))
                 .build();
 
@@ -37,7 +37,7 @@ public class FiltersTest extends WithApplication {
 
     @Test
     public void test() {
-        Router router = new RoutingDsl(instanceOf(PlayBodyParsers.class), instanceOf(JavaContextComponents.class))
+        Router router = new RoutingDsl(instanceOf(play.mvc.BodyParser.Default.class), instanceOf(JavaContextComponents.class))
                 .POST("/xx/Kiwi").routeTo(() -> Results.ok("success"))
                 .build();
 

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/advanced/routing/JavaRoutingDsl.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/advanced/routing/JavaRoutingDsl.java
@@ -124,7 +124,7 @@ public class JavaRoutingDsl extends WithApplication {
 
     @Test
     public void createNewRoutingDsl() {
-        BodyParser<AnyContent> bodyParser = app.injector().instanceOf(PlayBodyParsers.class).defaultBodyParser();
+        play.mvc.BodyParser.Default bodyParser = app.injector().instanceOf(play.mvc.BodyParser.Default.class);
         JavaContextComponents javaContextComponents = app.injector().instanceOf(JavaContextComponents.class);
 
         //#new-routing-dsl

--- a/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
@@ -34,7 +34,7 @@ public class BuiltInComponentsFromContextTest {
 
         @Override
         public Router router() {
-            return new RoutingDsl(defaultScalaBodyParser(), javaContextComponents())
+            return new RoutingDsl(defaultBodyParser(), javaContextComponents())
                     .GET("/").routeTo(() -> Results.ok("index"))
                     .build();
         }

--- a/framework/src/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
@@ -3,12 +3,14 @@
  */
 package play.routing;
 
+import akka.util.ByteString;
 import org.junit.Test;
 import play.Application;
+import play.libs.Json;
+import play.libs.XML;
 import play.mvc.Http;
 import play.mvc.PathBindable;
 import play.mvc.Result;
-import play.mvc.Results;
 
 import java.io.InputStream;
 import java.util.function.Function;
@@ -33,7 +35,7 @@ public abstract class AbstractRoutingDslTest {
     }
 
     @Test
-    public void shouldPreserveRequestBody() {
+    public void shouldPreserveRequestBodyAsText() {
         Router router = router(routingDsl -> routingDsl.POST("/with-body")
             .routeTo(() -> {
                 // This better emulates how users will access the request object
@@ -41,7 +43,67 @@ public abstract class AbstractRoutingDslTest {
                 return ok(request.body().asText());
             }).build());
 
-        assertThat(makeRequest(router, "POST", "/with-body", "The Body"), equalTo("The Body"));
+        String result = makeRequest(
+                router,
+                "POST",
+                "/with-body",
+                rb -> rb.bodyText("The Body")
+        );
+        assertThat(result, equalTo("The Body"));
+    }
+
+    @Test
+    public void shouldPreserveRequestBodyAsJson() {
+        Router router = router(routingDsl -> routingDsl.POST("/with-body")
+                .routeTo(() -> {
+                    // This better emulates how users will access the request object
+                    Http.Request request = Http.Context.current().request();
+                    return ok(request.body().asJson());
+                }).build());
+
+        String result = makeRequest(
+                router,
+                "POST",
+                "/with-body",
+                requestBuilder -> requestBuilder.bodyJson(Json.parse("{ \"a\": \"b\" }"))
+        );
+        assertThat(result, equalTo("{\"a\":\"b\"}"));
+    }
+
+    @Test
+    public void shouldPreserveRequestBodyAsXml() {
+        Router router = router(routingDsl -> routingDsl.POST("/with-body")
+                .routeTo(() -> {
+                    // This better emulates how users will access the request object
+                    Http.Request request = Http.Context.current().request();
+                    return ok(XML.toBytes(request.body().asXml()).utf8String());
+                }).build());
+
+        String result = makeRequest(
+                router,
+                "POST",
+                "/with-body",
+                requestBuilder -> requestBuilder.bodyXml(XML.fromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>"))
+        );
+        assertThat(result, equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>"));
+    }
+
+    @Test
+    public void shouldPreserveRequestBodyAsRawBuffer() {
+        Router router = router(routingDsl -> routingDsl.POST("/with-body")
+                .routeTo(() -> {
+                    // This better emulates how users will access the request object
+                    Http.Request request = Http.Context.current().request();
+                    return ok(request.body().asRaw().asBytes().utf8String());
+                }).build());
+
+        String result = makeRequest(
+                router,
+                "POST",
+                "/with-body",
+                requestBuilder -> requestBuilder.bodyRaw(ByteString.fromString("The Raw Body"))
+        );
+        assertThat(result, equalTo("The Raw Body"));
     }
 
     @Test
@@ -330,14 +392,11 @@ public abstract class AbstractRoutingDslTest {
     }
 
     private String makeRequest(Router router, String method, String path) {
-        return makeRequest(router, method, path, /* no body */null);
+        return makeRequest(router, method, path, Function.identity());
     }
 
-    private String makeRequest(Router router, String method, String path, String body) {
-        Http.RequestBuilder request = fakeRequest(method, path);
-        if (body != null) {
-            request.bodyText(body);
-        }
+    private String makeRequest(Router router, String method, String path, Function<Http.RequestBuilder, Http.RequestBuilder> bodySetter) {
+        Http.RequestBuilder request = bodySetter.apply(fakeRequest(method, path));
         Result result = routeAndCall(application(), router, request);
         if (result == null) {
             return null;

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -19,6 +19,8 @@ import play.core.server.Server
 
 class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
 
+  sequential
+
   val body =
     """
       |--aabbccddee

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -4,8 +4,8 @@
 package play.routing;
 
 import net.jodah.typetools.TypeResolver;
+import org.slf4j.LoggerFactory;
 import play.BuiltInComponents;
-import play.Logger;
 import play.api.Application;
 import play.api.mvc.AnyContent;
 import play.api.mvc.BodyParser;
@@ -13,8 +13,10 @@ import play.api.mvc.PathBindable;
 import play.api.mvc.PathBindable$;
 import play.api.mvc.PlayBodyParsers;
 import play.core.j.JavaContextComponents;
+import play.core.routing.HandlerInvokerFactory$;
 import play.libs.F;
 import play.libs.Scala;
+import play.mvc.Http;
 import play.mvc.Result;
 import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
@@ -90,9 +92,9 @@ import java.util.stream.StreamSupport;
  */
 public class RoutingDsl {
 
-    private static final Logger.ALogger logger = Logger.of(RoutingDsl.class);
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(RoutingDsl.class);
 
-    private final BodyParser<AnyContent> bodyParser;
+    private final BodyParser<Http.RequestBody> bodyParser;
     private final JavaContextComponents contextComponents;
 
     final List<Route> routes = new ArrayList<>();
@@ -111,22 +113,45 @@ public class RoutingDsl {
             "You should migrate to use a version that uses the #RoutingDsl(BodyParser, JavaContextComponents) constructor " +
             "or just inject an instance of play.routing.RoutingDsl."
         );
-        this.bodyParser = app().injector().instanceOf(PlayBodyParsers.class).defaultBodyParser();
+        this.bodyParser = RouterBuilderHelper$.MODULE$.toRequestBodyParser(app().injector().instanceOf(PlayBodyParsers.class).defaultBodyParser());
         this.contextComponents = app().injector().instanceOf(JavaContextComponents.class);
     }
 
+    /**
+     * Construct a new builder.
+     *
+     * @param bodyParser the default scala body parser.
+     * @param contextComponents java context components.
+     *
+     * @deprecated Deprecated as of 2.6.8. Use {@link #RoutingDsl(play.mvc.BodyParser.Default, JavaContextComponents)}
+     *             or {@link #fromComponents(BuiltInComponents)} instead.
+     */
     public RoutingDsl(BodyParser<AnyContent> bodyParser, JavaContextComponents contextComponents) {
-        this.bodyParser = bodyParser;
+        this.bodyParser = RouterBuilderHelper$.MODULE$.toRequestBodyParser(bodyParser);
         this.contextComponents = contextComponents;
     }
 
-    @Inject
+    /**
+     * Construct a new builder.
+     *
+     * @param bodyParsers scala body parsers.
+     * @param contextComponents java context components.
+     *
+     * @deprecated Deprecated as of 2.6.8. Use {@link #RoutingDsl(play.mvc.BodyParser.Default, JavaContextComponents)}
+     *             or {@link #fromComponents(BuiltInComponents)} instead.
+     */
     public RoutingDsl(PlayBodyParsers bodyParsers, JavaContextComponents contextComponents) {
         this(bodyParsers.defaultBodyParser(), contextComponents);
     }
 
+    @Inject
+    public RoutingDsl(play.mvc.BodyParser.Default bodyParser, JavaContextComponents contextComponents) {
+        this.bodyParser = HandlerInvokerFactory$.MODULE$.javaBodyParserToScala(bodyParser);
+        this.contextComponents = contextComponents;
+    }
+
     public static RoutingDsl fromComponents(BuiltInComponents components) {
-        return new RoutingDsl(components.defaultScalaBodyParser(), components.javaContextComponents());
+        return new RoutingDsl(components.defaultBodyParser(), components.javaContextComponents());
     }
 
     private Application app() {

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDslComponents.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDslComponents.java
@@ -32,7 +32,7 @@ import play.components.BodyParserComponents;
 public interface RoutingDslComponents extends BodyParserComponents {
 
     default RoutingDsl routingDsl() {
-        return new RoutingDsl(defaultScalaBodyParser(), javaContextComponents());
+        return new RoutingDsl(defaultBodyParser(), javaContextComponents());
     }
 
 }

--- a/framework/src/play-java/src/main/scala/play/routing/RoutingDslModule.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RoutingDslModule.scala
@@ -9,16 +9,25 @@ import play.api.inject._
 import play.api.{ Configuration, Environment }
 import play.api.mvc.PlayBodyParsers
 import play.core.j.JavaContextComponents
+import play.mvc.BodyParser.Default
 
 /**
  * A Play binding for the RoutingDsl API.
  */
 class RoutingDslModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    Seq(bind[RoutingDsl].toProvider[RoutingDslProvider])
+    Seq(
+      bind[Default].toSelf, // this bind is here because it is needed by RoutingDsl only
+      bind[RoutingDsl].toProvider[JavaRoutingDslProvider]
+    )
   }
 }
 
+@deprecated(since = "2.6.8", message = "Use JavaRoutingDslProvider instead")
 class RoutingDslProvider @Inject() (bodyParsers: PlayBodyParsers, contextComponents: JavaContextComponents) extends Provider[RoutingDsl] {
   override def get(): RoutingDsl = new RoutingDsl(bodyParsers.default, contextComponents)
+}
+
+class JavaRoutingDslProvider @Inject() (bodyParser: play.mvc.BodyParser.Default, contextComponents: JavaContextComponents) extends Provider[RoutingDsl] {
+  override def get(): RoutingDsl = new RoutingDsl(bodyParser, contextComponents)
 }


### PR DESCRIPTION
## Fixes

Fixes #7682

## Purpose

Scala's BodyParser resulting bodies are not handled by Java RequestBody API. By using a Java BodyParser, we can ensure that RoutingDsl actions are executed like regular Java Actions internally.