### PR TITLE
[master]: Stop Netty server reloading configuration on each request

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -93,6 +93,10 @@ Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]]
 
 Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 24.1-jre. Lots of changes were made in library, you can see the full changelog [here](https://github.com/google/guava/releases).
 
-### `Server.getHandlerFor` has been removed
+### Internal changes
 
-This method on the `Server` trait was used internally by the Play server code when routing requests. It has been removed and replaced with a method of the same name on the `Server` object.
+Many changes have been made to Play's internal APIs. These APIs are used internally and don't follow a normal deprecation process. Changes may be mentioned below to help those who integrate directly with Play internal APIs.
+
+#### `Server.getHandlerFor` has moved to `Server#getHandlerFor`
+
+The `getHandlerFor` method on the `Server` trait was used internally by the Play server code when routing requests. It has been removed and replaced with a method of the same name on the `Server` object.

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -92,3 +92,7 @@ Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]]
 ### `Guava` version updated to 24.0-jre
 
 Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 24.1-jre. Lots of changes were made in library, you can see the full changelog [here](https://github.com/google/guava/releases).
+
+### `Server.getHandlerFor` has been removed
+
+This method on the `Server` trait was used internally by the Play server code when routing requests. It has been removed and replaced with a method of the same name on the `Server` object.

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -467,7 +467,12 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.api.cache.CacheApi"),
       ProblemFilters.exclude[MissingTypesProblem]("play.api.cache.DefaultSyncCacheApi"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.cache.DefaultSyncCacheApi.getOrElse"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.cache.DefaultSyncCacheApi.getOrElse$default$2")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.cache.DefaultSyncCacheApi.getOrElse$default$2"),
+
+      // Remove Server trait's deprecated getHandler method
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.Server.getHandlerFor"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServer.getHandlerFor"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.getHandlerFor")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -206,9 +206,9 @@ class AkkaHttpServer(
       remoteAddress = remoteAddress,
       secureProtocol = secure,
       request = decodedRequest)
-    val (taggedRequestHeader, handler, newTryApp) = getHandler(convertedRequestHeader, tryApp)
+    val (taggedRequestHeader, handler) = Server.getHandlerFor(convertedRequestHeader, tryApp)
     val responseFuture = executeHandler(
-      newTryApp,
+      tryApp,
       decodedRequest,
       taggedRequestHeader,
       requestBodySource,
@@ -222,25 +222,6 @@ class AkkaHttpServer(
       case Some(headers.`Remote-Address`(RemoteAddress.IP(ip, Some(port)))) =>
         new InetSocketAddress(ip, port)
       case _ => throw new IllegalStateException("`Remote-Address` header was missing")
-    }
-  }
-
-  private def getHandler(
-    requestHeader: RequestHeader, tryApp: Try[Application]
-  ): (RequestHeader, Handler, Try[Application]) = {
-    Server.getHandlerFor(requestHeader, tryApp) match {
-      case Left(futureResult) =>
-        (
-          requestHeader,
-          EssentialAction(_ => Accumulator.done(futureResult)),
-          Failure(new Exception("getHandler returned Result, but not Application"))
-        )
-      case Right((newRequestHeader, handler, newApp)) =>
-        (
-          newRequestHeader,
-          handler,
-          Success(newApp) // TODO: Change getHandlerFor to use the app that we already had
-        )
     }
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
@@ -15,6 +15,7 @@ import play.api.routing.sird._
 import play.api.test.{ PlaySpecification, WsTestClient }
 import play.api.{ Application, Configuration }
 import play.core.ApplicationProvider
+import play.core.server.common.ServerDebugInfo
 import play.core.server.{ ServerConfig, ServerProvider }
 import play.it.{ AkkaHttpIntegrationSpecification, NettyIntegrationSpecification, ServerIntegrationSpecification }
 
@@ -168,6 +169,56 @@ trait ServerReloadingSpec extends PlaySpecification with WsTestClient with Serve
       }
     }
 
+    "only reload its configuration when the application changes" in {
+
+      val testAppProvider = new TestApplicationProvider
+      withApplicationProvider(testAppProvider) { implicit port: Port =>
+
+        def appWithConfig(conf: (String, Any)*): Success[Application] = {
+          Success(GuiceApplicationBuilder()
+            .configure(conf: _*)
+            .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
+            .build())
+        }
+
+        val app1 = appWithConfig("play.server.debug.addDebugInfoToRequests" -> true)
+        testAppProvider.provide(app1)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(1)"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(1)"
+
+        val app2 = Failure(new Exception())
+        testAppProvider.provide(app2)
+        await(wsUrl("/getserverconfigcachereloads").get()).status must_== 500
+        await(wsUrl("/getserverconfigcachereloads").get()).status must_== 500
+
+        val app3 = appWithConfig("play.server.debug.addDebugInfoToRequests" -> true)
+        testAppProvider.provide(app3)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(3)"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(3)"
+
+        val app4 = appWithConfig()
+        testAppProvider.provide(app4)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "None"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "None"
+
+        val app5 = appWithConfig("play.server.debug.addDebugInfoToRequests" -> true)
+        testAppProvider.provide(app5)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(5)"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(5)"
+
+        val app6 = Failure(new Exception())
+        testAppProvider.provide(app6)
+        await(wsUrl("/getserverconfigcachereloads").get()).status must_== 500
+        await(wsUrl("/getserverconfigcachereloads").get()).status must_== 500
+
+        val app7 = appWithConfig("play.server.debug.addDebugInfoToRequests" -> true)
+        testAppProvider.provide(app7)
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(7)"
+        await(wsUrl("/getserverconfigcachereloads").get()).body must_== "Some(7)"
+
+      }
+    }
+
   }
 }
 
@@ -186,6 +237,10 @@ private[server] object ServerReloadingSpec {
       }
       case GET(p"/getremoteaddress") => action { request: Request[_] =>
         Results.Ok(request.remoteAddress)
+      }
+      case GET(p"/getserverconfigcachereloads") => action { request: Request[_] =>
+        val reloadCount: Option[Int] = request.attrs.get(ServerDebugInfo.Attr).map(_.serverConfigCacheReloads)
+        Results.Ok(reloadCount.toString)
       }
     }
   }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -18,11 +18,9 @@ import play.api.http._
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.{ Application, Logger }
-import play.core.ApplicationProvider
 import play.core.server.{ NettyServer, Server }
 import play.core.server.common.{ ReloadCache, ServerResultUtils }
 
-import scala.compat.java8.FutureConverters
 import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
 
@@ -84,40 +82,31 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
 
     val tryRequest: Try[RequestHeader] = modelConversion(tryApp).convertRequest(channel, request)
 
-    def clientError(statusCode: Int, message: String) = {
+    def clientError(statusCode: Int, message: String): (RequestHeader, Handler) = {
       val unparsedTarget = modelConversion(tryApp).createUnparsedRequestTarget(request)
       val requestHeader = modelConversion(tryApp).createRequestHeader(channel, request, unparsedTarget)
-      val result = errorHandler(server.applicationProvider.current).onClientError(requestHeader, statusCode,
+      val result = errorHandler(tryApp).onClientError(requestHeader, statusCode,
         if (message == null) "" else message)
       // If there's a problem in parsing the request, then we should close the connection, once done with it
-      requestHeader -> Left(result.map(_.withHeaders(HeaderNames.CONNECTION -> "close")))
+      requestHeader -> Server.actionForResult(result.map(_.withHeaders(HeaderNames.CONNECTION -> "close")))
     }
 
-    val (requestHeader, resultOrHandler) = tryRequest match {
-
+    val (requestHeader, handler): (RequestHeader, Handler) = tryRequest match {
       case Failure(exception: TooLongFrameException) => clientError(Status.REQUEST_URI_TOO_LONG, exception.getMessage)
       case Failure(exception) => clientError(Status.BAD_REQUEST, exception.getMessage)
-      case Success(untagged) =>
-        Server.getHandlerFor(untagged, tryApp) match {
-
-          case Left(directResult) =>
-            untagged -> Left(directResult)
-
-          case Right((taggedRequestHeader, handler, application)) =>
-            taggedRequestHeader -> Right((handler, application))
-        }
-
+      case Success(untagged) => Server.getHandlerFor(untagged, tryApp)
     }
 
-    resultOrHandler match {
+    handler match {
 
       //execute normal action
-      case Right((action: EssentialAction, app)) =>
-        handleAction(action, requestHeader, request, Some(app))
+      case action: EssentialAction =>
+        handleAction(action, requestHeader, request, tryApp)
 
-      case Right((ws: WebSocket, app)) if requestHeader.headers.get(HeaderNames.UPGRADE).exists(_.equalsIgnoreCase("websocket")) =>
+      case ws: WebSocket if requestHeader.headers.get(HeaderNames.UPGRADE).exists(_.equalsIgnoreCase("websocket")) =>
         logger.trace("Serving this request with: " + ws)
 
+        val app = tryApp.get // Guaranteed to be Success for a WebSocket handler
         val wsProtocol = if (requestHeader.secure) "wss" else "ws"
         val wsUrl = s"$wsProtocol://${requestHeader.host}${requestHeader.path}"
         val bufferLimit = app.configuration.getDeprecated[ConfigMemorySize]("play.server.websocket.frame.maxLength", "play.websocket.buffer.limit").toBytes.toInt
@@ -130,7 +119,7 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
           case Left(result) =>
             // WebSocket was rejected, send result
             val action = EssentialAction(_ => Accumulator.done(result))
-            handleAction(action, requestHeader, request, Some(app))
+            handleAction(action, requestHeader, request, tryApp)
           case Right(flow) =>
             import app.materializer
             val processor = WebSocketHandler.messageFlowToFrameProcessor(flow, bufferLimit)
@@ -141,12 +130,12 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
           case error =>
             app.errorHandler.onServerError(requestHeader, error).flatMap { result =>
               val action = EssentialAction(_ => Accumulator.done(result))
-              handleAction(action, requestHeader, request, Some(app))
+              handleAction(action, requestHeader, request, tryApp)
             }
         }
 
       //handle bad websocket request
-      case Right((ws: WebSocket, app)) =>
+      case ws: WebSocket =>
         logger.trace("Bad websocket request")
         val action = EssentialAction(_ => Accumulator.done(
           Results.Status(Status.UPGRADE_REQUIRED)("Upgrade to WebSocket required").withHeaders(
@@ -154,19 +143,13 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
             HeaderNames.CONNECTION -> HeaderNames.UPGRADE
           )
         ))
-        handleAction(action, requestHeader, request, Some(app))
+        handleAction(action, requestHeader, request, tryApp)
 
       // This case usually indicates an error in Play's internal routing or handling logic
-      case Right((h, _)) =>
+      case h =>
         val ex = new IllegalStateException(s"Netty server doesn't handle Handlers of this type: $h")
         logger.error(ex.getMessage, ex)
         throw ex
-
-      case Left(e) =>
-        logger.trace("No handler, got direct result: " + e)
-        val action = EssentialAction(_ => Accumulator.done(e))
-        handleAction(action, requestHeader, request, None)
-
     }
   }
 
@@ -264,11 +247,9 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
    * Handle an essential action.
    */
   private def handleAction(action: EssentialAction, requestHeader: RequestHeader,
-    request: HttpRequest, app: Option[Application]): Future[HttpResponse] = {
-    implicit val mat: Materializer = app.fold(server.materializer)(_.materializer)
+    request: HttpRequest, tryApp: Try[Application]): Future[HttpResponse] = {
+    implicit val mat: Materializer = tryApp.fold(_ => server.materializer, _.materializer)
     import play.core.Execution.Implicits.trampoline
-
-    val tryApp = Try(app.get)
 
     // Execute the action on the Play default execution context
     val actionFuture = Future(action(requestHeader))(mat.executionContext)
@@ -283,24 +264,24 @@ private[play] class PlayRequestHandler(val server: NettyServer, val serverHeader
       }.recoverWith {
         case error =>
           logger.error("Cannot invoke the action", error)
-          errorHandler(app).onServerError(requestHeader, error)
+          errorHandler(tryApp).onServerError(requestHeader, error)
       }
       // Clean and validate the action's result
       validatedResult <- {
         val cleanedResult = resultUtils(tryApp).prepareCookies(requestHeader, actionResult)
-        resultUtils(tryApp).validateResult(requestHeader, cleanedResult, errorHandler(app))
+        resultUtils(tryApp).validateResult(requestHeader, cleanedResult, errorHandler(tryApp))
       }
       // Convert the result to a Netty HttpResponse
       convertedResult <- modelConversion(tryApp)
-        .convertResult(validatedResult, requestHeader, request.protocolVersion(), errorHandler(app))
+        .convertResult(validatedResult, requestHeader, request.protocolVersion(), errorHandler(tryApp))
     } yield convertedResult
   }
 
   /**
    * Get the error handler for the application.
    */
-  private def errorHandler(app: Option[Application]): HttpErrorHandler =
-    app.fold[HttpErrorHandler](DefaultHttpErrorHandler)(_.errorHandler)
+  private def errorHandler(tryApp: Try[Application]): HttpErrorHandler =
+    tryApp.fold[HttpErrorHandler](_ => DefaultHttpErrorHandler, _.errorHandler)
 
   /**
    * Sends a simple response with no body, then closes the connection.

--- a/framework/src/play-server/src/main/resources/reference.conf
+++ b/framework/src/play-server/src/main/resources/reference.conf
@@ -90,6 +90,16 @@ play {
       frame.maxLength = 64k
       frame.maxLength = ${?websocket.frame.maxLength}
     }
+
+    debug {
+      # If set to true this will attach an attribute to each request containing debug information. If the application
+      # fails to load (e.g. due to a compile issue in dev mode), then this configuration value is ignored and the debug
+      # information is always attached.
+      #
+      # Note: This configuration option is not part of Play's public API and is subject to change without the usual
+      # deprecation cycle.
+      addDebugInfoToRequests = false
+    }
   }
 
   editor = ${?PLAY_EDITOR}

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -10,6 +10,7 @@ import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.http.{ DefaultHttpErrorHandler, Port }
 import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
+import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
 import play.core._
@@ -31,23 +32,6 @@ trait WebSocketable {
 trait Server extends ReloadableServer {
 
   def mode: Mode
-
-  /**
-   * Try to get the handler for a request and return it as a `Right`. If we
-   * can't get the handler for some reason then return a result immediately
-   * as a `Left`. Reasons to return a `Left` value:
-   *
-   * - If there's a "web command" installed that intercepts the request.
-   * - If we fail to get the `Application` from the `applicationProvider`,
-   *   i.e. if there's an error loading the application.
-   * - If an exception is thrown.
-   *
-   * NOTE: This will use the ApplicationProvider of the server to get the application instance.
-   *       Use {@code Server.getHandlerFor(request, tryApp)} to pass a specific application instance
-   */
-  @deprecated("Use Server.getHandlerFor(request, tryApp) instead", "2.7.0")
-  def getHandlerFor(request: RequestHeader): Either[Future[Result], (RequestHeader, Handler, Application)] =
-    Server.getHandlerFor(request, applicationProvider.get)
 
   def applicationProvider: ApplicationProvider
 
@@ -94,10 +78,10 @@ object Server {
    *   i.e. if there's an error loading the application.
    * - If an exception is thrown.
    */
-  def getHandlerFor(
+  private[server] def getHandlerFor(
     request: RequestHeader,
     tryApp: Try[Application]
-  ): Either[Future[Result], (RequestHeader, Handler, Application)] = {
+  ): (RequestHeader, Handler) = {
     try {
       // Get the Application from the try.
       val application = tryApp.get
@@ -106,13 +90,22 @@ object Server {
       // logic to handle that request.
       val factoryMadeHeader: RequestHeader = application.requestFactory.copyRequestHeader(request)
       val (handlerHeader, handler) = application.requestHandler.handlerForRequest(factoryMadeHeader)
-      Right((handlerHeader, handler, application))
+      (handlerHeader, handler)
     } catch {
       case e: ThreadDeath => throw e
       case e: VirtualMachineError => throw e
       case e: Throwable =>
-        Left(DefaultHttpErrorHandler.onServerError(request, e))
+        val errorResult = DefaultHttpErrorHandler.onServerError(request, e)
+        val errorAction = actionForResult(errorResult)
+        (request, errorAction)
     }
+  }
+
+  /**
+   * Create a simple [[Handler]] which sends a [[Result]].
+   */
+  private[server] def actionForResult(errorResult: Future[Result]): Handler = {
+    EssentialAction(_ => Accumulator.done(errorResult))
   }
 
   /**

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
@@ -3,11 +3,14 @@
  */
 package play.core.server.common
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import play.api.Application
 import play.api.http.HttpConfiguration
 import play.api.libs.crypto.CookieSignerProvider
 import play.api.mvc.{ DefaultCookieHeaderEncoding, DefaultFlashCookieBaker, DefaultSessionCookieBaker }
 import play.api.mvc.request.DefaultRequestFactory
+import play.core.server.ServerProvider
 import play.utils.InlineCache
 
 import scala.util.{ Failure, Success, Try }
@@ -22,7 +25,18 @@ import scala.util.{ Failure, Success, Try }
  */
 private[play] abstract class ReloadCache[+T] {
 
-  private val reloadCache: Try[Application] => T = new InlineCache[Try[Application], T](reloadValue(_))
+  /**
+   * The count of how many times the cache has been reloaded. Due to the semantics of InlineCache this value
+   * could be called up to once per thread per application change.
+   */
+  private val reloadCounter = new AtomicInteger(0)
+
+  private[play] final def reloadCount: Int = reloadCounter.get
+
+  private val reloadCache: Try[Application] => T = new InlineCache[Try[Application], T]({ tryApp: Try[Application] =>
+    reloadCounter.incrementAndGet()
+    reloadValue(tryApp)
+  })
 
   /**
    * Get the cached `T` for the given application. If the application has changed
@@ -34,6 +48,24 @@ private[play] abstract class ReloadCache[+T] {
    * Calculate a fresh `T` for the given application.
    */
   protected def reloadValue(tryApp: Try[Application]): T
+
+  /**
+   * Helper to calculate the [[ServerDebugInfo]] after a reload.
+   * @param tryApp The application being loaded.
+   * @param serverProvider The server which embeds the application.
+   */
+  protected final def reloadDebugInfo(tryApp: Try[Application], serverProvider: ServerProvider): Option[ServerDebugInfo] = {
+    val enabled: Boolean = tryApp match {
+      case Success(app) => app.configuration.get[Boolean]("play.server.debug.addDebugInfoToRequests")
+      case Failure(_) => true // Always enable debug info when the app fails to load
+    }
+    if (enabled) {
+      Some(ServerDebugInfo(
+        serverProvider = serverProvider,
+        serverConfigCacheReloads = reloadCount
+      ))
+    } else None
+  }
 
   /**
    * Helper to calculate a `ServerResultUtil`.

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerDebugInfo.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerDebugInfo.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.common
+
+import play.api.libs.typedmap.{ TypedKey, TypedMap }
+import play.api.mvc.RequestHeader
+import play.core.server.ServerProvider
+
+/** An object attached to requests when server debugging is enabled. */
+private[play] final case class ServerDebugInfo(
+    serverProvider: ServerProvider,
+    serverConfigCacheReloads: Int
+)
+
+private[play] object ServerDebugInfo {
+  /** The attribute used to attach debug info to requests. */
+  val Attr = TypedKey[ServerDebugInfo]("serverDebugInfo")
+
+  /**
+   * Helper method for use in server backends. Attaches the debug info the request if the info is defined.
+   */
+  def attachToRequestHeader(rh: RequestHeader, serverDebugInfo: Option[ServerDebugInfo]): RequestHeader = {
+    serverDebugInfo match {
+      case None => rh
+      case Some(info) => rh.addAttr(Attr, info)
+    }
+  }
+}

--- a/framework/src/play/src/main/scala/play/core/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/ApplicationProvider.scala
@@ -39,6 +39,7 @@ trait ApplicationProvider {
   /**
    * Get the currently loaded application. May be empty in dev mode because of compile failure or before first load.
    */
+  @deprecated("Use ApplicationProvider.get instead", "2.6.13")
   def current: Option[Application] = get.toOption
 
   /**


### PR DESCRIPTION
Fixes #7812.

The caching of the `ReloadCache` uses reference equality so we need to be more careful when passing around the Try[Application] returned by `ApplicationProvider.get`. We need to make sure we keep the same reference.

Also did some refactoring of code while I was making these changes.