### PR TITLE
Fix LogbackLoggerConfigurator#init

### DIFF
--- a/framework/src/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/framework/src/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -25,10 +25,10 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
    * Initialize the Logger when there's no application ClassLoader available.
    */
   def init(rootPath: java.io.File, mode: Mode): Unit = {
-    // Set the global application mode for logging
-    play.api.Logger.setApplicationMode(mode)
-
-    configure(Environment(rootPath, this.getClass.getClassLoader, mode))
+    val properties = Map("application.home" -> rootPath.getAbsolutePath)
+    val resourceName = if (mode == Mode.Dev) "logback-play-dev.xml" else "logback-play-default.xml"
+    val resourceUrl = Option(this.getClass.getClassLoader.getResource(resourceName))
+    configure(properties, resourceUrl)
   }
 
   def configure(env: Environment): Unit = {
@@ -62,6 +62,9 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
     val configUrl = explicitResourceUrl orElse explicitFileUrl orElse explicitUrl orElse defaultResourceUrl
 
     val properties = LoggerConfigurator.generateProperties(env, configuration, optionalProperties)
+
+    // Set the global application mode for logging
+    play.api.Logger.setApplicationMode(env.mode)
 
     configure(properties, configUrl)
   }


### PR DESCRIPTION
I changed this in #8275 without realizing this was only used in initializing the dev mode server before an application is available, and is intentionally more minimal for that reason. This change should be minimal risk, since it reverts to the previous behavior in 2.6.12.

This also fixes another issue, which is that the global logging mode (used for `logger.forMode`) should be set in `configure`.