### PR TITLE
Move setAutoCommit call into try block

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -140,7 +140,13 @@ abstract class DefaultDatabase(val name: String, configuration: Config, environm
 
   def getConnection(autocommit: Boolean): Connection = {
     val connection = dataSource.getConnection
-    connection.setAutoCommit(autocommit)
+    try {
+      connection.setAutoCommit(autocommit)
+    } catch {
+      case e: Throwable =>
+        connection.close()
+        throw e
+    }
     connection
   }
 


### PR DESCRIPTION
The setAutoCommit call can potentially throw an exception, causing DB connections to leak. This commit wraps the call in a try/catch block, closing the connection if necessary.

## Fixes

Fixes #8196.