### PR TITLE
places the generated keystore into the root folder

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -20,7 +20,7 @@ import java.security.interfaces.RSAPublicKey
  */
 object FakeKeyStore {
   private val logger = Logger(FakeKeyStore.getClass)
-  val GeneratedKeyStore = "conf/generated.keystore"
+  val GeneratedKeyStore = "generated.keystore"
   val DnName = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
   val SignatureAlgorithmOID = AlgorithmId.sha256WithRSAEncryption_oid
   val SignatureAlgorithmName = "SHA256withRSA"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+//
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayService)
+  .enablePlugins(MediatorWorkaroundPlugin)
+  .settings(
+    libraryDependencies += guice,
+    PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6"),
+
+    InputKey[Unit]("verifyResourceContains") := {
+      val args = Def.spaceDelimited("<path> <status> <words> ...").parsed
+      val path = args.head
+      val status = args.tail.head.toInt
+      val assertions = args.tail.tail
+      DevModeBuild.verifyResourceContains(path, status, assertions, 0)
+    }
+  )

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
@@ -10,11 +10,9 @@ lazy val root = (project in file("."))
     PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
     scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6"),
 
-    InputKey[Unit]("verifyResourceContains") := {
-      val args = Def.spaceDelimited("<path> <status> <words> ...").parsed
-      val path = args.head
-      val status = args.tail.head.toInt
-      val assertions = args.tail.tail
-      DevModeBuild.verifyResourceContains(path, status, assertions, 0)
+    InputKey[Unit]("makeRequest") := {
+      val args = Def.spaceDelimited("<path> <status> ...").parsed
+      val path :: status :: headers = args
+      DevModeBuild.verifyResourceContains(path, status.toInt, Seq.empty, 0)
     }
   )

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/project/Build.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+import play.dev.filewatch.FileWatchService
+import play.sbt.run.toLoggerProxy
+import sbt._
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.util.Properties
+
+object DevModeBuild {
+
+  def jdk7WatchService = Def.setting {
+    FileWatchService.jdk7(Keys.sLog.value)
+  }
+
+  def jnotifyWatchService = Def.setting {
+    FileWatchService.jnotify(Keys.target.value)
+  }
+
+  // Using 30 max attempts so that we can give more chances to
+  // the file watcher service. This is relevant when using the
+  // default JDK watch service which does uses polling.
+  val MaxAttempts = 30
+  val WaitTime = 500l
+
+  val ConnectTimeout = 10000
+  val ReadTimeout = 10000
+
+  @tailrec
+  def verifyResourceContains(path: String, status: Int, assertions: Seq[String], attempts: Int, headers: (String, String)*): Unit = {
+    println(s"Attempt $attempts at $path")
+    val messages = ListBuffer.empty[String]
+    try {
+      val url = new java.net.URL("http://localhost:9000" + path)
+      val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]
+      conn.setConnectTimeout(ConnectTimeout)
+      conn.setReadTimeout(ReadTimeout)
+
+      headers.foreach(h => conn.setRequestProperty(h._1, h._2))
+
+      if (status == conn.getResponseCode) {
+        messages += s"Resource at $path returned $status as expected"
+      } else {
+        throw new RuntimeException(s"Resource at $path returned ${conn.getResponseCode} instead of $status")
+      }
+
+      val is = if (conn.getResponseCode >= 400) {
+        conn.getErrorStream
+      } else {
+        conn.getInputStream
+      }
+
+      // The input stream may be null if there's no body
+      val contents = if (is != null) {
+        val c = IO.readStream(is)
+        is.close()
+        c
+      } else ""
+      conn.disconnect()
+
+      assertions.foreach { assertion =>
+        if (contents.contains(assertion)) {
+          messages += s"Resource at $path contained $assertion"
+        } else {
+          throw new RuntimeException(s"Resource at $path didn't contain '$assertion':\n$contents")
+        }
+      }
+
+      messages.foreach(println)
+    } catch {
+      case e: Exception =>
+        println(s"Got exception: $e")
+        if (attempts < MaxAttempts) {
+          Thread.sleep(WaitTime)
+          verifyResourceContains(path, status, assertions, attempts + 1, headers: _*)
+        } else {
+          messages.foreach(println)
+          println(s"After $attempts attempts:")
+          throw e
+        }
+    }
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+
+unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "project" / s"scala-sbt-${sbtBinaryVersion.value}"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/resources/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.http.secret.key=";1[WE]JmK;XMCxV=S2P6kYl?A<^YcKYW3aui[SmusaQlkjq97A`M8l_S:iV?OmDh"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/scala/controllers/HomeController.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/scala/controllers/HomeController.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import javax.inject.Inject
+
+import play.api.mvc._
+
+/**
+ * A very small controller that renders a home page.
+ */
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def index = Action { implicit request =>
+    Ok("Hello, this is Play!")
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/scala/router/Routes.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/scala/router/Routes.scala
@@ -1,0 +1,14 @@
+package router
+
+import javax.inject.Inject
+
+import play.api.mvc._
+import play.api.routing.Router
+import play.api.routing.SimpleRouter
+import play.api.routing.sird._
+
+class Routes @Inject()(controller: controllers.HomeController) extends SimpleRouter {
+  override def routes: Router.Routes = {
+    case GET(p"/") => controller.index
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
@@ -1,0 +1,4 @@
+# runs the devmode and checks that a generated-keystore file is created
+> run -Dhttps.port=9443
+$ exists generated.keystore
+> playStop

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
@@ -1,4 +1,5 @@
 # runs the devmode and checks that a generated-keystore file is created
 > run -Dhttps.port=9443
 $ exists generated.keystore
+> makeRequest / 200
 > playStop


### PR DESCRIPTION
currently the generated keystore was always placed inside conf/
however that was/is bad in two ways:

1. it means that the generated.keystore is inside the distribution files
2. it also means that the generated.keystore needs the conf/ folder
   (which does not exists when using the maven layout)

this places it into the root folder and also adds a test to it,
to confirm that the correct folder is used.

Fixes #3677
we can close the issue than, because the ebean project has it's own [issue](https://github.com/playframework/play-ebean/issues/1).
