### PR TITLE
[2.5.x]: Fix whitesource name: remove additional dash

### DIFF
--- a/framework/project/PlayWhitesourcePlugin.scala
+++ b/framework/project/PlayWhitesourcePlugin.scala
@@ -18,7 +18,7 @@ object PlayWhitesourcePlugin extends AutoPlugin {
   override lazy val projectSettings = Seq(
     whitesourceProduct := "Lightbend Reactive Platform",
     whitesourceAggregateProjectName := "play-framework-2.5-" + {
-      if (isSnapshot.value) "-snapshot" else "-previous"
+      if (isSnapshot.value) "snapshot" else "previous"
     }
   )
 


### PR DESCRIPTION
## Purpose

Remove extra `-` at `whitesourceAggregateProjectName`.

## References

#8186.