### PR TITLE
Fix typo for `play.ws.ning.maxConnectionLifetime`

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -180,7 +180,7 @@ Please refer to the [AsyncHttpClientConfig Documentation](https://asynchttpclien
 * `play.ws.ning.ioThreadMultiplier`
 * `play.ws.ning.maxConnectionsPerHost`
 * `play.ws.ning.maxConnectionsTotal`
-* `play.ws.ning.maxConnectionLifeTime`
+* `play.ws.ning.maxConnectionLifetime`
 * `play.ws.ning.idleConnectionInPoolTimeout`
 * `ws.ning.webSocketIdleTimeout`
 * `play.ws.ning.maxNumberOfRedirects`

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -223,7 +223,7 @@ Please refer to the [AsyncHttpClientConfig Documentation](http://asynchttpclient
 * `play.ws.ning.ioThreadMultiplier`
 * `play.ws.ning.maxConnectionsPerHost`
 * `play.ws.ning.maxConnectionsTotal`
-* `play.ws.ning.maxConnectionLifeTime`
+* `play.ws.ning.maxConnectionLifetime`
 * `play.ws.ning.idleConnectionInPoolTimeout`
 * `play.ws.ning.webSocketIdleTimeout`
 * `play.ws.ning.maxNumberOfRedirects`


### PR DESCRIPTION
## Fixes

This PR fixes typo for `play.ws.ning.maxConnectionLifetime`


## Purpose

Fixing documentation mistake.

## References

https://github.com/playframework/playframework/blob/7abb4d5721f8313e59b8188c9efc89ead6fcb08e/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingConfig.scala#L79
