### PR TITLE
Documentation test task depending on publishLocal for play-docs

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -10,6 +10,11 @@ import sbt._
 
 lazy val main = Project("Play-Documentation", file(".")).enablePlugins(PlayDocsPlugin).disablePlugins(PlayEnhancer)
     .settings(
+
+      // We need to publishLocal playDocs since its jar file is
+      // a dependency of `docsJarFile` setting.
+      test in Test <<= (test in Test).dependsOn(publishLocal in playDocs),
+
       resolvers += Resolver.sonatypeRepo("releases"), // TODO: Delete this eventually, just needed for lag between deploying to sonatype and getting on maven central
       version := PlayVersion.current,
       libraryDependencies ++= Seq(

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -100,7 +100,7 @@ object BuildSettings {
       javaOptions in Test ++= Seq(maxMetaspace, "-Xmx512m", "-Xms128m"),
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
       bintrayPackage := "play-sbt-plugin",
-      apiURL in doc := {
+      apiURL := {
         val v = version.value
         if (isSnapshot.value) {
           v match {


### PR DESCRIPTION
## Purpose

We cannot have `apiURL` scoped since later sbt reads the setting without a scope. So the change introduced in #8317 had no effect on the generated pom file. We then need to "unscope" apiURL and run `publishLocal` for play-docs before running `test` for documentation.

## References

#8317.
