### PR TITLE
Use Akka's Reason when shutting down and disable Akka JVM hooks globally

### DIFF
--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -41,6 +41,11 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
+  # Since Akka 2.5.8 there's a setting to disable all Akka-provided JVM shutdown
+  # hooks. This will not only disable CoordinatedShutdown but also Artery or other
+  # Akka-managed hooks.
+  jvm-shutdown-hooks = off
+
   # CoordinatedShutdown is an extension introduced in Akka 2.5 that will
   # perform registered tasks in the order that is defined by the phases.
   # This setup extends Akka's default phases with Play-specific ones.

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -5,7 +5,6 @@ package play.api.libs.concurrent
 
 import javax.inject.{ Inject, Provider, Singleton }
 
-import akka.actor.CoordinatedShutdown.ClusterDowningReason
 import akka.actor._
 import akka.stream.{ ActorMaterializer, Materializer }
 import com.typesafe.config.{ Config, ConfigValueFactory }
@@ -13,10 +12,10 @@ import play.api._
 import play.api.inject.{ ApplicationLifecycle, Binding, Injector, bind }
 import play.core.ClosableLazy
 
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 import scala.reflect.ClassTag
-import scala.util.{ Success, Try }
+import scala.util.Try
 
 /**
  * Helper to access the application defined Akka Actor system.

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -5,6 +5,7 @@ package play.api.libs.concurrent
 
 import javax.inject.{ Inject, Provider, Singleton }
 
+import akka.actor.CoordinatedShutdown.ClusterDowningReason
 import akka.actor._
 import akka.stream.{ ActorMaterializer, Materializer }
 import com.typesafe.config.{ Config, ConfigValueFactory }
@@ -128,6 +129,8 @@ object ActorSystemProvider {
 
   private val logger = Logger(classOf[ActorSystemProvider])
 
+  case object ApplicationShutdownReason extends CoordinatedShutdown.Reason
+
   /**
    * Start an ActorSystem, using the given configuration and ClassLoader.
    *
@@ -174,7 +177,7 @@ object ActorSystemProvider {
       // The phases that should be run is a configurable setting so Play users
       // that embed an Akka Cluster node can opt-in to using Akka's CS or continue
       // to use their own shutdown code.
-      CoordinatedShutdown(system).run(Some(akkaRunCSFromPhase))
+      CoordinatedShutdown(system).run(ApplicationShutdownReason, Some(akkaRunCSFromPhase))
     }
 
     (system, stopHook)

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
+import akka.actor.CoordinatedShutdown.JvmExitReason
 import akka.actor.{ ActorSystem, CoordinatedShutdown }
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.specs2.mutable.Specification
@@ -121,7 +122,8 @@ class ActorSystemProviderSpec extends Specification {
     try {
       block(actorSystem)
     } finally {
-      CoordinatedShutdown(actorSystem).run()
+      // On testing, use any reason
+      CoordinatedShutdown(actorSystem).run(JvmExitReason)
     }
   }
 

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -3,15 +3,12 @@
  */
 package play.api.libs.concurrent
 
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
-import akka.actor.CoordinatedShutdown.JvmExitReason
 import akka.actor.{ ActorSystem, CoordinatedShutdown }
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.specs2.mutable.Specification
-import play.api.libs.concurrent.ActorSystemProvider.StopHook
 import play.api.{ Configuration, Environment }
 
 import scala.concurrent.duration.Duration
@@ -122,8 +119,7 @@ class ActorSystemProviderSpec extends Specification {
     try {
       block(actorSystem)
     } finally {
-      // On testing, use any reason
-      CoordinatedShutdown(actorSystem).run(JvmExitReason)
+      stopHook()
     }
   }
 


### PR DESCRIPTION
Akka `2.5.8` introduced the `Reason` argument on the `CoordinatedShutdown` API so CS users can distinguish the actual trigger of the shutdown process.

Akka `2.5.8` also introduced the `jvm-shutdown-hooks` setting to make sure there's a single responsible for registering JVM shutdown hooks. This setting should be disabled on Play's `2.6.x` branch.

- [ ] ~Play users that embed an Akka Cluster node inside the play application and use Artery will have to register the Artery shutdown manually. This need documentation.~ Artery is shutdown when the actor system is terminated which play will take care of.