### PR TITLE
update guava to 24.0-jre

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -84,3 +84,7 @@ The "old" `validate` methods of a Java form will not be executed anymore.
 Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]] you have to migrate such `validate` methods to [[class-level constraints|JavaForms#advanced-validation]].
 
 > **Important**: When upgrading to Play 2.7 you will not see any compiler warnings indicating that you have to migrate your `validate` methods (because Play executed them via reflection).
+
+### `Guava` version updated to 24.0-jre
+
+Play 2.6.x provided 23.0 version of Guava library. Now it is updated to the next major release, 24.0-jre. Lots of changes were made in library, you can see the full changelog [here](https://github.com/google/guava/releases).

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -87,4 +87,4 @@ Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]]
 
 ### `Guava` version updated to 24.0-jre
 
-Play 2.6.x provided 23.0 version of Guava library. Now it is updated to the next major release, 24.0-jre. Lots of changes were made in library, you can see the full changelog [here](https://github.com/google/guava/releases).
+Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 24.1-jre. Lots of changes were made in library, you can see the full changelog [here](https://github.com/google/guava/releases).

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -49,7 +49,7 @@ object Dependencies {
   val slf4j = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % slf4jVersion)
   val slf4jSimple = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
-  val guava = "com.google.guava" % "guava" % "24.0-jre"
+  val guava = "com.google.guava" % "guava" % "24.1-jre"
   val findBugs = "com.google.code.findbugs" % "jsr305" % "3.0.2" // Needed by guava
   val mockitoAll = "org.mockito" % "mockito-all" % "1.10.19"
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -49,7 +49,7 @@ object Dependencies {
   val slf4j = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % slf4jVersion)
   val slf4jSimple = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
-  val guava = "com.google.guava" % "guava" % "23.0"
+  val guava = "com.google.guava" % "guava" % "24.0-jre"
   val findBugs = "com.google.code.findbugs" % "jsr305" % "3.0.2" // Needed by guava
   val mockitoAll = "org.mockito" % "mockito-all" % "1.10.19"
 


### PR DESCRIPTION
## Purpose

Play framework still uses an old version of guava (23.0), however, there were 6 minor versions (23.1-23.6) and now the actual one is 24.0.