### PR TITLE
Set play.allowGlobalApplication=false by default

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -3,9 +3,15 @@
 
 This is a guide for migrating from Play 2.6 to Play 2.7. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.6 Migration Guide|Migration26]].
 
+### `play.allowGlobalApplication` defaults to `false`
+
+`play.allowGlobalApplication = false` is set by default in Play 2.7.0. This means `Play.current` will throw an exception when called. You can set this to `true` to make `Play.current` and other deprecated static helpers work again, but be aware that this feature will be removed in future versions.
+
+In the future, if you still need to use static instances of application components, you can use [static injection](https://github.com/google/guice/wiki/Injections#static-injections) to inject them using Guice, or manually set static fields on startup in your application loader. These approaches should be forward compatible with future versions of Play, as long as you are careful never to run apps concurrently (e.g. in tests).
+
 ### Guice compatibility changes
 
-Guice was upgraded to version [4.2.0](https://github.com/google/guice/wiki/Guice42), which causes following breaking changes:
+Guice was upgraded to version [4.2.0](https://github.com/google/guice/wiki/Guice42), which causes the following breaking changes:
 
  - `play.test.TestBrowser.waitUntil` expects a `java.util.function.Function` instead of a `com.google.common.base.Function` now.
  - In Scala, when overriding the `configure()` method of `AbstractModule`, you need to prefix that method with the `override` identifier now (because it's non-abstract now).

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
@@ -23,26 +23,29 @@ object JavaWSSpec extends Specification with Results with Status with Mockito {
   // It's much easier to test this in Scala because we need to set up a
   // fake application with routes.
 
-  def fakeApplication: PlayApplication = GuiceApplicationBuilder().routes {
-    case ("GET", "/feed") =>
-      Action {
-        val obj: JsObject = Json.obj(
-          "title" -> "foo",
-          "commentsUrl" -> "http://localhost:3333/comments"
-        )
-        Ok(obj)
-      }
-    case ("GET", "/comments") =>
-         Action {
-           val obj: JsObject = Json.obj(
-             "count" -> "10"
-           )
-           Ok(obj)
-         }
-    case (_, _) =>
-      Action {
-        BadRequest("no binding found")
-      }
+  def fakeApplication: PlayApplication = GuiceApplicationBuilder().appRoutes { app =>
+    val Action = app.injector.instanceOf[DefaultActionBuilder]
+    ({
+      case ("GET", "/feed") =>
+        Action {
+          val obj: JsObject = Json.obj(
+            "title" -> "foo",
+            "commentsUrl" -> "http://localhost:3333/comments"
+          )
+          Ok(obj)
+        }
+      case ("GET", "/comments") =>
+        Action {
+          val obj: JsObject = Json.obj(
+            "count" -> "10"
+          )
+          Ok(obj)
+        }
+      case (_, _) =>
+        Action {
+          BadRequest("no binding found")
+        }
+    })
   }.build()
 
   "The Java WSClient" should {

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayAkkaHttp.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayAkkaHttp.md
@@ -1,7 +1,9 @@
 <!--- Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com> -->
 #  Embedding an Akka Http server in your application
 
-Play Akka HTTP server is also configurable as a embedded Play server. The simplest way to start an Play Akka HTTP Server is to use the [`AkkaHttpServer`](api/scala/play/core/server/AkkaHttpServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouterWithComponents` method:
+While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application. This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary. A common use case is an application with only a few simple routes.
+
+One way start a Play Akka HTTP Server is to use the [`AkkaHttpServer`](api/scala/play/core/server/AkkaHttpServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouterWithComponents` method:
 
 @[simple-akka-http](code/ScalaAkkaEmbeddingPlay.scala)
 
@@ -9,11 +11,11 @@ By default, this will start a server on port 9000 in prod mode.  You can configu
 
 @[config-akka-http](code/ScalaAkkaEmbeddingPlay.scala)
 
-You may want to customise some of the components that Play provides, for example, the HTTP error handler.  A simple way of doing this is by using Play's components traits, the [`AkkaHttpServerComponents`](api/scala/play/core/server/AkkaHttpServerComponents.html) trait is provided for this purpose, and can be conveniently combined with [`BuiltInComponents`](api/scala/play/api/BuiltInComponents.html) to build the application that it requires:
+Play also provides components traits that make it easy to customize other components besides the router. The [`AkkaHttpServerComponents`](api/scala/play/core/server/AkkaHttpServerComponents.html) trait is provided for this purpose, and can be conveniently combined with [`BuiltInComponents`](api/scala/play/api/BuiltInComponents.html) to build the application that it requires. In this example we use [`DefaultAkkaHttpServerComponents`](api/scala/play/core/server/DefaultAkkaHttpServerComponents.html), which is equivalent to `AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents`:
 
 @[components-akka-http](code/ScalaAkkaEmbeddingPlay.scala)
 
-In this case, the server configuration can be overridden by overriding the `serverConfig` property.
+Here the only method you need to implement is `router`. Everything else has a default implementation that can be customized by overriding methods, such as in the case of `httpErrorHandler` above. The server configuration can be overridden by overriding the `serverConfig` property.
 
 To stop the server once you've started it, simply call the `stop` method:
 

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
@@ -1,9 +1,9 @@
 <!--- Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com> -->
 # Embedding a Netty server in your application
 
-While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.
+While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application. This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary. A common use case is an application with only a few simple routes.
 
-The simplest way to start an embedded Play server is to use the [`NettyServer`](api/scala/play/core/server/NettyServer$.html) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouterWithComponents` method:
+One way to start a Play Netty Server is to use the [`NettyServer`](api/scala/play/core/server/NettyServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouterWithComponents` method:
 
 @[simple](code/ScalaNettyEmbeddingPlay.scala)
 
@@ -11,11 +11,11 @@ By default, this will start a server on port 9000 in prod mode.  You can configu
 
 @[config](code/ScalaNettyEmbeddingPlay.scala)
 
-You may want to customise some of the components that Play provides, for example, the HTTP error handler.  A simple way of doing this is by using Play's components traits, the [`NettyServerComponents`](api/scala/play/core/server/NettyServerComponents.html) trait is provided for this purpose, and can be conveniently combined with [`BuiltInComponents`](api/scala/play/api/BuiltInComponents.html) to build the application that it requires:
+Play also provides components traits that make it easy to customize other components besides the router. The [`NettyServerComponents`](api/scala/play/core/server/NettyServerComponents.html) trait is provided for this purpose, and can be conveniently combined with [`BuiltInComponents`](api/scala/play/api/BuiltInComponents.html) to build the application that it requires. In this example we use [`DefaultNettyServerComponents`](api/scala/play/core/server/DefaultNettyServerComponents.html), which is equivalent to `NettyServerComponents with BuiltInComponents with NoHttpFiltersComponents`:
 
 @[components](code/ScalaNettyEmbeddingPlay.scala)
 
-In this case, the server configuration can be overridden by overriding the `serverConfig` property.
+Here the only method you need to implement is `router`. Everything else has a default implementation that can be customized by overriding methods, such as in the case of `httpErrorHandler` above. The server configuration can be overridden by overriding the `serverConfig` property.
 
 To stop the server once you've started it, simply call the `stop` method:
 

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
@@ -3,7 +3,7 @@
  */
 
 import org.specs2.mutable.Specification
-import play.api.NoHttpFiltersComponents
+import play.core.server.DefaultAkkaHttpServerComponents
 import play.api.test.WsTestClient
 
 import scala.concurrent.Await
@@ -76,7 +76,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
 
       import scala.concurrent.Future
 
-      val components = new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
+      val components = new DefaultAkkaHttpServerComponents {
 
         override lazy val router: Router = Router.from {
           case GET(p"/hello/$to") => Action {

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -8,11 +8,10 @@ import javax.inject.Inject
 
 import akka.actor._
 import akka.stream.ActorMaterializer
-import play.api.http._
 import play.api.test._
 import play.api.test.Helpers._
-import play.api.mvc.{AbstractController, BodyParsers, Controller, ControllerHelpers}
-import org.specs2.mutable.{Specification, SpecificationLike}
+import play.api.mvc._
+import org.specs2.mutable.Specification
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import play.api.Logger
@@ -20,7 +19,6 @@ import play.api.Logger
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import org.specs2.execute.AsResult
-import play.api.libs.Files.SingletonTemporaryFileCreator
 
 case class User(name: String)
 object User {
@@ -31,6 +29,13 @@ object User {
 class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
 
   "an action composition" should {
+
+    implicit val system = ActorSystem()
+    implicit val mat = ActorMaterializer()
+    implicit val ec: ExecutionContext = system.dispatcher
+    val parse = PlayBodyParsers()
+    val defaultParser = new BodyParsers.Default(parse)
+    val actionBuilder = new DefaultActionBuilderImpl(new BodyParsers.Default(parse))
 
     "Basic action composition" in {
       //#basic-logging
@@ -43,12 +48,8 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
         }
       }
       //#basic-logging
-      implicit val system = ActorSystem()
-      implicit val mat = ActorMaterializer()
-      implicit val ec: ExecutionContext = system.dispatcher
-      val parse = PlayBodyParsers()
-      val parser = new BodyParsers.Default(parse)
-      val loggingAction = new LoggingAction(parser)
+
+      val loggingAction = new LoggingAction(defaultParser)
 
       //#basic-logging-index
       class MyController @Inject()(loggingAction: LoggingAction,
@@ -98,12 +99,7 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       }
       //#actions-wrapping-builder
 
-      implicit val system = ActorSystem()
-      implicit val mat = ActorMaterializer()
-      implicit val ec: ExecutionContext = system.dispatcher
-      val parse = PlayBodyParsers()
-      val parser = new BodyParsers.Default(parse)
-      val loggingAction = new LoggingAction(parser)
+      val loggingAction = new LoggingAction(defaultParser)
 
       {
         //#actions-wrapping-index
@@ -116,6 +112,7 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       }
 
       {
+        val Action = actionBuilder
         //#actions-wrapping-direct
         def index = Logging {
           Action {
@@ -133,7 +130,9 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       //#actions-def-wrapping
       import play.api.mvc._
 
-      def logging[A](action: Action[A])= Action.async(action.parser) { request =>
+      //###skip:1
+      val Action = actionBuilder
+      def logging[A](action: Action[A]) = Action.async(action.parser) { request =>
         Logger.info("Calling action")
         action(request)
       }
@@ -152,6 +151,8 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       import play.api.mvc._
       import play.api.mvc.request.RemoteConnection
 
+      //###skip:1
+      val Action = actionBuilder
       def xForwardedFor[A](action: Action[A]) = Action.async(action.parser) { request =>
         val newRequest = request.headers.get("X-Forwarded-For") match {
           case None => request
@@ -171,6 +172,8 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       import play.api.mvc._
       //###insert: import play.api.mvc.Results._
 
+      //###skip:1
+      val Action = actionBuilder
       def onlyHttps[A](action: Action[A]) = Action.async(action.parser) { request =>
         request.headers.get("X-Forwarded-Proto").collect {
           case "https" => action(request)
@@ -184,11 +187,11 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
     }
 
     "allow modifying the result" in {
-      implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
-
       //#modify-result
       import play.api.mvc._
 
+      //###skip:1
+      val Action = actionBuilder
       def addUaHeader[A](action: Action[A]) = Action.async(action.parser) { request =>
         action(request).map(_.withHeaders("X-UA-Compatible" -> "Chrome=1"))
       }
@@ -213,11 +216,7 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
         }
       }
       //#authenticated-action-builder
-      implicit val system = ActorSystem()
-      implicit val mat = ActorMaterializer()
-      implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
-      val parser = new BodyParsers.Default()
-      val userAction = new UserAction(parser)
+      val userAction = new UserAction(defaultParser)
 
       def currentUser = userAction { request =>
         Ok("The current user is " + request.username.getOrElse("anonymous"))

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -45,7 +45,6 @@ class ScalaBodyParsersSpec extends SpecificationLike with ControllerHelpers {
     "A scala body parser" should {
 
       "parse request as json" in new WithController() {
-        import scala.concurrent.ExecutionContext.Implicits.global
         //#access-json-body
         def save = Action { request: Request[AnyContent] =>
           val body: AnyContent = request.body
@@ -150,13 +149,15 @@ class ScalaBodyParsersSpec extends SpecificationLike with ControllerHelpers {
         ok
       }
 
-      "parse the body as csv" in new WithApplication() {
+      "parse the body as csv" in new WithApplication() with Injecting {
         import scala.concurrent.ExecutionContext.Implicits.global
         //#csv
         import play.api.mvc.BodyParser
         import play.api.libs.streams._
         import akka.util.ByteString
         import akka.stream.scaladsl._
+
+        val Action = inject[DefaultActionBuilder]
 
         val csv: BodyParser[Seq[Seq[String]]] = BodyParser { req =>
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -5,7 +5,7 @@
 package scalaguide.http.errorhandling
 
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.mvc.Action
+import play.api.mvc.DefaultActionBuilder
 import play.api.test._
 
 import scala.reflect.ClassTag
@@ -15,8 +15,11 @@ class ScalaErrorHandling extends PlaySpecification with WsTestClient {
   def fakeApp[A](implicit ct: ClassTag[A]) = {
     GuiceApplicationBuilder()
       .configure("play.http.errorHandler" -> ct.runtimeClass.getName)
-      .routes {
-        case (_, "/error") => Action(_ => throw new RuntimeException("foo"))
+      .appRoutes { app =>
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        ({
+          case (_, "/error") => Action(_ => throw new RuntimeException("foo"))
+        })
       }
       .build()
   }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
@@ -13,9 +13,12 @@ import play.api.libs.json.Json
 class ExampleEssentialActionSpec extends PlaySpecification {
 
   "An essential action" should {
-    "can parse a JSON body" in new WithApplication() {
-      val action: EssentialAction = Action { request =>
-        val value = (request.body.asJson.get \ "field").as[String]
+    "can parse a JSON body" in new WithApplication() with Injecting {
+      val Action = inject[DefaultActionBuilder]
+      val parse = inject[PlayBodyParsers]
+
+      val action: EssentialAction = Action(parse.json) { request =>
+        val value = (request.body \ "field").as[String]
         Ok(value)
       }
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -6,13 +6,12 @@ package play.core.server
 
 import java.net.InetSocketAddress
 import java.security.{ Provider, SecureRandom }
-import javax.net.ssl._
 
 import akka.actor.ActorSystem
 import akka.http.play.WebSocketHandler
-import akka.http.scaladsl.model.{ headers, _ }
 import akka.http.scaladsl.model.headers.Expect
 import akka.http.scaladsl.model.ws.UpgradeToWebSocket
+import akka.http.scaladsl.model.{ headers, _ }
 import akka.http.scaladsl.settings.{ ParserSettings, ServerSettings }
 import akka.http.scaladsl.util.FastFuture._
 import akka.http.scaladsl.{ ConnectionContext, Http }
@@ -20,16 +19,17 @@ import akka.stream.Materializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import com.typesafe.config.{ Config, ConfigMemorySize }
+import javax.net.ssl._
 import play.api._
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.mvc.akkahttp.AkkaHttpHandler
 import play.api.routing.Router
+import play.core.ApplicationProvider
 import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder }
 import play.core.server.common.{ ReloadCache, ServerDebugInfo, ServerResultUtils }
 import play.core.server.ssl.ServerSSLEngine
-import play.core.ApplicationProvider
 import play.server.SSLEngineProvider
 
 import scala.concurrent.duration._
@@ -419,17 +419,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
 }
 
 /**
- * Creates an AkkaHttpServer from the given router:
- *
- * {{{
- *   val server = AkkaHttpServer.fromRouter(ServerConfig(port = Some(9002))) {
- *     case GET(p"/") => Action {
- *       Results.Ok("Hello")
- *     }
- *   }
- * }}}
- *
- * Or from a given router using [[BuiltInComponents]]:
+ * Creates an AkkaHttpServer from a given router using [[BuiltInComponents]]:
  *
  * {{{
  *   val server = AkkaHttpServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components =>
@@ -536,3 +526,20 @@ trait AkkaHttpServerComponents extends ServerComponents {
 
   def application: Application
 }
+
+/**
+ * A convenient helper trait for constructing an AkkaHttpServer, for example:
+ *
+ * {{{
+ *   val components = new DefaultAkkaHttpServerComponents {
+ *     override lazy val router = {
+ *       case GET(p"/") => Action(parse.json) { body =>
+ *         Ok("Hello")
+ *       }
+ *     }
+ *   }
+ *   val server = components.server
+ * }}}
+ */
+trait DefaultAkkaHttpServerComponents
+  extends AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -6,7 +6,6 @@ package play.api.inject.guice
 
 import play.api._
 import play.api.inject.{ ApplicationLifecycle, bind }
-import play.core.WebCommands
 
 /**
  * An ApplicationLoader that uses Guice to bootstrap the application.

--- a/framework/src/play-integration-test/src/test/java/play/routing/DependencyInjectedRoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/DependencyInjectedRoutingDslTest.java
@@ -16,7 +16,9 @@ public class DependencyInjectedRoutingDslTest extends AbstractRoutingDslTest {
 
     @BeforeClass
     public static void startApp() {
-        app = new GuiceApplicationBuilder().build();
+        app = new GuiceApplicationBuilder()
+                .configure("play.allowGlobalApplication", true)
+                .build();
         Helpers.start(app);
     }
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -279,17 +279,7 @@ class NettyServerProvider extends ServerProvider {
 }
 
 /**
- * Create a Netty server from the given router and server config:
- *
- * {{{
- *   val server = Netty.fromRouter(ServerConfig(port = Some(9002))) {
- *     case GET(p"/") => Action {
- *       Results.Ok("Hello")
- *     }
- *   }
- * }}}
- *
- * Or from a given router using [[BuiltInComponents]]:
+ * Create a Netty server zfrom a given router using [[BuiltInComponents]]:
  *
  * {{{
  *   val server = NettyServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components =>
@@ -349,3 +339,20 @@ trait NettyServerComponents extends ServerComponents {
 
   def application: Application
 }
+
+/**
+ * A convenient helper trait for constructing an NettyServer, for example:
+ *
+ * {{{
+ *   val components = new DefaultNettyServerComponents {
+ *     override lazy val router = {
+ *       case GET(p"/") => Action(parse.json) { body =>
+ *         Ok("Hello")
+ *       }
+ *     }
+ *   }
+ *   val server = components.server
+ * }}}
+ */
+trait DefaultNettyServerComponents
+  extends NettyServerComponents with BuiltInComponents with NoHttpFiltersComponents

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -252,6 +252,7 @@ private[server] trait ServerFromRouter {
    * @param routes the routes definitions
    * @return an AkkaHttpServer instance
    */
+  @deprecated("Use fromRouterWithComponents or use DefaultAkkaHttpServerComponents/DefaultNettyServerComponents", "2.7.0")
   def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): Server = {
     createServerFromRouter(config) { _ => Router.from(routes) }
   }

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -40,11 +40,9 @@ trait PlayRunners extends HttpVerbs {
   val FIREFOX = classOf[FirefoxDriver]
 
   /**
-   * Returns `true` if this application needs to run sequentially, rather than in parallel with other applications.
-   * Typically that means the application and/or test relies on some global state, so this defaults to the
-   * globalApplicationEnabled setting. This method is provided so the behavior can be customized if needed.
+   * Tests using servers share a test server port so we default to true.
    */
-  protected def shouldRunSequentially(app: Application): Boolean = app.globalApplicationEnabled
+  protected def shouldRunSequentially(app: Application): Boolean = true
 
   private[play] def runSynchronized[T](app: Application)(block: => T): T = {
     val needsLock = shouldRunSequentially(app)

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -10,7 +10,8 @@ promise.akka.actor.typed.timeout=5s
 
 play {
   # Defines whether the global application is allowed
-  allowGlobalApplication = true
+  # Set this to true if you need to use play.api.Play.current, Play.application, or any deprecated global helpers.
+  allowGlobalApplication = false
 
   logger {
     # This is a boolean configuration.


### PR DESCRIPTION
This sets `play.allowGlobalApplication = false` by default and updates the tests accordingly.

I also realized there are several places in our documentation where we use global state where we shouldn't be. Perhaps also it would be smart to remove the `Action` companion object to prevent conflicts with the one in `BaseController` and confusion about which `Action` you are using.

Fixes #8050 