### PR TITLE
Fix #8128 - Invalid query string in NettyHttpServer

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
@@ -79,6 +79,14 @@ class UriHandlingSpec extends PlaySpecification with EndpointIntegrationSpecific
           response.body.string must_=== """/?filter=a,b"""
         }
       }
+
+    "handle '/pat?param=%_D%' as a URI with an invalid query string" in makeRequest(
+      "/pat?param=%_D%"
+    ) {
+        case (endpoint, response) => {
+          response.body.string must_=== """/pat"""
+        }
+      }
   }
 
 }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -27,6 +27,7 @@ import play.core.server.common.{ ForwardedHeaderHandler, ServerResultUtils }
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 import scala.util.{ Failure, Try }
 
 private[server] class NettyModelConversion(
@@ -110,9 +111,15 @@ private[server] class NettyModelConversion(
       override val queryString: String = parsedQueryString.stripPrefix("?")
       override lazy val queryMap: Map[String, Seq[String]] = {
         val decoder = new QueryStringDecoder(parsedQueryString)
-        val decodedParameters = decoder.parameters()
-        if (decodedParameters.isEmpty) Map.empty
-        else decodedParameters.asScala.mapValues(_.asScala.toList).toMap
+        val decodedParameters =
+          try {
+            Some(decoder.parameters())
+          } catch {
+            case NonFatal(e) =>
+              logger.warn("Failed to parse query string; returning empty map.", e)
+              None
+          }
+        decodedParameters.filter(!_.isEmpty).map(_.asScala.mapValues(_.asScala.toList).toMap).getOrElse(Map.empty)
       }
     }
   }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -111,15 +111,13 @@ private[server] class NettyModelConversion(
       override val queryString: String = parsedQueryString.stripPrefix("?")
       override lazy val queryMap: Map[String, Seq[String]] = {
         val decoder = new QueryStringDecoder(parsedQueryString)
-        val decodedParameters =
-          try {
-            Some(decoder.parameters())
-          } catch {
-            case NonFatal(e) =>
-              logger.warn("Failed to parse query string; returning empty map.", e)
-              None
-          }
-        decodedParameters.filter(!_.isEmpty).map(_.asScala.mapValues(_.asScala.toList).toMap).getOrElse(Map.empty)
+        try {
+          decoder.parameters().asScala.mapValues(_.asScala.toList).toMap
+        } catch {
+          case NonFatal(e) =>
+            logger.warn("Failed to parse query string; returning empty map.", e)
+            Map.empty
+        }
       }
     }
   }


### PR DESCRIPTION
NettyModelConversion should return an empty map instead of an Internal Server Error if the query string can not be parsed.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #8128 

## Purpose

We should avoid returning Internal Server Error when query string can not be parsed. Returning an empty parameter map should provide a better user experience for the end user. Additionally, AkkaHttpServer vs NettyHttpServer behaving similarly is desirable in terms of consistency.
