### PR TITLE
Fix routes compiler cross scala versions

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -29,6 +29,14 @@ lazy val RoutesCompilerProject = PlayDevelopmentProject("Routes-Compiler", "rout
     .enablePlugins(SbtTwirl)
     .settings(
       libraryDependencies ++= routesCompilerDependencies(scalaVersion.value),
+      // TODO: Remove when updating to Scala 2.13.0-M4
+      // Should be removed when we update to Scala 2.13.0-M4 since this is the
+      // version added by interplay.
+      //
+      // See also:
+      // 1. the root project at build.sbt file.
+      // 2. RoutesCompilerProject project
+      crossScalaVersions := Seq(scala211, scala212, "2.13.0-M3"),
       TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")
     )
 
@@ -403,10 +411,13 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
     .settings(playCommonSettings: _*)
     .settings(
       scalaVersion := (scalaVersion in PlayProject).value,
+      // TODO: Remove when updating to Scala 2.13.0-M4
       // Should be removed when we update to Scala 2.13.0-M4 since this is the
       // version added by interplay.
       //
-      // See also playRuntimeSettings in project/BuildSettings.scala
+      // See also:
+      // 1. playRuntimeSettings in project/BuildSettings.scala
+      // 2. RoutesCompilerProject project
       crossScalaVersions := Seq(scala211, scala212, "2.13.0-M3"),
       playBuildRepoName in ThisBuild := "playframework",
       concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -540,13 +540,15 @@ object BuildSettings {
     // Argument for setting size of permgen space or meta space for all forked processes
     Docs.apiDocsInclude := true
   ) ++ Seq(
-    // TODO: Remove this when updating to Scala 2.13.0-M4
+    // TODO: Remove when updating to Scala 2.13.0-M4
     // Interplay 2.0.3 adds Scala 2.13.0-M4 to crossScalaVersions, but we don't want
     // that right because some dependencies don't have a build to M4 yet. As soon as
     // we decide that we could release to M4, than we can remove this setting and use
     // the one provided by interplay.
     //
-    // See also the root project at build.sbt file.
+    // See also:
+    // 1. the root project at build.sbt file.
+    // 2. RoutesCompilerProject project
     crossScalaVersions := Seq(ScalaVersions.scala211, ScalaVersions.scala212, "2.13.0-M3")
   )
 

--- a/framework/version.sbt
+++ b/framework/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.7.0-af4371c8ab54e4f3fbd6a2da42cb6094db66eb54"
+version in ThisBuild := "2.7.0-SNAPSHOT"

--- a/framework/version.sbt
+++ b/framework/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.7.0-SNAPSHOT"
+version in ThisBuild := "2.7.0-af4371c8ab54e4f3fbd6a2da42cb6094db66eb54"


### PR DESCRIPTION
## Purpose

A missing configuration for RoutesCompilerProject which does not inherit `crossScalaVersions` from `playRuntimeSettings`.

## References

See #8481 and #8473.
