### PR TITLE
[2.6.x]: Correct apiURL setting

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -93,10 +93,7 @@ object BuildSettings {
       apiURL in doc := {
         val v = version.value
         if (isSnapshot.value) {
-          v match {
-            case VersionPattern(epoch, major, _, _) => Some(url(raw"https://www.playframework.com/documentation/$epoch.$major.x/api/scala/index.html"))
-            case _ => Some(url("https://www.playframework.com/documentation/latest/api/scala/index.html"))
-          }
+          Some(url("https://www.playframework.com/documentation/2.6.x/api/scala/index.html"))
         } else {
           Some(url(raw"https://www.playframework.com/documentation/$v/api/scala/index.html"))
         }


### PR DESCRIPTION
We don't need/have a `VersionPattern` since we can assume that snapshots will use `2.6.x` version.