### PR TITLE
Remove set current app when allow global false

### DIFF
--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.execute.AsResult
 
-import play.api.Play.current
 import play.api.test._
 import play.api.mvc._
 import play.api.libs.json.Json

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaEhCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaEhCache.scala
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.execute.AsResult
 
-import play.api.Play.current
 import play.api.test._
 import play.api.mvc._
 import play.api.libs.json.Json

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -509,7 +509,10 @@ object BuildSettings {
       // Remove Server trait's deprecated getHandler method
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.Server.getHandlerFor"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.NettyServer.getHandlerFor"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.getHandlerFor")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.getHandlerFor"),
+
+      // Change signature of Play.privateMaybeApplication to return a Try[Application]
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.Play.privateMaybeApplication")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -66,16 +66,12 @@ object Play {
 
   /**
    * Returns the currently running application, or `null` if not defined.
-   *
-   * @deprecated This is a static reference to application, use DI, since 2.5.0
    */
   @deprecated("This is a static reference to application, use DI", "2.5.0")
   def unsafeApplication: Application = privateMaybeApplication.orNull
 
   /**
    * Optionally returns the current running application.
-   *
-   * @deprecated This is a static reference to application, use DI, since 2.5.0
    */
   @deprecated("This is a static reference to application, use DI instead", "2.5.0")
   def maybeApplication: Option[Application] = privateMaybeApplication
@@ -97,8 +93,6 @@ object Play {
    *
    * Note that by relying on this, your code will only work properly in
    * the context of a running application.
-   *
-   * @deprecated This is a static reference to application, use DI, since 2.5.0
    */
   @deprecated("This is a static reference to application, use DI instead", "2.5.0")
   implicit def current: Application = privateMaybeApplication.getOrElse(sys.error("There is no started application"))

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -79,18 +79,13 @@ object Play {
 
   private[play] def privateMaybeApplication: Try[Application] = {
     if (_currentApp != null) {
-      logger.warn(
-        """
-          |You are accessing the application using deprecated methods that exists only to access
-          |global state. If you need an instance of Application, use Dependency Injection.
-        """.stripMargin)
       Success(_currentApp)
     } else {
       Failure(sys.error(
         s"""
-           |The global application is disabled. Set $GlobalAppConfigKey to allow global state here.
-           |If $GlobalAppConfigKey is already configured to allow global state, then you need to start
-           |the application too.
+           |The global application reference is disabled. Play's global state is deprecated and will
+           |be removed in a future release. You should use dependency injection instead. To enable
+           |the global application anyway, set $GlobalAppConfigKey = true.
        """.stripMargin
       ))
 
@@ -138,6 +133,11 @@ object Play {
     // Set the current app if the global application is enabled
     // Also set it if the current app is null, in order to display more useful errors if we try to use the app
     if (globalApp) {
+      logger.warn(
+        s"""
+          |You are using the deprecated global state to set and access the current running application. If you
+          |need an instance of Application, set $GlobalAppConfigKey = false and use Dependency Injection instead.
+        """.stripMargin)
       _currentApp = app
     }
 

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -119,7 +119,7 @@ object Play {
     val globalApp = app.globalApplicationEnabled
 
     // Stop the current app if the new app needs to replace the current app instance
-    if (globalApp && _currentApp != null && _currentApp.globalApplicationEnabled) {
+    if (globalApp && _currentApp != null) {
       logger.info("Stopping current application")
       stop(_currentApp)
     }

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -5,7 +5,6 @@
 package play.api.http
 
 import javax.inject.{ Inject, Provider, Singleton }
-
 import com.typesafe.config.ConfigMemorySize
 import org.apache.commons.codec.digest.DigestUtils
 import play.api._
@@ -13,6 +12,7 @@ import play.api.mvc.Cookie.SameSite
 import play.core.cookie.encoding.{ ClientCookieDecoder, ClientCookieEncoder, ServerCookieDecoder, ServerCookieEncoder }
 
 import scala.concurrent.duration._
+import scala.util.{ Failure, Success }
 
 /**
  * HTTP related configuration of a Play application
@@ -273,7 +273,10 @@ object HttpConfiguration {
   /**
    * Don't use this - only exists for transition from global state
    */
-  private[play] def current = Play.privateMaybeApplication.fold(HttpConfiguration())(httpConfigurationCache)
+  private[play] def current: HttpConfiguration = Play.privateMaybeApplication match {
+    case Success(app) => httpConfigurationCache(app)
+    case Failure(_) => HttpConfiguration()
+  }
 
   /**
    * For calling from Java.

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -306,6 +306,7 @@ object DefaultHttpErrorHandler extends DefaultHttpErrorHandler(
 /**
  * A lazy HTTP error handler, that looks up the error handler from the current application
  */
+@deprecated("Access the global state. Inject a HttpErrorHandler instead", "2.7.0")
 object LazyHttpErrorHandler extends HttpErrorHandler {
 
   private def errorHandler = Play.privateMaybeApplication.fold[HttpErrorHandler](DefaultHttpErrorHandler)(_.errorHandler)

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -4,6 +4,8 @@
 
 package play.api.http
 
+import java.util.concurrent.CompletionStage
+
 import javax.inject._
 import play.api._
 import play.api.inject.Binding
@@ -18,6 +20,7 @@ import play.utils.{ PlayIO, Reflect }
 
 import scala.compat.java8.FutureConverters
 import scala.concurrent._
+import scala.util.{ Failure, Success }
 import scala.util.control.NonFatal
 
 /**
@@ -293,11 +296,11 @@ object DefaultHttpErrorHandler extends DefaultHttpErrorHandler(
     val conf = Configuration.load(Environment.simple())
     conf.getOptional[String]("play.editor") foreach setPlayEditor
   }
-  override def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
     setEditor
     super.onClientError(request, statusCode, message)
   }
-  override def onServerError(request: RequestHeader, exception: Throwable) = {
+  override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     setEditor
     super.onServerError(request, exception)
   }
@@ -309,12 +312,15 @@ object DefaultHttpErrorHandler extends DefaultHttpErrorHandler(
 @deprecated("Access the global state. Inject a HttpErrorHandler instead", "2.7.0")
 object LazyHttpErrorHandler extends HttpErrorHandler {
 
-  private def errorHandler = Play.privateMaybeApplication.fold[HttpErrorHandler](DefaultHttpErrorHandler)(_.errorHandler)
+  private def errorHandler: HttpErrorHandler = Play.privateMaybeApplication match {
+    case Success(app) => app.errorHandler
+    case Failure(_) => DefaultHttpErrorHandler
+  }
 
-  def onClientError(request: RequestHeader, statusCode: Int, message: String) =
+  def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] =
     errorHandler.onClientError(request, statusCode, message)
 
-  def onServerError(request: RequestHeader, exception: Throwable) =
+  def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
     errorHandler.onServerError(request, exception)
 }
 
@@ -325,9 +331,9 @@ object LazyHttpErrorHandler extends HttpErrorHandler {
 private[play] class JavaHttpErrorHandlerDelegate @Inject() (delegate: HttpErrorHandler) extends play.http.HttpErrorHandler {
   import play.core.Execution.Implicits.trampoline
 
-  def onClientError(request: Http.RequestHeader, statusCode: Int, message: String) =
+  def onClientError(request: Http.RequestHeader, statusCode: Int, message: String): CompletionStage[play.mvc.Result] =
     FutureConverters.toJava(delegate.onClientError(request.asScala(), statusCode, message).map(_.asJava))
 
-  def onServerError(request: Http.RequestHeader, exception: Throwable) =
+  def onServerError(request: Http.RequestHeader, exception: Throwable): CompletionStage[play.mvc.Result] =
     FutureConverters.toJava(delegate.onServerError(request.asScala(), exception).map(_.asJava))
 }

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -8,6 +8,7 @@ import play.api._
 import play.api.libs.crypto._
 
 // Keep Crypto around to manage global state for now...
+@deprecated("Access global state. Inject a CookieSigner instead", "2.7.0")
 private[play] object Crypto {
 
   private val cookieSignerCache: (Application) => CookieSigner = Application.instanceCache[CookieSigner]

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -7,17 +7,20 @@ package play.api.libs
 import play.api._
 import play.api.libs.crypto._
 
+import scala.util.{ Failure, Success }
+
 // Keep Crypto around to manage global state for now...
 @deprecated("Access global state. Inject a CookieSigner instead", "2.7.0")
 private[play] object Crypto {
 
-  private val cookieSignerCache: (Application) => CookieSigner = Application.instanceCache[CookieSigner]
+  private val cookieSignerCache: Application => CookieSigner = Application.instanceCache[CookieSigner]
 
   // Temporary placeholder until we can move out Session / Cookie singleton objects
   def cookieSigner: CookieSigner = {
-    Play.privateMaybeApplication.fold {
-      sys.error("The global cookie signer instance requires a running application!")
-    }(cookieSignerCache)
+    Play.privateMaybeApplication match {
+      case Success(app) => cookieSignerCache(app)
+      case Failure(cause) => throw new RuntimeException("The global cookie signer instance requires a running application.", cause)
+    }
   }
 
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -307,7 +307,7 @@ case class RawBuffer(memoryThreshold: Int, temporaryFileCreator: TemporaryFileCr
  */
 trait BodyParsers {
 
-  @inline private def maybeApp = Play.privateMaybeApplication
+  @inline private def maybeApp = Play.privateMaybeApplication.toOption
 
   private val hcCache = Application.instanceCache[HttpConfiguration]
   private lazy val mat: Materializer = ActorMaterializer()(ActorSystem("play-body-parsers"))

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -11,6 +11,7 @@ import play.api.mvc.Results._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.language.reflectiveCalls
+import scala.util.{ Failure, Success }
 
 /**
  * Helpers to create secure actions.
@@ -76,7 +77,7 @@ object Security {
    */
   @deprecated("Security.username is deprecated.", "2.6.0")
   lazy val username: String = {
-    Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String]("session.username")) match {
+    Play.privateMaybeApplication.toOption.flatMap(_.configuration.getOptional[String]("session.username")) match {
       case Some(usernameKey) =>
         logger.warn("The session.username configuration key is no longer supported.")
         logger.warn("Inject Configuration into your controller or component and call get[String](\"session.username\")")

--- a/framework/src/play/src/main/scala/play/core/Execution.scala
+++ b/framework/src/play/src/main/scala/play/core/Execution.scala
@@ -5,8 +5,11 @@
 package play.core
 
 import java.util.concurrent.ForkJoinPool
+
 import play.api.Play
+
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
+import scala.util.{ Failure, Success }
 
 /**
  * Provides access to Play's internal ExecutionContext.
@@ -14,14 +17,13 @@ import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 private[play] object Execution {
 
   /**
-   * @deprecated Use the application execution context.
    * @return the actorsystem's execution context
    */
   @deprecated("Use an injected execution context", "2.6.0")
   def internalContext: ExecutionContextExecutor = {
     Play.privateMaybeApplication match {
-      case None => common
-      case Some(app) => app.actorSystem.dispatcher
+      case Success(app) => app.actorSystem.dispatcher
+      case Failure(_) => common
     }
   }
 

--- a/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
@@ -17,7 +17,7 @@ class PlayGlobalAppSpec extends Specification {
     "start apps with global state enabled" in {
       val app = testApp(true)
       Play.start(app)
-      Play.privateMaybeApplication must beSome(app)
+      Play.privateMaybeApplication must beSuccessfulTry.withValue(app)
       Play.stop(app)
       success
     }
@@ -35,7 +35,7 @@ class PlayGlobalAppSpec extends Specification {
       Play.start(app2)
       app1.isTerminated must beTrue
       app2.isTerminated must beFalse
-      Play.privateMaybeApplication must beSome(app2)
+      Play.privateMaybeApplication must beSuccessfulTry.withValue(app2)
       Play.current must_== app2
       Play.stop(app1)
       Play.stop(app2)
@@ -48,7 +48,7 @@ class PlayGlobalAppSpec extends Specification {
       Play.start(app2)
       app1.isTerminated must beFalse
       app2.isTerminated must beFalse
-      Play.privateMaybeApplication must beSome(app2)
+      Play.privateMaybeApplication must beSuccessfulTry.withValue(app2)
       Play.stop(app1)
       Play.stop(app2)
       success
@@ -60,7 +60,7 @@ class PlayGlobalAppSpec extends Specification {
       Play.start(app2)
       app1.isTerminated must beFalse
       app2.isTerminated must beFalse
-      Play.privateMaybeApplication must beSome(app1)
+      Play.privateMaybeApplication must beSuccessfulTry.withValue(app1)
       Play.stop(app1)
       Play.stop(app2)
       success

--- a/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
@@ -77,5 +77,22 @@ class PlayGlobalAppSpec extends Specification {
       Play.stop(app2)
       success
     }
+    "should stop an app with global state disabled" in {
+      val app = testApp(false)
+      Play.start(app)
+      Play.privateMaybeApplication must throwA[RuntimeException]
+
+      Play.stop(app)
+      app.isTerminated must beTrue
+    }
+    "should unset current app when stopping with global state enabled" in {
+      val app = testApp(true)
+      Play.start(app)
+      Play.privateMaybeApplication must beSuccessfulTry.withValue(app)
+
+      Play.stop(app)
+      app.isTerminated must beTrue
+      Play.privateMaybeApplication must throwA[RuntimeException]
+    }
   }
 }


### PR DESCRIPTION
## Purpose

The current app was still being initialized even with the global state disabled. This removes that and adds some more warnings to instruct users to move away from `Play.current` and similars.

## Background Context

See discussion in our Gitter channel: https://gitter.im/playframework/contributors?at=5b106c1d52e35117cdf94838

## References

This can be considered a follow up of #8183.