### PR TITLE
Refactor invocation of Akka coordinated shutdown

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -233,16 +233,7 @@ class NettyServer(
     serverChannel
   }
 
-  override def stop(): Unit = {
-    // CoordinatedShutdown may be invoked many times over the same actorSystem but
-    // only the first invocation runs the tasks (later invocations are noop).
-    val runFromPhase = CoordinatedShutdownProvider.loadRunFromPhaseConfig(actorSystem)
-    val cs = CoordinatedShutdown(actorSystem)
-    Await.result(
-      cs.run(ServerStoppedReason, runFromPhase),
-      cs.totalTimeout() + Duration(5, TimeUnit.SECONDS)
-    )
-  }
+  override def stop(): Unit = CoordinatedShutdownProvider.syncShutdown(actorSystem, ServerStoppedReason)
 
   // Using CoordinatedShutdown means that instead of invoking code imperatively in `stop`
   // we have to register it as early as possible as CoordinatedShutdown tasks and

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -274,10 +274,7 @@ class DefaultApplication @Inject() (
 
   override def classloader: ClassLoader = environment.classLoader
 
-  override def stop(): Future[_] = {
-    val runFromPhase = CoordinatedShutdownProvider.loadRunFromPhaseConfig(actorSystem)
-    coordinatedShutdown.run(ApplicationStoppedReason, runFromPhase)
-  }
+  override def stop(): Future[_] = CoordinatedShutdownProvider.asyncShutdown(actorSystem, ApplicationStoppedReason)
 }
 
 private[play] final case object ApplicationStoppedReason extends CoordinatedShutdown.Reason

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -251,7 +251,7 @@ object CoordinatedShutdownProvider {
    * @param actorSystem the actor system whose configuration is read
    * @return the name of the configured coordinated shutdown phase, if present and non-empty, or `None`
    */
-  def loadRunFromPhaseConfig(actorSystem: ActorSystem): Option[String] =
+  private def loadRunFromPhaseConfig(actorSystem: ActorSystem): Option[String] =
     Try(actorSystem.settings.config.getString("play.akka.run-cs-from-phase"))
       .toOption
       .filterNot(_.isEmpty)

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -104,9 +104,8 @@ class ActorSystemProviderSpec extends Specification {
       implicit val ctx = actorSystem.dispatcher
       // lifecycle.stop is deprecated, use CS instead.
       //      val completeShutdown = lifecycle.stop().flatMap(_ => terminated)
-      val completeShutdown = cs.run(CoordinatedShutdown.UnknownReason, CoordinatedShutdownProvider.loadRunFromPhaseConfig(actorSystem))
+      CoordinatedShutdownProvider.syncShutdown(actorSystem, CoordinatedShutdown.UnknownReason)
 
-      Await.result(completeShutdown, fiveSec) must equalTo(Done)
       isRun.get() must equalTo(false)
     }
 


### PR DESCRIPTION
This refactors part of the coordinated shutdown code introduced in #8406, providing a shared implementation for asynchronous and synchronous shutdown using the configured `play.akka.run-cs-from-phase ` property.

This reduces duplication within the Play framework code, and I'd also like to use this from Lagom.