### PR TITLE
[2.6.x] Remove httpConfiguration from ServerResultUtils

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -232,7 +232,6 @@ class BasicHttpClient(port: Int, secure: Boolean) {
         } getOrElse {
           val httpConfig = HttpConfiguration()
           val serverResultUtils = new ServerResultUtils(
-            httpConfig,
             new DefaultSessionCookieBaker(httpConfig.session, httpConfig.secret, new CookieSignerProvider(httpConfig.secret).get),
             new DefaultFlashCookieBaker(httpConfig.flash, httpConfig.secret, new CookieSignerProvider(httpConfig.secret).get),
             new DefaultCookieHeaderEncoding(httpConfig.cookies)

--- a/framework/src/play-microbenchmark/src/test/scala/play/core/server/netty/NettyHelpers.scala
+++ b/framework/src/play-microbenchmark/src/test/scala/play/core/server/netty/NettyHelpers.scala
@@ -19,7 +19,6 @@ object NettyHelpers {
   val conversion: NettyModelConversion = {
     val httpConfig = HttpConfiguration()
     val serverResultUtils = new ServerResultUtils(
-      httpConfig,
       new DefaultSessionCookieBaker(httpConfig.session, httpConfig.secret, new CookieSignerProvider(httpConfig.secret).get),
       new DefaultFlashCookieBaker(httpConfig.flash, httpConfig.secret, new CookieSignerProvider(httpConfig.secret).get),
       new DefaultCookieHeaderEncoding(httpConfig.cookies)

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
@@ -39,7 +39,7 @@ private[play] abstract class ReloadCache[+T] {
    * Helper to calculate a `ServerResultUtil`.
    */
   protected final def reloadServerResultUtils(tryApp: Try[Application]): ServerResultUtils = {
-    val (httpConfiguration, sessionBaker, flashBaker, cookieHeaderEncoding) = tryApp match {
+    val (sessionBaker, flashBaker, cookieHeaderEncoding) = tryApp match {
       case Success(app) =>
         val requestFactory: DefaultRequestFactory = app.requestFactory match {
           case drf: DefaultRequestFactory => drf
@@ -47,7 +47,6 @@ private[play] abstract class ReloadCache[+T] {
         }
 
         (
-          HttpConfiguration.fromConfiguration(app.configuration, app.environment),
           requestFactory.sessionBaker,
           requestFactory.flashBaker,
           requestFactory.cookieHeaderEncoding
@@ -57,13 +56,12 @@ private[play] abstract class ReloadCache[+T] {
         val cookieSigner = new CookieSignerProvider(httpConfig.secret).get
 
         (
-          httpConfig,
           new DefaultSessionCookieBaker(httpConfig.session, httpConfig.secret, cookieSigner),
           new DefaultFlashCookieBaker(httpConfig.flash, httpConfig.secret, cookieSigner),
           new DefaultCookieHeaderEncoding(httpConfig.cookies)
         )
     }
-    new ServerResultUtils(httpConfiguration, sessionBaker, flashBaker, cookieHeaderEncoding)
+    new ServerResultUtils(sessionBaker, flashBaker, cookieHeaderEncoding)
   }
 
   /**

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -11,14 +11,12 @@ import play.api.mvc._
 import play.api.http._
 import play.api.http.HeaderNames._
 import play.api.http.Status._
-import play.api.libs.crypto.CookieSignerProvider
 import play.api.mvc.request.RequestAttrKey
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 private[play] final class ServerResultUtils(
-    httpConfiguration: HttpConfiguration,
     sessionBaker: SessionCookieBaker,
     flashBaker: FlashCookieBaker,
     cookieHeaderEncoding: CookieHeaderEncoding) {

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -28,7 +28,6 @@ class ServerResultUtilsSpec extends Specification {
   val resultUtils = {
     val httpConfig = HttpConfiguration()
     new ServerResultUtils(
-      httpConfig,
       new DefaultSessionCookieBaker(httpConfig.session, httpConfig.secret, new CookieSignerProvider(httpConfig.secret).get),
       new DefaultFlashCookieBaker(httpConfig.flash, httpConfig.secret, new CookieSignerProvider(httpConfig.secret).get),
       new DefaultCookieHeaderEncoding(httpConfig.cookies)


### PR DESCRIPTION
Backport of #8085 to the 2.6.x branch.