### PR TITLE
Changed import of "block-request" example in docs

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -167,7 +167,8 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
 
     "allow blocking the request" in {
       //#block-request
-      import play.api.mvc.Results._
+      import play.api.mvc._
+      //###insert: import play.api.mvc.Results._
 
       def onlyHttps[A](action: Action[A]) = Action.async(action.parser) { request =>
         request.headers.get("X-Forwarded-Proto").collect {

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -167,7 +167,7 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
 
     "allow blocking the request" in {
       //#block-request
-      import play.api.mvc._
+      import play.api.mvc.Results._
 
       def onlyHttps[A](action: Action[A]) = Action.async(action.parser) { request =>
         request.headers.get("X-Forwarded-Proto").collect {


### PR DESCRIPTION
Example called "block-request" uses Forbidden in onlyHttps method. Results traits should be imported so that you can use http results like Forbidden.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixed import statement of an example in docs

## Purpose

Results traits should be important in said example.

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
