### PR TITLE
Update play-ws to version 1.1.6

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -270,7 +270,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache" % caffeineVersion
   ) ++ jcacheApi
   
-  val playWsStandaloneVersion = "1.1.5"
+  val playWsStandaloneVersion = "1.1.6"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-xml" % playWsStandaloneVersion,


### PR DESCRIPTION
## Purpose

Update play-ws to version 1.1.6. This version is virtually identical to 1.1.4, but we had some fixes in the release process.
