### PR TITLE
Fix akka-http server configuration for request timeout

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -13,8 +13,8 @@ play {
       # How long to wait when binding to the listening socket
       bindTimeout = 5 seconds
 
-      # How long a request takes until it times out
-      requestTimeout = null
+      # How long a request takes until it times out. Set to null or "infinite" to disable the timeout.
+      requestTimeout = infinite
 
       # Enables/disables automatic handling of HEAD requests.
       # If this setting is enabled the server dispatches HEAD requests as GET

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -81,16 +81,15 @@ class AkkaHttpServer(
     val initialSettings = ServerSettings(initialConfig)
 
     val idleTimeout = serverConfig.get[Duration](if (secure) "https.idleTimeout" else "http.idleTimeout")
-    val requestTimeoutOption = akkaServerConfig.getOptional[Duration]("requestTimeout")
+    val requestTimeout = akkaServerConfig.get[Duration]("requestTimeout")
 
     // all akka settings that are applied to the server needs to be set here
-    val serverSettings: ServerSettings = initialSettings.withTimeouts {
-      val timeouts = initialSettings.timeouts.withIdleTimeout(idleTimeout)
-      requestTimeoutOption match {
-        case Some(requestTimeout) => timeouts.withRequestTimeout(requestTimeout)
-        case None => timeouts
-      }
-    }
+    val serverSettings: ServerSettings = initialSettings
+      .withTimeouts(
+        initialSettings.timeouts
+          .withIdleTimeout(idleTimeout)
+          .withRequestTimeout(requestTimeout)
+      )
       // Play needs these headers to fill in fields in its request model
       .withRawRequestUriHeader(true)
       .withRemoteAddressHeader(true)

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -850,8 +850,8 @@ play {
     # The name of the actor system that Play creates
     actor-system = "application"
 
-    # How long Play should wait for Akka to shutdown before timing it.  If null, waits indefinitely.
-    shutdown-timeout = null
+    # How long Play should wait for Akka to shutdown before timing it.  If "infinite" or null, waits indefinitely.
+    shutdown-timeout = infinite
 
     # The location to read Play's Akka configuration from
     config = "akka"


### PR DESCRIPTION
## Fixes

Fixes #8096.

## Purpose

The request timeout should be `Duration.Inf` when `play.server.akka.requestTimeout` is null.
