### PR TITLE
[WIP] Deprecate Java's Http.Context

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -72,6 +72,35 @@ Also, you can use your own pool that implements `play.api.db.ConnectionPool` by 
 play.db.pool=your.own.ConnectionPool
 ```
 
+### Java's `Http.Context` is deprecated now -> BIG FAT TODO
+
+1) Action composition now passes `Request` instead of `Context` object:
+
+```java
+public class SomeAction extends Action<Some> {
+
+    @Override
+    public CompletionStage<Result> call(final Context ctx) {
+    }
+
+}
+```
+
+is now
+
+```java
+    public CompletionStage<Result> call(final Request req) { ... }
+```
+
+2) args changes:
+
+`.args` -> `.args()`
+
+3) Some methods and constructors removed:
+
+* `withRequest(...)` not needed anymore
+* etc.
+
 ### Java `Http.Context` changed
 
 Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]] in Play 2.6, have finally been removed in Play 2.7.

--- a/framework/src/play-cache/src/main/java/play/cache/CachedAction.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CachedAction.java
@@ -6,7 +6,7 @@ package play.cache;
 import java.util.concurrent.CompletionStage;
 
 import play.mvc.Action;
-import play.mvc.Http.Context;
+import play.mvc.Http.Request;
 import play.mvc.Result;
 
 import javax.inject.Inject;
@@ -23,10 +23,10 @@ public class CachedAction extends Action<Cached> {
         this.cacheApi = cacheApi;
     }
 
-    public CompletionStage<Result> call(Context ctx) {
+    public CompletionStage<Result> call(Request req) {
         final String key = configuration.key();
         final Integer duration = configuration.duration();
-        return cacheApi.getOrElseUpdate(key, () -> delegate.call(ctx), duration);
+        return cacheApi.getOrElseUpdate(key, () -> delegate.call(req), duration);
     }
 
 }

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
@@ -28,7 +28,8 @@ public interface CSRFComponents extends ConfigurationComponents,
                 csrfConfig(),
                 sessionConfiguration(),
                 csrfTokenProvider(),
-                csrfTokenSigner().asScala()
+                csrfTokenSigner().asScala(),
+                javaRequestComponents()
         );
     }
 
@@ -55,7 +56,7 @@ public interface CSRFComponents extends ConfigurationComponents,
                 sessionConfiguration(),
                 csrfTokenProvider(),
                 csrfErrorHandler(),
-                javaContextComponents(),
+                javaRequestComponents(),
                 materializer()
         );
     }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -6,7 +6,7 @@ package play.filters.cors
 import akka.stream.Materializer
 import akka.util.ByteString
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
-import play.core.j.{ JavaContextComponents, JavaHttpErrorHandlerAdapter }
+import play.core.j.{ JavaRequestComponents, JavaHttpErrorHandlerAdapter }
 
 import scala.concurrent.Future
 import play.api.Logger
@@ -44,8 +44,8 @@ class CORSFilter(
     private val pathPrefixes: Seq[String] = Seq("/")) extends EssentialFilter with AbstractCORSPolicy {
 
   // Java constructor
-  def this(corsConfig: CORSConfig, errorHandler: play.http.HttpErrorHandler, pathPrefixes: java.util.List[String], contextComponents: JavaContextComponents) = {
-    this(corsConfig, new JavaHttpErrorHandlerAdapter(errorHandler, contextComponents), Seq(pathPrefixes.toArray.asInstanceOf[Array[String]]: _*))
+  def this(corsConfig: CORSConfig, errorHandler: play.http.HttpErrorHandler, pathPrefixes: java.util.List[String], requestComponents: JavaRequestComponents) = {
+    this(corsConfig, new JavaHttpErrorHandlerAdapter(errorHandler, requestComponents), Seq(pathPrefixes.toArray.asInstanceOf[Array[String]]: _*))
   }
 
   override protected val logger = Logger(classOf[CORSFilter])

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -9,7 +9,7 @@ import akka.stream.Materializer
 import play.api.http.SessionConfiguration
 import play.api.libs.crypto.CSRFTokenSigner
 import play.api.mvc._
-import play.core.j.JavaContextComponents
+import play.core.j.JavaRequestComponents
 import play.filters.csrf.CSRF._
 
 /**
@@ -37,8 +37,8 @@ class CSRFFilter(
   }
 
   // Java constructor for manually constructing the filter
-  def this(config: CSRFConfig, tokenSigner: play.libs.crypto.CSRFTokenSigner, sessionConfiguration: SessionConfiguration, tokenProvider: TokenProvider, errorHandler: CSRFErrorHandler, contextComponents: JavaContextComponents)(mat: Materializer) = {
-    this(config, tokenSigner.asScala, sessionConfiguration, tokenProvider, new JavaCSRFErrorHandlerAdapter(errorHandler, contextComponents))(mat)
+  def this(config: CSRFConfig, tokenSigner: play.libs.crypto.CSRFTokenSigner, sessionConfiguration: SessionConfiguration, tokenProvider: TokenProvider, errorHandler: CSRFErrorHandler, requestComponents: JavaRequestComponents)(mat: Materializer) = {
+    this(config, tokenSigner.asScala, sessionConfiguration, tokenProvider, new JavaCSRFErrorHandlerAdapter(errorHandler, requestComponents))(mat)
   }
 
   def apply(next: EssentialAction): EssentialAction = new CSRFAction(next, config, tokenSigner, tokenProvider, sessionConfiguration, errorHandler)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -15,7 +15,7 @@ import play.api.libs.crypto.{ CSRFTokenSigner, CSRFTokenSignerProvider }
 import play.api.libs.typedmap.TypedKey
 import play.api.mvc.Results._
 import play.api.mvc._
-import play.core.j.{ JavaContextComponents, JavaHelpers }
+import play.core.j.{ JavaRequestComponents, JavaHelpers }
 import play.filters.csrf.CSRF.{ CSRFHttpErrorHandler, _ }
 import play.mvc.Http
 import play.utils.Reflect
@@ -270,9 +270,9 @@ object CSRF {
     def handle(req: RequestHeader, msg: String) = Future.successful(Forbidden(msg))
   }
 
-  class JavaCSRFErrorHandlerAdapter @Inject() (underlying: CSRFErrorHandler, contextComponents: JavaContextComponents) extends ErrorHandler {
+  class JavaCSRFErrorHandlerAdapter @Inject() (underlying: CSRFErrorHandler, requestComponents: JavaRequestComponents) extends ErrorHandler {
     def handle(request: RequestHeader, msg: String) =
-      JavaHelpers.invokeWithContext(request, contextComponents, req => underlying.handle(req, msg))
+      JavaHelpers.invokeWithRequest(request, requestComponents, req => underlying.handle(req, msg))
   }
 
   class JavaCSRFErrorHandlerDelegate @Inject() (delegate: ErrorHandler) extends CSRFErrorHandler {

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -11,7 +11,7 @@ import play.api.http.{ HttpErrorHandler, Status }
 import play.api.inject._
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{ EssentialAction, EssentialFilter }
-import play.core.j.{ JavaContextComponents, JavaHttpErrorHandlerAdapter }
+import play.core.j.{ JavaRequestComponents, JavaHttpErrorHandlerAdapter }
 
 /**
  * A filter that denies requests by hosts that do not match a configured list of allowed hosts.
@@ -22,8 +22,8 @@ case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandle
   private val logger = Logger(this.getClass)
 
   // Java API
-  def this(config: AllowedHostsConfig, errorHandler: play.http.HttpErrorHandler, contextComponents: JavaContextComponents) {
-    this(config, new JavaHttpErrorHandlerAdapter(errorHandler, contextComponents))
+  def this(config: AllowedHostsConfig, errorHandler: play.http.HttpErrorHandler, requestComponents: JavaRequestComponents) {
+    this(config, new JavaHttpErrorHandlerAdapter(errorHandler, requestComponents))
   }
 
   private val hostMatchers: Seq[HostMatcher] = config.allowed map HostMatcher.apply

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture
 import play.api.Application
 import play.api.libs.ws._
 import play.api.mvc.{ DefaultSessionCookieBaker, SessionCookieBaker }
-import play.core.j.{ JavaAction, JavaActionAnnotations, JavaContextComponents, JavaHandlerComponents }
+import play.core.j.{ JavaAction, JavaActionAnnotations, JavaRequestComponents, JavaHandlerComponents }
 import play.core.routing.HandlerInvokerFactory
 import play.mvc.Http.{ Context, RequestHeader }
 import play.mvc.{ Controller, Result, Results }
@@ -22,7 +22,7 @@ import scala.reflect.ClassTag
 class JavaCSRFActionSpec extends CSRFCommonSpecs {
 
   def javaHandlerComponents(implicit app: Application) = inject[JavaHandlerComponents]
-  def javaContextComponents(implicit app: Application) = inject[JavaContextComponents]
+  def javaRequestComponents(implicit app: Application) = inject[JavaRequestComponents]
   def myAction(implicit app: Application) = inject[JavaCSRFActionSpec.MyAction]
 
   def javaAction[T: ClassTag](method: String, inv: => Result)(implicit app: Application) = new JavaAction(javaHandlerComponents) {

--- a/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
@@ -34,7 +34,7 @@ public class BuiltInComponentsFromContextTest {
 
         @Override
         public Router router() {
-            return new RoutingDsl(defaultBodyParser(), javaContextComponents())
+            return new RoutingDsl(defaultBodyParser(), javaRequestComponents())
                     .GET("/").routeTo(() -> Results.ok("index"))
                     .build();
         }

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
@@ -22,8 +22,8 @@ public class ActionCompositionOrderTest {
 
     static class ControllerComposition extends Action<ControllerAnnotation> {
         @Override
-        public CompletionStage<Result> call(Http.Context ctx) {
-            return delegate.call(ctx).thenApply(result -> {
+        public CompletionStage<Result> call(Http.Context req) {
+            return delegate.call(req).thenApply(result -> {
                 String newContent = this.annotatedElement.getClass().getName() + "controller" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });
@@ -37,8 +37,8 @@ public class ActionCompositionOrderTest {
 
     static class ActionComposition extends Action<ControllerAnnotation> {
         @Override
-        public CompletionStage<Result> call(Http.Context ctx) {
-            return delegate.call(ctx).thenApply(result -> {
+        public CompletionStage<Result> call(Http.Context req) {
+            return delegate.call(req).thenApply(result -> {
                 String newContent = this.annotatedElement.getClass().getName() + "action" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });
@@ -54,8 +54,8 @@ public class ActionCompositionOrderTest {
 
     static class WithUsernameAction extends Action<WithUsername> {
         @Override
-        public CompletionStage<Result> call(Http.Context ctx) {
-            return delegate.call(ctx.withRequest(ctx.request().addAttr(Security.USERNAME, configuration.value())));
+        public CompletionStage<Result> call(Http.Context req) {
+            return delegate.call(req.request().addAttr(Security.USERNAME, configuration.value()));
         }
     }
 
@@ -76,8 +76,8 @@ public class ActionCompositionOrderTest {
 
     public static class FirstAction extends Action<SomeRepeatable> {
         @Override
-        public CompletionStage<Result> call(Http.Context ctx) {
-            return delegate.call(ctx).thenApply(result -> {
+        public CompletionStage<Result> call(Http.Context req) {
+            return delegate.call(req).thenApply(result -> {
                 String newContent = this.annotatedElement.getClass().getName() + "action1" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });
@@ -86,8 +86,8 @@ public class ActionCompositionOrderTest {
 
     public static class SecondAction extends Action<SomeRepeatable> {
         @Override
-        public CompletionStage<Result> call(Http.Context ctx) {
-            return delegate.call(ctx).thenApply(result -> {
+        public CompletionStage<Result> call(Http.Context req) {
+            return delegate.call(req).thenApply(result -> {
                 String newContent = this.annotatedElement.getClass().getName() + "action2" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });
@@ -106,8 +106,8 @@ public class ActionCompositionOrderTest {
 
     public static class SomeActionAnnotationAction extends Action<SomeActionAnnotation> {
         @Override
-        public CompletionStage<Result> call(Http.Context ctx) {
-            return delegate.call(ctx).thenApply(result -> {
+        public CompletionStage<Result> call(Http.Context req) {
+            return delegate.call(req).thenApply(result -> {
                 String newContent = "do_NOT_treat_me_as_container_annotation" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
             });

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
 import play.api._
 import play.api.mvc.EssentialAction
-import play.core.j.{ JavaAction, JavaActionAnnotations, JavaContextComponents, JavaHandlerComponents }
+import play.core.j.{ JavaAction, JavaActionAnnotations, JavaRequestComponents, JavaHandlerComponents }
 import play.core.routing.HandlerInvokerFactory
 import play.mvc.{ Http, Result }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
@@ -4,7 +4,7 @@
 package play.it.libs
 
 import play.api.test._
-import play.core.j.{ JavaContextComponents, JavaHelpers }
+import play.core.j.{ JavaRequestComponents, JavaHelpers }
 import play.data.validation.Constraints.Required
 
 import scala.annotation.meta.field
@@ -16,7 +16,7 @@ class JavaFormSpec extends PlaySpecification {
   "A Java form" should {
 
     "throw a meaningful exception when get is called on an invalid form" in new WithApplication() {
-      val components = app.injector.instanceOf[JavaContextComponents]
+      val components = app.injector.instanceOf[JavaRequestComponents]
       JavaHelpers.withContext(FakeRequest(), components) { _ =>
         val formFactory = app.injector.instanceOf[play.data.FormFactory]
         val myForm = formFactory.form(classOf[FooForm]).bind(Map("id" -> "1234567891").asJava)

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
 import play.Application;
 import play.Environment;
-import play.core.j.JavaContextComponents;
+import play.core.j.JavaRequestComponents;
 import play.data.*;
 import play.data.format.Formatters;
 import play.data.Task;
@@ -53,8 +53,8 @@ public class HttpFormsTest {
         }
     }
 
-    private JavaContextComponents contextComponents(Application app) {
-        return app.injector().instanceOf(JavaContextComponents.class);
+    private JavaRequestComponents requestComponents(Application app) {
+        return app.injector().instanceOf(JavaRequestComponents.class);
     }
 
     private <T> Form<T> copyFormWithoutRawData(final Form<T> formToCopy, final Application app) {
@@ -75,7 +75,7 @@ public class HttpFormsTest {
             Map<String, String> data = new HashMap<>();
             data.put("amount", "1234567,89");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb, contextComponents(app));
+            Context ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse french input with french formatter
             ctx.changeLang("fr");
@@ -98,7 +98,7 @@ public class HttpFormsTest {
             data = new HashMap<>();
             data.put("amount", "1234567.89");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb, contextComponents(app));
+            ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse english input with french formatter
             ctx.changeLang("fr");
@@ -131,7 +131,7 @@ public class HttpFormsTest {
             Validator validator = app.injector().instanceOf(Validator.class);
 
             RequestBuilder rb = new RequestBuilder();
-            Context ctx = new Context(rb, contextComponents(app));
+            Context ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
 
             List<String> msgs = new ArrayList<>();
@@ -156,7 +156,7 @@ public class HttpFormsTest {
             Map<String, String> data = new HashMap<>();
             data.put("date", "3/10/1986");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb, contextComponents(app));
+            Context ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse date input with pattern from the default messages file
             Form<Birthday> myForm = formFactory.form(Birthday.class).bindFromRequest();
@@ -170,7 +170,7 @@ public class HttpFormsTest {
             data = new HashMap<>();
             data.put("date", "16.2.2001");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb, contextComponents(app));
+            ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse french date input with pattern from the french messages file
             ctx.changeLang("fr");
@@ -185,7 +185,7 @@ public class HttpFormsTest {
             data = new HashMap<>();
             data.put("date", "8-31-1950");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb, contextComponents(app));
+            ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse english date input with pattern from the en-US messages file
             ctx.changeLang("en-US");
@@ -207,7 +207,7 @@ public class HttpFormsTest {
             Map<String, String> data = new HashMap<>();
             data.put("alternativeDate", "1982-5-7");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb, contextComponents(app));
+            Context ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse date input with pattern from Play's default messages file
             Form<Birthday> myForm = formFactory.form(Birthday.class).bindFromRequest();
@@ -221,7 +221,7 @@ public class HttpFormsTest {
             data = new HashMap<>();
             data.put("alternativeDate", "10_4_2005");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb, contextComponents(app));
+            ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse french date input with pattern from the french messages file
             ctx.changeLang("fr");
@@ -236,7 +236,7 @@ public class HttpFormsTest {
             data = new HashMap<>();
             data.put("alternativeDate", "3/12/1962");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb, contextComponents(app));
+            ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse english date input with pattern from the en-US messages file
             ctx.changeLang("en-US");
@@ -260,7 +260,7 @@ public class HttpFormsTest {
             data.put("name", "peter");
             data.put("dueDate", "2009/11e/11");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb, contextComponents(app));
+            Context ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse date input with pattern from the default messages file
             Form<Task> myForm = formFactory.form(Task.class).bindFromRequest();
@@ -278,7 +278,7 @@ public class HttpFormsTest {
             data.put("dueDate", "2009/11e/11");
             Cookie frCookie = new Cookie("PLAY_LANG", "fr", 0, "/", null, false, false, null);
             rb = new RequestBuilder().cookie(frCookie).uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb, contextComponents(app));
+            ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse date input with pattern from the french messages file
             myForm = formFactory.form(Task.class).bindFromRequest();
@@ -305,7 +305,7 @@ public class HttpFormsTest {
             data.put("zip", "1234");
             data.put("anotherZip", "1234");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb, contextComponents(app));
+            Context ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse input with pattern from the default messages file
             Form<Task> myForm = formFactory.form(Task.class).bindFromRequest();
@@ -320,7 +320,7 @@ public class HttpFormsTest {
             data.put("zip", "567");
             data.put("anotherZip", "567");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb, contextComponents(app));
+            ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse input with pattern from the french messages file
             ctx.changeLang("fr");
@@ -336,7 +336,7 @@ public class HttpFormsTest {
             data.put("zip", "1234");
             data.put("anotherZip", "1234");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb, contextComponents(app));
+            ctx = new Context(rb, requestComponents(app));
             Context.current.set(ctx);
             // Parse WRONG input with pattern from the french messages file
             ctx.changeLang("fr");

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -16,7 +16,7 @@ import play.{ ApplicationLoader, BuiltInComponentsFromContext }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.WithApplication
 import play.api.Application
-import play.core.j.JavaContextComponents
+import play.core.j.JavaRequestComponents
 import play.data.validation.ValidationError
 import play.mvc.EssentialFilter
 import play.mvc.Http.{ Context, Request, RequestBuilder }
@@ -30,7 +30,7 @@ import scala.compat.java8.OptionConverters._
 class RuntimeDependencyInjectionFormSpec extends FormSpec {
   private var app: Option[Application] = None
 
-  override def defaultContextComponents: JavaContextComponents = app.getOrElse(application()).injector.instanceOf[JavaContextComponents]
+  override def defaultContextComponents: JavaRequestComponents = app.getOrElse(application()).injector.instanceOf[JavaRequestComponents]
 
   override def formFactory: FormFactory = app.getOrElse(application()).injector.instanceOf[FormFactory]
 
@@ -71,7 +71,7 @@ class CompileTimeDependencyInjectionFormSpec extends FormSpec {
     myComponents.application().asScala()
   }
 
-  override def defaultContextComponents: JavaContextComponents = components.getOrElse(new MyComponents(ApplicationLoader.create(play.Environment.simple()))).javaContextComponents()
+  override def defaultContextComponents: JavaRequestComponents = components.getOrElse(new MyComponents(ApplicationLoader.create(play.Environment.simple()))).javaRequestComponents()
 }
 
 trait FormSpec extends Specification {
@@ -80,7 +80,7 @@ trait FormSpec extends Specification {
 
   def formFactory: FormFactory
   def application(extraConfig: (String, Any)*): Application
-  def defaultContextComponents: JavaContextComponents
+  def defaultContextComponents: JavaRequestComponents
 
   "a java form" should {
 
@@ -102,10 +102,10 @@ trait FormSpec extends Specification {
         myForm.field("task.name").getValue.asScala must beSome("peter")
       }
       "have an error due to missing required value" in new WithApplication(application()) {
-        val contextComponents = defaultContextComponents
+        val requestComponents = defaultContextComponents
 
         val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891x"), "task.name" -> Array("peter")))
-        Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, contextComponents))
+        Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, requestComponents))
 
         val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest()
         myForm hasErrors () must beEqualTo(true)

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAEntityManagerContext.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAEntityManagerContext.java
@@ -49,12 +49,12 @@ public class JPAEntityManagerContext extends ThreadLocal<Deque<EntityManager>> {
     public Deque<EntityManager> emStack(boolean threadLocalFallback) {
         Http.Context context = Http.Context.current.get();
         if (context != null) {
-            Object emsObject = context.args.get(CURRENT_ENTITY_MANAGER);
+            Object emsObject = context.args().get(CURRENT_ENTITY_MANAGER);
             if (emsObject != null) {
                 return (Deque<EntityManager>) emsObject;
             } else {
                 Deque<EntityManager> ems = new ArrayDeque<>();
-                context.args.put(CURRENT_ENTITY_MANAGER, ems);
+                context.args().put(CURRENT_ENTITY_MANAGER, ems);
                 return ems;
             }
         } else {

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
@@ -21,11 +21,11 @@ public class TransactionalAction extends Action<Transactional> {
         this.jpaApi = jpaApi;
     }
 
-    public CompletionStage<Result> call(final Context ctx) {
+    public CompletionStage<Result> call(final Request req) {
         return jpaApi.withTransaction(
             configuration.value(),
             configuration.readOnly(),
-            () -> delegate.call(ctx)
+            () -> delegate.call(req)
         );
     }
 

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -8,7 +8,7 @@ import play.BuiltInComponents;
 import play.api.mvc.BodyParser;
 import play.api.mvc.PathBindable;
 import play.api.mvc.PathBindable$;
-import play.core.j.JavaContextComponents;
+import play.core.j.JavaRequestComponents;
 import play.core.routing.HandlerInvokerFactory$;
 import play.libs.F;
 import play.libs.Scala;
@@ -89,18 +89,18 @@ import java.util.stream.StreamSupport;
 public class RoutingDsl {
 
     private final BodyParser<Http.RequestBody> bodyParser;
-    private final JavaContextComponents contextComponents;
+    private final JavaRequestComponents requestComponents;
 
     final List<Route> routes = new ArrayList<>();
 
     @Inject
-    public RoutingDsl(play.mvc.BodyParser.Default bodyParser, JavaContextComponents contextComponents) {
+    public RoutingDsl(play.mvc.BodyParser.Default bodyParser, JavaRequestComponents requestComponents) {
         this.bodyParser = HandlerInvokerFactory$.MODULE$.javaBodyParserToScala(bodyParser);
-        this.contextComponents = contextComponents;
+        this.requestComponents = requestComponents;
     }
 
     public static RoutingDsl fromComponents(BuiltInComponents components) {
-        return new RoutingDsl(components.defaultBodyParser(), components.javaContextComponents());
+        return new RoutingDsl(components.defaultBodyParser(), components.javaRequestComponents());
     }
 
     /**
@@ -190,7 +190,7 @@ public class RoutingDsl {
      * @return The built router.
      */
     public play.routing.Router build() {
-        return new RouterBuilderHelper(this.bodyParser, this.contextComponents).build(this);
+        return new RouterBuilderHelper(this.bodyParser, this.requestComponents).build(this);
     }
 
     private RoutingDsl with(String method, String pathPattern, int arity, Object action, Class<?> actionFunction) {

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDslComponents.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDslComponents.java
@@ -32,7 +32,7 @@ import play.components.BodyParserComponents;
 public interface RoutingDslComponents extends BodyParserComponents {
 
     default RoutingDsl routingDsl() {
-        return new RoutingDsl(defaultBodyParser(), javaContextComponents());
+        return new RoutingDsl(defaultBodyParser(), javaRequestComponents());
     }
 
 }

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -29,7 +29,7 @@ object PlayMagicForJava extends JavaImplicitConversions {
   }
 
   implicit def requestHeader: play.api.mvc.RequestHeader = {
-    ctx._requestHeader
+    ctx.asScala()
   }
 
   implicit def implicitJavaMessages: play.api.i18n.Messages = {

--- a/framework/src/play-java/src/main/scala/play/routing/RoutingDslModule.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RoutingDslModule.scala
@@ -8,7 +8,7 @@ import javax.inject.{ Inject, Provider }
 import play.api.inject._
 import play.api.{ Configuration, Environment }
 import play.api.mvc.PlayBodyParsers
-import play.core.j.JavaContextComponents
+import play.core.j.JavaRequestComponents
 import play.mvc.BodyParser.Default
 
 /**
@@ -23,6 +23,6 @@ class RoutingDslModule extends Module {
   }
 }
 
-class JavaRoutingDslProvider @Inject() (bodyParser: play.mvc.BodyParser.Default, contextComponents: JavaContextComponents) extends Provider[RoutingDsl] {
-  override def get(): RoutingDsl = new RoutingDsl(bodyParser, contextComponents)
+class JavaRoutingDslProvider @Inject() (bodyParser: play.mvc.BodyParser.Default, requestComponents: JavaRequestComponents) extends Provider[RoutingDsl] {
+  override def get(): RoutingDsl = new RoutingDsl(bodyParser, requestComponents)
 }

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -10,7 +10,7 @@ import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
 import play.Application;
 import play.Environment;
-import play.core.j.JavaContextComponents;
+import play.core.j.JavaRequestComponents;
 import play.i18n.MessagesApi;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http.Context;
@@ -62,9 +62,9 @@ public class HttpTest {
     @Test
     public void testChangeLang() {
         withApplication((app) -> {
-            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+            JavaRequestComponents requestComponents = app.injector().instanceOf(JavaRequestComponents.class);
 
-            Context ctx = new Context(new RequestBuilder(), contextComponents);
+            Context ctx = new Context(new RequestBuilder(), requestComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("en");
             assertThat(responseLangCookie(ctx, messagesApi(app))).isNull();
@@ -81,9 +81,9 @@ public class HttpTest {
     @Test
     public void testChangeLangFailure() {
         withApplication((app) -> {
-            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+            JavaRequestComponents requestComponents = app.injector().instanceOf(JavaRequestComponents.class);
 
-            Context ctx = new Context(new RequestBuilder(), contextComponents);
+            Context ctx = new Context(new RequestBuilder(), requestComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("en");
             assertThat(responseLangCookie(ctx, messagesApi(app))).isNull();
@@ -98,9 +98,9 @@ public class HttpTest {
     @Test
     public void testClearLang() {
         withApplication((app) -> {
-            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+            JavaRequestComponents requestComponents = app.injector().instanceOf(JavaRequestComponents.class);
 
-            Context ctx = new Context(new RequestBuilder(), contextComponents);
+            Context ctx = new Context(new RequestBuilder(), requestComponents);
             // Set 'fr' as our initial language
             assertThat(ctx.changeLang("fr")).isTrue();
             assertThat(ctx.lang().code()).isEqualTo("fr");
@@ -116,9 +116,9 @@ public class HttpTest {
     @Test
     public void testSetTransientLang() {
         withApplication((app) -> {
-            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+            JavaRequestComponents requestComponents = app.injector().instanceOf(JavaRequestComponents.class);
 
-            Context ctx = new Context(new RequestBuilder(), contextComponents);
+            Context ctx = new Context(new RequestBuilder(), requestComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("en");
             assertThat(responseLangCookie(ctx, messagesApi(app))).isNull();
@@ -135,9 +135,9 @@ public class HttpTest {
     @Test(expected=IllegalArgumentException.class)
     public void testSetTransientLangFailure() {
         withApplication((app) -> {
-            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+            JavaRequestComponents requestComponents = app.injector().instanceOf(JavaRequestComponents.class);
 
-            Context ctx = new Context(new RequestBuilder(), contextComponents);
+            Context ctx = new Context(new RequestBuilder(), requestComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("en");
             assertThat(responseLangCookie(ctx, messagesApi(app))).isNull();
@@ -149,11 +149,11 @@ public class HttpTest {
     @Test
     public void testClearTransientLang() {
         withApplication((app) -> {
-            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+            JavaRequestComponents requestComponents = app.injector().instanceOf(JavaRequestComponents.class);
 
             Cookie frCookie = new Cookie("PLAY_LANG", "fr", null, "/", null, false, false, null);
             RequestBuilder rb = new RequestBuilder().cookie(frCookie);
-            Context ctx = new Context(rb, contextComponents);
+            Context ctx = new Context(rb, requestComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("fr");
             assertThat(responseLangCookie(ctx, messagesApi(app))).isNull();

--- a/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import play.api.Application;
 import play.api.Play;
 import play.api.inject.guice.GuiceApplicationBuilder;
-import play.core.j.JavaContextComponents;
+import play.core.j.JavaRequestComponents;
 import play.libs.Files.TemporaryFileCreator;
 import play.libs.typedmap.TypedKey;
 import play.mvc.Http.Context;
@@ -109,9 +109,9 @@ public class RequestBuilderTest {
     public void testFlash() {
         Application app = new GuiceApplicationBuilder().build();
         Play.start(app);
-        JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+        JavaRequestComponents requestComponents = app.injector().instanceOf(JavaRequestComponents.class);
         RequestBuilder builder = new RequestBuilder().flash("a","1").flash("b","1").flash("b","2");
-        Context ctx = new Context(builder, contextComponents);
+        Context ctx = new Context(builder, requestComponents);
         assertEquals("1", ctx.flash().get("a"));
         assertEquals("2", ctx.flash().get("b"));
     }
@@ -120,8 +120,8 @@ public class RequestBuilderTest {
     public void testSession() {
         Application app = new GuiceApplicationBuilder().build();
         Play.start(app);
-        JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
-        Context ctx = new Context(new RequestBuilder().session("a","1").session("b","1").session("b","2"), contextComponents);
+        JavaRequestComponents requestComponents = app.injector().instanceOf(JavaRequestComponents.class);
+        Context ctx = new Context(new RequestBuilder().session("a","1").session("b","1").session("b","2"), requestComponents);
         assertEquals("1", ctx.session().get("a"));
         assertEquals("2", ctx.session().get("b"));
         Play.stop(app);

--- a/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.Around
 import org.specs2.specification.Scope
 import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
 import play.api.{ Application, ApplicationLoader, Environment, Mode }
-import play.core.j.JavaContextComponents
+import play.core.j.JavaRequestComponents
 import play.core.server.ServerProvider
 
 // NOTE: Do *not* put any initialisation code in the below classes, otherwise delayedInit() gets invoked twice

--- a/framework/src/play/src/main/java/play/BuiltInComponents.java
+++ b/framework/src/play/src/main/java/play/BuiltInComponents.java
@@ -6,7 +6,7 @@ package play;
 import play.api.http.HttpConfiguration;
 import play.api.i18n.DefaultMessagesApiProvider;
 import play.components.*;
-import play.core.j.JavaContextComponents;
+import play.core.j.JavaRequestComponents;
 import play.core.j.JavaHelpers$;
 import play.http.ActionCreator;
 import play.http.DefaultActionCreator;
@@ -30,7 +30,7 @@ public interface BuiltInComponents extends
         TemporaryFileComponents {
 
     @Override
-    default JavaContextComponents javaContextComponents() {
+    default JavaRequestComponents javaRequestComponents() {
         return JavaHelpers$.MODULE$.createContextComponents(
                 messagesApi().asScala(),
                 langs().asScala(),

--- a/framework/src/play/src/main/java/play/BuiltInComponentsFromContext.java
+++ b/framework/src/play/src/main/java/play/BuiltInComponentsFromContext.java
@@ -139,7 +139,7 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
                 actionCreator(),
                 httpConfiguration(),
                 executionContext(),
-                javaContextComponents()
+                javaRequestComponents()
         );
 
         return javaHandlerComponents
@@ -182,7 +182,7 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
 
         play.api.http.HttpErrorHandler scalaErrorHandler = new JavaHttpErrorHandlerAdapter(
                 httpErrorHandler(),
-                javaContextComponents()
+                javaRequestComponents()
         );
 
         return new JavaCompatibleHttpRequestHandler(

--- a/framework/src/play/src/main/java/play/components/HttpErrorHandlerComponents.java
+++ b/framework/src/play/src/main/java/play/components/HttpErrorHandlerComponents.java
@@ -3,7 +3,7 @@
  */
 package play.components;
 
-import play.core.j.JavaContextComponents;
+import play.core.j.JavaRequestComponents;
 import play.core.j.JavaHttpErrorHandlerAdapter;
 import play.http.HttpErrorHandler;
 
@@ -12,11 +12,11 @@ import play.http.HttpErrorHandler;
  */
 public interface HttpErrorHandlerComponents {
 
-    JavaContextComponents javaContextComponents();
+    JavaRequestComponents javaRequestComponents();
 
     HttpErrorHandler httpErrorHandler();
 
     default play.api.http.HttpErrorHandler scalaHttpErrorHandler() {
-        return new JavaHttpErrorHandlerAdapter(httpErrorHandler(), javaContextComponents());
+        return new JavaHttpErrorHandlerAdapter(httpErrorHandler(), javaRequestComponents());
     }
 }

--- a/framework/src/play/src/main/java/play/core/j/MappedJavaHandlerComponents.java
+++ b/framework/src/play/src/main/java/play/core/j/MappedJavaHandlerComponents.java
@@ -25,16 +25,16 @@ public class MappedJavaHandlerComponents implements JavaHandlerComponents {
     private final ActionCreator actionCreator;
     private final HttpConfiguration httpConfiguration;
     private final ExecutionContext executionContext;
-    private final JavaContextComponents contextComponents;
+    private final JavaRequestComponents requestComponents;
 
     private final Map<Class<? extends Action<?>>, Supplier<Action<?>>> actions = new HashMap<>();
     private final Map<Class<? extends BodyParser<?>>, Supplier<BodyParser<?>>> bodyPasers = new HashMap<>();
 
-    public MappedJavaHandlerComponents(ActionCreator actionCreator, HttpConfiguration httpConfiguration, ExecutionContext executionContext, JavaContextComponents contextComponents) {
+    public MappedJavaHandlerComponents(ActionCreator actionCreator, HttpConfiguration httpConfiguration, ExecutionContext executionContext, JavaRequestComponents requestComponents) {
         this.actionCreator = actionCreator;
         this.httpConfiguration = httpConfiguration;
         this.executionContext = executionContext;
-        this.contextComponents = contextComponents;
+        this.requestComponents = requestComponents;
     }
 
     @Override @SuppressWarnings("unchecked")
@@ -63,8 +63,8 @@ public class MappedJavaHandlerComponents implements JavaHandlerComponents {
     }
 
     @Override
-    public JavaContextComponents contextComponents() {
-        return this.contextComponents;
+    public JavaRequestComponents requestComponents() {
+        return this.requestComponents;
     }
 
     public <A extends Action<?>> MappedJavaHandlerComponents addAction(Class<A> clazz, Supplier<A> actionSupplier) {

--- a/framework/src/play/src/main/java/play/http/DefaultActionCreator.java
+++ b/framework/src/play/src/main/java/play/http/DefaultActionCreator.java
@@ -27,8 +27,8 @@ public class DefaultActionCreator implements ActionCreator {
   public Action createAction(Request request, Method actionMethod) {
     return new Action.Simple() {
       @Override
-      public CompletionStage<Result> call(Http.Context ctx) {
-        return delegate.call(ctx);
+      public CompletionStage<Result> call(Http.Request req) {
+        return delegate.call(req);
       }
     };
   }

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -6,7 +6,7 @@ package play.mvc;
 import java.lang.reflect.AnnotatedElement;
 import java.util.concurrent.CompletionStage;
 
-import play.mvc.Http.Context;
+import play.mvc.Http.Request;
 
 /**
  * An action acts as decorator for the action method call.
@@ -40,12 +40,12 @@ public abstract class Action<T> extends Results {
     public Action<?> delegate;
 
     /**
-     * Executes this action with the given HTTP context and returns the result.
+     * Executes this action with the given HTTP request and returns the result.
      *
-     * @param ctx the http context in which to execute this action
+     * @param req the http request with which to execute this action
      * @return a promise to the action's result
      */
-    public abstract CompletionStage<Result> call(Context ctx);
+    public abstract CompletionStage<Result> call(Request req);
 
     /**
      * A simple action with no configuration.

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -57,16 +57,15 @@ public class Security {
             this.configurator = configurator;
         }
 
-        public CompletionStage<Result> call(final Context ctx) {
+        public CompletionStage<Result> call(final Request req) {
             Authenticator authenticator = configurator.apply(configuration);
-            String username = authenticator.getUsername(ctx);
+            String username = authenticator.getUsername(req);
             if (username == null) {
-                Result unauthorized = authenticator.onUnauthorized(ctx);
+                Result unauthorized = authenticator.onUnauthorized(req);
                 return CompletableFuture.completedFuture(unauthorized);
             } else {
-                Request usernameReq = ctx.request().addAttr(USERNAME, username);
-                Context usernameCtx = ctx.withRequest(usernameReq);
-                return delegate.call(usernameCtx);
+                Request usernameReq = req.request().addAttr(USERNAME, username);
+                return delegate.call(usernameReq);
             }
         }
 
@@ -80,20 +79,20 @@ public class Security {
         /**
          * Retrieves the username from the HTTP context; the default is to read from the session cookie.
          *
-         * @param ctx the current request context
+         * @param req the current request context
          * @return null if the user is not authenticated.
          */
-        public String getUsername(Context ctx) {
-            return ctx.session().get("username");
+        public String getUsername(Request req) {
+            return req.session().get("username");
         }
 
         /**
          * Generates an alternative result if the user is not authenticated; the default a simple '401 Not Authorized' page.
          *
-         * @param ctx the current request context
+         * @param req the current request context
          * @return a <code>401 Not Authorized</code> result
          */
-        public Result onUnauthorized(Context ctx) {
+        public Result onUnauthorized(Request req) {
             return unauthorized(views.html.defaultpages.unauthorized.render());
         }
 

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -18,7 +18,7 @@ import play.api.libs.crypto._
 import play.api.mvc._
 import play.api.mvc.request.{ DefaultRequestFactory, RequestFactory }
 import play.api.routing.Router
-import play.core.j.{ JavaContextComponents, JavaHelpers }
+import play.core.j.{ JavaRequestComponents, JavaHelpers }
 import play.core.{ DefaultWebCommands, SourceMapper, WebCommands }
 import play.utils._
 
@@ -351,7 +351,7 @@ trait BuiltInComponents extends I18nComponents {
 
   lazy val fileMimeTypes: FileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes).get
 
-  lazy val javaContextComponents: JavaContextComponents = JavaHelpers.createContextComponents(messagesApi, langs, fileMimeTypes, httpConfiguration)
+  lazy val javaRequestComponents: JavaRequestComponents = JavaHelpers.createContextComponents(messagesApi, langs, fileMimeTypes, httpConfiguration)
 
   // NOTE: the following helpers are declared as protected since they are only meant to be used inside BuiltInComponents
   // This also makes them not conflict with other methods of the same type when used with Macwire.

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -54,9 +54,9 @@ object HttpErrorHandler {
     val fromConfiguration = Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, JavaHttpErrorHandlerDelegate, DefaultHttpErrorHandler](environment, configuration,
       "play.http.errorHandler", "ErrorHandler")
 
-    val javaContextComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaContextComponents]).to[play.core.j.DefaultJavaContextComponents])
+    val javaRequestComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaRequestComponents]).to[play.core.j.DefaultJavaRequestComponents])
 
-    fromConfiguration ++ javaContextComponentsBindings
+    fromConfiguration ++ javaRequestComponentsBindings
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -51,10 +51,10 @@ object HttpRequestHandler {
       environment,
       configuration, "play.http.requestHandler", "RequestHandler")
 
-    val javaContextComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaContextComponents]).to[play.core.j.DefaultJavaContextComponents])
+    val javaRequestComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaRequestComponents]).to[play.core.j.DefaultJavaRequestComponents])
     val javaHandlerComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaHandlerComponents]).to[play.core.j.DefaultJavaHandlerComponents])
 
-    fromConfiguration ++ javaContextComponentsBindings ++ javaHandlerComponentsBindings
+    fromConfiguration ++ javaRequestComponentsBindings ++ javaHandlerComponentsBindings
   }
 }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
@@ -12,13 +12,13 @@ import play.http.{ HttpErrorHandler => JHttpErrorHandler }
 /**
  * Adapter from a Java HttpErrorHandler to a Scala HttpErrorHandler
  */
-class JavaHttpErrorHandlerAdapter @Inject() (underlying: JHttpErrorHandler, contextComponents: JavaContextComponents) extends HttpErrorHandler {
+class JavaHttpErrorHandlerAdapter @Inject() (underlying: JHttpErrorHandler, requestComponents: JavaRequestComponents) extends HttpErrorHandler {
 
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
-    JavaHelpers.invokeWithContext(request, contextComponents, req => underlying.onClientError(req, statusCode, message))
+    JavaHelpers.invokeWithRequest(request, requestComponents, req => underlying.onClientError(req, statusCode, message))
   }
 
   def onServerError(request: RequestHeader, exception: Throwable) = {
-    JavaHelpers.invokeWithContext(request, contextComponents, req => underlying.onServerError(req, exception))
+    JavaHelpers.invokeWithRequest(request, requestComponents, req => underlying.onServerError(req, exception))
   }
 }


### PR DESCRIPTION
**This is work in progress.**

Fixes #6168 (except the routing stuff)

Here is the way I see it:
A `Http.Context` object is created solely from of a request object (and components which you could inject into any object anyway), see [here](https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala#L161-L169). So a context is basically just an "enhancent" request, on which you can set headers, cookies, the language etc. after it was created.
So actually `Http.Context.current` was always just holding the current request inside a `ThreadLocal` (wrapped in a context object).
All the "enhancements" `Http.Context` provided can be achieved also in other ways by modifying the result and the "real" request object (see TODO below). So if we migrate the functionality context gave us to result/request and fix the routing problem, it means we can just remove `Http.Context` entirely because there wouldn't be a need for it anymore!

My approach now is making `Context` an interface and the `Request` interface now `extends Context`, so now the other way around is also true, a request is also a context. This way we can just deprecate context and for migration purposes still keep its methods around and deprecate them as well
I hope you get what I mean :wink:

I did some work and my approach seems logical to me (it also compiles ;) (except the tests))
There will be a small migration path (which I think is inevitable anyway), but I think it shouldn't too bad since major rewrites will not be necessary.

## TODO
Need to provide alternatives to all the methods/functionality `Http.Context` provided like`changeLang(...)`, `clearLang()`, `setTransientLang(...)`, `clearTransientLang()`, setting headers and cookies on `ctx.response()`, setting `ctx.flash()`, etc:

- [ ] `ok(...).withHeaders(...).withCookies(...).withSession(...)` etc. (or similar)
- [ ] `redirect(...).flashing(...)` etc. (or similar)
- [ ] `request.withLang(...).withTransientLang(...).clearLang(...)` etc. (or similar)

More:
- [ ] Figure out if the `args` map needs to be a request attribute so it's still available in error handlers (see #8304) or if a field inside request is enough
- [ ] Deprecate methods that use `Http.context.current` and override them with methods that pass request explicitly (e.g. here in [Form.java](https://github.com/playframework/playframework/blob/2.6.12/framework/src/play-java-forms/src/main/java/play/data/Form.java#L734))
- [ ] Fix tests
- [ ] Maybe add something like `-DdisableJavaCtxThreadLocal` do "disable" the threadlocal (can't be config since the context `ThreadLocal` ist `static`): need to subclass `ThreadLocal` and fail on `get()`
- [ ] **Router needs to pass request to action methods...**
