### PR TITLE
Windows compatibility fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+framework/src/play-integration-test/src/test/resources/testassets/* binary

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -245,6 +245,7 @@ lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Te
       parallelExecution in Test := false,
       mimaPreviousArtifacts := Set.empty,
       fork in Test := true,
+      javaOptions in Test += "-Dfile.encoding=UTF8",
       javaAgents += jettyAlpnAgent % "test"
     )
     .dependsOn(

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -49,7 +49,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       |Content-Disposition: form-data; name="$tokenName"
       |
       |$tokenValue
-      |--$Boundary--""".stripMargin.replaceAll("\n", "\r\n")
+      |--$Boundary--""".stripMargin.replaceAll(System.lineSeparator, "\r\n")
   }
 
   // This extracts the tests out into different configurations

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -171,33 +171,33 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
 
     "run a single @Repeatable annotation on a controller type" in makeRequest(new SingleRepeatableOnTypeController()) { response =>
       response.body must beEqualTo("""java.lang.Classaction1
-                                     |java.lang.Classaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.Classaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
 
     "run a single @Repeatable annotation on a controller action" in makeRequest(new SingleRepeatableOnActionController()) { response =>
       response.body must beEqualTo("""java.lang.reflect.Methodaction1
-                                     |java.lang.reflect.Methodaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.reflect.Methodaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
 
     "run multiple @Repeatable annotations on a controller type" in makeRequest(new MultipleRepeatableOnTypeController()) { response =>
       response.body must beEqualTo("""java.lang.Classaction1
                                      |java.lang.Classaction2
                                      |java.lang.Classaction1
-                                     |java.lang.Classaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.Classaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
 
     "run multiple @Repeatable annotations on a controller action" in makeRequest(new MultipleRepeatableOnActionController()) { response =>
       response.body must beEqualTo("""java.lang.reflect.Methodaction1
                                      |java.lang.reflect.Methodaction2
                                      |java.lang.reflect.Methodaction1
-                                     |java.lang.reflect.Methodaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.reflect.Methodaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
 
     "run single @Repeatable annotation on a controller type and a controller action" in makeRequest(new SingleRepeatableOnTypeAndActionController()) { response =>
       response.body must beEqualTo("""java.lang.reflect.Methodaction1
                                      |java.lang.reflect.Methodaction2
                                      |java.lang.Classaction1
-                                     |java.lang.Classaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.Classaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
 
     "run multiple @Repeatable annotations on a controller type and a controller action" in makeRequest(new MultipleRepeatableOnTypeAndActionController()) { response =>
@@ -208,7 +208,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
                                      |java.lang.Classaction1
                                      |java.lang.Classaction2
                                      |java.lang.Classaction1
-                                     |java.lang.Classaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.Classaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
 
     "run @Repeatable action composition annotations backward compatible" in makeRequest(new RepeatableBackwardCompatibilityController()) { response =>
@@ -217,19 +217,19 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
 
     "run @With annotation on a controller type" in makeRequest(new WithOnTypeController()) { response =>
       response.body must beEqualTo("""java.lang.Classaction1
-                                     |java.lang.Classaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.Classaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
 
     "run @With annotation on a controller action" in makeRequest(new WithOnActionController()) { response =>
       response.body must beEqualTo("""java.lang.reflect.Methodaction1
-                                     |java.lang.reflect.Methodaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.reflect.Methodaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
 
     "run @With annotations on a controller type and a controller action" in makeRequest(new WithOnTypeAndActionController()) { response =>
       response.body must beEqualTo("""java.lang.reflect.Methodaction1
                                      |java.lang.reflect.Methodaction2
                                      |java.lang.Classaction1
-                                     |java.lang.Classaction2""".stripMargin.replaceAll("\n", ""))
+                                     |java.lang.Classaction2""".stripMargin.replaceAll(System.lineSeparator, ""))
     }
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -60,7 +60,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
       result.status must_== OK
       result.body must_== "This is a test asset."
-      result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+      result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
       result.header(ETAG) must beSome(matching(etagPattern))
       result.header(LAST_MODIFIED) must beSome
       result.header(VARY) must beNone
@@ -91,7 +91,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
       result.status must_== OK
       result.body must_== "Content of baz.txt."
-      result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+      result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
       result.header(ETAG) must beSome(matching(etagPattern))
       result.header(LAST_MODIFIED) must beSome
       result.header(VARY) must beNone
@@ -104,7 +104,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
       result.status must_== OK
       result.body must_== "This is a test asset with spaces."
-      result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+      result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
       result.header(ETAG) must beSome(matching(etagPattern))
       result.header(LAST_MODIFIED) must beSome
       result.header(VARY) must beNone
@@ -124,7 +124,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome(matching(etagPattern))
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -143,7 +143,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome(matching(etagPattern))
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -162,7 +162,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome(matching(etagPattern))
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -182,7 +182,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome(matching(etagPattern))
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -202,7 +202,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome(matching(etagPattern))
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -223,7 +223,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome(matching(etagPattern))
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -343,7 +343,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
       val result = await(client.url("/nosuchfile.txt").get())
 
       result.status must_== NOT_FOUND
-      result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/html"))
+      result.header(CONTENT_TYPE) must beSome(startWith("text/html"))
     }
 
     "serve a versioned asset" in withServer() { client =>
@@ -351,7 +351,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
       result.status must_== OK
       result.body must_== "This is a test asset."
-      result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+      result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
       result.header(ETAG) must beSome("\"12345678901234567890123456789012\"")
       result.header(LAST_MODIFIED) must beSome
       result.header(VARY) must beNone
@@ -371,7 +371,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome("\"12345678901234567890123456789012\"")
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -390,7 +390,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome("\"12345678901234567890123456789012\"")
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -409,7 +409,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome("\"12345678901234567890123456789012\"")
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -429,7 +429,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome("\"12345678901234567890123456789012\"")
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -449,7 +449,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome("\"12345678901234567890123456789012\"")
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -472,7 +472,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.status must_== OK
         result.body must_== "This is a test asset."
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/plain"))
+        result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
         result.header(ETAG) must beSome("\"12345678901234567890123456789012\"")
         result.header(LAST_MODIFIED) must beSome
         result.header(VARY) must beNone
@@ -519,7 +519,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
         )
 
         result.status must_== PARTIAL_CONTENT
-        result.header(CONTENT_RANGE) must beSome.which(_.startsWith("bytes 0-499/"))
+        result.header(CONTENT_RANGE) must beSome(startWith("bytes 0-499/"))
         result.bodyAsBytes.length must beEqualTo(500)
         result.header(CONTENT_LENGTH) must beSome("500")
       }
@@ -533,7 +533,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
 
         result.bodyAsBytes.length must beEqualTo(500)
         result.status must_== PARTIAL_CONTENT
-        result.header(CONTENT_RANGE) must beSome.which(_.startsWith("bytes 500-999/"))
+        result.header(CONTENT_RANGE) must beSome(startWith("bytes 500-999/"))
         result.bodyAsBytes.length must beEqualTo(500)
         result.header(CONTENT_LENGTH) must beSome("500")
       }
@@ -546,7 +546,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
         )
 
         result.status must_== PARTIAL_CONTENT
-        result.header(CONTENT_RANGE) must beSome.which(_.startsWith("bytes 9500-9999/"))
+        result.header(CONTENT_RANGE) must beSome(startWith("bytes 9500-9999/"))
         result.bodyAsBytes.length must beEqualTo(500)
         result.header(CONTENT_LENGTH) must beSome("500")
       }
@@ -559,7 +559,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
         )
 
         result.status must_== PARTIAL_CONTENT
-        result.header(CONTENT_RANGE) must beSome.which(_.startsWith("bytes 9500-9999/10000"))
+        result.header(CONTENT_RANGE) must beSome(startWith("bytes 9500-9999/10000"))
         result.bodyAsBytes.length must beEqualTo(500)
         result.header(CONTENT_LENGTH) must beSome("500")
       }
@@ -572,7 +572,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
         )
 
         result.status must_== PARTIAL_CONTENT
-        result.header(CONTENT_RANGE) must beSome.which(_.startsWith("bytes 0-0,-1/"))
+        result.header(CONTENT_RANGE) must beSome(startWith("bytes 0-0,-1/"))
       }.pendingUntilFixed
 
       "Multiple intervals to get the second 500 bytes" in withServer() { client =>
@@ -583,7 +583,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
         )
 
         result.status must_== PARTIAL_CONTENT
-        result.header(CONTENT_TYPE) must beSome.which(_.startsWith("multipart/byteranges"))
+        result.header(CONTENT_TYPE) must beSome(startWith("multipart/byteranges"))
       }.pendingUntilFixed
 
       "Return status 416 when first byte is gt the length of the complete entity" in withServer() { client =>
@@ -603,7 +603,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
             .get()
         )
 
-        result.header(CONTENT_RANGE) must beSome.which(_ == "bytes */10000")
+        result.header(CONTENT_RANGE) must beSome("bytes */10000")
       }
 
       "No Content-Disposition header when serving assets" in withServer() { client =>

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -458,7 +458,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
       case _ => None
     }
 
-    new Headers(s.split("\n").flatMap(split(_, ":\\s*")))
+    new Headers(s.split(System.lineSeparator).flatMap(split(_, ":\\s*")))
   }
 
   def processHeaders(config: Map[String, Any], headers: Headers): Seq[(ForwardedEntry, Either[String, ParsedForwardedEntry], Option[Boolean])] = {

--- a/framework/src/play/src/test/scala/play/api/http/WriteableSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/WriteableSpec.scala
@@ -58,7 +58,7 @@ class WriteableSpec extends Specification {
           Writeable[FilePart[String]]((f: FilePart[String]) => codec.encode(f.ref), contentType)
         )
 
-        writeable.contentType must beSome.which(_.startsWith("multipart/form-data; boundary="))
+        writeable.contentType must beSome(startWith("multipart/form-data; boundary="))
       }
     }
   }

--- a/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -82,7 +82,7 @@ class BindersSpec extends Specification {
       |failed to parse q: failed: knew
       |failed to parse q: failed: a
       |failed to parse q: failed: man
-      |failed to parse q: failed: from""".stripMargin
+      |failed to parse q: failed: from""".stripMargin.replaceAll(System.lineSeparator, "\n") // Windows compatibility
 
       brokenSeqBinder.bind("q", params) must equalTo(Some(Left(err)))
     }

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -246,21 +246,21 @@ class RangeSetSpec extends Specification {
     "bytes=0-5,100-110" in {
       val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=0-5,100-110"))
       rangeSet must beAnInstanceOf[SatisfiableRangeSet]
-      rangeSet.entityLength must beSome.which(_ == 120)
+      rangeSet.entityLength must beSome(120)
       rangeSet.toString must beEqualTo("bytes 0-5,100-110/120")
     }
 
     "bytes=0-0,-1" in {
       val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=0-0,-1"))
       rangeSet must beAnInstanceOf[SatisfiableRangeSet]
-      rangeSet.entityLength must beSome.which(_ == 120)
+      rangeSet.entityLength must beSome(120)
       rangeSet.toString must beEqualTo("bytes 0-0,119-119/120")
     }
 
     "bytes=500-600,801-999" in {
       val rangeSet = RangeSet(entityLength = Some(1200), rangeHeader = Some("bytes=500-600,801-999"))
       rangeSet must beAnInstanceOf[SatisfiableRangeSet]
-      rangeSet.entityLength must beSome.which(_ == 1200)
+      rangeSet.entityLength must beSome(1200)
       rangeSet.toString must beEqualTo("bytes 500-600,801-999/1200")
     }
 
@@ -289,7 +289,7 @@ class RangeSetSpec extends Specification {
 
     "No header present" in {
       val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = None)
-      rangeSet.entityLength must beSome.which(_ == 120)
+      rangeSet.entityLength must beSome(120)
       rangeSet must beAnInstanceOf[NoHeaderRangeSet]
     }
   }
@@ -298,12 +298,12 @@ class RangeSetSpec extends Specification {
 
     "When last-byte-pos less than first-byte-pos" in {
       val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=20-30,40-10"))
-      rangeSet.entityLength must beSome.which(_ == 120)
+      rangeSet.entityLength must beSome(120)
       rangeSet must beAnInstanceOf[UnsatisfiableRangeSet]
     }
     "When first-byte-pos more than entity length" in {
       val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=0-0,200-210"))
-      rangeSet.entityLength must beSome.which(_ == 120)
+      rangeSet.entityLength must beSome(120)
       rangeSet must beAnInstanceOf[UnsatisfiableRangeSet]
     }
   }


### PR DESCRIPTION
With these changes the Play core project tests pass on Windows. There are still plenty of tests failing, but this is a start!

The Assets changes are designed for maximum compatibility. The `resourceNameAt` method tries to guard against users accessing resources outside a particular prefix on the classpath. Before this
change it used `File.getCanonicalPath` to avoid `..` paths from escaping the prefixed part of the classpath. The `File.getCanonicalPath` method unfortunately behaves differently on Windows from Linux or macOS. I have written a closely compatible method (all the tests pass). In the future we might want to re-examine
how we do this test - there may be a more elegant and safer check that we can do. For now, I'm trying to change as little as possible.