### PR TITLE
Add play-rconf on module directory

### DIFF
--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -191,6 +191,13 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 * **Documentation**: <https://github.com/tuxBurner/play-akkjobs/blob/master/README.md>
 * **Short description**: A simple Play 2.5 module, which allows you to manage jobs
 
+
+## Settings
+
+### Remote Configuration
+* **Website:** <https://github.com/play-rconf>
+* **Short description:** Loads and apply configuration items (keys & files) from remote providers like etcd, consul, DynamoDB...
+
 ## Templates and View
 
 ### Google Closure Template Plugin


### PR DESCRIPTION
This PR add the module [play-rconf](https://github.com/play-rconf) on the module directory. The announce and related discussions can be read at [discuss.lightbend.com/t/remote-configuration-for-play/834](https://discuss.lightbend.com/t/remote-configuration-for-play/834).

Signed-off-by: Thibault Meyer <meyer.thibault@gmail.com>

