### PR TITLE
[Proposal][WIP] Allow CIDRs in `play.filters.hosts.allowed` setting

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -234,7 +234,7 @@ lazy val PlayOpenIdProject = PlayCrossBuiltProject("Play-OpenID", "play-openid")
 lazy val PlayFiltersHelpersProject = PlayCrossBuiltProject("Filters-Helpers", "play-filters-helpers")
     .settings(
       parallelExecution in Test := false
-    ).dependsOn(PlayProject % "compile;test->test", PlayTestProject % "test",
+    ).dependsOn(PlayProject % "compile;test->test", PlayServerProject % "compile;test->test", PlayTestProject % "test",
         PlayJavaProject % "test", PlaySpecs2Project % "test", PlayAhcWsProject % "test")
 
 // This project is just for testing Play, not really a public artifact

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -234,7 +234,7 @@ lazy val PlayOpenIdProject = PlayCrossBuiltProject("Play-OpenID", "play-openid")
 lazy val PlayFiltersHelpersProject = PlayCrossBuiltProject("Filters-Helpers", "play-filters-helpers")
     .settings(
       parallelExecution in Test := false
-    ).dependsOn(PlayProject, PlayTestProject % "test",
+    ).dependsOn(PlayProject % "compile;test->test", PlayTestProject % "test",
         PlayJavaProject % "test", PlaySpecs2Project % "test", PlayAhcWsProject % "test")
 
 // This project is just for testing Play, not really a public artifact

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -225,12 +225,11 @@ class AllowedHostsFilterSpec extends PlaySpecification with ScalaCheck {
         a <- Gen.choose(0, 255)
         b <- Gen.choose(0, 255)
         c <- Gen.choose(0, 255)
-      } yield InvalidAddress(s"10.$a.$b.$c", cidr)
+      } yield s"10.$a.$b.$c" -> cidr
 
-      addGen.filter {
-        case InvalidAddress(ipAddress, cidr) =>
-          !Subnet(s"10.0.0.0/$cidr").isInRange(InetAddress.getByName(ipAddress))
-      }
+      addGen
+        .filter { case ((ipAddress, cidr)) => !Subnet(s"10.0.0.0/$cidr").isInRange(InetAddress.getByName(ipAddress)) }
+        .map { case ((ipAddress, cidr)) => InvalidAddress(ipAddress, cidr) }
     }
 
     implicit val arbInvalidAddress: Arbitrary[InvalidAddress] = Arbitrary(genInvalidAddress)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -222,7 +222,6 @@ class AllowedHostsFilterSpec extends PlaySpecification with ScalaCheck {
     def genInvalidAddress: Gen[InvalidAddress] = {
       val addGen = for {
         cidr <- genCIDR
-        (as, bs) <- genIpRanges(cidr)
         a <- Gen.choose(0, 255)
         b <- Gen.choose(0, 255)
         c <- Gen.choose(0, 255)

--- a/framework/src/play-server/src/main/scala/play/core/server/common/Subnet.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/Subnet.scala
@@ -31,7 +31,7 @@ private[common] case class Subnet(ip: InetAddress, cidr: Option[Int] = None) {
   }
 }
 
-private[common] object Subnet {
+private[play] object Subnet {
   def apply(s: String): Subnet = s.split("/") match {
     case Array(ip, subnet) => Subnet(InetAddresses.forString(ip), Some(subnet.toInt))
     case Array(ip) => Subnet(InetAddresses.forString(ip))


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Nothing

## Purpose

Hi,

I want to add the possibility to define the allowed hosts with "subnet IP ranges" (I don't know the real/exact name of this) like this:
```
play.filters.hosts.allowed = ["10.0.0.0/24"]
```

It is very useful in dynamic envs like Kubernetes, clouds, etc.

What's your opinion about this feature ? Do you think that it could have its place inside Play ?

## Background Context

For now, I just implemented the failing tests. I'll modify the `HostMatcher` and/or the `AllowedHostsFilter` classes if the idea interests Play maintainers.

## References

Nothing
