### PR TITLE
Correct docs to use CompletableFuture.supplyAsync

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaAsync.md
@@ -25,7 +25,7 @@ Play asynchronous API methods give you a `CompletionStage`. This is the case whe
 
 In this case, using `CompletionStage.thenApply` will execute the completion stage in the same calling thread as the previous task.  This is fine when you have a small amount of CPU bound logic with no blocking.
 
-A simple way to execute a block of code asynchronously and to get a `CompletionStage` is to use the `CompletionStage.supplyAsync()` method:
+A simple way to execute a block of code asynchronously and to get a `CompletionStage` is to use the `CompletableFuture.supplyAsync()` method:
 
 @[promise-async](code/javaguide/async/JavaAsync.java)
 


### PR DESCRIPTION
To get a `CompletionStage` is to use the `CompletableFuture.supplyAsync()` method but not "CompletionStage.supplyAsync()"

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
