### PR TITLE
Allow users to directly configure Akka HTTP settings

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -44,7 +44,7 @@ There are a couple of special things to know about configuration when running yo
 You can configure extra settings for the `run` command in your `build.sbt`. These settings won't be used when you deploy your application.
 
 ```
-PlayKeys.devSettings := Seq("play.server.http.port" -> "8080")
+PlayKeys.devSettings += "play.server.http.port" -> "8080"
 ```
 
 ### HTTP server settings in `application.conf`

--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -21,7 +21,7 @@ You can read more about the configuration settings in the [Akka HTTP documentati
 >
 > They will be automatically recognized. Keep in mind that Play configurations listed above will override the Akka ones.
 
-There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have [[enabled the `AkkaHttp2Support` plugin|/AkkaHttpServer#HTTP/2-support-(experimental)]]:
+There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have [[enabled the `AkkaHttp2Support` plugin|AkkaHttpServer#HTTP/2-support-(experimental)]]:
 
 @[](/confs/play-akka-http2-support/reference.conf)
 

--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -21,8 +21,30 @@ You can read more about the configuration settings in the [Akka HTTP documentati
 >
 > They will be automatically recognized. Keep in mind that Play configurations listed above will override the Akka ones.
 
-There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have enabled the `AkkaHttp2Support` plugin:
+There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have [[enabled the `AkkaHttp2Support` plugin|/AkkaHttpServer#HTTP/2-support-(experimental)]]:
 
 @[](/confs/play-akka-http2-support/reference.conf)
 
 > **Note:** In dev mode, when you use the `run` command, your `application.conf` settings will not be picked up by the server. This is because in dev mode the server starts before the application classpath is available. There are several [[other options|ConfigFile#Using-with-the-run-command]] you'll need to use instead.
+
+## Direct Akka HTTP configuration
+
+If you need direct access to Akka HTTP's `ServerSettings` and `ParserSettings` objects you can do this by extending Play's `AkkaHttpServer` class with your own. The `AkkaHttpServer` class has several protected methods which can be overridden to change how Play configures its Akka HTTP backend.
+
+Note that writing your own server class is advanced usage. Usually you can do all the configuration you need through normal configuration settings.
+
+The code below shows an example of a custom server which modifies some Akka HTTP settings. Below the server class is a `ServerProvider` class which acts as a factory for the custom server.
+
+@[custom-akka-http-server](code/CustomAkkaHttpServer.scala)
+
+Once you've written a custom server and `ServerProvider` class you'll need to tell Play about them by setting the `play.server.provider` configuration option to the full name of your `ServerProvider` class.
+
+For example, adding the following settings to your `build.sbt` and `application.conf` will tell Play to use your new server for both the sbt `run` task and when your application is deployed.
+
+`build.sbt`:
+
+@[custom-akka-http-server-provider](code/build.sbt)
+
+`application.conf`:
+
+@[custom-akka-http-server-provider](code/application.conf)

--- a/documentation/manual/working/commonGuide/configuration/code/CustomAkkaHttpServer.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/CustomAkkaHttpServer.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+//#custom-akka-http-server
+//###replace: package server
+package detailedtopics.configuration.customakkaserver
+
+import java.util.Random
+import play.core.server.{AkkaHttpServer, AkkaHttpServerProvider, ServerProvider}
+import akka.http.scaladsl.ConnectionContext
+import akka.http.scaladsl.model.HttpMethod
+import akka.http.scaladsl.settings.{ParserSettings, ServerSettings}
+
+/** A custom Akka HTTP server with advanced configuration. */
+class CustomAkkaHttpServer(context: AkkaHttpServer.Context) extends AkkaHttpServer(context) {
+  override protected def createParserSettings(): ParserSettings = {
+    val defaultSettings: ParserSettings =
+      super.createParserSettings()
+    defaultSettings.withCustomMethods(HttpMethod.custom("TICKLE"))
+  }
+  override protected def createServerSettings(port: Int, connectionContext: ConnectionContext, secure: Boolean): ServerSettings = {
+    val defaultSettings: ServerSettings =
+      super.createServerSettings(port, connectionContext, secure)
+    defaultSettings.withWebsocketRandomFactory(() => new Random())
+  }
+}
+
+/** A factory that instantiates a CustomAkkaHttpServer. */
+class CustomAkkaHttpServerProvider extends ServerProvider {
+  def createServer(context: ServerProvider.Context) = {
+    val serverContext = AkkaHttpServer.Context.fromServerProviderContext(context)
+    new CustomAkkaHttpServer(serverContext)
+  }
+}
+//#custom-akka-http-server

--- a/documentation/manual/working/commonGuide/configuration/code/CustomAkkaHttpServer.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/CustomAkkaHttpServer.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 //#custom-akka-http-server
 //###replace: package server
 package detailedtopics.configuration.customakkaserver

--- a/documentation/manual/working/commonGuide/configuration/code/application.conf
+++ b/documentation/manual/working/commonGuide/configuration/code/application.conf
@@ -1,3 +1,4 @@
 //#custom-akka-http-server-provider
-play.server.provider = server.CustomAkkaHttpServerProvider
+//###replace: play.server.provider = server.CustomAkkaHttpServerProvider
+#play.server.provider = server.CustomAkkaHttpServerProvider
 //#custom-akka-http-server-provider

--- a/documentation/manual/working/commonGuide/configuration/code/application.conf
+++ b/documentation/manual/working/commonGuide/configuration/code/application.conf
@@ -1,0 +1,3 @@
+//#custom-akka-http-server-provider
+play.server.provider = server.CustomAkkaHttpServerProvider
+//#custom-akka-http-server-provider

--- a/documentation/manual/working/commonGuide/configuration/code/build.sbt
+++ b/documentation/manual/working/commonGuide/configuration/code/build.sbt
@@ -4,7 +4,9 @@ libraryDependencies += ehcache
 //#play-ws-cache-deps
 
 //#prefix-with-play-akka-dev-mode
-PlayKeys.devSettings ++= Seq(
-  "play.akka.dev-mode.akka.cluster.log-info" -> "off"
-)
+PlayKeys.devSettings += "play.akka.dev-mode.akka.cluster.log-info" -> "off"
 //#prefix-with-play-akka-dev-mode
+
+//#custom-akka-http-server-provider
+PlayKeys.devSettings += "play.server.provider" -> "server.CustomAkkaHttpServerProvider"
+//#custom-akka-http-server-provider

--- a/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
+++ b/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
@@ -21,7 +21,7 @@ Please configure any work with blocking APIs off the main rendering thread, usin
 
 ## Configuring Akka HTTP
 
-You can configure the Akka HTTP server settings through [[application.conf|SettingsAkkaHttp]]. That also describes how to enable the HTTP/2 support.
+There are a variety of options that can be configured for the Akka HTTP server. These are given in the [[documentation on configuring Akka HTTP||SettingsAkkaHttp]].
 
 ## HTTP/2 support (experimental)
 

--- a/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
+++ b/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
@@ -3,6 +3,8 @@
 
 Play uses the [Akka HTTP](https://doc.akka.io/docs/akka-http/current/index.html) server backend to implement HTTP requests and responses using Akka Streams over the network.  Akka HTTP implements a full server stack for HTTP, including full HTTPS support, and has support for HTTP/2.
 
+The Akka HTTP server backend is the default in Play. You can also use the [[Netty backend|NettyServer]] if you choose.
+
 ## Akka HTTP Implementation
 
 Play's server backend uses the [low level server API](https://doc.akka.io/docs/akka-http/current/server-side/low-level-api.html?language=scala) to handle Akka's `HttpRequest` and `HttpResponse` classes.
@@ -54,3 +56,23 @@ export AGENT=$(pwd)/$(find target -name 'jetty-alpn-agent-*.jar' | head -1)
 ```
 
 You also may want to write a simple script to run your app with the needed options, as demonstrated the `./play` script in the [play-scala-tls-example](https://github.com/playframework/play-scala-tls-example/blob/2.5.x/play)
+
+## Manually selecting the Akka HTTP server
+
+If for some reason you have both the Akka HTTP and the Netty server JARs on your classpath, then Play won't be able to predictably choose a server backend. You'll need to manually select the Akka HTTP server. This can be done by explicitly overriding the `play.server.provider` configuration option and setting it to a value of `play.core.server.AkkaHttpServerProvider`.
+
+The `play.server.provider` configuration setting can be set in the same way as other configuration options. Different methods of setting configuration are described in the [[configuration file documentation|ConfigFile]]. Several examples of enabling the Akka HTTP server backend are shown below.
+
+The recommended way to do this is to add the setting to two places. First, to enable Akka HTTP for the sbt `run` task, add the following to your `build.sbt`:
+
+```
+PlayKeys.devSettings += "play.server.provider" -> "play.core.server.AkkaHttpServerProvider"
+```
+
+Second, to enable the Akka HTTP backend for when you deploy your application or when you use the sbt `start` task, add the following to your `application.conf` file:
+
+```
+play.server.provider = play.core.server.AkkaHttpServerProvider
+```
+
+By adding the setting to both `build.sbt` and `application.conf` you can ensure that the Akka HTTP backend will be used in all cases.

--- a/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
+++ b/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
@@ -21,7 +21,7 @@ Please configure any work with blocking APIs off the main rendering thread, usin
 
 ## Configuring Akka HTTP
 
-There are a variety of options that can be configured for the Akka HTTP server. These are given in the [[documentation on configuring Akka HTTP||SettingsAkkaHttp]].
+There are a variety of options that can be configured for the Akka HTTP server. These are given in the [[documentation on configuring Akka HTTP|SettingsAkkaHttp]].
 
 ## HTTP/2 support (experimental)
 

--- a/documentation/manual/working/commonGuide/server/NettyServer.md
+++ b/documentation/manual/working/commonGuide/server/NettyServer.md
@@ -17,11 +17,23 @@ Now Play should automatically select the Netty server for running in dev mode, p
 
 ## Manually selecting the Netty server
 
-If for some reason you have both the Akka HTTP server and the Netty HTTP server on your classpath, you'll need to manually select it.  This can be done using the `play.server.provider` system property, for example, in dev mode:
+If for some reason you have both the Akka HTTP and the Netty server JARs on your classpath, then Play won't be able to predictably choose a server backend. You'll need to manually select the Netty server. This can be done by explicitly overriding the `play.server.provider` configuration option and setting it to a value of `play.core.server.NettyServerProvider`.
+
+The `play.server.provider` configuration setting can be set in the same way as other configuration options. Different methods of setting configuration are described in the [[configuration file documentation|ConfigFile]]. Several examples of enabling the Netty server are shown below.
+
+The recommended way to do this is to add the setting to two places. First, to enable Netty for the sbt `run` task, add the following to your `build.sbt`:
 
 ```
-run -Dplay.server.provider=play.core.server.NettyServerProvider
+PlayKeys.devSettings += "play.server.provider" -> "play.core.server.NettyServerProvider"
 ```
+
+Second, to enable the Netty backend for when you deploy your application or when you use the sbt `start` task, add the following to your `application.conf` file:
+
+```
+play.server.provider = play.core.server.NettyServerProvider
+```
+
+By adding the setting to both `build.sbt` and `application.conf` you can ensure that the Netty backend will be used in all cases.
 
 ## Verifying that the Netty server is running
 

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSPComponents.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSPComponents.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.components;
 
 import play.components.ConfigurationComponents;

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSPReportComponents.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSPReportComponents.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.components;
 
 import play.components.BodyParserComponents;

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp;
 
 import play.api.mvc.request.RequestAttrKey;

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csp/CSP.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csp/CSP.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp;
 
 import play.mvc.With;

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csp/CSPAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csp/CSPAction.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp;
 
 import javax.inject.Inject;

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPActionBuilder.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp
 
 import akka.stream.Materializer

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp
 
 import play.api.Configuration

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPFilter.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp
 
 import akka.stream.Materializer

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPModule.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp
 
 import akka.stream.Materializer

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPProcessor.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPProcessor.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp
 
 import java.util.Base64

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp
 
 import java.util.Locale

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.filters.csp
 
 import akka.util.ByteString

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http
+
+import akka.http.scaladsl.model.HttpMethod
+import akka.http.scaladsl.settings.ParserSettings
+import okhttp3.RequestBody
+import okhttp3.internal.{ Util => OkUtil }
+import org.specs2.execute.AsResult
+import org.specs2.specification.core.Fragment
+import play.api.mvc.{ RequestHeader, Results }
+import play.api.routing.Router
+import play.api.test.PlaySpecification
+import play.core.server.{ AkkaHttpServer, ServerProvider }
+import play.it.test._
+
+class AkkaHttpCustomServerProviderSpec extends PlaySpecification
+  with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
+
+  val appFactory: ApplicationFactory = withRouter { components =>
+    import play.api.routing.sird.{ GET => SirdGet, _ }
+    object SirdFoo {
+      def unapply(rh: RequestHeader): Option[RequestHeader] =
+        if (rh.method.equalsIgnoreCase("foo")) Some(rh) else None
+    }
+    Router.from {
+      case SirdGet(p"/") => components.defaultActionBuilder(Results.Ok("get"))
+      case SirdFoo(p"/") => components.defaultActionBuilder(Results.Ok("foo"))
+    }
+  }
+
+  def requestWithMethod[A: AsResult](endpointRecipe: ServerEndpointRecipe, method: String, body: RequestBody)(f: Either[Int, String] => A): Fragment =
+    appFactory.withOkHttpEndpoints(Seq(endpointRecipe)) { okEndpoint: OkHttpEndpoint =>
+      val response = okEndpoint.configuredCall("/")(_.method(method, body))
+      val param: Either[Int, String] = if (response.code == 200) Right(response.body.string) else Left(response.code)
+      f(param)
+    }
+
+  import ServerEndpointRecipe.AkkaHttp11Plaintext
+
+  "an AkkaHttpServer with standard settings" should {
+    "serve a routed GET request" in requestWithMethod(AkkaHttp11Plaintext, "GET", null)(_ must_== Right("get"))
+    "not find an unrouted POST request" in requestWithMethod(AkkaHttp11Plaintext, "POST", OkUtil.EMPTY_REQUEST)(_ must_== Left(404))
+    "reject a routed FOO request" in requestWithMethod(AkkaHttp11Plaintext, "FOO", null)(_ must_== Left(501))
+    "reject an unrouted BAR request" in requestWithMethod (AkkaHttp11Plaintext, "BAR", OkUtil.EMPTY_REQUEST)(_ must_== Left(501))
+    "reject a long header value" in appFactory.withOkHttpEndpoints(Seq(AkkaHttp11Plaintext)) { okEndpoint: OkHttpEndpoint =>
+      val response = okEndpoint.configuredCall("/")(_.addHeader("X-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "abc"))
+      response.code must_== 431
+    }
+  }
+
+  "an AkkaHttpServer with a custom FOO method" should {
+
+    val customAkkaHttpEndpoint: ServerEndpointRecipe = AkkaHttp11Plaintext
+      .withDescription("Akka HTTP HTTP/1.1 (plaintext, supports FOO)")
+      .withServerProvider(new ServerProvider {
+        def createServer(context: ServerProvider.Context) =
+          new AkkaHttpServer(context) {
+            override protected def createParserSettings(): ParserSettings = {
+              super.createParserSettings.withCustomMethods(HttpMethod.custom("FOO"))
+            }
+          }
+      })
+
+    "serve a routed GET request" in requestWithMethod(customAkkaHttpEndpoint, "GET", null)(_ must_== Right("get"))
+    "not find an unrouted POST request" in requestWithMethod(customAkkaHttpEndpoint, "POST", OkUtil.EMPTY_REQUEST)(_ must_== Left(404))
+    "serve a routed FOO request" in requestWithMethod(customAkkaHttpEndpoint, "FOO", null)(_ must_== Right("foo"))
+    "reject an unrouted BAR request" in requestWithMethod (customAkkaHttpEndpoint, "BAR", OkUtil.EMPTY_REQUEST)(_ must_== Left(501))
+  }
+
+  "an AkkaHttpServer with a config to support long headers" should {
+
+    val customAkkaHttpEndpoint: ServerEndpointRecipe = AkkaHttp11Plaintext
+      .withDescription("Akka HTTP HTTP/1.1 (plaintext, long headers)")
+      .withServerProvider(new ServerProvider {
+        def createServer(context: ServerProvider.Context) =
+          new AkkaHttpServer(context) {
+            override protected def createParserSettings(): ParserSettings = {
+              super.createParserSettings.withMaxHeaderNameLength(100)
+            }
+          }
+      })
+
+    "accept a long header value" in appFactory.withOkHttpEndpoints(Seq(customAkkaHttpEndpoint)) { okEndpoint: OkHttpEndpoint =>
+      val response = okEndpoint.configuredCall("/")(_.addHeader("X-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "abc"))
+      response.code must_== 200
+    }
+  }
+
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.it.http
 
 import akka.http.scaladsl.model.HttpMethod

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
@@ -56,7 +56,7 @@ class AkkaHttpCustomServerProviderSpec extends PlaySpecification
       .withDescription("Akka HTTP HTTP/1.1 (plaintext, supports FOO)")
       .withServerProvider(new ServerProvider {
         def createServer(context: ServerProvider.Context) =
-          new AkkaHttpServer(context) {
+          new AkkaHttpServer(AkkaHttpServer.Context.fromServerProviderContext(context)) {
             override protected def createParserSettings(): ParserSettings = {
               super.createParserSettings.withCustomMethods(HttpMethod.custom("FOO"))
             }
@@ -75,7 +75,7 @@ class AkkaHttpCustomServerProviderSpec extends PlaySpecification
       .withDescription("Akka HTTP HTTP/1.1 (plaintext, long headers)")
       .withServerProvider(new ServerProvider {
         def createServer(context: ServerProvider.Context) =
-          new AkkaHttpServer(context) {
+          new AkkaHttpServer(AkkaHttpServer.Context.fromServerProviderContext(context)) {
             override protected def createParserSettings(): ParserSettings = {
               super.createParserSettings.withMaxHeaderNameLength(100)
             }

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -7,8 +7,6 @@ package play.it.test
 import org.specs2.execute.{ AsResult, PendingUntilFixed, Result, ResultExecution }
 import org.specs2.mutable.SpecLike
 import org.specs2.specification.core.Fragment
-import play.api.Configuration
-import play.core.server._
 
 /**
  * Mixin class for integration tests that want to run over different
@@ -30,7 +28,7 @@ trait EndpointIntegrationSpecification
      * and runs the given block of code.
      *
      * {{{
-     * withResult(Results.Ok("Hello")) withAllEndpoints { endpoint: ServerEndpoint =>
+     * withResult(Results.Ok("Hello")) withEndpoints(myEndpointRecipes) { endpoint: ServerEndpoint =>
      *   val response = ... connect to endpoint.port ...
      *   response.status must_== 200
      * }

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -38,6 +38,14 @@ trait OkHttpEndpointSupport {
 
     /** Make a request to the endpoint using the given path. */
     def call(path: String): Response = client.newCall(request(path)).execute()
+
+    /** Make a request to the endpoint using the given path and configuration. */
+    def configuredCall(path: String)(configure: Request.Builder => Request.Builder): Response = {
+      val withPath: Request.Builder = requestBuilder(path)
+      val configured: Request.Builder = configure(withPath)
+      val request: Request = configured.build()
+      client.newCall(request).execute()
+    }
   }
 
   /**
@@ -76,6 +84,22 @@ trait OkHttpEndpointSupport {
    * Implicit class that enhances [[ApplicationFactory]] with the [[withAllOkHttpEndpoints()]] method.
    */
   implicit class OkHttpApplicationFactory(appFactory: ApplicationFactory) {
+    /**
+     * Helper that creates a specs2 fragment for the given server endpoints.
+     * Each fragment creates an application, starts a server,
+     * starts an [[OkHttpClient]] and runs the given block of code.
+     *
+     * {{{
+     * withResult(Results.Ok("Hello")) withOkHttpEndpoints(myEndpointRecipes) {
+     *   okEndpoint: OkHttpEndpoint =>
+     *     val response = okEndpoint.makeRequest("/")
+     *     response.body.string must_== "Hello"
+     * }
+     * }}}
+     */
+    def withOkHttpEndpoints[A: AsResult](endpoints: Seq[ServerEndpointRecipe])(block: OkHttpEndpoint => A): Fragment =
+      appFactory.withEndpoints(endpoints) { endpoint: ServerEndpoint => withOkHttpEndpoint(endpoint)(block) }
+
     /**
      * Helper that creates a specs2 fragment for the server endpoints given in
      * [[allEndpointRecipes]]. Each fragment creates an application, starts a server,

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/ServerEndpointRecipe.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/ServerEndpointRecipe.scala
@@ -33,6 +33,9 @@ trait ServerEndpointRecipe {
   /** The provider used to create the server instance. */
   def serverProvider: ServerProvider
 
+  def withDescription(newDescription: String): ServerEndpointRecipe
+  def withServerProvider(newProvider: ServerProvider): ServerEndpointRecipe
+
   /**
    * Once a server has been started using this recipe, the running instance
    * can be queried to create an endpoint. Usually this just involves asking
@@ -42,7 +45,7 @@ trait ServerEndpointRecipe {
 }
 
 /** Provides a recipe for making an [[HttpEndpoint]]. */
-protected class HttpServerEndpointRecipe(
+class HttpServerEndpointRecipe(
     override val description: String,
     override val serverProvider: ServerProvider,
     extraServerConfiguration: Configuration = Configuration.empty,
@@ -62,11 +65,15 @@ protected class HttpServerEndpointRecipe(
       override def expectedServerAttr: Option[String] = recipe.expectedServerAttr
     }
   }
+  def withDescription(newDescription: String): HttpServerEndpointRecipe =
+    new HttpServerEndpointRecipe(newDescription, serverProvider, extraServerConfiguration, expectedHttpVersions, expectedServerAttr)
+  def withServerProvider(newProvider: ServerProvider): HttpServerEndpointRecipe =
+    new HttpServerEndpointRecipe(description, newProvider, extraServerConfiguration, expectedHttpVersions, expectedServerAttr)
   override def toString: String = s"HttpServerEndpointRecipe($description)"
 }
 
 /** Provides a recipe for making an [[HttpsEndpoint]]. */
-protected class HttpsServerEndpointRecipe(
+class HttpsServerEndpointRecipe(
     override val description: String,
     override val serverProvider: ServerProvider,
     extraServerConfiguration: Configuration = Configuration.empty,
@@ -92,6 +99,8 @@ protected class HttpsServerEndpointRecipe(
       )
     }
   }
+  def withDescription(newDescription: String) = new HttpsServerEndpointRecipe(newDescription, serverProvider, extraServerConfiguration, expectedHttpVersions, expectedServerAttr)
+  def withServerProvider(newProvider: ServerProvider) = new HttpsServerEndpointRecipe(description, newProvider, extraServerConfiguration, expectedHttpVersions, expectedServerAttr)
   override def toString: String = s"HttpsServerEndpointRecipe($description)"
 }
 

--- a/framework/src/play/src/main/scala/views/html/helper/CSPNonce.scala
+++ b/framework/src/play/src/main/scala/views/html/helper/CSPNonce.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package views.html.helper
 
 import play.api.mvc.RequestHeader


### PR DESCRIPTION
Fixes #8368.

Refactor the `AkkaHttpServer` class so that more of its internal behavior is accessible to advanced users. Users can now extend this class and override behavior through protected methods. The custom class can be hooked into Play through the existing `play.server.provider` setting.

By allowing users to change the Akka HTTP server behavior, particularly the server settings, we reduce the pressure on Play to provide a perfect and universal configuration out of the box. We can now provide a configuration that is right for most users and allow advanced users to reconfigure their settings as needed.

For example, it is now possible to modify the Akka HTTP server's configuration to extend the list of HTTP methods that is supported. This example is shown in an integration test.