### PR TITLE
remove apache commons libs

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -124,6 +124,25 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 }
 ```
 
+
+### Removed libraries
+
+In order to make the default play distribution a bit smaller we removed some libraries. The following libraries are no longer dependencies in Play 2.6, so you will need to manually add them to your build if you use them.
+
+#### Apache Commons (`commons-lang3` and `commons-codec`)
+
+Play had some internal uses of `commons-codec` and `commons-lang3` if you used it in your project you need to add it to your `build.sbt`:
+
+```scala
+libraryDependencies += "commons-codec" % "commons-codec" % "1.10"
+```
+
+or:
+
+```scala
+libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.6"
+```
+
 ### `Guava` version updated to 24.0-jre
 
 Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 24.1-jre. Lots of changes were made in library, you can see the full changelog [here](https://github.com/google/guava/releases).

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -127,7 +127,7 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
 ### Removed libraries
 
-In order to make the default play distribution a bit smaller we removed some libraries. The following libraries are no longer dependencies in Play 2.6, so you will need to manually add them to your build if you use them.
+In order to make the default play distribution a bit smaller we removed some libraries. The following libraries are no longer dependencies in Play 2.7, so you will need to manually add them to your build if you use them.
 
 #### Apache Commons (`commons-lang3` and `commons-codec`)
 

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -49,7 +49,8 @@ object BuildSettings {
 
   val fileHeaderSettings = Seq(
     excludeFilter in (Compile, headerSources) := HiddenFileFilter ||
-         fileUriRegexFilter(".*/cookie/encoding/.*") || fileUriRegexFilter(".*/inject/SourceProvider.java$"),
+         fileUriRegexFilter(".*/cookie/encoding/.*") || fileUriRegexFilter(".*/inject/SourceProvider.java$") ||
+         fileUriRegexFilter(".*/libs/reflect/.*"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>"))
   )
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -145,15 +145,11 @@ object Dependencies {
     Seq("akka-testkit").map("com.typesafe.akka" %% _ % akkaVersion % Test) ++
     jacksons ++
     Seq(
-      "commons-codec" % "commons-codec" % "1.10",
-
       playJson,
 
       guava,
       jjwt,
       jaxbApi,
-
-      "org.apache.commons" % "commons-lang3" % "3.6",
 
       "javax.transaction" % "jta" % "1.1",
       "javax.inject" % "javax.inject" % "1",

--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -197,7 +197,7 @@ object HttpBinApplication {
       Action { request =>
         request.headers.get("Authorization").flatMap { authorization =>
           authorization.split(" ").drop(1).headOption.filter { encoded =>
-            new String(org.apache.commons.codec.binary.Base64.decodeBase64(encoded.getBytes)).split(":").toList match {
+            new String(java.util.Base64.getDecoder.decode(encoded.getBytes)).split(":").toList match {
               case u :: p :: Nil if u == username && password == p => true
               case _ => false
             }

--- a/framework/src/play-java/src/main/java/play/libs/Comet.java
+++ b/framework/src/play-java/src/main/java/play/libs/Comet.java
@@ -10,7 +10,7 @@ import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import akka.util.ByteStringBuilder;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.lang3.StringEscapeUtils;
+import play.twirl.api.utils.StringEscapeUtils;
 
 import java.util.Arrays;
 

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
@@ -44,8 +44,7 @@ object CertificateGenerator {
   }
 
   def toPEM(certificate: X509Certificate) = {
-    import org.apache.commons.codec.binary.Base64
-    val encoder = new Base64(64)
+    val encoder = java.util.Base64.getMimeEncoder(64, Array('\r', '\n'))
     val certBegin = "-----BEGIN CERTIFICATE-----\n"
     val certEnd = "-----END CERTIFICATE-----"
 

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -4,7 +4,6 @@
 
 package play.i18n;
 
-import org.apache.commons.lang3.ArrayUtils;
 import play.libs.Scala;
 import play.mvc.Http;
 import scala.collection.Seq;
@@ -15,6 +14,7 @@ import javax.inject.Singleton;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The messages API.
@@ -57,7 +57,7 @@ public class MessagesApi {
     @SafeVarargs
     private static <T> List<T> wrapArgsToListIfNeeded(final T... args) {
         List<T> out;
-        if (ArrayUtils.isNotEmpty(args)
+        if (Optional.ofNullable(args).filter(a -> a.length > 0).isPresent()
                 && args.length == 1
                 && args[0] instanceof List){
             out = (List<T>) args[0];

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -57,11 +57,9 @@ public class MessagesApi {
     @SafeVarargs
     private static <T> List<T> wrapArgsToListIfNeeded(final T... args) {
         List<T> out;
-        if (Optional.ofNullable(args).filter(a -> a.length > 0).isPresent()
-                && args.length == 1
-                && args[0] instanceof List){
+        if (args != null && args.length == 1 && args[0] instanceof List) {
             out = (List<T>) args[0];
-        }else{
+        } else {
             out = Arrays.asList(args);
         }
         return out;

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -14,7 +14,6 @@ import javax.inject.Singleton;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * The messages API.

--- a/framework/src/play/src/main/java/play/libs/reflect/ClassUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/ClassUtils.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package play.libs.reflect;
+
+import java.lang.reflect.Array;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Imported from apache.commons.lang3 3.6
+ */
+abstract class ClassUtils {
+
+    public static int arrayGetLength(final Object array) {
+        if (array == null) {
+            return 0;
+        }
+        return Array.getLength(array);
+    }
+
+    /**
+     * An empty immutable {@code Class} array.
+     */
+    public static final Class<?>[] EMPTY_CLASS_ARRAY = new Class[0];
+
+    /**
+     * <p>Checks if one {@code Class} can be assigned to a variable of
+     * another {@code Class}.</p>
+     *
+     * <p>Unlike the {@link Class#isAssignableFrom(java.lang.Class)} method,
+     * this method takes into account widenings of primitive classes and
+     * {@code null}s.</p>
+     *
+     * <p>Primitive widenings allow an int to be assigned to a long, float or
+     * double. This method returns the correct result for these cases.</p>
+     *
+     * <p>{@code Null} may be assigned to any reference type. This method
+     * will return {@code true} if {@code null} is passed in and the
+     * toClass is non-primitive.</p>
+     *
+     * <p>Specifically, this method tests whether the type represented by the
+     * specified {@code Class} parameter can be converted to the type
+     * represented by this {@code Class} object via an identity conversion
+     * widening primitive or widening reference conversion. See
+     * <em><a href="http://java.sun.com/docs/books/jls/">The Java Language Specification</a></em>,
+     * sections 5.1.1, 5.1.2 and 5.1.4 for details.</p>
+     *
+     * <p><strong>Since Lang 3.0,</strong> this method will default behavior for
+     * calculating assignability between primitive and wrapper types <em>corresponding
+     * to the running Java version</em>; i.e. autoboxing will be the default
+     * behavior in VMs running Java versions >= 1.5.</p>
+     *
+     * @param cls  the Class to check, may be null
+     * @param toClass  the Class to try to assign into, returns false if null
+     * @return {@code true} if assignment possible
+     */
+    public static boolean isAssignable(Class<?> cls, Class<?> toClass) {
+        return isAssignable(cls, toClass,
+                /* actually play runs on VMs > 8 only so autoboxing is always true */true);
+    }
+
+    /**
+     * <p>Checks if one {@code Class} can be assigned to a variable of
+     * another {@code Class}.</p>
+     *
+     * <p>Unlike the {@link Class#isAssignableFrom(java.lang.Class)} method,
+     * this method takes into account widenings of primitive classes and
+     * {@code null}s.</p>
+     *
+     * <p>Primitive widenings allow an int to be assigned to a long, float or
+     * double. This method returns the correct result for these cases.</p>
+     *
+     * <p>{@code Null} may be assigned to any reference type. This method
+     * will return {@code true} if {@code null} is passed in and the
+     * toClass is non-primitive.</p>
+     *
+     * <p>Specifically, this method tests whether the type represented by the
+     * specified {@code Class} parameter can be converted to the type
+     * represented by this {@code Class} object via an identity conversion
+     * widening primitive or widening reference conversion. See
+     * <em><a href="http://java.sun.com/docs/books/jls/">The Java Language Specification</a></em>,
+     * sections 5.1.1, 5.1.2 and 5.1.4 for details.</p>
+     *
+     * @param cls  the Class to check, may be null
+     * @param toClass  the Class to try to assign into, returns false if null
+     * @param autoboxing  whether to use implicit autoboxing/unboxing between primitives and wrappers
+     * @return {@code true} if assignment possible
+     */
+    public static boolean isAssignable(Class<?> cls, Class<?> toClass, boolean autoboxing) {
+        if (toClass == null) {
+            return false;
+        }
+        // have to check for null, as isAssignableFrom doesn't
+        if (cls == null) {
+            return !toClass.isPrimitive();
+        }
+        //autoboxing:
+        if (autoboxing) {
+            if (cls.isPrimitive() && !toClass.isPrimitive()) {
+                cls = primitiveToWrapper(cls);
+                if (cls == null) {
+                    return false;
+                }
+            }
+            if (toClass.isPrimitive() && !cls.isPrimitive()) {
+                cls = wrapperToPrimitive(cls);
+                if (cls == null) {
+                    return false;
+                }
+            }
+        }
+        if (cls.equals(toClass)) {
+            return true;
+        }
+        if (cls.isPrimitive()) {
+            if (toClass.isPrimitive() == false) {
+                return false;
+            }
+            if (Integer.TYPE.equals(cls)) {
+                return Long.TYPE.equals(toClass)
+                        || Float.TYPE.equals(toClass)
+                        || Double.TYPE.equals(toClass);
+            }
+            if (Long.TYPE.equals(cls)) {
+                return Float.TYPE.equals(toClass)
+                        || Double.TYPE.equals(toClass);
+            }
+            if (Boolean.TYPE.equals(cls)) {
+                return false;
+            }
+            if (Double.TYPE.equals(cls)) {
+                return false;
+            }
+            if (Float.TYPE.equals(cls)) {
+                return Double.TYPE.equals(toClass);
+            }
+            if (Character.TYPE.equals(cls)) {
+                return Integer.TYPE.equals(toClass)
+                        || Long.TYPE.equals(toClass)
+                        || Float.TYPE.equals(toClass)
+                        || Double.TYPE.equals(toClass);
+            }
+            if (Short.TYPE.equals(cls)) {
+                return Integer.TYPE.equals(toClass)
+                        || Long.TYPE.equals(toClass)
+                        || Float.TYPE.equals(toClass)
+                        || Double.TYPE.equals(toClass);
+            }
+            if (Byte.TYPE.equals(cls)) {
+                return Short.TYPE.equals(toClass)
+                        || Integer.TYPE.equals(toClass)
+                        || Long.TYPE.equals(toClass)
+                        || Float.TYPE.equals(toClass)
+                        || Double.TYPE.equals(toClass);
+            }
+            // should never get here
+            return false;
+        }
+        return toClass.isAssignableFrom(cls);
+    }
+
+    /**
+     * <p>Checks if an array of Classes can be assigned to another array of Classes.</p>
+     *
+     * <p>This method calls {@link #isAssignable(Class, Class) isAssignable} for each
+     * Class pair in the input arrays. It can be used to check if a set of arguments
+     * (the first parameter) are suitably compatible with a set of method parameter types
+     * (the second parameter).</p>
+     *
+     * <p>Unlike the {@link Class#isAssignableFrom(java.lang.Class)} method, this
+     * method takes into account widenings of primitive classes and
+     * {@code null}s.</p>
+     *
+     * <p>Primitive widenings allow an int to be assigned to a {@code long},
+     * {@code float} or {@code double}. This method returns the correct
+     * result for these cases.</p>
+     *
+     * <p>{@code Null} may be assigned to any reference type. This method will
+     * return {@code true} if {@code null} is passed in and the toClass is
+     * non-primitive.</p>
+     *
+     * <p>Specifically, this method tests whether the type represented by the
+     * specified {@code Class} parameter can be converted to the type
+     * represented by this {@code Class} object via an identity conversion
+     * widening primitive or widening reference conversion. See
+     * <em><a href="http://java.sun.com/docs/books/jls/">The Java Language Specification</a></em>,
+     * sections 5.1.1, 5.1.2 and 5.1.4 for details.</p>
+     *
+     * @param classArray  the array of Classes to check, may be {@code null}
+     * @param toClassArray  the array of Classes to try to assign into, may be {@code null}
+     * @param autoboxing  whether to use implicit autoboxing/unboxing between primitives and wrappers
+     * @return {@code true} if assignment possible
+     */
+    public static boolean isAssignable(Class<?>[] classArray, Class<?>[] toClassArray, boolean autoboxing) {
+        if (arrayGetLength(classArray) != arrayGetLength(toClassArray)) {
+            return false;
+        }
+        if (classArray == null) {
+            classArray = EMPTY_CLASS_ARRAY;
+        }
+        if (toClassArray == null) {
+            toClassArray = EMPTY_CLASS_ARRAY;
+        }
+        for (int i = 0; i < classArray.length; i++) {
+            if (isAssignable(classArray[i], toClassArray[i], autoboxing) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Maps primitive {@code Class}es to their corresponding wrapper {@code Class}.
+     */
+    private static final Map<Class<?>, Class<?>> primitiveWrapperMap = new HashMap<>();
+    static {
+        primitiveWrapperMap.put(Boolean.TYPE, Boolean.class);
+        primitiveWrapperMap.put(Byte.TYPE, Byte.class);
+        primitiveWrapperMap.put(Character.TYPE, Character.class);
+        primitiveWrapperMap.put(Short.TYPE, Short.class);
+        primitiveWrapperMap.put(Integer.TYPE, Integer.class);
+        primitiveWrapperMap.put(Long.TYPE, Long.class);
+        primitiveWrapperMap.put(Double.TYPE, Double.class);
+        primitiveWrapperMap.put(Float.TYPE, Float.class);
+        primitiveWrapperMap.put(Void.TYPE, Void.TYPE);
+    }
+
+    /**
+     * Maps wrapper {@code Class}es to their corresponding primitive types.
+     */
+    private static final Map<Class<?>, Class<?>> wrapperPrimitiveMap = new HashMap<Class<?>, Class<?>>();
+    static {
+        for (Class<?> primitiveClass : primitiveWrapperMap.keySet()) {
+            Class<?> wrapperClass = primitiveWrapperMap.get(primitiveClass);
+            if (!primitiveClass.equals(wrapperClass)) {
+                wrapperPrimitiveMap.put(wrapperClass, primitiveClass);
+            }
+        }
+    }
+
+    /**
+     * <p>Converts the specified primitive Class object to its corresponding
+     * wrapper Class object.</p>
+     *
+     * <p>NOTE: From v2.2, this method handles {@code Void.TYPE},
+     * returning {@code Void.TYPE}.</p>
+     *
+     * @param cls  the class to convert, may be null
+     * @return the wrapper class for {@code cls} or {@code cls} if
+     * {@code cls} is not a primitive. {@code null} if null input.
+     * @since 2.1
+     */
+    static Class<?> primitiveToWrapper(final Class<?> cls) {
+        Class<?> convertedClass = cls;
+        if (cls != null && cls.isPrimitive()) {
+            convertedClass = primitiveWrapperMap.get(cls);
+        }
+        return convertedClass;
+    }
+
+
+    /**
+     * <p>Converts the specified wrapper class to its corresponding primitive
+     * class.</p>
+     *
+     * <p>This method is the counter part of {@code primitiveToWrapper()}.
+     * If the passed in class is a wrapper class for a primitive type, this
+     * primitive type will be returned (e.g. {@code Integer.TYPE} for
+     * {@code Integer.class}). For other classes, or if the parameter is
+     * <b>null</b>, the return value is <b>null</b>.</p>
+     *
+     * @param cls the class to convert, may be <b>null</b>
+     * @return the corresponding primitive type if {@code cls} is a
+     * wrapper class, <b>null</b> otherwise
+     * @see #primitiveToWrapper(Class)
+     * @since 2.4
+     */
+    public static Class<?> wrapperToPrimitive(Class<?> cls) {
+        return wrapperPrimitiveMap.get(cls);
+    }
+
+}

--- a/framework/src/play/src/main/java/play/libs/reflect/ClassUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/ClassUtils.java
@@ -1,8 +1,4 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
- */
-
-/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/framework/src/play/src/main/java/play/libs/reflect/ClassUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/ClassUtils.java
@@ -1,4 +1,7 @@
 /*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/framework/src/play/src/main/java/play/libs/reflect/ClassUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/ClassUtils.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/framework/src/play/src/main/java/play/libs/reflect/ConstructorUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/ConstructorUtils.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package play.libs.reflect;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+/**
+ * Imported from apache.commons.lang3 3.6
+ */
+public class ConstructorUtils {
+
+    /**
+     * <p>Validate that the specified argument is not {@code null};
+     * otherwise throwing an exception with the specified message.
+     *
+     * <pre>notNull(myObject, "The object must not be null");</pre>
+     *
+     * @param <T> the object type
+     * @param object  the object to check
+     * @param message  the {@link String#format(String, Object...)} exception message if invalid, not null
+     * @param values  the optional values for the formatted exception message
+     * @return the validated object (never {@code null} for method chaining)
+     * @throws NullPointerException if the object is {@code null}
+     */
+    private static <T> T notNull(final T object, final String message, final Object... values) {
+        if (object == null) {
+            throw new NullPointerException(String.format(message, values));
+        }
+        return object;
+    }
+
+    /**
+     * <p>Checks if the specified constructor is accessible.</p>
+     *
+     * <p>This simply ensures that the constructor is accessible.</p>
+     *
+     * @param <T> the constructor type
+     * @param ctor  the prototype constructor object, not {@code null}
+     * @return the constructor, {@code null} if no matching accessible constructor found
+     * @see java.lang.SecurityManager
+     * @throws NullPointerException if {@code ctor} is {@code null}
+     */
+    public static <T> Constructor<T> getAccessibleConstructor(final Constructor<T> ctor) {
+        notNull(ctor, "constructor cannot be null");
+        return MemberUtils.isAccessible(ctor)
+                && isAccessible(ctor.getDeclaringClass()) ? ctor : null;
+    }
+
+    /**
+     * <p>Finds an accessible constructor with compatible parameters.</p>
+     *
+     * <p>This checks all the constructor and finds one with compatible parameters
+     * This requires that every parameter is assignable from the given parameter types.
+     * This is a more flexible search than the normal exact matching algorithm.</p>
+     *
+     * <p>First it checks if there is a constructor matching the exact signature.
+     * If not then all the constructors of the class are checked to see if their
+     * signatures are assignment-compatible with the parameter types.
+     * The first assignment-compatible matching constructor is returned.</p>
+     *
+     * @param <T> the constructor type
+     * @param cls  the class to find a constructor for, not {@code null}
+     * @param parameterTypes find method with compatible parameters
+     * @return the constructor, null if no matching accessible constructor found
+     * @throws NullPointerException if {@code cls} is {@code null}
+     */
+    public static <T> Constructor<T> getMatchingAccessibleConstructor(final Class<T> cls,
+                                                                      final Class<?>... parameterTypes) {
+        notNull(cls, "class cannot be null");
+        // see if we can find the constructor directly
+        // most of the time this works and it's much faster
+        try {
+            final Constructor<T> ctor = cls.getConstructor(parameterTypes);
+            MemberUtils.setAccessibleWorkaround(ctor);
+            return ctor;
+        } catch (final NoSuchMethodException e) { // NOPMD - Swallow
+        }
+        Constructor<T> result = null;
+        /*
+         * (1) Class.getConstructors() is documented to return Constructor<T> so as
+         * long as the array is not subsequently modified, everything's fine.
+         */
+        final Constructor<?>[] ctors = cls.getConstructors();
+
+        // return best match:
+        for (Constructor<?> ctor : ctors) {
+            // compare parameters
+            if (MemberUtils.isMatchingConstructor(ctor, parameterTypes)) {
+                // get accessible version of constructor
+                ctor = getAccessibleConstructor(ctor);
+                if (ctor != null) {
+                    MemberUtils.setAccessibleWorkaround(ctor);
+                    if (result == null || MemberUtils.compareConstructorFit(ctor, result, parameterTypes) < 0) {
+                        // temporary variable for annotation, see comment above (1)
+                        @SuppressWarnings("unchecked")
+                        final
+                        Constructor<T> constructor = (Constructor<T>)ctor;
+                        result = constructor;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Learn whether the specified class is generally accessible, i.e. is
+     * declared in an entirely {@code public} manner.
+     * @param type to check
+     * @return {@code true} if {@code type} and any enclosing classes are
+     *         {@code public}.
+     */
+    private static boolean isAccessible(final Class<?> type) {
+        Class<?> cls = type;
+        while (cls != null) {
+            if (!Modifier.isPublic(cls.getModifiers())) {
+                return false;
+            }
+            cls = cls.getEnclosingClass();
+        }
+        return true;
+    }
+
+}

--- a/framework/src/play/src/main/java/play/libs/reflect/ConstructorUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/ConstructorUtils.java
@@ -1,8 +1,4 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
- */
-
-/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/framework/src/play/src/main/java/play/libs/reflect/ConstructorUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/ConstructorUtils.java
@@ -1,4 +1,7 @@
 /*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/framework/src/play/src/main/java/play/libs/reflect/ConstructorUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/ConstructorUtils.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/framework/src/play/src/main/java/play/libs/reflect/MemberUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/MemberUtils.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package play.libs.reflect;
+
+import java.lang.reflect.*;
+
+/**
+ * Imported from apache.commons.lang3 3.6
+ */
+abstract class MemberUtils {
+
+    private static final int ACCESS_TEST = Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE;
+
+    /** Array of primitive number types ordered by "promotability" */
+    private static final Class<?>[] ORDERED_PRIMITIVE_TYPES = { Byte.TYPE, Short.TYPE,
+            Character.TYPE, Integer.TYPE, Long.TYPE, Float.TYPE, Double.TYPE };
+
+    /**
+     * Returns whether a given set of modifiers implies package access.
+     * @param modifiers to test
+     * @return {@code true} unless {@code package}/{@code protected}/{@code private} modifier detected
+     */
+    static boolean isPackageAccess(final int modifiers) {
+        return (modifiers & ACCESS_TEST) == 0;
+    }
+
+    /**
+     * Returns whether a {@link Member} is accessible.
+     * @param m Member to check
+     * @return {@code true} if <code>m</code> is accessible
+     */
+    static boolean isAccessible(final Member m) {
+        return m != null && Modifier.isPublic(m.getModifiers()) && !m.isSynthetic();
+    }
+
+    /**
+     * XXX Default access superclass workaround.
+     *
+     * When a {@code public} class has a default access superclass with {@code public} members,
+     * these members are accessible. Calling them from compiled code works fine.
+     * Unfortunately, on some JVMs, using reflection to invoke these members
+     * seems to (wrongly) prevent access even when the modifier is {@code public}.
+     * Calling {@code setAccessible(true)} solves the problem but will only work from
+     * sufficiently privileged code. Better workarounds would be gratefully
+     * accepted.
+     * @param o the AccessibleObject to set as accessible
+     * @return a boolean indicating whether the accessibility of the object was set to true.
+     */
+    static boolean setAccessibleWorkaround(final AccessibleObject o) {
+        if (o == null || o.isAccessible()) {
+            return false;
+        }
+        final Member m = (Member) o;
+        if (!o.isAccessible() && Modifier.isPublic(m.getModifiers()) && isPackageAccess(m.getDeclaringClass().getModifiers())) {
+            try {
+                o.setAccessible(true);
+                return true;
+            } catch (final SecurityException e) { // NOPMD
+                // ignore in favor of subsequent IllegalAccessException
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Compares the relative fitness of two Constructors in terms of how well they
+     * match a set of runtime parameter types, such that a list ordered
+     * by the results of the comparison would return the best match first
+     * (least).
+     *
+     * @param left the "left" Constructor
+     * @param right the "right" Constructor
+     * @param actual the runtime parameter types to match against
+     * {@code left}/{@code right}
+     * @return int consistent with {@code compare} semantics
+     * @since 3.5
+     */
+    static int compareConstructorFit(final Constructor<?> left, final Constructor<?> right, final Class<?>[] actual) {
+        return compareParameterTypes(Executable.of(left), Executable.of(right), actual);
+    }
+
+    /**
+     * Compares the relative fitness of two Methods in terms of how well they
+     * match a set of runtime parameter types, such that a list ordered
+     * by the results of the comparison would return the best match first
+     * (least).
+     *
+     * @param left the "left" Method
+     * @param right the "right" Method
+     * @param actual the runtime parameter types to match against
+     * {@code left}/{@code right}
+     * @return int consistent with {@code compare} semantics
+     * @since 3.5
+     */
+    static int compareMethodFit(final Method left, final Method right, final Class<?>[] actual) {
+        return compareParameterTypes(Executable.of(left), Executable.of(right), actual);
+    }
+
+    /**
+     * Compares the relative fitness of two Executables in terms of how well they
+     * match a set of runtime parameter types, such that a list ordered
+     * by the results of the comparison would return the best match first
+     * (least).
+     *
+     * @param left the "left" Executable
+     * @param right the "right" Executable
+     * @param actual the runtime parameter types to match against
+     * {@code left}/{@code right}
+     * @return int consistent with {@code compare} semantics
+     */
+    private static int compareParameterTypes(final Executable left, final Executable right, final Class<?>[] actual) {
+        final float leftCost = getTotalTransformationCost(actual, left);
+        final float rightCost = getTotalTransformationCost(actual, right);
+        return leftCost < rightCost ? -1 : rightCost < leftCost ? 1 : 0;
+    }
+
+
+    /**
+     * Gets the number of steps required to promote a primitive number to another
+     * type.
+     * @param srcClass the (primitive) source class
+     * @param destClass the (primitive) destination class
+     * @return The cost of promoting the primitive
+     */
+    private static float getPrimitivePromotionCost(final Class<?> srcClass, final Class<?> destClass) {
+        float cost = 0.0f;
+        Class<?> cls = srcClass;
+        if (!cls.isPrimitive()) {
+            // slight unwrapping penalty
+            cost += 0.1f;
+            cls = ClassUtils.wrapperToPrimitive(cls);
+        }
+        for (int i = 0; cls != destClass && i < ORDERED_PRIMITIVE_TYPES.length; i++) {
+            if (cls == ORDERED_PRIMITIVE_TYPES[i]) {
+                cost += 0.1f;
+                if (i < ORDERED_PRIMITIVE_TYPES.length - 1) {
+                    cls = ORDERED_PRIMITIVE_TYPES[i + 1];
+                }
+            }
+        }
+        return cost;
+    }
+
+    /**
+     * Returns the sum of the object transformation cost for each class in the
+     * source argument list.
+     * @param srcArgs The source arguments
+     * @param executable The executable to calculate transformation costs for
+     * @return The total transformation cost
+     */
+    private static float getTotalTransformationCost(final Class<?>[] srcArgs, final Executable executable) {
+        final Class<?>[] destArgs = executable.getParameterTypes();
+        final boolean isVarArgs = executable.isVarArgs();
+
+        // "source" and "destination" are the actual and declared args respectively.
+        float totalCost = 0.0f;
+        final long normalArgsLen = isVarArgs ? destArgs.length-1 : destArgs.length;
+        if (srcArgs.length < normalArgsLen) {
+            return Float.MAX_VALUE;
+        }
+        for (int i = 0; i < normalArgsLen; i++) {
+            totalCost += getObjectTransformationCost(srcArgs[i], destArgs[i]);
+        }
+        if (isVarArgs) {
+            // When isVarArgs is true, srcArgs and dstArgs may differ in length.
+            // There are two special cases to consider:
+            final boolean noVarArgsPassed = srcArgs.length < destArgs.length;
+            final boolean explicitArrayForVarags = srcArgs.length == destArgs.length && srcArgs[srcArgs.length-1].isArray();
+
+            final float varArgsCost = 0.001f;
+            final Class<?> destClass = destArgs[destArgs.length-1].getComponentType();
+            if (noVarArgsPassed) {
+                // When no varargs passed, the best match is the most generic matching type, not the most specific.
+                totalCost += getObjectTransformationCost(destClass, Object.class) + varArgsCost;
+            } else if (explicitArrayForVarags) {
+                final Class<?> sourceClass = srcArgs[srcArgs.length-1].getComponentType();
+                totalCost += getObjectTransformationCost(sourceClass, destClass) + varArgsCost;
+            } else {
+                // This is typical varargs case.
+                for (int i = destArgs.length-1; i < srcArgs.length; i++) {
+                    final Class<?> srcClass = srcArgs[i];
+                    totalCost += getObjectTransformationCost(srcClass, destClass) + varArgsCost;
+                }
+            }
+        }
+        return totalCost;
+    }
+
+    /**
+     * Gets the number of steps required needed to turn the source class into
+     * the destination class. This represents the number of steps in the object
+     * hierarchy graph.
+     * @param srcClass The source class
+     * @param destClass The destination class
+     * @return The cost of transforming an object
+     */
+    private static float getObjectTransformationCost(Class<?> srcClass, final Class<?> destClass) {
+        if (destClass.isPrimitive()) {
+            return getPrimitivePromotionCost(srcClass, destClass);
+        }
+        float cost = 0.0f;
+        while (srcClass != null && !destClass.equals(srcClass)) {
+            if (destClass.isInterface() && ClassUtils.isAssignable(srcClass, destClass)) {
+                // slight penalty for interface match.
+                // we still want an exact match to override an interface match,
+                // but
+                // an interface match should override anything where we have to
+                // get a superclass.
+                cost += 0.25f;
+                break;
+            }
+            cost++;
+            srcClass = srcClass.getSuperclass();
+        }
+        /*
+         * If the destination class is null, we've traveled all the way up to
+         * an Object match. We'll penalize this by adding 1.5 to the cost.
+         */
+        if (srcClass == null) {
+            cost += 1.5f;
+        }
+        return cost;
+    }
+
+
+    static boolean isMatchingMethod(final Method method, final Class<?>[] parameterTypes) {
+        return isMatchingExecutable(Executable.of(method), parameterTypes);
+    }
+
+    static boolean isMatchingConstructor(final Constructor<?> method, final Class<?>[] parameterTypes) {
+        return isMatchingExecutable(Executable.of(method), parameterTypes);
+    }
+
+    private static boolean isMatchingExecutable(final Executable method, final Class<?>[] parameterTypes) {
+        final Class<?>[] methodParameterTypes = method.getParameterTypes();
+        if (method.isVarArgs()) {
+            int i;
+            for (i = 0; i < methodParameterTypes.length - 1 && i < parameterTypes.length; i++) {
+                if (!ClassUtils.isAssignable(parameterTypes[i], methodParameterTypes[i], true)) {
+                    return false;
+                }
+            }
+            final Class<?> varArgParameterType = methodParameterTypes[methodParameterTypes.length - 1].getComponentType();
+            for (; i < parameterTypes.length; i++) {
+                if (!ClassUtils.isAssignable(parameterTypes[i], varArgParameterType, true)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return ClassUtils.isAssignable(parameterTypes, methodParameterTypes, true);
+    }
+
+    /**
+     * <p> A class providing a subset of the API of java.lang.reflect.Executable in Java 1.8,
+     * providing a common representation for function signatures for Constructors and Methods.</p>
+     */
+    private static final class Executable {
+        private final Class<?>[] parameterTypes;
+        private final boolean  isVarArgs;
+
+        private static Executable of(final Method method) {
+            return new Executable(method);
+        }
+
+        private static Executable of(final Constructor<?> constructor) {
+            return new Executable(constructor);
+        }
+
+        private Executable(final Method method) {
+            parameterTypes = method.getParameterTypes();
+            isVarArgs = method.isVarArgs();
+        }
+
+        private Executable(final Constructor<?> constructor) {
+            parameterTypes = constructor.getParameterTypes();
+            isVarArgs = constructor.isVarArgs();
+        }
+
+        public Class<?>[] getParameterTypes() {
+            return parameterTypes;
+        }
+
+        public boolean isVarArgs() {
+            return isVarArgs;
+        }
+    }
+}

--- a/framework/src/play/src/main/java/play/libs/reflect/MemberUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/MemberUtils.java
@@ -1,8 +1,4 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
- */
-
-/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/framework/src/play/src/main/java/play/libs/reflect/MemberUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/MemberUtils.java
@@ -1,4 +1,7 @@
 /*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/framework/src/play/src/main/java/play/libs/reflect/MemberUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/MemberUtils.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/framework/src/play/src/main/java/play/libs/reflect/MethodUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/MethodUtils.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package play.libs.reflect;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * Imported from apache.commons.lang3 3.6
+ */
+public class MethodUtils {
+
+    /**
+     * <p>{@link MethodUtils} instances should NOT be constructed in standard programming.
+     * Instead, the class should be used as
+     * {@code MethodUtils.getAccessibleMethod(method)}.</p>
+     *
+     * <p>This constructor is {@code public} to permit tools that require a JavaBean
+     * instance to operate.</p>
+     */
+    public MethodUtils() {
+        super();
+    }
+
+    /**
+     * <p>Returns an accessible method (that is, one that can be invoked via
+     * reflection) that implements the specified Method. If no such method
+     * can be found, return {@code null}.</p>
+     *
+     * @param method The method that we wish to call
+     * @return The accessible method
+     */
+    public static Method getAccessibleMethod(Method method) {
+        if (!MemberUtils.isAccessible(method)) {
+            return null;
+        }
+        // If the declaring class is public, we are done
+        final Class<?> cls = method.getDeclaringClass();
+        if (Modifier.isPublic(cls.getModifiers())) {
+            return method;
+        }
+        final String methodName = method.getName();
+        final Class<?>[] parameterTypes = method.getParameterTypes();
+
+        // Check the implemented interfaces and subinterfaces
+        method = getAccessibleMethodFromInterfaceNest(cls, methodName,
+                parameterTypes);
+
+        // Check the superclass chain
+        if (method == null) {
+            method = getAccessibleMethodFromSuperclass(cls, methodName,
+                    parameterTypes);
+        }
+        return method;
+    }
+
+    /**
+     * <p>Returns an accessible method (that is, one that can be invoked via
+     * reflection) by scanning through the superclasses. If no such method
+     * can be found, return {@code null}.</p>
+     *
+     * @param cls Class to be checked
+     * @param methodName Method name of the method we wish to call
+     * @param parameterTypes The parameter type signatures
+     * @return the accessible method or {@code null} if not found
+     */
+    private static Method getAccessibleMethodFromSuperclass(final Class<?> cls,
+                                                            final String methodName, final Class<?>... parameterTypes) {
+        Class<?> parentClass = cls.getSuperclass();
+        while (parentClass != null) {
+            if (Modifier.isPublic(parentClass.getModifiers())) {
+                try {
+                    return parentClass.getMethod(methodName, parameterTypes);
+                } catch (final NoSuchMethodException e) {
+                    return null;
+                }
+            }
+            parentClass = parentClass.getSuperclass();
+        }
+        return null;
+    }
+
+    /**
+     * <p>Returns an accessible method (that is, one that can be invoked via
+     * reflection) that implements the specified method, by scanning through
+     * all implemented interfaces and subinterfaces. If no such method
+     * can be found, return {@code null}.</p>
+     *
+     * <p>There isn't any good reason why this method must be {@code private}.
+     * It is because there doesn't seem any reason why other classes should
+     * call this rather than the higher level methods.</p>
+     *
+     * @param cls Parent class for the interfaces to be checked
+     * @param methodName Method name of the method we wish to call
+     * @param parameterTypes The parameter type signatures
+     * @return the accessible method or {@code null} if not found
+     */
+    private static Method getAccessibleMethodFromInterfaceNest(Class<?> cls,
+                                                               final String methodName, final Class<?>... parameterTypes) {
+        // Search up the superclass chain
+        for (; cls != null; cls = cls.getSuperclass()) {
+
+            // Check the implemented interfaces of the parent class
+            final Class<?>[] interfaces = cls.getInterfaces();
+            for (Class<?> anInterface : interfaces) {
+                // Is this interface public?
+                if (!Modifier.isPublic(anInterface.getModifiers())) {
+                    continue;
+                }
+                // Does the method exist on this interface?
+                try {
+                    return anInterface.getDeclaredMethod(methodName,
+                            parameterTypes);
+                } catch (final NoSuchMethodException e) { // NOPMD
+                    /*
+                     * Swallow, if no method is found after the loop then this
+                     * method returns null.
+                     */
+                }
+                // Recursively check our parent interfaces
+                final Method method = getAccessibleMethodFromInterfaceNest(anInterface,
+                        methodName, parameterTypes);
+                if (method != null) {
+                    return method;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * <p>Finds an accessible method that matches the given name and has compatible parameters.
+     * Compatible parameters mean that every method parameter is assignable from
+     * the given parameters.
+     * In other words, it finds a method with the given name
+     * that will take the parameters given.</p>
+     *
+     * <p>This method can match primitive parameter by passing in wrapper classes.
+     * For example, a {@code Boolean} will match a primitive {@code boolean}
+     * parameter.
+     * </p>
+     *
+     * @param cls find method in this class
+     * @param methodName find method with this name
+     * @param parameterTypes find method with most compatible parameters
+     * @return The accessible method
+     */
+    public static Method getMatchingAccessibleMethod(final Class<?> cls,
+                                                     final String methodName, final Class<?>... parameterTypes) {
+        try {
+            final Method method = cls.getMethod(methodName, parameterTypes);
+            MemberUtils.setAccessibleWorkaround(method);
+            return method;
+        } catch (final NoSuchMethodException e) { // NOPMD - Swallow the exception
+        }
+        // search through all methods
+        Method bestMatch = null;
+        final Method[] methods = cls.getMethods();
+        for (final Method method : methods) {
+            // compare name and parameters
+            if (method.getName().equals(methodName) &&
+                    MemberUtils.isMatchingMethod(method, parameterTypes)) {
+                // get accessible version of method
+                final Method accessibleMethod = getAccessibleMethod(method);
+                if (accessibleMethod != null && (bestMatch == null || MemberUtils.compareMethodFit(
+                        accessibleMethod,
+                        bestMatch,
+                        parameterTypes) < 0)) {
+                    bestMatch = accessibleMethod;
+                }
+            }
+        }
+        if (bestMatch != null) {
+            MemberUtils.setAccessibleWorkaround(bestMatch);
+        }
+
+        if (bestMatch != null && bestMatch.isVarArgs() && bestMatch.getParameterTypes().length > 0 && parameterTypes.length > 0) {
+            final Class<?>[] methodParameterTypes = bestMatch.getParameterTypes();
+            final Class<?> methodParameterComponentType = methodParameterTypes[methodParameterTypes.length - 1].getComponentType();
+            final String methodParameterComponentTypeName = ClassUtils.primitiveToWrapper(methodParameterComponentType).getName();
+            final String parameterTypeName = parameterTypes[parameterTypes.length - 1].getName();
+            final String parameterTypeSuperClassName = parameterTypes[parameterTypes.length - 1].getSuperclass().getName();
+
+            if (!methodParameterComponentTypeName.equals(parameterTypeName)
+                    && !methodParameterComponentTypeName.equals(parameterTypeSuperClassName)) {
+                return null;
+            }
+        }
+
+        return bestMatch;
+    }
+
+}

--- a/framework/src/play/src/main/java/play/libs/reflect/MethodUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/MethodUtils.java
@@ -1,8 +1,4 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
- */
-
-/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/framework/src/play/src/main/java/play/libs/reflect/MethodUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/MethodUtils.java
@@ -1,4 +1,7 @@
 /*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/framework/src/play/src/main/java/play/libs/reflect/MethodUtils.java
+++ b/framework/src/play/src/main/java/play/libs/reflect/MethodUtils.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -5,10 +5,9 @@
 package play.api.http
 
 import javax.inject.{ Inject, Provider, Singleton }
-
 import com.typesafe.config.ConfigMemorySize
-import org.apache.commons.codec.digest.DigestUtils
 import play.api._
+import play.api.libs.Codecs
 import play.api.mvc.Cookie.SameSite
 import play.core.cookie.encoding.{ ClientCookieDecoder, ClientCookieEncoder, ServerCookieDecoder, ServerCookieEncoder }
 
@@ -259,7 +258,7 @@ object HttpConfiguration {
           // No application.conf?  Oh well, just use something hard coded.
           "she sells sea shells on the sea shore"
         )(_.toString)
-        val md5Secret = DigestUtils.md5Hex(secret)
+        val md5Secret = Codecs.md5(secret)
         logger.debug(s"Generated dev mode secret $md5Secret for app at ${appConfLocation.getOrElse("unknown location")}")
         md5Secret
       case Some(s) => s

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -5,10 +5,10 @@
 package play.api.inject
 
 import java.lang.reflect.Constructor
-import play.{ Environment => JavaEnvironment }
 
-import org.apache.commons.lang3.reflect.ConstructorUtils
+import play.{ Environment => JavaEnvironment }
 import play.api._
+import play.libs.reflect.ConstructorUtils
 
 import scala.annotation.varargs
 import scala.reflect.ClassTag

--- a/framework/src/play/src/main/scala/play/api/libs/Codecs.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Codecs.scala
@@ -4,13 +4,19 @@
 
 package play.api.libs
 
-import org.apache.commons.codec.digest.DigestUtils
-import org.apache.commons.codec.binary.Hex
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+import com.google.common.io.BaseEncoding
 
 /**
  * Utilities for Codecs operations.
  */
 object Codecs {
+
+  private def hexEncoder = BaseEncoding.base16.lowerCase
+  private def sha1MessageDigest = MessageDigest.getInstance("SHA-1")
+  private def md5MessageDigest = MessageDigest.getInstance("MD5")
 
   /**
    * Computes the SHA-1 digest for a byte array.
@@ -18,7 +24,7 @@ object Codecs {
    * @param bytes the data to hash
    * @return the SHA-1 digest, encoded as a hex string
    */
-  def sha1(bytes: Array[Byte]): String = DigestUtils.sha1Hex(bytes)
+  def sha1(bytes: Array[Byte]): String = toHexString(sha1MessageDigest.digest(bytes))
 
   /**
    * Computes the MD5 digest for a byte array.
@@ -26,28 +32,35 @@ object Codecs {
    * @param bytes the data to hash
    * @return the MD5 digest, encoded as a hex string
    */
-  def md5(bytes: Array[Byte]): String = DigestUtils.md5Hex(bytes)
+  def md5(bytes: Array[Byte]): String = toHexString(md5MessageDigest.digest(bytes))
+  /**
+   * Computes the MD5 digest for a String.
+   *
+   * @param text the data to hash
+   * @return the MD5 digest, encoded as a hex string
+   */
+  def md5(text: String): String = toHexString(md5MessageDigest.digest(text.getBytes(StandardCharsets.UTF_8)))
   /**
    * Compute the SHA-1 digest for a `String`.
    *
    * @param text the text to hash
    * @return the SHA-1 digest, encoded as a hex string
    */
-  def sha1(text: String): String = DigestUtils.sha1Hex(text)
+  def sha1(text: String): String = toHexString(sha1MessageDigest.digest(text.getBytes(StandardCharsets.UTF_8)))
 
   /**
    * Converts a byte array into an array of characters that denotes a hexadecimal representation.
    */
-  def toHex(array: Array[Byte]): Array[Char] = Hex.encodeHex(array)
+  def toHex(array: Array[Byte]): Array[Char] = toHexString(array).toCharArray
 
   /**
    * Converts a byte array into a `String` that denotes a hexadecimal representation.
    */
-  def toHexString(array: Array[Byte]): String = Hex.encodeHexString(array)
+  def toHexString(array: Array[Byte]): String = hexEncoder.encode(array)
 
   /**
    * Transform an hexadecimal String to a byte array.
    */
-  def hexStringToByte(hexString: String): Array[Byte] = Hex.decodeHex(hexString.toCharArray)
+  def hexStringToByte(hexString: String): Array[Byte] = hexEncoder.decode(hexString.toLowerCase)
 
 }

--- a/framework/src/play/src/main/scala/play/api/libs/Comet.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Comet.scala
@@ -7,7 +7,7 @@ package play.api.libs
 import akka.NotUsed
 import akka.stream.scaladsl.{ Flow, Source }
 import akka.util.{ ByteString, ByteStringBuilder }
-import org.apache.commons.lang3.StringEscapeUtils
+import play.twirl.api.utils.StringEscapeUtils
 import play.api.libs.json.{ JsValue, Json }
 import play.twirl.api._
 

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
@@ -7,9 +7,10 @@ package play.api.libs.crypto
 import java.nio.charset.StandardCharsets
 import java.security.{ MessageDigest, SecureRandom }
 import java.time.Clock
+
 import javax.inject.{ Inject, Provider, Singleton }
 
-import org.apache.commons.codec.binary.Hex
+import play.api.libs.Codecs
 
 /**
  * Cryptographic utilities for generating and validating CSRF tokens.
@@ -110,7 +111,7 @@ class DefaultCSRFTokenSigner @Inject() (signer: CookieSigner, clock: Clock) exte
   def generateToken: String = {
     val bytes = new Array[Byte](12)
     random.nextBytes(bytes)
-    new String(Hex.encodeHex(bytes))
+    Codecs.toHexString(bytes)
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
@@ -40,7 +40,7 @@ object JavaScriptReverseRouter {
   }
 
   def apply(name: String, ajaxMethod: Option[String], host: String, routes: JavaScriptReverseRoute*): JavaScript = JavaScript {
-    import org.apache.commons.lang3.StringEscapeUtils.{ escapeEcmaScript => esc }
+    import play.twirl.api.utils.StringEscapeUtils.{ escapeEcmaScript => esc }
     val ajaxField = ajaxMethod.fold("")(m => s"ajax:function(c){c=c||{};c.url=r.url;c.type=r.method;return $m(c)},")
     val routesStr = routes.map { route =>
       val nameParts = route.name.split('.')

--- a/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -8,11 +8,11 @@ import java.util.Optional
 import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
 import akka.stream.scaladsl.Flow
-import org.apache.commons.lang3.reflect.MethodUtils
 import play.api.http.ActionCompositionConfiguration
 import play.api.mvc._
 import play.api.routing.HandlerDef
 import play.core.j._
+import play.libs.reflect.MethodUtils
 import play.mvc.Http.{ Context, RequestBody }
 
 import scala.compat.java8.{ FutureConverters, OptionConverters }


### PR DESCRIPTION
currently play added a lot of "helper" libraries in the past,
however with recent JVM upgrades and more and more stuff inside
the JVM itself these got more and more unnecessary.

Actually this imports some Classes from apache commons lang3,
however only a really small subset of the library is imported.
The subset itself barly changed over the recent years and Play
mostly used just the reflect stuff of commons lang3

Edit:
actually I'm not against these libraries, I'm actually like them, however I think Play should use as few helper libraries as possible. It's easier for users to upgrade them without any breakage and it also reduces the Play footprint.

If people are ok with the PR I will still need to write docs.
