### PR TITLE
akka 2.5.13

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.5.12"
+  val akkaVersion = "2.5.13"
   val akkaHttpVersion = "10.1.3"
   val playJsonVersion = "2.6.9"
 


### PR DESCRIPTION
https://akka.io/blog/news/2018/06/08/akka-2.5.13-released

There is a config change in the release, but I don't think it effects us:
```
akka.typed -> akka.actor.typed
akka.testkit.typed -> akka.actor.testkit.typed
```