### PR TITLE
Start the application when database is not available

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -96,6 +96,10 @@ Other methods that were added to improve Java API:
 
 HikariCP was updated to the latest version which finally removed the configuration `initializationFailFast`, replaced by `initializationFailTimeout`. See [HikariCP changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) and [documentation for `initializationFailTimeout`](https://github.com/brettwooldridge/HikariCP#infrequently-used) to better understand how to use this configuration.
 
+### HikariCP will not fail fast
+
+Play 2.7 changes the default value for HikariCP's `initializationFailTimeout` to `-1`. That means your application will start even if the database is not available. You can revert to the old behavior by configuring `initializationFailTimeout` to `1` which will make the pool to fail fast. See more details at [[SettingsJDBC]].
+
 ## BoneCP removed
 
 BoneCP is removed. If your application is configured to use BoneCP, you need to switch to [HikariCP](http://brettwooldridge.github.io/HikariCP/) which is the default JDBC connection pool.

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -540,12 +540,16 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.api.PlayConfig$"),
       ProblemFilters.exclude[MissingClassProblem]("play.api.PlayConfig"),
 
-      // Add play.Application environmnent() method
+      // Add play.Application environment() method
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.Application.environment"),
 
       // Added getOptional to Java (async)cacheApi
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.AsyncCacheApi.getOptional"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.SyncCacheApi.getOptional")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.SyncCacheApi.getOptional"),
+
+      // Remove DefaultDBApi.connect method
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.DefaultDBApi.connect$default$1"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.DefaultDBApi.connect")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -96,7 +96,7 @@ play {
         # 3. A value less than zero will bypass any initial connection attempt, and the pool will start immediately
         #    while trying to obtain connections in the background. Consequently, later efforts to obtain a connection
         #    may fail.
-        initializationFailTimeout = 1
+        initializationFailTimeout = -1
 
         # Sets whether internal queries should be isolated
         isolateInternalQueries = false

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -82,6 +82,7 @@ class DBApiProvider(
       Configuration(config).getPrototypedMap(dbKey, "play.db.prototype").mapValues(_.underlying)
     } else Map.empty[String, Config]
     val db = new DefaultDBApi(configs, pool, environment, maybeInjector.getOrElse(NewInstanceInjector))
+    db.initialize(logInitialization = environment.mode != Mode.Test)
     lifecycle.addStopHook { () => Future.fromTry(Try(db.shutdown())) }
     db
   }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -4,15 +4,14 @@
 
 package play.api.db
 
-import javax.inject.{ Inject, Provider, Singleton }
-
 import com.typesafe.config.Config
+import javax.inject.{ Inject, Provider, Singleton }
+import play.api._
+import play.api.inject._
+import play.db.NamedDatabaseImpl
 
 import scala.concurrent.Future
-
-import play.api.inject._
-import play.api._
-import play.db.NamedDatabaseImpl
+import scala.util.Try
 
 /**
  * DB runtime inject module.
@@ -83,8 +82,7 @@ class DBApiProvider(
       Configuration(config).getPrototypedMap(dbKey, "play.db.prototype").mapValues(_.underlying)
     } else Map.empty[String, Config]
     val db = new DefaultDBApi(configs, pool, environment, maybeInjector.getOrElse(NewInstanceInjector))
-    lifecycle.addStopHook { () => Future.successful(db.shutdown()) }
-    db.connect(logConnection = environment.mode != Mode.Test)
+    lifecycle.addStopHook { () => Future.fromTry(Try(db.shutdown())) }
     db
   }
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -82,8 +82,8 @@ class DBApiProvider(
       Configuration(config).getPrototypedMap(dbKey, "play.db.prototype").mapValues(_.underlying)
     } else Map.empty[String, Config]
     val db = new DefaultDBApi(configs, pool, environment, maybeInjector.getOrElse(NewInstanceInjector))
-    db.initialize(logInitialization = environment.mode != Mode.Test)
     lifecycle.addStopHook { () => Future.fromTry(Try(db.shutdown())) }
+    db.initialize(logInitialization = environment.mode != Mode.Test)
     db
   }
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
@@ -5,9 +5,8 @@
 package play.api.db
 
 import com.typesafe.config.Config
-import play.api.inject.{ NewInstanceInjector, Injector }
-import scala.util.control.NonFatal
-import play.api.{ Environment, Configuration, Logger }
+import play.api.inject.{ Injector, NewInstanceInjector }
+import play.api.{ Environment, Logger }
 
 /**
  * Default implementation of the DB API.
@@ -17,8 +16,6 @@ class DefaultDBApi(
     defaultConnectionPool: ConnectionPool = new HikariCPConnectionPool(Environment.simple()),
     environment: Environment = Environment.simple(),
     injector: Injector = NewInstanceInjector) extends DBApi {
-
-  import DefaultDBApi._
 
   lazy val databases: Seq[Database] = {
     configuration.map {
@@ -33,19 +30,6 @@ class DefaultDBApi(
 
   def database(name: String): Database = {
     databaseByName.getOrElse(name, throw new IllegalArgumentException(s"Could not find database for $name"))
-  }
-
-  /**
-   * Try to connect to all data sources.
-   */
-  def connect(logConnection: Boolean = false): Unit = databases.foreach { db =>
-    try {
-      db.getConnection().close()
-      if (logConnection) logger.info(s"Database [${db.name}] connected at ${db.url}")
-    } catch {
-      case NonFatal(e) =>
-        throw Configuration(configuration(db.name)).reportError("url", s"Cannot connect to database [${db.name}]", Some(e))
-    }
   }
 
   def initialize(logInitialization: Boolean = false): Unit = {

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
@@ -48,6 +48,12 @@ class DefaultDBApi(
     }
   }
 
+  def initialize(logInitialization: Boolean = false): Unit = {
+    // Accessing the dataSource for the database makes the connection pool to
+    // initialize. We will them be able to check for configuration errors.
+    databases.foreach(_.dataSource)
+  }
+
   def shutdown(): Unit = databases.foreach(_.shutdown())
 }
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
@@ -34,7 +34,7 @@ class DefaultDBApi(
 
   def initialize(logInitialization: Boolean): Unit = {
     // Accessing the dataSource for the database makes the connection pool to
-    // initialize. We will them be able to check for configuration errors.
+    // initialize. We will then be able to check for configuration errors.
     databases.foreach(_.dataSource)
   }
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
@@ -32,7 +32,7 @@ class DefaultDBApi(
     databaseByName.getOrElse(name, throw new IllegalArgumentException(s"Could not find database for $name"))
   }
 
-  def initialize(logInitialization: Boolean = false): Unit = {
+  def initialize(logInitialization: Boolean): Unit = {
     // Accessing the dataSource for the database makes the connection pool to
     // initialize. We will them be able to check for configuration errors.
     databases.foreach(_.dataSource)

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.db
+
+import org.specs2.mutable.Specification
+import play.api.inject._
+import play.api.test.WithApplication
+
+class DBApiSpec extends Specification {
+
+  "DBApi" should {
+
+    "not avoid application start when there is a configuration error" in new WithApplication(_.configure(
+      // a bogus URL which is not accepted by H2, just to prove that
+      // the application will start without a proper database config.
+      "db.default.url" -> "jdbc:bogus://localhost:1234",
+      "db.default.driver" -> "org.h2.Driver"
+    ).bindings(
+        // We then add some component that we will try to access
+        // to check that other components are successfully instanced
+        // when there is a database misconfiguration.
+        bind[EagerComponent].toInstance(EagerComponent(true)))
+    ) {
+      val eagerComponent = app.injector.instanceOf[EagerComponent]
+      eagerComponent.started must beTrue
+    }
+
+    "create all the configured databases" in new WithApplication(_.configure(
+      // default
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.default.driver" -> "org.h2.Driver",
+
+      // test
+      "db.test.url" -> "jdbc:h2:mem:test",
+      "db.test.driver" -> "org.h2.Driver",
+
+      // other
+      "db.other.url" -> "jdbc:h2:mem:other",
+      "db.other.driver" -> "org.h2.Driver"
+    )) {
+      val dbApi = app.injector.instanceOf[DBApi]
+      dbApi.database("default").url must beEqualTo("jdbc:h2:mem:default")
+      dbApi.database("test").url must beEqualTo("jdbc:h2:mem:test")
+      dbApi.database("other").url must beEqualTo("jdbc:h2:mem:other")
+    }
+  }
+}
+
+case class EagerComponent(started: Boolean)

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
@@ -25,7 +25,7 @@ class DBApiSpec extends Specification {
 
     "fail to start the application even when there is a database misconfiguration" in {
       new WithApplication(_.configure(
-        // Having a wrong configuration like a invalid url is different from having
+        // Having a wrong configuration like an invalid url is different from having
         // a valid configuration where the database is not available yet. We should
         // fail fast and report this since it is a programming error.
         "db.default.url" -> "jdbc:bogus://localhost",

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
@@ -5,26 +5,20 @@
 package play.api.db
 
 import org.specs2.mutable.Specification
-import play.api.inject._
 import play.api.test.WithApplication
 
 class DBApiSpec extends Specification {
 
   "DBApi" should {
 
-    "not avoid application start when there is a configuration error" in new WithApplication(_.configure(
+    "start the application even when database is not available" in new WithApplication(_.configure(
       // a bogus URL which is not accepted by H2, just to prove that
       // the application will start without a proper database config.
       "db.default.url" -> "jdbc:bogus://localhost:1234",
       "db.default.driver" -> "org.h2.Driver"
-    ).bindings(
-        // We then add some component that we will try to access
-        // to check that other components are successfully instanced
-        // when there is a database misconfiguration.
-        bind[EagerComponent].toInstance(EagerComponent(true)))
-    ) {
-      val eagerComponent = app.injector.instanceOf[EagerComponent]
-      eagerComponent.started must beTrue
+    )) {
+      val dependsOnDbApi = app.injector.instanceOf[DependsOnDbApi]
+      dependsOnDbApi.dBApi must not beNull
     }
 
     "create all the configured databases" in new WithApplication(_.configure(
@@ -48,4 +42,4 @@ class DBApiSpec extends Specification {
   }
 }
 
-case class EagerComponent(started: Boolean)
+case class DependsOnDbApi(dBApi: DBApi)

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
@@ -30,7 +30,7 @@ class DriverRegistrationSpec extends Specification {
     }
 
     "be registered for both Acolyte & H2 when databases are connected" in {
-      dbApi.initialize()
+      dbApi.initialize(logInitialization = true)
 
       (DriverManager.getDriver(jdbcUrl) aka "Acolyte driver" must not(beNull)).
         and(DriverManager.getDriver("jdbc:h2:mem:").

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
@@ -30,7 +30,7 @@ class DriverRegistrationSpec extends Specification {
     }
 
     "be registered for both Acolyte & H2 when databases are connected" in {
-      dbApi.connect()
+      dbApi.initialize()
 
       (DriverManager.getDriver(jdbcUrl) aka "Acolyte driver" must not(beNull)).
         and(DriverManager.getDriver("jdbc:h2:mem:").

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -70,8 +70,8 @@ class HikariCPConfigSpec extends Specification {
         new HikariCPConfig(dbConfig, reference).toHikariConfig.getMaximumPoolSize must beEqualTo(10)
       }
 
-      "initializationFailTimeout to 1" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getInitializationFailTimeout must beEqualTo(1)
+      "initializationFailTimeout to -1" in new Configs {
+        new HikariCPConfig(dbConfig, reference).toHikariConfig.getInitializationFailTimeout must beEqualTo(-1)
       }
 
       "isolateInternalQueries to false" in new Configs {


### PR DESCRIPTION
## Purpose

Currently, when there is a database misconfiguration or when the database is not available, we fail to start the application. This PR changes it to avoid trying to connect to the database eagerly and delaying it to when an actual database connection is needed.

## References

See https://github.com/lagom/lagom/pull/1409 and also discussion at https://github.com/playframework/playframework/issues/6706. See also [this discussion at our gitter channel](https://gitter.im/playframework/contributors?at=5b3370086ceffe4eba373b79).

