### PR TITLE
Store AsciiSet fields in ServerResultUtils

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -81,7 +81,7 @@ private[play] final class ServerResultUtils(
   }
 
   /** Set of characters that are allowed in a header name. */
-  private[this] val allowedHeaderNameChars: AsciiBitSet = locally {
+  private[this] val allowedHeaderNameChars: AsciiBitSet = {
     /*
      * From https://tools.ietf.org/html/rfc7230#section-3.2:
      *   field-name     = token
@@ -98,7 +98,7 @@ private[play] final class ServerResultUtils(
   def validateHeaderNameChars(headerName: String): Unit = validateString(allowedHeaderNameChars, "header name", headerName)
 
   /** Set of characters that are allowed in a header name. */
-  private[this] val allowedHeaderValueChars: AsciiBitSet = locally {
+  private[this] val allowedHeaderValueChars: AsciiBitSet = {
     /*
      * From https://tools.ietf.org/html/rfc7230#section-3.2:
      *   field-value    = *( field-content / obs-fold )

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -3,8 +3,6 @@
  */
 package play.core.server.common
 
-import java.util.{ BitSet => JBitSet }
-
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
@@ -83,7 +81,7 @@ private[play] final class ServerResultUtils(
   }
 
   /** Set of characters that are allowed in a header name. */
-  private def allowedHeaderNameChars: AsciiBitSet = {
+  private[this] val allowedHeaderNameChars: AsciiBitSet = locally {
     /*
      * From https://tools.ietf.org/html/rfc7230#section-3.2:
      *   field-name     = token
@@ -100,7 +98,7 @@ private[play] final class ServerResultUtils(
   def validateHeaderNameChars(headerName: String): Unit = validateString(allowedHeaderNameChars, "header name", headerName)
 
   /** Set of characters that are allowed in a header name. */
-  private def allowedHeaderValueChars: AsciiBitSet = {
+  private[this] val allowedHeaderValueChars: AsciiBitSet = locally {
     /*
      * From https://tools.ietf.org/html/rfc7230#section-3.2:
      *   field-value    = *( field-content / obs-fold )


### PR DESCRIPTION
Prevent O(headers.length * 2) overhead of bitset construction in ServerResultUtils

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose
This PR should improve performance of ServerResultUtils by avoiding per-response construction of AsciiBitSet instances.

## Background Context

Why did you take this approach?

I noticed a lot of time being spent creating AsciiBitSet instances in flame graphs. See below:

![screen shot 2018-04-20 at 3 15 58 pm](https://user-images.githubusercontent.com/871949/39069466-d24eaabc-44ad-11e8-849f-82c33d79f1c8.png)

