### PR TITLE
[docs]: Document merge strategy for sbt-assembly-plugin

### DIFF
--- a/documentation/manual/working/commonGuide/production/code/assembly.sbt
+++ b/documentation/manual/working/commonGuide/production/code/assembly.sbt
@@ -5,4 +5,18 @@
 //#assembly
 mainClass in assembly := Some("play.core.server.ProdServerStart")
 fullClasspath in assembly += Attributed.blank(PlayKeys.playPackageAssets.value)
+
+assemblyMergeStrategy in assembly := {
+  case manifest if manifest.contains("MANIFEST.MF") =>
+    // We don't need manifest files since sbt-assembly will create
+    // one with the given settings
+    MergeStrategy.discard
+  case referenceOverrides if referenceOverrides.contains("reference-overrides.conf") =>
+    // Keep the content for all reference-overrides.conf files
+    MergeStrategy.concat
+  case x =>
+    // For all the other files, use the default sbt-assembly merge strategy
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
 //#assembly


### PR DESCRIPTION
## Purpose

The documented configuration for sbt-assembly is incomplete. This adds the necessary merge strategy to make it work with sbt.

## References

https://github.com/sbt/sbt-assembly#merge-strategy
