### PR TITLE
The Java context args map is a request attribute now

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -74,8 +74,16 @@ play.db.pool=your.own.ConnectionPool
 
 ### Java `Http.Context` changed
 
+#### `args` is `args()` now
+
+The context arguments map, which previously was accessible via `contextObj.args`, is now a request attribute. This has the advantage that it's tied to a request and is therefore available everywhere where a request is availabe as well.
+To access the context arguments you now have to call the method `contextObj.args()` - which is just a shortcut for retrieving the request attribute [`RequestAttrKey.ContextArgs`](api/scala/play/api/mvc/request/RequestAttrKey$.html) (e.g. via  `request.attrs().getOptional(RequestAttrKey.ContextArgs().asJava())`).
+Because the context arguments map is still a normal Java `Map` you can use it like before via `args().get(...)`, `args().put(...)`, etc.
+
+#### Context arguments no longer contain request tags
+
 Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]] in Play 2.6, have finally been removed in Play 2.7.
-Therefore the `args` map of a `Http.Context` instance no longer contains these removed request tags as well.
+Therefore the `args()` map of a `Http.Context` instance no longer contains these removed request tags as well.
 Instead you can use the `contextObj.request().attrs()` method now, which provides you the equivalent request attributes.
 
 ### All Java form `validate` methods need to be migrated to class-level constraints

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
@@ -85,7 +85,7 @@ public class JavaActionsComposition extends Controller {
     // #pass-arg-action
     public class PassArgAction extends play.mvc.Action.Simple {
         public CompletionStage<Result> call(Http.Context ctx) {
-            ctx.args.put("user", User.findById(1234));
+            ctx.args().put("user", User.findById(1234));
             return delegate.call(ctx);
         }
     }
@@ -94,7 +94,7 @@ public class JavaActionsComposition extends Controller {
     // #pass-arg-action-index
     @With(PassArgAction.class)
     public static Result passArgIndex() {
-        Object user = ctx().args.get("user");
+        Object user = ctx().args().get("user");
         return ok(Json.toJson(user));
     }
     // #pass-arg-action-index

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -448,7 +448,12 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.routing.Router$Tags"),
 
       // Upgrade Guice from 4.1.0 to 4.2.0 which uses java.util.function.Function instead of com.google.common.base.Function now
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.test.TestBrowser.waitUntil")
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.test.TestBrowser.waitUntil"),
+
+      // Java Context args map is a request attribute now - ctx field became ctx() method now
+      ProblemFilters.exclude[MissingFieldProblem]("play.mvc.Http#Context.args"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.mvc.Http#Context.this"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.mvc.Http#Context.this")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -51,8 +51,8 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
             CSRF.Token newToken = helper.generateToken();
 
             // Place this token into the context
-            ctx.args.put(CSRF_TOKEN, newToken.value());
-            ctx.args.put(CSRF_TOKEN_NAME, newToken.name());
+            ctx.args().put(CSRF_TOKEN, newToken.value());
+            ctx.args().put(CSRF_TOKEN_NAME, newToken.name());
 
             // Create a new Scala RequestHeader with the token
             request = helper.tagRequest(request, newToken);

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/HttpErrorHandlerSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http
+
+import java.util.concurrent.CompletableFuture
+
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSResponse
+import play.api.test.{ PlaySpecification, TestServer, WsTestClient }
+import play.mvc.{ Http, Result, Results }
+
+class HttpErrorHandlerSpec extends PlaySpecification with WsTestClient {
+  "A Java http error handler" should {
+    "be able to access the context args previously set within a failed action method" in makeRequest(new MockController {
+      override def action: Result = {
+        Http.Context.current().args().put("foobar", "aBc_xYz")
+        throw new RuntimeException("booom!")
+      }
+    }, Map("play.http.errorHandler" -> classOf[CustomJavaErrorHandler].getName)) { response =>
+      response.body must beEqualTo("Hello from http error handler onServerError: aBc_xYz")
+    }
+  }
+
+  def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef] = Map.empty)(block: WSResponse => T): T = {
+    implicit val port = testServerPort
+    lazy val app: Application = GuiceApplicationBuilder().configure(configuration).routes {
+      case _ => JAction(app, controller)
+    }.build()
+
+    running(TestServer(port, app)) {
+      val response = await(wsUrl("/").get())
+      block(response)
+    }
+  }
+}
+
+class CustomJavaErrorHandler extends play.http.HttpErrorHandler {
+  override def onServerError(req: play.mvc.Http.RequestHeader, exception: Throwable) =
+    CompletableFuture.completedFuture(play.mvc.Results.ok("Hello from http error handler onServerError: " + Http.Context.current().args().get("foobar")))
+  override def onClientError(req: play.mvc.Http.RequestHeader, status: Int, msg: String) =
+    CompletableFuture.completedFuture(play.mvc.Results.ok("I will not be called"))
+}

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -87,14 +87,14 @@ trait FormSpec extends Specification {
     "with a root name" should {
       "be valid with all fields" in {
         val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891"), "task.name" -> Array("peter"), "task.dueDate" -> Array("15/12/2009"), "task.endDate" -> Array("2008-11-21")))
-        Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+        Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
         val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest()
         myForm hasErrors () must beEqualTo(false)
       }
       "allow to access the value of an invalid form prefixing fields with the root name" in new WithApplication(application()) {
         val req = FormSpec.dummyRequest(Map("task.id" -> Array("notAnInt"), "task.name" -> Array("peter"), "task.done" -> Array("true"), "task.dueDate" -> Array("15/12/2009")))
-        Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+        Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
         val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest()
 
@@ -105,7 +105,7 @@ trait FormSpec extends Specification {
         val contextComponents = defaultContextComponents
 
         val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891x"), "task.name" -> Array("peter")))
-        Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, contextComponents))
+        Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, contextComponents))
 
         val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest()
         myForm hasErrors () must beEqualTo(true)
@@ -114,21 +114,21 @@ trait FormSpec extends Specification {
     }
     "be valid with all fields" in {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11-21")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
     "be valid with mandatory params passed" in {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
     "query params ignored when using POST" in {
       val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "POST", "?name=michael&id=55555")
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
@@ -137,7 +137,7 @@ trait FormSpec extends Specification {
     }
     "query params ignored when using PUT" in {
       val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "PUT", "?name=michael&id=55555")
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
@@ -146,7 +146,7 @@ trait FormSpec extends Specification {
     }
     "query params ignored when using PATCH" in {
       val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "PATCH", "?name=michael&id=55555")
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
@@ -156,7 +156,7 @@ trait FormSpec extends Specification {
 
     "query params NOT ignored when using GET" in {
       val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "GET", "?name=michael&id=55555")
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
@@ -166,7 +166,7 @@ trait FormSpec extends Specification {
     }
     "query params NOT ignored when using DELETE" in {
       val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "DELETE", "?name=michael&id=55555")
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
@@ -176,7 +176,7 @@ trait FormSpec extends Specification {
     }
     "query params NOT ignored when using HEAD" in {
       val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "HEAD", "?name=michael&id=55555")
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
@@ -186,7 +186,7 @@ trait FormSpec extends Specification {
     }
     "query params NOT ignored when using OPTIONS" in {
       val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "OPTIONS", "?name=michael&id=55555")
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
@@ -197,7 +197,7 @@ trait FormSpec extends Specification {
 
     "have an error due to badly formatted date" in new WithApplication(application()) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
@@ -212,14 +212,14 @@ trait FormSpec extends Specification {
     }
     "throws an exception when trying to access value of invalid form via get()" in new WithApplication(application()) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm.get must throwAn[IllegalStateException]
     }
     "allow to access the value of an invalid form even when not even one valid value was supplied" in new WithApplication(application()) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("notAnInt"), "dueDate" -> Array("2009/11e/11")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm.value().get().getId() must_== null
@@ -227,7 +227,7 @@ trait FormSpec extends Specification {
     }
     "have an error due to badly formatted date after using setTransientLang" in new WithApplication(application("play.i18n.langs" -> Seq("en", "en-US", "fr"))) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       Context.current.get().setTransientLang("fr")
 
@@ -241,7 +241,7 @@ trait FormSpec extends Specification {
     }
     "have an error due to badly formatted date after using changeLang" in new WithApplication(application("play.i18n.langs" -> Seq("en", "en-US", "fr"))) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       Context.current.get().changeLang("fr")
 
@@ -255,7 +255,7 @@ trait FormSpec extends Specification {
     }
     "have an error due to missing required value" in new WithApplication(application()) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
@@ -263,7 +263,7 @@ trait FormSpec extends Specification {
     }
     "have an error due to bad value in Id field" in new WithApplication(application()) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
@@ -272,7 +272,7 @@ trait FormSpec extends Specification {
 
     "have an error due to badly formatted date for default date binder" in new WithApplication(application()) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11e-21")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAEntityManagerContext.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAEntityManagerContext.java
@@ -49,12 +49,12 @@ public class JPAEntityManagerContext extends ThreadLocal<Deque<EntityManager>> {
     public Deque<EntityManager> emStack(boolean threadLocalFallback) {
         Http.Context context = Http.Context.current.get();
         if (context != null) {
-            Object emsObject = context.args.get(CURRENT_ENTITY_MANAGER);
+            Object emsObject = context.args().get(CURRENT_ENTITY_MANAGER);
             if (emsObject != null) {
                 return (Deque<EntityManager>) emsObject;
             } else {
                 Deque<EntityManager> ems = new ArrayDeque<>();
-                context.args.put(CURRENT_ENTITY_MANAGER, ems);
+                context.args().put(CURRENT_ENTITY_MANAGER, ems);
                 return ems;
             }
         } else {

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -105,7 +105,6 @@ public class Http {
             this.response = new Response();
             this.session = new Session(Scala.asJava(header.session().data()));
             this.flash = new Flash(Scala.asJava(header.flash().data()));
-            this.args = new HashMap<>();
             this.components = components;
         }
 
@@ -117,14 +116,13 @@ public class Http {
          * @param request the request with body
          * @param sessionData the session data extracted from the session cookie
          * @param flashData the flash data extracted from the flash cookie
-         * @param args any arbitrary data to associate with this request context.
          * @param components the context components.
          */
         public Context(Long id, play.api.mvc.RequestHeader header, Request request,
-                Map<String,String> sessionData, Map<String,String> flashData, Map<String,Object> args,
+                Map<String,String> sessionData, Map<String,String> flashData,
                 JavaContextComponents components) {
             this(id, header, request, new Response(), new Session(sessionData), new Flash(flashData),
-                new HashMap<>(args), components);
+                components);
         }
 
         /**
@@ -138,18 +136,16 @@ public class Http {
          * @param response the response instance to use
          * @param session the session instance to use
          * @param flash the flash instance to use
-         * @param args any arbitrary data to associate with this request context.
          * @param components the context components.
          */
         public Context(Long id, play.api.mvc.RequestHeader header, Request request, Response response,
-                Session session, Flash flash, Map<String,Object> args, JavaContextComponents components) {
+                Session session, Flash flash, JavaContextComponents components) {
             this.id = id;
             this.header = header;
             this.request = request;
             this.response = response;
             this.session = session;
             this.flash = flash;
-            this.args = args;
             this.components = components;
         }
 
@@ -345,7 +341,9 @@ public class Http {
         /**
          * Free space to store your request specific data.
          */
-        public Map<String, Object> args;
+        public Map<String, Object> args() {
+            return this.request.attrs().getOptional(RequestAttrKey.ContextArgs().asJava()).orElse(null);
+        }
 
         public FileMimeTypes fileMimeTypes() {
             return components.fileMimeTypes();
@@ -437,7 +435,7 @@ public class Http {
          * @return The new context.
          */
         public Context withRequest(Request request) {
-            return new Context(id, header, request, response, session, flash, args, components);
+            return new Context(id, header, request, response, session, flash, components);
         }
     }
 
@@ -452,8 +450,7 @@ public class Http {
          * @param wrapped the context the created instance will wrap
          */
         public WrappedContext(Context wrapped) {
-            super(wrapped.id(), wrapped._requestHeader(), wrapped.request(), wrapped.session(), wrapped.flash(), wrapped.args, wrapped.components);
-            this.args = wrapped.args;
+            super(wrapped.id(), wrapped._requestHeader(), wrapped.request(), wrapped.session(), wrapped.flash(), wrapped.components);
             this.wrapped = wrapped;
         }
 
@@ -1101,6 +1098,15 @@ public class Http {
          */
         public RequestBuilder id(Long id) {
             attr(new TypedKey(RequestAttrKey.Id()), id);
+            return this;
+        }
+
+        /**
+         * @param args the map to be used as context args
+         * @return the builder instance
+         */
+        public RequestBuilder contextArgs(Map args) {
+            attr(new TypedKey(RequestAttrKey.ContextArgs()), args);
             return this;
         }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/request/RequestAttrKey.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/request/RequestAttrKey.scala
@@ -38,4 +38,10 @@ object RequestAttrKey {
    * The key for the request attribute storing the server name.
    */
   val Server = TypedKey[String]("Server-Name")
+
+  /**
+   * The key for the request attribute storing the request's
+   * context args (useful for Play Java applications).
+   */
+  val ContextArgs = TypedKey[java.util.Map[String, Object]]("Context-Args")
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
@@ -118,11 +118,13 @@ class DefaultRequestFactory @Inject() (
       override protected def emptyMarker: Flash = null
       override protected def create: Flash = flashBaker.decodeFromCookie(cookieCell.value.get(flashBaker.COOKIE_NAME))
     }
+    val contextArgs: java.util.Map[String, Object] = new java.util.HashMap()
     val updatedAttrMap = attrs + (
       RequestAttrKey.Id -> requestId,
       RequestAttrKey.Cookies -> cookieCell,
       RequestAttrKey.Session -> sessionCell,
-      RequestAttrKey.Flash -> flashCell
+      RequestAttrKey.Flash -> flashCell,
+      RequestAttrKey.ContextArgs -> contextArgs
     )
     new RequestHeaderImpl(connection, method, target, version, headers, updatedAttrMap)
   }

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -164,7 +164,6 @@ trait JavaHelpers {
       new JRequestImpl(req),
       req.session.data.asJava,
       req.flash.data.asJava,
-      new java.util.HashMap[String, Object],
       components
     )
   }
@@ -182,7 +181,6 @@ trait JavaHelpers {
       new JRequestImpl(req),
       req.session.data.asJava,
       req.flash.data.asJava,
-      new java.util.HashMap[String, Object],
       components
     )
   }


### PR DESCRIPTION
Fixes #8303

This has several benefits:
* We can be sure that everywhere where a request is available we also have access to the context args request attribute, unlike now where the ctx args map is tied to a context object.
* Only exactly one arguments map exists during a request life cycle - and not several.
* We don't need to pass the context args map (or its content) back and forth, which doesn't even work right now when Play internals have to pass it from a Java component to a Scala component and back to Java components (without polluting the Scala api with the Java context args concept).