### PR TITLE
Fix add header for Java RequestHeader

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -570,7 +570,11 @@ public class Http {
          * @return this with the new header added
          */
         public Headers addHeader(String name, String value) {
-            this.headers.put(name, Collections.singletonList(value));
+            if (this.headers.containsKey(name)) {
+                this.headers.get(name).add(value);
+            } else {
+                this.headers.put(name, Collections.singletonList(value));
+            }
             return this;
         }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
@@ -102,7 +102,11 @@ class Headers(protected var _headers: Seq[(String, String)]) {
    */
   lazy val toSimpleMap: Map[String, String] = toMap.mapValues(_.headOption.getOrElse(""))
 
-  lazy val asJava: play.mvc.Http.Headers = new play.mvc.Http.Headers(this.toMap.mapValues(_.asJava).asJava)
+  lazy val asJava: play.mvc.Http.Headers = {
+    val mappedValues: Map[String, java.util.List[String]] = this.toMap
+      .mapValues(v => new java.util.ArrayList[String](v.asJava))
+    new play.mvc.Http.Headers(mappedValues.asJava)
+  }
 
   /**
    * A headers map with all keys normalized to lowercase

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -4,6 +4,7 @@
 package play.api.mvc
 
 import java.security.cert.X509Certificate
+import java.util
 
 import org.specs2.mutable.Specification
 import play.api.http.HeaderNames._
@@ -11,6 +12,8 @@ import play.api.http.HttpConfiguration
 import play.api.i18n.Lang
 import play.api.libs.typedmap.{ TypedKey, TypedMap }
 import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestTarget }
+
+import scala.collection.JavaConverters._
 
 class RequestHeaderSpec extends Specification {
 
@@ -24,6 +27,44 @@ class RequestHeaderSpec extends Specification {
       "keep the headers accessible case insensitively" in {
         val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
         rh.asJava.getHeaders.contains("host") must beTrue
+      }
+      "add new headers" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
+        rh.asJava.getHeaders.addHeader("New-Header", "Value").contains("New-Header") must beTrue
+      }
+      "add value to an existing header" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com", "Header" -> "1"))
+        rh.asJava
+          .getHeaders
+          .addHeader("Header", "2")
+          .getAll("Header")
+          .asScala must containAllOf(Seq("1", "2"))
+      }
+      "add multiple values to an existing header" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com", "Header" -> "1"))
+        rh.asJava
+          .getHeaders
+          .addHeader("Header", util.Arrays.asList("2", "3"))
+          .getAll("Header")
+          .asScala must containAllOf(Seq("1", "2", "3"))
+      }
+      "add new header when using toMap" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com", "Header" -> "1"))
+        val headersMap = rh.asJava
+          .getHeaders
+          .toMap
+
+        headersMap.put("New-Header", util.Arrays.asList("Value"))
+        headersMap.get("New-Header").contains("Value") must beTrue
+      }
+      "add value to an existing header when using toMap" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com", "Header" -> "1"))
+        val headersMap = rh.asJava
+          .getHeaders
+          .toMap
+
+        headersMap.get("Header").add("2")
+        headersMap.get("Header").asScala must containAllOf(Seq("1", "2"))
       }
     }
 


### PR DESCRIPTION
## Purpose

There are two problems here:

1. Http.Headers are not preserving existing values

When adding a new header either with a single value or multiple values, the existing values are discarded.

2. Not possible to add new values when using toMap

This is a more specific use case: after calling:

    val headersMap = scalaHeaders.asJava.toMap

It is not possible to add values to existing headers like:

    headersMap.get("Some-Header").add("New-Value")

Because the existing List inside the map does not implement `add`, but uses the default `add` implementation from `AbstractList` which throws UnsupportedOperationException. The problems happen because when transforming Scala collections into Java ones (using for example `scalaSeq.asJava`) the result type is a direct child of `AbstractList`, but that doesn't override `add`.

To fix that, `play.api.mvc.Headers.asJava` needs to use an appropriated implementation of `List`.