### PR TITLE
Update interplay to version 1.3.14

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -391,8 +391,6 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
       Docs.apiDocsInclude := false,
       Docs.apiDocsIncludeManaged := false,
       mimaReportBinaryIssues := (),
-      commands += Commands.quickPublish,
-      whitesourceAggregateProjectName := "playframework-master",
-      whitesourceAggregateProjectToken := "f21388d8-a520-4d3a-afbd-b5cadcea0a6d"
+      commands += Commands.quickPublish
     ).settings(Release.settings: _*)
     .aggregate(publishedProjects: _*)

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -14,7 +14,7 @@ val Versions = new {
   val webjarsLocatorCore = "0.33"
   val sbtHeader = "1.8.0"
   val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.3.12")
-  val interplay: String = sys.props.getOrElse("interplay.version", "1.3.12")
+  val interplay: String = sys.props.getOrElse("interplay.version", "1.3.14")
 }
 
 buildInfoKeys := Seq[BuildInfoKey](

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -196,6 +196,7 @@ $ copy-file changes/application.conf.1 conf/application.conf
 > verifyReloads 4
 
 # Revert to the original application.conf
+$ sleep 1000
 $ copy-file conf/application.original conf/application.conf
 > verifyResourceContains / 200
 


### PR DESCRIPTION
## Purpose

Updates interplay to version 1.3.14. This version changes the naming scheme for Whitesource projects.

## References

https://github.com/playframework/interplay/pull/44
