### PR TITLE
Ignores 2.6.8 when validating mima compat

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -150,7 +150,7 @@ object BuildSettings {
   def playRuntimeSettings: Seq[Setting[_]] = playCommonSettings ++ mimaDefaultSettings ++ Seq(
     mimaPreviousArtifacts := {
       // Binary compatibility is tested against these versions
-      val invalidVersions = Seq("2.6.4")
+      val invalidVersions = Seq("2.6.4", "2.6.8")
       val previousVersions = {
         val VersionPattern = """^(\d+).(\d+).(\d+)(-.*)?""".r
         version.value match {


### PR DESCRIPTION
`2.6.8` had a build failure when releasing so not all artifacts are available on bintray/maven central. 

Mima validation must ignore `2.6.8`