### PR TITLE
Accept sub protocol web socket connections for akka-http

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
@@ -23,7 +23,7 @@ object WebSocketHandler {
    */
   def handleWebSocket(upgrade: UpgradeToWebSocket, flow: Flow[Message, Message, _], bufferLimit: Int): HttpResponse = upgrade match {
     case lowLevel: UpgradeToWebSocketLowLevel =>
-      lowLevel.handleFrames(messageFlowToFrameFlow(flow, bufferLimit))
+      lowLevel.handleFrames(messageFlowToFrameFlow(flow, bufferLimit), upgrade.requestedProtocols.headOption)
     case other => throw new IllegalArgumentException("UpgradeToWebsocket is not an Akka HTTP UpgradeToWebsocketLowLevel")
   }
 


### PR DESCRIPTION
With netty we accept any sub protocol https://github.com/playframework/playframework/pull/1722
Netty under the hood picks the first one the user specified to respond
with.

This does the same in akka-http and will unblock users who use
sub-protocols but don't need an API to control the response e.g.
they just have one sub-protocol or don't care which one is picked.

