### PR TITLE
Add documentation about Java Config

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -13,6 +13,7 @@ lazy val main = Project("Play-Documentation", file(".")).enablePlugins(PlayDocsP
       resolvers += Resolver.sonatypeRepo("releases"), // TODO: Delete this eventually, just needed for lag between deploying to sonatype and getting on maven central
       version := PlayVersion.current,
       libraryDependencies ++= Seq(
+        "com.typesafe" % "config" % "1.3.1" % Test,
         "com.h2database" % "h2" % "1.4.191" % Test,
         "org.mockito" % "mockito-core" % "1.9.5" % "test",
         // https://github.com/logstash/logstash-logback-encoder/tree/logstash-logback-encoder-4.9#including

--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -25,7 +25,11 @@ These system properties specify a replacement for `application.conf`, not an add
 
 The configuration can be available in your controller (or your component), to use the default settings or your custom one, thanks to Dependency Injection (in [[Scala|ScalaDependencyInjection]] or in [[Java|JavaDependencyInjection]]).
 
-@[dependency-injection](code/Configuration.scala)
+Scala
+: @[dependency-injection](code/Configuration.scala)
+
+Java
+: @[dependency-injection](code/javaguide/configuration/MyController.java)
 
 ## Using with Akka
 

--- a/documentation/manual/working/commonGuide/configuration/code/javaguide/configuration/MyController.java
+++ b/documentation/manual/working/commonGuide/configuration/code/javaguide/configuration/MyController.java
@@ -1,0 +1,19 @@
+//#dependency-injection
+//###replace: package controllers
+package javaguide.configuration;
+
+import com.typesafe.config.Config;
+import play.mvc.Controller;
+
+import javax.inject.Inject;
+
+public class MyController extends Controller {
+
+    private final Config config;
+
+    @Inject
+    public MyController(Config config) {
+        this.config = config;
+    }
+}
+//#dependency-injection

--- a/documentation/manual/working/javaGuide/main/config/JavaConfig.md
+++ b/documentation/manual/working/javaGuide/main/config/JavaConfig.md
@@ -1,0 +1,14 @@
+<!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+# The Typesafe Config API
+
+Play uses the [Typesafe config library](https://github.com/typesafehub/config) as the configuration library. If you're not familiar with Typesafe config, you may also want to read the documentation on [[configuration file syntax and features|ConfigFile]].
+
+## Accessing the configuration
+
+Typically, you'll obtain a `Config` object through [[Dependency Injection|JavaDependencyInjection]], or simply by passing an instance of `Config` to your component:
+
+@[](code/javaguide/config/MyController.java)
+
+## API documentation
+
+Since Play just uses `Config` object, you can [see the javadoc for the class](https://static.javadoc.io/com.typesafe/config/1.3.1/com/typesafe/config/Config.html) to see what you can do and how to access configuration data.

--- a/documentation/manual/working/javaGuide/main/config/code/javaguide/config/MyController.java
+++ b/documentation/manual/working/javaGuide/main/config/code/javaguide/config/MyController.java
@@ -1,0 +1,17 @@
+//###replace: package controllers
+package javaguide.config;
+
+import com.typesafe.config.Config;
+import play.mvc.Controller;
+
+import javax.inject.Inject;
+
+public class MyController extends Controller {
+
+    private final Config config;
+
+    @Inject
+    public MyController(Config config) {
+        this.config = config;
+    }
+}

--- a/documentation/manual/working/javaGuide/main/config/index.toc
+++ b/documentation/manual/working/javaGuide/main/config/index.toc
@@ -1,0 +1,2 @@
+JavaConfig:The Config API
+

--- a/documentation/manual/working/javaGuide/main/index.toc
+++ b/documentation/manual/working/javaGuide/main/index.toc
@@ -1,4 +1,5 @@
 JavaHome:Section contents
+config:Config API
 http:HTTP programming
 async:Asynchronous HTTP programming
 templates:The Twirl template engine

--- a/documentation/manual/working/scalaGuide/main/config/ScalaConfig.md
+++ b/documentation/manual/working/scalaGuide/main/config/ScalaConfig.md
@@ -5,7 +5,7 @@ Play uses the [Typesafe config library](https://github.com/typesafehub/config), 
 
 ## Accessing the configuration
 
-Typically, you'll obtain a `Configuration` object through dependendency injection, or simply by passing an instance of `Configuration` to your component:
+Typically, you'll obtain a `Configuration` object through [[Dependency Injection|ScalaDependencyInjection]]dependency injection, or simply by passing an instance of `Configuration` to your component:
 
 @[inject-config](code/ScalaConfig.scala)
 


### PR DESCRIPTION
## Purpose

We already have `ScalaConfig` page. This adds the equivalent Java version.