### PR TITLE
Handle database not available in Prod/Dev/Test modes

### DIFF
--- a/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -75,7 +75,7 @@ public class DatabaseTest {
         Database db = Databases.inMemory("test", options, config);
 
         assertThat(db.getName(), equalTo("test"));
-        assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test"));
+        assertThat(db.getUrl(), startsWith("jdbc:h2:mem:test"));
 
         db.shutdown();
     }

--- a/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -69,13 +69,13 @@ public class DatabaseTest {
     }
 
     @Test
-    public void createInMemoryDatabaseWithUrlOptions() throws Exception {
+    public void createInMemoryDatabaseWithUrlOptions() {
         Map<String, String> options = ImmutableMap.of("MODE", "MySQL");
         Map<String, Object> config = ImmutableMap.<String, Object>of();
         Database db = Databases.inMemory("test", options, config);
 
         assertThat(db.getName(), equalTo("test"));
-        assertThat(db.getUrl(), startsWith("jdbc:h2:mem:test"));
+        assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test;MODE=MySQL"));
 
         db.shutdown();
     }

--- a/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -27,7 +27,7 @@ public class DatabaseTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void createDatabase() throws Exception {
+    public void createDatabase() {
         Database db = Databases.createFrom("test", "org.h2.Driver", "jdbc:h2:mem:test");
         assertThat(db.getName(), equalTo("test"));
         assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test"));
@@ -35,7 +35,7 @@ public class DatabaseTest {
     }
 
     @Test
-    public void createDefaultDatabase() throws Exception {
+    public void createDefaultDatabase() {
         Database db = Databases.createFrom("org.h2.Driver", "jdbc:h2:mem:default");
         assertThat(db.getName(), equalTo("default"));
         assertThat(db.getUrl(), equalTo("jdbc:h2:mem:default"));
@@ -65,7 +65,7 @@ public class DatabaseTest {
     }
 
     @Test
-    public void createNamedInMemoryDatabase() throws Exception {
+    public void createNamedInMemoryDatabase() {
         Database db = Databases.inMemory("test");
         assertThat(db.getName(), equalTo("test"));
         assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test"));
@@ -124,7 +124,7 @@ public class DatabaseTest {
     }
 
     @Test
-    public void provideConnectionHelpers() throws Exception {
+    public void provideConnectionHelpers() {
         Database db = Databases.inMemory("test-withConnection");
 
         db.withConnection(c -> {
@@ -145,7 +145,7 @@ public class DatabaseTest {
     }
 
     @Test
-    public void provideTransactionHelper() throws Exception {
+    public void provideTransactionHelper() {
         Database db = Databases.inMemory("test-withTransaction");
 
         boolean created = db.withTransaction(c -> {

--- a/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -48,12 +48,16 @@ public class DatabaseTest {
         Database db = Databases.createFrom("test", "org.h2.Driver", "jdbc:h2:mem:test", config);
         assertThat(db.getName(), equalTo("test"));
         assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test"));
+
+        // Forces the data source initialization, and then JNDI registration.
+        db.getDataSource();
+
         assertThat(JNDI.initialContext().lookup("DefaultDS"), equalTo(db.getDataSource()));
         db.shutdown();
     }
 
     @Test
-    public void createDefaultInMemoryDatabase() throws Exception {
+    public void createDefaultInMemoryDatabase() {
         Database db = Databases.inMemory();
         assertThat(db.getName(), equalTo("default"));
         assertThat(db.getUrl(), equalTo("jdbc:h2:mem:default"));
@@ -85,6 +89,10 @@ public class DatabaseTest {
         Database db = Databases.inMemoryWith("jndiName", "DefaultDS");
         assertThat(db.getName(), equalTo("default"));
         assertThat(db.getUrl(), equalTo("jdbc:h2:mem:default"));
+
+        // Forces the data source initialization, and then JNDI registration.
+        db.getDataSource();
+
         assertThat(JNDI.initialContext().lookup("DefaultDS"), equalTo(db.getDataSource()));
         db.shutdown();
     }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -43,7 +43,7 @@ object Databases {
    */
   def inMemory(name: String = "default", urlOptions: Map[String, String] = Map.empty, config: Map[String, _ <: Any] = Map.empty): Database = {
     val driver = "org.h2.Driver"
-    val urlExtra = urlOptions.map { case (k, v) => k + "=" + v }.mkString(";", ";", "")
+    val urlExtra = if (urlOptions.nonEmpty) urlOptions.map { case (k, v) => k + "=" + v }.mkString(";", ";", "") else ""
     val url = "jdbc:h2:mem:" + name + urlExtra
     Databases(driver, url, name, config)
   }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -125,11 +125,13 @@ abstract class DefaultDatabase(val name: String, configuration: Config, environm
   }
 
   lazy val url: String = {
-    val connection = dataSource.getConnection
-    try {
-      connection.getMetaData.getURL
-    } finally {
-      connection.close()
+    databaseConfig.url.getOrElse {
+      val connection = dataSource.getConnection
+      try {
+        connection.getMetaData.getURL
+      } finally {
+        connection.close()
+      }
     }
   }
 

--- a/framework/src/play-jdbc/src/test/resources/application.conf
+++ b/framework/src/play-jdbc/src/test/resources/application.conf
@@ -1,0 +1,2 @@
+# Necessary when running tests using DEV or PROD mode.
+play.http.secret.key=dummy

--- a/framework/src/play-jdbc/src/test/resources/logback-test.xml
+++ b/framework/src/play-jdbc/src/test/resources/logback-test.xml
@@ -13,6 +13,8 @@
         </encoder>
     </appender>
 
+    <logger name="play" level="INFO" />
+
     <root level="WARN">
         <appender-ref ref="STDOUT" />
     </root>

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
@@ -6,17 +6,28 @@ package play.api.db
 
 import javax.inject.Inject
 import org.specs2.mutable.Specification
-import play.api.PlayException
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.{ Application, Environment, Mode, PlayException }
 import play.api.test.WithApplication
 
-class DBApiSpec extends Specification {
+class TestDBApiSpec extends DBApiSpec(Mode.Test)
+class DevDBApiSpec extends DBApiSpec(Mode.Dev)
+class ProdDBApiSpec extends DBApiSpec(Mode.Prod)
+
+abstract class DBApiSpec(mode: Mode) extends Specification {
+
+  def app(conf: (String, Any)*): Application = {
+    GuiceApplicationBuilder(environment = Environment.simple(mode = mode))
+      .configure(conf: _*)
+      .build()
+  }
 
   "DBApi" should {
 
-    "start the application when database is not available" in new WithApplication(_.configure(
+    "start the application when database is not available" in new WithApplication(app(
       // Here we have a URL that is valid for H2, but the database is not available.
       // We should not fail to start the application here.
-      "db.default.url" -> "jdbc:h2:tcp://localhost/~/bogus",
+      "db.default.url" -> "jdbc:h2:tcp://localhost/~/notavailable",
       "db.default.driver" -> "org.h2.Driver"
     )) {
       val dependsOnDbApi = app.injector.instanceOf[DependsOnDbApi]
@@ -24,7 +35,7 @@ class DBApiSpec extends Specification {
     }
 
     "fail to start the application when there is a database misconfiguration" in {
-      new WithApplication(_.configure(
+      new WithApplication(app(
         // Having a wrong configuration like an invalid url is different from having
         // a valid configuration where the database is not available yet. We should
         // fail fast and report this since it is a programming error.
@@ -34,7 +45,7 @@ class DBApiSpec extends Specification {
     }
 
     "fail to start the application when database is not available and configured to fail fast" in {
-      new WithApplication(_.configure(
+      new WithApplication(app(
         // Here we have a URL that is valid for H2, but the database is not available.
         "db.default.url" -> "jdbc:bogus://localhost",
         "db.default.driver" -> "org.h2.Driver",
@@ -44,7 +55,7 @@ class DBApiSpec extends Specification {
     }
 
     "correct report the configuration error" in {
-      new WithApplication(_.configure(
+      new WithApplication(app(
         // The configuration is correct, but the database is not available
         "db.default.url" -> "jdbc:h2:tcp://localhost/~/notavailable",
         "db.default.driver" -> "org.h2.Driver",
@@ -59,7 +70,14 @@ class DBApiSpec extends Specification {
       )) {} must throwA[PlayException]("Configuration error\\[Cannot initialize to database \\[bogus\\]\\]")
     }
 
-    "create all the configured databases" in new WithApplication(_.configure(
+    "correct report the configuration error when there is not URL configured" in {
+      new WithApplication(app(
+        // Missing url configuration
+        "db.test.driver" -> "org.h2.Driver"
+      )) {} must throwA[PlayException]("Configuration error\\[Cannot initialize to database \\[test\\]\\]")
+    }
+
+    "create all the configured databases" in new WithApplication(app(
       // default
       "db.default.url" -> "jdbc:h2:mem:default",
       "db.default.driver" -> "org.h2.Driver",
@@ -73,9 +91,9 @@ class DBApiSpec extends Specification {
       "db.other.driver" -> "org.h2.Driver"
     )) {
       val dbApi = app.injector.instanceOf[DBApi]
-      dbApi.database("default").url must beEqualTo("jdbc:h2:mem:default")
-      dbApi.database("test").url must beEqualTo("jdbc:h2:mem:test")
-      dbApi.database("other").url must beEqualTo("jdbc:h2:mem:other")
+      dbApi.database("default").url must startingWith("jdbc:h2:mem:default")
+      dbApi.database("test").url must startingWith("jdbc:h2:mem:test")
+      dbApi.database("other").url must startingWith("jdbc:h2:mem:other")
     }
   }
 }

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -40,13 +40,13 @@ class DatabasesSpec extends Specification {
     "create default in-memory database" in new WithDatabase {
       val db = Databases.inMemory()
       db.name must_== "default"
-      db.url must startWith("jdbc:h2:mem:default")
+      db.url must beEqualTo("jdbc:h2:mem:default")
     }
 
     "create named in-memory database" in new WithDatabase {
       val db = Databases.inMemory(name = "test")
       db.name must_== "test"
-      db.url must startWith("jdbc:h2:mem:test")
+      db.url must beEqualTo("jdbc:h2:mem:test")
     }
 
     "create in-memory database with url options" in new WithDatabase {

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -40,19 +40,19 @@ class DatabasesSpec extends Specification {
     "create default in-memory database" in new WithDatabase {
       val db = Databases.inMemory()
       db.name must_== "default"
-      db.url must_== "jdbc:h2:mem:default"
+      db.url must startWith("jdbc:h2:mem:default")
     }
 
     "create named in-memory database" in new WithDatabase {
       val db = Databases.inMemory(name = "test")
       db.name must_== "test"
-      db.url must_== "jdbc:h2:mem:test"
+      db.url must startWith("jdbc:h2:mem:test")
     }
 
     "create in-memory database with url options" in new WithDatabase {
       val db = Databases.inMemory(urlOptions = Map("MODE" -> "MySQL"))
       db.name must_== "default"
-      db.url must_== "jdbc:h2:mem:default"
+      db.url must startWith("jdbc:h2:mem:default")
       db.dataSource match {
         case ds: HikariDataSource => ds.getJdbcUrl must_== "jdbc:h2:mem:default;MODE=MySQL"
         case _ =>

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -5,7 +5,7 @@
 package play.api.db
 
 import java.sql.SQLException
-import com.zaxxer.hikari.HikariDataSource
+
 import org.jdbcdslog.LogSqlDataSource
 import org.specs2.mutable.{ After, Specification }
 
@@ -52,11 +52,13 @@ class DatabasesSpec extends Specification {
     "create in-memory database with url options" in new WithDatabase {
       val db = Databases.inMemory(urlOptions = Map("MODE" -> "MySQL"))
       db.name must_== "default"
-      db.url must startWith("jdbc:h2:mem:default")
-      db.dataSource match {
-        case ds: HikariDataSource => ds.getJdbcUrl must_== "jdbc:h2:mem:default;MODE=MySQL"
-        case _ =>
-      }
+      db.url must_== "jdbc:h2:mem:default;MODE=MySQL"
+    }
+
+    "create in-memory database with url as is when there are no additional options" in new WithDatabase {
+      val db = Databases.inMemory()
+      db.name must_== "default"
+      db.url must_== "jdbc:h2:mem:default"
     }
 
     "supply connections" in new WithDatabase {


### PR DESCRIPTION
## Purpose

In #8497 we did not handle other modes besides test. In Prod and Dev modes, there is a log entry that requires the database URL and, to get the database URL, Play was trying to get datasource metadata,
which requires a connection.

Then the log entry forced the database connection pool to initialize and fail. The new implementation gets the configured URL instead.

## References

https://github.com/playframework/playframework/pull/8502#discussion_r202928829
