### PR TITLE
Allow serving of a "default asset" #7634

### DIFF
--- a/core/play-integration-test/src/test/resources/testassets/fallbackasset.txt
+++ b/core/play-integration-test/src/test/resources/testassets/fallbackasset.txt
@@ -1,0 +1,1 @@
+fallbackasset

--- a/core/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -48,7 +48,57 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
       } { implicit port => withClient(block) }
     }
 
+    def withServerFallback[T](additionalConfig: Option[String] = None)(block: WSClient => T): T = {
+      Server.withApplicationFromContext(ServerConfig(mode = Mode.Prod, port = Some(0))) { context =>
+        new BuiltInComponentsFromContext(context) with AssetsComponents with HttpFiltersComponents {
+
+          override def configuration: Configuration = additionalConfig match {
+            case Some(s) =>
+              val underlying = ConfigFactory.parseString(s)
+              super.configuration ++ Configuration(underlying)
+            case None => super.configuration
+          }
+
+          override def router: Router = Router.from {
+            case req => assets.at("/testassets", req.path, fallback = "fallbackasset.txt")
+          }
+
+          defaultCacheControl = configuration.get[Option[String]]("play.assets.defaultCache")
+          aggressiveCacheControl = configuration.get[Option[String]]("play.assets.aggressiveCache")
+
+        }.application
+      } { implicit port =>
+        withClient(block)
+      }
+    }
+
     val etagPattern = """([wW]/)?"([^"]|\\")*""""
+
+    "serve an asset with fallback" in withServerFallback() { client =>
+      val result = await(client.url("/bar.txt").get())
+
+      result.status must_== OK
+      result.body must_== "This is a test asset."
+      result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
+      result.header(ETAG) must beSome(matching(etagPattern))
+      result.header(LAST_MODIFIED) must beSome
+      result.header(VARY) must beNone
+      result.header(CONTENT_ENCODING) must beNone
+      result.header(CACHE_CONTROL) must_== defaultCacheControl
+    }
+
+    "serve a fallback" in withServerFallback() { client =>
+      val result = await(client.url("/nonexistantfile.txt").get())
+
+      result.status must_== OK
+      result.body must_== "fallbackasset"
+      result.header(CONTENT_TYPE) must beSome(startWith("text/plain"))
+      result.header(ETAG) must beSome(matching(etagPattern))
+      result.header(LAST_MODIFIED) must beSome
+      result.header(VARY) must beNone
+      result.header(CONTENT_ENCODING) must beNone
+      result.header(CACHE_CONTROL) must_== defaultCacheControl
+    }
 
     "serve an asset" in withServer() { client =>
       val result = await(client.url("/bar.txt").get())

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -815,12 +815,18 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: E
    * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded.
    * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /).
    * @param aggressiveCaching if true then an aggressive set of caching directives will be used. Defaults to false.
+   * @param fallback the file to serve if the requested asset cannot be found. Defaults to no fallback.
    */
-  def at(path: String, file: String, aggressiveCaching: Boolean = false): Action[AnyContent] = Action.async {
-    implicit request => assetAt(path, file, aggressiveCaching)
+  def at(
+      path: String,
+      file: String,
+      aggressiveCaching: Boolean = false,
+      fallback: String = ""
+  ): Action[AnyContent] = Action.async { implicit request =>
+    assetAt(path, file, aggressiveCaching, fallback)
   }
 
-  private def assetAt(path: String, file: String, aggressiveCaching: Boolean)(
+  private def assetAt(path: String, file: String, aggressiveCaching: Boolean, fallback: String = "")(
       implicit request: RequestHeader
   ): Future[Result] = {
     val assetName: Option[String]                                    = resourceNameAt(path, file)
@@ -858,7 +864,12 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: E
             )
           })
         }
-      case None => notFound
+      case None =>
+        if (fallback.isEmpty) {
+          notFound
+        } else {
+          assetAt(path, fallback, aggressiveCaching)
+        }
     }
 
     pendingResult.recoverWith {

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -817,14 +817,15 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: E
    * @param aggressiveCaching if true then an aggressive set of caching directives will be used. Defaults to false.
    * @param fallback the file to serve if the requested asset cannot be found. Defaults to no fallback.
    */
-  def at(
-      path: String,
-      file: String,
-      aggressiveCaching: Boolean = false,
-      fallback: String = ""
-  ): Action[AnyContent] = Action.async { implicit request =>
+  def at(path: String, file: String, aggressiveCaching: Boolean, fallback: String): Action[AnyContent] = Action.async {
+    implicit request =>
     assetAt(path, file, aggressiveCaching, fallback)
   }
+
+  def at(path: String, file: String, fallback: String): Action[AnyContent] = at(path, file, false, fallback)
+
+  def at(path: String, file: String, aggressiveCaching: Boolean = false): Action[AnyContent] =
+    at(path, file, aggressiveCaching, "")
 
   private def assetAt(path: String, file: String, aggressiveCaching: Boolean, fallback: String = "")(
       implicit request: RequestHeader

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -819,7 +819,7 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: E
    */
   def at(path: String, file: String, aggressiveCaching: Boolean, fallback: String): Action[AnyContent] = Action.async {
     implicit request =>
-    assetAt(path, file, aggressiveCaching, fallback)
+      assetAt(path, file, aggressiveCaching, fallback)
   }
 
   def at(path: String, file: String, fallback: String): Action[AnyContent] = at(path, file, false, fallback)
@@ -866,7 +866,7 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: E
           })
         }
       case None =>
-        if (fallback.isEmpty) {
+        if ("".eq(fallback)) {
           notFound
         } else {
           assetAt(path, fallback, aggressiveCaching)

--- a/documentation/manual/working/commonGuide/assets/AssetsOverview.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsOverview.md
@@ -100,6 +100,10 @@ The router will invoke the `Assets.at` action with the following parameters:
 controllers.Assets.at("/public", "javascripts/jquery.js")
 ```
 
+Play also supports a `fallback` parameter, `fallback` file be returned if an asset cannot be found. This can be very useful for single page applications. Here is an example of a mapping that a single page application might use:
+
+@[assets-wildcard-spa](code/common.assets.routes)
+
 To route to a single static file, both the path and file have to be specified:
 
 @[assets-single-static-file](code/common.assets.routes)

--- a/documentation/manual/working/commonGuide/assets/AssetsOverview.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsOverview.md
@@ -102,7 +102,7 @@ controllers.Assets.at("/public", "javascripts/jquery.js")
 
 Play also supports a `fallback` parameter, `fallback` file be returned if an asset cannot be found. This can be very useful for single page applications. Here is an example of a mapping that a single page application might use:
 
-@[assets-wildcard-spa](code/common.assets.routes)
+@[assets-wildcard-spa](code/common.fallback.assets.routes)
 
 To route to a single static file, both the path and file have to be specified:
 

--- a/documentation/manual/working/commonGuide/assets/code/CommonFallbackAssets.scala
+++ b/documentation/manual/working/commonGuide/assets/code/CommonFallbackAssets.scala
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package common.fallback.assets
+
+package object controllers {
+  type Assets = _root_.controllers.Assets
+}

--- a/documentation/manual/working/commonGuide/assets/code/common.assets.routes
+++ b/documentation/manual/working/commonGuide/assets/code/common.assets.routes
@@ -4,10 +4,6 @@
 GET  /assets/*file        controllers.Assets.at(path="/public", file)
 #assets-wildcard
 
-#assets-wildcard-spa
-GET  /assets/*file        controllers.Assets.at(path="/public", file, fallback = "index.html")
-#assets-wildcard-spa
-
 #assets-single-static-file
 GET  /favicon.ico        controllers.Assets.at(path="/public", file="favicon.ico")
 #assets-single-static-file

--- a/documentation/manual/working/commonGuide/assets/code/common.assets.routes
+++ b/documentation/manual/working/commonGuide/assets/code/common.assets.routes
@@ -4,6 +4,10 @@
 GET  /assets/*file        controllers.Assets.at(path="/public", file)
 #assets-wildcard
 
+#assets-wildcard-spa
+GET  /assets/*file        controllers.Assets.at(path="/public", file, fallback = "index.html")
+#assets-wildcard-spa
+
 #assets-single-static-file
 GET  /favicon.ico        controllers.Assets.at(path="/public", file="favicon.ico")
 #assets-single-static-file

--- a/documentation/manual/working/commonGuide/assets/code/common.fallback.assets.routes
+++ b/documentation/manual/working/commonGuide/assets/code/common.fallback.assets.routes
@@ -1,0 +1,3 @@
+#assets-wildcard-spa
+GET  /assets/*file        controllers.Assets.at(path="/public", file, fallback = "index.html")
+#assets-wildcard-spa


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #7634 

## Purpose

The purpose of this PR is to provide an easy way for SPAs to integrate with Play.

## Background Context

When building SPAs if a path cannot be resolved it should be proxied to SPAs html page. The issue is solved by allowing users to specify a fallback file, this file will be served if no file is found. The file is always served with status 200.

## References

#7634 
