### PR TITLE
Call ExecutionContext.prepare in Action.apply

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -95,7 +95,7 @@ trait Action[A] extends EssentialAction {
       val request = Request(rh, a)
       logger.trace("Invoking action with request: " + request)
       apply(request)
-  }(executionContext)
+  }(executionContext.prepare)
 
   /**
    * The execution context to run this action in


### PR DESCRIPTION
Fixes #8224.

Small change without tests which should be OK. Writing a unit test for this is a bit tricky because it may need a custom Accumulator to test properly. However I think it's OK to make this change so long as no existing unit tests fail.