### PR TITLE
Update made to the reports path

### DIFF
--- a/documentation/manual/working/commonGuide/build/SBTDebugging.md
+++ b/documentation/manual/working/commonGuide/build/SBTDebugging.md
@@ -9,7 +9,7 @@ By default, sbt generates reports of all your dependencies, including dependency
 
 The reports are generated into xml files, with an accompanying XSL stylesheet that allow browsers that support XSL to convert the XML reports into HTML.  Browsers with this support include Firefox and Safari, and notably don't include Chrome.
 
-The reports can be found in the `target/resolution-cache/reports` directory of your project, one is generated for each scope in your project, and are named `organization-projectId_scalaVersion-scope.xml`, for example, `com.example-my-first-app_2.11-compile.xml`.  When opened in Firefox, this report looks something like this:
+The reports can be found in the `target/scala-2.12/resolution-cache/reports/` directory of your project, one is generated for each scope in your project, and are named `organization-projectId_scalaVersion-scope.xml`, for example, `com.example-my-first-app_2.11-compile.xml`.  When opened in Firefox, this report looks something like this:
 
 [[images/ivy-report.png]]
 


### PR DESCRIPTION
This page https://www.playframework.com/documentation/2.6.x/SBTDebugging appears to have some out of date / incorrect information on it. For example it says

The reports can be found in the target/resolution-cache/reports directory

but they are actually located in target/scala-2.12/resolution-cache/reports/