### PR TITLE
Allow users to directly configure Akka HTTP settings

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -44,7 +44,7 @@ There are a couple of special things to know about configuration when running yo
 You can configure extra settings for the `run` command in your `build.sbt`. These settings won't be used when you deploy your application.
 
 ```
-PlayKeys.devSettings := Seq("play.server.http.port" -> "8080")
+PlayKeys.devSettings += "play.server.http.port" -> "8080"
 ```
 
 ### HTTP server settings in `application.conf`

--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -21,8 +21,30 @@ You can read more about the configuration settings in the [Akka HTTP documentati
 >
 > They will be automatically recognized. Keep in mind that Play configurations listed above will override the Akka ones.
 
-There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have enabled the `AkkaHttp2Support` plugin:
+There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have [[enabled the `AkkaHttp2Support` plugin|AkkaHttpServer#HTTP/2-support-(experimental)]]:
 
 @[](/confs/play-akka-http2-support/reference.conf)
 
 > **Note:** In dev mode, when you use the `run` command, your `application.conf` settings will not be picked up by the server. This is because in dev mode the server starts before the application classpath is available. There are several [[other options|ConfigFile#Using-with-the-run-command]] you'll need to use instead.
+
+## Direct Akka HTTP configuration
+
+If you need direct access to Akka HTTP's `ServerSettings` and `ParserSettings` objects you can do this by extending Play's `AkkaHttpServer` class with your own. The `AkkaHttpServer` class has several protected methods which can be overridden to change how Play configures its Akka HTTP backend.
+
+Note that writing your own server class is advanced usage. Usually you can do all the configuration you need through normal configuration settings.
+
+The code below shows an example of a custom server which modifies some Akka HTTP settings. Below the server class is a `ServerProvider` class which acts as a factory for the custom server.
+
+@[custom-akka-http-server](code/CustomAkkaHttpServer.scala)
+
+Once you've written a custom server and `ServerProvider` class you'll need to tell Play about them by setting the `play.server.provider` configuration option to the full name of your `ServerProvider` class.
+
+For example, adding the following settings to your `build.sbt` and `application.conf` will tell Play to use your new server for both the sbt `run` task and when your application is deployed.
+
+`build.sbt`:
+
+@[custom-akka-http-server-provider](code/build.sbt)
+
+`application.conf`:
+
+@[custom-akka-http-server-provider](code/application.conf)

--- a/documentation/manual/working/commonGuide/configuration/code/CustomAkkaHttpServer.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/CustomAkkaHttpServer.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+//#custom-akka-http-server
+//###replace: package server
+package detailedtopics.configuration.customakkaserver
+
+import java.util.Random
+import play.core.server.{AkkaHttpServer, AkkaHttpServerProvider, ServerProvider}
+import akka.http.scaladsl.ConnectionContext
+import akka.http.scaladsl.model.HttpMethod
+import akka.http.scaladsl.settings.{ParserSettings, ServerSettings}
+
+/** A custom Akka HTTP server with advanced configuration. */
+class CustomAkkaHttpServer(context: AkkaHttpServer.Context) extends AkkaHttpServer(context) {
+  override protected def createParserSettings(): ParserSettings = {
+    val defaultSettings: ParserSettings =
+      super.createParserSettings()
+    defaultSettings.withCustomMethods(HttpMethod.custom("TICKLE"))
+  }
+  override protected def createServerSettings(port: Int, connectionContext: ConnectionContext, secure: Boolean): ServerSettings = {
+    val defaultSettings: ServerSettings =
+      super.createServerSettings(port, connectionContext, secure)
+    defaultSettings.withWebsocketRandomFactory(() => new Random())
+  }
+}
+
+/** A factory that instantiates a CustomAkkaHttpServer. */
+class CustomAkkaHttpServerProvider extends ServerProvider {
+  def createServer(context: ServerProvider.Context) = {
+    val serverContext = AkkaHttpServer.Context.fromServerProviderContext(context)
+    new CustomAkkaHttpServer(serverContext)
+  }
+}
+//#custom-akka-http-server

--- a/documentation/manual/working/commonGuide/configuration/code/application.conf
+++ b/documentation/manual/working/commonGuide/configuration/code/application.conf
@@ -1,0 +1,4 @@
+//#custom-akka-http-server-provider
+//###replace: play.server.provider = server.CustomAkkaHttpServerProvider
+#play.server.provider = server.CustomAkkaHttpServerProvider
+//#custom-akka-http-server-provider

--- a/documentation/manual/working/commonGuide/configuration/code/build.sbt
+++ b/documentation/manual/working/commonGuide/configuration/code/build.sbt
@@ -4,7 +4,9 @@ libraryDependencies += ehcache
 //#play-ws-cache-deps
 
 //#prefix-with-play-akka-dev-mode
-PlayKeys.devSettings ++= Seq(
-  "play.akka.dev-mode.akka.cluster.log-info" -> "off"
-)
+PlayKeys.devSettings += "play.akka.dev-mode.akka.cluster.log-info" -> "off"
 //#prefix-with-play-akka-dev-mode
+
+//#custom-akka-http-server-provider
+PlayKeys.devSettings += "play.server.provider" -> "server.CustomAkkaHttpServerProvider"
+//#custom-akka-http-server-provider

--- a/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
+++ b/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
@@ -3,6 +3,8 @@
 
 Play uses the [Akka HTTP](https://doc.akka.io/docs/akka-http/current/index.html) server backend to implement HTTP requests and responses using Akka Streams over the network.  Akka HTTP implements a full server stack for HTTP, including full HTTPS support, and has support for HTTP/2.
 
+The Akka HTTP server backend is the default in Play. You can also use the [[Netty backend|NettyServer]] if you choose.
+
 ## Akka HTTP Implementation
 
 Play's server backend uses the [low level server API](https://doc.akka.io/docs/akka-http/current/server-side/low-level-api.html?language=scala) to handle Akka's `HttpRequest` and `HttpResponse` classes.
@@ -19,7 +21,7 @@ Please configure any work with blocking APIs off the main rendering thread, usin
 
 ## Configuring Akka HTTP
 
-You can configure the Akka HTTP server settings through [[application.conf|SettingsAkkaHttp]]. That also describes how to enable the HTTP/2 support.
+There are a variety of options that can be configured for the Akka HTTP server. These are given in the [[documentation on configuring Akka HTTP|SettingsAkkaHttp]].
 
 ## HTTP/2 support (experimental)
 
@@ -54,3 +56,23 @@ export AGENT=$(pwd)/$(find target -name 'jetty-alpn-agent-*.jar' | head -1)
 ```
 
 You also may want to write a simple script to run your app with the needed options, as demonstrated the `./play` script in the [play-scala-tls-example](https://github.com/playframework/play-scala-tls-example/blob/2.5.x/play)
+
+## Manually selecting the Akka HTTP server
+
+If for some reason you have both the Akka HTTP and the Netty server JARs on your classpath, then Play won't be able to predictably choose a server backend. You'll need to manually select the Akka HTTP server. This can be done by explicitly overriding the `play.server.provider` configuration option and setting it to a value of `play.core.server.AkkaHttpServerProvider`.
+
+The `play.server.provider` configuration setting can be set in the same way as other configuration options. Different methods of setting configuration are described in the [[configuration file documentation|ConfigFile]]. Several examples of enabling the Akka HTTP server backend are shown below.
+
+The recommended way to do this is to add the setting to two places. First, to enable Akka HTTP for the sbt `run` task, add the following to your `build.sbt`:
+
+```
+PlayKeys.devSettings += "play.server.provider" -> "play.core.server.AkkaHttpServerProvider"
+```
+
+Second, to enable the Akka HTTP backend for when you deploy your application or when you use the sbt `start` task, add the following to your `application.conf` file:
+
+```
+play.server.provider = play.core.server.AkkaHttpServerProvider
+```
+
+By adding the setting to both `build.sbt` and `application.conf` you can ensure that the Akka HTTP backend will be used in all cases.

--- a/documentation/manual/working/commonGuide/server/NettyServer.md
+++ b/documentation/manual/working/commonGuide/server/NettyServer.md
@@ -17,11 +17,23 @@ Now Play should automatically select the Netty server for running in dev mode, p
 
 ## Manually selecting the Netty server
 
-If for some reason you have both the Akka HTTP server and the Netty HTTP server on your classpath, you'll need to manually select it.  This can be done using the `play.server.provider` system property, for example, in dev mode:
+If for some reason you have both the Akka HTTP and the Netty server JARs on your classpath, then Play won't be able to predictably choose a server backend. You'll need to manually select the Netty server. This can be done by explicitly overriding the `play.server.provider` configuration option and setting it to a value of `play.core.server.NettyServerProvider`.
+
+The `play.server.provider` configuration setting can be set in the same way as other configuration options. Different methods of setting configuration are described in the [[configuration file documentation|ConfigFile]]. Several examples of enabling the Netty server are shown below.
+
+The recommended way to do this is to add the setting to two places. First, to enable Netty for the sbt `run` task, add the following to your `build.sbt`:
 
 ```
-run -Dplay.server.provider=play.core.server.NettyServerProvider
+PlayKeys.devSettings += "play.server.provider" -> "play.core.server.NettyServerProvider"
 ```
+
+Second, to enable the Netty backend for when you deploy your application or when you use the sbt `start` task, add the following to your `application.conf` file:
+
+```
+play.server.provider = play.core.server.NettyServerProvider
+```
+
+By adding the setting to both `build.sbt` and `application.conf` you can ensure that the Netty backend will be used in all cases.
 
 ## Verifying that the Netty server is running
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -38,35 +38,46 @@ import scala.util.{ Failure, Success, Try }
 /**
  * Starts a Play server using Akka HTTP.
  */
-class AkkaHttpServer(
-    config: ServerConfig,
-    val applicationProvider: ApplicationProvider,
-    actorSystem: ActorSystem,
-    materializer: Materializer,
-    stopHook: () => Future[_]) extends Server {
+class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
+
+  @deprecated("Use new AkkaHttpServer(Context) instead", "2.6.14")
+  def this(config: ServerConfig, applicationProvider: ApplicationProvider, actorSystem: ActorSystem, materializer: Materializer, stopHook: () => Future[_]) =
+    this(AkkaHttpServer.Context(config, applicationProvider, actorSystem, materializer, stopHook))
 
   import AkkaHttpServer._
 
-  assert(config.port.isDefined || config.sslPort.isDefined, "AkkaHttpServer must be given at least one of an HTTP and an HTTPS port")
+  assert(context.config.port.isDefined || context.config.sslPort.isDefined, "AkkaHttpServer must be given at least one of an HTTP and an HTTPS port")
 
-  private val serverConfig = config.configuration.get[Configuration]("play.server")
-  private val akkaServerConfig = config.configuration.get[Configuration]("play.server.akka")
+  /** Helper to access server configuration under the `play.server` prefix. */
+  private val serverConfig = context.config.configuration.get[Configuration]("play.server")
+  /** Helper to access server configuration under the `play.server.akka` prefix. */
+  private val akkaServerConfig = context.config.configuration.get[Configuration]("play.server.akka")
 
-  override def mode: Mode = config.mode
+  override def mode: Mode = context.config.mode
+  override def applicationProvider: ApplicationProvider = context.appProvider
 
   // Remember that some user config may not be available in development mode due to its unusual ClassLoader.
-  implicit private val system: ActorSystem = actorSystem
-  implicit private val mat: Materializer = materializer
+  implicit private val system: ActorSystem = context.actorSystem
+  implicit private val mat: Materializer = context.materializer
 
   private val http2Enabled: Boolean = akkaServerConfig.getOptional[Boolean]("http2.enabled") getOrElse false
 
   /**
-   * The underlying Config object used to initialize Akka HTTP. We patch in a setting to enable
-   * or disable HTTP/2.
+   * Play's configuration for the Akka HTTP server. Initialized by a call to [[createAkkaHttpConfig()]].
+   *
+   * Note that the rest of the [[ActorSystem]] outside Akka HTTP is initialized by the configuration in [[config]].
    */
-  private val initialConfig: Config = (Configuration(system.settings.config) ++ Configuration(
-    "akka.http.server.preview.enable-http2" -> http2Enabled
-  )).underlying
+  protected val akkaHttpConfig: Config = createAkkaHttpConfig()
+
+  /**
+   * Creates the configuration used to initialize the Akka HTTP subsystem. By default this uses the ActorSystem's
+   * configuration, with an additional setting patched in to enable or disable HTTP/2.
+   */
+  protected def createAkkaHttpConfig(): Config = {
+    (Configuration(system.settings.config) ++ Configuration(
+      "akka.http.server.preview.enable-http2" -> http2Enabled
+    )).underlying
+  }
 
   /**
    * Parses the config setting `infinite` as `Long.MaxValue` otherwise uses Config's built-in
@@ -79,23 +90,26 @@ class AkkaHttpServer(
     }
   }
 
-  /**
-   * Play's custom parser settings for Akka HTTP.
-   */
-  private val parserSettings: ParserSettings = ParserSettings(initialConfig)
+  /** Play's parser settings for Akka HTTP. Initialized by a call to [[createParserSettings()]]. */
+  protected val parserSettings: ParserSettings = createParserSettings()
+
+  /** Called by Play when creating its Akka HTTP parser settings. Result stored in [[parserSettings]]. */
+  protected def createParserSettings(): ParserSettings = ParserSettings(akkaHttpConfig)
     .withMaxContentLength(getPossiblyInfiniteBytes(akkaServerConfig.underlying, "max-content-length"))
     .withIncludeTlsSessionInfoHeader(akkaServerConfig.get[Boolean]("tls-session-info-header"))
     .withModeledHeaderParsing(false) // Disable most of Akka HTTP's header parsing; use RawHeaders instead
 
-  /** Listen for incoming connections and handle them with the `handleRequest` method. */
-  private def createServerBinding(port: Int, connectionContext: ConnectionContext, secure: Boolean): Http.ServerBinding = {
-    val initialSettings = ServerSettings(initialConfig)
-
+  /**
+   * Create Akka HTTP settings for a given port binding.
+   *
+   * Called by Play when binding a handler to a server port. Will be called once per port. Called by the
+   * [[createServerBinding()]] method.
+   */
+  protected def createServerSettings(port: Int, connectionContext: ConnectionContext, secure: Boolean): ServerSettings = {
     val idleTimeout = serverConfig.get[Duration](if (secure) "https.idleTimeout" else "http.idleTimeout")
     val requestTimeout = akkaServerConfig.get[Duration]("requestTimeout")
-
-    // all akka settings that are applied to the server needs to be set here
-    val serverSettings: ServerSettings = initialSettings
+    val initialSettings = ServerSettings(akkaHttpConfig)
+    initialSettings
       .withTimeouts(
         initialSettings.timeouts
           .withIdleTimeout(idleTimeout)
@@ -109,15 +123,21 @@ class AkkaHttpServer(
       .withServerHeader(akkaServerConfig.get[Option[String]]("server-header").collect { case s if s.nonEmpty => headers.Server(s) })
       .withDefaultHostHeader(headers.Host(akkaServerConfig.get[String]("default-host-header")))
       .withParserSettings(parserSettings)
+  }
 
+  /**
+   * Bind Akka HTTP to a port to listen for incoming connections. Calls [[createServerSettings()]] to configure the
+   * binding and [[handleRequest()]] as a handler for the binding.
+   */
+  private def createServerBinding(port: Int, connectionContext: ConnectionContext, secure: Boolean): Http.ServerBinding = {
     // TODO: pass in Inet.SocketOption and LoggerAdapter params?
     val bindingFuture: Future[Http.ServerBinding] = try {
       Http()
         .bindAndHandleAsync(
           handler = handleRequest(_, connectionContext.isSecure),
-          interface = config.address, port = port,
+          interface = context.config.address, port = port,
           connectionContext = connectionContext,
-          settings = serverSettings)
+          settings = createServerSettings(port, connectionContext, secure))
     } catch {
       // Http2SupportNotPresentException is private[akka] so we need to match the name
       case e: Throwable if e.getClass.getSimpleName == "Http2SupportNotPresentException" =>
@@ -130,11 +150,11 @@ class AkkaHttpServer(
     Await.result(bindingFuture, bindTimeout)
   }
 
-  private val httpServerBinding = config.port.map(port => createServerBinding(port, ConnectionContext.noEncryption(), secure = false))
+  private val httpServerBinding = context.config.port.map(port => createServerBinding(port, ConnectionContext.noEncryption(), secure = false))
 
-  private val httpsServerBinding = config.sslPort.map { port =>
+  private val httpsServerBinding = context.config.sslPort.map { port =>
     val connectionContext = try {
-      val engineProvider = ServerSSLEngine.createSSLEngineProvider(config, applicationProvider)
+      val engineProvider = ServerSSLEngine.createSSLEngineProvider(context.config, applicationProvider)
       // There is a mismatch between the Play SSL API and the Akka IO SSL API, Akka IO takes an SSL context, and
       // couples it with all the configuration that it will eventually pass to the created SSLEngine. Play has a
       // factory for creating an SSLEngine, so the user can configure it themselves.  However, that means that in
@@ -275,7 +295,7 @@ class AkkaHttpServer(
     // default execution context used for executing the action
     implicit val defaultExecutionContext: ExecutionContext = tryApp match {
       case Success(app) => app.actorSystem.dispatcher
-      case Failure(_) => actorSystem.dispatcher
+      case Failure(_) => system.dispatcher
     }
 
     (handler, upgradeToWebSocket) match {
@@ -283,7 +303,7 @@ class AkkaHttpServer(
       case (action: EssentialAction, _) =>
         runAction(tryApp, request, taggedRequestHeader, requestBodySource, action, errorHandler)
       case (websocket: WebSocket, Some(upgrade)) =>
-        val bufferLimit = config.configuration.getDeprecated[ConfigMemorySize]("play.server.websocket.frame.maxLength", "play.websocket.buffer.limit").toBytes.toInt
+        val bufferLimit = context.config.configuration.getDeprecated[ConfigMemorySize]("play.server.websocket.frame.maxLength", "play.websocket.buffer.limit").toBytes.toInt
 
         websocket(taggedRequestHeader).fast.flatMap {
           case Left(result) =>
@@ -308,7 +328,7 @@ class AkkaHttpServer(
     action: EssentialAction,
     errorHandler: HttpErrorHandler): Future[HttpResponse] = {
     runAction(applicationProvider.get, request, taggedRequestHeader, requestBodySource,
-      action, errorHandler)(actorSystem.dispatcher)
+      action, errorHandler)(system.dispatcher)
   }
 
   private[play] def runAction(
@@ -382,7 +402,7 @@ class AkkaHttpServer(
     // Call provided hook
     // Do this last because the hooks were created before the server,
     // so the server might need them to run until the last moment.
-    Await.result(stopHook(), Duration.Inf)
+    Await.result(context.stopHook(), Duration.Inf)
   }
 
   override lazy val mainAddress: InetSocketAddress = {
@@ -450,6 +470,48 @@ object AkkaHttpServer extends ServerFromRouter {
   private val logger = Logger(classOf[AkkaHttpServer])
 
   /**
+   * The values needed to initialize an [[AkkaHttpServer]].
+   *
+   * @param config Basic server configuration values.
+   * @param appProvider An object which can be queried to get an Application.
+   * @param actorSystem An ActorSystem that the server can use.
+   * @param stopHook A function that should be called by the server when it stops.
+   * This function can be used to close resources that are provided to the server.
+   */
+  final case class Context(
+      config: ServerConfig,
+      appProvider: ApplicationProvider,
+      actorSystem: ActorSystem,
+      materializer: Materializer,
+      stopHook: () => Future[_])
+
+  object Context {
+
+    /**
+     * Create a `Context` object from several common components.
+     */
+    def fromComponents(
+      serverConfig: ServerConfig,
+      application: Application,
+      stopHook: () => Future[_] = () => Future.successful(())): Context =
+      AkkaHttpServer.Context(
+        config = serverConfig,
+        appProvider = ApplicationProvider(application),
+        actorSystem = application.actorSystem,
+        materializer = application.materializer,
+        stopHook = stopHook
+      )
+
+    /**
+     * Create a `Context` object from a `ServerProvider.Context`.
+     */
+    def fromServerProviderContext(serverProviderContext: ServerProvider.Context): Context = {
+      import serverProviderContext._
+      AkkaHttpServer.Context(config, appProvider, actorSystem, materializer, stopHook)
+    }
+  }
+
+  /**
    * A ServerProvider for creating an AkkaHttpServer.
    */
   implicit val provider: AkkaHttpServerProvider = new AkkaHttpServerProvider
@@ -462,8 +524,7 @@ object AkkaHttpServer extends ServerFromRouter {
    * @return A started Netty server, serving the application.
    */
   def fromApplication(application: Application, config: ServerConfig = ServerConfig()): AkkaHttpServer = {
-    new AkkaHttpServer(config, ApplicationProvider(application), application.actorSystem,
-      application.materializer, () => Future.successful(()))
+    new AkkaHttpServer(Context.fromComponents(config, application))
   }
 
   // Preserve binary compatibility on the 2.6.x branch by casting the return type
@@ -483,9 +544,9 @@ object AkkaHttpServer extends ServerFromRouter {
  * Knows how to create an AkkaHttpServer.
  */
 class AkkaHttpServerProvider extends ServerProvider {
-  def createServer(context: ServerProvider.Context) =
-    new AkkaHttpServer(context.config, context.appProvider, context.actorSystem, context.materializer,
-      context.stopHook)
+  def createServer(context: ServerProvider.Context) = {
+    new AkkaHttpServer(AkkaHttpServer.Context.fromServerProviderContext(context))
+  }
 }
 
 /**
@@ -495,8 +556,7 @@ trait AkkaHttpServerComponents extends ServerComponents {
   lazy val server: AkkaHttpServer = {
     // Start the application first
     Play.start(application)
-    new AkkaHttpServer(serverConfig, ApplicationProvider(application), application.actorSystem,
-      application.materializer, serverStopHook)
+    new AkkaHttpServer(AkkaHttpServer.Context.fromComponents(serverConfig, application, serverStopHook))
   }
 
   def application: Application

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http
+
+import akka.http.scaladsl.model.HttpMethod
+import akka.http.scaladsl.settings.ParserSettings
+import okhttp3.RequestBody
+import okhttp3.internal.{ Util => OkUtil }
+import org.specs2.execute.AsResult
+import org.specs2.specification.core.Fragment
+import play.api.mvc.{ RequestHeader, Results }
+import play.api.routing.Router
+import play.api.test.PlaySpecification
+import play.core.server.{ AkkaHttpServer, ServerProvider }
+import play.it.test._
+
+class AkkaHttpCustomServerProviderSpec extends PlaySpecification
+  with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {
+
+  val appFactory: ApplicationFactory = withRouter { components =>
+    import play.api.routing.sird.{ GET => SirdGet, _ }
+    object SirdFoo {
+      def unapply(rh: RequestHeader): Option[RequestHeader] =
+        if (rh.method.equalsIgnoreCase("foo")) Some(rh) else None
+    }
+    Router.from {
+      case SirdGet(p"/") => components.defaultActionBuilder(Results.Ok("get"))
+      case SirdFoo(p"/") => components.defaultActionBuilder(Results.Ok("foo"))
+    }
+  }
+
+  def requestWithMethod[A: AsResult](endpointRecipe: ServerEndpointRecipe, method: String, body: RequestBody)(f: Either[Int, String] => A): Fragment =
+    appFactory.withOkHttpEndpoints(Seq(endpointRecipe)) { okEndpoint: OkHttpEndpoint =>
+      val response = okEndpoint.configuredCall("/")(_.method(method, body))
+      val param: Either[Int, String] = if (response.code == 200) Right(response.body.string) else Left(response.code)
+      f(param)
+    }
+
+  import ServerEndpointRecipe.AkkaHttp11Plaintext
+
+  "an AkkaHttpServer with standard settings" should {
+    "serve a routed GET request" in requestWithMethod(AkkaHttp11Plaintext, "GET", null)(_ must_== Right("get"))
+    "not find an unrouted POST request" in requestWithMethod(AkkaHttp11Plaintext, "POST", OkUtil.EMPTY_REQUEST)(_ must_== Left(404))
+    "reject a routed FOO request" in requestWithMethod(AkkaHttp11Plaintext, "FOO", null)(_ must_== Left(501))
+    "reject an unrouted BAR request" in requestWithMethod (AkkaHttp11Plaintext, "BAR", null)(_ must_== Left(501))
+    "reject a long header value" in appFactory.withOkHttpEndpoints(Seq(AkkaHttp11Plaintext)) { okEndpoint: OkHttpEndpoint =>
+      val response = okEndpoint.configuredCall("/")(_.addHeader("X-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "abc"))
+      response.code must_== 431
+    }
+  }
+
+  "an AkkaHttpServer with a custom FOO method" should {
+
+    val customAkkaHttpEndpoint: ServerEndpointRecipe = AkkaHttp11Plaintext
+      .withDescription("Akka HTTP HTTP/1.1 (plaintext, supports FOO)")
+      .withServerProvider(new ServerProvider {
+        def createServer(context: ServerProvider.Context) =
+          new AkkaHttpServer(AkkaHttpServer.Context.fromServerProviderContext(context)) {
+            override protected def createParserSettings(): ParserSettings = {
+              super.createParserSettings.withCustomMethods(HttpMethod.custom("FOO"))
+            }
+          }
+      })
+
+    "serve a routed GET request" in requestWithMethod(customAkkaHttpEndpoint, "GET", null)(_ must_== Right("get"))
+    "not find an unrouted POST request" in requestWithMethod(customAkkaHttpEndpoint, "POST", OkUtil.EMPTY_REQUEST)(_ must_== Left(404))
+    "serve a routed FOO request" in requestWithMethod(customAkkaHttpEndpoint, "FOO", null)(_ must_== Right("foo"))
+    "reject an unrouted BAR request" in requestWithMethod (customAkkaHttpEndpoint, "BAR", null)(_ must_== Left(501))
+  }
+
+  "an AkkaHttpServer with a config to support long headers" should {
+
+    val customAkkaHttpEndpoint: ServerEndpointRecipe = AkkaHttp11Plaintext
+      .withDescription("Akka HTTP HTTP/1.1 (plaintext, long headers)")
+      .withServerProvider(new ServerProvider {
+        def createServer(context: ServerProvider.Context) =
+          new AkkaHttpServer(AkkaHttpServer.Context.fromServerProviderContext(context)) {
+            override protected def createParserSettings(): ParserSettings = {
+              super.createParserSettings.withMaxHeaderNameLength(100)
+            }
+          }
+      })
+
+    "accept a long header value" in appFactory.withOkHttpEndpoints(Seq(customAkkaHttpEndpoint)) { okEndpoint: OkHttpEndpoint =>
+      val response = okEndpoint.configuredCall("/")(_.addHeader("X-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "abc"))
+      response.code must_== 200
+    }
+  }
+
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -6,8 +6,6 @@ package play.it.test
 import org.specs2.execute.{ AsResult, PendingUntilFixed, Result, ResultExecution }
 import org.specs2.mutable.SpecificationLike
 import org.specs2.specification.core.Fragment
-import play.api.Configuration
-import play.core.server._
 
 /**
  * Mixin class for integration tests that want to run over different
@@ -29,7 +27,7 @@ trait EndpointIntegrationSpecification
      * and runs the given block of code.
      *
      * {{{
-     * withResult(Results.Ok("Hello")) withAllEndpoints { endpoint: ServerEndpoint =>
+     * withResult(Results.Ok("Hello")) withEndpoints(myEndpointRecipes) { endpoint: ServerEndpoint =>
      *   val response = ... connect to endpoint.port ...
      *   response.status must_== 200
      * }

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -38,6 +38,14 @@ trait OkHttpEndpointSupport {
 
     /** Make a request to the endpoint using the given path. */
     def call(path: String): Response = client.newCall(request(path)).execute()
+
+    /** Make a request to the endpoint using the given path and configuration. */
+    def configuredCall(path: String)(configure: Request.Builder => Request.Builder): Response = {
+      val withPath: Request.Builder = requestBuilder(path)
+      val configured: Request.Builder = configure(withPath)
+      val request: Request = configured.build()
+      client.newCall(request).execute()
+    }
   }
 
   /**
@@ -67,6 +75,22 @@ trait OkHttpEndpointSupport {
    * Implicit class that enhances [[ApplicationFactory]] with the [[withAllOkHttpEndpoints()]] method.
    */
   implicit class OkHttpApplicationFactory(appFactory: ApplicationFactory) {
+    /**
+     * Helper that creates a specs2 fragment for the given server endpoints.
+     * Each fragment creates an application, starts a server,
+     * starts an [[OkHttpClient]] and runs the given block of code.
+     *
+     * {{{
+     * withResult(Results.Ok("Hello")) withOkHttpEndpoints(myEndpointRecipes) {
+     *   okEndpoint: OkHttpEndpoint =>
+     *     val response = okEndpoint.makeRequest("/")
+     *     response.body.string must_== "Hello"
+     * }
+     * }}}
+     */
+    def withOkHttpEndpoints[A: AsResult](endpoints: Seq[ServerEndpointRecipe])(block: OkHttpEndpoint => A): Fragment =
+      appFactory.withEndpoints(endpoints) { endpoint: ServerEndpoint => withOkHttpEndpoint(endpoint)(block) }
+
     /**
      * Helper that creates a specs2 fragment for the server endpoints given in
      * [[allEndpointRecipes]]. Each fragment creates an application, starts a server,

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/ServerEndpointRecipe.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/ServerEndpointRecipe.scala
@@ -32,6 +32,9 @@ trait ServerEndpointRecipe {
   /** The provider used to create the server instance. */
   def serverProvider: ServerProvider
 
+  def withDescription(newDescription: String): ServerEndpointRecipe
+  def withServerProvider(newProvider: ServerProvider): ServerEndpointRecipe
+
   /**
    * Once a server has been started using this recipe, the running instance
    * can be queried to create an endpoint. Usually this just involves asking
@@ -41,7 +44,7 @@ trait ServerEndpointRecipe {
 }
 
 /** Provides a recipe for making an [[HttpEndpoint]]. */
-protected class HttpServerEndpointRecipe(
+class HttpServerEndpointRecipe(
     override val description: String,
     override val serverProvider: ServerProvider,
     extraServerConfiguration: Configuration = Configuration.empty,
@@ -61,11 +64,15 @@ protected class HttpServerEndpointRecipe(
       override def expectedServerAttr: Option[String] = recipe.expectedServerAttr
     }
   }
+  def withDescription(newDescription: String): HttpServerEndpointRecipe =
+    new HttpServerEndpointRecipe(newDescription, serverProvider, extraServerConfiguration, expectedHttpVersions, expectedServerAttr)
+  def withServerProvider(newProvider: ServerProvider): HttpServerEndpointRecipe =
+    new HttpServerEndpointRecipe(description, newProvider, extraServerConfiguration, expectedHttpVersions, expectedServerAttr)
   override def toString: String = s"HttpServerEndpointRecipe($description)"
 }
 
 /** Provides a recipe for making an [[HttpsEndpoint]]. */
-protected class HttpsServerEndpointRecipe(
+class HttpsServerEndpointRecipe(
     override val description: String,
     override val serverProvider: ServerProvider,
     extraServerConfiguration: Configuration = Configuration.empty,
@@ -91,6 +98,8 @@ protected class HttpsServerEndpointRecipe(
       )
     }
   }
+  def withDescription(newDescription: String) = new HttpsServerEndpointRecipe(newDescription, serverProvider, extraServerConfiguration, expectedHttpVersions, expectedServerAttr)
+  def withServerProvider(newProvider: ServerProvider) = new HttpsServerEndpointRecipe(description, newProvider, extraServerConfiguration, expectedHttpVersions, expectedServerAttr)
   override def toString: String = s"HttpsServerEndpointRecipe($description)"
 }
 


### PR DESCRIPTION
This is a backport of #8392.