### PR TITLE
Fix crossScalaVersions value for root project

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -5,6 +5,7 @@ import BuildSettings._
 import Dependencies._
 import Generators._
 import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaReportBinaryIssues}
+import interplay.ScalaVersions._
 import interplay.PlayBuildBase.autoImport._
 import sbt.Keys.parallelExecution
 import com.lightbend.sbt.javaagent.JavaAgent.JavaAgentKeys.{javaAgents, resolvedJavaAgents}
@@ -402,6 +403,11 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
     .settings(playCommonSettings: _*)
     .settings(
       scalaVersion := (scalaVersion in PlayProject).value,
+      // Should be removed when we update to Scala 2.13.0-M4 since this is the
+      // version added by interplay.
+      //
+      // See also playRuntimeSettings in project/BuildSettings.scala
+      crossScalaVersions := Seq(scala211, scala212, "2.13.0-M3"),
       playBuildRepoName in ThisBuild := "playframework",
       concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
       libraryDependencies ++= (runtime(scalaVersion.value) ++ jdbcDeps),

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -545,6 +545,8 @@ object BuildSettings {
     // that right because some dependencies don't have a build to M4 yet. As soon as
     // we decide that we could release to M4, than we can remove this setting and use
     // the one provided by interplay.
+    //
+    // See also the root project at build.sbt file.
     crossScalaVersions := Seq(ScalaVersions.scala211, ScalaVersions.scala212, "2.13.0-M3")
   )
 


### PR DESCRIPTION
## Purpose

Correct the value for `crossScalaVersions` at the root project. It should not use the default Scala 2.13 version defined by interplay 2.0.3.

## References

See #8473.