### PR TITLE
remove duplicate execution of action async block

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -34,7 +34,6 @@ trait CORSActionBuilder extends ActionBuilder[Request, AnyContent] with Abstract
           case r: Request[A] => Accumulator.done(block(r))
           case _ => Accumulator.done(block(req.withBody(request.body)))
         }
-        Accumulator.done(block(req.asInstanceOf[Request[A]]))
       }
     }
 


### PR DESCRIPTION
In our code we are using the CORSActionBuilder.  We updated to play 2.6 and discovered that our async actions that use this builder were executing twice!

Upon investigation, it turned out that there is some code that evaluates the block twice, discarding the first result.  However because Future has a side effect when created, the code is executed. a second time.

It looks like the duplication was just the author considered two approaches and never settled on a specific one but left both in.

## Purpose

This PR removes the second of the approaches, this meaning the block will be called exactly once.

## References

Original change here:
https://github.com/playframework/playframework/pull/7409/files#diff-fa325da5d47d46c39e3044b9fcf62397R33
Our code that uses the cors builder:
https://github.com/guardian/members-data-api/blob/7b5aad94b0c909aad6fa0282e8d2a6c285f9602e/membership-attribute-service/app/controllers/AccountController.scala#L41

@marcospereira any suggestion whether I took the right approach?