### PR TITLE
[Backport 2.6.x] Removes Illegal reflective access of DelegatingClassLoader (#8355)

### DIFF
--- a/framework/src/run-support/src/main/java/play/runsupport/classloader/ApplicationClassLoaderProvider.java
+++ b/framework/src/run-support/src/main/java/play/runsupport/classloader/ApplicationClassLoaderProvider.java
@@ -3,6 +3,8 @@
  */
 package play.runsupport.classloader;
 
+import java.net.URLClassLoader;
+
 public interface ApplicationClassLoaderProvider {
-  ClassLoader get();
+  URLClassLoader get();
 }

--- a/framework/src/run-support/src/main/java/play/runsupport/classloader/DelegatingClassLoader.java
+++ b/framework/src/run-support/src/main/java/play/runsupport/classloader/DelegatingClassLoader.java
@@ -4,14 +4,9 @@
 package play.runsupport.classloader;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.Vector;
+import java.net.URLClassLoader;
+import java.util.*;
 
 public class DelegatingClassLoader extends ClassLoader {
 
@@ -37,24 +32,10 @@ public class DelegatingClassLoader extends ClassLoader {
 
   @Override
   public URL getResource(String name) {
-    // -- Delegate resource loading. We have to hack here because the default implementation is already recursive.
-    Method findResource;
-    try {
-      findResource = ClassLoader.class.getDeclaredMethod("findResource", String.class);
-    } catch (NoSuchMethodException e) {
-      throw new IllegalStateException(e);
-    }
-    findResource.setAccessible(true);
-    ClassLoader appClassLoader = applicationClassLoaderProvider.get();
+    URLClassLoader appClassLoader = applicationClassLoaderProvider.get();
     URL resource = null;
     if (appClassLoader != null) {
-      try {
-        resource = (URL) findResource.invoke(appClassLoader, name);
-      } catch (IllegalAccessException e) {
-        throw new IllegalStateException(e);
-      } catch (InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      }
+      resource = appClassLoader.findResource(name);
     }
     return resource != null ? resource : super.getResource(name);
   }
@@ -62,23 +43,10 @@ public class DelegatingClassLoader extends ClassLoader {
   @SuppressWarnings("unchecked")
   @Override
   public Enumeration<URL> getResources(String name) throws IOException {
-    Method findResources;
-    try {
-      findResources = ClassLoader.class.getDeclaredMethod("findResources", String.class);
-    } catch (NoSuchMethodException e) {
-      throw new IllegalStateException(e);
-    }
-    findResources.setAccessible(true);
-    ClassLoader appClassLoader = applicationClassLoaderProvider.get();
+    URLClassLoader appClassLoader = applicationClassLoaderProvider.get();
     Enumeration<URL> resources1;
     if (appClassLoader != null) {
-      try {
-        resources1 = (Enumeration<URL>) findResources.invoke(appClassLoader, name);
-      } catch (IllegalAccessException e) {
-        throw new IllegalStateException(e);
-      } catch (InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      }
+      resources1 = appClassLoader.findResources(name);
     } else {
       resources1 = new Vector<URL>().elements();
     }


### PR DESCRIPTION
under JDK 9+ DelegatingClassLoader raised an Illegal reflective access
error.
By changing ApplicationClassLoaderProvider to use an URLClassLoader
the whole reflective access can be removed.

**WARNING:** this breaks bin compatibility (maybe), but only for dev-mode, so if that's a no-go we can reject it. Because it raises the type of ClassLoader to URLClassLoader