### PR TITLE
Remove method which isn't needed anymore

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -265,7 +265,11 @@ object BuildSettings {
       ProblemFilters.exclude[MissingTypesProblem]("play.filters.https.RedirectHttpsConfiguration$"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.apply"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.this"),
+
+      // invokeWithContextOpt is unnecessary since JavaGlobalSettingsAdapter has been removed in Play 2.6
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.j.JavaHelpers.invokeWithContextOpt"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.j.JavaAction.invokeWithContextOpt")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -237,30 +237,6 @@ trait JavaHelpers {
    * Java request, and converting the resulting Java result to a Scala result, before returning
    * it.
    *
-   * This is intended for use by methods in the JavaGlobalSettingsAdapter, which need to be handled
-   * like Java actions, but are not Java actions. In this case, f may return null, so we wrap its
-   * result in an Option. E.g. see the default behavior of GlobalSettings.onError.
-   *
-   * @param request The request
-   * @param components the context components
-   * @param f The function to invoke
-   * @return The result
-   */
-  def invokeWithContextOpt(request: RequestHeader, components: JavaContextComponents, f: JRequest => CompletionStage[JResult]): Option[Future[Result]] = {
-    val javaContext = createJavaContext(request, components)
-    try {
-      JContext.current.set(javaContext)
-      Option(f(javaContext.request())).map(cs => FutureConverters.toScala(cs).map(createResult(javaContext, _))(trampoline))
-    } finally {
-      JContext.current.remove()
-    }
-  }
-
-  /**
-   * Invoke the given function with the right context set, converting the scala request to a
-   * Java request, and converting the resulting Java result to a Scala result, before returning
-   * it.
-   *
    * This is intended for use by callback methods in Java adapters.
    *
    * @param request The request


### PR DESCRIPTION
`invokeWithContextOpt` isn't used and also not need anymore.
Also it's javadocs says
> This is intended for use by methods in the JavaGlobalSettingsAdapter...

[JavaGlobalSettingsAdapter](https://github.com/playframework/playframework/blob/2.5.x/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala) was removed #5955 and therefore only exists up to the `2.5.x` branch which means since the 2.6 release that method is useless.