### PR TITLE
[2.6.x] Added asScala API to EssentialFilter

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -209,12 +209,12 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
 
     "Scala EssentialFilter should work when converting from Scala to Java" in withServer()(ScalaEssentialFilter.asJava) { ws =>
       val result = Await.result(ws.url("/ok").get(), Duration.Inf)
-      result.header(ScalaEssentialFilter.header).getOrElse("") must_== ScalaEssentialFilter.expectedValue
+      result.header(ScalaEssentialFilter.header) must beSome(ScalaEssentialFilter.expectedValue)
     }
 
     "Java EssentialFilter should work when converting from Java to Scala" in withServer()(JavaEssentialFilter.asScala) { ws =>
       val result = Await.result(ws.url("/ok").get(), Duration.Inf)
-      result.header(JavaEssentialFilter.header).getOrElse("") must_== JavaEssentialFilter.expectedValue
+      result.header(JavaEssentialFilter.header) must beSome(JavaEssentialFilter.expectedValue)
     }
 
     "Scala EssentialFilter should preserve the same type when converting from Scala to Java then back to Scala" in {

--- a/framework/src/play/src/main/java/play/mvc/EssentialFilter.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialFilter.java
@@ -15,4 +15,9 @@ public abstract class EssentialFilter implements play.api.mvc.EssentialFilter {
     public EssentialFilter asJava() {
         return this;
     }
+
+    @Override
+    public play.api.mvc.EssentialFilter asScala() {
+        return this;
+    }
 }

--- a/framework/src/play/src/main/java/play/mvc/EssentialFilter.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialFilter.java
@@ -16,7 +16,6 @@ public abstract class EssentialFilter implements play.api.mvc.EssentialFilter {
         return this;
     }
 
-    @Override
     public play.api.mvc.EssentialFilter asScala() {
         return this;
     }

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -13,7 +13,11 @@ trait EssentialFilter {
 
   def asJava: play.mvc.EssentialFilter = new play.mvc.EssentialFilter {
     override def apply(next: play.mvc.EssentialAction) = EssentialFilter.this(next).asJava
+
+    override def asScala: EssentialFilter = this
   }
+
+  def asScala: EssentialFilter = this
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -14,10 +14,8 @@ trait EssentialFilter {
   def asJava: play.mvc.EssentialFilter = new play.mvc.EssentialFilter {
     override def apply(next: play.mvc.EssentialAction) = EssentialFilter.this(next).asJava
 
-    override def asScala: EssentialFilter = this
+    override def asScala: EssentialFilter = EssentialFilter.this
   }
-
-  def asScala: EssentialFilter = this
 }
 
 /**


### PR DESCRIPTION
## Fixes

Fixes #8509

## Purpose

Adding `asScala` API for `EssentialFilter`, so that Java `EssentialFilter` generated by Scala `EssentialFilter.asJava` can be converted back to the original object.