### PR TITLE
Rename Java form methods back to original names

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
@@ -315,8 +315,8 @@ public class JavaForms extends WithApplication {
         //#fill
         userForm = userForm.fill(new User("bob@gmail.com", "secret"));
         //#fill
-        assertThat(userForm.field("email").getValue().get(), equalTo("bob@gmail.com"));
-        assertThat(userForm.field("password").getValue().get(), equalTo("secret"));
+        assertThat(userForm.field("email").value().get(), equalTo("bob@gmail.com"));
+        assertThat(userForm.field("password").value().get(), equalTo("secret"));
     }
 
     @Test
@@ -352,7 +352,7 @@ public class JavaForms extends WithApplication {
         Form<WithLocalTime> form = application.injector().instanceOf(FormFactory.class).form(WithLocalTime.class);
         WithLocalTime obj = form.bind(ImmutableMap.of("time", "23:45")).get();
         assertThat(obj.getTime(), equalTo(LocalTime.of(23, 45)));
-        assertThat(form.fill(obj).field("time").getValue().get(), equalTo("23:45"));
+        assertThat(form.fill(obj).field("time").value().get(), equalTo("23:45"));
     }
 
     public static class WithLocalTime {

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -308,16 +308,10 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.j.RequestImpl.username"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.j.RequestImpl.withUsername"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.DynamicForm.data"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.DynamicForm.error"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.DynamicForm.reject"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form#Field.name"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form#Field.value"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form#Field.valueOr"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.data"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.discardErrors"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.error"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.errors"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.globalError"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.reject"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.format.Formatters.parse"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.http.HandlerForRequest.getRequest"),
@@ -459,7 +453,15 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.routing.Router$Tags"),
 
       // Upgrade Guice from 4.1.0 to 4.2.0 which uses java.util.function.Function instead of com.google.common.base.Function now
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.test.TestBrowser.waitUntil")
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.test.TestBrowser.waitUntil"),
+
+      // "Renamed" methods in Java form api
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.data.Form#Field.value"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.data.Form#Field.name"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.data.Form.error"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.data.Form.globalError"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.data.Form.errors"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.data.DynamicForm.error")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -98,7 +98,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public DynamicForm fill(Map<String, Object> value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
-        return new DynamicForm(form.rawData(), form.allErrors(), form.value(), messagesApi, formatters, validator);
+        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validator);
     }
 
     /**
@@ -136,7 +136,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         data = newData;
 
         Form<Dynamic> form = super.bind(data, allowedFields);
-        return new DynamicForm(form.rawData(), form.allErrors(), form.value(), messagesApi, formatters, validator);
+        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validator);
     }
 
     /**
@@ -150,15 +150,25 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         // javadoc cannot find the static inner class.
         Field field = super.field(asDynamicKey(key));
         return new Field(this, key, field.constraints(), field.format(), field.errors(),
-            field.getValue().orElse((String)value(key).orElse(null))
+            field.value().orElse((String)value(key).orElse(null))
         );
     }
 
     /**
      * Retrieve an error by key.
+     *
+     * @deprecated Deprecated as of 2.7.0. Method has been renamed to {@link #error(String)}.
      */
+    @Deprecated
     public Optional<ValidationError> getError(String key) {
-        return super.getError(asDynamicKey(key));
+        return error(key);
+    }
+
+    /**
+     * Retrieve an error by key.
+     */
+    public Optional<ValidationError> error(String key) {
+        return super.error(asDynamicKey(key));
     }
 
     /**
@@ -171,7 +181,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     public DynamicForm withError(final String key, final String error, final List<Object> args) {
         final Form<Dynamic> form = super.withError(asDynamicKey(key), error, args);
-        return new DynamicForm(this.rawData, form.allErrors(), form.value(), this.messagesApi, this.formatters, this.validator);
+        return new DynamicForm(this.rawData, form.errors(), form.value(), this.messagesApi, this.formatters, this.validator);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -16,10 +16,8 @@ import org.springframework.validation.DataBinder;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
-import play.Logger;
 import play.data.format.Formatters;
 import play.data.validation.Constraints;
-import play.data.validation.Constraints.Validatable;
 import play.data.validation.ValidationError;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
@@ -35,7 +33,6 @@ import javax.validation.metadata.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -89,7 +86,7 @@ public class Form<T> {
 
     private final String rootName;
     private final Class<T> backedType;
-    private final Map<String,String> data;
+    private final Map<String,String> rawData;
     private final List<ValidationError> errors;
     private final Optional<T> value;
     private final Class<?>[] groups;
@@ -157,7 +154,7 @@ public class Form<T> {
     public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
         this.rootName = rootName;
         this.backedType = clazz;
-        this.data = data != null ? new HashMap<>(data) : new HashMap<>();
+        this.rawData = data != null ? new HashMap<>(data) : new HashMap<>();
         this.errors = errors != null ? new ArrayList<>(errors) : new ArrayList<>();
         this.value = value;
         this.groups = groups;
@@ -494,7 +491,7 @@ public class Form<T> {
      * @return the actual form data as unmodifiable map.
      */
     public Map<String,String> rawData() {
-        return Collections.unmodifiableMap(data);
+        return Collections.unmodifiableMap(rawData);
     }
 
     public String name() {
@@ -558,8 +555,20 @@ public class Form<T> {
      * Retrieves the first global error (an error without any key), if it exists.
      *
      * @return An error.
+     *
+     * @deprecated Deprecated as of 2.7.0. Method has been renamed to {@link #globalError()}.
      */
+    @Deprecated
     public Optional<ValidationError> getGlobalError() {
+        return globalError();
+    }
+
+    /**
+     * Retrieves the first global error (an error without any key), if it exists.
+     *
+     * @return An error.
+     */
+    public Optional<ValidationError> globalError() {
         return globalErrors().stream().findFirst();
     }
 
@@ -567,8 +576,20 @@ public class Form<T> {
      * Returns all errors.
      *
      * @return All errors associated with this form.
+     *
+     * @deprecated Deprecated as of 2.7.0. Method has been renamed to {@link #errors()}.
      */
+    @Deprecated
     public List<ValidationError> allErrors() {
+        return errors();
+    }
+
+    /**
+     * Returns all errors.
+     *
+     * @return All errors associated with this form.
+     */
+    public List<ValidationError> errors() {
         return Collections.unmodifiableList(errors);
     }
 
@@ -586,8 +607,19 @@ public class Form<T> {
     /**
      * @param key    the field name associated with the error.
      * @return an error by key
+     *
+     * @deprecated Deprecated as of 2.7.0. Method has been renamed to {@link #error(String)}.
      */
+    @Deprecated
     public Optional<ValidationError> getError(String key) {
+        return error(key);
+    }
+
+    /**
+     * @param key    the field name associated with the error.
+     * @return an error by key
+     */
+    public Optional<ValidationError> error(String key) {
         return errors(key).stream().findFirst();
     }
 
@@ -663,7 +695,7 @@ public class Form<T> {
         }
         final List<ValidationError> copiedErrors = new ArrayList<>(this.errors);
         copiedErrors.add(error);
-        return new Form<T>(this.rootName, this.backedType, this.data, copiedErrors, this.value, this.groups, this.messagesApi, this.formatters, this.validator);
+        return new Form<T>(this.rootName, this.backedType, this.rawData, copiedErrors, this.value, this.groups, this.messagesApi, this.formatters, this.validator);
     }
 
     /**
@@ -710,7 +742,7 @@ public class Form<T> {
      * @return a copy of this form but with the errors discarded.
      */
     public Form<T> discardingErrors() {
-        return new Form<T>(this.rootName, this.backedType, this.data, new ArrayList<>(), this.value, this.groups, this.messagesApi, this.formatters, this.validator);
+        return new Form<T>(this.rootName, this.backedType, this.rawData, new ArrayList<>(), this.value, this.groups, this.messagesApi, this.formatters, this.validator);
     }
 
     /**
@@ -733,8 +765,8 @@ public class Form<T> {
 
         // Value
         String fieldValue = null;
-        if (data.containsKey(key)) {
-            fieldValue = data.get(key);
+        if (rawData.containsKey(key)) {
+            fieldValue = rawData.get(key);
         } else {
             if (value.isPresent()) {
                 BeanWrapper beanWrapper = new BeanWrapperImpl(value.get());
@@ -826,7 +858,7 @@ public class Form<T> {
     }
 
     public String toString() {
-        return "Form(of=" + backedType + ", data=" + data + ", value=" + value +", errors=" + errors + ")";
+        return "Form(of=" + backedType + ", data=" + rawData + ", value=" + value +", errors=" + errors + ")";
     }
 
     /**
@@ -882,15 +914,35 @@ public class Form<T> {
 
         /**
          * @return The field name.
+         *
+         * @deprecated Deprecated as of 2.7.0. Method has been renamed to {@link #name()}.
          */
+        @Deprecated
         public Optional<String> getName() {
+            return name();
+        }
+
+        /**
+         * @return The field name.
+         */
+        public Optional<String> name() {
             return Optional.ofNullable(name);
         }
 
         /**
          * @return The field value, if defined.
+         *
+         * @deprecated Deprecated as of 2.7.0. Method has been renamed to {@link #value()}.
          */
+        @Deprecated
         public Optional<String> getValue() {
+            return value();
+        }
+
+        /**
+         * @return The field value, if defined.
+         */
+        public Optional<String> value() {
             return Optional.ofNullable(value);
         }
 

--- a/framework/src/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
+++ b/framework/src/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
@@ -16,7 +16,7 @@ object PlayFormsMagicForJava {
   implicit def javaFieldtoScalaField(jField: play.data.Form.Field): play.api.data.Field = {
     new play.api.data.Field(
       null,
-      jField.getName.orElse(null),
+      jField.name.orElse(null),
       Option(jField.constraints).map(c => c.asScala.map { jT =>
         jT._1 -> jT._2.asScala
       }).getOrElse(Nil),
@@ -27,7 +27,7 @@ object PlayFormsMagicForJava {
           jE.messages.asScala,
           jE.arguments.asScala)
       }).getOrElse(Nil),
-      OptionConverters.toScala(jField.getValue)) {
+      OptionConverters.toScala(jField.value)) {
 
       override def apply(key: String) = {
         javaFieldtoScalaField(jField.sub(key))

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -58,7 +58,7 @@ public class HttpFormsTest {
     }
 
     private <T> Form<T> copyFormWithoutRawData(final Form<T> formToCopy, final Application app) {
-        return new Form<T>(formToCopy.name(), formToCopy.getBackedType(), null, formToCopy.allErrors(), formToCopy.value(),
+        return new Form<T>(formToCopy.name(), formToCopy.getBackedType(), null, formToCopy.errors(), formToCopy.value(),
             (Class[])null, app.injector().instanceOf(MessagesApi.class), app.injector().instanceOf(Formatters.class), app.injector().instanceOf(Validator.class));
     }
 
@@ -84,7 +84,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasGlobalErrors()).isFalse();
             Money money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567.89"));
-            assertThat(copyFormWithoutRawData(myForm, app).field("amount").getValue().get()).isEqualTo("1 234 567,89");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value().get()).isEqualTo("1 234 567,89");
             // Parse french input with english formatter
             ctx.changeLang("en");
             myForm = formFactory.form(Money.class).bindFromRequest();
@@ -92,7 +92,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasGlobalErrors()).isFalse();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("123456789"));
-            assertThat(copyFormWithoutRawData(myForm, app).field("amount").getValue().get()).isEqualTo("123,456,789");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value().get()).isEqualTo("123,456,789");
 
             // Prepare Request and Context with english number
             data = new HashMap<>();
@@ -107,7 +107,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasGlobalErrors()).isFalse();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567"));
-            assertThat(copyFormWithoutRawData(myForm, app).field("amount").getValue().get()).isEqualTo("1 234 567");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value().get()).isEqualTo("1 234 567");
             // Parse english input with english formatter
             ctx.changeLang("en");
             myForm = formFactory.form(Money.class).bindFromRequest();
@@ -115,7 +115,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasGlobalErrors()).isFalse();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567.89"));
-            assertThat(copyFormWithoutRawData(myForm, app).field("amount").getValue().get()).isEqualTo("1,234,567.89");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value().get()).isEqualTo("1,234,567.89");
 
             // Clean up (Actually not really necassary because formatters are not global anyway ;-)
             formatters.conversion.removeConvertible(BigDecimal.class, String.class); // removes print conversion
@@ -163,7 +163,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             Birthday birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("date").getValue().get()).isEqualTo("03/10/1986");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").value().get()).isEqualTo("03/10/1986");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1986, 10, 3));
 
             // Prepare Request and Context
@@ -178,7 +178,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("date").getValue().get()).isEqualTo("16.02.2001");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").value().get()).isEqualTo("16.02.2001");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(2001, 2, 16));
 
             // Prepare Request and Context
@@ -193,7 +193,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("date").getValue().get()).isEqualTo("08-31-1950");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").value().get()).isEqualTo("08-31-1950");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1950, 8, 31));
         });
     }
@@ -214,7 +214,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             Birthday birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").getValue().get()).isEqualTo("1982-05-07");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value().get()).isEqualTo("1982-05-07");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1982, 5, 7));
 
             // Prepare Request and Context
@@ -229,7 +229,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").getValue().get()).isEqualTo("10_04_2005");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value().get()).isEqualTo("10_04_2005");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(2005, 10, 4));
 
             // Prepare Request and Context
@@ -244,7 +244,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").getValue().get()).isEqualTo("03/12/1962");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value().get()).isEqualTo("03/12/1962");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1962, 12, 3));
         });
     }
@@ -266,10 +266,10 @@ public class HttpFormsTest {
             Form<Task> myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            assertThat(myForm.getError("dueDate").get().messages().size()).isEqualTo(2);
-            assertThat(myForm.getError("dueDate").get().messages().get(0)).isEqualTo("error.invalid");
-            assertThat(myForm.getError("dueDate").get().messages().get(1)).isEqualTo("error.invalid.java.util.Date");
-            assertThat(myForm.getError("dueDate").get().message()).isEqualTo("error.invalid.java.util.Date");
+            assertThat(myForm.error("dueDate").get().messages().size()).isEqualTo(2);
+            assertThat(myForm.error("dueDate").get().messages().get(0)).isEqualTo("error.invalid");
+            assertThat(myForm.error("dueDate").get().messages().get(1)).isEqualTo("error.invalid.java.util.Date");
+            assertThat(myForm.error("dueDate").get().message()).isEqualTo("error.invalid.java.util.Date");
 
             // Prepare Request and Context
             data = new HashMap<>();
@@ -284,11 +284,11 @@ public class HttpFormsTest {
             myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            assertThat(myForm.getError("dueDate").get().messages().size()).isEqualTo(3);
-            assertThat(myForm.getError("dueDate").get().messages().get(0)).isEqualTo("error.invalid");
-            assertThat(myForm.getError("dueDate").get().messages().get(1)).isEqualTo("error.invalid.java.util.Date");
-            assertThat(myForm.getError("dueDate").get().messages().get(2)).isEqualTo("error.invalid.dueDate");
-            assertThat(myForm.getError("dueDate").get().message()).isEqualTo("error.invalid.dueDate");
+            assertThat(myForm.error("dueDate").get().messages().size()).isEqualTo(3);
+            assertThat(myForm.error("dueDate").get().messages().get(0)).isEqualTo("error.invalid");
+            assertThat(myForm.error("dueDate").get().messages().get(1)).isEqualTo("error.invalid.java.util.Date");
+            assertThat(myForm.error("dueDate").get().messages().get(2)).isEqualTo("error.invalid.dueDate");
+            assertThat(myForm.error("dueDate").get().message()).isEqualTo("error.invalid.dueDate");
         });
     }
 
@@ -343,10 +343,10 @@ public class HttpFormsTest {
             myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            assertThat(myForm.getError("zip").get().messages().size()).isEqualTo(1);
-            assertThat(myForm.getError("zip").get().message()).isEqualTo("error.i18nconstraint");
-            assertThat(myForm.getError("anotherZip").get().messages().size()).isEqualTo(1);
-            assertThat(myForm.getError("anotherZip").get().message()).isEqualTo("error.anotheri18nconstraint");
+            assertThat(myForm.error("zip").get().messages().size()).isEqualTo(1);
+            assertThat(myForm.error("zip").get().message()).isEqualTo("error.i18nconstraint");
+            assertThat(myForm.error("anotherZip").get().messages().size()).isEqualTo(1);
+            assertThat(myForm.error("anotherZip").get().message()).isEqualTo("error.anotheri18nconstraint");
         });
     }
 

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -73,12 +73,12 @@ class DynamicFormSpec extends Specification {
 
     "allow access to the equivalent of the raw data when filled" in {
       val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
-      form("foo").getValue().get() must_== "bar"
+      form("foo").value().get() must_== "bar"
     }
 
     "don't throw NullPointerException when all components of form are null" in {
       val form = new DynamicForm(null, null, null).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
-      form("foo").getValue().get() must_== "bar"
+      form("foo").value().get() must_== "bar"
     }
 
     "convert jField to scala Field when all components of jField are null" in {

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -99,7 +99,7 @@ trait FormSpec extends Specification {
         val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest()
 
         myForm hasErrors () must beEqualTo(true)
-        myForm.field("task.name").getValue.asScala must beSome("peter")
+        myForm.field("task.name").value.asScala must beSome("peter")
       }
       "have an error due to missing required value" in new WithApplication(application()) {
         val contextComponents = defaultContextComponents
@@ -335,9 +335,9 @@ trait FormSpec extends Specification {
 
     "support email validation" in {
       val userEmail = formFactory.form(classOf[UserEmail])
-      userEmail.bind(Map("email" -> "john@example.com").asJava).allErrors().asScala must beEmpty
-      userEmail.bind(Map("email" -> "o'flynn@example.com").asJava).allErrors().asScala must beEmpty
-      userEmail.bind(Map("email" -> "john@ex'ample.com").asJava).allErrors().asScala must not(beEmpty)
+      userEmail.bind(Map("email" -> "john@example.com").asJava).errors().asScala must beEmpty
+      userEmail.bind(Map("email" -> "o'flynn@example.com").asJava).errors().asScala must beEmpty
+      userEmail.bind(Map("email" -> "john@ex'ample.com").asJava).errors().asScala must not(beEmpty)
     }
 
     "support custom validators" in {
@@ -379,7 +379,7 @@ trait FormSpec extends Specification {
       )))
 
       listForm.hasErrors must beEqualTo(true)
-      listForm.allErrors().size() must beEqualTo(4)
+      listForm.errors().size() must beEqualTo(4)
       listForm.errors("list[1]").get(0).messages().size() must beEqualTo(1)
       listForm.errors("list[1]").get(0).messages().get(0) must beEqualTo("error.min")
       listForm.value().get().getList.get(0) must beEqualTo(4)
@@ -396,7 +396,7 @@ trait FormSpec extends Specification {
       val optForm = formFactory.form(classOf[TypeArgumentForm]).bindFromRequest(FormSpec.dummyRequest(Map(
         "optional" -> Array("Microsoft Corporation")
       )))
-      optForm.allErrors().size() must beEqualTo(0)
+      optForm.errors().size() must beEqualTo(0)
       optForm.get().getOptional.get must beEqualTo("Microsoft Corporation")
     }
 
@@ -409,7 +409,7 @@ trait FormSpec extends Specification {
       form.field("name").constraints().get(3)._1 must beEqualTo("constraint.pattern")
       form.hasErrors must beEqualTo(true)
       form.hasGlobalErrors() must beEqualTo(false)
-      form.allErrors().size() must beEqualTo(4)
+      form.errors().size() must beEqualTo(4)
       form.errors("name").size() must beEqualTo(4)
       val nameErrorMessages = form.errors("name").asScala.flatMap(_.messages().asScala)
       nameErrorMessages.size must beEqualTo(4)
@@ -649,7 +649,7 @@ trait FormSpec extends Specification {
     "honor its validate method" in {
       "when it returns an error object" in {
         val myForm = formFactory.form(classOf[SomeUser]).bind(Map("password" -> "asdfasdf", "repeatPassword" -> "vwxyz").asJava)
-        myForm.getError("password").get.message() must beEqualTo ("Passwords do not match")
+        myForm.error("password").get.message() must beEqualTo ("Passwords do not match")
       }
       "when it returns an null (error) object" in {
         val myForm = formFactory.form(classOf[SomeUser]).bind(Map("password" -> "asdfasdf", "repeatPassword" -> "asdfasdf").asJava)
@@ -658,7 +658,7 @@ trait FormSpec extends Specification {
       }
       "when it returns an error object but is skipped because its not in validation group" in {
         val myForm = formFactory.form(classOf[SomeUser], classOf[LoginCheck]).bind(Map("password" -> "asdfasdf", "repeatPassword" -> "vwxyz").asJava)
-        myForm.getError("password").isPresent must beFalse
+        myForm.error("password").isPresent must beFalse
       }
       "when it returns a string" in {
         val myForm = formFactory.form(classOf[LoginUser]).bind(Map("email" -> "fail@google.com").asJava)
@@ -680,7 +680,7 @@ trait FormSpec extends Specification {
       "when it returns an empty error list" in {
         val myForm = formFactory.form(classOf[AnotherUser]).bind(Map("name" -> "Kiki").asJava)
         myForm.globalErrors().size() must beEqualTo(0)
-        myForm.allErrors().size() must beEqualTo(0)
+        myForm.errors().size() must beEqualTo(0)
         myForm.errors("name").size() must beEqualTo(0)
       }
     }

--- a/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -23,7 +23,7 @@ class PartialValidationSpec extends Specification {
   "partial validation" should {
     "not fail when fields not in the same group fail validation" in {
       val form = formFactory.form(classOf[SomeForm], classOf[Partial]).bind(Map("prop2" -> "Hello", "prop3" -> "abc").asJava)
-      form.allErrors().asScala must beEmpty
+      form.errors().asScala must beEmpty
     }
 
     "fail when a field in the group fails validation" in {


### PR DESCRIPTION
From Play 2.5 to 2.6 we needed to change the return types of a couple Java form methods thats why we added new methods and deprecated the old ones to have a smooth migration path.

This pr renames give the methods their old names again (which are much better and more consistent with the other methods within their classes)