### PR TITLE
Simplify ReloadableServer interface

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -87,6 +87,10 @@ By default, routers are unprefixed, so this will only cause a change in behavior
 
 In Play 2.6, we extracted most of Play-WS into a [standalone project](https://github.com/playframework/play-ws) that has an independent release cycle. Play-WS now has a significant release that requires some changes in Play itself.
 
+## Run Hooks
+
+`RunHook.afterStarted()` no longer takes an `InetSocketAddress` as a parameter.
+
 ### Scala API
 
 1. `play.api.libs.ws.WSRequest.requestTimeout` now returns an `Option[Duration]` instead of an `Option[Int]`.

--- a/documentation/manual/working/commonGuide/build/SBTCookbook.md
+++ b/documentation/manual/working/commonGuide/build/SBTCookbook.md
@@ -6,7 +6,7 @@
 When Play runs in dev mode, that is, when using `sbt run`, it's often useful to hook into this to start up additional processes that are required for development.  This can be done by defining a `PlayRunHook`, which is a trait with the following methods:
 
  * `beforeStarted(): Unit` - called before the play application is started, but after all "before run" tasks have been completed.
- * `afterStarted(addr: InetSocketAddress): Unit` - called after the play application has been started.
+ * `afterStarted(): Unit` - called after the play application has been started.
  * `afterStopped(): Unit` - called after the play process has been stopped.
 
 Now let's say you want to build a Web application with `grunt` before the application is started.  First, you need to create a Scala object in the `project/` directory to extend `PlayRunHook`.  Let's name it `Grunt.scala`:

--- a/documentation/manual/working/commonGuide/build/code/runhook.sbt
+++ b/documentation/manual/working/commonGuide/build/code/runhook.sbt
@@ -48,7 +48,7 @@ def Grunt2(base: File) = {
           Process("grunt dist", base).run
         }
 
-        override def afterStarted(addr: InetSocketAddress): Unit = {
+        override def afterStarted(): Unit = {
           watchProcess = Some(Process("grunt watch", base).run)
         }
 

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -567,7 +567,11 @@ object BuildSettings {
       // Merge Lagom changes to KeyStore generation
       // https://github.com/playframework/playframework/pull/8574
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ssl.FakeKeyStore.DnName"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ssl.FakeKeyStore.createSelfSignedCertificate")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ssl.FakeKeyStore.createSelfSignedCertificate"),
+
+      // Simplify ReloadableServer interface
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.core.server.Server.mainAddress"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ReloadableServer.mainAddress")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/build-link/src/main/java/play/core/server/ReloadableServer.java
+++ b/framework/src/build-link/src/main/java/play/core/server/ReloadableServer.java
@@ -19,11 +19,4 @@ public interface ReloadableServer {
    */
   void reload();
 
-  /**
-   * Get the address of the server.
-   *
-   * @return The address of the server.
-   */
-  java.net.InetSocketAddress mainAddress(); 
-
 }

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -237,7 +237,7 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
       java.lang.Integer.valueOf(port)).asInstanceOf[ReloadableServer]
 
     println()
-    println(Colors.green("Documentation server started, you can now view the docs by going to http://" + server.mainAddress()))
+    println(Colors.green("Documentation server started, you can now view the docs in your web browser"))
     println()
 
     waitForKey()

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -46,6 +46,13 @@ trait Server extends ReloadableServer {
   }
 
   /**
+   * Get the address of the server.
+   *
+   * @return The address of the server.
+   */
+  def mainAddress: java.net.InetSocketAddress
+
+  /**
    * Returns the HTTP port of the server.
    *
    * This is useful when the port number has been automatically selected (by setting a port number of 0).

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -139,9 +139,6 @@ object Reloader {
 
     /** Reloads the application.*/
     def reload(): Unit
-
-    /** URL at which the application is running (if started) */
-    def url(): String
   }
 
   /**
@@ -242,7 +239,7 @@ object Reloader {
       }
 
       // Notify hooks
-      runHooks.run(_.afterStarted(server.mainAddress))
+      runHooks.run(_.afterStarted())
 
       new DevServer {
         val buildLink = reloader
@@ -260,7 +257,6 @@ object Reloader {
             case (key, _) => System.clearProperty(key)
           }
         }
-        def url(): String = server.mainAddress().getHostName + ":" + server.mainAddress().getPort
       }
     } catch {
       case e: Throwable =>
@@ -323,9 +319,6 @@ object Reloader {
 
       /** Reloads the application.*/
       def reload(): Unit = ()
-
-      /** URL at which the application is running (if started) */
-      def url(): String = server.mainAddress().getHostName + ":" + server.mainAddress().getPort
 
       def close(): Unit = server.stop()
     }

--- a/framework/src/run-support/src/main/scala/play/runsupport/RunHook.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/RunHook.scala
@@ -22,9 +22,8 @@ trait RunHook {
 
   /**
    * Called after the play application has been started.
-   * @param addr The address/socket that play is listening to
    */
-  def afterStarted(addr: InetSocketAddress): Unit = ()
+  def afterStarted(): Unit = ()
 
   /**
    * Called after the play process has been stopped.

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayRunHook.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayRunHook.scala
@@ -14,10 +14,10 @@ trait PlayRunHook extends play.runsupport.RunHook
 
 object PlayRunHook {
 
-  def makeRunHookFromOnStarted(f: (java.net.InetSocketAddress) => Unit): PlayRunHook = {
+  def makeRunHookFromOnStarted(f: () => Unit): PlayRunHook = {
     // We create an object for a named class...
     object OnStartedPlayRunHook extends PlayRunHook {
-      override def afterStarted(addr: InetSocketAddress): Unit = f(addr)
+      override def afterStarted(): Unit = f()
     }
     OnStartedPlayRunHook
   }


### PR DESCRIPTION
This PR removes `mainAddress` from `ReloadableServer`. This address was only used in two places:

1. The documentation plugin printed the server address on the console
2. The `RunHook` passed it to `afterStarted`. I could not find a single usage anywhere on github or the internet of the address being used in a run hook. The run hooks are not heavily used in the first place. The most common usage is for js build tool integrations (e.g. [react webpack support](https://github.com/nouhoum/play-react-webpack/blob/master/project/Webpack.scala), [vue webpack support](https://github.com/gbogard/play-vue-webpack/blob/master/project/WebpackServer.scala), [grunt support](https://www.playframework.com/documentation/2.6.x/SBTCookbook)). None of these integrations or any others rely on the server address

The motivation for removing this is to make `ReloadableServer` more generic. I'm working on improving Gradle's Play Framework support ([just got this commit in. woohoo!](https://github.com/gradle/gradle/commit/9321204a00af62f035c96a28e6f2685a2346fd77)). LinkedIn builds the majority of new services on Play Framework. However, we have legacy services which run on Jetty and several other platforms. I'd like to make our other servers implement `ReloadableServer` as well. However, one of the complications is that `mainAddress` had a couple assumptions baked in:

1. I've encountered non TCP sockets (such as unix domain sockets), which would not be instances of InetSocketAddress
2. Some servers support multiple listen addresses so there may not be just one address.