### PR TITLE
Small improvements in Application Java API

### DIFF
--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/JavaAkka.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/JavaAkka.java
@@ -111,7 +111,7 @@ public class JavaAkka {
                 public CompletionStage<Result> index() {
                     return new javaguide.akka.async.Application().index();
                 }
-            }, fakeRequest(), app.getWrappedApplication().materializer());
+            }, fakeRequest(), app.asScala().materializer());
             assertThat(contentAsString(result), equalTo("Got 2"));
         });
 

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
@@ -44,7 +44,7 @@ public class JavaFileUploadTest extends WithApplication {
                 .bodyMultipart(
                         Collections.singletonList(part),
                         play.libs.Files.singletonTemporaryFileCreator(),
-                        app.getWrappedApplication().materializer()
+                        app.asScala().materializer()
                 );
 
         Result result = Helpers.route(app, request);

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -538,7 +538,10 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.ConfigLoader.seqPlayConfigLoader"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.ConfigLoader.playConfigLoader"),
       ProblemFilters.exclude[MissingClassProblem]("play.api.PlayConfig$"),
-      ProblemFilters.exclude[MissingClassProblem]("play.api.PlayConfig")
+      ProblemFilters.exclude[MissingClassProblem]("play.api.PlayConfig"),
+
+      // Add play.Application environmnent() method
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.Application.environment")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
+++ b/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
@@ -73,7 +73,7 @@ public class GuiceApplicationLoaderTest {
                 .withConfig(config);
         Application app = loader.load(context);
 
-        assertThat(app.getWrappedApplication().httpConfiguration().context(), equalTo("/tests"));
+        assertThat(app.asScala().httpConfiguration().context(), equalTo("/tests"));
     }
 
     public interface A {}

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -46,11 +46,11 @@ public class HttpFormsTest {
         Application app = new GuiceApplicationBuilder()
           .withConfigLoader(HttpFormsTest::addLangs)
           .build();
-        play.api.Play.start(app.getWrappedApplication());
+        play.api.Play.start(app.asScala());
         try {
             r.accept(app);
         } finally {
-            play.api.Play.stop(app.getWrappedApplication());
+            play.api.Play.stop(app.asScala());
         }
     }
 

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -52,11 +52,11 @@ public class HttpTest {
         Application app = new GuiceApplicationBuilder()
           .withConfigLoader(HttpTest::addLangs)
           .build();
-        play.api.Play.start(app.getWrappedApplication());
+        play.api.Play.start(app.asScala());
         try {
             r.accept(app);
         } finally {
-            play.api.Play.stop(app.getWrappedApplication());
+            play.api.Play.stop(app.asScala());
         }
     }
 

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -386,7 +386,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             Request request = requestBuilder.build();
             Router routes = (Router) router.getClassLoader().loadClass(router.getName() + "$").getDeclaredField("MODULE$").get(null);
             return routes.route(request).map(handler ->
-                invokeHandler(app.getWrappedApplication(), handler, request, timeout)
+                invokeHandler(app.asScala(), handler, request, timeout)
             ).orElse(null);
         } catch (RuntimeException e) {
             throw e;
@@ -420,7 +420,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
         try {
             Request request = requestBuilder.build();
             return router.route(request).map(handler ->
-                    invokeHandler(app.getWrappedApplication(), handler, request, timeout)
+                    invokeHandler(app.asScala(), handler, request, timeout)
             ).orElse(null);
         } catch (RuntimeException e) {
             throw e;
@@ -476,7 +476,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     @SuppressWarnings("unchecked")
     public static Result route(Application app, RequestBuilder requestBuilder, long timeout) {
         final scala.Option<scala.concurrent.Future<play.api.mvc.Result>> opt = play.api.test.Helpers.jRoute(
-                app.getWrappedApplication(),
+                app.asScala(),
                 requestBuilder.build().asScala(),
                 requestBuilder.body()
         );
@@ -489,7 +489,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @param application the application to start.
      */
     public static void start(Application application) {
-        play.api.Play.start(application.getWrappedApplication());
+        play.api.Play.start(application.asScala());
     }
 
     /**
@@ -498,7 +498,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @param application the application to stop.
      */
     public static void stop(Application application) {
-        play.api.Play.stop(application.getWrappedApplication());
+        play.api.Play.stop(application.asScala());
     }
 
     /**
@@ -508,7 +508,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @param block       the block to run after the Play app is started.
      */
     public static void running(Application application, final Runnable block) {
-        Helpers$.MODULE$.running(application.getWrappedApplication(), asScala(() -> { block.run(); return null; }));
+        Helpers$.MODULE$.running(application.asScala(), asScala(() -> { block.run(); return null; }));
     }
 
     /**

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -26,7 +26,7 @@ public class TestServer extends play.api.test.TestServer {
      * @param application The Application to load in this server.
      */
     public TestServer(int port, Application application) {
-        super(createServerConfig(Optional.of(port), Optional.empty()), application.getWrappedApplication(),
+        super(createServerConfig(Optional.of(port), Optional.empty()), application.asScala(),
                 play.libs.Scala.<ServerProvider>None());
     }
 
@@ -37,7 +37,7 @@ public class TestServer extends play.api.test.TestServer {
      * @param sslPort HTTPS port to bind on
      */
     public TestServer(int port, Application application, int sslPort) {
-        super(createServerConfig(Optional.of(port), Optional.of(sslPort)), application.getWrappedApplication(),
+        super(createServerConfig(Optional.of(port), Optional.of(sslPort)), application.asScala(),
                 play.libs.Scala.<ServerProvider>None());
     }
 

--- a/framework/src/play-test/src/main/java/play/test/WithApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/WithApplication.java
@@ -47,7 +47,7 @@ public class WithApplication {
     public void startPlay() {
         app = provideApplication();
         Helpers.start(app);
-        mat = app.getWrappedApplication().materializer();
+        mat = app.asScala().materializer();
     }
 
     @After

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -24,7 +24,10 @@ public interface Application {
      *
      * @return the application
      * @see Application#asScala() method
+     *
+     * @deprecated Use {@link #asScala()} instead.
      */
+    @Deprecated
     play.api.Application getWrappedApplication();
 
     /**
@@ -34,6 +37,13 @@ public interface Application {
      * @see play.api.Application
      */
     play.api.Application asScala();
+
+    /**
+     * Get the application environment.
+     *
+     * @return the environment.
+     */
+    Environment environment();
 
     /**
      * Get the application configuration.
@@ -56,7 +66,7 @@ public interface Application {
      * @return the application path
      */
     default File path() {
-        return getWrappedApplication().path();
+        return asScala().path();
     }
 
     /**
@@ -65,7 +75,7 @@ public interface Application {
      * @return the application classloader
      */
     default ClassLoader classloader() {
-        return getWrappedApplication().classloader();
+        return asScala().classloader();
     }
 
     /**
@@ -74,7 +84,7 @@ public interface Application {
      * @return true if the application is in DEV mode
      */
     default boolean isDev() {
-        return getWrappedApplication().isDev();
+        return asScala().isDev();
     }
 
     /**
@@ -83,7 +93,7 @@ public interface Application {
      * @return true if the application is in PROD mode
      */
     default boolean isProd() {
-        return getWrappedApplication().isProd();
+        return asScala().isProd();
     }
 
     /**
@@ -92,7 +102,7 @@ public interface Application {
      * @return true if the application is in TEST mode
      */
     default boolean isTest() {
-        return getWrappedApplication().isTest();
+        return asScala().isTest();
     }
 
 }

--- a/framework/src/play/src/main/java/play/DefaultApplication.java
+++ b/framework/src/play/src/main/java/play/DefaultApplication.java
@@ -20,6 +20,7 @@ public class DefaultApplication implements Application {
 
     private final play.api.Application application;
     private final Config config;
+    private final Environment environment;
     private final Injector injector;
 
     /**
@@ -30,10 +31,25 @@ public class DefaultApplication implements Application {
      * @param injector the new application's injector
      */
     @Inject
-    public DefaultApplication(play.api.Application application, Config config, Injector injector) {
+    public DefaultApplication(play.api.Application application, Config config, Injector injector, Environment environment) {
         this.application = application;
         this.config = config;
         this.injector = injector;
+        this.environment = environment;
+    }
+
+    /**
+     * Create an application that wraps a Scala application.
+     *
+     * @param application the application to wrap
+     * @param config the new application's configuration
+     * @param injector the new application's injector
+     *
+     * @deprecated Use {@link #DefaultApplication(play.api.Application, Config, Injector, Environment)} instead.
+     */
+    @Deprecated
+    public DefaultApplication(play.api.Application application, Config config, Injector injector) {
+        this(application, config, injector, new Environment(application.environment()));
     }
 
     /**
@@ -64,6 +80,15 @@ public class DefaultApplication implements Application {
     @Override
     public play.api.Application asScala() {
         return application;
+    }
+
+    /**
+     * Get the application environment.
+     *
+     * @return the environment.
+     */
+    public Environment environment() {
+        return environment;
     }
 
     /**


### PR DESCRIPTION
## Purpose

1. Deprecated getWrappedApplication in favor of asScala which idiomatic to Play APIs
2. Add environment method to access application's environment.

## References

Notice that while reviewing https://github.com/lagom/lagom/pull/1397.