### PR TITLE
Remove newlines in twirl templates

### DIFF
--- a/framework/src/play-docs-sbt-plugin/src/main/twirl/com/typesafe/play/docs/sbtplugin/translationReport.scala.html
+++ b/framework/src/play-docs-sbt-plugin/src/main/twirl/com/typesafe/play/docs/sbtplugin/translationReport.scala.html
@@ -1,5 +1,4 @@
 @(report: com.typesafe.play.docs.sbtplugin.PlayDocsValidation.TranslationReport, version: String)
-
 <!DOCTYPE html>
 <html lang="en">
     <head>

--- a/framework/src/play/src/main/scala/views/defaultpages/badRequest.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/badRequest.scala.html
@@ -2,7 +2,6 @@
  * Default page for 400 Bad Request responses.
  *@
 @(method: String, uri: String, error:String)
-
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -44,10 +43,3 @@
 
     </body>
 </html>
-
-
-
-
-
-
-

--- a/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
@@ -3,7 +3,6 @@
  * This page display the error in the source code context.
  *@
 @(playEditor: Option[String], error: play.api.UsefulException)
-
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -213,10 +212,3 @@
 
     </body>
 </html>
-
-
-
-
-
-
-

--- a/framework/src/play/src/main/scala/views/defaultpages/devNotFound.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devNotFound.scala.html
@@ -3,7 +3,6 @@
  * This page display the routes file content.
  *@
 @(method: String, uri: String, router: Option[play.api.routing.Router])
-
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -132,10 +131,3 @@
 
     </body>
 </html>
-
-
-
-
-
-
-

--- a/framework/src/play/src/main/scala/views/defaultpages/error.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/error.scala.html
@@ -2,7 +2,6 @@
  * Default page for 500 Internal Server Error responses, in production mode.
  *@
 @(error: play.api.UsefulException)
-
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -44,10 +43,3 @@
 
     </body>
 </html>
-
-
-
-
-
-
-

--- a/framework/src/play/src/main/scala/views/defaultpages/notFound.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/notFound.scala.html
@@ -2,7 +2,6 @@
  * Default page for 404 Not Found responses, in production mode.
  *@
 @(method: String, uri: String)
-
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -44,10 +43,3 @@
 
     </body>
 </html>
-
-
-
-
-
-
-

--- a/framework/src/play/src/main/scala/views/defaultpages/unauthorized.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/unauthorized.scala.html
@@ -35,10 +35,8 @@
     </head>
     <body>
         <h1>Unauthorized</h1>
-
         <p id="detail">
             You must be authenticated to access this page.
         </p>
-
     </body>
 </html>

--- a/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
@@ -14,7 +14,6 @@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @boxValue = @{ args.toMap.get('value).getOrElse("true") }
-
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="checkbox" id="@id" name="@name" value="@boxValue" @if(value == Some(boxValue)){checked="checked"} @toHtmlArgs(htmlArgs.filterKeys(_ != 'value))/>
     <span>@args.toMap.get('_text)</span>

--- a/framework/src/play/src/main/scala/views/helper/defaultFieldConstructor.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/defaultFieldConstructor.scala.html
@@ -14,7 +14,6 @@
  * @param el The field informations.
  *@
 @(elements: FieldElements)
-
 <dl class="@elements.args.get('_class) @if(elements.hasErrors) {error}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
     @if(elements.hasName) {
     <dt>@elements.name</dt>

--- a/framework/src/play/src/main/scala/views/helper/form.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/form.scala.html
@@ -13,7 +13,6 @@
  * @param body The form body.
  *@
 @(action: play.api.mvc.Call, args: (Symbol,String)*)(body: => Html) 
-
 <form action="@action.path" method="@action.method" @toHtmlArgs(args.toMap)>
     @body
 </form>

--- a/framework/src/play/src/main/scala/views/helper/input.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/input.scala.html
@@ -2,9 +2,7 @@
  * Prepare a generic HTML input.
  *@
 @(field: play.api.data.Field, args: (Symbol, Any)* )(inputDef: (String, String, Option[String], Map[Symbol,Any]) => Html)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @id = @{ args.toMap.get('id).map(_.toString).getOrElse(field.id) }
-
 @handler(
     FieldElements(
         id,

--- a/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
@@ -17,7 +17,6 @@
 * @param handler The field constructor.
 *@
 @(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @input(field, args.map{ x => if(x._1 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
   <span class="buttonset" id="@id">
     @defining(field.indexes.map( i => field("[%s]".format(i)).value ).flatten.toSet) { values =>

--- a/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
@@ -11,7 +11,6 @@
  * @param handler The field constructor.
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="date" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)/>
 }

--- a/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
@@ -11,7 +11,6 @@
  * @param handler The field constructor.
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="file" id="@id" name="@name" @toHtmlArgs(htmlArgs)/>
 }

--- a/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
@@ -11,7 +11,6 @@
  * @param handler The field constructor.
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="password" id="@id" name="@name" @toHtmlArgs(htmlArgs)/>
 }

--- a/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
@@ -17,7 +17,6 @@
  * @param handler The field constructor.
  *@
 @(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @input(field, args.map{ x => if(x._1 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
   <span class="buttonset" id="@id">
     @options.map { v =>

--- a/framework/src/play/src/main/scala/views/helper/inputText.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputText.scala.html
@@ -11,9 +11,7 @@
  * @param handler The field constructor.
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @inputType = @{ args.toMap.get('type).map(_.toString).getOrElse("text") }
-
 @input(field, args.filter(_._1 != 'type):_*) { (id, name, value, htmlArgs) =>
     <input type="@inputType" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)/>
 }

--- a/framework/src/play/src/main/scala/views/helper/javascriptRouter.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/javascriptRouter.scala.html
@@ -22,7 +22,6 @@
  * @param routes Set of routes to include in this javascript router.
  *@
 @(name:String = "Router")(routes: play.api.routing.JavaScriptReverseRoute*)(implicit request: play.api.mvc.RequestHeader)
-
 <script type="text/javascript">
     @Html(play.api.routing.JavaScriptReverseRouter(name)(routes: _*).body.replace("/", "\\/"))
 </script>

--- a/framework/src/play/src/main/scala/views/helper/requireJs.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/requireJs.scala.html
@@ -14,5 +14,4 @@
  *@
 
 @(module: String, core: String, isProd: Boolean, productionFolderPrefix: String = "-min", folder: String = "javascripts")
-
 <script type="text/javascript" data-main="@{if(isProd) module.replace(folder,folder+productionFolderPrefix) else module}" src="@core"></script>

--- a/framework/src/play/src/main/scala/views/helper/select.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/select.scala.html
@@ -22,7 +22,6 @@
  * @param handler The field constructor.
  *@
 @(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     @defining( if( htmlArgs.contains('multiple) ) "%s[]".format(name) else name ) { selectName =>
     @defining( field.indexes.nonEmpty && htmlArgs.contains('multiple) match {

--- a/framework/src/play/src/main/scala/views/helper/textarea.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/textarea.scala.html
@@ -11,7 +11,6 @@
  * @param handler The field constructor.
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <textarea id="@id" name="@name" @toHtmlArgs(htmlArgs)>@value</textarea>
 }

--- a/framework/src/play/src/main/scala/views/play20/manual.scala.html
+++ b/framework/src/play/src/main/scala/views/play20/manual.scala.html
@@ -1,5 +1,4 @@
 @(title: String, main: Option[String], sidebar: Option[String], locate: String => String)
-
 <html>
     <head>
         <title>@title</title>

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/views/index.scala.html
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/views/index.scala.html
@@ -1,7 +1,4 @@
 @(message: String)
-
 @main("Welcome to Play") {
-
     @message
-
 }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/views/main.scala.html
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/views/main.scala.html
@@ -1,7 +1,5 @@
 @(title: String)(content: Html)
-
 <!DOCTYPE html>
-
 <html>
     <head>
         <title>@title</title>


### PR DESCRIPTION
In the twirl repo some people were annoyed that Play/twirl adds many unnecessary newlines when using form helpers, etc.
Together with https://github.com/playframework/twirl/pull/169 this will be a bit better now.