### PR TITLE
Fix scripted test for dev mode

### DIFF
--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -195,9 +195,11 @@ $ copy-file changes/application.conf.1 conf/application.conf
 > verifyResourceContains / 500
 > verifyReloads 4
 
-> playStop
 # Revert to the original application.conf
 $ copy-file conf/application.original conf/application.conf
+> verifyResourceContains / 200
+
+> playStop
 
 # devSettings tests
 # -----------------


### PR DESCRIPTION
## Purpose

Scripted test for dev-mode is broken when running in Travis (I could not reproduce it locally, maybe due to different OS). I suspect this is somehow related to the differences between file watcher services for Mac OS and Linux (used by Travis).

## References

#8173 is where the test was introduced. #8179 is a backport that needs a fix too.