### PR TITLE
[2.6.x] Only apply logback-test.xml in Test mode

### DIFF
--- a/framework/src/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/framework/src/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -51,12 +51,17 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
     def defaultResourceUrl = {
       import ContextInitializer._
       // Order specified in https://logback.qos.ch/manual/configuration.html#auto_configuration
-      Stream(
-        TEST_AUTOCONFIG_FILE,
+
+      // We only apply logback-test.xml in Test mode. See https://github.com/playframework/playframework/issues/8361
+      val testConfigs = env.mode match {
+        case Mode.Test => Stream(TEST_AUTOCONFIG_FILE)
+        case _ => Stream.empty
+      }
+      (testConfigs ++ Stream(
         GROOVY_AUTOCONFIG_FILE,
         AUTOCONFIG_FILE,
         if (env.mode == Mode.Dev) "logback-play-dev.xml" else "logback-play-default.xml"
-      ).flatMap(env.resource).headOption
+      )).flatMap(env.resource).headOption
     }
 
     val configUrl = explicitResourceUrl orElse explicitFileUrl orElse explicitUrl orElse defaultResourceUrl


### PR DESCRIPTION
Fixes #8361 by only applying `logback-test.xml` in test mode, where it is most likely intended. For master I plan to add to the migration guide something about `logback-test.xml` and how to use it properly.