### PR TITLE
Make ConfigLoader for durations use Duration.fromNanos

### DIFF
--- a/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -39,7 +39,23 @@ class ConfigurationSpec extends Specification {
 
       "simple duration" in {
         val conf = config("my.duration" -> "10s")
-        conf.get[Duration]("my.duration") must beEqualTo(10.seconds)
+        val value = conf.get[Duration]("my.duration")
+        value must beEqualTo(10.seconds)
+        value.toString must beEqualTo("10 seconds")
+      }
+
+      "use minutes when possible" in {
+        val conf = config("my.duration" -> "120s")
+        val value = conf.get[Duration]("my.duration")
+        value must beEqualTo(2.minutes)
+        value.toString must beEqualTo("2 minutes")
+      }
+
+      "use seconds when minutes aren't accurate enough" in {
+        val conf = config("my.duration" -> "121s")
+        val value = conf.get[Duration]("my.duration")
+        value must beEqualTo(121.seconds)
+        value.toString must beEqualTo("121 seconds")
       }
 
       "handle 'infinite' as Duration.Inf" in {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] ~Have you added copyright headers to new files?~ (no new files created)
* [x] ~Have you checked that both Scala and Java APIs are updated?~ (there's no Java API for this)
* [x] ~Have you updated the documentation for both Scala and Java sections?~ (there's no documentation for durations)
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #8370

## Purpose

To use a more human-readable representation of durations.

## Notes

- I also made the `ConfigLoader`s for `Duration` use the loaders for `FiniteDuration` underneath to avoid repetition - hence the reordering of vals. If the reason for not using them in the first place had something to do with overhead (or there's any other reason to keep it as it was), I can revert that piece of the change.