### PR TITLE
add a way to read X-Forwarded-Proto in RedirectHttpsFilter

### DIFF
--- a/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
@@ -53,3 +53,10 @@ play.filters.https.port = 9443
 
 then the URL in the `Location` header will include the port specifically, e.g. https://playframework.com:9443/some/url
 
+## X-Forwarded-Proto Header
+
+It is possible to only redirect if a `x-forwarded-proto` header is set to `http`, this can be enabled by adding the following to `application.conf`:
+
+```
+play.filters.https.xForwardedProtoEnabled = true
+```

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -259,7 +259,13 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache_="),
       ProblemFilters.exclude[FinalMethodProblem]("play.api.inject.guice.FakeRoutes.handlerFor"),
       ProblemFilters.exclude[FinalMethodProblem]("play.core.routing.GeneratedRouter.handlerFor"),
-      ProblemFilters.exclude[FinalMethodProblem]("play.api.routing.SimpleRouterImpl.handlerFor")
+      ProblemFilters.exclude[FinalMethodProblem]("play.api.routing.SimpleRouterImpl.handlerFor"),
+
+      // Added xForwardedForProto handling to RedirectHttpsFilter
+      ProblemFilters.exclude[MissingTypesProblem]("play.filters.https.RedirectHttpsConfiguration$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.this")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -216,6 +216,12 @@ play.filters {
     # not change the HTTP method according to [RFC 7238](https://tools.ietf.org/html/rfc7538).
     redirectStatusCode = 308
 
+    # A boolean defining wheter to only redirect if a x-forwarded-proto header is set to http.
+    # This is a defacto standard that will be used by various proxys or load balancers to determine
+    # if a redirect should happen.
+    # [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto)
+    xForwardedProtoEnabled = false
+
     # The HTTPS port to use in the Redirect's Location URL.
     # e.g. port = 9443 results in https://playframework.com:9443/some/url
     port = null

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -77,7 +77,7 @@ case class RedirectHttpsConfiguration(
     redirectStatusCode: Int = PERMANENT_REDIRECT,
     sslPort: Option[Int] = None, // should match up to ServerConfig.sslPort
     redirectEnabled: Boolean = true,
-    xForwardedProtoEnabled: Boolean = false,
+    xForwardedProtoEnabled: Boolean = false
 ) {
   @deprecated("Use redirectEnabled && strictTransportSecurity.isDefined", "2.7.0")
   def hstsEnabled: Boolean = redirectEnabled && strictTransportSecurity.isDefined

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -11,6 +11,7 @@ import play.api.inject.{ SimpleModule, bind }
 import play.api.mvc._
 import play.api.{ Configuration, Environment, Mode }
 import play.api.Logger
+import play.api.http.HeaderNames
 
 /**
  * A filter that redirects HTTP requests to https requests.
@@ -36,7 +37,7 @@ class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration) extends
 
   @inline
   private[this] def forwardedProto(req: RequestHeader) = {
-    if (xForwardedProtoEnabled) req.headers.get("x-forwarded-proto").contains("http")
+    if (xForwardedProtoEnabled) req.headers.get(HeaderNames.X_FORWARDED_PROTO).contains("http")
     else true
   }
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -54,7 +54,7 @@ class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration) extends
           logger.info(s"Not redirecting to HTTPS because $redirectEnabledPath flag is not set.")
         } else {
           logger.debug(s"Not redirecting to HTTPS because $forwardedProtoEnabled flag is set and " +
-              "X-Forwareded-Proto is not present.")
+              "X-Forwarded-Proto is not present.")
         }
         next(req)
       }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -54,7 +54,7 @@ class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration) extends
           logger.info(s"Not redirecting to HTTPS because $redirectEnabledPath flag is not set.")
         } else {
           logger.debug(s"Not redirecting to HTTPS because $forwardedProtoEnabled flag is set and " +
-              "X-Forwarded-Proto is not present.")
+            "X-Forwarded-Proto is not present.")
         }
         next(req)
       }
@@ -92,8 +92,8 @@ private object RedirectHttpsKeys {
 }
 
 @Singleton
-class RedirectHttpsConfigurationProvider @Inject()(c: Configuration, e: Environment)
-    extends Provider[RedirectHttpsConfiguration] {
+class RedirectHttpsConfigurationProvider @Inject() (c: Configuration, e: Environment)
+  extends Provider[RedirectHttpsConfiguration] {
 
   import RedirectHttpsKeys._
 
@@ -110,7 +110,7 @@ class RedirectHttpsConfigurationProvider @Inject()(c: Configuration, e: Environm
       if (e.mode != Mode.Prod) {
         logger.info(
           s"RedirectHttpsFilter is disabled by default except in Prod mode.\n" +
-              s"See https://www.playframework.com/documentation/2.6.x/RedirectHttpsFilter"
+            s"See https://www.playframework.com/documentation/2.6.x/RedirectHttpsFilter"
         )
       }
       e.mode == Mode.Prod

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -110,6 +110,29 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
 
       header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=12345; includeSubDomains")
     }
+
+    "not redirect when xForwardedProtoEnabled is set but no header present" in new WithApplication(buildApp(
+      """
+        |play.filters.https.redirectEnabled = true
+        |play.filters.https.xForwardedProtoEnabled = true
+      """.stripMargin, mode = Mode.Test)) {
+      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+      val result = route(app, request().withConnection(secure)).get
+
+      header(STRICT_TRANSPORT_SECURITY, result) must beNone
+      status(result) must_== OK
+    }
+    "redirect when xForwardedProtoEnabled is set and header is present" in new WithApplication(buildApp(
+      """
+        |play.filters.https.redirectEnabled = true
+        |play.filters.https.xForwardedProtoEnabled = true
+      """.stripMargin, mode = Mode.Test)) {
+      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+      val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")).get
+
+      header(STRICT_TRANSPORT_SECURITY, result) must beNone
+      status(result) must_== PERMANENT_REDIRECT
+    }
   }
 
   private def request(uri: String = "/") = {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -122,6 +122,17 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       header(STRICT_TRANSPORT_SECURITY, result) must beNone
       status(result) must_== OK
     }
+    "redirect when xForwardedProtoEnabled is not set and no header present" in new WithApplication(buildApp(
+      """
+        |play.filters.https.redirectEnabled = true
+        |play.filters.https.xForwardedProtoEnabled = false
+      """.stripMargin, mode = Mode.Test)) {
+      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+      val result = route(app, request().withConnection(secure)).get
+
+      header(STRICT_TRANSPORT_SECURITY, result) must beNone
+      status(result) must_== PERMANENT_REDIRECT
+    }
     "redirect when xForwardedProtoEnabled is set and header is present" in new WithApplication(buildApp(
       """
         |play.filters.https.redirectEnabled = true

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -22,6 +22,7 @@ import play.core.ApplicationProvider
 import play.core.server.{ NettyServer, Server }
 import play.core.server.common.{ ReloadCache, ServerResultUtils }
 
+import scala.compat.java8.FutureConverters
 import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
 


### PR DESCRIPTION
currently the RedirectHttpsFilter is really handy if one actually
directly wants to use a L4/L7 cloud load balancer, however
most of these need Health Checks and aren't happy if one just
redirects to HTTPS, so there is a header to look for and if it
is present it will redirect to HTTPS if it isn't present it
will just serve the content.
