### PR TITLE
WIP: remove guava

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/Twitter.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/Twitter.java
@@ -14,8 +14,6 @@ import play.libs.ws.WSClient;
 import play.mvc.Controller;
 import play.mvc.Result;
 
-import com.google.common.base.Strings;
-
 import javax.inject.Inject;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -52,7 +50,7 @@ public class Twitter extends Controller {
 
     public Result auth() {
         String verifier = request().getQueryString("oauth_verifier");
-        if (Strings.isNullOrEmpty(verifier)) {
+        if (verifier == null || verifier == "") {
             String url = routes.Twitter.auth().absoluteURL(request());
             RequestToken requestToken = TWITTER.retrieveRequestToken(url);
             saveSessionTokenPair(requestToken);

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -145,6 +145,7 @@ object Dependencies {
     Seq("akka-testkit").map("com.typesafe.akka" %% _ % akkaVersion % Test) ++
     jacksons ++
     Seq(
+      "com.comcast" %% "ip4s" % "1.0.1",
       playJson,
 
       guava,

--- a/framework/src/play-guice/src/main/java/play/inject/guice/GuiceBuilder.java
+++ b/framework/src/play-guice/src/main/java/play/inject/guice/GuiceBuilder.java
@@ -4,7 +4,6 @@
 
 package play.inject.guice;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -15,6 +14,7 @@ import play.inject.Injector;
 import play.libs.Scala;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -99,7 +99,7 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
      * @return a copy of this builder configured with the key=value
      */
     public final Self configure(String key, Object value) {
-        return configure(ImmutableMap.of(key, value));
+        return configure(Collections.singletonMap(key, value));
     }
 
     /**

--- a/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -7,8 +7,6 @@ package play.inject.guice;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Rule;
@@ -18,6 +16,9 @@ import play.Application;
 import play.api.inject.guice.GuiceApplicationBuilderSpec;
 import play.inject.Injector;
 import play.libs.Scala;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -48,7 +49,7 @@ public class GuiceApplicationBuilderTest {
                 // override the scala api configuration, which should underlie the java api configuration
                 bind(play.api.Configuration.class).to(new GuiceApplicationBuilderSpec.ExtendConfiguration(Scala.varargs(Scala.Tuple("a", 1)))),
                 // also override the java api configuration
-                bind(Config.class).to(new ExtendConfiguration(ConfigFactory.parseMap(ImmutableMap.of("b", 2)))),
+                bind(Config.class).to(new ExtendConfiguration(ConfigFactory.parseMap(Collections.singletonMap("b", 2)))),
                 bind(A.class).to(A2.class))
             .injector()
             .instanceOf(Application.class);
@@ -71,7 +72,7 @@ public class GuiceApplicationBuilderTest {
 
     @Test
     public void setInitialConfigurationLoader() {
-        Config extra = ConfigFactory.parseMap(ImmutableMap.of("a", 1));
+        Config extra = ConfigFactory.parseMap(Collections.singletonMap("a", 1));
         Application app = new GuiceApplicationBuilder()
             .withConfigLoader(env -> extra.withFallback(ConfigFactory.load(env.classLoader())))
             .build();
@@ -82,7 +83,7 @@ public class GuiceApplicationBuilderTest {
     @Test
     public void setModuleLoader() {
         Injector injector = new GuiceApplicationBuilder()
-            .withModuleLoader((env, conf) -> ImmutableList.of(
+            .withModuleLoader((env, conf) -> Arrays.asList(
                 Guiceable.modules(new play.api.inject.BuiltinModule(), new play.api.i18n.I18nModule(), new play.api.mvc.CookiesModule()),
                 Guiceable.bindings(bind(A.class).to(A1.class))))
             .injector();

--- a/framework/src/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
+++ b/framework/src/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
@@ -4,10 +4,10 @@
 
 package play.inject.guice;
 
-import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collections;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -62,8 +62,8 @@ public class GuiceInjectorBuilderTest {
     @Test
     public void setConfiguration() {
         Config conf = new GuiceInjectorBuilder()
-            .configure(ConfigFactory.parseMap(ImmutableMap.of("a", 1)))
-            .configure(ImmutableMap.of("b", 2))
+            .configure(ConfigFactory.parseMap(Collections.singletonMap("a", 1)))
+            .configure(Collections.singletonMap("b", 2))
             .configure("c", 3)
             .configure("d.1", 4)
             .configure("d.2", 5)

--- a/framework/src/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
@@ -6,7 +6,7 @@ package play.core.server.common
 
 import java.net.{ Inet4Address, Inet6Address, InetAddress }
 
-import com.google.common.net.InetAddresses
+import com.comcast.ip4s.{IpAddress => SIpAddress}
 import play.core.server.common.ForwardedHeaderHandler.{ ForwardedHeaderVersion, Rfc7239, Xforwarded }
 import play.core.server.common.NodeIdentifierParser._
 
@@ -68,8 +68,8 @@ private[common] class NodeIdentifierParser(version: ForwardedHeaderVersion) exte
   private def obfport = regex("_[\\p{Alnum}\\._-]+".r)
 
   private def inetAddress = new PartialFunction[String, InetAddress] {
-    def isDefinedAt(s: String) = Try { InetAddresses.forString(s) }.isSuccess
-    def apply(s: String) = Try { InetAddresses.forString(s) }.get
+    def isDefinedAt(s: String) = SIpAddress(s).isDefined
+    def apply(s: String) = Try { SIpAddress(s).get.toInetAddress }.get
   }
 }
 

--- a/framework/src/play-server/src/main/scala/play/core/server/common/Subnet.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/Subnet.scala
@@ -6,7 +6,7 @@ package play.core.server.common
 
 import java.net.InetAddress
 
-import com.google.common.net.InetAddresses
+import com.comcast.ip4s.IpAddress
 
 private[common] case class Subnet(ip: InetAddress, cidr: Option[Int] = None) {
 
@@ -34,8 +34,8 @@ private[common] case class Subnet(ip: InetAddress, cidr: Option[Int] = None) {
 
 private[common] object Subnet {
   def apply(s: String): Subnet = s.split("/") match {
-    case Array(ip, subnet) => Subnet(InetAddresses.forString(ip), Some(subnet.toInt))
-    case Array(ip) => Subnet(InetAddresses.forString(ip))
+    case Array(ip, subnet) => Subnet(IpAddress(ip).get.toInetAddress, Some(subnet.toInt))
+    case Array(ip) => Subnet(IpAddress(ip).get.toInetAddress)
     case _ => throw new IllegalArgumentException(s"$s contains more than one '/'.")
   }
 

--- a/framework/src/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
@@ -10,10 +10,8 @@ import java.nio.file.Files
 import java.util.Properties
 import java.util.concurrent._
 
-import com.google.common.io.{ Files => GFiles }
-import org.specs2.matcher.EventuallyMatchers
 import org.specs2.mutable.Specification
-import play.api.{ Mode, Play }
+import play.api.Play
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContext, Future }
@@ -72,10 +70,8 @@ class StartupErrorServerProvider extends ServerProvider {
 
 class ProdServerStartSpec extends Specification {
 
-  sequential
-
   def withTempDir[T](block: File => T) = {
-    val temp = GFiles.createTempDir()
+    val temp = Files.createTempDirectory(System.currentTimeMillis() + "-1")
     try {
       block(temp)
     } finally {

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -6,7 +6,7 @@ package play.core.server.common
 
 import java.net.InetAddress
 
-import com.google.common.net.InetAddresses
+import com.comcast.ip4s.IpAddress
 import org.specs2.mutable.Specification
 import play.api.mvc.Headers
 import org.specs2.mutable.Specification
@@ -474,7 +474,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
   }
 
-  def addr(ip: String): InetAddress = InetAddresses.forString(ip)
+  def addr(ip: String): InetAddress = IpAddress(ip).get.toInetAddress
 
   val localhost: InetAddress = addr("127.0.0.1")
 

--- a/framework/src/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
@@ -7,7 +7,7 @@ package play.core.server.common
 import org.specs2.mutable.Specification
 import ForwardedHeaderHandler.{ ForwardedHeaderVersion, Rfc7239, Xforwarded }
 import NodeIdentifierParser._
-import com.google.common.net.InetAddresses
+import com.comcast.ip4s.IpAddress
 
 class NodeIdentifierParserSpec extends Specification {
 
@@ -16,7 +16,7 @@ class NodeIdentifierParserSpec extends Specification {
     parser.parseNode(str)
   }
 
-  private def ip(s: String): Ip = Ip(InetAddresses.forString(s))
+  private def ip(s: String): Ip = Ip(IpAddress(s).get.toInetAddress)
 
   "NodeIdentifierParser" should {
 

--- a/framework/src/play-server/src/test/scala/play/core/server/common/SubnetSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/SubnetSpec.scala
@@ -4,7 +4,7 @@
 
 package play.core.server.common
 
-import com.google.common.net.InetAddresses
+import com.comcast.ip4s.IpAddress
 import org.specs2.matcher.DataTables
 import org.specs2.mutable.Specification
 
@@ -22,7 +22,7 @@ class SubnetSpec extends Specification with DataTables {
         "2001:dbfe::/31" !! "2001:dbff::" ! true |
         "2001:db8:cafe::17" !! "2001:db8:cafe::17" ! true |>
         {
-          (a, b, c) => Subnet(a).isInRange(InetAddresses.forString(b)) mustEqual c
+          (a, b, c) => Subnet(a).isInRange(IpAddress(b).get.toInetAddress) mustEqual c
         }
     }
   }

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -9,12 +9,13 @@ import java.lang.ref.Reference
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{ Files => JFiles, _ }
 import java.time.{ Clock, Instant }
+import java.util.{Collections => JCollections}
+import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Predicate
-import javax.inject.{ Inject, Provider, Singleton }
 
+import javax.inject.{ Inject, Provider, Singleton }
 import akka.actor.{ ActorSystem, Cancellable }
 import com.google.common.base.{ FinalizablePhantomReference, FinalizableReferenceQueue }
-import com.google.common.collect.Sets
 import org.slf4j.LoggerFactory
 import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
@@ -153,7 +154,7 @@ object Files {
     //
     // https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/FinalizableReferenceQueue.html
     // Keeping references ensures that the FinalizablePhantomReference itself is not garbage-collected.
-    private val references = Sets.newConcurrentHashSet[Reference[TemporaryFile]]()
+    private val references = JCollections.newSetFromMap[Reference[TemporaryFile]](new ConcurrentHashMap())
 
     private val TempDirectoryPrefix = "playtemp"
     private val playTempFolder: Path = {

--- a/framework/src/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
@@ -4,10 +4,9 @@
 
 package play.api.mvc.request
 
+import com.comcast.ip4s.IpAddress
 import java.net.InetAddress
 import java.security.cert.X509Certificate
-
-import com.google.common.net.InetAddresses
 
 /**
  * Contains information about the connection from the remote client to the server.
@@ -55,7 +54,7 @@ object RemoteConnection {
     val ras = remoteAddressString
     val ccc = clientCertificateChain
     new RemoteConnection {
-      override lazy val remoteAddress: InetAddress = InetAddresses.forString(ras)
+      override lazy val remoteAddress: InetAddress = IpAddress(ras).get.toInetAddress
       override val remoteAddressString: String = ras
       override val secure: Boolean = s
       override val clientCertificateChain: Option[Seq[X509Certificate]] = ccc


### PR DESCRIPTION
**Warning this PR is not 100% done yet and is just a preview (still needs to remove some occurences) (i just wanted to get it out, since it floated around on my computer for some time)**

The hardest part of removing guava will be the following two classes (which is not done yet):
* FinalizablePhantomReference
* FinalizableReferenceQueue

and maybe
* BaseEncoding (which implements our Hex Encoder, shouldn't be too hard...)

Everything else is just replacing the stuff from guava, with stuff that we already have in our framework, like `CharStreams` or some kind of `Primitives` checks that we have in some kind of different form.

## Purpose

removes guava
currently I think guava is one of the greatest library of all the time. however it's freaking aweful if a framework depend on it, since first of all guava is *quite* big (2.6mb), second we only use like 2-3 classes from it and the `InetAddress` stuff, so that we do not need to rely on the Java `InetAddress` which sometimes might try to resolve a ip/host (unnecessarily), for that I pulled in a new scala library from comcast, called ip4s which makes ip parsing, etc quite easy and comes with a relativ small size <200kb. and last it means that sometimes upgrades to guava are impossible in user code.

we also use a lot of `Immutable*` however the Maps aren't really needed since they won't leak into user code and the `ImmutableList` stuff can be replaced by java8 code that makes list immutable

This PR helps that people who **need** guava can actually use the latest and greatest guava and probably reduce the size of play for all scala users that might never need guava at all.
