### PR TITLE
[2.6.x]: Make InlineCache use a soft (not weak) reference

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -206,7 +206,11 @@ object BuildSettings {
 
       // Pass a default server header to netty
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler.this"),
+
+      // Made InlineCache.cache private and changed the type (class is private[play])
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache_=")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -219,7 +219,7 @@ object Application {
    * instance if this method is called from different threads
    * at the same time.
    *
-   * The cache uses a WeakReference to both the Application and
+   * The cache uses a SoftReference to both the Application and
    * the returned instance so it will not cause memory leaks.
    * Unlike WeakHashMap it doesn't use a ReferenceQueue, so values
    * will still be cleaned even if the ReferenceQueue is never

--- a/framework/src/play/src/main/scala/play/utils/InlineCache.scala
+++ b/framework/src/play/src/main/scala/play/utils/InlineCache.scala
@@ -45,7 +45,7 @@ private[play] final class InlineCache[A <: AnyRef, B](f: A => B) extends (A => B
    * reach the same value. If the input value is different, then
    * there's no point sharing the value across threads anyway.
    */
-  var cache: SoftReference[(A, B)] = null
+  private var cache: SoftReference[(A, B)] = null
 
   override def apply(a: A): B = {
     // Get the current value of the cache into a local variable.


### PR DESCRIPTION
This is a backport of #8086 to the 2.6.x branch. cc @TimMoore 