### PR TITLE
Add PlayFOP to "Play modules" page

### DIFF
--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -220,6 +220,12 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 * **Documentation:** <https://github.com/innoveit/play2-pdf/blob/master/README.md>
 * **Short description** Generate PDF output from HTML templates
 
+### PlayFOP (Java and Scala)
+
+* **Website (live demo, user guide, other docs):** <https://www.dmanchester.com/playfop>
+* **Repository:** <https://github.com/dmanchester/playfop>
+* **Short description:** A library for creating PDFs, images, and other types of output in Play applications.
+
 ### Play-Bootstrap (Java and Scala)
 * **Website:** <https://adrianhurt.github.io/play-bootstrap/>
 * **Repository:** <https://github.com/adrianhurt/play-bootstrap>

--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -224,7 +224,7 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 
 * **Website (live demo, user guide, other docs):** <https://www.dmanchester.com/playfop>
 * **Repository:** <https://github.com/dmanchester/playfop>
-* **Short description:** A library for creating PDFs, images, and other types of output in Play applications.
+* **Short description:** A library for creating PDFs, images, and other types of output in Play applications. Accepts XSL-FO that an application has generated and processes it with [Apache FOP](https://xmlgraphics.apache.org/fop/).
 
 ### Play-Bootstrap (Java and Scala)
 * **Website:** <https://adrianhurt.github.io/play-bootstrap/>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Add new library, PlayFOP, to "Play modules" page.

## References

* Announced PlayFOP in Play forum on 13/14 June 2018: ["Now available (with live demo): PlayFOP, a library for creating PDFs, images, and other types of output in Play applications"](https://discuss.lightbend.com/t/now-available-with-live-demo-playfop-a-library-for-creating-pdfs-images-and-other-types-of-output-in-play-applications/1293).
* Discussed PlayFOP and this pull request with @gmethvin via e-mail.