### PR TITLE
Update Twirl to version 1.4.0-M2

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -46,7 +46,8 @@ If you were using the `StaticRoutesGenerator` with dependency-injected controlle
 
 
 ### `application/javascript` as default content type for JavaScript
-`application/javascript` is now the default content-type returned for JavaScript instead of `text/javascript`.
+
+`application/javascript` is now the default content-type returned for JavaScript instead of `text/javascript`. For generated `<script>` tags, we are now also omitting the `type` attribute. See more details about omitting `type` attribute at the [HTML 5 specification](https://www.w3.org/TR/html51/semantics-scripting.html#element-attrdef-script-type).  
 
 ### `Router#withPrefix` should always add prefix
 

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/controllers/Application.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/controllers/Application.java
@@ -5,6 +5,7 @@
 package javaguide.binder.controllers;
 
 //#javascript-router-resource-imports
+import play.mvc.Http;
 import play.routing.JavaScriptReverseRouter;
 import play.mvc.Controller;
 import play.mvc.Result;
@@ -19,7 +20,7 @@ public class Application extends Controller {
                 routes.javascript.Users.list(),
                 routes.javascript.Users.get()
             )
-        ).as("text/javascript");
+        ).as(Http.MimeTypes.JAVASCRIPT);
     }
     //#javascript-router-resource
 
@@ -31,6 +32,6 @@ public class Application extends Controller {
                 routes.javascript.Users.get()
             )
             //#javascript-router-resource-custom-method
-        ).as("text/javascript");
+        ).as(Http.MimeTypes.JAVASCRIPT);
     }
 }

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaComet.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaComet.java
@@ -63,15 +63,15 @@ public class JavaComet extends WithApplication {
     @Test
     public void foreverIframe() {
         String content = contentAsString(MockJavaActionHelper.call(new Controller1(app.injector().instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat), mat);
-        assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('kiki');</script>"));
-        assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('foo');</script>"));
-        assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('bar');</script>"));
+        assertThat(content, containsString("<script>parent.cometMessage('kiki');</script>"));
+        assertThat(content, containsString("<script>parent.cometMessage('foo');</script>"));
+        assertThat(content, containsString("<script>parent.cometMessage('bar');</script>"));
     }
 
     @Test
     public void foreverIframeWithJson() {
         String content = contentAsString(MockJavaActionHelper.call(new Controller2(app.injector().instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat), mat);
-        assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage({\"foo\":\"bar\"});</script>"));
+        assertThat(content, containsString("<script>parent.cometMessage({\"foo\":\"bar\"});</script>"));
     }
 
 }

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/Users.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/Users.scala
@@ -6,7 +6,7 @@ package scalaguide.binder.controllers
 
 //#javascript-router-resource-imports
 import javax.inject.Inject
-
+import play.api.http.MimeTypes
 import play.api.mvc._
 import play.api.routing._
 //#javascript-router-resource-imports
@@ -19,7 +19,7 @@ class Application @Inject()(components: ControllerComponents) extends AbstractCo
                 routes.javascript.Users.list,
                 routes.javascript.Users.get
             )
-        ).as("text/javascript")
+        ).as(MimeTypes.JAVASCRIPT)
     }
     //#javascript-router-resource
 
@@ -31,7 +31,7 @@ class Application @Inject()(components: ControllerComponents) extends AbstractCo
                 routes.javascript.Users.get
             )
             //#javascript-router-resource-custom-method
-        ).as("text/javascript")
+        ).as(MimeTypes.JAVASCRIPT)
     }
     
 }

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
@@ -43,7 +43,7 @@ class ScalaCometSpec extends PlaySpecification {
         val controllerComponents = inject[ControllerComponents]
         val controller = new MockController(controllerComponents)
         val result = controller.cometString.apply(FakeRequest())
-        contentAsString(result) must contain("<html><body><script type=\"text/javascript\">parent.cometMessage('kiki');</script><script type=\"text/javascript\">parent.cometMessage('foo');</script><script type=\"text/javascript\">parent.cometMessage('bar');</script>")
+        contentAsString(result) must contain("<html><body><script>parent.cometMessage('kiki');</script><script>parent.cometMessage('foo');</script><script>parent.cometMessage('bar');</script>")
       } finally {
         app.stop()
       }
@@ -54,7 +54,7 @@ class ScalaCometSpec extends PlaySpecification {
         val controllerComponents = inject[ControllerComponents]
         val controller = new MockController(controllerComponents)
         val result = controller.cometJson.apply(FakeRequest())
-        contentAsString(result) must contain("<html><body><script type=\"text/javascript\">parent.cometMessage(\"jsonString\");</script>")
+        contentAsString(result) must contain("<html><body><script>parent.cometMessage(\"jsonString\");</script>")
       } finally {
         app.stop()
       }

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -13,7 +13,7 @@ val Versions = new {
   val sbtDoge = "0.1.5"
   val webjarsLocatorCore = "0.33"
   val sbtHeader = "5.0.0"
-  val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.3.15")
+  val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.4.0-M2")
   val interplay: String = sys.props.getOrElse("interplay.version", "2.0.1")
 }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -297,7 +297,7 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
     }) { response =>
       response.header(TRANSFER_ENCODING) must beSome("chunked")
       response.header(CONTENT_LENGTH) must beNone
-      response.body must contain("<html><body><script type=\"text/javascript\">callback('a');</script><script type=\"text/javascript\">callback('b');</script><script type=\"text/javascript\">callback('c');</script>")
+      response.body must contain("<html><body><script>callback('a');</script><script>callback('b');</script><script>callback('c');</script>")
     }
 
     "chunk comet results from json" in makeRequest(new MockController {
@@ -311,7 +311,7 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
     }) { response =>
       response.header(TRANSFER_ENCODING) must beSome("chunked")
       response.header(CONTENT_LENGTH) must beNone
-      response.body must contain("<html><body><script type=\"text/javascript\">callback({\"foo\":\"bar\"});</script>")
+      response.body must contain("<html><body><script>callback({\"foo\":\"bar\"});</script>")
     }
 
     "chunk event source results" in makeRequest(new MockController {

--- a/framework/src/play-java/src/main/java/play/libs/Comet.java
+++ b/framework/src/play-java/src/main/java/play/libs/Comet.java
@@ -84,7 +84,7 @@ public abstract class Comet {
 
     private static ByteString formatted(ByteString callbackName, ByteString javascriptMessage) {
         ByteStringBuilder b = new ByteStringBuilder();
-        b.append(ByteString.fromString("<script type=\"text/javascript\">"));
+        b.append(ByteString.fromString("<script>"));
         b.append(callbackName);
         b.append(ByteString.fromString("("));
         b.append(javascriptMessage);

--- a/framework/src/play/src/main/scala/play/api/libs/Comet.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Comet.scala
@@ -82,7 +82,7 @@ object Comet {
 
   private def formatted(callbackName: ByteString, javascriptMessage: ByteString): ByteString = {
     val b: ByteStringBuilder = new ByteStringBuilder
-    b.append(ByteString.fromString("""<script type="text/javascript">"""))
+    b.append(ByteString.fromString("""<script>"""))
     b.append(callbackName)
     b.append(ByteString.fromString("("))
     b.append(javascriptMessage)
@@ -99,7 +99,7 @@ object Comet {
       case other =>
         throw new IllegalStateException("Illegal type found: only String or JsValue elements are valid")
     }
-    Html(s"""<script type="text/javascript">${callbackName}(${javascriptMessage});</script>""")
+    Html(s"""<script>${callbackName}(${javascriptMessage});</script>""")
   }
 
 }

--- a/framework/src/play/src/test/scala/play/api/libs/CometSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/CometSpec.scala
@@ -53,7 +53,7 @@ class CometSpec extends Specification {
         implicit val m = app.materializer
         val controller = new MockController(m, ActionBuilder.ignoringBody)
         val result = controller.cometString.apply(FakeRequest())
-        contentAsString(result) must contain("<html><body><script type=\"text/javascript\">parent.cometMessage('kiki');</script><script type=\"text/javascript\">parent.cometMessage('foo');</script><script type=\"text/javascript\">parent.cometMessage('bar');</script>")
+        contentAsString(result) must contain("<html><body><script>parent.cometMessage('kiki');</script><script>parent.cometMessage('foo');</script><script>parent.cometMessage('bar');</script>")
       } finally {
         app.stop()
       }
@@ -65,7 +65,7 @@ class CometSpec extends Specification {
         implicit val m = app.materializer
         val controller = new MockController(m, ActionBuilder.ignoringBody)
         val result = controller.cometJson.apply(FakeRequest())
-        contentAsString(result) must contain("<html><body><script type=\"text/javascript\">parent.cometMessage(\"jsonString\");</script>")
+        contentAsString(result) must contain("<html><body><script>parent.cometMessage(\"jsonString\");</script>")
       } finally {
         app.stop()
       }


### PR DESCRIPTION
## Purpose

Some of the APIs were changed to avoid using text/javascript on `type` attributes. Instead, they are just omitting the attribute since the browsers should infer the script type.

See https://www.w3.org/TR/html51/semantics-scripting.html#element-attrdef-script-type