### PR TITLE
Fix a typo in ScalaConfig.md

### DIFF
--- a/documentation/manual/working/scalaGuide/main/config/ScalaConfig.md
+++ b/documentation/manual/working/scalaGuide/main/config/ScalaConfig.md
@@ -5,7 +5,7 @@ Play uses the [Typesafe config library](https://github.com/typesafehub/config), 
 
 ## Accessing the configuration
 
-Typically, you'll obtain a `Configuration` object through [[Dependency Injection|ScalaDependencyInjection]]dependency injection, or simply by passing an instance of `Configuration` to your component:
+Typically, you'll obtain a `Configuration` object through [[Dependency Injection|ScalaDependencyInjection]], or simply by passing an instance of `Configuration` to your component:
 
 @[inject-config](code/ScalaConfig.scala)
 


### PR DESCRIPTION
Removed a repeated phrase in documentation

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

No open issues as far as I can see

## Purpose

Fix a typo in the documentation.

## Background Context

N/A

## References

N/A