### PR TITLE
Introduce an akka-http specific Handler

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/api/mvc/akkahttp/AkkaHttpHandler.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/api/mvc/akkahttp/AkkaHttpHandler.scala
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-package play.core.server.akkahttp
+package play.api.mvc.akkahttp
 
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import play.api.mvc.Handler

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -23,8 +23,9 @@ import play.api._
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
+import play.api.mvc.akkahttp.AkkaHttpHandler
 import play.api.routing.Router
-import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder, AkkaHttpHandler }
+import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder }
 import play.core.server.common.{ ReloadCache, ServerResultUtils }
 import play.core.server.ssl.ServerSSLEngine
 import play.core.ApplicationProvider

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -24,7 +24,7 @@ import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
-import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder }
+import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder, AkkaHttpHandler }
 import play.core.server.common.{ ReloadCache, ServerResultUtils }
 import play.core.server.ssl.ServerSSLEngine
 import play.core.ApplicationProvider
@@ -282,6 +282,8 @@ class AkkaHttpServer(
       case (websocket: WebSocket, None) =>
         // WebSocket handler for non WebSocket request
         sys.error(s"WebSocket returned for non WebSocket request")
+      case (akkaHttpHandler: AkkaHttpHandler, _) =>
+        akkaHttpHandler(request)
       case (unhandled, _) => sys.error(s"AkkaHttpServer doesn't handle Handlers of this type: $unhandled")
 
     }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpHandler.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpHandler.scala
@@ -10,3 +10,7 @@ import play.mvc.Http.RequestHeader
 import scala.concurrent.Future
 
 trait AkkaHttpHandler extends (HttpRequest => Future[HttpResponse]) with Handler
+
+object AkkaHttpHandler {
+  def apply(handler: HttpRequest => Future[HttpResponse]): AkkaHttpHandler = (request: HttpRequest) => handler(request)
+}

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpHandler.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpHandler.scala
@@ -12,5 +12,7 @@ import scala.concurrent.Future
 trait AkkaHttpHandler extends (HttpRequest => Future[HttpResponse]) with Handler
 
 object AkkaHttpHandler {
-  def apply(handler: HttpRequest => Future[HttpResponse]): AkkaHttpHandler = (request: HttpRequest) => handler(request)
+  def apply(handler: HttpRequest => Future[HttpResponse]): AkkaHttpHandler = new AkkaHttpHandler {
+    def apply(request: HttpRequest): Future[HttpResponse] = handler(request)
+  }
 }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpHandler.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpHandler.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.akkahttp
+
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import play.api.mvc.Handler
+import play.mvc.Http.RequestHeader
+
+import scala.concurrent.Future
+
+trait AkkaHttpHandler extends (HttpRequest => Future[HttpResponse]) with Handler

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/AkkaHttpRouter.scala
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/AkkaHttpRouter.scala
@@ -1,9 +1,12 @@
 package controllers
 
 import javax.inject.Inject
+
 import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, StatusCodes}
 import akka.stream.Materializer
+
 import play.api.routing.Router
+import play.api.mvc.akkahttp.AkkaHttpHandler
 
 class AkkaHttpRouter @Inject() ()(implicit mat: Materializer) extends Router {
 

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/AkkaHttpRouter.scala
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/AkkaHttpRouter.scala
@@ -7,11 +7,8 @@ import play.api.routing.Router
 
 class AkkaHttpRouter @Inject() ()(implicit mat: Materializer) extends Router {
 
-  val handler = new AkkaHttpHandler {
-    override def apply(request: HttpRequest): Future[HttpResponse] =
-      Future.successful(
-        HttpResponse(StatusCodes.OK, entity = HttpEntity("Responded using Akka HTTP HttpResponse API")
-      )
+  val handler = AkkaHttpHandler { request =>
+      Future.successful(HttpResponse(StatusCodes.OK, entity = HttpEntity("Responded using Akka HTTP HttpResponse API")))
   }
 
   override def routes: Routes = { case _ ⇒ handler }

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/AkkaHttpRouter.scala
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/AkkaHttpRouter.scala
@@ -11,7 +11,7 @@ class AkkaHttpRouter @Inject() ()(implicit mat: Materializer) extends Router {
       Future.successful(HttpResponse(StatusCodes.OK, entity = HttpEntity("Responded using Akka HTTP HttpResponse API")))
   }
 
-  override def routes: Routes = { case _ ⇒ handler }
+  override def routes: Routes = { case _ => handler }
 
   override def documentation: Seq[(String, String, String)] = Seq.empty
 

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/AkkaHttpRouter.scala
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/AkkaHttpRouter.scala
@@ -1,0 +1,22 @@
+package controllers
+
+import javax.inject.Inject
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, StatusCodes}
+import akka.stream.Materializer
+import play.api.routing.Router
+
+class AkkaHttpRouter @Inject() ()(implicit mat: Materializer) extends Router {
+
+  val handler = new AkkaHttpHandler {
+    override def apply(request: HttpRequest): Future[HttpResponse] =
+      Future.successful(
+        HttpResponse(StatusCodes.OK, entity = HttpEntity("Responded using Akka HTTP HttpResponse API")
+      )
+  }
+
+  override def routes: Routes = { case _ ⇒ handler }
+
+  override def documentation: Seq[(String, String, String)] = Seq.empty
+
+  override def withPrefix(prefix: String): Router = this
+}

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/conf/routes
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/conf/routes
@@ -1,1 +1,2 @@
 GET        /                    controllers.Application.index
+->         /akkaHttpApi         controllers.AkkaHttpRouter

--- a/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -23,11 +23,8 @@ object AkkaTestServer extends App {
     case GET(p"/") => Action { implicit req =>
       Results.Ok(s"Hello world")
     }
-    case GET(p"/akkaHttpApi") => new AkkaHttpHandler {
-      override def apply(request: HttpRequest): Future[HttpResponse] =
-        Future.successful(
-          HttpResponse(StatusCodes.OK, entity = HttpEntity("Responded using Akka HTTP HttpResponse API"))
-        )
+    case GET(p"/akkaHttpApi") => AkkaHttpHandler { request =>
+      Future.successful(HttpResponse(StatusCodes.OK, entity = HttpEntity("Responded using Akka HTTP HttpResponse API")))
     }
   }
   println("Server (Akka HTTP) started: http://127.0.0.1:9000/ ")

--- a/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -3,9 +3,13 @@
  */
 package play
 
+import akka.http.scaladsl.model._
 import play.core.server._
 import play.api.routing.sird._
 import play.api.mvc._
+import play.core.server.akkahttp.AkkaHttpHandler
+
+import scala.concurrent.Future
 
 object AkkaTestServer extends App {
 
@@ -18,6 +22,12 @@ object AkkaTestServer extends App {
   )) {
     case GET(p"/") => Action { implicit req =>
       Results.Ok(s"Hello world")
+    }
+    case GET(p"/akkaHttpApi") => new AkkaHttpHandler {
+      override def apply(request: HttpRequest): Future[HttpResponse] =
+        Future.successful(
+          HttpResponse(StatusCodes.OK, entity = HttpEntity("Responded using Akka HTTP HttpResponse API"))
+        )
     }
   }
   println("Server (Akka HTTP) started: http://127.0.0.1:9000/ ")

--- a/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model._
 import play.core.server._
 import play.api.routing.sird._
 import play.api.mvc._
-import play.core.server.akkahttp.AkkaHttpHandler
+import play.api.mvc.akkahttp.AkkaHttpHandler
 
 import scala.concurrent.Future
 


### PR DESCRIPTION
Exposing the akka-http types. This would be useful in providing the server side of an [akka-grpc](https://github.com/akka/akka-grpc) service in a Play application next to 'normal' Play routes.

This is pretty minimal but it'd be nice already, so we can experiment with this approach and flesh it out more later.