### PR TITLE
Doc on ProdConf: Redundant conf path in logger.resource

### DIFF
--- a/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
+++ b/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
@@ -133,7 +133,7 @@ You can also specify another logback configuration file via a System property. P
 Specify another logback configuration file to be loaded from the classpath:
 
 ```
-$ /path/to/bin/<project-name> -Dlogger.resource=conf/prod-logger.xml
+$ /path/to/bin/<project-name> -Dlogger.resource=prod-logger.xml
 ```
 
 ### Using `-Dlogger.file`


### PR DESCRIPTION
Removing conf from -Dlogger.resource path as it resolves to conf/conf otherwise.

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
