### PR TITLE
Fixed bug where error messages with parameters are not correctly formatted

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -430,7 +430,7 @@ case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
    * Displays the formatted message, for use in a template.
    */
   def format(implicit messages: play.api.i18n.Messages): String = {
-    messages.apply(message, args)
+    messages.apply(message, args: _*)
   }
 }
 

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -354,6 +354,19 @@ class FormSpec extends Specification {
     (form.errorsAsJson \ "foo")(0).asOpt[String] must beSome("This is a custom error")
   }
 
+  "correctly format error messages with arguments" in {
+    val messagesApi: MessagesApi = {
+      val config = Configuration.reference
+      val langs = new DefaultLangsProvider(config).get
+      new DefaultMessagesApiProvider(Environment.simple(), config, langs, HttpConfiguration()).get
+    }
+    implicit val messages = messagesApi.preferred(Seq.empty)
+
+    val filled = ScalaForms.parametarizederrorMessageForm.fillAndValidate("john")
+    filled.errors("name").find(_.message == "error.minLength").map(_.format) must beSome("Minimum length is 5")
+
+  }
+
   "render form using java.time.LocalDate" in {
     import java.time.LocalDate
     val dateForm = Form("date" -> localDate)
@@ -528,4 +541,7 @@ object ScalaForms {
   val byteNumberForm = Form("byteNumber" -> shortNumber(10, 42))
 
   val charForm = Form("gender" -> char)
+
+  val parametarizederrorMessageForm = Form("name" -> nonEmptyText(minLength = 5))
+
 }

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -362,7 +362,7 @@ class FormSpec extends Specification {
     }
     implicit val messages = messagesApi.preferred(Seq.empty)
 
-    val filled = ScalaForms.parametarizederrorMessageForm.fillAndValidate("john")
+    val filled = ScalaForms.parameterizederrorMessageForm.fillAndValidate("john")
     filled.errors("name").find(_.message == "error.minLength").map(_.format) must beSome("Minimum length is 5")
 
   }
@@ -542,6 +542,6 @@ object ScalaForms {
 
   val charForm = Form("gender" -> char)
 
-  val parametarizederrorMessageForm = Form("name" -> nonEmptyText(minLength = 5))
+  val parameterizederrorMessageForm = Form("name" -> nonEmptyText(minLength = 5))
 
 }


### PR DESCRIPTION
## Fixes

Fixed https://github.com/playframework/playframework/issues/8081

The FormError.format method should call messages.apply(message, args: _*)
instead of messages.apply(message, args) in order to properly format the values of the arguments.
