### PR TITLE
Update play-ws to version 2.0.0-M2

### DIFF
--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -68,3 +68,26 @@ The CSP filter uses Google's [Strict CSP policy](https://csp.withgoogle.com/docs
 ## HikariCP upgraded
 
 [HikariCP](https://github.com/brettwooldridge/HikariCP) was updated to its latest major version. Have a look at the [[Migration Guide|Migration27#HikariCP]] to see what changed.
+
+## Play WS `curl` filter for Java
+
+Play WS enables you to create `play.libs.ws.WSRequestFilter` to inspect or enrich the requests made. Play provides a "log as `curl`" filter, but this was lacking for Java developers. You can now write something like:
+
+```java
+ws.url("https://www.playframework.com")
+  .setRequestFilter(new AhcCurlRequestLogger())
+  .addHeader("My-Header", "Header value")
+  .get();
+```
+
+And then the following log will be printed:
+
+```
+curl \
+  --verbose \
+  --request GET \
+  --header 'My-Header: Header Value' \\
+  'https://www.playframework.com'
+```
+
+This can be specially useful if you want to reproduce the request in isolation and also change `curl` parameters to see how it goes.

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -3,20 +3,20 @@
 
 This is a guide for migrating from Play 2.6 to Play 2.7. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.6 Migration Guide|Migration26]].
 
-### `play.allowGlobalApplication` defaults to `false`
+## `play.allowGlobalApplication` defaults to `false`
 
 `play.allowGlobalApplication = false` is set by default in Play 2.7.0. This means `Play.current` will throw an exception when called. You can set this to `true` to make `Play.current` and other deprecated static helpers work again, but be aware that this feature will be removed in future versions.
 
 In the future, if you still need to use static instances of application components, you can use [static injection](https://github.com/google/guice/wiki/Injections#static-injections) to inject them using Guice, or manually set static fields on startup in your application loader. These approaches should be forward compatible with future versions of Play, as long as you are careful never to run apps concurrently (e.g. in tests).
 
-### Guice compatibility changes
+## Guice compatibility changes
 
 Guice was upgraded to version [4.2.0](https://github.com/google/guice/wiki/Guice42), which causes the following breaking changes:
 
  - `play.test.TestBrowser.waitUntil` expects a `java.util.function.Function` instead of a `com.google.common.base.Function` now.
  - In Scala, when overriding the `configure()` method of `AbstractModule`, you need to prefix that method with the `override` identifier now (because it's non-abstract now).
 
-### `play.Logger` deprecated
+## `play.Logger` deprecated
 
 `play.Logger` has been deprecated in favor of using SLF4J directly. You can create an SLF4J logger with `private static final Logger logger = LoggerFactory.getLogger(YourClass.class);`. If you'd like a more concise solution, you may also consider [Project Lombok's `@Slf4j` annotation](https://projectlombok.org/features/log).
 
@@ -28,11 +28,11 @@ Each logger should have a unique name matching the name of the class it is in. I
 
     <logger name="play" level="INFO" />
 
-### Evolutions comment syntax changes
+## Evolutions comment syntax changes
 
 Play Evolutions now properly supports SQL92 comment syntax. This means you can write evolutions using `--` at the beginning of a line instead of `#` wherever you choose. Newly generated evolutions using the Evolutions API will now also use SQL92-style comment syntax in all areas. Documentation has also been updated accordingly to prefer the SQL92 style, though the older comment style is still fully supported.
 
-### StaticRoutesGenerator removed
+## StaticRoutesGenerator removed
 
 The `StaticRoutesGenerator`, which was deprecated in 2.6.0, has been removed. If you are still using it, you will likely have to remove a line like this so your build compiles:
 
@@ -49,17 +49,54 @@ If you were using the `StaticRoutesGenerator` with dependency-injected controlle
 
 `application/javascript` is now the default content-type returned for JavaScript instead of `text/javascript`. For generated `<script>` tags, we are now also omitting the `type` attribute. See more details about omitting `type` attribute at the [HTML 5 specification](https://www.w3.org/TR/html51/semantics-scripting.html#element-attrdef-script-type).  
 
-### `Router#withPrefix` should always add prefix
+## `Router#withPrefix` should always add prefix
 
 Previously, `router.withPrefix(prefix)` was meant to add a prefix to a router, but still allowed "legacy implementations" to update their existing prefix. Play's `SimpleRouter` and other classes followed this behavior. Now all implementations have been updated to add the prefix, so `router.withPrefix(prefix)` should always return a router that routes `s"$prefix/$path"` the same way `router` routes `path`.
 
 By default routers are unprefixed, so this will only cause a change in behavior if you are calling `withPrefix` on a router that has already been returned by `withPrefix`. To replace a prefix that has already been set on a router, you must call `withPrefix` on the original unprefixed router rather than the prefixed version.
 
-### HikariCP
+## Play WS Updates
+
+In Play 2.6, we extracted most of Play-WS into a [standalone project](https://github.com/playframework/play-ws) that has an independent release cycle. This project now has a major release that requires some changes in Play itself.
+
+### Scala API
+
+1. `play.api.libs.ws.WSRequest.requestTimeout` now returns an `Option[Duration]` instead of an `Option[Int]`.
+
+### Java API:
+
+1. `play.libs.ws.WSRequest.getUsername` now returns an `Optional<String>` instead of a `String`.
+1. `play.libs.ws.WSRequest.getContentType` now returns an `Optional<String>` instead of a `String`.
+1. `play.libs.ws.WSRequest.getPassword` now returns an `Optional<String>` instead of a `String`.
+1. `play.libs.ws.WSRequest.getScheme` now returns an `Optional<WSScheme` instead of a `WSScheme`.
+1. `play.libs.ws.WSRequest.getCalculator` now returns an `Optional<WSSignatureCalculator>` instead of a `WSSignatureCalculator`.
+1. `play.libs.ws.WSRequest.getRequestTimeout` now returns an `Optional<Duration>` instead of a `long`.
+1. `play.libs.ws.WSRequest.getRequestTimeoutDuration` was removed in favor of using `play.libs.ws.WSRequest.getRequestTimeout`.
+1. `play.libs.ws.WSRequest.getFollowRedirects` now returns an `Optional<Boolean>` instead of a `boolean`.
+
+Some new methods were added to improve the Java API too:
+
+New method `play.libs.ws.WSResponse.getBodyAsSource` converts a response body into `Source<ByteString, ?>`. For example:
+
+```java
+wsClient.url("https://www.playframework.com")
+    .stream() // this returns a CompletionStage<StandaloneWSResponse>
+    .thenApply(StandaloneWSResponse::getBodyAsSource);
+```
+
+Other methods that were added to improve Java API:
+
+1. `play.libs.ws.WSRequest.getBody` returns the body configured for that request. It can be useful when implementing `play.libs.ws.WSRequestFilter`
+1. `play.libs.ws.WSRequest.getMethod` returns the method configured for that request.
+1. `play.libs.ws.WSRequest.getAuth` returns the `WSAuth`.
+1. `play.libs.ws.WSRequest.setAuth` sets the `WSAuth` for that request.
+1. `play.libs.ws.WSResponse.getUri` gets the `URI` for that response. 
+
+## HikariCP update and new configuration
 
 HikariCP was updated to the latest version which finally removed the configuration `initializationFailFast` which was replaced by `initializationFailTimeout`. See [HikariCP changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) and [documentation for `initializationFailTimeout`](https://github.com/brettwooldridge/HikariCP#infrequently-used) to better understand how to use this configuration.
 
-### BoneCP removed
+## BoneCP removed
 
 BoneCP is removed. If your application is configured to use BoneCP, you need to switch to [HikariCP](http://brettwooldridge.github.io/HikariCP/) which is the default JDBC connection pool.
 
@@ -83,20 +120,20 @@ Also, you can use your own pool that implements `play.api.db.ConnectionPool` by 
 play.db.pool=your.own.ConnectionPool
 ```
 
-### Java `Http.Context` changed
+## Java `Http.Context` changed
 
 Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]] in Play 2.6, have finally been removed in Play 2.7.
 Therefore the `args` map of a `Http.Context` instance no longer contains these removed request tags as well.
 Instead you can use the `contextObj.request().attrs()` method now, which provides you the equivalent request attributes.
 
-### All Java form `validate` methods need to be migrated to class-level constraints
+## All Java form `validate` methods need to be migrated to class-level constraints
 
 The "old" `validate` methods of a Java form will not be executed anymore.
 Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]] you have to migrate such `validate` methods to [[class-level constraints|JavaForms#advanced-validation]].
 
 > **Important**: When upgrading to Play 2.7 you will not see any compiler warnings indicating that you have to migrate your `validate` methods (because Play executed them via reflection).
 
-### SecurityHeadersFilter's contentSecurityPolicy deprecated for CSPFilter
+## SecurityHeadersFilter's contentSecurityPolicy deprecated for CSPFilter
 
 The [[SecurityHeaders filter|SecurityHeaders]] has a `contentSecurityPolicy` property: this is deprecated in 2.7.0.  `contentSecurityPolicy` has been changed from `default-src 'self'` to `null` -- the default setting of `null` means that a `Content-Security-Policy` header will not be added to HTTP responses from the SecurityHeaders filter.  Please use the new [[CSPFilter]] to enable CSP functionality.
 
@@ -112,7 +149,7 @@ play.filters.enabled += play.filters.csp.CSPFilter
 
 Please see the documentation in [[CSPFilter]] for more information.
 
-### play.mvc.Results.TODO moved to play.mvc.Controller.TODO
+## play.mvc.Results.TODO moved to play.mvc.Controller.TODO
 
 All Play's error pages have been updated to render a CSP nonce if the [[CSP filter|CSPFilter]] is present.  This means that the error page templates must take a request as a parameter.  In 2.6.x, the `TODO` field was previously rendered as a static result instead of an action with an HTTP context, and so may have been called outside the controller.  In 2.7.0, the `TODO` field has been removed, and there is now a `TODO()` method in `play.mvc.Controller` instead:
 
@@ -125,12 +162,11 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 }
 ```
 
-
-### Removed libraries
+## Removed libraries
 
 In order to make the default play distribution a bit smaller we removed some libraries. The following libraries are no longer dependencies in Play 2.7, so you will need to manually add them to your build if you use them.
 
-#### Apache Commons (`commons-lang3` and `commons-codec`)
+### Apache Commons (`commons-lang3` and `commons-codec`)
 
 Play had some internal uses of `commons-codec` and `commons-lang3` if you used it in your project you need to add it to your `build.sbt`:
 
@@ -144,14 +180,14 @@ or:
 libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.6"
 ```
 
-### `Guava` version updated to 25.1-jre
+## `Guava` version updated to 25.1-jre
 
 Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 25.1-jre. Lots of changes were made in library, you can see the full changelog [here](https://github.com/google/guava/releases).
 
-### Internal changes
+## Internal changes
 
 Many changes have been made to Play's internal APIs. These APIs are used internally and don't follow a normal deprecation process. Changes may be mentioned below to help those who integrate directly with Play internal APIs.
 
-#### `Server.getHandlerFor` has moved to `Server#getHandlerFor`
+### `Server.getHandlerFor` has moved to `Server#getHandlerFor`
 
 The `getHandlerFor` method on the `Server` trait was used internally by the Play server code when routing requests. It has been removed and replaced with a method of the same name on the `Server` object.

--- a/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/JavaCache.java
+++ b/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/JavaCache.java
@@ -106,7 +106,7 @@ public class JavaCache extends WithApplication {
 
         assertThat(contentAsString(call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)), equalTo("Hello world"));
         assertThat(cache.sync().get("homePage"), notNullValue());
-        cache.set("homePage", Results.ok("something else"));
+        cache.sync().set("homePage", Results.ok("something else"));
         assertThat(contentAsString(call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)), equalTo("something else"));
     }
 

--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -140,9 +140,23 @@ The `largeImage` in the code snippet above is a `Source<ByteString, ?>`.
 
 ### Request Filters
 
-You can do additional processing on a [`WSRequest`](api/java/play/libs/ws/WSRequest.html) by adding a request filter.  A request filter is added by extending the `play.libs.ws.WSRequestFilter` trait, and then adding it to the request with [`request.withRequestFilter(filter)`](api/java/play/libs/ws/WSRequest.html#setRequestFilter-play.libs.ws.WSRequestFilter-).
+You can do additional processing on a [`WSRequest`](api/java/play/libs/ws/WSRequest.html) by adding a request filter.  A request filter is added by extending the `play.libs.ws.WSRequestFilter` interface, and then adding it to the request with [`request.setRequestFilter(filter)`](api/java/play/libs/ws/WSRequest.html#setRequestFilter-play.libs.ws.WSRequestFilter-).
 
 @[ws-request-filter](code/javaguide/ws/JavaWS.java)
+
+A sample request filter that logs the request in [cURL](https://curl.haxx.se/) format to SLF4J has been added in `play.libs.ws.ahc.AhcCurlRequestLogger`.
+
+@[curl-logger-filter](code/javaguide/ws/JavaWS.java)
+
+will output:
+
+```
+curl \
+  --verbose \
+  --request GET \
+  --header 'Header-Key: Header value' \
+  'https://www.playframework.com'
+```
 
 ## Processing the Response
 

--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -146,7 +146,7 @@ You can do additional processing on a [`WSRequest`](api/java/play/libs/ws/WSRequ
 
 A sample request filter that logs the request in [cURL](https://curl.haxx.se/) format to SLF4J has been added in `play.libs.ws.ahc.AhcCurlRequestLogger`.
 
-@[curl-logger-filter](code/javaguide/ws/JavaWS.java)
+@[ws-curl-logger-filter](code/javaguide/ws/JavaWS.java)
 
 will output:
 

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -28,6 +28,7 @@ import play.libs.Json;
 // #json-imports
 
 // #multipart-imports
+import play.libs.ws.ahc.AhcCurlRequestLogger;
 import play.mvc.Http.MultipartFormData.*;
 // #multipart-imports
 
@@ -155,6 +156,13 @@ public class JavaWS {
             // #ws-stream-request
             CompletionStage<WSResponse> wsResponse = ws.url(url).setBody(body(largeImage)).execute("PUT");
             // #ws-stream-request
+
+            // #ws-curl-logger-filter
+            ws.url("https://www.playframework.com")
+              .setRequestFilter(new AhcCurlRequestLogger())
+              .addHeader("Header-Name", "Header value")
+              .get();
+            // #ws-curl-logger-filter
         }
 
         public void responseExamples() {

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -33,6 +33,7 @@ import play.mvc.Http.MultipartFormData.*;
 // #multipart-imports
 
 import java.io.*;
+import java.nio.file.*;
 import java.util.Optional;
 import java.util.stream.*;
 
@@ -141,7 +142,7 @@ public class JavaWS {
             // #ws-post-multipart
 
             // #ws-post-multipart2
-            Source<ByteString, ?> file = FileIO.fromFile(new File("hello.txt"));
+            Source<ByteString, ?> file = FileIO.fromPath(Paths.get("hello.txt"));
             FilePart<Source<ByteString, ?>> fp = new FilePart<>("hello", "hello.txt", "text/plain", file);
             DataPart dp = new DataPart("key", "value");
 

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -513,8 +513,27 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.getHandlerFor"),
 
       // Change signature of Play.privateMaybeApplication to return a Try[Application]
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.Play.privateMaybeApplication")
-    ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.Play.privateMaybeApplication"),
+
+      // Update Play WS to version 2.0.0
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.WSRequest.getRequestTimeoutDuration"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.WSRequest.getRequestTimeout"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.WSRequest.getFollowRedirects"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.WSRequest.getPassword"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.WSRequest.getCalculator"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.WSRequest.getUsername"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.WSRequest.getScheme"),
+      // Updates Play WS to version 2.0.0 has impact on AHC implementation
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.AhcWSRequest.getRequestTimeoutDuration"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.AhcWSRequest.asCookie"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.AhcWSRequest.getPassword"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.AhcWSRequest.getUsername"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.AhcWSRequest.getScheme"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.ahc.AhcWSRequest.getRequestTimeout"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.ahc.AhcWSRequest.getCalculator"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.ahc.AhcWSRequest.getContentType"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.ws.ahc.AhcWSRequest.getFollowRedirects")
+  ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"
     },

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -284,7 +284,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache" % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.0.0-M1"
+  val playWsStandaloneVersion = "2.0.0-M2"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-xml" % playWsStandaloneVersion,

--- a/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -8,17 +8,7 @@ import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.w3c.dom.Document;
-import play.libs.ws.BodyWritable;
-import play.libs.ws.DefaultWSCookie;
-import play.libs.ws.StandaloneWSRequest;
-import play.libs.ws.StandaloneWSResponse;
-import play.libs.ws.WSAuthScheme;
-import play.libs.ws.WSBodyWritables;
-import play.libs.ws.WSCookie;
-import play.libs.ws.WSRequest;
-import play.libs.ws.WSRequestFilter;
-import play.libs.ws.WSResponse;
-import play.libs.ws.WSSignatureCalculator;
+import play.libs.ws.*;
 import play.mvc.Http;
 
 import java.io.File;
@@ -282,11 +272,11 @@ public class AhcWSRequest implements WSRequest {
         return converter.apply(request.addCookie(asCookie(cookie)));
     }
 
-    public WSCookie asCookie(Http.Cookie cookie) {
+    private WSCookie asCookie(Http.Cookie cookie) {
         return new DefaultWSCookie(cookie.name(), cookie.value(),
                 cookie.domain(),
                 cookie.path(),
-                Optional.ofNullable(cookie.maxAge()).map(c -> c.longValue()).filter(f -> f > -1L).orElse(null),
+                Optional.ofNullable(cookie.maxAge()).map(Integer::longValue).filter(f -> f > -1L).orElse(null),
                 cookie.secure(),
                 cookie.httpOnly());
     }
@@ -314,6 +304,11 @@ public class AhcWSRequest implements WSRequest {
     @Override
     public WSRequest setAuth(String username, String password, WSAuthScheme scheme) {
         return converter.apply(request.setAuth(username, password, scheme));
+    }
+
+    @Override
+    public StandaloneWSRequest setAuth(WSAuthInfo authInfo) {
+        return converter.apply(request.setAuth(authInfo));
     }
 
     @Override
@@ -363,6 +358,31 @@ public class AhcWSRequest implements WSRequest {
     }
 
     @Override
+    public Optional<WSAuthInfo> getAuth() {
+        return request.getAuth();
+    }
+
+    @Override
+    public Optional<BodyWritable> getBody() {
+        return request.getBody();
+    }
+
+    @Override
+    public Optional<WSSignatureCalculator> getCalculator() {
+        return request.getCalculator();
+    }
+
+    @Override
+    public Optional<String> getContentType() {
+        return request.getContentType();
+    }
+
+    @Override
+    public Optional<Boolean> getFollowRedirects() {
+        return request.getFollowRedirects();
+    }
+
+    @Override
     public String getUrl() {
         return request.getUrl();
     }
@@ -383,51 +403,13 @@ public class AhcWSRequest implements WSRequest {
     }
 
     @Override
+    public Optional<Duration> getRequestTimeout() {
+        return request.getRequestTimeout();
+    }
+
+    @Override
     public Map<String, List<String>> getQueryParameters() {
         return request.getQueryParameters();
-    }
-
-    @Override
-    public String getUsername() {
-        return request.getUsername();
-    }
-
-    @Override
-    public String getPassword() {
-        return request.getPassword();
-    }
-
-    @Override
-    public WSAuthScheme getScheme() {
-        return request.getScheme();
-    }
-
-    @Override
-    public WSSignatureCalculator getCalculator() {
-        return request.getCalculator();
-    }
-
-    /**
-     * @deprecated use {@link #getRequestTimeoutDuration()}
-     */
-    @Deprecated
-    public long getRequestTimeout() {
-        return request.getRequestTimeoutDuration().get(ChronoUnit.MILLIS);
-    }
-
-    @Override
-    public Duration getRequestTimeoutDuration() {
-        return request.getRequestTimeoutDuration();
-    }
-
-    @Override
-    public boolean getFollowRedirects() {
-        return request.getFollowRedirects();
-    }
-
-    @Override
-    public String getContentType() {
-        return request.getContentType();
     }
 
 }

--- a/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSResponse.java
+++ b/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSResponse.java
@@ -11,6 +11,7 @@ import org.w3c.dom.Document;
 import play.libs.ws.*;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -90,6 +91,11 @@ public class AhcWSResponse implements WSResponse {
     @Override
     public String getBody() {
         return underlying.getBody();
+    }
+
+    @Override
+    public URI getUri() {
+        return underlying.getUri();
     }
 
     /**

--- a/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
+++ b/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
@@ -74,7 +74,7 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
   /**
    * The timeout for the request
    */
-  override def requestTimeout: Option[Int] = underlying.requestTimeout
+  override def requestTimeout: Option[Duration] = underlying.requestTimeout
 
   /**
    * The virtual host this request will use

--- a/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSResponse.scala
+++ b/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSResponse.scala
@@ -4,6 +4,8 @@
 
 package play.api.libs.ws.ahc
 
+import java.net.URI
+
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.shaded.ahc.org.asynchttpclient.{ Response => AHCResponse }
@@ -63,6 +65,8 @@ case class AhcWSResponse(underlying: StandaloneWSResponse) extends WSResponse wi
   override def cookie(name: String): Option[WSCookie] = underlying.cookie(name)
 
   override def body: String = underlying.body
+
+  override def uri: URI = underlying.uri
 
   /**
    * The response body as a byte string.

--- a/framework/src/play-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -15,7 +15,6 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -564,56 +563,4 @@ public interface WSRequest extends StandaloneWSRequest {
      */
     @Override
     Map<String, List<String>> getQueryParameters();
-
-    /**
-     * @return the auth username, null if not an authenticated request.
-     */
-    @Override
-    String getUsername();
-
-    /**
-     * @return the auth password, null if not an authenticated request
-     */
-    @Override
-    String getPassword();
-
-    /**
-     * @return the auth scheme, null if not an authenticated request.
-     */
-    @Override
-    WSAuthScheme getScheme();
-
-    /**
-     * @return the signature calculator (example: OAuth), null if none is set.
-     */
-    @Override
-    WSSignatureCalculator getCalculator();
-
-    /**
-     * Gets the original request timeout.
-     *
-     * @deprecated use {@link #getRequestTimeoutDuration()}
-     * @return the timeout
-     */
-    @Override
-    @Deprecated
-    Duration getRequestTimeoutDuration();
-
-    /**
-     * Gets the original request timeout in milliseconds, passed into the
-     * request as input.
-     *
-     * @deprecated use {@link #getRequestTimeoutDuration()}
-     * @return the timeout
-     */
-    @Deprecated
-    long getRequestTimeout();
-
-    /**
-     * If the {@link #setFollowRedirects(boolean)} method has been called, then returns true.
-     *
-     * @return true if the request is configured to follow redirect, false otherwise.
-     */
-    @Override
-    boolean getFollowRedirects();
 }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
@@ -135,7 +135,7 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
   /**
    * The timeout for the request
    */
-  override def requestTimeout: Option[Int]
+  override def requestTimeout: Option[Duration]
 
   /**
    * The virtual host this request will use


### PR DESCRIPTION
## Purpose

Update the version of standalone ws to 2.0.0-M2.

This version has some breaking changes that were documented in our migration guide. Most of them just involve changing return types to use Optional or Duration.