### PR TITLE
Remove Defensive Copy in Writeable for JsValue

### DIFF
--- a/framework/src/play/src/main/scala/play/api/http/Writeable.scala
+++ b/framework/src/play/src/main/scala/play/api/http/Writeable.scala
@@ -97,7 +97,7 @@ trait DefaultWriteables extends LowPriorityWriteables {
    * `Writeable` for `JsValue` values that writes to UTF-8, so they can be sent with the application/json media type.
    */
   implicit def writeableOf_JsValue: Writeable[JsValue] = {
-    Writeable(a => ByteString(Json.toBytes(a)))
+    Writeable(a => ByteString.fromArrayUnsafe(Json.toBytes(a)))
   }
 
   /**


### PR DESCRIPTION
Avoid unnecessary byte array defensive copies in Writeable of JsValue since Json.toBytes already makes a defensive copy from the backing shared buffer

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?
