### PR TITLE
[Backport 2.6.x] added jaxb-api so that jdk 9+ classpath works without configuration

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -56,6 +56,10 @@ object Dependencies {
   val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.7"
 
   val jjwt = "io.jsonwebtoken" % "jjwt" % "0.7.0"
+  // currently jjwt needs the JAXB Api package in JDK 9+
+  // since it actually uses javax/xml/bind/DatatypeConverter
+  // See: https://github.com/jwtk/jjwt/issues/317
+  val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.0"
 
   val jdbcDeps = Seq(
     "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
@@ -143,6 +147,7 @@ object Dependencies {
 
       guava,
       jjwt,
+      jaxbApi,
 
       "org.apache.commons" % "commons-lang3" % "3.6",
 

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -6,7 +6,7 @@ val Versions = new {
   // when updating sbtNativePackager version, be sure to also update the documentation links in
   // documentation/manual/working/commonGuide/production/Deploying.md
   val sbtNativePackager = "1.3.4"
-  val mima = "0.1.18"
+  val mima = "0.3.0"
   val sbtScalariform = "1.8.2"
   val sbtJavaAgent = "0.1.4"
   val sbtJmh = "0.2.27"


### PR DESCRIPTION
as suggested by @marcospereira.

Guess this won't break any user code. it only adds a dependency, which should not make any binary compatibility problems.
