### PR TITLE
Upgrade netty 

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -153,7 +153,7 @@ object Dependencies {
     specsBuild.map(_ % Test) ++
     javaTestDeps
 
-  val nettyVersion = "4.1.18.Final"
+  val nettyVersion = "4.1.19.Final"
 
   val netty = Seq(
     "com.typesafe.netty" % "netty-reactive-streams-http" % "2.0.0",


### PR DESCRIPTION
Fixes **a regression which could cause a core-dump when using one of the native transports (!)**

http://netty.io/news/2017/12/18/4-1-19-Final.html
