### PR TITLE
Avoid multiple calls to ApplicationProvider#get for a single request

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -177,21 +177,22 @@ class AkkaHttpServer(
     }
   }
 
-  private def resultUtils: ServerResultUtils =
-    reloadCache.cachedFrom(applicationProvider.get).resultUtils
-  private def modelConversion: AkkaModelConversion =
-    reloadCache.cachedFrom(applicationProvider.get).modelConversion
+  private def resultUtils(tryApp: Try[Application]): ServerResultUtils =
+    reloadCache.cachedFrom(tryApp).resultUtils
+  private def modelConversion(tryApp: Try[Application]): AkkaModelConversion =
+    reloadCache.cachedFrom(tryApp).modelConversion
 
   private def handleRequest(request: HttpRequest, secure: Boolean): Future[HttpResponse] = {
     val remoteAddress: InetSocketAddress = remoteAddressOfRequest(request)
     val decodedRequest = HttpRequestDecoder.decodeRequest(request)
     val requestId = requestIDs.incrementAndGet()
-    val (convertedRequestHeader, requestBodySource) = modelConversion.convertRequest(
+    val tryApp = applicationProvider.get
+    val (convertedRequestHeader, requestBodySource) = modelConversion(tryApp).convertRequest(
       requestId = requestId,
       remoteAddress = remoteAddress,
       secureProtocol = secure,
       request = decodedRequest)
-    val (taggedRequestHeader, handler, newTryApp) = getHandler(convertedRequestHeader)
+    val (taggedRequestHeader, handler, newTryApp) = getHandler(convertedRequestHeader, tryApp)
     val responseFuture = executeHandler(
       newTryApp,
       decodedRequest,
@@ -210,8 +211,10 @@ class AkkaHttpServer(
     }
   }
 
-  private def getHandler(requestHeader: RequestHeader): (RequestHeader, Handler, Try[Application]) = {
-    getHandlerFor(requestHeader) match {
+  private def getHandler(
+    requestHeader: RequestHeader, tryApp: Try[Application]
+  ): (RequestHeader, Handler, Try[Application]) = {
+    Server.getHandlerFor(requestHeader, tryApp) match {
       case Left(futureResult) =>
         (
           requestHeader,
@@ -251,13 +254,13 @@ class AkkaHttpServer(
     (handler, upgradeToWebSocket) match {
       //execute normal action
       case (action: EssentialAction, _) =>
-        runAction(request, taggedRequestHeader, requestBodySource, action, errorHandler)
+        runAction(tryApp, request, taggedRequestHeader, requestBodySource, action, errorHandler)
       case (websocket: WebSocket, Some(upgrade)) =>
         val bufferLimit = config.configuration.getDeprecated[ConfigMemorySize]("play.server.websocket.frame.maxLength", "play.websocket.buffer.limit").toBytes.toInt
 
         websocket(taggedRequestHeader).fast.flatMap {
           case Left(result) =>
-            modelConversion.convertResult(taggedRequestHeader, result, request.protocol, errorHandler)
+            modelConversion(tryApp).convertResult(taggedRequestHeader, result, request.protocol, errorHandler)
           case Right(flow) =>
             Future.successful(WebSocketHandler.handleWebSocket(upgrade, flow, bufferLimit))
         }
@@ -276,10 +279,13 @@ class AkkaHttpServer(
     taggedRequestHeader: RequestHeader,
     requestBodySource: Either[ByteString, Source[ByteString, _]],
     action: EssentialAction,
-    errorHandler: HttpErrorHandler): Future[HttpResponse] =
-    runAction(request, taggedRequestHeader, requestBodySource, action, errorHandler)(actorSystem.dispatcher)
+    errorHandler: HttpErrorHandler): Future[HttpResponse] = {
+    runAction(applicationProvider.get, request, taggedRequestHeader, requestBodySource,
+      action, errorHandler)(actorSystem.dispatcher)
+  }
 
   private[play] def runAction(
+    tryApp: Try[Application],
     request: HttpRequest,
     taggedRequestHeader: RequestHeader,
     requestBodySource: Either[ByteString, Source[ByteString, _]],
@@ -310,8 +316,8 @@ class AkkaHttpServer(
         errorHandler.onServerError(taggedRequestHeader, e)
     }
     val responseFuture: Future[HttpResponse] = resultFuture.flatMap { result =>
-      val cleanedResult: Result = resultUtils.prepareCookies(taggedRequestHeader, result)
-      modelConversion.convertResult(taggedRequestHeader, cleanedResult, request.protocol, errorHandler)
+      val cleanedResult: Result = resultUtils(tryApp).prepareCookies(taggedRequestHeader, result)
+      modelConversion(tryApp).convertResult(taggedRequestHeader, cleanedResult, request.protocol, errorHandler)
     }
     responseFuture
   }

--- a/framework/src/play/src/main/scala/play/core/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/ApplicationProvider.scala
@@ -31,6 +31,8 @@ trait ApplicationProvider {
 
   /**
    * Get the application. In dev mode this lazily loads the application.
+   *
+   * NOTE: This should be called once per request. Calling multiple times may result in multiple compilations.
    */
   def get: Try[Application]
 


### PR DESCRIPTION
As far as I can tell, `ApplicationProvider#get` is not meant to be called multiple times for the same request. It looks like that was the case previously, but in 2.6.x we've added some caching based on the `Try[Application]` instance and are calling the `ApplicationProvider` to get the current instance each time. The current dev mode reload logic forces a reload next time (`forceReloadNextTime = true`) when compilation fails, so if `get` is called more than once for a single request, that causes multiple compilations per request.

My solution here proposes to get the `Try[Application]` once and pass that instance around for the handling of the request.

Fixes #7753 