### PR TITLE
Don't assume developers are male

### DIFF
--- a/documentation/manual/working/commonGuide/database/Evolutions.md
+++ b/documentation/manual/working/commonGuide/database/Evolutions.md
@@ -82,7 +82,7 @@ For example, to enable `autoApply` for all evolutions, you might set `play.evolu
 
 ## Synchronizing concurrent changes
 
-Now let’s imagine that we have two developers working on this project. Developer A will work on a feature that requires a new database table. So he will create the following `2.sql` evolution script:
+Now let’s imagine that we have two developers working on this project. Developer A will work on a feature that requires a new database table. So they will create the following `2.sql` evolution script:
 
 ```
 # Add Post
@@ -104,7 +104,7 @@ DROP TABLE Post;
 
 Play will apply this evolution script to Developer A’s database.
 
-On the other hand, developer B will work on a feature that requires altering the User table. So she will also create the following `2.sql` evolution script:
+On the other hand, developer B will work on a feature that requires altering the User table. So they will also create the following `2.sql` evolution script:
 
 ```
 # Update User
@@ -116,7 +116,7 @@ ALTER TABLE User ADD age INT;
 ALTER TABLE User DROP age;
 ```
 
-Developer B finishes her feature and commits (let’s say they are using Git). Now developer A has to merge the his colleague’s work before continuing, so he runs git pull, and the merge has a conflict, like:
+Developer B finishes their feature and commits (let’s say they are using Git). Now developer A has to merge their colleague’s work before continuing, so they run git pull, and the merge has a conflict, like:
 
 ```
 Auto-merging db/evolutions/2.sql
@@ -180,7 +180,7 @@ DROP TABLE Post;
 
 This evolution script represents the new revision 2 of the database, that is different of the previous revision 2 that developer A has already applied.
 
-So Play will detect it and ask developer A to synchronize his database by first reverting the old revision 2 already applied, and by applying the new revision 2 script:
+So Play will detect it and ask developer A to synchronize their database by first reverting the old revision 2 already applied, and by applying the new revision 2 script:
 
 ## Inconsistent states
 

--- a/documentation/manual/working/commonGuide/database/Evolutions.md
+++ b/documentation/manual/working/commonGuide/database/Evolutions.md
@@ -82,7 +82,7 @@ For example, to enable `autoApply` for all evolutions, you might set `play.evolu
 
 ## Synchronizing concurrent changes
 
-Now let’s imagine that we have two developers working on this project. Developer A will work on a feature that requires a new database table. So they will create the following `2.sql` evolution script:
+Now let’s imagine that we have two developers working on this project. Jamie will work on a feature that requires a new database table. So Jamie will create the following `2.sql` evolution script:
 
 ```
 # Add Post
@@ -102,9 +102,9 @@ CREATE TABLE Post (
 DROP TABLE Post;
 ```
 
-Play will apply this evolution script to Developer A’s database.
+Play will apply this evolution script to Jamie’s database.
 
-On the other hand, developer B will work on a feature that requires altering the User table. So they will also create the following `2.sql` evolution script:
+On the other hand, Robin will work on a feature that requires altering the User table. So Robin will also create the following `2.sql` evolution script:
 
 ```
 # Update User
@@ -116,7 +116,7 @@ ALTER TABLE User ADD age INT;
 ALTER TABLE User DROP age;
 ```
 
-Developer B finishes their feature and commits (let’s say they are using Git). Now developer A has to merge their colleague’s work before continuing, so they run git pull, and the merge has a conflict, like:
+Robin finishes the feature and commits (let’s say by using Git). Now Jamie has to merge Robin’s work before continuing, so Jamie runs git pull, and the merge has a conflict, like:
 
 ```
 Auto-merging db/evolutions/2.sql
@@ -124,7 +124,7 @@ CONFLICT (add/add): Merge conflict in db/evolutions/2.sql
 Automatic merge failed; fix conflicts and then commit the result.
 ```
 
-Each developer has created a `2.sql` evolution script. So developer A needs to merge the contents of this file:
+Each developer has created a `2.sql` evolution script. So Jamie needs to merge the contents of this file:
 
 ```
 <<<<<<< HEAD
@@ -178,9 +178,9 @@ ALTER TABLE User DROP age;
 DROP TABLE Post;
 ```
 
-This evolution script represents the new revision 2 of the database, that is different of the previous revision 2 that developer A has already applied.
+This evolution script represents the new revision 2 of the database, that is different of the previous revision 2 that Jamie has already applied.
 
-So Play will detect it and ask developer A to synchronize their database by first reverting the old revision 2 already applied, and by applying the new revision 2 script:
+So Play will detect it and ask Jamie to synchronize the database by first reverting the old revision 2 already applied, and by applying the new revision 2 script:
 
 ## Inconsistent states
 

--- a/documentation/manual/working/commonGuide/database/Evolutions.md
+++ b/documentation/manual/working/commonGuide/database/Evolutions.md
@@ -104,7 +104,7 @@ DROP TABLE Post;
 
 Play will apply this evolution script to Developer A’s database.
 
-On the other hand, developer B will work on a feature that requires altering the User table. So he will also create the following `2.sql` evolution script:
+On the other hand, developer B will work on a feature that requires altering the User table. So she will also create the following `2.sql` evolution script:
 
 ```
 # Update User
@@ -116,7 +116,7 @@ ALTER TABLE User ADD age INT;
 ALTER TABLE User DROP age;
 ```
 
-Developer B finishes his feature and commits (let’s say they are using Git). Now developer A has to merge the his colleague’s work before continuing, so he runs git pull, and the merge has a conflict, like:
+Developer B finishes her feature and commits (let’s say they are using Git). Now developer A has to merge the his colleague’s work before continuing, so he runs git pull, and the merge has a conflict, like:
 
 ```
 Auto-merging db/evolutions/2.sql


### PR DESCRIPTION
## Purpose

One simple technique to normalize the thought of women being developers is to use he for some examples and she for others. When reading this part of the documentation, I stumbled upon the example where both developers are assumed to be male.

An alternative, that is not assuming any gender at all (going beyond binary gender identification), would be to use completely gender neutral language.


# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?