### PR TITLE
Remove references to g8Scaffold

### DIFF
--- a/documentation/manual/gettingStarted/NewApplication.md
+++ b/documentation/manual/gettingStarted/NewApplication.md
@@ -1,21 +1,22 @@
 <!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+
 # Creating a new application
 
 ## Using Play Starter Projects
 
 If you've never used Play before, then you can [download a starter project](https://playframework.com/download#starters). The starter projects have lots of comments explaining how everything works and have links to documentation that goes more in depth.
 
-If you download and unzip one of the .zip files [at the starter projects](https://playframework.com/download#starters), you'll see the `sbt` executable file -- this is a packaged version of [sbt](http://www.scala-sbt.org), the build tool Play uses. If you're on Windows, you would use `sbt.bat` instead.
+If you download and unzip one of the .zip files [at the starter projects](https://playframework.com/download#starters), you'll see the `sbt` executable file -- this is a packaged version of [sbt](http://www.scala-sbt.org), the build tool Play uses. If you're on Windows, you need to use `sbt.bat` instead.
 
 See [our download page](https://playframework.com/download#starters) to get more details about how to use the starter projects.
 
 ## Create a new application using SBT
 
-If you have [sbt 0.13.13 or higher](http://www.scala-sbt.org) installed, you can create your own Play project using `sbt new` using a minimal [giter8](http://foundweekends.org/giter8) template (roughly like a maven archetype). This is a good choice if you already know Play and want to create a new project immediately.
+If you have [sbt 0.13.13 or higher](http://www.scala-sbt.org) installed, you can create your Play project using `sbt new` using a minimal [giter8](http://foundweekends.org/giter8) template (roughly like a maven archetype). This is a good choice if you already know Play and want to create a new project immediately.
 
 > **Note**: If running Windows, you may need to run sbt using `sbt.bat` instead of `sbt`. This documentation assumes the command is `sbt`.
 
-Note that the seed templates are already configured with [[CSRF|ScalaCsrf]] and [[security headers filters|SecurityHeaders]], whereas the other projects are not specifically set up for security out of the box.
+Note that the seed templates are already configured with [[CSRF|ScalaCsrf]] and [[security headers filters|SecurityHeaders]], whereas the other projects are not explicitly set up for security out of the box.
 
 ### Play Java Seed
 
@@ -29,9 +30,9 @@ sbt new playframework/play-java-seed.g8
 sbt new playframework/play-scala-seed.g8
 ```
 
-After that, use `sbt run` and then go to http://localhost:9000 to see the running server.
+After that, use `sbt run` and then go to <http://localhost:9000> to see the running server.
 
-Type `g8Scaffold form` from sbt to create the scaffold controller, template and tests needed to process a form. You can also create your own giter8 seeds and scaffolds based off this one by forking from the https://github.com/playframework/play-java-seed.g8 or https://github.com/playframework/play-scala-seed.g8 github projects.
+You can also [create your own giter8 seeds](http://www.foundweekends.org/giter8/usage.html) and based off this one by forking from the <https://github.com/playframework/play-java-seed.g8> or <https://github.com/playframework/play-scala-seed.g8> GitHub projects.
 
 ## Play Example Projects
 

--- a/documentation/manual/gettingStarted/Tutorials.md
+++ b/documentation/manual/gettingStarted/Tutorials.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play Tutorials
 
 Play's documentation shows the available features and how to use them, but the documentation will not show how to create an application from start to finish.  This is where tutorials and examples come in.
@@ -20,17 +21,15 @@ If you have [sbt 0.13.13 or higher](http://scala-sbt.org) installed, you can cre
 
 > **Note**: If running Windows, you may need to run sbt using `sbt.bat` instead of `sbt`. This documentation assumes the command is `sbt`.
 
-Type `g8Scaffold form` from sbt to create the scaffold controller, template and tests needed to process a form.
-
 #### Java
 
-```
+```bash
 sbt new playframework/play-java-seed.g8
 ```
 
 #### Scala
 
-```
+```bash
 sbt new playframework/play-scala-seed.g8
 ```
 


### PR DESCRIPTION
## Fixes

Fixes playframework/play-scala-starter-example#68.

## Purpose

The giter8 sbt plugin for scaffold does not have a final release for sbt 1.0 which is used in our seeds and starter projects.