### PR TITLE
Fix wrong comments

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -487,11 +487,11 @@ object AkkaHttpServer extends ServerFromRouter {
   implicit val provider: AkkaHttpServerProvider = new AkkaHttpServerProvider
 
   /**
-   * Create a Netty server from the given application and server configuration.
+   * Create a Akka HTTP server from the given application and server configuration.
    *
    * @param application The application.
    * @param config The server configuration.
-   * @return A started Netty server, serving the application.
+   * @return A started Akka HTTP server, serving the application.
    */
   def fromApplication(application: Application, config: ServerConfig = ServerConfig()): AkkaHttpServer = {
     new AkkaHttpServer(Context.fromComponents(config, application))


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

This fixes comments which mistakenly say not `Akka HTTP` but `Netty`.

## Purpose

Fix incorrect comments.
