### PR TITLE
Change Akka HTTP backend to use raw headers

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion = "2.5.11"
-  val akkaHttpVersion = "10.0.11"
+  val akkaHttpVersion = "10.0.13"
   val playJsonVersion = "2.6.9"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -6,8 +6,8 @@ package play.core.server.akkahttp
 import java.net.{ InetAddress, InetSocketAddress, URI }
 import java.security.cert.X509Certificate
 import java.util.Locale
-import javax.net.ssl.SSLPeerUnverifiedException
 
+import javax.net.ssl.SSLPeerUnverifiedException
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
@@ -44,42 +44,10 @@ private[server] class AkkaModelConversion(
    * for its body.
    */
   def convertRequest(requestId: Long, remoteAddress: InetSocketAddress, secureProtocol: Boolean, request: HttpRequest)(implicit fm: Materializer): (RequestHeader, Either[ByteString, Source[ByteString, Any]]) = {
-
     (
       convertRequestHeader(requestId, remoteAddress, secureProtocol, request),
       convertRequestBody(request)
     )
-
-    //    // FIXME this is if you want to try out avoiding conversion
-    //    (
-    //      new RequestHeaderImpl(
-    //        forwardedHeaderHandler.forwardedConnection(
-    //          new RemoteConnection {
-    //            override def remoteAddress: InetAddress = InetAddress.getLocalHost
-    //            override def secure: Boolean = secureProtocol
-    //            // TODO - Akka does not yet expose the SSLEngine used for the request
-    //            override lazy val clientCertificateChain = None
-    //          },
-    //          Headers()),
-    //        request.method.name,
-    //        new RequestTarget {
-    //          override lazy val uri: URI = new URI(uriString)
-    //          override lazy val uriString: String = request.header[`Raw-Request-URI`] match {
-    //            case None =>
-    //              logger.warn("Can't get raw request URI.")
-    //              request.uri.toString
-    //            case Some(rawUri) =>
-    //              rawUri.uri
-    //          }
-    //          override lazy val path: String = request.uri.path.toString
-    //          override lazy val queryMap: Map[String, Seq[String]] = request.uri.query().toMultiMap
-    //        },
-    //        request.protocol.value,
-    //        Headers(),
-    //        TypedMap.empty
-    //      ),
-    //      None
-    //    )
   }
 
   /**
@@ -300,38 +268,51 @@ private[server] class AkkaModelConversion(
     }
   }
 
+  // These headers are listed in the Akka HTTP's HttpResponseRenderer class as being invalid when given as RawHeaders
+  private val mustParseHeaders: Set[String] = Set(
+    HeaderNames.CONTENT_TYPE, HeaderNames.CONTENT_LENGTH, HeaderNames.TRANSFER_ENCODING, HeaderNames.DATE,
+    HeaderNames.SERVER, HeaderNames.CONNECTION
+  ).map(_.toLowerCase(Locale.ROOT))
+
   private def convertHeaders(headers: Iterable[(String, String)]): immutable.Seq[HttpHeader] = {
     headers.flatMap {
-      case (HeaderNames.SET_COOKIE, value) =>
-        resultUtils.splitSetCookieHeaderValue(value).map(RawHeader(HeaderNames.SET_COOKIE, _))
-      case (HeaderNames.CONTENT_DISPOSITION, value) =>
-        RawHeader(HeaderNames.CONTENT_DISPOSITION, value) :: Nil
-      case (name, value) if name != HeaderNames.TRANSFER_ENCODING =>
-        HttpHeader.parse(name, value) match {
-          case HttpHeader.ParsingResult.Ok(header, errors /* errors are ignored if Ok */ ) =>
-            if (!header.renderInResponses()) {
-              // since play did not enforce the http spec when it came to headers
-              // we actually relax it by converting the parsed header to a RawHeader
-              // This will still fail on content-type, content-length, transfer-encoding, date, server and connection headers.
-              illegalResponseHeaderValue match {
-                case ParserSettings.IllegalResponseHeaderValueProcessingMode.Warn =>
-                  logger.warn(s"HTTP Header '$header' is not allowed in responses, you can turn off this warning by setting `play.server.akka.illegal-response-header-value-processing-mode = ignore`")
-                  RawHeader(name, value) :: Nil
-                case ParserSettings.IllegalResponseHeaderValueProcessingMode.Ignore =>
-                  RawHeader(name, value) :: Nil
-                case ParserSettings.IllegalResponseHeaderValueProcessingMode.Error =>
-                  logger.error(s"HTTP Header '$header' is not allowed in responses")
-                  Nil
-              }
-            } else {
-              header :: Nil
-            }
-          case HttpHeader.ParsingResult.Error(error) =>
-            sys.error(s"Error parsing header: $error")
+      case (name, value) =>
+        val lowerName = name.toLowerCase(Locale.ROOT)
+        if (lowerName == "set-cookie") {
+          resultUtils.splitSetCookieHeaderValue(value).map(RawHeader(HeaderNames.SET_COOKIE, _))
+        } else if (mustParseHeaders.contains(lowerName)) {
+          parseHeader(name, value)
+        } else {
+          resultUtils.validateHeaderNameChars(name)
+          resultUtils.validateHeaderValueChars(value)
+          RawHeader(name, value) :: Nil
         }
-
-      case _ => Nil
     }(collection.breakOut): Vector[HttpHeader]
+  }
+
+  private def parseHeader(name: String, value: String): Seq[HttpHeader] = {
+    HttpHeader.parse(name, value) match {
+      case HttpHeader.ParsingResult.Ok(header, errors /* errors are ignored if Ok */ ) =>
+        if (!header.renderInResponses()) {
+          // since play did not enforce the http spec when it came to headers
+          // we actually relax it by converting the parsed header to a RawHeader
+          // This will still fail on content-type, content-length, transfer-encoding, date, server and connection headers.
+          illegalResponseHeaderValue match {
+            case ParserSettings.IllegalResponseHeaderValueProcessingMode.Warn =>
+              logger.warn(s"HTTP Header '$header' is not allowed in responses, you can turn off this warning by setting `play.server.akka.illegal-response-header-value-processing-mode = ignore`")
+              RawHeader(name, value) :: Nil
+            case ParserSettings.IllegalResponseHeaderValueProcessingMode.Ignore =>
+              RawHeader(name, value) :: Nil
+            case ParserSettings.IllegalResponseHeaderValueProcessingMode.Error =>
+              logger.error(s"HTTP Header '$header' is not allowed in responses")
+              Nil
+          }
+        } else {
+          header :: Nil
+        }
+      case HttpHeader.ParsingResult.Error(error) =>
+        sys.error(s"Error parsing header: $error")
+    }
   }
 }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -49,7 +49,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       |Content-Disposition: form-data; name="$tokenName"
       |
       |$tokenValue
-      |--$Boundary--""".stripMargin.replaceAll(System.lineSeparator, "\r\n")
+      |--$Boundary--""".stripMargin.replaceAll("\r?\n", "\r\n")
   }
 
   // This extracts the tests out into different configurations

--- a/framework/src/play-integration-test/src/test/scala/play/it/LogTester.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/LogTester.scala
@@ -3,56 +3,45 @@
  */
 package play.it
 
-import org.slf4j.LoggerFactory
-import ch.qos.logback.core.AppenderBase
+import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
-import scala.collection.mutable.ListBuffer
-import ch.qos.logback.classic.{ Logger, LoggerContext, Level }
+import ch.qos.logback.core.AppenderBase
+import org.slf4j.LoggerFactory
+
+import scala.collection.immutable
+import scala.collection.mutable.ArrayBuffer
 
 /**
  * Test utility for testing Play logs
  */
 object LogTester {
 
-  def withLogBuffer[T](block: LogBuffer => T) = {
-    val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-    val root = ctx.getLogger("ROOT")
-    val rootLevel = root.getLevel
-    val playLogger = play.api.Logger(this.getClass).asInstanceOf[Logger]
-    val playLevel = playLogger.getLevel
-    val appender = new LogBuffer()
-    appender.start()
-    try {
-      root.addAppender(appender)
-      root.setLevel(Level.ALL)
-      playLogger.addAppender(appender)
-      playLogger.setLevel(Level.ALL)
-      block(appender)
-    } finally {
-      root.detachAppender(appender)
-      root.setLevel(rootLevel)
-      playLogger.detachAppender(appender)
-      playLogger.setLevel(playLevel)
+  /** Record log events and return them for analysis. */
+  def recordLogEvents[T](block: => T): (T, immutable.Seq[ILoggingEvent]) = {
 
+    /** Collects all log events that occur */
+    class RecordingAppender extends AppenderBase[ILoggingEvent] {
+      private val eventBuffer = ArrayBuffer[ILoggingEvent]()
+
+      override def append(e: ILoggingEvent): Unit = synchronized {
+        eventBuffer += e
+      }
+
+      def events: immutable.Seq[ILoggingEvent] = synchronized {
+        eventBuffer.to[immutable.Seq]
+      }
     }
+
+    // Get the Logback root logger and attach a RecordingAppender
+    val rootLogger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger]
+    val appender = new RecordingAppender()
+    appender.setContext(rootLogger.getLoggerContext)
+    appender.start()
+    rootLogger.addAppender(appender)
+    val result: T = block
+    rootLogger.detachAppender(appender)
+    appender.stop()
+    (result, appender.events)
   }
 
-}
-
-class LogBuffer extends AppenderBase[ILoggingEvent] {
-  private val buffer = ListBuffer.empty[ILoggingEvent]
-
-  def append(eventObject: ILoggingEvent) = buffer.synchronized {
-    buffer.append(eventObject)
-  }
-
-  def find(
-    level: Option[Level] = None,
-    logger: Option[String] = None,
-    messageContains: Option[String] = None): List[ILoggingEvent] = buffer.synchronized {
-    val byLevel = level.fold(buffer) { l => buffer.filter(_.getLevel == l) }
-    val byLogger = logger.fold(byLevel) { l => byLevel.filter(_.getLoggerName == l) }
-    val byMessageContains = logger.fold(byLogger) { m => byLogger.filter(_.getMessage.contains(m)) }
-    byMessageContains.toList
-  }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaResponseHeaderHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaResponseHeaderHandlingSpec.scala
@@ -6,7 +6,7 @@ package play.it.http
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test.{ PlaySpecification, Port }
-import play.it.AkkaHttpIntegrationSpecification
+import play.it.{ AkkaHttpIntegrationSpecification, LogTester }
 
 class AkkaResponseHeaderHandlingSpec extends PlaySpecification with AkkaHttpIntegrationSpecification {
 
@@ -34,6 +34,32 @@ class AkkaResponseHeaderHandlingSpec extends PlaySpecification with AkkaHttpInte
       responses.length must_== 1
       responses(0).status must_== 200
       responses(0).headers.get("Authorization") must_== Some("invalid")
+    }
+
+    "don't strip quotes from Link header" in withServer((Action, _) => Action { rh =>
+      // Test the header reported in https://github.com/playframework/playframework/issues/7733
+      Results.Ok.withHeaders("Link" -> """<http://example.com/some/url>; rel="next"""")
+    }) { port =>
+      val responses = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )
+      responses(0).headers.get("Link") must_== Some("""<http://example.com/some/url>; rel="next"""")
+    }
+
+    "don't log a warning for Set-Cookie headers with negative ages" in {
+      val problemHeaderValue = "PLAY_FLASH=; Max-Age=-86400; Expires=Tue, 30 Jan 2018 06:29:53 GMT; Path=/; HTTPOnly"
+      withServer((Action, _) => Action { rh =>
+        // Test the header reported in https://github.com/playframework/playframework/issues/8205
+        Results.Ok.withHeaders("Set-Cookie" -> problemHeaderValue)
+      }) { port =>
+        val (Seq(response), logMessages) = LogTester.recordLogEvents {
+          BasicHttpClient.makeRequests(port)(
+            BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+          )
+        }
+        response.status must_== 200
+        logMessages.map(_.getFormattedMessage) must not contain (contain(problemHeaderValue))
+      }
     }
 
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -3,6 +3,8 @@
  */
 package play.it.http
 
+import org.specs2.execute.AsResult
+import org.specs2.matcher.MatchResult
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test._
@@ -12,7 +14,43 @@ import play.it._
 
 class NettyRequestHeadersSpec extends RequestHeadersSpec with NettyIntegrationSpecification
 
-class AkkaHttpRequestHeadersSpec extends RequestHeadersSpec with AkkaHttpIntegrationSpecification
+class AkkaHttpRequestHeadersSpec extends RequestHeadersSpec with AkkaHttpIntegrationSpecification {
+
+  "Akka HTTP request header handling" should {
+
+    "not complain about invalid User-Agent headers" in {
+
+      // This test modifies the global (!) logger to capture log messages.
+      // The test will not be reliable when run concurrently. However, since
+      // we're checking for the *absence* of log messages the worst thing
+      // that will happen is that the test will pass when it should fail. We
+      // should not get spurious failures which would cause our CI testing
+      // to fail. I think it's still worth including this test because it
+      // will still often report correct failures, even if it's not perfect.
+
+      withServerAndConfig()((Action, _) => Action { rh =>
+        Results.Ok(rh.headers.get("User-Agent").toString)
+      }) { port =>
+        def testAgent(agent: String) = {
+          val (_, logMessages) = LogTester.recordLogEvents {
+            val Seq(response) = BasicHttpClient.makeRequests(port)(
+              BasicRequest("GET", "/", "HTTP/1.1", Map(
+                "User-Agent" -> agent
+              ), "")
+            )
+            response.body must beLeft(s"Some($agent)")
+          }
+          logMessages.map(_.getFormattedMessage) must not contain (contain(agent))
+        }
+        // These agent strings come from https://github.com/playframework/playframework/issues/7997
+        testAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_3 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Mobile/15A432 [FBAN/FBIOS;FBAV/147.0.0.46.81;FBBV/76961488;FBDV/iPhone8,1;FBMD/iPhone;FBSN/iOS;FBSV/11.0.3;FBSS/2;FBCR/T-Mobile.pl;FBID/phone;FBLC/pl_PL;FBOP/5;FBRV/0]")
+        testAgent("Mozilla/5.0 (Linux; Android 7.0; TRT-LX1 Build/HUAWEITRT-LX1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/148.0.0.51.62;]")
+        testAgent("Mozilla/5.0 (Linux; Android 7.0; SM-G955F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/142.0.0.18.63;]")
+      }
+
+    }
+  }
+}
 
 trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecification with HttpHeadersCommonSpec {
 
@@ -112,5 +150,50 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
         )
       }
     }
+
+    "preserve the value of headers" in {
+      def headerValueInRequest(headerName: String, headerValue: String): MatchResult[Either[String, _]] = {
+        withServer((Action, _) => Action { rh =>
+          Results.Ok(rh.headers.get(headerName).toString)
+        }) { port =>
+          val Seq(response) = BasicHttpClient.makeRequests(port)(
+            // an empty body implies no parsing is used and no content type is derived from the body.
+            BasicRequest("GET", "/", "HTTP/1.1", Map(headerName -> headerValue), "")
+          )
+          response.body must beLeft(s"Some($headerValue)")
+        }
+      }
+      // This example comes from https://github.com/playframework/playframework/issues/7719
+      "for UTF-8 Content-Disposition headers" in headerValueInRequest("Content-Disposition", "attachment; filename*=UTF-8''Roget%27s%20Thesaurus.pdf")
+      // This example comes from https://github.com/playframework/playframework/issues/7737#issuecomment-323335828
+      "for Authorization headers" in headerValueInRequest("Authorization", """OAuth realm="https://api.clever-cloud.com/v2/oauth", oauth_consumer_key="<key>", oauth_token="<token>", oauth_signature_method="HMAC-SHA512", oauth_signature="<signature>", oauth_timestamp="1502979668", oauth_nonce="402047"""")
+    }
+
+    "preserve the case of header names" in {
+      def headerNameInRequest(headerName: String, headerValue: String): MatchResult[Either[String, _]] = {
+        withServer((Action, _) => Action { rh =>
+          Results.Ok(rh.headers.keys.filter(_.equalsIgnoreCase(headerName)).mkString)
+        }) { port =>
+          val Seq(response) = BasicHttpClient.makeRequests(port)(
+            // an empty body implies no parsing is used and no content type is derived from the body.
+            BasicRequest("GET", "/", "HTTP/1.1", Map(headerName -> headerValue), "")
+          )
+          response.body must beLeft(headerName)
+        }
+      }
+      "'Foo' header" in headerNameInRequest("Foo", "Bar")
+      "'foo' header" in headerNameInRequest("foo", "bar")
+      // Authorization examples taken from https://github.com/playframework/playframework/issues/7735
+      "'Authorization' header" in headerNameInRequest("Authorization", "some value")
+      "'authorization' header" in headerNameInRequest("authorization", "some value")
+      // User agent examples taken from https://github.com/playframework/playframework/issues/7735#issuecomment-360180932
+      "'User-Agent' header with valid value" in headerNameInRequest(
+        "User-Agent",
+        """Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_2 like Mac OS X) AppleWebKit/604.4.7 (KHTML, like Gecko) Mobile/15C202""")
+      "'User-Agent' header with invalid value" in headerNameInRequest(
+        "User-Agent",
+        """Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_2 like Mac OS X) AppleWebKit/604.4.7 (KHTML, like Gecko) Mobile/15C202 [FBAN/FBIOS;FBAV/155.0.0.36.93;FBBV/87992437;FBDV/iPhone9,3;FBMD/iPhone;FBSN/iOS;FBSV/11.2.2;FBSS/2;FBCR/3Ireland;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]""")
+    }
+
   }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/ScalaWSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/ScalaWSSpec.scala
@@ -3,8 +3,12 @@
  */
 package play.it.libs
 
+import java.util.Locale
+
 import org.specs2.matcher.MatchResult
+import play.api.http.HeaderNames
 import play.api.libs.ws.{ WSBodyReadables, WSBodyWritables }
+import play.api.libs.oauth._
 import play.api.test.PlaySpecification
 import play.it.{ AkkaHttpIntegrationSpecification, NettyIntegrationSpecification, ServerIntegrationSpecification }
 
@@ -112,6 +116,59 @@ trait ScalaWSSpec extends PlaySpecification with ServerIntegrationSpecification 
         ws.url("/").withQueryStringParameters("lorem" -> "ipsum").
           sign(calc) aka "signed request" must not(throwA[Exception])
       }
+    }
+
+    "preserve the case of an Authorization header" >> {
+
+      def withAuthorizationCheck[T](block: play.api.libs.ws.WSClient => T) = {
+        Server.withRouterFromComponents() { c =>
+          {
+            case _ => c.defaultActionBuilder { req: Request[AnyContent] =>
+              Results.Ok(req.headers.keys.filter(_.equalsIgnoreCase("authorization")).mkString)
+            }
+          }
+        } { implicit port =>
+          WsTestClient.withClient(block)
+        }
+      }
+
+      "when signing with the OAuthCalculator" in {
+        val oauthCalc = {
+          val consumerKey = ConsumerKey("key", "secret")
+          val requestToken = RequestToken("token", "secret")
+          OAuthCalculator(consumerKey, requestToken)
+        }
+        "expect title-case header with signed request" in withAuthorizationCheck { ws =>
+          val body = await(ws.url("/").sign(oauthCalc).execute()).body
+          body must_== ("Authorization")
+        }
+      }
+
+      // Attempt to replicate https://github.com/playframework/playframework/issues/7735
+      "when signing with a custom calculator" in {
+        val customCalc = new WSSignatureCalculator with SignatureCalculator {
+          def calculateAndAddSignature(request: play.shaded.ahc.org.asynchttpclient.Request, requestBuilder: RequestBuilderBase[_]) = {
+            requestBuilder.addHeader(HeaderNames.AUTHORIZATION, "some value")
+          }
+        }
+        "expect title-case header with signed request" in withAuthorizationCheck { ws =>
+          val body = await(ws.url("/").sign(customCalc).execute()).body
+          body must_== ("Authorization")
+        }
+      }
+
+      // Attempt to replicate https://github.com/playframework/playframework/issues/7735
+      "when sending an explicit header" in {
+        "preserve a title-case 'Authorization' header" in withAuthorizationCheck { ws =>
+          val body = await(ws.url("/").withHttpHeaders("Authorization" -> "some value").execute()).body
+          body must_== ("Authorization")
+        }
+        "preserve a lower-case 'authorization' header" in withAuthorizationCheck { ws =>
+          val body = await(ws.url("/").withHttpHeaders("authorization" -> "some value").execute()).body
+          body must_== ("authorization")
+        }
+      }
+
     }
   }
 

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -3,6 +3,8 @@
  */
 package play.core.server.common
 
+import java.util.{ BitSet => JBitSet }
+
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
@@ -12,7 +14,9 @@ import play.api.http._
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.mvc.request.RequestAttrKey
+import play.core.utils.{ AsciiBitSet, AsciiRange, AsciiSet }
 
+import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
@@ -76,6 +80,52 @@ private[play] final class ServerResultUtils(
     } else {
       Future.successful(result)
     }
+  }
+
+  /** Set of characters that are allowed in a header name. */
+  private def allowedHeaderNameChars: AsciiBitSet = {
+    /*
+     * From https://tools.ietf.org/html/rfc7230#section-3.2:
+     *   field-name     = token
+     * From https://tools.ietf.org/html/rfc7230#section-3.2.6:
+     *   token          = 1*tchar
+     *   tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+     *                  / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+     *                  / DIGIT / ALPHA
+     */
+    val TChar = AsciiSet('!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~') ||| AsciiSet.Sets.Digit ||| AsciiSet.Sets.Alpha
+    TChar.toBitSet
+  }
+
+  def validateHeaderNameChars(headerName: String): Unit = validateString(allowedHeaderNameChars, "header name", headerName)
+
+  /** Set of characters that are allowed in a header name. */
+  private def allowedHeaderValueChars: AsciiBitSet = {
+    /*
+     * From https://tools.ietf.org/html/rfc7230#section-3.2:
+     *   field-value    = *( field-content / obs-fold )
+     *   field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+     *   field-vchar    = VCHAR / obs-text
+     * From https://tools.ietf.org/html/rfc7230#section-3.2.6:
+     *   obs-text       = %x80-FF
+     */
+    val ObsText = new AsciiRange(0x80, 0xFF)
+    val FieldVChar = AsciiSet.Sets.VChar ||| ObsText
+    val FieldContent = FieldVChar ||| AsciiSet(' ', '\t')
+    FieldContent.toBitSet
+  }
+
+  def validateHeaderValueChars(headerValue: String): Unit = validateString(allowedHeaderValueChars, "header value", headerValue)
+
+  private def validateString(allowedSet: AsciiBitSet, setDescription: String, string: String): Unit = {
+    @tailrec def loop(i: Int): Unit = {
+      if (i < string.length) {
+        val c = string.charAt(i)
+        if (!allowedSet.get(c)) throw new IllegalArgumentException(s"Invalid $setDescription character: '$c' (${c.toInt})")
+        loop(i + 1)
+      }
+    }
+    loop(0)
   }
 
   /**

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -458,7 +458,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
       case _ => None
     }
 
-    new Headers(s.split(System.lineSeparator).flatMap(split(_, ":\\s*")))
+    new Headers(s.split("\r?\n").flatMap(split(_, ":\\s*")))
   }
 
   def processHeaders(config: Map[String, Any], headers: Headers): Seq[(ForwardedEntry, Either[String, ParsedForwardedEntry], Option[Boolean])] = {

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -162,4 +162,44 @@ class ServerResultUtilsSpec extends Specification {
       hasNoEntity(response, 304)
     }
   }
+
+  "resultUtils.validateHeaderNameChars" should {
+    "accept Foo" in {
+      resultUtils.validateHeaderNameChars("Foo") must not(throwAn[IllegalArgumentException])
+    }
+    "accept allowed chars" in {
+      resultUtils.validateHeaderNameChars("!#$%&'*+-.^_`|~01239azAZ") must not(throwAn[IllegalArgumentException])
+    }
+    "not accept control characters" in {
+      resultUtils.validateHeaderNameChars("\0") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars("\u0001") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars("\u001f") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars("\u00ff") must (throwAn[IllegalArgumentException])
+    }
+    "not accept delimiters" in {
+      resultUtils.validateHeaderNameChars(":") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars(" ") must (throwAn[IllegalArgumentException])
+    }
+  }
+
+  "resultUtils.validateHeaderValueChars" should {
+    "accept bar" in {
+      resultUtils.validateHeaderValueChars("bar") must not(throwAn[IllegalArgumentException])
+    }
+    "accept tokens" in {
+      resultUtils.validateHeaderValueChars("!#$%&'*+-.^_`|~01239azAZ") must not(throwAn[IllegalArgumentException])
+    }
+    "accept separators" in {
+      resultUtils.validateHeaderValueChars("\"(),/:;<=>?@[\\]{}") must not(throwAn[IllegalArgumentException])
+    }
+    "accept space and htab" in {
+      resultUtils.validateHeaderValueChars(" \t") must not(throwAn[IllegalArgumentException])
+    }
+    "not accept control characters" in {
+      resultUtils.validateHeaderValueChars("\0") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars("\u0001") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars("\u001f") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars("\u007f") must (throwAn[IllegalArgumentException])
+    }
+  }
 }

--- a/framework/src/play/src/main/scala/play/core/utils/AsciiSet.scala
+++ b/framework/src/play/src/main/scala/play/core/utils/AsciiSet.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.utils
+
+import java.util.{ BitSet => JBitSet }
+
+object AsciiSet {
+
+  /** Create a set of a single character. */
+  def apply(c: Char): AsciiChar = new AsciiChar(c)
+  /** Create a set of more than one character. */
+  def apply(c: Char, cs: Char*): AsciiSet = cs.foldLeft[AsciiSet](apply(c)) {
+    case (acc, c1) => acc ||| apply(c1)
+  }
+
+  /** Some useful sets of ASCII characters. */
+  object Sets {
+    // Core Rules (https://tools.ietf.org/html/rfc5234#appendix-B.1).
+    // These are used in HTTP (https://tools.ietf.org/html/rfc7230#section-1.2).
+    val Digit: AsciiSet = new AsciiRange('0', '9')
+    val Lower: AsciiSet = new AsciiRange('a', 'z')
+    val Upper: AsciiSet = new AsciiRange('A', 'Z')
+    val Alpha: AsciiSet = Lower ||| Upper
+    val AlphaDigit: AsciiSet = Alpha ||| Digit
+    // https://en.wikipedia.org/wiki/ASCII#Printable_characters
+    val VChar: AsciiSet = new AsciiRange(0x20, 0x7e)
+  }
+}
+
+/**
+ * A set of ASCII characters. The set should be built out of [[AsciiRange]],
+ * [[AsciiChar]], [[AsciiUnion]], etc then converted to an [[AsciiBitSet]]
+ * using `toBitSet` for fast querying.
+ */
+trait AsciiSet {
+  /**
+   * The internal method used to query for set membership.
+   * Doesn't do any bounds checks. Also may be slow, so to
+   * query from outside this package you should convert to an
+   * [[AsciiBitSet]] using `toBitSet`.
+   */
+  private[utils] def getInternal(i: Int): Boolean
+  /** Join together two sets. */
+  def |||(that: AsciiSet): AsciiUnion = new AsciiUnion(this, that)
+  /** Convert into an [[AsciiBitSet]] for fast querying. */
+  def toBitSet: AsciiBitSet = {
+    val bitSet = new JBitSet(256)
+    for (i <- (0 until 256)) {
+      if (this.getInternal(i)) { bitSet.set(i) }
+    }
+    new AsciiBitSet(bitSet)
+  }
+}
+/** An inclusive range of ASCII characters */
+private[play] final class AsciiRange(first: Int, last: Int) extends AsciiSet {
+  assert(first >= 0 && first < last && last < 256)
+  override def toString: String = s"(${Integer.toHexString(first)}- ${Integer.toHexString(last)})"
+  private[utils] override def getInternal(i: Int): Boolean = i >= first && i <= last
+}
+private[play] object AsciiRange {
+  /** Helper to construct an [[AsciiRange]]. */
+  def apply(first: Int, last: Int): AsciiRange = new AsciiRange(first, last)
+}
+/** A set with a single ASCII character in it. */
+private[play] final class AsciiChar(i: Int) extends AsciiSet {
+  assert(i >= 0 && i < 256)
+  private[utils] override def getInternal(i: Int): Boolean = i == this.i
+}
+/** A union of two [[AsciiSet]]s. */
+private[play] final class AsciiUnion(a: AsciiSet, b: AsciiSet) extends AsciiSet {
+  require(a != null && b != null)
+  private[utils] override def getInternal(i: Int): Boolean = a.getInternal(i) || b.getInternal(i)
+}
+/**
+ * An efficient representation of a set of ASCII characters. Created by
+ * building an [[AsciiSet]] then calling `toBitSet` on it.
+ */
+private[play] final class AsciiBitSet private[utils] (bitSet: JBitSet) extends AsciiSet {
+  final def get(i: Int): Boolean = {
+    if (i < 0 || i > 255) throw new IllegalArgumentException(s"Character $i cannot match AsciiSet because it is out of range")
+    getInternal(i)
+  }
+  private[utils] override def getInternal(i: Int): Boolean = bitSet.get(i)
+  override def toBitSet: AsciiBitSet = this
+}

--- a/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
@@ -5,7 +5,8 @@ package play.utils
 
 import java.io.ByteArrayOutputStream
 import java.nio.charset.Charset
-import java.util.BitSet
+
+import play.core.utils.{ AsciiBitSet, AsciiSet }
 
 /**
  * Provides support for correctly encoding pieces of URIs.
@@ -48,7 +49,7 @@ object UriEncoding {
     val in = s.getBytes(inputCharset)
     val out = new ByteArrayOutputStream()
     for (b <- in) {
-      val allowed = segmentChars.get(b & 0xFF)
+      val allowed = segmentChars.get(b & 0xff)
       if (allowed) {
         out.write(b)
       } else {
@@ -186,30 +187,22 @@ object UriEncoding {
   // segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
   //               ; non-zero-length segment without any colon ":"
   /** The set of ASCII character codes that are allowed in a URI path segment. */
-  private val segmentChars: BitSet = membershipTable(pchar)
+  private val segmentChars: AsciiBitSet = pchar.toBitSet
 
   /** The characters allowed in a path segment; defined in RFC 3986 */
-  private def pchar: Seq[Char] = {
+  private def pchar: AsciiSet = {
     // RFC 3986, 2.3. Unreserved Characters
     // unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
-    val alphaDigit = for ((min, max) <- Seq(('a', 'z'), ('A', 'Z'), ('0', '9')); c <- min to max) yield c
-    val unreserved = alphaDigit ++ Seq('-', '.', '_', '~')
+    val unreserved = AsciiSet.Sets.AlphaDigit ||| AsciiSet('-', '.', '_', '~')
 
     // RFC 3986, 2.2. Reserved Characters
     // sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
     //             / "*" / "+" / "," / ";" / "="
-    val subDelims = Seq('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=')
+    val subDelims = AsciiSet('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=')
 
     // RFC 3986, 3.3. Path
     // pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-    unreserved ++ subDelims ++ Seq(':', '@')
-  }
-
-  /** Create a BitSet to act as a membership lookup table for the given characters. */
-  private def membershipTable(chars: Seq[Char]): BitSet = {
-    val bits = new BitSet(256)
-    for (c <- chars) { bits.set(c.toInt) }
-    bits
+    unreserved ||| subDelims ||| AsciiSet(':', '@')
   }
 
   /**

--- a/framework/src/play/src/test/scala/play/libs/json/JavaJsonSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/json/JavaJsonSpec.scala
@@ -25,7 +25,7 @@ class JavaJsonSpec extends Specification {
         |  "a" : 2.5,
         |  "copyright" : "\u00a9",
         |  "baz" : [ 1, 2, 3 ]
-        |}""".stripMargin
+        |}""".stripMargin.replaceAll("\r?\n", System.lineSeparator)
 
     val testJsonInputStream = new ByteArrayInputStream(testJsonString.getBytes("UTF-8"))
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -213,7 +213,7 @@ $ copy-file conf/application.original conf/application.conf
 # A test overriding a akka setting that should be picked by dev mode
 > set PlayKeys.devSettings ++= Seq("akka.http.parsing.max-header-value-length" -> "32 bytes")
 > run
-> makeRequestWithHeader / 400 this-is-a-header-value-longer-than-32-chars
+> makeRequestWithHeader / 431 this-is-a-header-value-longer-than-32-chars
 > playStop
 
 # Should prioritize play.akka.dev-mode
@@ -222,5 +222,5 @@ $ copy-file conf/application.original conf/application.conf
 # This should NOT be picked
 > set PlayKeys.devSettings ++= Seq("akka.http.parsing.max-header-value-length" -> "1 megabyte")
 > run
-> makeRequestWithHeader / 400 this-is-a-header-value-longer-than-32-chars
+> makeRequestWithHeader / 431 this-is-a-header-value-longer-than-32-chars
 > playStop


### PR DESCRIPTION
Fixes #7733, #7735, #7719, #7997, #8205.

Maybe fixed, but not verified: #7737, #8149.

Most request and response headers are now unparsed by Akka HTTP and stored as RawHeaders. That Akka HTTP won't log warnings, won't reject headers and won't reformat headers.

Several headers are still parsed in order for Akka HTTP to function properly: Content-Type, Content-Encoding, WebSocket related headers, etc. These headers are in a whitelist in the Akka HTTP source.

I was originally going to merge #8296 and then backport it, but we're waiting on a version of Akka HTTP to be ready for the *master* branch, so instead we can merge this to *2.6.x* and then forward port it later.