### PR TITLE
Fix play.allowGlobalApplication default to false (#8050)

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
@@ -22,7 +22,7 @@ object JavaWSSpec extends Specification with Results with Status with Mockito {
   // It's much easier to test this in Scala because we need to set up a
   // fake application with routes.
 
-  def fakeApplication: PlayApplication = GuiceApplicationBuilder().routes {
+  def fakeApplication: PlayApplication = GuiceApplicationBuilder().configure("play.allowGlobalApplication" -> true).routes {
     case ("GET", "/feed") =>
       Action {
         val obj: JsObject = Json.obj(

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -14,7 +14,7 @@ import play.api.mvc.{AbstractController, BodyParsers, Controller, ControllerHelp
 import org.specs2.mutable.{Specification, SpecificationLike}
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
-import play.api.Logger
+import play.api.{ Configuration, Logger }
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
@@ -282,7 +282,8 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
   }
 
   def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-    running() { app =>
+    val globalAppConfig = Configuration.from(Map("play.allowGlobalApplication" -> true))
+    running(_.configure(globalAppConfig)) { app =>
       implicit val mat = ActorMaterializer()(app.actorSystem)
       val result = action(request).run()
       status(result) must_== expectedResponse

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -13,7 +13,7 @@ class ScalaErrorHandling extends PlaySpecification with WsTestClient {
 
   def fakeApp[A](implicit ct: ClassTag[A]) = {
     GuiceApplicationBuilder()
-      .configure("play.http.errorHandler" -> ct.runtimeClass.getName)
+      .configure("play.http.errorHandler" -> ct.runtimeClass.getName, "play.allowGlobalApplication" -> true)
       .routes {
         case (_, "/error") => Action(_ => throw new RuntimeException("foo"))
       }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
@@ -4,6 +4,7 @@
 package scalaguide.tests.specs2
 
 import play.api.mvc._
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import play.api.mvc.Results._
 import play.api.libs.json.Json
@@ -12,7 +13,8 @@ import play.api.libs.json.Json
 class ExampleEssentialActionSpec extends PlaySpecification {
 
   "An essential action" should {
-    "can parse a JSON body" in new WithApplication() {
+    val app = GuiceApplicationBuilder().configure("play.allowGlobalApplication" -> true).build()
+    "can parse a JSON body" in new WithApplication(app) {
       val action: EssentialAction = Action { request =>
         val value = (request.body.asJson.get \ "field").as[String]
         Ok(value)

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -65,7 +65,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
   }(block)
 
   def withServer[T](routes: (String, String) => Handler)(block: WSClient => T): T = {
-    val app = GuiceApplicationBuilder().configure("play.http.filters" -> "play.api.http.NoHttpFilters").appRoutes(a => {
+    val app = GuiceApplicationBuilder().configure("play.http.filters" -> "play.api.http.NoHttpFilters", "play.allowGlobalApplication" -> true).appRoutes(a => {
       case (method, path) => routes(method, path)
     }).build()
     running(TestServer(testServerPort, app))(block(app.injector.instanceOf[WSClient]))

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -294,7 +294,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
 
   def withServer[T](config: Seq[(String, String)])(router: PartialFunction[(String, String), Handler])(block: WSClient => T) = {
     implicit val app = GuiceApplicationBuilder()
-      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "foobar"))
+      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "foobar", "play.allowGlobalApplication" -> true))
       .routes(router)
       .build()
     val ws = inject[WSClient]
@@ -303,7 +303,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
 
   def withActionServer[T](config: Seq[(String, String)])(router: Application => PartialFunction[(String, String), Handler])(block: WSClient => T) = {
     implicit val app = GuiceApplicationBuilder()
-      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "foobar"))
+      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "foobar", "play.allowGlobalApplication" -> true))
       .appRoutes(app => router(app))
       .build()
     val ws = inject[WSClient]

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.it
 
+import play.api.Configuration
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -25,6 +26,8 @@ trait ServerIntegrationSpecificationSpec extends PlaySpecification
 
   def expectedServerTag: Option[String]
 
+  val globalAppConfig = Configuration.from(Map("play.allowGlobalApplication" -> true))
+
   "ServerIntegrationSpecification" should {
 
     val httpServerTagRoutes: PartialFunction[(String, String), Handler] = {
@@ -35,7 +38,7 @@ trait ServerIntegrationSpecificationSpec extends PlaySpecification
     }
 
     "run the right HTTP server when using TestServer constructor" in {
-      running(TestServer(testServerPort, GuiceApplicationBuilder().routes(httpServerTagRoutes).build())) {
+      running(TestServer(testServerPort, GuiceApplicationBuilder().configure(globalAppConfig).routes(httpServerTagRoutes).build())) {
         val plainRequest = wsUrl("/httpServerTag")(testServerPort)
         val responseFuture = plainRequest.get()
         val response = await(responseFuture)
@@ -45,7 +48,7 @@ trait ServerIntegrationSpecificationSpec extends PlaySpecification
     }
 
     "run the right server when using WithServer trait" in new WithServer(
-      app = GuiceApplicationBuilder().routes(httpServerTagRoutes).build()) {
+      app = GuiceApplicationBuilder().configure(globalAppConfig).routes(httpServerTagRoutes).build()) {
       val response = await(wsUrl("/httpServerTag").get())
       response.status must equalTo(OK)
       response.body must_== expectedServerTag.toString

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaRequestTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaRequestTimeoutSpec.scala
@@ -7,7 +7,7 @@ import java.io.IOException
 import java.util.Properties
 
 import akka.stream.scaladsl.Sink
-import play.api.Mode
+import play.api.{ Configuration, Mode }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{ EssentialAction, Results }
 import play.api.test._
@@ -33,9 +33,11 @@ class AkkaRequestTimeoutSpec extends PlaySpecification with AkkaHttpIntegrationS
         "play.server.akka.requestTimeout" -> getTimeout(httpTimeout)
       ).asJava)
       val serverConfig = ServerConfig(port = Some(testServerPort), mode = Mode.Test, properties = props)
+      val globalAppConfig = Configuration.from(Map("play.allowGlobalApplication" -> true))
       running(play.api.test.TestServer(
         config = serverConfig,
         application = new GuiceApplicationBuilder()
+          .configure(globalAppConfig)
           .routes({
             case _ => action
           }).build(),

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaResponseHeaderHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaResponseHeaderHandlingSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.it.http
 
+import play.api.Configuration
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test.{ PlaySpecification, Port }
@@ -14,7 +15,8 @@ class AkkaResponseHeaderHandlingSpec extends PlaySpecification with AkkaHttpInte
 
     def withServer[T](action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, GuiceApplicationBuilder().appRoutes { app =>
+      val globalAppConfig = Configuration.from(Map("play.allowGlobalApplication" -> true))
+      running(TestServer(port, GuiceApplicationBuilder().configure(globalAppConfig).appRoutes { app =>
         val Action = app.injector.instanceOf[DefaultActionBuilder]
         val parse = app.injector.instanceOf[PlayBodyParsers]
         ({ case _ => action(Action, parse) })

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -23,8 +23,9 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
 
     def withServer[T](errorHandler: HttpErrorHandler = DefaultHttpErrorHandler)(block: Port => T) = {
       val port = testServerPort
+      val globalAppConfig = Map("play.allowGlobalApplication" -> true.asInstanceOf[java.lang.Boolean])
 
-      val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple())) with HttpFiltersComponents {
+      val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple(), globalAppConfig)) with HttpFiltersComponents {
         def router = {
           import sird._
           Router.from {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.it.http
 
+import play.api.Configuration
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.streams.Accumulator
 import play.it._
@@ -18,7 +19,8 @@ trait Expect100ContinueSpec extends PlaySpecification with ServerIntegrationSpec
 
     def withServer[T](action: DefaultActionBuilder => EssentialAction)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, GuiceApplicationBuilder().appRoutes { app =>
+      val globalAppConfig = Configuration.from(Map("play.allowGlobalApplication" -> true))
+      running(TestServer(port, GuiceApplicationBuilder().configure(globalAppConfig).appRoutes { app =>
         val Action = app.injector.instanceOf[DefaultActionBuilder]
         ({ case _ => action(Action) })
       }.build())) {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
@@ -4,6 +4,7 @@
 package play.it.http
 
 import akka.stream.scaladsl.Source
+import play.api.Configuration
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{ Results, EssentialAction }
@@ -26,7 +27,8 @@ trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecifi
 
     def withServer[T](action: EssentialAction)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, GuiceApplicationBuilder().routes { case _ => action }.build())) {
+      val globalAppConfig = Configuration.from(Map("play.allowGlobalApplication" -> true))
+      running(TestServer(port, GuiceApplicationBuilder().configure(globalAppConfig).routes { case _ => action }.build())) {
         block(port)
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -46,12 +46,14 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       val port = testServerPort
       val props = new Properties(System.getProperties)
       val serverConfig = ServerConfig(port = Some(port), sslPort = httpsPort, mode = Mode.Test, properties = props)
+      val globalAppConfig = Map("play.allowGlobalApplication" -> true)
 
       val configuration = Configuration.load(play.api.Environment.simple(), extraConfig)
 
       running(play.api.test.TestServer(
         config = serverConfig.copy(configuration = configuration),
         application = new GuiceApplicationBuilder()
+          .configure(globalAppConfig)
           .routes({
             case _ => action
           }).build(),

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -18,7 +18,8 @@ import play.routing.{ Router => JRouter }
 class GuiceJavaActionCompositionSpec extends JavaActionCompositionSpec {
   override def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef] = Map.empty)(block: WSResponse => T): T = {
     implicit val port = testServerPort
-    lazy val app: Application = GuiceApplicationBuilder().configure(configuration).routes {
+    val globalAppConfig = Map("play.allowGlobalApplication" -> true)
+    lazy val app: Application = GuiceApplicationBuilder().configure(configuration ++ globalAppConfig).routes {
       case _ => JAction(app, controller)
     }.build()
 
@@ -38,7 +39,8 @@ class BuiltInComponentsJavaActionCompositionSpec extends JavaActionCompositionSp
 
   override def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef])(block: (WSResponse) => T): T = {
     implicit val port = testServerPort
-    val components = new play.BuiltInComponentsFromContext(context(configuration)) {
+    val globalAppConfig = Map("play.allowGlobalApplication" -> true.asInstanceOf[java.lang.Boolean])
+    val components = new play.BuiltInComponentsFromContext(context(configuration ++ globalAppConfig)) {
 
       override def javaHandlerComponents(): MappedJavaHandlerComponents = {
         import java.util.function.{ Supplier => JSupplier }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaCachedActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaCachedActionSpec.scala
@@ -9,7 +9,7 @@ import javax.inject.{ Inject, Provider }
 import akka.Done
 import com.github.benmanes.caffeine.cache.{ Cache, Caffeine }
 import com.google.common.primitives.Primitives
-import play.api.Application
+import play.api.{ Application, Configuration }
 import play.api.cache.AsyncCacheApi
 import play.api.cache.caffeine.CaffeineCacheModule
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -29,7 +29,9 @@ class JavaCachedActionSpec extends PlaySpecification with WsTestClient {
     import play.api.inject.bind
 
     implicit val port = testServerPort
+    val globalAppConfig = Configuration.from(Map("play.allowGlobalApplication" -> true))
     lazy val app: Application = GuiceApplicationBuilder()
+      .configure(globalAppConfig)
       .disable[CaffeineCacheModule]
       .bindings(
         bind[play.api.cache.AsyncCacheApi].toProvider[TestAsyncCacheApiProvider],

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaHttpHandlerSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaHttpHandlerSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http
 
-import play.api.Application
+import play.api.{ Application, Configuration }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.typedmap.TypedKey
 import play.api.libs.ws.WSResponse
@@ -19,7 +19,8 @@ trait JavaHttpHandlerSpec extends PlaySpecification with WsTestClient with Serve
 
   def handlerResponse[T](handler: Handler)(block: WSResponse => T): T = {
     implicit val port = testServerPort
-    val app: Application = GuiceApplicationBuilder().routes {
+    val globalAppConfig = Configuration.from(Map("play.allowGlobalApplication" -> true))
+    val app: Application = GuiceApplicationBuilder().configure(globalAppConfig).routes {
       case _ => handler
     }.build()
     running(TestServer(port, app)) {

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ promise.akka.actor.typed.timeout=5s
 
 play {
   # Defines whether the global application is allowed
-  allowGlobalApplication = true
+  allowGlobalApplication = false
 
   logger {
     # This is a boolean configuration.

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -197,7 +197,7 @@ trait Application {
    * also affecting the deprecated Play APIs that use these.
    */
   lazy val globalApplicationEnabled: Boolean = {
-    configuration.getOptional[Boolean](Play.GlobalAppConfigKey).getOrElse(true)
+    configuration.getOptional[Boolean](Play.GlobalAppConfigKey).getOrElse(false)
   }
 }
 

--- a/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
@@ -27,6 +27,13 @@ class PlayGlobalAppSpec extends Specification {
       Play.stop(app)
       success
     }
+    "start apps with global state disabled with default configuration" in {
+      val app = PlayCoreTestApplication()
+      Play.start(app)
+      Play.privateMaybeApplication must throwA[RuntimeException]
+      Play.stop(app)
+      success
+    }
     "shut down the first app when starting a second app with global state enabled" in {
       val app1 = testApp(true)
       Play.start(app1)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
~* [ ] Have you added copyright headers to new files?~
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

- this fix play.allowGlobalApplication default to `false`

## References

#8050
