### PR TITLE
Implementation for issue #8527 (Content-Disposition of multipart/form-data too strict for some implementations)

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -233,12 +233,6 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
       result must not(beEmpty)
       result.get must equalTo(("document", "hello.txt", None))
     }
-
-    "accept also 'Content-Disposition: arbitrary' for part (see issue #8527)" in {
-      val result = PartInfoMatcher.unapply(Map("content-disposition" -> """arbitrary; name=partName"""))
-      result must not(beEmpty)
-      result.get must equalTo("partName")
-    }
   }
 
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -227,12 +227,6 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
       result must not(beEmpty)
       result.get must equalTo(("document", "hello.txt", None))
     }
-
-    "accept also 'Content-Disposition: arbitrary' for file (see issue #8527)" in {
-      val result = FileInfoMatcher.unapply(Map("content-disposition" -> """arbitrary; name=document; filename=hello.txt"""))
-      result must not(beEmpty)
-      result.get must equalTo(("document", "hello.txt", None))
-    }
   }
 
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -56,7 +56,7 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
       |Content-Disposition: file; name="file3"; filename="file3.txt"
       |Content-Type: text/plain
       |
-      |the third file (with 'Content-Disposition: file' instead of 'form-data', see issue #8527)
+      |the third file (with 'Content-Disposition: file' instead of 'form-data' as used in webhook callbacks of some scanners, see issue #8527)
       |
       |--aabbccddee--
       |""".stripMargin.lines.mkString("\r\n")
@@ -78,7 +78,7 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
           case filePart => PlayIO.readFileAsString(filePart.ref) must_== "the second file\r\n"
         }
         parts.file("file3") must beSome.like {
-          case filePart => PlayIO.readFileAsString(filePart.ref) must_== "the third file (with 'Content-Disposition: file' instead of 'form-data', see issue #8527)\r\n"
+          case filePart => PlayIO.readFileAsString(filePart.ref) must_== "the third file (with 'Content-Disposition: file' instead of 'form-data' as used in webhook callbacks of some scanners, see issue #8527)\r\n"
         }
     }
   }
@@ -222,7 +222,7 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
       result.get must equalTo(("document", "hello.txt", None))
     }
 
-    "accept also 'Content-Disposition: file' for file (see issue #8527)" in {
+    "accept also 'Content-Disposition: file' for file as used in webhook callbacks of some scanners (see issue #8527)" in {
       val result = FileInfoMatcher.unapply(Map("content-disposition" -> """file; name=document; filename=hello.txt"""))
       result must not(beEmpty)
       result.get must equalTo(("document", "hello.txt", None))

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -191,7 +191,7 @@ object Multipart {
             case key => (key.trim, "")
           }(breakOut): Map[String, String])
 
-        _ <- values.get("form-data")
+        _ <- values.get("name")
         partName <- values.get("name")
         fileName <- values.get("filename")
         contentType = headers.get("content-type")
@@ -210,7 +210,7 @@ object Multipart {
             case KeyValue(key, v) => (key.trim, v.trim)
             case key => (key.trim, "")
           }(breakOut): Map[String, String])
-        _ <- values.get("form-data")
+        _ <- values.get("name")
         partName <- values.get("name")
       } yield partName
     }

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -210,7 +210,7 @@ object Multipart {
             case KeyValue(key, v) => (key.trim, v.trim)
             case key => (key.trim, "")
           }(breakOut): Map[String, String])
-        _ <- values.get("name")
+        _ <- values.get("form-data")
         partName <- values.get("name")
       } yield partName
     }

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -191,7 +191,7 @@ object Multipart {
             case key => (key.trim, "")
           }(breakOut): Map[String, String])
 
-        _ <- values.get("name")
+        _ <- values.get("form-data").orElse(values.get("file"))
         partName <- values.get("name")
         fileName <- values.get("filename")
         contentType = headers.get("content-type")


### PR DESCRIPTION
# Fixes

This pull request contains an implementation for the problem described in issue #8527 (Content-Disposition of multipart/form-data too strict for some implementations).

## Short summary of issue

Play did not recognise webhook callbacks from scanners because the manufacturer uses `Content-Disposition: file` instead of `form-data` (probably, they are in accordance with older standards, see investigation in issue #8527).

# Solution and tests

We have added respective tests and changed the implementation accordingly (solution 1 proposed in the issue).

Furthermore, we have tested the resulting Play snapshot with the scanner software that previously did not interoperate with Play (see issue #8527).

# CLA

We signed the Lightbend CLA.