### PR TITLE
use less vulnerable version of jackson-databind

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
 
   val specsSbt = specsBuild
 
-  val jacksonVersion = "2.8.11"
+  val jacksonVersion = "2.8.11.1"
   val jacksons = Seq(
     "com.fasterxml.jackson.core" % "jackson-core",
     "com.fasterxml.jackson.core" % "jackson-annotations",

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -25,14 +25,17 @@ object Dependencies {
 
   val specsSbt = specsBuild
 
-  val jacksonVersion = "2.8.11.1"
+  val jacksonVersion = "2.8.11"
+  val jacksonDatabindVersion = "2.8.11.1"
   val jacksons = Seq(
     "com.fasterxml.jackson.core" % "jackson-core",
     "com.fasterxml.jackson.core" % "jackson-annotations",
-    "com.fasterxml.jackson.core" % "jackson-databind",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
-  ).map(_ % jacksonVersion)
+  ).map(_ % jacksonVersion) ++
+    Seq(
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+    )
 
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
 


### PR DESCRIPTION
## Fixes

Pulls in the new version of jackson-databind - 2.8.11.1 - which fixes 
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7489
see the change in
https://github.com/FasterXML/jackson-databind/issues/1931

## Purpose

This PR uses a fixed version of jackson-databind.  It is only a 0.0.0.1 version update so there shouldn't be any issues.

