### PR TITLE
Update play-ws to 1.1.9

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -268,7 +268,7 @@ object Dependencies {
   ) ++ jcacheApi
 
   val caffeineVersion = "2.5.6"
-  val playWsStandaloneVersion = "1.1.8"
+  val playWsStandaloneVersion = "1.1.9"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-xml" % playWsStandaloneVersion,


### PR DESCRIPTION
This brings in cachecontrol 1.1.3 which in turn removes an unneeded dependency on slf4j-nop.

Cc @TimMoore.