### PR TITLE
Do not throw exception when trying to get a cookie that doesnt exist …

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -280,7 +280,7 @@ public class Result {
         return new Cookies() {
             @Override
             public Cookie get(String name) {
-                return cookies.stream().filter(c -> c.name().equals(name)).findFirst().get();
+                return cookies.stream().filter(c -> c.name().equals(name)).findFirst().orElse(null);
             }
 
             @Override


### PR DESCRIPTION
…for a Result

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

In our tests, we use the router to generate Results and then check for the existence of cookies. We know that cookies should only be set in some instances, so our tests generate the Result then check if the cookie is present or not. Currently though if the cookie is missing it throws an exception instead of returning null
