### PR TITLE
Refactoring CoordinatedShutdownProvider object

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -24,7 +24,7 @@ import com.typesafe.config.{ Config, ConfigMemorySize }
 import javax.net.ssl._
 import play.api._
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
-import play.api.libs.concurrent.CoordinatedShutdownProvider
+import play.api.libs.concurrent.{ CoordinatedShutdownProvider, CoordinatedShutdownSupport }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.mvc.akkahttp.AkkaHttpHandler
@@ -366,7 +366,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
       }
   }
 
-  override def stop(): Unit = CoordinatedShutdownProvider.syncShutdown(context.actorSystem, ServerStoppedReason)
+  override def stop(): Unit = CoordinatedShutdownSupport.syncShutdown(context.actorSystem, ServerStoppedReason)
 
   // Using CoordinatedShutdown means that instead of invoking code imperatively in `stop`
   // we have to register it as early as possible as CoordinatedShutdown tasks and

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -5,7 +5,6 @@
 package play.core.server
 
 import java.net.InetSocketAddress
-import java.util.concurrent.TimeUnit
 
 import akka.Done
 import akka.actor.{ ActorSystem, CoordinatedShutdown }
@@ -24,9 +23,8 @@ import io.netty.handler.codec.http._
 import io.netty.handler.logging.{ LogLevel, LoggingHandler }
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.timeout.IdleStateHandler
-import io.netty.util
 import play.api._
-import play.api.libs.concurrent.CoordinatedShutdownProvider
+import play.api.libs.concurrent.CoordinatedShutdownSupport
 import play.api.routing.Router
 import play.core._
 import play.core.server.Server.ServerStoppedReason
@@ -36,7 +34,7 @@ import play.server.SSLEngineProvider
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext, ExecutionContextExecutor, Future }
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 
 sealed trait NettyTransport
@@ -233,7 +231,7 @@ class NettyServer(
     serverChannel
   }
 
-  override def stop(): Unit = CoordinatedShutdownProvider.syncShutdown(actorSystem, ServerStoppedReason)
+  override def stop(): Unit = CoordinatedShutdownSupport.syncShutdown(actorSystem, ServerStoppedReason)
 
   // Using CoordinatedShutdown means that instead of invoking code imperatively in `stop`
   // we have to register it as early as possible as CoordinatedShutdown tasks and

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -15,7 +15,7 @@ import play.api.http._
 import play.api.i18n.I18nComponents
 import play.api.inject.{ ApplicationLifecycle, _ }
 import play.api.libs.Files._
-import play.api.libs.concurrent.{ ActorSystemProvider, CoordinatedShutdownProvider }
+import play.api.libs.concurrent.{ ActorSystemProvider, CoordinatedShutdownProvider, CoordinatedShutdownSupport }
 import play.api.libs.crypto._
 import play.api.mvc._
 import play.api.mvc.request.{ DefaultRequestFactory, RequestFactory }
@@ -274,7 +274,7 @@ class DefaultApplication @Inject() (
 
   override def classloader: ClassLoader = environment.classLoader
 
-  override def stop(): Future[_] = CoordinatedShutdownProvider.asyncShutdown(actorSystem, ApplicationStoppedReason)
+  override def stop(): Future[_] = CoordinatedShutdownSupport.asyncShutdown(actorSystem, ApplicationStoppedReason)
 }
 
 private[play] final case object ApplicationStoppedReason extends CoordinatedShutdown.Reason

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -288,7 +288,7 @@ private[play] object CoordinatedShutdownProvider {
  * Provider for the coordinated shutdown
  */
 @Singleton
-private[play] class CoordinatedShutdownProvider @Inject() (actorSystem: ActorSystem, applicationLifecycle: ApplicationLifecycle) extends Provider[CoordinatedShutdown] {
+class CoordinatedShutdownProvider @Inject() (actorSystem: ActorSystem, applicationLifecycle: ApplicationLifecycle) extends Provider[CoordinatedShutdown] {
 
   import CoordinatedShutdownProvider.logger
 

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -242,7 +242,7 @@ class ActorRefProvider[T <: Actor: ClassTag](name: String, props: Props => Props
   }
 }
 
-private[play] object CoordinatedShutdownProvider {
+private[play] object CoordinatedShutdownSupport {
 
   private[play] lazy val logger = LoggerFactory.getLogger(classOf[CoordinatedShutdownProvider])
 
@@ -290,7 +290,7 @@ private[play] object CoordinatedShutdownProvider {
 @Singleton
 class CoordinatedShutdownProvider @Inject() (actorSystem: ActorSystem, applicationLifecycle: ApplicationLifecycle) extends Provider[CoordinatedShutdown] {
 
-  import CoordinatedShutdownProvider.logger
+  import CoordinatedShutdownSupport.logger
 
   lazy val get: CoordinatedShutdown = {
 

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -242,7 +242,7 @@ class ActorRefProvider[T <: Actor: ClassTag](name: String, props: Props => Props
   }
 }
 
-object CoordinatedShutdownProvider {
+private[play] object CoordinatedShutdownProvider {
 
   private[play] lazy val logger = LoggerFactory.getLogger(classOf[CoordinatedShutdownProvider])
 
@@ -288,7 +288,7 @@ object CoordinatedShutdownProvider {
  * Provider for the coordinated shutdown
  */
 @Singleton
-class CoordinatedShutdownProvider @Inject() (actorSystem: ActorSystem, applicationLifecycle: ApplicationLifecycle) extends Provider[CoordinatedShutdown] {
+private[play] class CoordinatedShutdownProvider @Inject() (actorSystem: ActorSystem, applicationLifecycle: ApplicationLifecycle) extends Provider[CoordinatedShutdown] {
 
   import CoordinatedShutdownProvider.logger
 

--- a/framework/src/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
@@ -56,11 +56,10 @@ class DefaultApplicationLifecycleSpec extends Specification {
     "runs stop() only once" in {
       val counter = new AtomicInteger(0)
       val lifecycle = new DefaultApplicationLifecycle()
-      val buffer = mutable.ListBuffer[Int]()
       lifecycle.addStopHook{
         () =>
           counter.incrementAndGet()
-          Future.successful()
+          Future.successful(())
       }
 
       val f1 = lifecycle.stop()

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -100,7 +100,7 @@ class ActorSystemProviderSpec extends Specification {
       cs.addTask(PhaseActorSystemTerminate, "test-ActorSystemTerminateExecuted")(run(phaseActorSystemTerminateExecuted))
       cs.addTask(PhaseCustomDefinedPhase, "test-PhaseCustomDefinedPhaseExecuted")(run(phaseCustomDefinedPhaseExecuted))
 
-      CoordinatedShutdownProvider.syncShutdown(actorSystem, CoordinatedShutdown.UnknownReason)
+      CoordinatedShutdownSupport.syncShutdown(actorSystem, CoordinatedShutdown.UnknownReason)
 
       phaseBeforeServiceUnbindExecuted.get() must equalTo(true)
       phaseActorSystemTerminateExecuted.get() must equalTo(true)


### PR DESCRIPTION
## Purpose

Two main changes here:

1. Users should interact directly with Akka's CoordinatedShutdown API instead of relying on Play helpers. This way evolutions on Akka API will be available faster and more consistently.
1. Renaming from `CoordinatedShutdownProvider` to `CoordinatedShutdownSupport`.

This may later have some impact on Lagom since it depending on these APIs (at least this is the direction in  https://github.com/lagom/lagom/pull/1453. What we can do is to access Play's `CoordinatedShutdownSupport` just like it was done in [`TrampolineContextAccessor.scala`](https://github.com/lagom/lagom/blob/349d7f94d592ed63a63d5959425a480e061774e7/service/core/api/src/main/scala/TrampolineContextAccessor.scala#L7).