### PR TITLE
added jaxb-api so that jdk 9+ classpath works without configuration

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -62,6 +62,10 @@ object Dependencies {
   val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.7"
 
   val jjwt = "io.jsonwebtoken" % "jjwt" % "0.9.0"
+  // currently jjwt needs the JAXB Api package in JDK 9+
+  // since it actually uses javax/xml/bind/DatatypeConverter
+  // See: https://github.com/jwtk/jjwt/issues/317
+  val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.0"
 
   val jdbcDeps = Seq(
     "com.zaxxer" % "HikariCP" % "3.1.0",
@@ -147,6 +151,7 @@ object Dependencies {
 
       guava,
       jjwt,
+      jaxbApi,
 
       "org.apache.commons" % "commons-lang3" % "3.6",
 

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -6,7 +6,7 @@ val Versions = new {
   // when updating sbtNativePackager version, be sure to also update the documentation links in
   // documentation/manual/working/commonGuide/production/Deploying.md
   val sbtNativePackager = "1.3.4"
-  val mima = "0.1.18"
+  val mima = "0.3.0"
   val sbtScalariform = "1.8.2"
   val sbtJavaAgent = "0.1.4"
   val sbtJmh = "0.2.27"


### PR DESCRIPTION
currently this adds the jaxb-api jar (122kb) so that play will work without any flag under jdk 9+.
An alternative would be to either fork jjwt and fix the outstanding issue or use a different JWT implementation.
We could also wait for a fix directly in jjwt however I guess it's fine to add jaxb-api.jar for known since it is only 122kb and than we could run play under jdk 9+ without any flags/problems.

After we merge that Play will still print:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

However this is probably not easy to fix, but can be ignored until we add support for JPMS (which can't work without the help of the Scala Compiler anyway).

(We could also add tests for JDK 10 if scala [2.12.6](https://github.com/scala/scala-dev/issues/480) hits