### PR TITLE
[2.6.x]: Stop Netty server reloading configuration on each request

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -213,7 +213,17 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.utils.InlineCache.cache_="),
 
       // private[play]
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.runAction")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.runAction"),
+
+      // Change the values the server caches internally when an app reloads
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer#ReloadCacheValues.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer#ReloadCacheValues.this"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.core.server.AkkaHttpServer$ReloadCacheValues$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer#ReloadCacheValues.apply"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.core.server.netty.PlayRequestHandler$ReloadCacheValues$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler#ReloadCacheValues.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler#ReloadCacheValues.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler#ReloadCacheValues.this")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -25,7 +25,7 @@ import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
 import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder }
-import play.core.server.common.{ ReloadCache, ServerResultUtils }
+import play.core.server.common.{ ReloadCache, ServerDebugInfo, ServerResultUtils }
 import play.core.server.ssl.ServerSSLEngine
 import play.core.ApplicationProvider
 import play.server.SSLEngineProvider
@@ -169,7 +169,8 @@ class AkkaHttpServer(
    */
   private case class ReloadCacheValues(
       resultUtils: ServerResultUtils,
-      modelConversion: AkkaModelConversion
+      modelConversion: AkkaModelConversion,
+      serverDebugInfo: Option[ServerDebugInfo]
   )
 
   /**
@@ -186,7 +187,8 @@ class AkkaHttpServer(
         illegalResponseHeaderValue)
       ReloadCacheValues(
         resultUtils = serverResultUtils,
-        modelConversion = modelConversion
+        modelConversion = modelConversion,
+        serverDebugInfo = reloadDebugInfo(tryApp, provider)
       )
     }
   }
@@ -197,23 +199,31 @@ class AkkaHttpServer(
     reloadCache.cachedFrom(tryApp).modelConversion
 
   private def handleRequest(request: HttpRequest, secure: Boolean): Future[HttpResponse] = {
-    val remoteAddress: InetSocketAddress = remoteAddressOfRequest(request)
-    val decodedRequest = HttpRequestDecoder.decodeRequest(request)
-    val requestId = requestIDs.incrementAndGet()
-    val tryApp = applicationProvider.get
-    val (convertedRequestHeader, requestBodySource) = modelConversion(tryApp).convertRequest(
-      requestId = requestId,
-      remoteAddress = remoteAddress,
-      secureProtocol = secure,
-      request = decodedRequest)
-    val (taggedRequestHeader, handler, newTryApp) = getHandler(convertedRequestHeader, tryApp)
-    val responseFuture = executeHandler(
-      newTryApp,
-      decodedRequest,
-      taggedRequestHeader,
-      requestBodySource,
-      handler
-    )
+    val tryApp: Try[Application] = applicationProvider.get
+    val decodedRequest: HttpRequest = HttpRequestDecoder.decodeRequest(request)
+    val (convertedRequestHeader, requestBodySource): (RequestHeader, Either[ByteString, Source[ByteString, Any]]) = {
+      val remoteAddress: InetSocketAddress = remoteAddressOfRequest(request)
+      val requestId: Long = requestIDs.incrementAndGet()
+      modelConversion(tryApp).convertRequest(
+        requestId = requestId,
+        remoteAddress = remoteAddress,
+        secureProtocol = secure,
+        request = decodedRequest)
+    }
+    val debugInfoRequestHeader: RequestHeader = {
+      val debugInfo: Option[ServerDebugInfo] = reloadCache.cachedFrom(tryApp).serverDebugInfo
+      ServerDebugInfo.attachToRequestHeader(convertedRequestHeader, debugInfo)
+    }
+    val responseFuture: Future[HttpResponse] = {
+      val (taggedRequestHeader, handler) = getHandler(debugInfoRequestHeader, tryApp)
+      executeHandler(
+        tryApp,
+        decodedRequest,
+        taggedRequestHeader,
+        requestBodySource,
+        handler
+      )
+    }
     responseFuture
   }
 
@@ -227,23 +237,22 @@ class AkkaHttpServer(
 
   private def getHandler(
     requestHeader: RequestHeader, tryApp: Try[Application]
-  ): (RequestHeader, Handler, Try[Application]) = {
-    Server.getHandlerFor(requestHeader, new ApplicationProvider {
+  ): (RequestHeader, Handler) = {
+    val sameAppProvider = new ApplicationProvider {
       override def handleWebCommand(requestHeader: RequestHeader): Option[Result] =
         applicationProvider.handleWebCommand(requestHeader)
       override def get: Try[Application] = tryApp
-    }) match {
+    }
+    Server.getHandlerFor(requestHeader, sameAppProvider) match {
       case Left(futureResult) =>
         (
           requestHeader,
-          EssentialAction(_ => Accumulator.done(futureResult)),
-          Failure(new Exception("getHandler returned Result, but not Application"))
+          EssentialAction(_ => Accumulator.done(futureResult))
         )
-      case Right((newRequestHeader, handler, newApp)) =>
+      case Right((newRequestHeader, handler)) =>
         (
           newRequestHeader,
-          handler,
-          Success(newApp) // TODO: Change getHandlerFor to use the app that we already had
+          handler
         )
     }
   }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -214,8 +214,8 @@ class AkkaHttpServer(
       val debugInfo: Option[ServerDebugInfo] = reloadCache.cachedFrom(tryApp).serverDebugInfo
       ServerDebugInfo.attachToRequestHeader(convertedRequestHeader, debugInfo)
     }
+    val (taggedRequestHeader, handler) = getHandler(debugInfoRequestHeader, tryApp)
     val responseFuture: Future[HttpResponse] = {
-      val (taggedRequestHeader, handler) = getHandler(debugInfoRequestHeader, tryApp)
       executeHandler(
         tryApp,
         decodedRequest,

--- a/framework/src/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
@@ -15,6 +15,7 @@ import play.api.routing.sird._
 import play.api.test.{ PlaySpecification, WsTestClient }
 import play.api.{ Application, Configuration }
 import play.core.ApplicationProvider
+import play.core.server.common.ServerDebugInfo
 import play.core.server.{ ServerConfig, ServerProvider }
 import play.it.{ AkkaHttpIntegrationSpecification, NettyIntegrationSpecification, ServerIntegrationSpecification }
 
@@ -168,6 +169,56 @@ trait ServerReloadingSpec extends PlaySpecification with WsTestClient with Serve
       }
     }
 
+    "only reload its configuration when the application changes" in {
+
+      val testAppProvider = new TestApplicationProvider
+      withApplicationProvider(testAppProvider) { implicit port: Port =>
+
+        def appWithConfig(conf: (String, Any)*): Success[Application] = {
+          Success(GuiceApplicationBuilder()
+            .configure(conf: _*)
+            .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
+            .build())
+        }
+
+        val app1 = appWithConfig("play.server.debug.addDebugInfoToRequests" -> true)
+        testAppProvider.provide(app1)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(1)"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(1)"
+
+        val app2 = Failure(new Exception())
+        testAppProvider.provide(app2)
+        await(wsUrl("/getserverconfigcachereloads").get()).status must_== 500
+        await(wsUrl("/getserverconfigcachereloads").get()).status must_== 500
+
+        val app3 = appWithConfig("play.server.debug.addDebugInfoToRequests" -> true)
+        testAppProvider.provide(app3)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(3)"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(3)"
+
+        val app4 = appWithConfig()
+        testAppProvider.provide(app4)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "None"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "None"
+
+        val app5 = appWithConfig("play.server.debug.addDebugInfoToRequests" -> true)
+        testAppProvider.provide(app5)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(5)"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(5)"
+
+        val app6 = Failure(new Exception())
+        testAppProvider.provide(app6)
+        await(wsUrl("/getserverconfigcachereloads").get()).status must_== 500
+        await(wsUrl("/getserverconfigcachereloads").get()).status must_== 500
+
+        val app7 = appWithConfig("play.server.debug.addDebugInfoToRequests" -> true)
+        testAppProvider.provide(app7)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(7)"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(7)"
+
+      }
+    }
+
   }
 }
 
@@ -186,6 +237,10 @@ private[server] object ServerReloadingSpec {
       }
       case GET(p"/getremoteaddress") => action { request: Request[_] =>
         Results.Ok(request.remoteAddress)
+      }
+      case GET(p"/getserverconfigcachereloads") => action { request: Request[_] =>
+        val reloadCount: Option[Int] = request.attrs.get(ServerDebugInfo.Attr).map(_.serverConfigCacheReloads)
+        Results.Ok(reloadCount.toString)
       }
     }
   }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -134,7 +134,7 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
       case Right(ws: WebSocket) if requestHeader.headers.get(HeaderNames.UPGRADE).exists(_.equalsIgnoreCase("websocket")) =>
         logger.trace("Serving this request with: " + ws)
 
-        val app = tryApp.get
+        val app = tryApp.get // Guaranteed to be Success for a WebSocket handler
         val wsProtocol = if (requestHeader.secure) "wss" else "ws"
         val wsUrl = s"$wsProtocol://${requestHeader.host}${requestHeader.path}"
         val bufferLimit = app.configuration.getDeprecated[ConfigMemorySize]("play.server.websocket.frame.maxLength", "play.websocket.buffer.limit").toBytes.toInt

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -268,7 +268,10 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
    */
   private def handleAction(action: EssentialAction, requestHeader: RequestHeader,
     request: HttpRequest, tryApp: Try[Application]): Future[HttpResponse] = {
-    implicit val mat: Materializer = tryApp.fold(_ => server.materializer, _.materializer)
+    implicit val mat: Materializer = tryApp match {
+      case Success(app) => app.materializer
+      case Failure(_) => server.materializer
+    }
     import play.core.Execution.Implicits.trampoline
 
     // Execute the action on the Play default execution context
@@ -300,8 +303,11 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
   /**
    * Get the error handler for the application.
    */
-  private def errorHandler(app: Try[Application]): HttpErrorHandler =
-    app.fold[HttpErrorHandler](_ => DefaultHttpErrorHandler, _.errorHandler)
+  private def errorHandler(tryApp: Try[Application]): HttpErrorHandler =
+    tryApp match {
+      case Success(app) => app.errorHandler
+      case Failure(_) => DefaultHttpErrorHandler
+    }
 
   /**
    * Sends a simple response with no body, then closes the connection.

--- a/framework/src/play-server/src/main/resources/reference.conf
+++ b/framework/src/play-server/src/main/resources/reference.conf
@@ -90,6 +90,16 @@ play {
       frame.maxLength = 64k
       frame.maxLength = ${?websocket.frame.maxLength}
     }
+
+    debug {
+      # If set to true this will attach an attribute to each request containing debug information. If the application
+      # fails to load (e.g. due to a compile issue in dev mode), then this configuration value is ignored and the debug
+      # information is always attached.
+      #
+      # Note: This configuration option is not part of Play's public API and is subject to change without the usual
+      # deprecation cycle.
+      addDebugInfoToRequests = false
+    }
   }
 
   editor = ${?PLAY_EDITOR}

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -49,6 +49,7 @@ trait Server extends ReloadableServer {
    * NOTE: This will use the ApplicationProvider of the server to get the application instance.
    *       Use {@code Server.getHandlerFor(request, provider)} to pass a specific application instance
    */
+  @deprecated("Use Server.getHandlerFor instead", "2.6.13")
   def getHandlerFor(request: RequestHeader): Either[Future[Result], (RequestHeader, Handler, Application)] =
     Server.getHandlerFor(request, applicationProvider)
 

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
@@ -3,11 +3,14 @@
  */
 package play.core.server.common
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import play.api.Application
 import play.api.http.HttpConfiguration
 import play.api.libs.crypto.CookieSignerProvider
 import play.api.mvc.{ DefaultCookieHeaderEncoding, DefaultFlashCookieBaker, DefaultSessionCookieBaker }
 import play.api.mvc.request.DefaultRequestFactory
+import play.core.server.ServerProvider
 import play.utils.InlineCache
 
 import scala.util.{ Failure, Success, Try }
@@ -22,7 +25,18 @@ import scala.util.{ Failure, Success, Try }
  */
 private[play] abstract class ReloadCache[+T] {
 
-  private val reloadCache: Try[Application] => T = new InlineCache[Try[Application], T](reloadValue(_))
+  /**
+   * The count of how many times the cache has been reloaded. Due to the semantics of InlineCache this value
+   * could be called up to once per thread per application change.
+   */
+  private val reloadCounter = new AtomicInteger(0)
+
+  private[play] final def reloadCount: Int = reloadCounter.get
+
+  private val reloadCache: Try[Application] => T = new InlineCache[Try[Application], T]({ tryApp: Try[Application] =>
+    reloadCounter.incrementAndGet()
+    reloadValue(tryApp)
+  })
 
   /**
    * Get the cached `T` for the given application. If the application has changed
@@ -34,6 +48,24 @@ private[play] abstract class ReloadCache[+T] {
    * Calculate a fresh `T` for the given application.
    */
   protected def reloadValue(tryApp: Try[Application]): T
+
+  /**
+   * Helper to calculate the [[ServerDebugInfo]] after a reload.
+   * @param tryApp The application being loaded.
+   * @param serverProvider The server which embeds the application.
+   */
+  protected final def reloadDebugInfo(tryApp: Try[Application], serverProvider: ServerProvider): Option[ServerDebugInfo] = {
+    val enabled: Boolean = tryApp match {
+      case Success(app) => app.configuration.get[Boolean]("play.server.debug.addDebugInfoToRequests")
+      case Failure(_) => true // Always enable debug info when the app fails to load
+    }
+    if (enabled) {
+      Some(ServerDebugInfo(
+        serverProvider = serverProvider,
+        serverConfigCacheReloads = reloadCount
+      ))
+    } else None
+  }
 
   /**
    * Helper to calculate a `ServerResultUtil`.

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerDebugInfo.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerDebugInfo.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.common
+
+import play.api.libs.typedmap.{ TypedKey, TypedMap }
+import play.api.mvc.RequestHeader
+import play.core.server.ServerProvider
+
+/** An object attached to requests when server debugging is enabled. */
+private[play] final case class ServerDebugInfo(
+    serverProvider: ServerProvider,
+    serverConfigCacheReloads: Int
+)
+
+private[play] object ServerDebugInfo {
+  /** The attribute used to attach debug info to requests. */
+  val Attr = TypedKey[ServerDebugInfo]("serverDebugInfo")
+
+  /**
+   * Helper method for use in server backends. Attaches the debug info the request if the info is defined.
+   */
+  def attachToRequestHeader(rh: RequestHeader, serverDebugInfo: Option[ServerDebugInfo]): RequestHeader = {
+    serverDebugInfo match {
+      case None => rh
+      case Some(info) => rh.addAttr(Attr, info)
+    }
+  }
+}

--- a/framework/src/play/src/main/scala/play/core/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/ApplicationProvider.scala
@@ -39,6 +39,7 @@ trait ApplicationProvider {
   /**
    * Get the currently loaded application. May be empty in dev mode because of compile failure or before first load.
    */
+  @deprecated("Use ApplicationProvider.get instead", "2.6.13")
   def current: Option[Application] = get.toOption
 
   /**


### PR DESCRIPTION
Fixes #7812.

The caching of the `ReloadCache` uses reference equality so we need to be more careful when passing around the Try[Application] returned by `ApplicationProvider.get`. We need to make sure we keep the same reference.