### PR TITLE
Add binding to fix 2.6.x build failure

### DIFF
--- a/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -13,6 +13,7 @@ import play.api.inject.BindingKey
 import play.api.mvc.{ RequestHeader, Results }
 import play.api.routing._
 import play.api.{ Configuration, Environment, Mode, OptionalSourceMapper }
+import play.core.j._
 import play.core.test.{ FakeRequest, Fakes }
 import play.i18n.{ Langs, MessagesApi }
 
@@ -94,7 +95,8 @@ class HttpErrorHandlerSpec extends Specification {
         BindingKey(classOf[Environment]).to(env),
         BindingKey(classOf[HttpConfiguration]).to(httpConfiguration),
         BindingKey(classOf[FileMimeTypesConfiguration]).toProvider[FileMimeTypesConfigurationProvider],
-        BindingKey(classOf[FileMimeTypes]).toProvider[DefaultFileMimeTypesProvider]
+        BindingKey(classOf[FileMimeTypes]).toProvider[DefaultFileMimeTypesProvider],
+        BindingKey(classOf[JavaContextComponents]).to[DefaultJavaContextComponents]
       )).instanceOf[HttpErrorHandler]
   }
 


### PR DESCRIPTION
`HttpErrorHandlerSpec` on the 2.6.x branch is [failing at the moment](https://github.com/playframework/playframework/pull/8414#issuecomment-389706494) due to a [pushed backport](https://github.com/playframework/playframework/pull/8398#issuecomment-388272038). This fixes the test.