### PR TITLE
Cache Content-Type in Result Conversion

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -227,11 +227,37 @@ private[server] class AkkaModelConversion(
     }
   }
 
+  /**
+   * Retains a local cache of Content-Type strings to the resolved [[ContentType]] value to avoid future work to
+   * fully parse the same string on future responses
+   */
+  private[this] val contentTypeCache: java.util.concurrent.ConcurrentHashMap[String, ContentType] = {
+    val map = new java.util.concurrent.ConcurrentHashMap[String, ContentType]()
+    //  This mapping is commonly used and doesn't need to contain a codec
+    map.put(play.api.http.ContentTypes.JSON, ContentTypes.`application/json`)
+    map.put(play.api.http.ContentTypes.BINARY, ContentTypes.`application/octet-stream`)
+    map
+  }
+
   def parseContentType(contentType: Option[String]): ContentType = {
-    contentType.fold(ContentTypes.NoContentType: ContentType) { ct =>
-      ContentType.parse(ct).left.map { errors =>
-        throw new RuntimeException(s"Error parsing response Content-Type: <$ct>: $errors")
-      }.merge
+    //  Parsing the content type as if it were a client provided value is not fast, but can be cached on first use
+    def parseAndCacheSlowPath(ct: String): ContentType = {
+      ContentType.parse(ct) match {
+        case Right(parsed) =>
+          contentTypeCache.putIfAbsent(ct, parsed)
+          parsed
+        case Left(errors) => throw new RuntimeException(s"Error parsing response Content-Type: <$ct>: $errors")
+      }
+    }
+    contentType match {
+      case None => ContentTypes.NoContentType
+      case Some(ct) =>
+        val cached = contentTypeCache.get(ct)
+        if (cached ne null) {
+          cached
+        } else {
+          parseAndCacheSlowPath(ct)
+        }
     }
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

Adds a local ConcurrentHashMap to cache the Akka HTTP `ContentType` associated with Play's string representation. This observation comes from the same flame graphs produced in https://github.com/playframework/playframework/pull/8374 , but can be seen relative to that change in this higher resolution sample graph below:

![screen shot 2018-04-24 at 3 27 23 pm](https://user-images.githubusercontent.com/871949/39262553-b469ff04-488d-11e8-9231-266358c0c4fe.png)


