### PR TITLE
Link to Markdown plugin directs to 404 page

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -43,7 +43,7 @@ For more information, please see the [Play documentation guidelines](https://www
 
 ## IDE integration
 
-There is no out of the box integration, but you can use IntelliJ IDEA's [Scala plugin](http://blog.jetbrains.com/scala/) or the [Eclipse](https://github.com/typesafehub/sbteclipse) plugin to generate a project for you.  If you are using IntelliJ IDEA, the [Markdown plugin](https://plugins.jetbrains.com/plugin/5970?pr=idea) will make editing documentation much easier.
+There is no out of the box integration, but you can use IntelliJ IDEA's [Scala plugin](http://blog.jetbrains.com/scala/) or the [Eclipse](https://github.com/typesafehub/sbteclipse) plugin to generate a project for you.  If you are using IntelliJ IDEA, the [Markdown Support](https://www.jetbrains.com/help/idea/markdown.html) plugin will make editing documentation much easier.
 
 ## Testing
 


### PR DESCRIPTION
Markdown Support plugin now links to IntelliJ IDEA Markdown help page

## Purpose

A simple documentation issue fix.
