### PR TITLE
removes commons-io

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
@@ -12,7 +12,6 @@ import akka.stream.OverflowStrategy;
 import akka.NotUsed;
 
 import javaguide.testhelpers.MockJavaAction;
-import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import play.core.j.JavaHandlerComponents;
 import play.http.HttpEntity;
@@ -125,7 +124,9 @@ public class JavaStream extends WithApplication {
         File file = new File("/tmp/fileToServe.pdf");
         file.deleteOnExit();
         try (OutputStream os = java.nio.file.Files.newOutputStream(file.toPath())) {
-            IOUtils.write("hi", os, "UTF-8");
+            os.write("hi".getBytes("UTF-8"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
         Result result = call(new Controller2(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat);
         assertThat(contentAsString(result, mat), equalTo("hi"));

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -175,10 +175,7 @@ object Dependencies {
       case Some((2, v)) if v >= 12 => specs2Deps.map(_ % Test) ++ Seq(specsMatcherExtra % Test)
       case _ => specs2DepsForSbt.map(_ % Test) ++ Seq(specsMatcherExtraForSbt % Test)
     }
-    deps ++ scalaParserCombinators(scalaVersion) ++ Seq(
-      "commons-io" % "commons-io" % "2.6",
-      logback % Test
-    )
+    deps ++ scalaParserCombinators(scalaVersion) ++ (logback % Test :: Nil)
   }
 
   private def sbtPluginDep(moduleId: ModuleID, sbtVersion: String, scalaVersion: String) = {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -5,31 +5,31 @@
 package play.filters.gzip
 
 import javax.inject.Inject
-
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.Application
-import play.api.http.{ HttpChunk, HttpEntity, HttpFilters, HttpProtocol }
+import play.api.http.{HttpChunk, HttpEntity, HttpFilters, HttpProtocol}
 import play.api.inject._
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.routing.{ Router, SimpleRouterImpl }
+import play.api.routing.{Router, SimpleRouterImpl}
 import play.api.test._
-import play.api.mvc.{ AnyContentAsEmpty, Cookie, DefaultActionBuilder, Result }
+import play.api.mvc.{AnyContentAsEmpty, Cookie, DefaultActionBuilder, Result}
 import play.api.mvc.Results._
-import java.util.zip.{ Deflater, GZIPInputStream }
-import java.io.ByteArrayInputStream
+import java.util.zip.{Deflater, GZIPInputStream}
+import java.io.{ByteArrayInputStream, InputStreamReader}
 
-import org.apache.commons.io.IOUtils
+import com.google.common.io.CharStreams
 
 import scala.concurrent.Future
 import scala.util.Random
-import org.specs2.matcher.{ DataTables, MatchResult }
+import org.specs2.matcher.{DataTables, MatchResult}
 
 object GzipFilterSpec {
-  class ResultRouter @Inject() (action: DefaultActionBuilder, result: Result) extends SimpleRouterImpl({ case _ => action(result) })
+  class ResultRouter @Inject()(action: DefaultActionBuilder, result: Result)
+      extends SimpleRouterImpl({ case _ => action(result) })
 
-  class Filters @Inject() (gzipFilter: GzipFilter) extends HttpFilters {
+  class Filters @Inject()(gzipFilter: GzipFilter) extends HttpFilters {
     def filters = Seq(gzipFilter)
   }
 
@@ -53,8 +53,8 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       |codings are assigned a qvalue of 0, except the identity coding which gets q=0.001,
       |which is the lowest possible acceptable qvalue.
       |This seems to be the most consistent behaviour with respect to the other "accept"
-      |header fields described in sect 14.1-5.""".stripMargin in withApplication(Ok("meep")) { implicit app =>
-
+      |header fields described in sect 14.1-5.""".stripMargin in withApplication(
+      Ok("meep")) { implicit app =>
       val (plain, gzipped) = (None, Some("gzip"))
 
       "Accept-Encoding of request" || "Response" |
@@ -85,102 +85,143 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
         "gzip;q=0.5, identity;q=1" !! plain |
         "gzip;q=0.6, identity;q=0.5" !! gzipped |
         "*;q=0.7, gzip;q=0.6, identity;q=0.4" !! gzipped |
-        "" !! plain |> {
-
-          (codings, expectedEncoding) =>
-            header(CONTENT_ENCODING, requestAccepting(app, codings)) must be equalTo expectedEncoding
-        }
+        "" !! plain |> { (codings, expectedEncoding) =>
+        header(CONTENT_ENCODING, requestAccepting(app, codings)) must be equalTo expectedEncoding
+      }
     }
 
     "not gzip empty responses" in withApplication(Ok) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
     }
 
-    "not gzip responses when not requested" in withApplication(Ok("hello")) { implicit app =>
-      checkNotGzipped(route(app, FakeRequest()).get, "hello")(app.materializer)
+    "not gzip responses when not requested" in withApplication(Ok("hello")) {
+      implicit app =>
+        checkNotGzipped(route(app, FakeRequest()).get, "hello")(
+          app.materializer)
     }
 
     "not gzip HEAD requests" in withApplication(Ok) { implicit app =>
-      checkNotGzipped(route(app, FakeRequest("HEAD", "/").withHeaders(ACCEPT_ENCODING -> "gzip")).get, "")(app.materializer)
+      checkNotGzipped(route(app,
+                            FakeRequest("HEAD", "/").withHeaders(
+                              ACCEPT_ENCODING -> "gzip")).get,
+                      "")(app.materializer)
     }
 
-    "not gzip no content responses" in withApplication(NoContent) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
+    "not gzip no content responses" in withApplication(NoContent) {
+      implicit app =>
+        checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
     }
 
-    "not gzip not modified responses" in withApplication(NotModified) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
+    "not gzip not modified responses" in withApplication(NotModified) {
+      implicit app =>
+        checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
     }
 
-    "gzip content type which is on the whiteList" in withApplication(Ok("hello").as("text/css"), whiteList = contentTypes) { implicit app =>
+    "gzip content type which is on the whiteList" in withApplication(
+      Ok("hello").as("text/css"),
+      whiteList = contentTypes) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "gzip content type which is on the whiteList ignoring case" in withApplication(Ok("hello").as("TeXt/CsS"), whiteList = List("TExT/HtMl", "tExT/cSs")) { implicit app =>
+    "gzip content type which is on the whiteList ignoring case" in withApplication(
+      Ok("hello").as("TeXt/CsS"),
+      whiteList = List("TExT/HtMl", "tExT/cSs")) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "gzip uppercase content type which is on the whiteList" in withApplication(Ok("hello").as("TEXT/CSS"), whiteList = contentTypes) { implicit app =>
+    "gzip uppercase content type which is on the whiteList" in withApplication(
+      Ok("hello").as("TEXT/CSS"),
+      whiteList = contentTypes) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "gzip content type with charset which is on the whiteList" in withApplication(Ok("hello").as("text/css; charset=utf-8"), whiteList = contentTypes) { implicit app =>
+    "gzip content type with charset which is on the whiteList" in withApplication(
+      Ok("hello").as("text/css; charset=utf-8"),
+      whiteList = contentTypes) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "don't gzip content type which is not on the whiteList" in withApplication(Ok("hello").as("text/plain"), whiteList = contentTypes) { implicit app =>
+    "don't gzip content type which is not on the whiteList" in withApplication(
+      Ok("hello").as("text/plain"),
+      whiteList = contentTypes) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "don't gzip content type with charset which is not on the whiteList" in withApplication(Ok("hello").as("text/plain; charset=utf-8"), whiteList = contentTypes) { implicit app =>
+    "don't gzip content type with charset which is not on the whiteList" in withApplication(
+      Ok("hello").as("text/plain; charset=utf-8"),
+      whiteList = contentTypes) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "don't gzip content type which is on the blackList" in withApplication(Ok("hello").as("text/css"), blackList = contentTypes) { implicit app =>
+    "don't gzip content type which is on the blackList" in withApplication(
+      Ok("hello").as("text/css"),
+      blackList = contentTypes) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "don't gzip content type with charset which is on the blackList" in withApplication(Ok("hello").as("text/css; charset=utf-8"), blackList = contentTypes) { implicit app =>
+    "don't gzip content type with charset which is on the blackList" in withApplication(
+      Ok("hello").as("text/css; charset=utf-8"),
+      blackList = contentTypes) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "gzip content type which is not on the blackList" in withApplication(Ok("hello").as("text/plain"), blackList = contentTypes) { implicit app =>
+    "gzip content type which is not on the blackList" in withApplication(
+      Ok("hello").as("text/plain"),
+      blackList = contentTypes) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "gzip content type with charset which is not on the blackList" in withApplication(Ok("hello").as("text/plain; charset=utf-8"), blackList = contentTypes) { implicit app =>
+    "gzip content type with charset which is not on the blackList" in withApplication(
+      Ok("hello").as("text/plain; charset=utf-8"),
+      blackList = contentTypes) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "ignore blackList if there is a whiteList" in withApplication(Ok("hello").as("text/css; charset=utf-8"), whiteList = contentTypes, blackList = contentTypes) { implicit app =>
+    "ignore blackList if there is a whiteList" in withApplication(
+      Ok("hello").as("text/css; charset=utf-8"),
+      whiteList = contentTypes,
+      blackList = contentTypes) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "gzip 'text/html' content type when using media range 'text/*' in the whiteList" in withApplication(Ok("hello").as("text/css"), whiteList = List("text/*")) { implicit app =>
+    "gzip 'text/html' content type when using media range 'text/*' in the whiteList" in withApplication(
+      Ok("hello").as("text/css"),
+      whiteList = List("text/*")) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "don't gzip 'application/javascript' content type when using media range 'text/*' in the whiteList" in withApplication(Ok("hello").as("application/javascript"), whiteList = List("text/*")) { implicit app =>
+    "don't gzip 'application/javascript' content type when using media range 'text/*' in the whiteList" in withApplication(
+      Ok("hello").as("application/javascript"),
+      whiteList = List("text/*")) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "fail closed to not gziping an invalid contentType if there is a whiteList and no blacklist" in withApplication(Ok("hello").as("aA(\\A@*- 1  a-"), whiteList = List("text/*")) { implicit app =>
+    "fail closed to not gziping an invalid contentType if there is a whiteList and no blacklist" in withApplication(
+      Ok("hello").as("aA(\\A@*- 1  a-"),
+      whiteList = List("text/*")) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "fail closed to not gziping an invalid contentType if there is a whiteList and a blacklist" in withApplication(Ok("hello").as("aA(\\A@*- 1  a-"), whiteList = List("text/*"), blackList = List("text/*")) { implicit app =>
+    "fail closed to not gziping an invalid contentType if there is a whiteList and a blacklist" in withApplication(
+      Ok("hello").as("aA(\\A@*- 1  a-"),
+      whiteList = List("text/*"),
+      blackList = List("text/*")) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "fail opened to gziping an invalid contentType if there is a blacklist and no whitelist" in withApplication(Ok("hello").as("aA(\\A@*- 1  a-"), blackList = List("text/*")) { implicit app =>
+    "fail opened to gziping an invalid contentType if there is a blacklist and no whitelist" in withApplication(
+      Ok("hello").as("aA(\\A@*- 1  a-"),
+      blackList = List("text/*")) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "gzip an invalid contentType if there is neither a blacklist nor a whitelist" in withApplication(Ok("hello").as("aA(\\A@*- 1  a-")) { implicit app =>
+    "gzip an invalid contentType if there is neither a blacklist nor a whitelist" in withApplication(
+      Ok("hello").as("aA(\\A@*- 1  a-")) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
-    "gzip chunked responses" in withApplication(Ok.chunked(Source(List("foo", "bar")))) { implicit app =>
+    "gzip chunked responses" in withApplication(
+      Ok.chunked(Source(List("foo", "bar")))) { implicit app =>
       val result = makeGzipRequest(app)
       checkGzippedBody(result, "foobar")(app.materializer)
       await(result).body must beAnInstanceOf[HttpEntity.Chunked]
@@ -190,14 +231,16 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
 
     "a streamed body" should {
 
-      val entity = HttpEntity.Streamed(Source.single(ByteString(body)), Some(1000), None)
+      val entity =
+        HttpEntity.Streamed(Source.single(ByteString(body)), Some(1000), None)
 
       "not buffer more than the configured threshold" in withApplication(
-        Ok.sendEntity(entity), chunkedThreshold = 512) { implicit app =>
-          val result = makeGzipRequest(app)
-          checkGzippedBody(result, body)(app.materializer)
-          await(result).body must beAnInstanceOf[HttpEntity.Chunked]
-        }
+        Ok.sendEntity(entity),
+        chunkedThreshold = 512) { implicit app =>
+        val result = makeGzipRequest(app)
+        checkGzippedBody(result, body)(app.materializer)
+        await(result).body must beAnInstanceOf[HttpEntity.Chunked]
+      }
 
       "preserve original headers, cookies, flash and session values" in {
 
@@ -209,13 +252,16 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
             .withSession("sessionName" -> "sessionValue"),
           chunkedThreshold = 2048 // body size is 1000
         ) { implicit app =>
-            val result = makeGzipRequest(app)
-            checkGzipped(result)
-            header(SERVER, result) must beSome("Play")
-            cookies(result).get("cookieName") must beSome.which(cookie => cookie.value == "cookieValue")
-            flash(result).get("flashName") must beSome.which(value => value == "flashValue")
-            session(result).get("sessionName") must beSome.which(value => value == "sessionValue")
-          }
+          val result = makeGzipRequest(app)
+          checkGzipped(result)
+          header(SERVER, result) must beSome("Play")
+          cookies(result).get("cookieName") must beSome.which(cookie =>
+            cookie.value == "cookieValue")
+          flash(result).get("flashName") must beSome.which(value =>
+            value == "flashValue")
+          session(result).get("sessionName") must beSome.which(value =>
+            value == "sessionValue")
+        }
 
         "when buffer more than configured threshold" in withApplication(
           Ok.sendEntity(entity)
@@ -225,32 +271,38 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
             .withSession("sessionName" -> "sessionValue"),
           chunkedThreshold = 512
         ) { implicit app =>
-            val result = makeGzipRequest(app)
-            checkGzippedBody(result, body)(app.materializer)
-            header(SERVER, result) must beSome("Play")
-            cookies(result).get("cookieName") must beSome.which(cookie => cookie.value == "cookieValue")
-            flash(result).get("flashName") must beSome.which(value => value == "flashValue")
-            session(result).get("sessionName") must beSome.which(value => value == "sessionValue")
-          }
+          val result = makeGzipRequest(app)
+          checkGzippedBody(result, body)(app.materializer)
+          header(SERVER, result) must beSome("Play")
+          cookies(result).get("cookieName") must beSome.which(cookie =>
+            cookie.value == "cookieValue")
+          flash(result).get("flashName") must beSome.which(value =>
+            value == "flashValue")
+          session(result).get("sessionName") must beSome.which(value =>
+            value == "sessionValue")
+        }
       }
 
       "not fallback to a chunked body when HTTP 1.0 is being used and the chunked threshold is exceeded" in withApplication(
-        Ok.sendEntity(entity), chunkedThreshold = 512) { implicit app =>
-          val result = route(app, gzipRequest.withVersion(HttpProtocol.HTTP_1_0)).get
-          checkGzippedBody(result, body)(app.materializer)
-          val entity = await(result).body
-          entity must beLike {
-            // Make sure it's a streamed entity with no content length
-            case HttpEntity.Streamed(_, None, None) => ok
-          }
-
+        Ok.sendEntity(entity),
+        chunkedThreshold = 512) { implicit app =>
+        val result =
+          route(app, gzipRequest.withVersion(HttpProtocol.HTTP_1_0)).get
+        checkGzippedBody(result, body)(app.materializer)
+        val entity = await(result).body
+        entity must beLike {
+          // Make sure it's a streamed entity with no content length
+          case HttpEntity.Streamed(_, None, None) => ok
         }
+
+      }
     }
 
     "a chunked body" should {
-      val chunkedBody = Source.fromIterator(() =>
-        Seq[HttpChunk](HttpChunk.Chunk(ByteString("First chunk")), HttpChunk.LastChunk(FakeHeaders())).iterator
-      )
+      val chunkedBody = Source.fromIterator(
+        () =>
+          Seq[HttpChunk](HttpChunk.Chunk(ByteString("First chunk")),
+                         HttpChunk.LastChunk(FakeHeaders())).iterator)
 
       val entity = HttpEntity.Chunked(chunkedBody, Some("text/plain"))
 
@@ -261,18 +313,23 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
           .flashing("flashName" -> "flashValue")
           .withSession("sessionName" -> "sessionValue")
       ) { implicit app =>
-          val result = makeGzipRequest(app)
-          checkGzipped(result)
-          header(SERVER, result) must beSome("Play")
-          cookies(result).get("cookieName") must beSome.which(cookie => cookie.value == "cookieValue")
-          flash(result).get("flashName") must beSome.which(value => value == "flashValue")
-          session(result).get("sessionName") must beSome.which(value => value == "sessionValue")
-        }
+        val result = makeGzipRequest(app)
+        checkGzipped(result)
+        header(SERVER, result) must beSome("Play")
+        cookies(result).get("cookieName") must beSome.which(cookie =>
+          cookie.value == "cookieValue")
+        flash(result).get("flashName") must beSome.which(value =>
+          value == "flashValue")
+        session(result).get("sessionName") must beSome.which(value =>
+          value == "sessionValue")
+      }
     }
 
     "a strict body" should {
 
-      "zip a strict body even if it exceeds the threshold" in withApplication(Ok(body), 512) { implicit app =>
+      "zip a strict body even if it exceeds the threshold" in withApplication(
+        Ok(body),
+        512) { implicit app =>
         val result = makeGzipRequest(app)
         checkGzippedBody(result, body)(app.materializer)
         await(result).body must beAnInstanceOf[HttpEntity.Strict]
@@ -285,24 +342,37 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
           .flashing("flashName" -> "flashValue")
           .withSession("sessionName" -> "sessionValue")
       ) { implicit app =>
-          val result = makeGzipRequest(app)
-          checkGzipped(result)
-          header(SERVER, result) must beSome("Play")
-          cookies(result).get("cookieName") must beSome.which(cookie => cookie.value == "cookieValue")
-          flash(result).get("flashName") must beSome.which(value => value == "flashValue")
-          session(result).get("sessionName") must beSome.which(value => value == "sessionValue")
-        }
-
-      "preserve original Vary header values" in withApplication(Ok("hello").withHeaders(VARY -> "original")) { implicit app =>
         val result = makeGzipRequest(app)
         checkGzipped(result)
-        header(VARY, result) must beSome.which(header => header contains "original,")
+        header(SERVER, result) must beSome("Play")
+        cookies(result).get("cookieName") must beSome.which(cookie =>
+          cookie.value == "cookieValue")
+        flash(result).get("flashName") must beSome.which(value =>
+          value == "flashValue")
+        session(result).get("sessionName") must beSome.which(value =>
+          value == "sessionValue")
       }
 
-      "preserve original Vary header values and not duplicate case-insensitive ACCEPT-ENCODING" in withApplication(Ok("hello").withHeaders(VARY -> "original,ACCEPT-encoding")) { implicit app =>
+      "preserve original Vary header values" in withApplication(
+        Ok("hello").withHeaders(VARY -> "original")) { implicit app =>
         val result = makeGzipRequest(app)
         checkGzipped(result)
-        header(VARY, result) must beSome.which(header => header.split(",").count(_.toLowerCase(java.util.Locale.ENGLISH) == ACCEPT_ENCODING.toLowerCase(java.util.Locale.ENGLISH)) == 1)
+        header(VARY, result) must beSome.which(header =>
+          header contains "original,")
+      }
+
+      "preserve original Vary header values and not duplicate case-insensitive ACCEPT-ENCODING" in withApplication(
+        Ok("hello").withHeaders(VARY -> "original,ACCEPT-encoding")) {
+        implicit app =>
+          val result = makeGzipRequest(app)
+          checkGzipped(result)
+          header(VARY, result) must beSome.which(
+            header =>
+              header
+                .split(",")
+                .count(
+                  _.toLowerCase(java.util.Locale.ENGLISH) == ACCEPT_ENCODING
+                    .toLowerCase(java.util.Locale.ENGLISH)) == 1)
       }
     }
 
@@ -326,28 +396,41 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     }
     "GzipFilterConfig.compressionLevel" should {
       "changing the compressionLevel should result in a change in the output size" in {
-        val result1 = withApplication(Ok(compressibleBody), compressionLevel = 1) { implicit app =>
-          contentAsBytes(makeGzipRequest(app))
-        }
-        val result9 = withApplication(Ok(compressibleBody), compressionLevel = 9) { implicit app =>
-          contentAsBytes(makeGzipRequest(app))
-        }
+        val result1 =
+          withApplication(Ok(compressibleBody), compressionLevel = 1) {
+            implicit app =>
+              contentAsBytes(makeGzipRequest(app))
+          }
+        val result9 =
+          withApplication(Ok(compressibleBody), compressionLevel = 9) {
+            implicit app =>
+              contentAsBytes(makeGzipRequest(app))
+          }
         result1.length should be > result9.length
       }
 
       "NOT changing the compressionLevel should NOT result in a change in the output size" in {
-        val result1a = withApplication(Ok(compressibleBody), compressionLevel = 1) { implicit app =>
-          contentAsBytes(makeGzipRequest(app))
-        }
-        val result1b = withApplication(Ok(compressibleBody), compressionLevel = 1) { implicit app =>
-          contentAsBytes(makeGzipRequest(app))
-        }
+        val result1a =
+          withApplication(Ok(compressibleBody), compressionLevel = 1) {
+            implicit app =>
+              contentAsBytes(makeGzipRequest(app))
+          }
+        val result1b =
+          withApplication(Ok(compressibleBody), compressionLevel = 1) {
+            implicit app =>
+              contentAsBytes(makeGzipRequest(app))
+          }
         result1a.length === result1b.length
       }
     }
   }
 
-  def withApplication[T](result: Result, chunkedThreshold: Int = 1024, whiteList: List[String] = List.empty, blackList: List[String] = List.empty, compressionLevel: Int = Deflater.DEFAULT_COMPRESSION)(block: Application => T): T = {
+  def withApplication[T](result: Result,
+                         chunkedThreshold: Int = 1024,
+                         whiteList: List[String] = List.empty,
+                         blackList: List[String] = List.empty,
+                         compressionLevel: Int = Deflater.DEFAULT_COMPRESSION)(
+      block: Application => T): T = {
     val application = new GuiceApplicationBuilder()
       .configure(
         "play.filters.gzip.chunkedThreshold" -> chunkedThreshold,
@@ -355,34 +438,41 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
         "play.filters.gzip.contentType.whiteList" -> whiteList,
         "play.filters.gzip.contentType.blackList" -> blackList,
         "play.filters.gzip.compressionLevel" -> compressionLevel
-      ).overrides(
-          bind[Result].to(result),
-          bind[Router].to[ResultRouter],
-          bind[HttpFilters].to[Filters]
-        ).build()
+      )
+      .overrides(
+        bind[Result].to(result),
+        bind[Router].to[ResultRouter],
+        bind[HttpFilters].to[Filters]
+      )
+      .build()
     running(application)(block(application))
   }
 
   val contentTypes = List("text/html", "text/css", "application/javascript")
 
-  def gzipRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withHeaders(ACCEPT_ENCODING -> "gzip")
+  def gzipRequest: FakeRequest[AnyContentAsEmpty.type] =
+    FakeRequest().withHeaders(ACCEPT_ENCODING -> "gzip")
 
-  def makeGzipRequest(app: Application): Future[Result] = route(app, gzipRequest).get
+  def makeGzipRequest(app: Application): Future[Result] =
+    route(app, gzipRequest).get
 
-  def requestAccepting(app: Application, codings: String): Future[Result] = route(app, FakeRequest().withHeaders(ACCEPT_ENCODING -> codings)).get
+  def requestAccepting(app: Application, codings: String): Future[Result] =
+    route(app, FakeRequest().withHeaders(ACCEPT_ENCODING -> codings)).get
 
   def gunzip(bytes: ByteString): String = {
     val is = new GZIPInputStream(new ByteArrayInputStream(bytes.toArray))
-    val result = IOUtils.toString(is, "UTF-8")
-    is.close()
-    result
+    val reader = new InputStreamReader(is, "UTF-8")
+    try CharStreams.toString(reader)
+    finally reader.close()
   }
 
   def checkGzipped(result: Future[Result]): MatchResult[Option[String]] = {
-    header(CONTENT_ENCODING, result) aka "Content encoding header" must beSome("gzip")
+    header(CONTENT_ENCODING, result) aka "Content encoding header" must beSome(
+      "gzip")
   }
 
-  def checkGzippedBody(result: Future[Result], body: String)(implicit mat: Materializer): MatchResult[Any] = {
+  def checkGzippedBody(result: Future[Result], body: String)(
+      implicit mat: Materializer): MatchResult[Any] = {
     checkGzipped(result)
     val resultBody = contentAsBytes(result)
     await(result).body.contentLength.foreach { cl =>
@@ -391,7 +481,8 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     gunzip(resultBody) must_== body
   }
 
-  def checkNotGzipped(result: Future[Result], body: String)(implicit mat: Materializer): MatchResult[Any] = {
+  def checkNotGzipped(result: Future[Result], body: String)(
+      implicit mat: Materializer): MatchResult[Any] = {
     header(CONTENT_ENCODING, result) must beNone
     contentAsString(result) must_== body
   }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -9,27 +9,27 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.Application
-import play.api.http.{HttpChunk, HttpEntity, HttpFilters, HttpProtocol}
+import play.api.http.{ HttpChunk, HttpEntity, HttpFilters, HttpProtocol }
 import play.api.inject._
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.routing.{Router, SimpleRouterImpl}
+import play.api.routing.{ Router, SimpleRouterImpl }
 import play.api.test._
-import play.api.mvc.{AnyContentAsEmpty, Cookie, DefaultActionBuilder, Result}
+import play.api.mvc.{ AnyContentAsEmpty, Cookie, DefaultActionBuilder, Result }
 import play.api.mvc.Results._
-import java.util.zip.{Deflater, GZIPInputStream}
-import java.io.{ByteArrayInputStream, InputStreamReader}
+import java.util.zip.{ Deflater, GZIPInputStream }
+import java.io.{ ByteArrayInputStream, InputStreamReader }
 
 import com.google.common.io.CharStreams
 
 import scala.concurrent.Future
 import scala.util.Random
-import org.specs2.matcher.{DataTables, MatchResult}
+import org.specs2.matcher.{ DataTables, MatchResult }
 
 object GzipFilterSpec {
-  class ResultRouter @Inject()(action: DefaultActionBuilder, result: Result)
-      extends SimpleRouterImpl({ case _ => action(result) })
+  class ResultRouter @Inject() (action: DefaultActionBuilder, result: Result)
+    extends SimpleRouterImpl({ case _ => action(result) })
 
-  class Filters @Inject()(gzipFilter: GzipFilter) extends HttpFilters {
+  class Filters @Inject() (gzipFilter: GzipFilter) extends HttpFilters {
     def filters = Seq(gzipFilter)
   }
 
@@ -55,40 +55,40 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       |This seems to be the most consistent behaviour with respect to the other "accept"
       |header fields described in sect 14.1-5.""".stripMargin in withApplication(
       Ok("meep")) { implicit app =>
-      val (plain, gzipped) = (None, Some("gzip"))
+        val (plain, gzipped) = (None, Some("gzip"))
 
-      "Accept-Encoding of request" || "Response" |
-        //------------------------------------++------------+
-        "gzip" !! gzipped |
-        "compress,gzip" !! gzipped |
-        "compress, gzip" !! gzipped |
-        "gzip,compress" !! gzipped |
-        "deflate, gzip,compress" !! gzipped |
-        "gzip, compress" !! gzipped |
-        "identity, gzip, compress" !! gzipped |
-        "GZip" !! gzipped |
-        "*" !! gzipped |
-        "*;q=0" !! plain |
-        "*; q=0" !! plain |
-        "*;q=0.000" !! plain |
-        "gzip;q=0" !! plain |
-        "gzip; q=0.00" !! plain |
-        "*;q=0, gZIP" !! gzipped |
-        "compress;q=0.1, *;q=0, gzip" !! gzipped |
-        "compress;q=0.1, *;q=0, gzip;q=0.005" !! gzipped |
-        "compress, gzip;q=0.001" !! gzipped |
-        "compress, gzip;q=0.002" !! gzipped |
-        "compress;q=1, *;q=0, gzip;q=0.000" !! plain |
-        "compress;q=1, *;q=0" !! plain |
-        "identity" !! plain |
-        "gzip;q=0.5, identity" !! plain |
-        "gzip;q=0.5, identity;q=1" !! plain |
-        "gzip;q=0.6, identity;q=0.5" !! gzipped |
-        "*;q=0.7, gzip;q=0.6, identity;q=0.4" !! gzipped |
-        "" !! plain |> { (codings, expectedEncoding) =>
-        header(CONTENT_ENCODING, requestAccepting(app, codings)) must be equalTo expectedEncoding
+        "Accept-Encoding of request" || "Response" |
+          //------------------------------------++------------+
+          "gzip" !! gzipped |
+          "compress,gzip" !! gzipped |
+          "compress, gzip" !! gzipped |
+          "gzip,compress" !! gzipped |
+          "deflate, gzip,compress" !! gzipped |
+          "gzip, compress" !! gzipped |
+          "identity, gzip, compress" !! gzipped |
+          "GZip" !! gzipped |
+          "*" !! gzipped |
+          "*;q=0" !! plain |
+          "*; q=0" !! plain |
+          "*;q=0.000" !! plain |
+          "gzip;q=0" !! plain |
+          "gzip; q=0.00" !! plain |
+          "*;q=0, gZIP" !! gzipped |
+          "compress;q=0.1, *;q=0, gzip" !! gzipped |
+          "compress;q=0.1, *;q=0, gzip;q=0.005" !! gzipped |
+          "compress, gzip;q=0.001" !! gzipped |
+          "compress, gzip;q=0.002" !! gzipped |
+          "compress;q=1, *;q=0, gzip;q=0.000" !! plain |
+          "compress;q=1, *;q=0" !! plain |
+          "identity" !! plain |
+          "gzip;q=0.5, identity" !! plain |
+          "gzip;q=0.5, identity;q=1" !! plain |
+          "gzip;q=0.6, identity;q=0.5" !! gzipped |
+          "*;q=0.7, gzip;q=0.6, identity;q=0.4" !! gzipped |
+          "" !! plain |> { (codings, expectedEncoding) =>
+            header(CONTENT_ENCODING, requestAccepting(app, codings)) must be equalTo expectedEncoding
+          }
       }
-    }
 
     "not gzip empty responses" in withApplication(Ok) { implicit app =>
       checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
@@ -101,10 +101,12 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     }
 
     "not gzip HEAD requests" in withApplication(Ok) { implicit app =>
-      checkNotGzipped(route(app,
-                            FakeRequest("HEAD", "/").withHeaders(
-                              ACCEPT_ENCODING -> "gzip")).get,
-                      "")(app.materializer)
+      checkNotGzipped(
+        route(
+        app,
+        FakeRequest("HEAD", "/").withHeaders(
+          ACCEPT_ENCODING -> "gzip")).get,
+        "")(app.materializer)
     }
 
     "not gzip no content responses" in withApplication(NoContent) {
@@ -120,112 +122,112 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     "gzip content type which is on the whiteList" in withApplication(
       Ok("hello").as("text/css"),
       whiteList = contentTypes) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "gzip content type which is on the whiteList ignoring case" in withApplication(
       Ok("hello").as("TeXt/CsS"),
       whiteList = List("TExT/HtMl", "tExT/cSs")) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "gzip uppercase content type which is on the whiteList" in withApplication(
       Ok("hello").as("TEXT/CSS"),
       whiteList = contentTypes) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "gzip content type with charset which is on the whiteList" in withApplication(
       Ok("hello").as("text/css; charset=utf-8"),
       whiteList = contentTypes) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "don't gzip content type which is not on the whiteList" in withApplication(
       Ok("hello").as("text/plain"),
       whiteList = contentTypes) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "don't gzip content type with charset which is not on the whiteList" in withApplication(
       Ok("hello").as("text/plain; charset=utf-8"),
       whiteList = contentTypes) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "don't gzip content type which is on the blackList" in withApplication(
       Ok("hello").as("text/css"),
       blackList = contentTypes) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "don't gzip content type with charset which is on the blackList" in withApplication(
       Ok("hello").as("text/css; charset=utf-8"),
       blackList = contentTypes) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "gzip content type which is not on the blackList" in withApplication(
       Ok("hello").as("text/plain"),
       blackList = contentTypes) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "gzip content type with charset which is not on the blackList" in withApplication(
       Ok("hello").as("text/plain; charset=utf-8"),
       blackList = contentTypes) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "ignore blackList if there is a whiteList" in withApplication(
       Ok("hello").as("text/css; charset=utf-8"),
       whiteList = contentTypes,
       blackList = contentTypes) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "gzip 'text/html' content type when using media range 'text/*' in the whiteList" in withApplication(
       Ok("hello").as("text/css"),
       whiteList = List("text/*")) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "don't gzip 'application/javascript' content type when using media range 'text/*' in the whiteList" in withApplication(
       Ok("hello").as("application/javascript"),
       whiteList = List("text/*")) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "fail closed to not gziping an invalid contentType if there is a whiteList and no blacklist" in withApplication(
       Ok("hello").as("aA(\\A@*- 1  a-"),
       whiteList = List("text/*")) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "fail closed to not gziping an invalid contentType if there is a whiteList and a blacklist" in withApplication(
       Ok("hello").as("aA(\\A@*- 1  a-"),
       whiteList = List("text/*"),
       blackList = List("text/*")) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "fail opened to gziping an invalid contentType if there is a blacklist and no whitelist" in withApplication(
       Ok("hello").as("aA(\\A@*- 1  a-"),
       blackList = List("text/*")) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "gzip an invalid contentType if there is neither a blacklist nor a whitelist" in withApplication(
       Ok("hello").as("aA(\\A@*- 1  a-")) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+        checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+      }
 
     "gzip chunked responses" in withApplication(
       Ok.chunked(Source(List("foo", "bar")))) { implicit app =>
-      val result = makeGzipRequest(app)
-      checkGzippedBody(result, "foobar")(app.materializer)
-      await(result).body must beAnInstanceOf[HttpEntity.Chunked]
-    }
+        val result = makeGzipRequest(app)
+        checkGzippedBody(result, "foobar")(app.materializer)
+        await(result).body must beAnInstanceOf[HttpEntity.Chunked]
+      }
 
     val body = Random.nextString(1000)
 
@@ -237,10 +239,10 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       "not buffer more than the configured threshold" in withApplication(
         Ok.sendEntity(entity),
         chunkedThreshold = 512) { implicit app =>
-        val result = makeGzipRequest(app)
-        checkGzippedBody(result, body)(app.materializer)
-        await(result).body must beAnInstanceOf[HttpEntity.Chunked]
-      }
+          val result = makeGzipRequest(app)
+          checkGzippedBody(result, body)(app.materializer)
+          await(result).body must beAnInstanceOf[HttpEntity.Chunked]
+        }
 
       "preserve original headers, cookies, flash and session values" in {
 
@@ -252,16 +254,16 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
             .withSession("sessionName" -> "sessionValue"),
           chunkedThreshold = 2048 // body size is 1000
         ) { implicit app =>
-          val result = makeGzipRequest(app)
-          checkGzipped(result)
-          header(SERVER, result) must beSome("Play")
-          cookies(result).get("cookieName") must beSome.which(cookie =>
-            cookie.value == "cookieValue")
-          flash(result).get("flashName") must beSome.which(value =>
-            value == "flashValue")
-          session(result).get("sessionName") must beSome.which(value =>
-            value == "sessionValue")
-        }
+            val result = makeGzipRequest(app)
+            checkGzipped(result)
+            header(SERVER, result) must beSome("Play")
+            cookies(result).get("cookieName") must beSome.which(cookie =>
+              cookie.value == "cookieValue")
+            flash(result).get("flashName") must beSome.which(value =>
+              value == "flashValue")
+            session(result).get("sessionName") must beSome.which(value =>
+              value == "sessionValue")
+          }
 
         "when buffer more than configured threshold" in withApplication(
           Ok.sendEntity(entity)
@@ -271,38 +273,39 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
             .withSession("sessionName" -> "sessionValue"),
           chunkedThreshold = 512
         ) { implicit app =>
-          val result = makeGzipRequest(app)
-          checkGzippedBody(result, body)(app.materializer)
-          header(SERVER, result) must beSome("Play")
-          cookies(result).get("cookieName") must beSome.which(cookie =>
-            cookie.value == "cookieValue")
-          flash(result).get("flashName") must beSome.which(value =>
-            value == "flashValue")
-          session(result).get("sessionName") must beSome.which(value =>
-            value == "sessionValue")
-        }
+            val result = makeGzipRequest(app)
+            checkGzippedBody(result, body)(app.materializer)
+            header(SERVER, result) must beSome("Play")
+            cookies(result).get("cookieName") must beSome.which(cookie =>
+              cookie.value == "cookieValue")
+            flash(result).get("flashName") must beSome.which(value =>
+              value == "flashValue")
+            session(result).get("sessionName") must beSome.which(value =>
+              value == "sessionValue")
+          }
       }
 
       "not fallback to a chunked body when HTTP 1.0 is being used and the chunked threshold is exceeded" in withApplication(
         Ok.sendEntity(entity),
         chunkedThreshold = 512) { implicit app =>
-        val result =
-          route(app, gzipRequest.withVersion(HttpProtocol.HTTP_1_0)).get
-        checkGzippedBody(result, body)(app.materializer)
-        val entity = await(result).body
-        entity must beLike {
-          // Make sure it's a streamed entity with no content length
-          case HttpEntity.Streamed(_, None, None) => ok
-        }
+          val result =
+            route(app, gzipRequest.withVersion(HttpProtocol.HTTP_1_0)).get
+          checkGzippedBody(result, body)(app.materializer)
+          val entity = await(result).body
+          entity must beLike {
+            // Make sure it's a streamed entity with no content length
+            case HttpEntity.Streamed(_, None, None) => ok
+          }
 
-      }
+        }
     }
 
     "a chunked body" should {
       val chunkedBody = Source.fromIterator(
         () =>
-          Seq[HttpChunk](HttpChunk.Chunk(ByteString("First chunk")),
-                         HttpChunk.LastChunk(FakeHeaders())).iterator)
+          Seq[HttpChunk](
+            HttpChunk.Chunk(ByteString("First chunk")),
+            HttpChunk.LastChunk(FakeHeaders())).iterator)
 
       val entity = HttpEntity.Chunked(chunkedBody, Some("text/plain"))
 
@@ -313,16 +316,16 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
           .flashing("flashName" -> "flashValue")
           .withSession("sessionName" -> "sessionValue")
       ) { implicit app =>
-        val result = makeGzipRequest(app)
-        checkGzipped(result)
-        header(SERVER, result) must beSome("Play")
-        cookies(result).get("cookieName") must beSome.which(cookie =>
-          cookie.value == "cookieValue")
-        flash(result).get("flashName") must beSome.which(value =>
-          value == "flashValue")
-        session(result).get("sessionName") must beSome.which(value =>
-          value == "sessionValue")
-      }
+          val result = makeGzipRequest(app)
+          checkGzipped(result)
+          header(SERVER, result) must beSome("Play")
+          cookies(result).get("cookieName") must beSome.which(cookie =>
+            cookie.value == "cookieValue")
+          flash(result).get("flashName") must beSome.which(value =>
+            value == "flashValue")
+          session(result).get("sessionName") must beSome.which(value =>
+            value == "sessionValue")
+        }
     }
 
     "a strict body" should {
@@ -330,10 +333,10 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       "zip a strict body even if it exceeds the threshold" in withApplication(
         Ok(body),
         512) { implicit app =>
-        val result = makeGzipRequest(app)
-        checkGzippedBody(result, body)(app.materializer)
-        await(result).body must beAnInstanceOf[HttpEntity.Strict]
-      }
+          val result = makeGzipRequest(app)
+          checkGzippedBody(result, body)(app.materializer)
+          await(result).body must beAnInstanceOf[HttpEntity.Strict]
+        }
 
       "preserve original headers, cookie, flash and session values" in withApplication(
         Ok("hello")
@@ -342,38 +345,38 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
           .flashing("flashName" -> "flashValue")
           .withSession("sessionName" -> "sessionValue")
       ) { implicit app =>
-        val result = makeGzipRequest(app)
-        checkGzipped(result)
-        header(SERVER, result) must beSome("Play")
-        cookies(result).get("cookieName") must beSome.which(cookie =>
-          cookie.value == "cookieValue")
-        flash(result).get("flashName") must beSome.which(value =>
-          value == "flashValue")
-        session(result).get("sessionName") must beSome.which(value =>
-          value == "sessionValue")
-      }
+          val result = makeGzipRequest(app)
+          checkGzipped(result)
+          header(SERVER, result) must beSome("Play")
+          cookies(result).get("cookieName") must beSome.which(cookie =>
+            cookie.value == "cookieValue")
+          flash(result).get("flashName") must beSome.which(value =>
+            value == "flashValue")
+          session(result).get("sessionName") must beSome.which(value =>
+            value == "sessionValue")
+        }
 
       "preserve original Vary header values" in withApplication(
         Ok("hello").withHeaders(VARY -> "original")) { implicit app =>
-        val result = makeGzipRequest(app)
-        checkGzipped(result)
-        header(VARY, result) must beSome.which(header =>
-          header contains "original,")
-      }
+          val result = makeGzipRequest(app)
+          checkGzipped(result)
+          header(VARY, result) must beSome.which(header =>
+            header contains "original,")
+        }
 
       "preserve original Vary header values and not duplicate case-insensitive ACCEPT-ENCODING" in withApplication(
         Ok("hello").withHeaders(VARY -> "original,ACCEPT-encoding")) {
-        implicit app =>
-          val result = makeGzipRequest(app)
-          checkGzipped(result)
-          header(VARY, result) must beSome.which(
-            header =>
-              header
-                .split(",")
-                .count(
-                  _.toLowerCase(java.util.Locale.ENGLISH) == ACCEPT_ENCODING
-                    .toLowerCase(java.util.Locale.ENGLISH)) == 1)
-      }
+          implicit app =>
+            val result = makeGzipRequest(app)
+            checkGzipped(result)
+            header(VARY, result) must beSome.which(
+              header =>
+                header
+                  .split(",")
+                  .count(
+                    _.toLowerCase(java.util.Locale.ENGLISH) == ACCEPT_ENCODING
+                      .toLowerCase(java.util.Locale.ENGLISH)) == 1)
+        }
     }
 
     // Random output doesn't compress well and makes for an unreliable comparison between compression levels. This
@@ -425,12 +428,13 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     }
   }
 
-  def withApplication[T](result: Result,
-                         chunkedThreshold: Int = 1024,
-                         whiteList: List[String] = List.empty,
-                         blackList: List[String] = List.empty,
-                         compressionLevel: Int = Deflater.DEFAULT_COMPRESSION)(
-      block: Application => T): T = {
+  def withApplication[T](
+    result: Result,
+    chunkedThreshold: Int = 1024,
+    whiteList: List[String] = List.empty,
+    blackList: List[String] = List.empty,
+    compressionLevel: Int = Deflater.DEFAULT_COMPRESSION)(
+    block: Application => T): T = {
     val application = new GuiceApplicationBuilder()
       .configure(
         "play.filters.gzip.chunkedThreshold" -> chunkedThreshold,
@@ -472,7 +476,8 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
   }
 
   def checkGzippedBody(result: Future[Result], body: String)(
-      implicit mat: Materializer): MatchResult[Any] = {
+    implicit
+    mat: Materializer): MatchResult[Any] = {
     checkGzipped(result)
     val resultBody = contentAsBytes(result)
     await(result).body.contentLength.foreach { cl =>
@@ -482,7 +487,8 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
   }
 
   def checkNotGzipped(result: Future[Result], body: String)(
-      implicit mat: Materializer): MatchResult[Any] = {
+    implicit
+    mat: Materializer): MatchResult[Any] = {
     header(CONTENT_ENCODING, result) must beNone
     contentAsString(result) must_== body
   }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -103,9 +103,9 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     "not gzip HEAD requests" in withApplication(Ok) { implicit app =>
       checkNotGzipped(
         route(
-        app,
-        FakeRequest("HEAD", "/").withHeaders(
-          ACCEPT_ENCODING -> "gzip")).get,
+          app,
+          FakeRequest("HEAD", "/").withHeaders(
+            ACCEPT_ENCODING -> "gzip")).get,
         "")(app.materializer)
     }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -7,10 +7,10 @@ package play.it.http
 import java.net.{ Socket, SocketTimeoutException }
 import java.io._
 import java.security.cert.X509Certificate
+
+import com.google.common.io.CharStreams
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
-
-import org.apache.commons.io.IOUtils
 import play.api.http.HttpConfiguration
 import play.api.libs.crypto.CookieSignerProvider
 import play.api.mvc.{ DefaultCookieHeaderEncoding, DefaultFlashCookieBaker, DefaultSessionCookieBaker }
@@ -258,7 +258,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
   private def consumeRemaining(reader: BufferedReader): String = {
     val writer = new StringWriter()
     try {
-      IOUtils.copy(reader, writer)
+      CharStreams.copy(reader, writer)
     } catch {
       case timeout: SocketTimeoutException => throw timeout
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -8,10 +8,10 @@ import controllers.AssetsComponents
 import play.api._
 import play.api.libs.ws.WSClient
 import play.api.test._
-import org.apache.commons.io.IOUtils
-import java.io.ByteArrayInputStream
+import java.io.{ ByteArrayInputStream, InputStreamReader }
 import java.nio.charset.StandardCharsets
 
+import com.google.common.io.CharStreams
 import com.typesafe.config.ConfigFactory
 import play.api.routing.Router
 import play.core.server.{ Server, ServerConfig }
@@ -250,7 +250,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
       //result.header(CONTENT_ENCODING) must beSome("gzip")
       val ahcResult: play.shaded.ahc.org.asynchttpclient.Response = result.underlying.asInstanceOf[play.shaded.ahc.org.asynchttpclient.Response]
       val is = new ByteArrayInputStream(ahcResult.getResponseBodyAsBytes)
-      IOUtils.toString(is, StandardCharsets.UTF_8) must_== "This is a test gzipped asset.\n"
+      CharStreams.toString(new InputStreamReader(is, StandardCharsets.UTF_8)) must_== "This is a test gzipped asset.\n"
       // release deflate resources
       is.close()
       success

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -14,8 +14,8 @@ import scala.xml.NodeSeq
 import java.io.File
 import java.nio.charset.StandardCharsets
 
-import org.apache.commons.io.FileUtils
 import play.api.Application
+import java.nio.file.Files
 
 class XmlBodyParserSpec extends PlaySpecification {
 
@@ -104,7 +104,7 @@ class XmlBodyParserSpec extends PlaySpecification {
 
     "parse XML bodies without loading in a related schema" in new WithApplication() {
       val f = File.createTempFile("xxe", ".txt")
-      FileUtils.writeStringToFile(f, "I shouldn't be there!", StandardCharsets.UTF_8)
+      Files.write(f.toPath, "I shouldn't be there!".getBytes(StandardCharsets.UTF_8))
       f.deleteOnExit()
       val xml = s"""<?xml version="1.0" encoding="ISO-8859-1"?>
                   | <!DOCTYPE foo [
@@ -117,13 +117,14 @@ class XmlBodyParserSpec extends PlaySpecification {
     "parse XML bodies without loading in a related schema from a parameter" in new WithApplication() {
       val externalParameterEntity = File.createTempFile("xep", ".dtd")
       val externalGeneralEntity = File.createTempFile("xxe", ".txt")
-      FileUtils.writeStringToFile(
-        externalParameterEntity,
+      Files.write(
+        externalParameterEntity.toPath,
         s"""
-          |<!ENTITY % xge SYSTEM "${externalGeneralEntity.toURI}">
-          |<!ENTITY % pe "<!ENTITY xxe '%xge;'>">
-        """.stripMargin, StandardCharsets.UTF_8)
-      FileUtils.writeStringToFile(externalGeneralEntity, "I shouldnt be there!", StandardCharsets.UTF_8)
+           |<!ENTITY % xge SYSTEM "${externalGeneralEntity.toURI}">
+           |<!ENTITY % pe "<!ENTITY xxe '%xge;'>">
+        """.stripMargin.getBytes(StandardCharsets.UTF_8)
+      )
+      Files.write(externalGeneralEntity.toPath, "I shouldnt be there!".getBytes(StandardCharsets.UTF_8))
       externalGeneralEntity.deleteOnExit()
       externalParameterEntity.deleteOnExit()
       val xml = s"""<?xml version="1.0" encoding="ISO-8859-1"?>

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
@@ -5,7 +5,11 @@
 package play.routes.compiler
 
 import java.io.File
-import org.apache.commons.io.FileUtils
+import java.nio.charset.Charset
+import java.nio.file.Files
+
+import scala.collection.JavaConverters._
+
 import scala.io.Codec
 
 /**
@@ -36,7 +40,7 @@ object RoutesCompiler {
     def unapply(file: File): Option[GeneratedSource] = {
 
       val lines: Array[String] = if (file.exists) {
-        FileUtils.readFileToString(file, implicitly[Codec].name).split('\n')
+        Files.readAllLines(file.toPath, Charset.forName(implicitly[Codec].name)).asScala.toArray[String]
       } else {
         Array.empty[String]
       }
@@ -90,7 +94,7 @@ object RoutesCompiler {
       generated.map {
         case (filename, content) =>
           val file = new File(generatedDir, filename)
-          FileUtils.writeStringToFile(file, content, implicitly[Codec].name)
+          Files.write(file.toPath, content.getBytes(implicitly[Codec].name))
           file
       }
     }

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
@@ -94,6 +94,10 @@ object RoutesCompiler {
       generated.map {
         case (filename, content) =>
           val file = new File(generatedDir, filename)
+          if (!file.exists()) {
+            file.getParentFile.mkdirs()
+            file.createNewFile()
+          }
           Files.write(file.toPath, content.getBytes(implicitly[Codec].name))
           file
       }

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -6,8 +6,7 @@ package play.routes.compiler
 
 import java.io.File
 import java.nio.charset.Charset
-
-import org.apache.commons.io.FileUtils
+import java.nio.file.Files
 
 import scala.util.parsing.combinator._
 import scala.util.parsing.input._
@@ -22,8 +21,7 @@ object RoutesFileParser {
    * @return Either the list of compilation errors encountered, or a list of routing rules
    */
   def parse(routesFile: File): Either[Seq[RoutesCompilationError], List[Rule]] = {
-
-    val routesContent = FileUtils.readFileToString(routesFile, Charset.defaultCharset())
+    val routesContent = new String(Files.readAllBytes(routesFile.toPath), Charset.defaultCharset())
 
     parseContent(routesContent, routesFile)
   }


### PR DESCRIPTION
actually this only removes commons-io inside the routes generator and
inside our specs, there is just no need to use it, because we do not
really use it that much.

no need for any migration guide since play does only use it in the
sbt plugin

It's more a hygenic change in the first place, no need for commons-io if we have guava