### PR TITLE
Clarify the CorsFilter documentation

### DIFF
--- a/documentation/manual/working/commonGuide/filters/CorsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/CorsFilter.md
@@ -38,7 +38,7 @@ The available options include:
 * `play.filters.cors.exposedHeaders` - set custom HTTP headers to be exposed in the response (by default no headers are exposed)
 * `play.filters.cors.supportsCredentials` - disable/enable support for credentials (by default credentials support is enabled)
 * `play.filters.cors.preflightMaxAge` - set how long the results of a preflight request can be cached in a preflight result cache (by default 1 hour)
-* `play.filters.cors.serveForbiddenOrigins` - enable/disable serving requests with origins not in whitelist as non-CORS requests (by default they are forbidden)
+* `play.filters.cors.serveForbiddenOrigins` - enable/disable serving requests with origins not in whitelist as non-CORS requests (by default they are forbidden) *added in version 2.5.16*
 
 For example:
 


### PR DESCRIPTION
Updates the option list to include the version for serveForbiddenOrigins, which is only part of the last few versions of 2.5.x

For anyone running an existing project in an earlier version of play 2.5, this is rather confusing.
