### PR TITLE
Use Max-Age=0 to expire a cookie

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -143,7 +143,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       }
     }) { response =>
       val setCookie = response.headers.get("Set-Cookie").mkString("\n")
-      setCookie must contain("PLAY_SESSION=; Max-Age=-86400")
+      setCookie must contain("PLAY_SESSION=; Max-Age=0")
       response.body must_== "foo"
     }
     "ensure context.withRequest in an Action maintains Flash" in makeRequest(new MockController {
@@ -154,7 +154,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       }
     }) { response =>
       val setCookie = response.headers.get("Set-Cookie").mkString("\n")
-      setCookie must contain("PLAY_FLASH=; Max-Age=-86400")
+      setCookie must contain("PLAY_FLASH=; Max-Age=0")
       response.body must_== "foo"
     }
     "ensure context.withRequest in an Action maintains Response" in makeRequest(new MockController {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -262,7 +262,7 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
         Results.ok("Hello world")
       }
     }) { response =>
-      response.header("Set-Cookie").get must contain("PLAY_SESSION=; Max-Age=-86400")
+      response.header("Set-Cookie").get must contain("PLAY_SESSION=; Max-Age=0")
       response.body must_== "Hello world"
     }
 

--- a/framework/src/play/src/main/java/play/core/cookie/encoding/ClientCookieDecoder.java
+++ b/framework/src/play/src/main/java/play/core/cookie/encoding/ClientCookieDecoder.java
@@ -240,7 +240,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
 
         private void setMaxAge(String value) {
             try {
-                maxAge = Integer.valueOf(value);
+                maxAge = Math.max(Integer.valueOf(value), 0);
             } catch (NumberFormatException e1) {
                 // ignore failure to parse -> treat as session cookie
             }

--- a/framework/src/play/src/main/java/play/core/cookie/encoding/ServerCookieEncoder.java
+++ b/framework/src/play/src/main/java/play/core/cookie/encoding/ServerCookieEncoder.java
@@ -82,7 +82,9 @@ public final class ServerCookieEncoder extends CookieEncoder {
 
         if (cookie.maxAge() != Integer.MIN_VALUE) {
             add(buf, CookieHeaderNames.MAX_AGE, cookie.maxAge());
-            Date expires = new Date(cookie.maxAge() * 1000l + System.currentTimeMillis());
+            Date expires = cookie.maxAge() <= 0
+                ? new Date(0) // Set expires to the Unix epoch
+                : new Date(cookie.maxAge() * 1000L + System.currentTimeMillis());
             add(buf, CookieHeaderNames.EXPIRES, HttpHeaderDateFormat.get().format(expires));
         }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -27,7 +27,7 @@ import scala.util.control.NonFatal
  *
  * @param name the cookie name
  * @param value the cookie value
- * @param maxAge the cookie expiration date in seconds, `None` for a transient cookie, or a value less than 0 to expire a cookie now
+ * @param maxAge the cookie expiration date in seconds, `None` for a transient cookie, or a value 0 or less to expire a cookie now
  * @param path the cookie path, defaulting to the root path `/`
  * @param domain the cookie domain
  * @param secure whether this cookie is secured, sent only for HTTPS requests
@@ -96,10 +96,11 @@ object Cookie {
   import scala.concurrent.duration._
 
   /**
-   * The cookie's max age, in seconds, when we expire the cookie. This is also used to determine Expires. It's set
-   * to one day ago to work for clients that only support Expires and have a clock that is slightly behind.
+   * The cookie's Max-Age, in seconds, when we expire the cookie.
+   *
+   * When Max-Age = 0, Expires is set to 0 epoch time for compatibility with older browsers.
    */
-  val DiscardedMaxAge: Int = -1.day.toSeconds.toInt
+  val DiscardedMaxAge: Int = 0
 }
 
 /**

--- a/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -6,9 +6,9 @@ package play.api.mvc
 import java.time.{ Instant, ZoneId }
 
 import org.specs2.mutable._
-import play.api.http.{ JWTConfiguration, SecretConfiguration, SessionConfiguration }
+import play.api.http.{ JWTConfiguration, SecretConfiguration }
 import play.api.mvc.Cookie.SameSite
-import play.core.cookie.encoding.ServerCookieEncoder
+import play.core.cookie.encoding.{ DefaultCookie, ServerCookieEncoder }
 import play.core.test._
 
 import scala.concurrent.duration._
@@ -61,6 +61,13 @@ class CookiesSpec extends Specification {
     "properly encode field name which starts with $" in {
       val output = encoder.encode("$Test", "Test")
       output must be_==("$Test=Test")
+    }
+
+    "properly encode discarded cookies" in {
+      val dc = new DefaultCookie("foo", "bar")
+      dc.setMaxAge(0)
+      val encoded = encoder.encode(dc)
+      encoded must_== "foo=bar; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
     }
   }
 


### PR DESCRIPTION
Fixes #8332. Use 0 as the max-age for discarded cookies for maximum compatibility. Since non-positive Max-Age values always mean "expire now", set the expiration date of such cookies to 1 Jan 1970.