### PR TITLE
Fix documentation server run

### DIFF
--- a/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -7,14 +7,13 @@ import java.io.File
 import java.util.concurrent.Callable
 
 import play.api._
-import play.api.http.FileMimeTypes
 import play.api.mvc._
 import play.api.routing.Router
+import play.api.routing.sird._
 import play.core._
 import play.core.server._
 
 import scala.concurrent.Future
-import scala.util.Success
 
 /**
  * Used to start the documentation server.
@@ -28,31 +27,29 @@ class DocServerStart {
       val environment = Environment(projectPath, this.getClass.getClassLoader, Mode.Test)
       val context = ApplicationLoader.Context.create(environment)
       new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
-        lazy val router = Router.empty
+        lazy val router = Router.from {
+          case GET(p"/@documentation/$file*") => Action { request =>
+            buildDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[Result]].get
+          }
+          case GET(p"/@report") => Action { request =>
+            if (request.getQueryString("force").isDefined) {
+              forceTranslationReport.call()
+              Results.Redirect("/@report")
+            } else {
+              Results.Ok.sendFile(translationReport.call(), inline = true, fileName = _ => "report.html")(executionContext, fileMimeTypes)
+            }
+          }
+          case _ => Action {
+            Results.Redirect("/@documentation/Home")
+          }
+        }
       }
     }
     val application: Application = components.application
 
     Play.start(application)
 
-    val applicationProvider = new ApplicationProvider {
-      implicit val ec = application.actorSystem.dispatcher
-      implicit val fileMimeTypes = components.fileMimeTypes
-      override def get = Success(application)
-      override def handleWebCommand(request: RequestHeader) =
-        buildDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[Result]].orElse(
-          if (request.path == "/@report") {
-            if (request.getQueryString("force").isDefined) {
-              forceTranslationReport.call()
-              Some(Results.Redirect("/@report"))
-            } else {
-              Some(Results.Ok.sendFile(translationReport.call(), inline = true, fileName = _ => "report.html"))
-            }
-          } else None
-        ).orElse(
-            Some(Results.Redirect("/@documentation"))
-          )
-    }
+    val applicationProvider = ApplicationProvider(application)
 
     val config = ServerConfig(
       rootDir = projectPath,


### PR DESCRIPTION
## Purpose

Uses regular routes and actions instead of WebCommands to server documentation pages.

## References

See #7986.
