### PR TITLE
Fix WS digest authorization for play 2.5.x

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -621,9 +621,10 @@ public class AhcWSRequest implements WSRequest {
 
     Realm auth(String username, String password, WSAuthScheme scheme) {
         Realm.AuthScheme authScheme = Realm.AuthScheme.valueOf(scheme.name());
+        Boolean usePreemptiveAuth = !(this.scheme != null && this.scheme == WSAuthScheme.DIGEST);
         return (new Realm.Builder(username, password))
                 .setScheme(authScheme)
-                .setUsePreemptiveAuth(true)
+                .setUsePreemptiveAuth(usePreemptiveAuth)
                 .build();
     }
 }

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -6,7 +6,7 @@ package play.libs.ws.ahc
 import org.asynchttpclient.{ Request, RequestBuilderBase, SignatureCalculator }
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
-import play.libs.ws.WSSignatureCalculator
+import play.libs.ws.{ WSAuthScheme, WSSignatureCalculator }
 import play.libs.oauth.OAuth
 
 class AhcWSRequestSpec extends Specification with Mockito {
@@ -147,6 +147,22 @@ class AhcWSRequestSpec extends Specification with Mockito {
       request.setHeader("Content-Type", "application/xml")
       val req = request.buildRequest()
       req.getHeaders.get("Content-Type") must be_==("application/json; charset=US-ASCII")
+    }
+
+    "Set Realm.UsePreemptiveAuth to false when WSAuthScheme.DIGEST being used" in {
+      val client = mock[AhcWSClient]
+      val request = new AhcWSRequest(client, "http://example.com", /*materializer*/ null)
+      request.setAuth("usr", "pwd", WSAuthScheme.DIGEST)
+      val req = request.buildRequest()
+      req.getRealm.isUsePreemptiveAuth must beFalse
+    }
+
+    "Set Realm.UsePreemptiveAuth to true when WSAuthScheme.DIGEST not being used" in {
+      val client = mock[AhcWSClient]
+      val request = new AhcWSRequest(client, "http://example.com", /*materializer*/ null)
+      request.setAuth("usr", "pwd", WSAuthScheme.BASIC)
+      val req = request.buildRequest()
+      req.getRealm.isUsePreemptiveAuth must beTrue
     }
   }
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcWS.scala
@@ -28,6 +28,7 @@ import scala.collection.immutable.TreeMap
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.Duration
 import akka.stream.scaladsl.Sink
+import org.asynchttpclient.Realm.AuthScheme
 
 /**
  * A WS client backed by an AsyncHttpClient.
@@ -227,9 +228,14 @@ case class AhcWSRequest(client: AhcWSClient,
    * Add http auth headers. Defaults to HTTP Basic.
    */
   private[libs] def auth(username: String, password: String, scheme: Realm.AuthScheme = Realm.AuthScheme.BASIC): Realm = {
+    val usePreemptiveAuth = scheme match {
+      case AuthScheme.DIGEST => false
+      case _ => true
+    }
+
     new Realm.Builder(username, password)
       .setScheme(scheme)
-      .setUsePreemptiveAuth(true)
+      .setUsePreemptiveAuth(usePreemptiveAuth)
       .build()
   }
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -297,6 +297,22 @@ object AhcWSSpec extends PlaySpecification with Mockito {
       actual.getRealm.getScheme must be equalTo AuthScheme.NTLM
     }
 
+    "Set Realm.UsePreemptiveAuth to false when WSAuthScheme.DIGEST being used" in WsTestClient.withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withAuth("usr", "pwd", WSAuthScheme.DIGEST)
+        .asInstanceOf[AhcWSRequest]
+        .buildRequest()
+      req.getRealm.isUsePreemptiveAuth must beFalse
+    }
+
+    "Set Realm.UsePreemptiveAuth to true when WSAuthScheme.DIGEST not being used" in WsTestClient.withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withAuth("usr", "pwd", WSAuthScheme.BASIC)
+        .asInstanceOf[AhcWSRequest]
+        .buildRequest()
+      req.getRealm.isUsePreemptiveAuth must beTrue
+    }
+
     "support a proxy server" in new WithApplication {
       val proxy = DefaultWSProxyServer(host = "localhost", port = 8080)
       val req: AHCRequest = WS.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[AhcWSRequest].buildRequest()


### PR DESCRIPTION
# Helpful things

## Fixes

Fixes [#6467](https://github.com/playframework/playframework/issues/6467). Because this fix not present in branch 2.5.x

## Purpose

Set usePreemptiveAuth option to false when used with Digest auth

## Background Context

See comment AsyncHttpClient/async-http-client#792 (comment)

## References

#6467
#6468

