### PR TITLE
Add ConfigLoader macro

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -5,7 +5,7 @@ package play.filters.headers
 
 import javax.inject.{ Inject, Provider, Singleton }
 
-import play.api.Configuration
+import play.api.{ ConfigLoader, Configuration }
 import play.api.http.HeaderNames
 import play.api.inject._
 import play.api.mvc._
@@ -107,17 +107,10 @@ case class SecurityHeadersConfig(
  */
 object SecurityHeadersConfig {
 
-  def fromConfiguration(conf: Configuration): SecurityHeadersConfig = {
-    val config = conf.get[Configuration]("play.filters.headers")
+  private implicit val configLoader: ConfigLoader[SecurityHeadersConfig] = ConfigLoader.forClass
 
-    SecurityHeadersConfig(
-      frameOptions = config.get[Option[String]]("frameOptions"),
-      xssProtection = config.get[Option[String]]("xssProtection"),
-      contentTypeOptions = config.get[Option[String]]("contentTypeOptions"),
-      permittedCrossDomainPolicies = config.get[Option[String]]("permittedCrossDomainPolicies"),
-      contentSecurityPolicy = config.get[Option[String]]("contentSecurityPolicy"),
-      referrerPolicy = config.get[Option[String]]("referrerPolicy"),
-      allowActionSpecificHeaders = config.get[Option[Boolean]]("allowActionSpecificHeaders").getOrElse(false))
+  def fromConfiguration(conf: Configuration): SecurityHeadersConfig = {
+    conf.get[SecurityHeadersConfig]("play.filters.headers")
   }
 }
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -6,7 +6,7 @@ package play.filters.hosts
 import javax.inject.{ Inject, Provider, Singleton }
 
 import play.api.MarkerContexts.SecurityMarkerContext
-import play.api.{ Configuration, Logger }
+import play.api.{ ConfigLoader, Configuration, Logger }
 import play.api.http.{ HttpErrorHandler, Status }
 import play.api.inject._
 import play.api.libs.streams.Accumulator
@@ -74,11 +74,14 @@ case class AllowedHostsConfig(allowed: Seq[String]) {
 }
 
 object AllowedHostsConfig {
+
+  private implicit val configLoader: ConfigLoader[AllowedHostsConfig] = ConfigLoader.forClass
+
   /**
    * Parses out the AllowedHostsConfig from play.api.Configuration (usually this means application.conf).
    */
   def fromConfiguration(conf: Configuration): AllowedHostsConfig = {
-    AllowedHostsConfig(conf.get[Seq[String]]("play.filters.hosts.allowed"))
+    conf.get[AllowedHostsConfig]("play.filters.hosts")
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/ConfigLoaderMacros.scala
+++ b/framework/src/play/src/main/scala/play/api/ConfigLoaderMacros.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api
+
+import scala.reflect.macros.blackbox
+
+private[api] class ConfigLoaderMacros(val c: blackbox.Context) {
+
+  import c.universe._
+
+  def forClass[T](implicit t: WeakTypeTag[T]): Tree = {
+    val tpe = t.tpe
+    // Look at all public constructors
+    val publicConstructors: Seq[MethodSymbol] = tpe.members.collect {
+      case m if m.isConstructor && m.isPublic && !m.fullName.endsWith("$init$") =>
+        m.asMethod
+    }(collection.breakOut)
+
+    val constructor = publicConstructors match {
+      case Seq() =>
+        c.abort(c.enclosingPosition, s"Public constructor not found for type $tpe")
+      case Seq(cons) =>
+        cons
+      case constructors =>
+        // If multiple public constructors are found, try to select the primary constructor, otherwise give up
+        constructors.find(_.isPrimaryConstructor).getOrElse(
+          c.abort(c.enclosingPosition, s"Multiple public constructors found for $tpe but one is not primary")
+        )
+    }
+
+    val confTerm = TermName(c.freshName("conf$"))
+    val argumentLists = constructor.paramLists.map { params =>
+      params.map { p =>
+        q"implicitly[_root_.play.api.ConfigLoader[${p.typeSignature}]].load($confTerm, ${p.name.decodedName.toString})"
+      }
+    }
+    q"""
+      new _root_.play.api.ConfigLoader[$tpe] {
+        override def load(config: _root_.com.typesafe.config.Config, path: String) = {
+          val $confTerm = config.getConfig(path)
+          new $tpe(...$argumentLists)
+        }
+      }
+    """
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -1022,6 +1022,29 @@ trait ConfigLoader[A] { self =>
 
 object ConfigLoader {
 
+  import scala.language.experimental.macros
+
+  /**
+   * Generate a ConfigLoader for a class using the parameters of a single public constructor.
+   *
+   * For example:
+   *
+   * {{{
+   *   case class Person(firstName: String, lastName: String, age: Int)
+   *   object Person {
+   *     implicit val configLoader: ConfigLoader[Person] = ConfigLoader.forClass[Person]
+   *   }
+   *
+   *   // assume config is "person { firstName = Arthur, lastName = Dent, age = 42 }"
+   *   val person = config.get[Person]("person")
+   *   // person is Person("Arthur", "Dent", 42)
+   * }}}
+   *
+   * The macro chooses a constructor to determine the property names and types. It will first check to see if there is a
+   * single public constructor. If there are multiple it will use the primary constructor.
+   */
+  def forClass[T]: ConfigLoader[T] = macro ConfigLoaderMacros.forClass[T]
+
   def apply[A](f: Config => String => A): ConfigLoader[A] = new ConfigLoader[A] {
     def load(config: Config, path: String): A = f(config)(path)
   }


### PR DESCRIPTION
This adds a macro `ConfigLoader.forClass[T]`  that attempts to generate a configuration loader based on a class.

For example, if you have

```scala
case class SecurityHeadersConfig(
    frameOptions: Option[String],
    xssProtection: Option[String],
    contentTypeOptions: Option[String],
    permittedCrossDomainPolicies: Option[String],
    contentSecurityPolicy: Option[String],
    referrerPolicy: Option[String],
    allowActionSpecificHeaders: Boolean = false
)
object SecurityHeadersConfig {
  implicit val configLoader: ConfigLoader[SecurityHeadersConfig] = ConfigLoader.forClass
}
```

the macro allows you to use `configuration.get[SecurityHeadersConfig](path)` to read an object like:

```
{
    frameOptions = "DENY"
    xssProtection = "1; mode=block"
    contentTypeOptions = "nosniff"
    permittedCrossDomainPolicies = "master-only"
    contentSecurityPolicy = null
    referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
    allowActionSpecificHeaders = false
}
```

I was actually hoping I could use the macro in more places, but we'd need to separate the macro into a separate library to use it for `HttpConfiguration` and many of the config classes we use in Play. Also we have some custom logic in our config loading to deal with deprecation and other unusual cases. Mainly this is interesting for end users, since it makes it much simpler to design your app to deal with configuration in a type-safe way.