### PR TITLE
Send errors from filters to the application HttpErrorHandler

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -31,7 +31,7 @@ import play.core.ApplicationProvider
 import play.server.SSLEngineProvider
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
@@ -243,23 +243,20 @@ class AkkaHttpServer(
       case Failure(_) => DefaultHttpErrorHandler
     }
 
+    // default execution context used for executing the action
+    implicit val defaultExecutionContext: ExecutionContext = tryApp match {
+      case Success(app) => app.actorSystem.dispatcher
+      case Failure(_) => actorSystem.dispatcher
+    }
+
     (handler, upgradeToWebSocket) match {
       //execute normal action
       case (action: EssentialAction, _) =>
-        val actionWithErrorHandling = EssentialAction { rh =>
-          import play.core.Execution.Implicits.trampoline
-          action(rh).recoverWith {
-            case error => errorHandler.onServerError(taggedRequestHeader, error)
-          }
-        }
-        executeAction(request, taggedRequestHeader, requestBodySource, actionWithErrorHandling, errorHandler)
-
+        runAction(request, taggedRequestHeader, requestBodySource, action, errorHandler)
       case (websocket: WebSocket, Some(upgrade)) =>
-        import play.core.Execution.Implicits.trampoline
-
         val bufferLimit = config.configuration.getDeprecated[ConfigMemorySize]("play.server.websocket.frame.maxLength", "play.websocket.buffer.limit").toBytes.toInt
 
-        websocket(taggedRequestHeader).flatMap {
+        websocket(taggedRequestHeader).fast.flatMap {
           case Left(result) =>
             modelConversion.convertResult(taggedRequestHeader, result, request.protocol, errorHandler)
           case Right(flow) =>
@@ -274,15 +271,23 @@ class AkkaHttpServer(
     }
   }
 
+  @deprecated("This method is an internal API and should not be public", "2.6.10")
   def executeAction(
     request: HttpRequest,
     taggedRequestHeader: RequestHeader,
     requestBodySource: Either[ByteString, Source[ByteString, _]],
     action: EssentialAction,
-    errorHandler: HttpErrorHandler): Future[HttpResponse] = {
+    errorHandler: HttpErrorHandler): Future[HttpResponse] =
+    runAction(request, taggedRequestHeader, requestBodySource, action, errorHandler)(actorSystem.dispatcher)
 
-    import play.core.Execution.Implicits.trampoline
-    val actionAccumulator: Accumulator[ByteString, Result] = action(taggedRequestHeader)
+  private[play] def runAction(
+    request: HttpRequest,
+    taggedRequestHeader: RequestHeader,
+    requestBodySource: Either[ByteString, Source[ByteString, _]],
+    action: EssentialAction,
+    errorHandler: HttpErrorHandler)(implicit ec: ExecutionContext): Future[HttpResponse] = {
+
+    val futureAcc: Future[Accumulator[ByteString, Result]] = Future(action(taggedRequestHeader))
 
     val source = if (request.header[Expect].contains(Expect.`100-continue`)) {
       // If we expect 100 continue, then we must not feed the source into the accumulator until the accumulator
@@ -294,12 +299,18 @@ class AkkaHttpServer(
       requestBodySource
     }
 
-    val resultFuture: Future[Result] = source match {
-      case Left(bytes) if bytes.isEmpty => actionAccumulator.run()
-      case Left(bytes) => actionAccumulator.run(bytes)
-      case Right(s) => actionAccumulator.run(s)
+    // here we use FastFuture so the flatMap shouldn't actually need the executionContext
+    val resultFuture: Future[Result] = futureAcc.fast.flatMap { actionAccumulator =>
+      source match {
+        case Left(bytes) if bytes.isEmpty => actionAccumulator.run()
+        case Left(bytes) => actionAccumulator.run(bytes)
+        case Right(s) => actionAccumulator.run(s)
+      }
+    }.recoverWith {
+      case e: Throwable =>
+        errorHandler.onServerError(taggedRequestHeader, e)
     }
-    val responseFuture: Future[HttpResponse] = resultFuture.fast.flatMap { result =>
+    val responseFuture: Future[HttpResponse] = resultFuture.flatMap { result =>
       val cleanedResult: Result = resultUtils.prepareCookies(taggedRequestHeader, result)
       modelConversion.convertResult(taggedRequestHeader, cleanedResult, request.protocol, errorHandler)
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/HttpFiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/HttpFiltersSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http
+
+import play.api.http.HttpErrorHandler
+import play.api.mvc._
+import play.api.routing.Router
+import play.api.test.PlaySpecification
+import play.api.{ Application, ApplicationLoader, BuiltInComponentsFromContext, Environment }
+import play.it.test.{ ApplicationFactories, ApplicationFactory, EndpointIntegrationSpecification, OkHttpEndpointSupport }
+
+import scala.concurrent.Future
+
+class HttpFiltersSpec extends PlaySpecification
+  with EndpointIntegrationSpecification with ApplicationFactories with OkHttpEndpointSupport {
+
+  "Play http filters" should {
+
+    val appFactory: ApplicationFactory = new ApplicationFactory {
+      override def create(): Application = {
+        val components = new BuiltInComponentsFromContext(
+          ApplicationLoader.Context.create(Environment.simple())) {
+          import play.api.mvc.Results._
+          import play.api.routing.sird
+          import play.api.routing.sird._
+          override lazy val router: Router = Router.from {
+            case sird.GET(p"/") => Action { Ok("Done!") }
+            case sird.GET(p"/error") => Action { Ok("Done!") }
+            case sird.GET(p"/invalid") => Action { Ok("Done!") }
+          }
+          override lazy val httpFilters: Seq[EssentialFilter] = Seq(
+            // A non-essential filter that throws an exception
+            new Filter {
+              override def mat = materializer
+              override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
+                if (rh.path.contains("invalid")) {
+                  throw new RuntimeException("INVALID")
+                }
+                f(rh)
+              }
+            },
+            new EssentialFilter {
+              // an essential filter returning an action that throws before returning an accumulator
+              def apply(next: EssentialAction) = EssentialAction { rh =>
+                if (rh.path.contains("error")) {
+                  throw new RuntimeException("ERROR")
+                }
+                next(rh)
+              }
+            }
+          )
+
+          override lazy val httpErrorHandler: HttpErrorHandler = new HttpErrorHandler {
+            override def onServerError(request: RequestHeader, exception: Throwable) = {
+              Future(InternalServerError(exception.getMessage))
+            }
+            override def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
+              Future(InternalServerError(message))
+            }
+          }
+        }
+        components.application
+      }
+    }
+
+    "send exceptions from Filters to the HttpErrorHandler" in appFactory.withAllOkHttpEndpoints { endpoint =>
+      val request = new okhttp3.Request.Builder()
+        .url(endpoint.endpoint.pathUrl("/error"))
+        .get()
+        .build()
+      val response = endpoint.client.newCall(request).execute()
+      response.code must_== 500
+      response.body.string must_== "ERROR"
+    }
+
+    "send exceptions from EssentialFilters to the HttpErrorHandler" in appFactory.withAllOkHttpEndpoints { endpoint =>
+      val request = new okhttp3.Request.Builder()
+        .url(endpoint.endpoint.pathUrl("/invalid"))
+        .get()
+        .build()
+      val response = endpoint.client.newCall(request).execute()
+      response.code must_== 500
+      response.body.string must_== "INVALID"
+    }
+  }
+}

--- a/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/run/PlaySource.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/run/PlaySource.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 // This is a naive way to make sbt.internal.io.Source accessible. That is why we
 // are declaring the package here as sbt.internal.io. You can see the code for
 // sbt.internal.io.Source here:


### PR DESCRIPTION
Fixes #8089

This refactors the request handling code in the `AkkaHttpServer` and `NettyServer` slightly, so that the action is always executed in a future using the Play default execution context, then that future is flatMapped with a function that runs the body accumulator, and the resulting future is recovered using the error handler.

I added a test that tests with both the `Filter` and `EssentialFilter` case.