### PR TITLE
Fixed a number of binding issues

### DIFF
--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -7,7 +7,7 @@ package play.api.http
 import javax.inject._
 
 import play.api._
-import play.api.inject.{ Binding, BindingKey }
+import play.api.inject.Binding
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.http.Status._
@@ -52,12 +52,8 @@ object HttpErrorHandler {
    * Get the bindings for the error handler from the configuration
    */
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    val fromConfiguration = Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, JavaHttpErrorHandlerDelegate, DefaultHttpErrorHandler](environment, configuration,
+    Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, JavaHttpErrorHandlerDelegate, DefaultHttpErrorHandler](environment, configuration,
       "play.http.errorHandler", "ErrorHandler")
-
-    val javaContextComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaContextComponents]).to[play.core.j.DefaultJavaContextComponents])
-
-    fromConfiguration ++ javaContextComponentsBindings
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -48,14 +48,9 @@ object HttpRequestHandler {
 
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
 
-    val fromConfiguration = Reflect.bindingsFromConfiguration[HttpRequestHandler, play.http.HttpRequestHandler, play.core.j.JavaHttpRequestHandlerAdapter, play.http.DefaultHttpRequestHandler, JavaCompatibleHttpRequestHandler](
+    Reflect.bindingsFromConfiguration[HttpRequestHandler, play.http.HttpRequestHandler, play.core.j.JavaHttpRequestHandlerAdapter, play.http.DefaultHttpRequestHandler, JavaCompatibleHttpRequestHandler](
       environment,
       configuration, "play.http.requestHandler", "RequestHandler")
-
-    val javaContextComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaContextComponents]).to[play.core.j.DefaultJavaContextComponents])
-    val javaHandlerComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaHandlerComponents]).to[play.core.j.DefaultJavaHandlerComponents])
-
-    fromConfiguration ++ javaContextComponentsBindings ++ javaHandlerComponentsBindings
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/inject/Binding.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Binding.scala
@@ -5,10 +5,13 @@
 package play.api.inject
 
 import java.lang.annotation.Annotation
+import java.lang.reflect.Modifier
+
 import javax.inject.Provider
+import play.api.PlayException
+
 import scala.language.existentials
 import scala.reflect.ClassTag
-
 import play.inject.SourceProvider
 
 /**
@@ -169,8 +172,9 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
    *
    * This class will be instantiated and injected by the injection framework.
    */
-  def to(implementation: Class[_ <: T]): Binding[T] =
-    Binding(this, Some(ConstructionTarget(implementation)), None, false, SourceLocator.source)
+  def to(implementation: Class[_ <: T]): Binding[T] = {
+    Binding(this, Some(ConstructionTarget(validateTargetNonAbstract(implementation))), None, false, SourceLocator.source)
+  }
 
   /**
    * Bind this binding key to the given implementation class.
@@ -207,7 +211,7 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
    * whenever an instance of the class is needed.
    */
   def toProvider[P <: Provider[_ <: T]](provider: Class[P]): Binding[T] =
-    Binding(this, Some(ProviderConstructionTarget[T](provider)), None, false, SourceLocator.source)
+    Binding(this, Some(ProviderConstructionTarget[T](validateTargetNonAbstract(provider))), None, false, SourceLocator.source)
 
   /**
    * Bind this binding key to the given provider class.
@@ -230,6 +234,16 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
 
   override def toString = {
     s"$clazz${qualifier.fold("")(" qualified with " + _)}"
+  }
+
+  private def validateTargetNonAbstract[T](target: Class[T]): Class[T] = {
+    if (target.isInterface || Modifier.isAbstract(target.getModifiers)) {
+      throw new PlayException(
+        "Cannot bind abstract target",
+        s"""You have attempted to bind $target as a construction target for $this, however, $target is abstract. If you wish to bind this as an alias, bind it to a ${classOf[BindingKey[_]]} instead."""
+      )
+    }
+    target
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -5,21 +5,22 @@
 package play.api.inject
 
 import java.util.concurrent.Executor
-import javax.inject.{ Inject, Provider, Singleton }
 
+import javax.inject.{ Inject, Provider, Singleton }
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.typesafe.config.Config
 import play.api._
 import play.api.http.HttpConfiguration._
 import play.api.http._
-import play.api.libs.Files.TemporaryFileReaperConfiguration.TemporaryFileReaperConfigurationProvider
+import play.api.libs.Files.TemporaryFileReaperConfigurationProvider
 import play.api.libs.Files._
 import play.api.libs.concurrent._
 import play.api.mvc._
 import play.api.mvc.request.{ DefaultRequestFactory, RequestFactory }
 import play.api.routing.Router
 import play.core.j.JavaRouterAdapter
+import play.core.routing.GeneratedRouter
 import play.libs.concurrent.HttpExecutionContext
 
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
@@ -70,21 +71,23 @@ class BuiltinModule extends SimpleModule((env, conf) => {
     bind[Application].to[DefaultApplication],
     bind[play.Application].to[play.DefaultApplication],
 
-    bind[Router].toProvider[RoutesProvider],
     bind[play.routing.Router].to[JavaRouterAdapter],
     bind[ActorSystem].toProvider[ActorSystemProvider],
     bind[Materializer].toProvider[MaterializerProvider],
     bind[ExecutionContextExecutor].toProvider[ExecutionContextProvider],
-    bind[ExecutionContext].to[ExecutionContextExecutor],
-    bind[Executor].to[ExecutionContextExecutor],
+    bind[ExecutionContext].to(bind[ExecutionContextExecutor]),
+    bind[Executor].to(bind[ExecutionContextExecutor]),
     bind[HttpExecutionContext].toSelf,
 
+    bind[play.core.j.JavaContextComponents].to[play.core.j.DefaultJavaContextComponents],
+    bind[play.core.j.JavaHandlerComponents].to[play.core.j.DefaultJavaHandlerComponents],
     bind[FileMimeTypes].toProvider[DefaultFileMimeTypesProvider]
   ) ++ dynamicBindings(
       HttpErrorHandler.bindingsFromConfiguration,
       HttpFilters.bindingsFromConfiguration,
       HttpRequestHandler.bindingsFromConfiguration,
-      ActionCreator.bindingsFromConfiguration
+      ActionCreator.bindingsFromConfiguration,
+      RoutesProvider.bindingsFromConfiguration
     )
 })
 
@@ -104,5 +107,21 @@ class RoutesProvider @Inject() (injector: Injector, environment: Environment, co
     val router = Router.load(environment, configuration)
       .fold[Router](Router.empty)(injector.instanceOf(_))
     router.withPrefix(prefix)
+  }
+}
+
+object RoutesProvider {
+
+  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+    val routerClass = Router.load(environment, configuration)
+
+    // If it's a generated router, then we need to provide a binding for it. Otherwise, it's the users
+    // (or the library that provided the router) job to provide a binding for it.
+    val routerInstanceBinding = routerClass match {
+      case Some(generated) if classOf[GeneratedRouter].isAssignableFrom(generated) =>
+        Seq(bind(generated).toSelf)
+      case _ => Nil
+    }
+    routerInstanceBinding :+ bind[Router].toProvider[RoutesProvider]
   }
 }

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -345,9 +345,15 @@ object Files {
     def createWithDefaults() = apply()
 
     @Singleton
+    @deprecated("On JDK8 and earlier, Class.getSimpleName on doubly nested Scala classes throws an exception. Use Files.TemporaryFileReaperConfigurationProvider instead. See https://github.com/scala/bug/issues/2034.", "2.6.14")
     class TemporaryFileReaperConfigurationProvider @Inject() (configuration: Configuration) extends Provider[TemporaryFileReaperConfiguration] {
       lazy val get = fromConfiguration(configuration)
     }
+  }
+
+  @Singleton
+  class TemporaryFileReaperConfigurationProvider @Inject() (configuration: Configuration) extends Provider[TemporaryFileReaperConfiguration] {
+    lazy val get = TemporaryFileReaperConfiguration.fromConfiguration(configuration)
   }
 
   /**


### PR DESCRIPTION
This fixes a number of issues with bindings that don't manifest when using Guice, but do when using CDI. The issues fixed are:

* `ExecutionContext` and `Executor` were both bound to interfaces, which is illegal. Guice seems to be ok with this if there are bindings for the interfaces they are bound to, but other DI implementations aren't. I've replaced their bindings with alias bindings (because that's really what we want here), and I've also added validation to ensure this dosen't happen again.
* There were duplicate bindings for `JavaContextComponents`. This wasn't noticed because they came from the `HttpErrorHandler` and `HttpRequestHander` dynamic bindings methods. But the JavaContextComponents binding isn't dynamic, so I pulled it out of there and in to `BuiltinModule`. For some reason, Guice seems to dedup bindings when they are identical. Other DI providers don't.
* If the router is generated, add a binding for it. This isn't a problem for Guice since it supports just in time bindings, but other DI providers don't.
* There's a JDK bug that causes `Class.getSimpleName` and other methods like `Class.isAnonymousClass` that depend on it to throw an exception when called on doubly nested Scala classes (https://github.com/scala/bug/issues/2034). This is fixed in JDK9, but in the meantime, any DI framework that checks if a class is anonymous will fail for any such classes. `TemporaryFileReaperConfigurationProvider` is one such class, so I've moved it up a level (keeping the old one for binary compatibility and deprecating it).

With these changes applied, I've managed to get Play running on the Weld CDI container.