### PR TITLE
Use Guice to initialize database connection pools

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -82,7 +82,7 @@ class DBApiProvider(
     val configs = if (config.hasPath(dbKey)) {
       Configuration(config).getPrototypedMap(dbKey, "play.db.prototype").mapValues(_.underlying)
     } else Map.empty[String, Config]
-    val db = new DefaultDBApi(configs, pool, environment)
+    val db = new DefaultDBApi(configs, pool, environment, maybeInjector.getOrElse(NewInstanceInjector))
     lifecycle.addStopHook { () => Future.successful(db.shutdown()) }
     db.connect(logConnection = environment.mode != Mode.Test)
     db

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -197,7 +197,7 @@ abstract class DefaultDatabase(val name: String, configuration: Config, environm
 /**
  * Default implementation of the database API using a connection pool.
  */
-class PooledDatabase(name: String, configuration: Config, environment: Environment, pool: ConnectionPool)
+class PooledDatabase(name: String, configuration: Config, environment: Environment, private[play] val pool: ConnectionPool)
   extends DefaultDatabase(name, configuration, environment) {
 
   def this(name: String, configuration: Configuration) = this(name, configuration.underlying, Environment.simple(), new HikariCPConnectionPool(Environment.simple()))

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
@@ -4,32 +4,58 @@
 
 package play.api.db
 
+import javax.inject._
+import play.api.Environment
 import play.api.test._
 
 class ConnectionPoolConfigSpec extends PlaySpecification {
 
   "DBModule bindings" should {
 
-    "use HikariCP when default pool is default" in new WithApplication(_.configure(
+    "use HikariCP as default pool" in new WithApplication(_.configure(
       "db.default.url" -> "jdbc:h2:mem:default",
       "db.other.driver" -> "org.h2.Driver",
       "db.other.url" -> "jdbc:h2:mem:other"
     )) {
-      val db = app.injector.instanceOf[DBApi]
-      db.database("default").withConnection { c =>
-        c.getClass.getName must contain("hikari")
+      val db = app.injector.instanceOf[DBApi].database("default")
+      db must beLike {
+        case pdb: PooledDatabase => pdb.pool must haveClass[HikariCPConnectionPool]
       }
     }
 
-    "use HikariCP when default pool is 'hikaricp'" in new WithApplication(_.configure(
+    "use HikariCP when default pool set to 'hikaricp'" in new WithApplication(_.configure(
       "play.db.pool" -> "hikaricp",
       "db.default.url" -> "jdbc:h2:mem:default",
       "db.other.driver" -> "org.h2.Driver",
       "db.other.url" -> "jdbc:h2:mem:other"
     )) {
-      val db = app.injector.instanceOf[DBApi]
-      db.database("default").withConnection { c =>
-        c.getClass.getName must contain("hikari")
+      val db = app.injector.instanceOf[DBApi].database("default")
+      db must beLike {
+        case pdb: PooledDatabase => pdb.pool must haveClass[HikariCPConnectionPool]
+      }
+    }
+
+    "use custom class when default pool set to class name" in new WithApplication(_.configure(
+      "play.db.pool" -> classOf[CustomConnectionPool].getName,
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other"
+    )) {
+      val db = app.injector.instanceOf[DBApi].database("default")
+      db must beLike {
+        case pdb: PooledDatabase => pdb.pool must haveClass[CustomConnectionPool]
+      }
+    }
+
+    "use custom class when database pool set to class name" in new WithApplication(_.configure(
+      "db.default.pool" -> classOf[CustomConnectionPool].getName,
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other"
+    )) {
+      val db = app.injector.instanceOf[DBApi].database("default")
+      db must beLike {
+        case pdb: PooledDatabase => pdb.pool must haveClass[CustomConnectionPool]
       }
     }
 
@@ -52,3 +78,6 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
   }
 
 }
+
+@Singleton
+class CustomConnectionPool @Inject() (environment: Environment) extends HikariCPConnectionPool(environment)


### PR DESCRIPTION
Fixes #8402.

We now pass the Injector value to the initialization code so that it can use Guice to load a value instead of always using the default constructor.

Increases visibility of PooledDatabase.pool field so that we can unit test its value more easily. May fail the MiMA tests because I wasn't able to run these locally.