### PR TITLE
currently this should cancel the remoteIn

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -185,7 +185,7 @@ object WebSocketFlowHandler {
                         push(remoteOut, close)
                         // And complete both remote out and remote in
                         complete(remoteOut)
-                        cancel(appIn)
+                        cancel(remoteIn)
                       } else {
                         // Store so we can send later
                         state = ClientInitiatedClose(close)


### PR DESCRIPTION
in a previous version I changed that from `completionStage()` to
complete and cancel, because `completionStage()` will fail under netty.

however since appOut and appIn is already closed at that point it
needs to be a `cancel(remoteIn)` as the comment suggested.
