### PR TITLE
Remove `play.akka.run-cs-from-phase` configuration

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -227,3 +227,21 @@ Many changes have been made to Play's internal APIs. These APIs are used interna
 ### `Server.getHandlerFor` has moved to `Server#getHandlerFor`
 
 The `getHandlerFor` method on the `Server` trait was used internally by the Play server code when routing requests. It has been removed and replaced with a method of the same name on the `Server` object.
+
+## CoordinatedShutdown `play.akka.run-cs-from-phase` configuration
+
+The configuration `play.akka.run-cs-from-phase` is not supported anymore and adding it has no effect. A warning is logged if it is present. Play now run all the phases to ensure that all hooks registered in `ApplicationLifecycle` or all the tasks added to coordinated shutdown are executed. If you need to run `CoordinatedShutdown` from a specific phase, you can always do it manually:
+
+```scala
+val reason = CoordinatedShutdown.UnknownReason
+val runFromPhase = Some(CoordinatedShutdown.PhaseBeforeClusterShutdown)
+val coordinatedShutdown = CoodinatedShutdown(actorSystem).run(reason, runFromPhase)
+```
+
+And for Java:
+
+```java
+CoordinatedShutdown.Reason reason = CoordinatedShutdown.unknownReason();
+Optional<String> runFromPhase = Optional.of("");
+CoordinatedShutdown.get(actorSystem).run(reason, runFromPhase);
+```

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -230,7 +230,7 @@ The `getHandlerFor` method on the `Server` trait was used internally by the Play
 
 ## CoordinatedShutdown `play.akka.run-cs-from-phase` configuration
 
-The configuration `play.akka.run-cs-from-phase` is not supported anymore and adding it has no effect. A warning is logged if it is present. Play now run all the phases to ensure that all hooks registered in `ApplicationLifecycle` or all the tasks added to coordinated shutdown are executed. If you need to run `CoordinatedShutdown` from a specific phase, you can always do it manually:
+The configuration `play.akka.run-cs-from-phase` is not supported anymore and adding it has no effect. A warning is logged if it is present. Play now runs all the phases to ensure that all hooks registered in `ApplicationLifecycle` and all the tasks added to coordinated shutdown are executed. If you need to run `CoordinatedShutdown` from a specific phase, you can always do it manually:
 
 ```scala
 val reason = CoordinatedShutdown.UnknownReason

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -902,14 +902,8 @@ play {
           # only used by the Server. Defaults to 'on'.
           run-by-jvm-shutdown-hook = on
         }
-
       }
     }
-
-    # When Play is shutting down it will use Akka's CoordinatedShutdown. By default, the shutdown will run
-    # all phases. You can choose what phase to run.
-    # See https://doc.akka.io/docs/akka/current/actors.html?language=scala#coordinated-shutdown
-    run-cs-from-phase = "before-service-unbind"
   }
 
   #Assets configuration

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -8,22 +8,20 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
 import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.actor.CoordinatedShutdown._
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.specs2.mutable.Specification
 import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.api.{ Configuration, Environment }
 
+import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, Future, Promise }
-import scala.util.Success
 
 class ActorSystemProviderSpec extends Specification {
 
   val akkaMaxDelayInSec = 2147483
   val fiveSec = Duration(5, "seconds")
   val oneSec = Duration(100, "milliseconds")
-  val mustRunPhase = CoordinatedShutdown.PhaseServiceStop
-  val mustNotRunPhase = CoordinatedShutdown.PhaseBeforeServiceUnbind
 
   val akkaTimeoutKey = "akka.coordinated-shutdown.phases.actor-system-terminate.timeout"
   val playTimeoutKey = "play.akka.shutdown-timeout"
@@ -31,15 +29,15 @@ class ActorSystemProviderSpec extends Specification {
   "ActorSystemProvider" should {
 
     "use Play's 'play.akka.shutdown-timeout' if defined " in {
-      withOverridenTimeout {
+      withOverriddenTimeout {
         _.withValue(playTimeoutKey, ConfigValueFactory.fromAnyRef("12 s"))
       } { actorSystem =>
         actorSystem.settings.config.getDuration(akkaTimeoutKey).getSeconds must equalTo(12)
       }
     }
 
-    "use an infinite timeout if usingg Play's 'play.akka.shutdown-timeout = null' " in {
-      withOverridenTimeout {
+    "use an infinite timeout if using Play's 'play.akka.shutdown-timeout = null' " in {
+      withOverriddenTimeout {
         _.withFallback(ConfigFactory.parseResources("src/test/resources/application-infinite-timeout.conf"))
       } { actorSystem =>
         actorSystem.settings.config.getDuration(akkaTimeoutKey).getSeconds must equalTo(akkaMaxDelayInSec)
@@ -47,7 +45,7 @@ class ActorSystemProviderSpec extends Specification {
     }
 
     "use Play's 'Duration.Inf' when no 'play.akka.shutdown-timeout' is defined and user overwrites Akka's default" in {
-      withOverridenTimeout {
+      withOverriddenTimeout {
         _.withValue(akkaTimeoutKey, ConfigValueFactory.fromAnyRef("21 s"))
       } { actorSystem =>
         actorSystem.settings.config.getDuration(akkaTimeoutKey).getSeconds must equalTo(akkaMaxDelayInSec)
@@ -55,7 +53,7 @@ class ActorSystemProviderSpec extends Specification {
     }
 
     "use infinite when 'play.akka.shutdown-timeout = null' and user overwrites Akka's default" in {
-      withOverridenTimeout {
+      withOverriddenTimeout {
         _.withFallback(ConfigFactory.parseResources("src/test/resources/application-infinite-timeout.conf"))
           .withValue(akkaTimeoutKey, ConfigValueFactory.fromAnyRef("17 s"))
       } { actorSystem =>
@@ -63,55 +61,72 @@ class ActorSystemProviderSpec extends Specification {
       }
     }
 
-    "run the CoordinatedShutdown from the configured phase system when the stopHook is run" in {
+    "run all the phases for coordinated shutdown" in {
+
+      val phaseBeforeServiceUnbindExecuted = new AtomicBoolean(false)
+      val phaseServiceUnbindExecuted = new AtomicBoolean(false)
+      val phaseServiceRequestsDoneExecuted = new AtomicBoolean(false)
+      val phaseServiceStopExecuted = new AtomicBoolean(false)
+      val phaseBeforeClusterShutdownExecuted = new AtomicBoolean(false)
+      val phaseClusterShardingShutdownRegionExecuted = new AtomicBoolean(false)
+      val phaseClusterLeaveExecuted = new AtomicBoolean(false)
+      val phaseClusterExitingExecuted = new AtomicBoolean(false)
+      val phaseClusterExitingDoneExecuted = new AtomicBoolean(false)
+      val phaseClusterShutdownExecuted = new AtomicBoolean(false)
+      val phaseBeforeActorSystemTerminateExecuted = new AtomicBoolean(false)
+      val phaseActorSystemTerminateExecuted = new AtomicBoolean(false)
 
       val config = Configuration
         .load(Environment.simple())
         .underlying
-        .withValue(
-          "play.akka.run-cs-from-phase",
-          ConfigValueFactory.fromAnyRef(mustRunPhase))
 
       val (actorSystem, _) = ActorSystemProvider.start(
         this.getClass.getClassLoader,
         Configuration(config)
       )
+
       val lifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle()
 
-      val promise = Promise[Done]()
-      val terminated = promise.future
-      val isRun = new AtomicBoolean(false)
-
       val cs = new CoordinatedShutdownProvider(actorSystem, lifecycle).get
-      cs.addTask(mustRunPhase, "termination-promise") {
-        () =>
-          promise.complete(Success(Done))
-          Future.successful(Done)
-      }
-      cs.addTask(mustNotRunPhase, "is-ignored-promise") {
-        () =>
-          isRun.set(true)
-          Future.successful(Done)
+
+      def run(atomicBoolean: AtomicBoolean) = () => {
+        atomicBoolean.set(true)
+        Future.successful(Done)
       }
 
-      try {
-        Await.result(terminated, oneSec)
-        failure
-      } catch {
-        case _: Throwable =>
-      }
+      cs.addTask(PhaseBeforeServiceUnbind, "test-BeforeServiceUnbindExecuted")(run(phaseBeforeServiceUnbindExecuted))
+      cs.addTask(PhaseServiceUnbind, "test-ServiceUnbindExecuted")(run(phaseServiceUnbindExecuted))
+      cs.addTask(PhaseServiceRequestsDone, "test-ServiceRequestsDoneExecuted")(run(phaseServiceRequestsDoneExecuted))
+      cs.addTask(PhaseServiceStop, "test-ServiceStopExecuted")(run(phaseServiceStopExecuted))
+      cs.addTask(PhaseBeforeClusterShutdown, "test-BeforeClusterShutdownExecuted")(run(phaseBeforeClusterShutdownExecuted))
+      cs.addTask(PhaseClusterShardingShutdownRegion, "test-ClusterShardingShutdownRegionExecuted")(run(phaseClusterShardingShutdownRegionExecuted))
+      cs.addTask(PhaseClusterLeave, "test-ClusterLeaveExecuted")(run(phaseClusterLeaveExecuted))
+      cs.addTask(PhaseClusterExiting, "test-ClusterExitingExecuted")(run(phaseClusterExitingExecuted))
+      cs.addTask(PhaseClusterExitingDone, "test-ClusterExitingDoneExecuted")(run(phaseClusterExitingDoneExecuted))
+      cs.addTask(PhaseClusterShutdown, "test-ClusterShutdownExecuted")(run(phaseClusterShutdownExecuted))
+      cs.addTask(PhaseBeforeActorSystemTerminate, "test-BeforeActorSystemTerminateExecuted")(run(phaseBeforeActorSystemTerminateExecuted))
+      cs.addTask(PhaseActorSystemTerminate, "test-ActorSystemTerminateExecuted")(run(phaseActorSystemTerminateExecuted))
 
-      implicit val ctx = actorSystem.dispatcher
-      // lifecycle.stop is deprecated, use CS instead.
-      //      val completeShutdown = lifecycle.stop().flatMap(_ => terminated)
       CoordinatedShutdownProvider.syncShutdown(actorSystem, CoordinatedShutdown.UnknownReason)
 
-      isRun.get() must equalTo(false)
+      phaseBeforeServiceUnbindExecuted.get() must equalTo(true)
+      phaseServiceUnbindExecuted.get() must equalTo(true)
+      phaseServiceRequestsDoneExecuted.get() must equalTo(true)
+      phaseServiceStopExecuted.get() must equalTo(true)
+      phaseBeforeClusterShutdownExecuted.get() must equalTo(true)
+      phaseClusterShardingShutdownRegionExecuted.get() must equalTo(true)
+      phaseClusterLeaveExecuted.get() must equalTo(true)
+      phaseClusterExitingExecuted.get() must equalTo(true)
+      phaseClusterExitingDoneExecuted.get() must equalTo(true)
+      phaseClusterShutdownExecuted.get() must equalTo(true)
+      phaseBeforeActorSystemTerminateExecuted.get() must equalTo(true)
+      phaseActorSystemTerminateExecuted.get() must equalTo(true)
+
     }
 
   }
 
-  private def withOverridenTimeout[T](reconfigure: Config => Config)(block: ActorSystem => T): T = {
+  private def withOverriddenTimeout[T](reconfigure: Config => Config)(block: ActorSystem => T): T = {
     val config: Config = reconfigure(Configuration
       .load(Environment.simple())
       .underlying


### PR DESCRIPTION
## Purpose

The default now is to run all the phases. Users can create an instance of CoordinatedShutdown and run from a specific phase if they want/need to.