### PR TITLE
Remove references to `Model`

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -65,9 +65,9 @@ Sometimes you’ll want to fill a form with existing values, typically for editi
 
 > **Tip:** `Form` objects are immutable - calls to methods like `bind()` and `fill()` will return a new object filled with the new data.
 
-## Handling a form that is not related to a Model
+## Handling a form with dynamic fields
 
-You can use a `DynamicForm` if you need to retrieve data from an html form that is not related to a `Model`:
+You can use a `DynamicForm` if you need to retrieve data from an html form with dynamic fields:
 
 @[dynamic](code/javaguide/forms/JavaForms.java)
 


### PR DESCRIPTION
## Fixes

Fixes #7937

## Purpose

This PR changes `JavaForms` documentation so it does not reference `Model` anymore.

## Background Context

Changes made according to suggestions from #7937.