### PR TITLE
Upgrades ALPN agent to 2.0.7

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
   val acolyteVersion = "1.0.46"
   val acolyte = "org.eu.acolyte" % "jdbc-driver" % acolyteVersion
 
-  val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.6"
+  val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.7"
 
   val jjwt = "io.jsonwebtoken" % "jjwt" % "0.7.0"
 


### PR DESCRIPTION
Fixes APLN issue found in https://github.com/playframework/playframework/issues/8234#issuecomment-367217731

The TL;DR is that if you have Java b161 and you run the integration tests, you get:

```
[jetty-alpn-agent] Replacing: sun/security/ssl/Alerts
Exception in thread "specs2.fixed.env397465184-3" java.lang.NoClassDefFoundError: sun/security/ssl/SupportedEllipticCurvesExtension
```

The latest ALPN is 2.0.7 and has support for b161, and adding it fixes the problem.

https://github.com/jetty-project/jetty-alpn-agent/releases/tag/jetty-alpn-agent-2.0.7