### PR TITLE
used typed keys to pass the current context lang to scala (#8288)

### DIFF
--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -100,6 +100,15 @@ public class HttpTest {
             assertThat(ctx2.changeLang("en-US")).isTrue();
             // The messages language 'en-US'
             assertThat(ctx2.messages().lang().code()).isEqualTo("en-US");
+
+            // check's that the order stays the same even when no cookie is changed
+            // by using setTransientLang which will not set any cookie
+            Context ctx3 = new Context(
+                    new RequestBuilder().cookie(cookie).header(Http.HeaderNames.ACCEPT_LANGUAGE, "en"),
+                    contextComponents);
+
+            ctx3.setTransientLang("en-US");
+            assertThat(ctx3.messages().lang().code()).isEqualTo("en-US");
         });
     }
 

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -79,6 +79,32 @@ public class HttpTest {
     }
 
     @Test
+    public void testMessagesOrder() {
+        withApplication((app) -> {
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+            Context ctx1 = new Context(new RequestBuilder().header(Http.HeaderNames.ACCEPT_LANGUAGE, "en-US"),
+                    contextComponents);
+            // if no cookie is provided the context lang order will have the accept language as the default lang
+            assertThat(ctx1.messages().lang().code()).isEqualTo("en-US");
+
+
+            Cookie cookie = Cookie.builder("PLAY_LANG", "fr").build();
+            Context ctx2 = new Context(
+                    new RequestBuilder().cookie(cookie).header(Http.HeaderNames.ACCEPT_LANGUAGE, "en"),
+                    contextComponents);
+
+            // if no context lang is provided the language order will be cookie > accept language
+            assertThat(ctx2.messages().lang().code()).isEqualTo("fr");
+
+            // if a context lang is set the language order will be context lang > cookie > accept language
+            // Change the language to 'en-US'
+            assertThat(ctx2.changeLang("en-US")).isTrue();
+            // The language and cookie should now be 'en-US'
+            assertThat(ctx2.messages().lang().code()).isEqualTo("en-US");
+        });
+    }
+
+    @Test
     public void testChangeLangFailure() {
         withApplication((app) -> {
             JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -87,7 +87,6 @@ public class HttpTest {
             // if no cookie is provided the context lang order will have the accept language as the default lang
             assertThat(ctx1.messages().lang().code()).isEqualTo("en-US");
 
-
             Cookie cookie = Cookie.builder("PLAY_LANG", "fr").build();
             Context ctx2 = new Context(
                     new RequestBuilder().cookie(cookie).header(Http.HeaderNames.ACCEPT_LANGUAGE, "en"),
@@ -99,7 +98,7 @@ public class HttpTest {
             // if a context lang is set the language order will be context lang > cookie > accept language
             // Change the language to 'en-US'
             assertThat(ctx2.changeLang("en-US")).isTrue();
-            // The language and cookie should now be 'en-US'
+            // The messages language 'en-US'
             assertThat(ctx2.messages().lang().code()).isEqualTo("en-US");
         });
     }

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -17,7 +17,7 @@ public interface Messages {
 
     public static class Attrs {
 
-        public static TypedKey<play.api.i18n.Lang> CurrentContextLang = play.api.i18n.Messages.Attrs$.MODULE$.CurrentContextLang().asJava();
+        public static TypedKey<play.api.i18n.Lang> CurrentLang = play.api.i18n.Messages.Attrs$.MODULE$.CurrentLang().asJava();
 
     }
 

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -3,6 +3,8 @@
  */
 package play.i18n;
 
+import play.libs.typedmap.TypedKey;
+
 import java.util.List;
 
 /**
@@ -12,6 +14,12 @@ import java.util.List;
  * return MessagesApi.
  */
 public interface Messages {
+
+    public static class Attrs {
+
+        public static TypedKey<play.api.i18n.Lang> CurrentContextLang = play.api.i18n.Messages.Attrs$.MODULE$.CurrentContextLang().asJava();
+
+    }
 
     /**
      * Get the lang for these messages.

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -225,7 +225,7 @@ public class Http {
          * @return the messages for the current lang
          */
         public Messages messages() {
-            Request request = lang != null ? request().addAttr(Messages.Attrs.CurrentContextLang, lang) : request();
+            Request request = lang != null ? request().addAttr(Messages.Attrs.CurrentLang, lang) : request();
             return messagesApi().preferred(request);
         }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -225,7 +225,7 @@ public class Http {
          * @return the messages for the current lang
          */
         public Messages messages() {
-            TypedKey<play.api.i18n.Lang> key = Messages$.MODULE$.currentContextLang().asJava();
+            TypedKey<play.api.i18n.Lang> key = play.api.i18n.Messages.Attrs$.MODULE$.CurrentContextLang().asJava();
             Request request = lang != null ? request().addAttr(key, lang) : request();
             return messagesApi().preferred(request);
         }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -225,8 +225,7 @@ public class Http {
          * @return the messages for the current lang
          */
         public Messages messages() {
-            TypedKey<play.api.i18n.Lang> key = play.api.i18n.Messages.Attrs$.MODULE$.CurrentContextLang().asJava();
-            Request request = lang != null ? request().addAttr(key, lang) : request();
+            Request request = lang != null ? request().addAttr(Messages.Attrs.CurrentContextLang, lang) : request();
             return messagesApi().preferred(request);
         }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -8,10 +8,10 @@ import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.Lists;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import play.api.http.HttpConfiguration;
+import play.api.i18n.Messages$;
 import play.api.libs.json.JsValue;
 import play.api.mvc.Headers$;
 import play.api.mvc.request.*;
@@ -225,16 +225,9 @@ public class Http {
          * @return the messages for the current lang
          */
         public Messages messages() {
-            Cookie langCookie = request().cookies().get(messagesApi().langCookieName());
-            Lang cookieLang = langCookie == null ? null : new Lang(play.api.i18n.Lang.apply(langCookie.value()));
-            LinkedList<Lang> langs = Lists.newLinkedList(request().acceptLanguages());
-            if (cookieLang != null) {
-                langs.addFirst(cookieLang);
-            }
-            if (lang != null) {
-                langs.addFirst(lang);
-            }
-            return messagesApi().preferred(langs);
+            TypedKey<play.api.i18n.Lang> key = Messages$.MODULE$.currentContextLang().asJava();
+            Request request = lang != null ? request().addAttr(key, lang) : request();
+            return messagesApi().preferred(request);
         }
 
         /**

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -45,8 +45,6 @@ object Messages extends MessagesImplicits {
 
   }
 
-
-
   private[play] val messagesApiCache = Application.instanceCache[MessagesApi]
 
   /**

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -470,7 +470,7 @@ class DefaultMessagesApi @Inject() (
   override def preferred(request: RequestHeader): Messages = {
     val maybeLangFromContext = request.attrs.get(Messages.Attrs.CurrentContextLang)
     val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
-    val lang = langs.preferred(maybeLangFromCookie.toSeq ++ request.acceptLanguages ++ maybeLangFromContext.toSeq)
+    val lang = langs.preferred(maybeLangFromContext.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
     MessagesImpl(lang, this)
   }
 

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -11,6 +11,7 @@ import javax.inject.{ Inject, Provider, Singleton }
 
 import play.api._
 import play.api.http.HttpConfiguration
+import play.api.libs.typedmap.TypedKey
 import play.api.mvc._
 import play.libs.Scala
 import play.mvc.Http
@@ -33,6 +34,8 @@ import scala.util.parsing.input._
  * }}}
  */
 object Messages extends MessagesImplicits {
+
+  private[play] val currentContextLang = TypedKey.apply[Lang]("contextLang")
 
   private[play] val messagesApiCache = Application.instanceCache[MessagesApi]
 
@@ -457,8 +460,9 @@ class DefaultMessagesApi @Inject() (
   }
 
   override def preferred(request: RequestHeader): Messages = {
+    val maybeLangFromContext = request.attrs.get(Messages.currentContextLang)
     val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
-    val lang = langs.preferred(maybeLangFromCookie.toSeq ++ request.acceptLanguages)
+    val lang = langs.preferred(maybeLangFromContext.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
     MessagesImpl(lang, this)
   }
 

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -40,9 +40,7 @@ object Messages extends MessagesImplicits {
    * Currently all Attributes are only available inside the [[MessagesApi]] methods.
    */
   object Attrs {
-
-    val CurrentContextLang: TypedKey[Lang] = TypedKey("CurrentContextLang")
-
+    val CurrentLang: TypedKey[Lang] = TypedKey("CurrentLang")
   }
 
   private[play] val messagesApiCache = Application.instanceCache[MessagesApi]
@@ -468,7 +466,7 @@ class DefaultMessagesApi @Inject() (
   }
 
   override def preferred(request: RequestHeader): Messages = {
-    val maybeLangFromContext = request.attrs.get(Messages.Attrs.CurrentContextLang)
+    val maybeLangFromContext = request.attrs.get(Messages.Attrs.CurrentLang)
     val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
     val lang = langs.preferred(maybeLangFromContext.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
     MessagesImpl(lang, this)

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -35,7 +35,17 @@ import scala.util.parsing.input._
  */
 object Messages extends MessagesImplicits {
 
-  private[play] val currentContextLang = TypedKey.apply[Lang]("contextLang")
+  /**
+   * Request Attributes for the MessagesApi
+   * Currently all Attributes are only available inside the [[MessagesApi]] methods.
+   */
+  object Attrs {
+
+    val CurrentContextLang: TypedKey[Lang] = TypedKey("CurrentContextLang")
+
+  }
+
+
 
   private[play] val messagesApiCache = Application.instanceCache[MessagesApi]
 
@@ -460,9 +470,9 @@ class DefaultMessagesApi @Inject() (
   }
 
   override def preferred(request: RequestHeader): Messages = {
-    val maybeLangFromContext = request.attrs.get(Messages.currentContextLang)
+    val maybeLangFromContext = request.attrs.get(Messages.Attrs.CurrentContextLang)
     val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
-    val lang = langs.preferred(maybeLangFromContext.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
+    val lang = langs.preferred(maybeLangFromCookie.toSeq ++ request.acceptLanguages ++ maybeLangFromContext.toSeq)
     MessagesImpl(lang, this)
   }
 


### PR DESCRIPTION
# Helpful things

## Fixes

Fixes #8288

## Purpose

Currently in Play 2.6.x we tried to have a change that adds the current context language from Java to the MessagesApi in Scala, however due to bin incompatible changes it got reverted here: https://github.com/playframework/playframework/commit/c7855328e14f7f99d68f8d5ce072e1bbe5f26cc6

## Background Context

This addresses it by using a TypedKey, which has the benefit of not breaking any api contract and also not introducing any kind of binary incompability.
It also saves duplicated code.
