### PR TITLE
[2.6.x] Stop overriding run-coordinated-shutdown-when-down

### DIFF
--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -68,14 +68,4 @@ akka {
     run-by-jvm-shutdown-hook = off
 
   }
-
-  cluster {
-
-    # Run the coordinated shutdown when the cluster is shutdown for other
-    # reasons than when leaving, e.g. when downing. This will terminate
-    # the ActorSystem when the cluster extension is shutdown.
-    run-coordinated-shutdown-when-down = off
-
-  }
-
 }

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -896,16 +896,6 @@ play {
         run-by-jvm-shutdown-hook = off
 
       }
-
-      cluster {
-
-        # Run the coordinated shutdown when the cluster is shutdown for other
-        # reasons than when leaving, e.g. when downing. This will terminate
-        # the ActorSystem when the cluster extension is shutdown.
-        run-coordinated-shutdown-when-down = off
-
-      }
-
     }
 
     # When Play is shutting down an ActorSystem it will use Akka's CoordinatedShutdown. Instead of running all


### PR DESCRIPTION
This undoes some of the changes from #8053 that we now believe to be detrimental.

See discussion at https://github.com/playframework/playframework/pull/8053#discussion_r153903732