### PR TITLE
Upgrade + rename Hibernate ORM

### DIFF
--- a/documentation/manual/working/commonGuide/build/code/dependencies.sbt
+++ b/documentation/manual/working/commonGuide/build/code/dependencies.sbt
@@ -13,7 +13,7 @@ libraryDependencies += "org.apache.derby" % "derby" % "10.13.1.1" % "test"
 //#multi-deps
 libraryDependencies ++= Seq(
   "org.apache.derby" % "derby" % "10.13.1.1",
-  "org.hibernate" % "hibernate-entitymanager" % "5.2.10.Final"
+  "org.hibernate" % "hibernate-core" % "5.2.15.Final"
 )
 //#multi-deps
 

--- a/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
+++ b/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
@@ -5,7 +5,7 @@
 //#jpa-sbt-dependencies
 libraryDependencies ++= Seq(
   javaJpa,
-  "org.hibernate" % "hibernate-entitymanager" % "5.1.0.Final" // replace by your jpa implementation
+  "org.hibernate" % "hibernate-core" % "5.2.15.Final" // replace by your jpa implementation
 )
 //#jpa-sbt-dependencies
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -63,8 +63,8 @@ object Dependencies {
     "tyrex" % "tyrex" % "1.0.1") ++ specsBuild.map(_ % Test)
 
   val jpaDeps = Seq(
-    "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.0.Final",
-    "org.hibernate" % "hibernate-entitymanager" % "5.2.11.Final" % "test"
+    "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.2.Final",
+    "org.hibernate" % "hibernate-core" % "5.2.15.Final" % "test"
   )
 
   val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0"


### PR DESCRIPTION
`hibernate-entitymanager` was moved to `hibernate-core` with the 5.2 release:
https://github.com/hibernate/hibernate-orm/wiki/Migration-Guide---5.2#hibernate-entitymanager-merged-into-hibernate-core
https://mvnrepository.com/artifact/org.hibernate/hibernate-entitymanager
