### PR TITLE
Pass Java Http.Context to error handlers

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -84,3 +84,28 @@ The "old" `validate` methods of a Java form will not be executed anymore.
 Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]] you have to migrate such `validate` methods to [[class-level constraints|JavaForms#advanced-validation]].
 
 > **Important**: When upgrading to Play 2.7 you will not see any compiler warnings indicating that you have to migrate your `validate` methods (because Play executed them via reflection).
+
+### Java `ErrorHandler`s get `Http.Context` passed
+
+To avoid calling the static method [`Http.Context.current()`](api/java/play/mvc/Http.Context.html#current) (which will likely be removed in the future) Play now passes the [`Http.Context`](api/java/play/mvc/Http.Context.html) to all the methods of all error handlers.
+This only effects you if you implemented your own [`HttpErrorHandler`](api/java/play/http/HttpErrorHandler.html) (or subclassed [`DefaultHttpErrorHandler`](api/java/play/http/DefaultHttpErrorHandler.html)) or [`CSRFErrorHandler`](api/java/play/filters/csrf/CSRFErrorHandler.html). All the methods of these interfaces and classes get an `Optional<Http.Context>` passed as the last argument now.
+
+> **Info**: An `Optional` is passed because a `Http.Context` is not always available:
+When a request fails at the `BodyParser` level an error handler will be called but a `Http.Context` hasn't been created yet by Play. Therefore in such cases the parameter will be `Optional.empty`.
+
+Overview of the changed methods:
+
+* **In [`HttpErrorHandler`](api/java/play/http/HttpErrorHandler.html) / [`DefaultHttpErrorHandler`](api/java/play/http/DefaultHttpErrorHandler.html):**
+`onClientError(..., Optional<Context> context)`
+`onServerError(..., Optional<Context> context)`
+
+* **In [`DefaultHttpErrorHandler`](api/java/play/http/DefaultHttpErrorHandler.html):**
+`onBadRequest(..., Optional<Context> context)`
+`onForbidden(..., Optional<Context> context)`
+`onNotFound(..., Optional<Context> context)`
+`onOtherClientError(..., Optional<Context> context)`
+`onDevServerError(..., Optional<Context> context)`
+`onProdServerError(..., Optional<Context> context)`
+
+* **In [`CSRFErrorHandler`](api/java/play/filters/csrf/CSRFErrorHandler.html):**
+`handle(..., Optional<Http.Context> context)`

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/def/ErrorHandler.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/def/ErrorHandler.java
@@ -17,6 +17,7 @@ import play.mvc.*;
 import javax.inject.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.Optional;
 
 @Singleton
 public class ErrorHandler extends DefaultHttpErrorHandler {
@@ -27,13 +28,13 @@ public class ErrorHandler extends DefaultHttpErrorHandler {
         super(config, environment, sourceMapper, routes);
     }
 
-    protected CompletionStage<Result> onProdServerError(RequestHeader request, UsefulException exception) {
+    protected CompletionStage<Result> onProdServerError(RequestHeader request, UsefulException exception, Optional<Http.Context> context) {
         return CompletableFuture.completedFuture(
                 Results.internalServerError("A server error occurred: " + exception.getMessage())
         );
     }
 
-    protected CompletionStage<Result> onForbidden(RequestHeader request, String message) {
+    protected CompletionStage<Result> onForbidden(RequestHeader request, String message, Optional<Http.Context> context) {
         return CompletableFuture.completedFuture(
                 Results.forbidden("You're not allowed to access this resource.")
         );

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/root/ErrorHandler.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/root/ErrorHandler.java
@@ -9,17 +9,18 @@ import play.mvc.*;
 import play.mvc.Http.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.Optional;
 import javax.inject.Singleton;
 
 @Singleton
 public class ErrorHandler implements HttpErrorHandler {
-    public CompletionStage<Result> onClientError(RequestHeader request, int statusCode, String message) {
+    public CompletionStage<Result> onClientError(RequestHeader request, int statusCode, String message, Optional<Http.Context> context) {
         return CompletableFuture.completedFuture(
                 Results.status(statusCode, "A client error occurred: " + message)
         );
     }
 
-    public CompletionStage<Result> onServerError(RequestHeader request, Throwable exception) {
+    public CompletionStage<Result> onServerError(RequestHeader request, Throwable exception, Optional<Http.Context> context) {
         return CompletableFuture.completedFuture(
                 Results.internalServerError("A server error occurred: " + exception.getMessage())
         );

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -448,7 +448,23 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.routing.Router$Tags"),
 
       // Upgrade Guice from 4.1.0 to 4.2.0 which uses java.util.function.Function instead of com.google.common.base.Function now
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.test.TestBrowser.waitUntil")
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.test.TestBrowser.waitUntil"),
+
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.core.j.JavaHelpers.invokeWithContext"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.core.j.JavaAction.invokeWithContext"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.core.j.JavaHelpers.invokeWithContext"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.http.DefaultHttpErrorHandler.onServerError"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.http.DefaultHttpErrorHandler.onClientError"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.http.HttpErrorHandler.onServerError"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.http.HttpErrorHandler.onClientError"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.http.HttpErrorHandler.onServerError"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.http.HttpErrorHandler.onClientError"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.JavaHttpErrorHandlerDelegate.onClientError"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.JavaHttpErrorHandlerDelegate.onServerError"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.csrf.CSRFErrorHandler#DefaultCSRFErrorHandler.handle"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.csrf.CSRFErrorHandler.handle"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.filters.csrf.CSRFErrorHandler.handle"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.csrf.CSRF#JavaCSRFErrorHandlerDelegate.handle")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
@@ -10,6 +10,7 @@ import scala.compat.java8.FutureConverters;
 
 import javax.inject.Inject;
 import java.util.concurrent.CompletionStage;
+import java.util.Optional;
 
 /**
  * This interface handles the CSRF error.
@@ -23,7 +24,7 @@ public interface CSRFErrorHandler {
      * @param msg message is passed by framework.
      * @return Client gets this result.
      */
-    CompletionStage<Result> handle(Http.RequestHeader req, String msg);
+    CompletionStage<Result> handle(Http.RequestHeader req, String msg, Optional<Http.Context> context);
 
     class DefaultCSRFErrorHandler extends Results implements CSRFErrorHandler {
 
@@ -35,7 +36,7 @@ public interface CSRFErrorHandler {
         }
 
         @Override
-        public CompletionStage<Result> handle(Http.RequestHeader requestHeader, String msg) {
+        public CompletionStage<Result> handle(Http.RequestHeader requestHeader, String msg, Optional<Http.Context> context) {
             return FutureConverters.toJava(errorHandler.handle(requestHeader.asScala(), msg))
                     .thenApply(play.api.mvc.Result::asJava);
         }

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -6,6 +6,7 @@ package play.filters.csrf;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -109,6 +110,6 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
         }
 
         CSRFErrorHandler handler = configurator.apply(this.configuration);
-        return handler.handle(request.asJava(), msg);
+        return handler.handle(request.asJava(), msg, Optional.ofNullable(ctx));
     }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -272,13 +272,13 @@ object CSRF {
 
   class JavaCSRFErrorHandlerAdapter @Inject() (underlying: CSRFErrorHandler, contextComponents: JavaContextComponents) extends ErrorHandler {
     def handle(request: RequestHeader, msg: String) =
-      JavaHelpers.invokeWithContext(request, contextComponents, req => underlying.handle(req, msg))
+      JavaHelpers.invokeWithContext(request, contextComponents, (req, ctx) => underlying.handle(req, msg, Optional.ofNullable(ctx)))
   }
 
   class JavaCSRFErrorHandlerDelegate @Inject() (delegate: ErrorHandler) extends CSRFErrorHandler {
     import play.core.Execution.Implicits.trampoline
 
-    def handle(requestHeader: Http.RequestHeader, msg: String) =
+    def handle(requestHeader: Http.RequestHeader, msg: String, ctx: Optional[Http.Context]) =
       FutureConverters.toJava(delegate.handle(requestHeader.asScala(), msg).map(_.asJava))
   }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -4,6 +4,7 @@
 package play.filters.csrf
 
 import java.util.concurrent.CompletableFuture
+import java.util.Optional
 import javax.inject.Inject
 
 import akka.stream.scaladsl.Source
@@ -318,7 +319,7 @@ class CustomErrorHandler extends CSRF.ErrorHandler {
 }
 
 class JavaErrorHandler extends CSRFErrorHandler {
-  def handle(req: Http.RequestHeader, msg: String) = CompletableFuture.completedFuture(play.mvc.Results.unauthorized())
+  def handle(req: Http.RequestHeader, msg: String, ctx: Optional[Http.Context]) = CompletableFuture.completedFuture(play.mvc.Results.unauthorized())
 }
 
 class CsrfFilters @Inject() (filter: CSRFFilter) extends HttpFilters {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -4,6 +4,7 @@
 package play.filters.csrf
 
 import java.util.concurrent.CompletableFuture
+import java.util.Optional
 
 import play.api.Application
 import play.api.libs.ws._
@@ -131,7 +132,7 @@ object JavaCSRFActionSpec {
   }
 
   class CustomErrorHandler extends CSRFErrorHandler {
-    def handle(req: RequestHeader, msg: String) = {
+    def handle(req: RequestHeader, msg: String, ctx: Optional[Context]) = {
       CompletableFuture.completedFuture(Results.unauthorized(msg))
     }
   }

--- a/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -4,6 +4,7 @@
 package play.api.http
 
 import java.util.concurrent.CompletableFuture
+import java.util.Optional
 
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.specs2.mutable.Specification
@@ -108,8 +109,8 @@ class CustomScalaErrorHandler extends HttpErrorHandler {
 }
 
 class CustomJavaErrorHandler extends play.http.HttpErrorHandler {
-  def onClientError(req: play.mvc.Http.RequestHeader, status: Int, msg: String) =
+  def onClientError(req: play.mvc.Http.RequestHeader, status: Int, msg: String, ctx: Optional[play.mvc.Http.Context]) =
     CompletableFuture.completedFuture(play.mvc.Results.ok())
-  def onServerError(req: play.mvc.Http.RequestHeader, exception: Throwable) =
+  def onServerError(req: play.mvc.Http.RequestHeader, exception: Throwable, ctx: Optional[play.mvc.Http.Context]) =
     CompletableFuture.completedFuture(play.mvc.Results.ok())
 }

--- a/framework/src/play/src/main/java/play/http/HttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/HttpErrorHandler.java
@@ -5,8 +5,10 @@ package play.http;
 
 import play.mvc.Http.RequestHeader;
 import play.mvc.Result;
+import play.mvc.Http;
 
 import java.util.concurrent.CompletionStage;
+import java.util.Optional;
 
 /**
  * Component for handling HTTP errors in Play.
@@ -23,7 +25,7 @@ public interface HttpErrorHandler {
      * @param message The error message.
      * @return a CompletionStage with the Result.
      */
-    CompletionStage<Result> onClientError(RequestHeader request, int statusCode, String message);
+    CompletionStage<Result> onClientError(RequestHeader request, int statusCode, String message, Optional<Http.Context> context);
 
     /**
      * Invoked when a server error occurs.
@@ -32,5 +34,5 @@ public interface HttpErrorHandler {
      * @param exception The server error.
      * @return a CompletionStage with the Result.
      */
-    CompletionStage<Result> onServerError(RequestHeader request, Throwable exception);
+    CompletionStage<Result> onServerError(RequestHeader request, Throwable exception, Optional<Http.Context> context);
 }

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -380,7 +380,7 @@ public interface BodyParser<A> {
                   if (status instanceof MaxSizeNotExceeded$) {
                       return resultFuture;
                   } else {
-                      return errorHandler.onClientError(request, Status$.MODULE$.REQUEST_ENTITY_TOO_LARGE(), "Request entity too large")
+                      return errorHandler.onClientError(request, Status$.MODULE$.REQUEST_ENTITY_TOO_LARGE(), "Request entity too large", Optional.empty())
                               .thenApply(F.Either::<Result, A>Left);
                   }
                })
@@ -422,7 +422,7 @@ public interface BodyParser<A> {
                 try {
                     return CompletableFuture.completedFuture(F.Either.Right(parse(request, bytes)));
                 } catch (Exception e) {
-                    return errorHandler.onClientError(request, Status$.MODULE$.BAD_REQUEST(), errorMessage + ": " + e.getMessage())
+                    return errorHandler.onClientError(request, Status$.MODULE$.BAD_REQUEST(), errorMessage + ": " + e.getMessage(), Optional.empty())
                             .thenApply(F.Either::<Result, A>Left);
                 }
             }, JavaParsers.trampoline());

--- a/framework/src/play/src/main/java/play/mvc/BodyParsers.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParsers.java
@@ -5,6 +5,7 @@ package play.mvc;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.Optional;
 
 import play.api.http.Status$;
 import play.http.HttpErrorHandler;
@@ -40,7 +41,7 @@ public class BodyParsers {
             return parser.apply(request);
         } else {
             CompletionStage<Result> result =
-                    errorHandler.onClientError(request, Status$.MODULE$.UNSUPPORTED_MEDIA_TYPE(), errorMessage);
+                    errorHandler.onClientError(request, Status$.MODULE$.UNSUPPORTED_MEDIA_TYPE(), errorMessage, Optional.empty());
             return Accumulator.done(result.thenApply(F.Either::Left));
         }
     }

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -20,6 +20,8 @@ import scala.compat.java8.FutureConverters
 import scala.concurrent._
 import scala.util.control.NonFatal
 
+import java.util.Optional
+
 /**
  * Component for handling HTTP errors in Play.
  *
@@ -308,9 +310,9 @@ object LazyHttpErrorHandler extends HttpErrorHandler {
 private[play] class JavaHttpErrorHandlerDelegate @Inject() (delegate: HttpErrorHandler) extends play.http.HttpErrorHandler {
   import play.core.Execution.Implicits.trampoline
 
-  def onClientError(request: Http.RequestHeader, statusCode: Int, message: String) =
+  def onClientError(request: Http.RequestHeader, statusCode: Int, message: String, context: Optional[Http.Context]) =
     FutureConverters.toJava(delegate.onClientError(request.asScala(), statusCode, message).map(_.asJava))
 
-  def onServerError(request: Http.RequestHeader, exception: Throwable) =
+  def onServerError(request: Http.RequestHeader, exception: Throwable, context: Optional[Http.Context]) =
     FutureConverters.toJava(delegate.onServerError(request.asScala(), exception).map(_.asJava))
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -244,9 +244,9 @@ trait JavaHelpers {
    * @param f The function to invoke
    * @return The result
    */
-  def invokeWithContext(request: RequestHeader, components: JavaContextComponents, f: JRequest => CompletionStage[JResult]): Future[Result] = {
+  def invokeWithContext(request: RequestHeader, components: JavaContextComponents, f: (JRequest, JContext) => CompletionStage[JResult]): Future[Result] = {
     withContext(request, components) { javaContext =>
-      FutureConverters.toScala(f(javaContext.request())).map(createResult(javaContext, _))(trampoline)
+      FutureConverters.toScala(f(javaContext.request(), javaContext)).map(createResult(javaContext, _))(trampoline)
     }
   }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
@@ -9,16 +9,18 @@ import play.api.http.HttpErrorHandler
 import play.api.mvc.RequestHeader
 import play.http.{ HttpErrorHandler => JHttpErrorHandler }
 
+import java.util.Optional
+
 /**
  * Adapter from a Java HttpErrorHandler to a Scala HttpErrorHandler
  */
 class JavaHttpErrorHandlerAdapter @Inject() (underlying: JHttpErrorHandler, contextComponents: JavaContextComponents) extends HttpErrorHandler {
 
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
-    JavaHelpers.invokeWithContext(request, contextComponents, req => underlying.onClientError(req, statusCode, message))
+    JavaHelpers.invokeWithContext(request, contextComponents, (req, ctx) => underlying.onClientError(req, statusCode, message, Optional.ofNullable(ctx)))
   }
 
   def onServerError(request: RequestHeader, exception: Throwable) = {
-    JavaHelpers.invokeWithContext(request, contextComponents, req => underlying.onServerError(req, exception))
+    JavaHelpers.invokeWithContext(request, contextComponents, (req, ctx) => underlying.onServerError(req, exception, Optional.ofNullable(ctx)))
   }
 }


### PR DESCRIPTION
This is related to #6168
Since we are planning to remove `Http.Context.current` in future versions we also need to be able to access the current context from within the error handlers.
Just read the migration note I added: All methods of all error handlers now get an `Optional<Http.Context>` passed as the last argument (there are cases where it can be `empty`).

Actually I named the commit `"invokeWithContext also passes on ctx as method parameter"`, so my pull request can also be seen as a "fix" of the `invokeWithContext` method - now it *really* invokes a method with a (passed) context as argument :wink: - before this method was only seen as like: "set the `Http.Context.current` thread local with a context and then invoke a method".