### PR TITLE
Preserve all devSettings including Akka's

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -51,6 +51,12 @@ In `run` mode the HTTP server part of Play starts before the application has bee
 > run -Dhttp.port=1234
 ```
 
+There is also a specific *namespace* if you need to customize Akka configuration for development mode (the mode used with `run` command). You need to prefix your configuration in `PlayKeys.devSettings` with `play.akka.dev-mode`, for example:
+
+@[prefix-with-play-akka-dev-mode](code/build.sbt)
+
+This is specially useful if there is some conflict between the Akka ActorSystem used run development mode and the ActorSystem used by the application itself.
+
 ## HOCON Syntax
 
 HOCON has similarities to JSON; you can find the JSON spec at <http://json.org/> of course.

--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -25,4 +25,4 @@ There is also a separate configuration file for the HTTP/2 support in Akka HTTP,
 
 @[](/confs/play-akka-http2-support/reference.conf)
 
-> **Note:** In dev mode, when you use the `run` command, your `application.conf` settings will not be picked up by the server. This is because in dev mode the server starts before the application classpath is available. There are several [[other options|Configuration#Using-with-the-run-command]] you'll need to use instead.
+> **Note:** In dev mode, when you use the `run` command, your `application.conf` settings will not be picked up by the server. This is because in dev mode the server starts before the application classpath is available. There are several [[other options|ConfigFile#Using-with-the-run-command]] you'll need to use instead.

--- a/documentation/manual/working/commonGuide/configuration/code/build.sbt
+++ b/documentation/manual/working/commonGuide/configuration/code/build.sbt
@@ -2,3 +2,9 @@
 libraryDependencies += ws
 libraryDependencies += ehcache
 //#play-ws-cache-deps
+
+//#prefix-with-play-akka-dev-mode
+PlayKeys.devSettings ++= Seq(
+  "play.akka.dev-mode.akka.cluster.log-info" -> "off"
+)
+//#prefix-with-play-akka-dev-mode

--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -7,7 +7,6 @@ import java.io._
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import play.api._
-import play.api.mvc._
 import play.core._
 import play.utils.Threads
 import scala.collection.JavaConverters._
@@ -208,7 +207,18 @@ object DevServerStart {
         // config will lead to resource conflicts, for example, if the actor system is configured to open a remote port,
         // then both the dev mode and the application actor system will attempt to open that remote port, and one of
         // them will fail.
-        val devModeAkkaConfig = serverConfig.configuration.underlying.getConfig("play.akka.dev-mode")
+        val devModeAkkaConfig = {
+          serverConfig
+            .configuration
+            .underlying
+            // "play.akka.dev-mode" has the priority, so if there is a conflict
+            // between the actor system for dev mode and the application actor system
+            // users can resolve it by add a specific configuration for dev mode.
+            .getConfig("play.akka.dev-mode")
+            // We then fallback to the app configuration to avoid losing configurations
+            // made using devSettings, system properties and application.conf itself.
+            .withFallback(serverConfig.configuration.underlying)
+        }
         val actorSystem = ActorSystem("play-dev-mode", devModeAkkaConfig)
 
         val serverContext = ServerProvider.Context(serverConfig, appProvider, actorSystem,

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/Module.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/Module.scala
@@ -12,7 +12,7 @@ class Module(environment: Environment, configuration: Configuration) extends Abs
     writer.close()
 
     if (configuration.getOptional[Boolean]("fail").getOrElse(false)) {
-      throw new RuntimeException()
+      throw new RuntimeException("fail=true")
     }
   }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -26,11 +26,16 @@ lazy val root = (project in file("."))
       }
     },
 
+    InputKey[Unit]("makeRequestWithHeader") := {
+      val args = Def.spaceDelimited("<path> <status> <headers> ...").parsed
+      val path :: status :: headers = args
+      val headerValue = headers.mkString
+      DevModeBuild.verifyResourceContains(path, status.toInt, Seq.empty, 0, "Header" -> headerValue)
+    },
+
     InputKey[Unit]("verifyResourceContains") := {
       val args = Def.spaceDelimited("<path> <status> <words> ...").parsed
-      val path = args.head
-      val status = args.tail.head.toInt
-      val assertions = args.tail.tail
-      DevModeBuild.verifyResourceContains(path, status, assertions, 0)
+      val path :: status :: assertions = args
+      DevModeBuild.verifyResourceContains(path, status.toInt, assertions, 0)
     }
   )

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
@@ -29,7 +29,7 @@ object DevModeBuild {
   val ReadTimeout = 10000
 
   @tailrec
-  def verifyResourceContains(path: String, status: Int, assertions: Seq[String], attempts: Int): Unit = {
+  def verifyResourceContains(path: String, status: Int, assertions: Seq[String], attempts: Int, headers: (String, String)*): Unit = {
     println(s"Attempt $attempts at $path")
     val messages = ListBuffer.empty[String]
     try {
@@ -37,6 +37,8 @@ object DevModeBuild {
       val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]
       conn.setConnectTimeout(ConnectTimeout)
       conn.setReadTimeout(ReadTimeout)
+
+      headers.foreach(h => conn.setRequestProperty(h._1, h._2))
 
       if (status == conn.getResponseCode) {
         messages += s"Resource at $path returned $status as expected"
@@ -72,7 +74,7 @@ object DevModeBuild {
         println(s"Got exception: $e")
         if (attempts < MaxAttempts) {
           Thread.sleep(WaitTime)
-          verifyResourceContains(path, status, assertions, attempts + 1)
+          verifyResourceContains(path, status, assertions, attempts + 1, headers: _*)
         } else {
           messages.foreach(println)
           println(s"After $attempts attempts:")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -189,9 +189,35 @@ $ copy-file changes/Application.scala.3 app/controllers/Application.scala
 
 # Change a resource (also introduces a startup failure)
 $ sleep 1000
+# Making a copy so that we can revert to it later
+$ copy-file conf/application.conf conf/application.original
 $ copy-file changes/application.conf.1 conf/application.conf
 > verifyResourceContains / 500
 > verifyReloads 4
 
 > playStop
+# Revert to the original application.conf
+$ copy-file conf/application.original conf/application.conf
 
+# devSettings tests
+# -----------------
+
+# First a test without the dev-setting to ensure everything works
+> run
+> makeRequestWithHeader / 200 this-is-a-header-value-longer-than-32-chars
+> playStop
+
+# A test overriding a akka setting that should be picked by dev mode
+> set PlayKeys.devSettings ++= Seq("akka.http.parsing.max-header-value-length" -> "32 bytes")
+> run
+> makeRequestWithHeader / 400 this-is-a-header-value-longer-than-32-chars
+> playStop
+
+# Should prioritize play.akka.dev-mode
+> set PlayKeys.devSettings ++= Seq("play.akka.dev-mode.akka.http.parsing.max-header-value-length" -> "32 bytes")
+
+# This should NOT be picked
+> set PlayKeys.devSettings ++= Seq("akka.http.parsing.max-header-value-length" -> "1 megabyte")
+> run
+> makeRequestWithHeader / 400 this-is-a-header-value-longer-than-32-chars
+> playStop


### PR DESCRIPTION
## Fixes

Fixes #7990 #7617.

## Purpose

Not all `devSettings` are being respected because we use a distinct `ActorSystem` to run the application in DEV mode and this actor system was not considering `devSettings`. So now, it first gets specific configuration under `play.akka.dev-mode` (which could be used to solve conflicts between DEV's ActorSystem and app's ActorSystem) and then falls back to `devSettings` + application configuration.

This PR also adds documentation to explain better `play.akka.dev-mode`.