### PR TITLE
Removes Illegal reflective access of DelegatingClassLoader

### DIFF
--- a/framework/src/run-support/src/main/java/play/runsupport/classloader/ApplicationClassLoaderProvider.java
+++ b/framework/src/run-support/src/main/java/play/runsupport/classloader/ApplicationClassLoaderProvider.java
@@ -3,6 +3,8 @@
  */
 package play.runsupport.classloader;
 
+import java.net.URLClassLoader;
+
 public interface ApplicationClassLoaderProvider {
-  ClassLoader get();
+  URLClassLoader get();
 }

--- a/framework/src/run-support/src/main/java/play/runsupport/classloader/DelegatingClassLoader.java
+++ b/framework/src/run-support/src/main/java/play/runsupport/classloader/DelegatingClassLoader.java
@@ -4,14 +4,9 @@
 package play.runsupport.classloader;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.Vector;
+import java.net.URLClassLoader;
+import java.util.*;
 
 public class DelegatingClassLoader extends ClassLoader {
 
@@ -37,24 +32,10 @@ public class DelegatingClassLoader extends ClassLoader {
 
   @Override
   public URL getResource(String name) {
-    // -- Delegate resource loading. We have to hack here because the default implementation is already recursive.
-    Method findResource;
-    try {
-      findResource = ClassLoader.class.getDeclaredMethod("findResource", String.class);
-    } catch (NoSuchMethodException e) {
-      throw new IllegalStateException(e);
-    }
-    findResource.setAccessible(true);
-    ClassLoader appClassLoader = applicationClassLoaderProvider.get();
+    URLClassLoader appClassLoader = applicationClassLoaderProvider.get();
     URL resource = null;
     if (appClassLoader != null) {
-      try {
-        resource = (URL) findResource.invoke(appClassLoader, name);
-      } catch (IllegalAccessException e) {
-        throw new IllegalStateException(e);
-      } catch (InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      }
+      resource = appClassLoader.findResource(name);
     }
     return resource != null ? resource : super.getResource(name);
   }
@@ -62,23 +43,10 @@ public class DelegatingClassLoader extends ClassLoader {
   @SuppressWarnings("unchecked")
   @Override
   public Enumeration<URL> getResources(String name) throws IOException {
-    Method findResources;
-    try {
-      findResources = ClassLoader.class.getDeclaredMethod("findResources", String.class);
-    } catch (NoSuchMethodException e) {
-      throw new IllegalStateException(e);
-    }
-    findResources.setAccessible(true);
-    ClassLoader appClassLoader = applicationClassLoaderProvider.get();
+    URLClassLoader appClassLoader = applicationClassLoaderProvider.get();
     Enumeration<URL> resources1;
     if (appClassLoader != null) {
-      try {
-        resources1 = (Enumeration<URL>) findResources.invoke(appClassLoader, name);
-      } catch (IllegalAccessException e) {
-        throw new IllegalStateException(e);
-      } catch (InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      }
+      resources1 = appClassLoader.findResources(name);
     } else {
       resources1 = new Vector<URL>().elements();
     }

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -7,17 +7,16 @@ import java.io.{ Closeable, File }
 import java.net.{ URL, URLClassLoader }
 import java.security.{ AccessController, PrivilegedAction }
 import java.time.Instant
-import java.util.{ Timer, TimerTask }
 import java.util.concurrent.atomic.AtomicReference
-import java.util.jar.JarFile
+import java.util.{ Timer, TimerTask }
 
+import better.files.{ File => _, _ }
 import play.api.PlayException
 import play.core.{ Build, BuildLink }
-import play.dev.filewatch.{ FileWatchService, SourceModificationWatch, WatchState }
+import play.dev.filewatch.FileWatchService
 import play.runsupport.classloader.{ ApplicationClassLoaderProvider, DelegatingClassLoader }
 
 import scala.collection.JavaConverters._
-import better.files.{ File => _, _ }
 
 object Reloader {
 
@@ -218,7 +217,7 @@ object Reloader {
      * to the applicationLoader, creating a full circle for resource loading.
      */
     lazy val delegatingLoader: ClassLoader = new DelegatingClassLoader(commonClassLoader, Build.sharedClasses, buildLoader, new ApplicationClassLoaderProvider {
-      def get: ClassLoader = { reloader.getClassLoader.orNull }
+      def get: URLClassLoader = { reloader.getClassLoader.orNull }
     })
 
     lazy val applicationLoader = new NamedURLClassLoader("DependencyClassLoader", urls(dependencyClasspath), delegatingLoader)
@@ -291,7 +290,7 @@ object Reloader {
     lazy val delegatingLoader: ClassLoader = new DelegatingClassLoader(
       parentClassLoader,
       Build.sharedClasses, buildLoader, new ApplicationClassLoaderProvider {
-        def get: ClassLoader = { applicationLoader }
+        def get: URLClassLoader = { applicationLoader }
       })
 
     lazy val applicationLoader = new NamedURLClassLoader("DependencyClassLoader", urls(dependencyClasspath),
@@ -333,7 +332,7 @@ object Reloader {
 
 }
 
-import Reloader._
+import play.runsupport.Reloader._
 
 class Reloader(
     reloadCompile: () => CompileResult,
@@ -346,7 +345,7 @@ class Reloader(
     reloadLock: AnyRef) extends BuildLink {
 
   // The current classloader for the application
-  @volatile private var currentApplicationClassLoader: Option[ClassLoader] = None
+  @volatile private var currentApplicationClassLoader: Option[URLClassLoader] = None
   // Flag to force a reload on the next request.
   // This is set if a compile error occurs, and also by the forceReload method on BuildLink, which is called for
   // example when evolutions have been applied.


### PR DESCRIPTION
# Helpful things

## Fixes

Fixes #8350

## Purpose

under JDK 9+ DelegatingClassLoader raised an Illegal reflective access
error.
By changing ApplicationClassLoaderProvider to use an URLClassLoader
the whole reflective access can be removed.

## Background Context

Currently nobody uses `ApplicationClassLoaderProvider` with a different `ClassLoader` than an `URLClassLoader`. I even checked Lagom and they basically have the same classes than Play which also implement and URLClassLoader. Gradle does not use anything from `play.runsupport`.

After that PR on sbt 1.1.2 and master Branch we would still see (and of course we still need to add jaxb):
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/Users/schmitch/.ivy2/cache/com.google.inject/guice/jars/guice-4.2.0.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
But that can't be fixed on our side 