### PR TITLE
Fix issues when building on Windows

### DIFF
--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -19,9 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.concurrent.CompletionStage;
@@ -38,7 +36,6 @@ import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static play.mvc.Results.ok;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 
@@ -110,8 +107,7 @@ public class JavaFileUpload extends WithApplication {
         private File generateTempFile() {
             try {
                 final EnumSet<PosixFilePermission> attrs = EnumSet.of(OWNER_READ, OWNER_WRITE);
-                final FileAttribute<?> attr = PosixFilePermissions.asFileAttribute(attrs);
-                final Path path = Files.createTempFile("multipartBody", "tempFile", attr);
+                final Path path = Files.createTempFile("multipartBody", "tempFile");
                 return path.toFile();
             } catch (IOException e) {
                 throw new IllegalStateException(e);

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -19,9 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -32,8 +30,6 @@ import play.test.WithApplication;
 
 import javax.inject.Inject;
 
-import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
-import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static play.test.Helpers.contentAsString;
@@ -106,7 +102,6 @@ public class JavaFileUpload extends WithApplication {
          */
         private File generateTempFile() {
             try {
-                final EnumSet<PosixFilePermission> attrs = EnumSet.of(OWNER_READ, OWNER_WRITE);
                 final Path path = Files.createTempFile("multipartBody", "tempFile");
                 return path.toFile();
             } catch (IOException e) {

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -86,6 +86,7 @@ object BuildSettings {
         Resolver.typesafeRepo("releases"),
         Resolver.typesafeIvyRepo("releases")
       ),
+      javacOptions ++= Seq("-encoding",  "UTF-8", "-Xlint:unchecked", "-Xlint:deprecation"),
       scalacOptions in(Compile, doc) := {
         // disable the new scaladoc feature for scala 2.12.0, might be removed in 2.12.0-1 (https://github.com/scala/scala-dev/issues/249)
         CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
## Fixes

Fixes #8449.

## Purpose

Make it possible to build Play on Windows without changing any project configurations. This was tested on a Windows 10 VM.