### PR TITLE
Prevent none/none to leak into Play (master)

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -100,7 +100,9 @@ import AkkaDependency._
 lazy val PlayAkkaHttpServerProject = PlayCrossBuiltProject("Play-Akka-Http-Server", "play-akka-http-server")
     .dependsOn(PlayServerProject, StreamsProject)
     .dependsOn(PlayGuiceProject % "test")
-    .addAkkaModuleDependency("akka-http-core")
+    .settings(
+      libraryDependencies ++= specsBuild.map(_ % "test")
+    ).addAkkaModuleDependency("akka-http-core")
 
 lazy val PlayAkkaHttp2SupportProject = PlayCrossBuiltProject("Play-Akka-Http2-Support", "play-akka-http2-support")
     .dependsOn(PlayAkkaHttpServerProject)

--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.akkahttp
+
+import akka.http.scaladsl.model._
+import org.specs2.mutable.Specification
+import play.api.http.HeaderNames
+
+class AkkaHeadersWrapperTest extends Specification {
+  val emptyRequest: HttpRequest = HttpRequest()
+
+  "AkkaHeadersWrapper" should {
+    "return no Content-Type Header when there's not entity (therefore no content type ) in the request" in {
+      val request = emptyRequest.copy()
+      val headersWrapper = AkkaHeadersWrapper(request, None, request.headers, None, "some-uri")
+
+      headersWrapper.headers.find { case (k, _) => k == HeaderNames.CONTENT_TYPE } must be(None)
+    }
+
+    "return the appropriate Content-Type Header when there's a request entity" in {
+      val plainTextEntity = HttpEntity("Some payload")
+      val request = emptyRequest.copy(entity = plainTextEntity)
+      val headersWrapper = AkkaHeadersWrapper(request, None, request.headers, None, "some-uri")
+
+      val actualHeaderValue = headersWrapper
+        .headers
+        .find { case (k, _) => k == HeaderNames.CONTENT_TYPE }
+        .get._2
+      actualHeaderValue mustEqual "text/plain; charset=UTF-8"
+    }
+
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -3,7 +3,6 @@
  */
 package play.it.http
 
-import org.specs2.specification.core.Fragments
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test._

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.it.http
 
+import org.specs2.specification.core.Fragments
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test._
@@ -11,35 +12,36 @@ import play.core.server.ServerConfig
 import play.it._
 
 class NettyRequestHeadersSpec extends RequestHeadersSpec with NettyIntegrationSpecification
+
 class AkkaHttpRequestHeadersSpec extends RequestHeadersSpec with AkkaHttpIntegrationSpecification
 
 trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecification with HttpHeadersCommonSpec {
 
   sequential
 
+  def withServerAndConfig[T](configuration: (String, Any)*)(action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
+    val port = testServerPort
+
+    val serverConfig: ServerConfig = {
+      val c = ServerConfig(port = Some(testServerPort), mode = Mode.Test)
+      c.copy(configuration = c.configuration ++ Configuration(configuration: _*))
+    }
+    running(play.api.test.TestServer(serverConfig, GuiceApplicationBuilder().appRoutes { app =>
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
+      val parse = app.injector.instanceOf[PlayBodyParsers]
+      ({
+        case _ => action(Action, parse)
+      })
+    }.build(), Some(integrationServerProvider))) {
+      block(port)
+    }
+  }
+
+  def withServer[T](action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
+    withServerAndConfig()(action)(block)
+  }
+
   "Play request header handling" should {
-
-    def withServerAndConfig[T](configuration: (String, Any)*)(action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
-      val port = testServerPort
-
-      val serverConfig: ServerConfig = {
-        val c = ServerConfig(port = Some(testServerPort), mode = Mode.Test)
-        c.copy(configuration = c.configuration ++ Configuration(configuration: _*))
-      }
-      running(play.api.test.TestServer(serverConfig, GuiceApplicationBuilder().appRoutes { app =>
-        val Action = app.injector.instanceOf[DefaultActionBuilder]
-        val parse = app.injector.instanceOf[PlayBodyParsers]
-        ({
-          case _ => action(Action, parse)
-        })
-      }.build(), Some(integrationServerProvider))) {
-        block(port)
-      }
-    }
-
-    def withServer[T](action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
-      withServerAndConfig()(action)(block)
-    }
 
     "get request headers properly" in withServer((Action, _) => Action { rh =>
       Results.Ok(rh.headers.getAll("Origin").mkString(","))
@@ -66,6 +68,17 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
         BasicRequest("GET", "/", "HTTP/1.1", Map("origin" -> "http://foo"), "")
       )
       response.body.left.toOption must beSome("https://bar.com")
+    }
+
+    "not expose a content-type when there's no body" in withServer((Action, _) => Action { rh =>
+      // the body is a String representation of `get("Content-Type")`
+      Results.Ok(rh.headers.get("Content-Type").getOrElse("no-header"))
+    }) { port =>
+      val Seq(response) = BasicHttpClient.makeRequests(port)(
+        // an empty body implies no parsing is used and no content type is derived from the body.
+        BasicRequest("GET", "/", "HTTP/1.1", Map.empty, "")
+      )
+      response.body.left.toOption must beSome("no-header")
     }
 
     "pass common tests for headers" in withServer((Action, _) => Action { rh =>


### PR DESCRIPTION
Fixes #8228

When switching backends small changes between Netty and Akka HTTP slipped. Akka HTTP models the lack of a Content-Type header with something like `Some(ContentType("none/none"))`. This PR captures that case and propagates the equivalent of `None` instead.