### PR TITLE
Make InlineCache use a soft (not weak) reference

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -245,7 +245,11 @@ object BuildSettings {
 
       // Pass a default server header to netty
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler.this"),
+
+      // Made InlineCache.cache private and changed the type (class is private[play])
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache_=")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -218,7 +218,7 @@ object Application {
    * instance if this method is called from different threads
    * at the same time.
    *
-   * The cache uses a WeakReference to both the Application and
+   * The cache uses a SoftReference to both the Application and
    * the returned instance so it will not cause memory leaks.
    * Unlike WeakHashMap it doesn't use a ReferenceQueue, so values
    * will still be cleaned even if the ReferenceQueue is never

--- a/framework/src/play/src/main/scala/play/utils/InlineCache.scala
+++ b/framework/src/play/src/main/scala/play/utils/InlineCache.scala
@@ -45,7 +45,7 @@ private[play] final class InlineCache[A <: AnyRef, B](f: A => B) extends (A => B
    * reach the same value. If the input value is different, then
    * there's no point sharing the value across threads anyway.
    */
-  var cache: SoftReference[(A, B)] = null
+  private var cache: SoftReference[(A, B)] = null
 
   override def apply(a: A): B = {
     // Get the current value of the cache into a local variable.


### PR DESCRIPTION
Objects that are referenced only by a weak reference will be eagerly
collected on the next GC run. Using a soft reference ensures that the
referent is only collected when there is memory pressure.

This should improve the utilization of the cache and reduce the need to
repopulate it.

See discussion in https://stackoverflow.com/a/299702/29470 for example.

I'm not sure whether this is actually a good idea, but I wanted to propose it for discussion. 😄 

ATTN: @richdougherty 