### PR TITLE
add `play.api.Configuration#load` to the public API

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -33,10 +33,11 @@ object Configuration {
 
   private[this] lazy val dontAllowMissingConfig = ConfigFactory.load(dontAllowMissingConfigOptions)
 
-  def load(classLoader: ClassLoader, 
-           properties: Properties, 
-           directSettings: Map[String, AnyRef], 
-           allowMissingApplicationConf: Boolean): Configuration = {
+  def load(
+    classLoader: ClassLoader, 
+    properties: Properties, 
+    directSettings: Map[String, AnyRef], 
+    allowMissingApplicationConf: Boolean): Configuration = {
 
     try {
       // Get configuration from the system properties.

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -33,7 +33,9 @@ object Configuration {
 
   private[this] lazy val dontAllowMissingConfig = ConfigFactory.load(dontAllowMissingConfigOptions)
 
-  def load(classLoader: ClassLoader, properties: Properties, directSettings: Map[String, AnyRef], 
+  def load(classLoader: ClassLoader, 
+           properties: Properties, 
+           directSettings: Map[String, AnyRef], 
            allowMissingApplicationConf: Boolean): Configuration = {
 
     try {

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -34,9 +34,9 @@ object Configuration {
   private[this] lazy val dontAllowMissingConfig = ConfigFactory.load(dontAllowMissingConfigOptions)
 
   def load(
-    classLoader: ClassLoader, 
-    properties: Properties, 
-    directSettings: Map[String, AnyRef], 
+    classLoader: ClassLoader,
+    properties: Properties,
+    directSettings: Map[String, AnyRef],
     allowMissingApplicationConf: Boolean): Configuration = {
 
     try {

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -33,11 +33,8 @@ object Configuration {
 
   private[this] lazy val dontAllowMissingConfig = ConfigFactory.load(dontAllowMissingConfigOptions)
 
-  private[play] def load(
-    classLoader: ClassLoader,
-    properties: Properties,
-    directSettings: Map[String, AnyRef],
-    allowMissingApplicationConf: Boolean): Configuration = {
+  def load(classLoader: ClassLoader, properties: Properties, directSettings: Map[String, AnyRef], 
+           allowMissingApplicationConf: Boolean): Configuration = {
 
     try {
       // Get configuration from the system properties.


### PR DESCRIPTION
In Lagom, clients require an `application.conf` [lest an exception be thrown](https://github.com/lagom/lagom/issues/412).

To mitigate this, passing `allowMissingApplicationConf` to `Configuration#load` would be perfect. Unfortunately, it is only part of the private API. 

This PR adds `Configuration#load` (with `allowMissingApplicationConf`) to the public API.