### PR TITLE
java versions of runningHttpPort/runningHttpsPort methods added to Te…

### DIFF
--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
@@ -23,13 +23,15 @@ public class ServerFunctionalTest extends WithServer {
     @Test
     public void testInServer() throws Exception {
         OptionalInt optHttpPort = testServer.getRunningHttpPort();
-        int port = optHttpPort.orElseGet(
-                () -> testServer.getRunningHttpsPort().orElseThrow(
-                        () -> new IllegalStateException("Both HTTP and HTTPS ports are not provided")
-                )
-        );
-        boolean isHttpConn = optHttpPort.isPresent();
-        String url = (isHttpConn ? "http://" : "https://") + "localhost:" + port + "/";
+        String url;
+        int port;
+        if(optHttpsPort.isPresent()){
+            port = testServer.getRunningHttpsPort().getAsInt();
+            url = "https://localhost:" + port;
+        }else {
+            port = testServer.getRunningHttpPort().getAsInt();
+            url = "http://localhost:" + port;
+        }
         try (WSClient ws = play.test.WSTestClient.newClient(port)) {
             CompletionStage<WSResponse> stage = ws.url(url).get();
             WSResponse response = stage.toCompletableFuture().get();

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
@@ -21,8 +21,8 @@ public class ServerFunctionalTest extends WithServer {
 
     @Test
     public void testInServer() throws Exception {
-        int port = testServer.getRunningHttpPort().orElse(
-                testServer.getRunningHttpsPort().orElseThrow(
+        int port = testServer.getRunningHttpPort().orElseGet(
+                () -> testServer.getRunningHttpsPort().orElseThrow(
                         () -> new IllegalStateException("Both HTTP and HTTPS ports are not provided")
                 )
         );

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
@@ -4,6 +4,7 @@
 
 package javaguide.tests;
 
+import java.util.OptionalInt;
 import java.util.concurrent.*;
 
 import org.junit.*;
@@ -21,12 +22,14 @@ public class ServerFunctionalTest extends WithServer {
 
     @Test
     public void testInServer() throws Exception {
-        int port = testServer.getRunningHttpPort().orElseGet(
+        OptionalInt optHttpPort = testServer.getRunningHttpPort();
+        int port = optHttpPort.orElseGet(
                 () -> testServer.getRunningHttpsPort().orElseThrow(
                         () -> new IllegalStateException("Both HTTP and HTTPS ports are not provided")
                 )
         );
-        String url = "http://localhost:" + port + "/";
+        boolean isHttpConn = optHttpPort.isPresent();
+        String url = (isHttpConn ? "http://" : "https://") + "localhost:" + port + "/";
         try (WSClient ws = play.test.WSTestClient.newClient(port)) {
             CompletionStage<WSResponse> stage = ws.url(url).get();
             WSResponse response = stage.toCompletableFuture().get();

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
@@ -25,7 +25,7 @@ public class ServerFunctionalTest extends WithServer {
         OptionalInt optHttpsPort = testServer.getRunningHttpsPort();
         String url;
         int port;
-        if(optHttpsPort.isPresent()) {
+        if (optHttpsPort.isPresent()) {
             port = optHttpsPort.getAsInt();
             url = "https://localhost:" + port;
         } else {

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
@@ -22,11 +22,11 @@ public class ServerFunctionalTest extends WithServer {
 
     @Test
     public void testInServer() throws Exception {
-        OptionalInt optHttpPort = testServer.getRunningHttpPort();
+        OptionalInt optHttpsPort = testServer.getRunningHttpsPort();
         String url;
         int port;
         if(optHttpsPort.isPresent()){
-            port = testServer.getRunningHttpsPort().getAsInt();
+            port = optHttpsPort.getAsInt();
             url = "https://localhost:" + port;
         }else {
             port = testServer.getRunningHttpPort().getAsInt();

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
@@ -25,10 +25,10 @@ public class ServerFunctionalTest extends WithServer {
         OptionalInt optHttpsPort = testServer.getRunningHttpsPort();
         String url;
         int port;
-        if(optHttpsPort.isPresent()){
+        if(optHttpsPort.isPresent()) {
             port = optHttpsPort.getAsInt();
             url = "https://localhost:" + port;
-        }else {
+        } else {
             port = testServer.getRunningHttpPort().getAsInt();
             url = "http://localhost:" + port;
         }

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
@@ -21,9 +21,13 @@ public class ServerFunctionalTest extends WithServer {
 
     @Test
     public void testInServer() throws Exception {
-        int timeout = 5000;
-        String url = "http://localhost:" + this.testServer.port() + "/";
-        try (WSClient ws = play.test.WSTestClient.newClient(this.testServer.port())) {
+        int port = testServer.getRunningHttpPort().orElse(
+                testServer.getRunningHttpsPort().orElseThrow(
+                        () -> new IllegalStateException("Both HTTP and HTTPS ports are not provided")
+                )
+        );
+        String url = "http://localhost:" + port + "/";
+        try (WSClient ws = play.test.WSTestClient.newClient(port)) {
             CompletionStage<WSResponse> stage = ws.url(url).get();
             WSResponse response = stage.toCompletableFuture().get();
             assertEquals(NOT_FOUND, response.getStatus());

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -543,6 +543,17 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a new Test server.
      *
+     * @param port    the port to run the server on.
+     * @param sslPort the port to run the server on.
+     * @return the test server.
+     */
+    public static TestServer testServer(int port, int sslPort) {
+        return new TestServer(port, fakeApplication(), sslPort);
+    }
+
+    /**
+     * Creates a new Test server.
+     *
      *
      * @param port    the port to run the server on.
      * @param app     the Play application.

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -23,7 +23,7 @@ public class TestServer extends play.api.test.TestServer {
     /**
      * A test web server.
      *
-     * @param port        HTTP port to bind on.
+     * @param port HTTP port to bind on.
      * @param application The Application to load in this server.
      */
     public TestServer(int port, Application application) {
@@ -34,9 +34,9 @@ public class TestServer extends play.api.test.TestServer {
     /**
      * A test web server with HTTPS support
      *
-     * @param port        HTTP port to bind on
+     * @param port HTTP port to bind on
      * @param application The Application to load in this server
-     * @param sslPort     HTTPS port to bind on
+     * @param sslPort HTTPS port to bind on
      */
     public TestServer(int port, Application application, int sslPort) {
         super(createServerConfig(Optional.of(port), Optional.of(sslPort)), application.asScala(),

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -13,6 +13,7 @@ import scala.compat.java8.OptionConverters;
 
 import java.io.File;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * A test Netty web server.
@@ -47,4 +48,21 @@ public class TestServer extends play.api.test.TestServer {
                 Mode.TEST.asScala(), System.getProperties());
     }
 
+    /**
+     * The HTTP port that the server is running on.
+     */
+    @SuppressWarnings("unchecked")
+    public OptionalInt getRunningHttpPort() {
+        Option scalaPortOption = runningHttpPort();
+        return OptionConverters.specializer_OptionalInt().fromScala(scalaPortOption);
+    }
+
+    /**
+     * The HTTPS port that the server is running on.
+     */
+    @SuppressWarnings("unchecked")
+    public OptionalInt getRunningHttpsPort(){
+        Option scalaPortOption = runningHttpsPort();
+        return OptionConverters.specializer_OptionalInt().fromScala(scalaPortOption);
+    }
 }

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -16,14 +16,14 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 /**
- * A test Netty web server.
+ * A test web server.
  */
 public class TestServer extends play.api.test.TestServer {
 
     /**
-     * A test Netty web server.
+     * A test web server.
      *
-     * @param port HTTP port to bind on.
+     * @param port        HTTP port to bind on.
      * @param application The Application to load in this server.
      */
     public TestServer(int port, Application application) {
@@ -32,10 +32,11 @@ public class TestServer extends play.api.test.TestServer {
     }
 
     /**
-     * A test Netty web server with HTTPS support
-     * @param port HTTP port to bind on
+     * A test web server with HTTPS support
+     *
+     * @param port        HTTP port to bind on
      * @param application The Application to load in this server
-     * @param sslPort HTTPS port to bind on
+     * @param sslPort     HTTPS port to bind on
      */
     public TestServer(int port, Application application, int sslPort) {
         super(createServerConfig(Optional.of(port), Optional.of(sslPort)), application.asScala(),
@@ -61,7 +62,7 @@ public class TestServer extends play.api.test.TestServer {
      * The HTTPS port that the server is running on.
      */
     @SuppressWarnings("unchecked")
-    public OptionalInt getRunningHttpsPort(){
+    public OptionalInt getRunningHttpsPort() {
         Option scalaPortOption = runningHttpsPort();
         return OptionConverters.specializer_OptionalInt().fromScala(scalaPortOption);
     }

--- a/framework/src/play-test/src/test/java/play/test/TestServerTest.java
+++ b/framework/src/play-test/src/test/java/play/test/TestServerTest.java
@@ -1,0 +1,33 @@
+package play.test;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestServerTest {
+    @Test
+    public void shouldReturnHttpPort() {
+        int testServerPort = play.api.test.Helpers.testServerPort();
+        final TestServer testServer = Helpers.testServer(testServerPort);
+        testServer.start();
+        assertTrue("No value for http port", testServer.getRunningHttpPort().isPresent());
+        assertFalse("ssl port value is present, but was not set", testServer.getRunningHttpsPort().isPresent());
+        assertEquals(testServerPort, testServer.getRunningHttpPort().getAsInt());
+        testServer.stop();
+    }
+
+    @Test
+    public void shouldReturnHttpAndSslPorts() {
+        int port =  play.api.test.Helpers.testServerPort();
+        int sslPort =  port + 1;
+        final TestServer testServer = Helpers.testServer(port, sslPort);
+        testServer.start();
+        assertTrue("No value for ssl port", testServer.getRunningHttpsPort().isPresent());
+        assertEquals(sslPort, testServer.getRunningHttpsPort().getAsInt());
+        assertTrue("No value for http port", testServer.getRunningHttpPort().isPresent());
+        assertEquals(port, testServer.getRunningHttpPort().getAsInt());
+        testServer.stop();
+    }
+}

--- a/framework/src/play-test/src/test/java/play/test/TestServerTest.java
+++ b/framework/src/play-test/src/test/java/play/test/TestServerTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.test;
 
 import org.junit.Test;

--- a/framework/src/play-test/src/test/java/play/test/TestServerTest.java
+++ b/framework/src/play-test/src/test/java/play/test/TestServerTest.java
@@ -23,8 +23,8 @@ public class TestServerTest {
 
     @Test
     public void shouldReturnHttpAndSslPorts() {
-        int port =  play.api.test.Helpers.testServerPort();
-        int sslPort =  port + 1;
+        int port = play.api.test.Helpers.testServerPort();
+        int sslPort = port + 1;
         final TestServer testServer = Helpers.testServer(port, sslPort);
         testServer.start();
         assertTrue("No value for ssl port", testServer.getRunningHttpsPort().isPresent());

--- a/framework/src/play-test/src/test/java/play/test/TestServerTest.java
+++ b/framework/src/play-test/src/test/java/play/test/TestServerTest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.test;
 
 import org.junit.Test;


### PR DESCRIPTION

## Fixes

Fixes #8294 

## Purpose

According to referred issue, two methods, getRunningHttpPort() and getRunningHttpsPort were added to Java API (TestServer.java). Now both of them return OptionalInt, instead of scala-specific Option[Int] 

## Background Context

scala.compat.java8.OptionConverters was used to make conversion between Option[Int] and OptionalInt. However, there are some issues while operating with scala optionals directly from java code such as kinds of type erasure, so type was omitted and SuppressWarnings("unchecked") annotation was used (like it was used in other places of project, HttpEntity.java, for example)