### PR TITLE
fix Results class name in the doc

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaActions.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActions.md
@@ -9,7 +9,7 @@ An action is basically a Java method that processes the request parameters, and 
 
 @[simple-action](code/javaguide/http/JavaActions.java)
 
-An action returns a `play.mvc.Result` value, representing the HTTP response to send to the web client. In this example `ok` constructs a **200 OK** response containing a **text/plain** response body. For more examples of HTTP responses see [`play.mvc.Result` methods](api/java/play/mvc/Results.html#method.summary).
+An action returns a `play.mvc.Result` value, representing the HTTP response to send to the web client. In this example `ok` constructs a **200 OK** response containing a **text/plain** response body. For more examples of HTTP responses see [`play.mvc.Results` methods](api/java/play/mvc/Results.html#method.summary).
 
 ## Controllers 
 


### PR DESCRIPTION
The link to `play.mvc.Results` class methods is correct, but its name in the text is `play.mvc.Result`, which is not correct. This can be misleading since there's a different class named `play.mvc.Result` with its own methods.
