### PR TITLE
Fix asJava play.api.Application conversion

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -6,10 +6,9 @@ package play.api
 
 import java.io._
 
-import akka.Done
-import javax.inject.{ Inject, Singleton }
 import akka.actor.{ ActorSystem, CoordinatedShutdown }
 import akka.stream.{ ActorMaterializer, Materializer }
+import javax.inject.{ Inject, Singleton }
 import play.api.ApplicationLoader.DevContext
 import play.api.http._
 import play.api.i18n.I18nComponents
@@ -107,7 +106,7 @@ trait Application {
    * Return the application as a Java application.
    */
   def asJava: play.Application = {
-    new play.DefaultApplication(this, configuration.underlying, injector.asJava)
+    new play.DefaultApplication(this, configuration.underlying, injector.asJava, environment.asJava)
   }
 
   /**

--- a/framework/src/play/src/test/resources/application.conf
+++ b/framework/src/play/src/test/resources/application.conf
@@ -1,1 +1,0 @@
-# Empty. Exists for test purpose.

--- a/framework/src/play/src/test/resources/application.conf
+++ b/framework/src/play/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+# Empty. Exists for test purpose.

--- a/framework/src/play/src/test/resources/logback-test.xml
+++ b/framework/src/play/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+  -->
+<configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- We use short exception stack trace logging to limit output for travis. -->
+            <!-- Change to full if you need to do further debugging, but never commit that. -->
+            <pattern>%level %logger{15} - %message%n%ex{short}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/framework/src/play/src/test/scala/play/api/ApplicationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ApplicationSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api
+
+import com.typesafe.config.ConfigFactory
+import org.specs2.mutable.Specification
+import play.core.test._
+
+class ApplicationSpec extends Specification {
+
+  "Scala Application" should {
+
+    "honors Environment mode" in {
+      "Mode.Test" in withApplication(Environment.simple(mode = Mode.Test)) { application =>
+        application.isTest must beTrue
+      }
+      "Mode.Dev" in withApplication(Environment.simple(mode = Mode.Dev)) { application =>
+        application.isDev must beTrue
+      }
+      "Mode.Prod" in withApplication(Environment.simple(mode = Mode.Prod)) { application =>
+        application.isProd must beTrue
+      }
+    }
+
+    "when converting to Java application" should {
+
+      "preserve environment" in {
+        "test mode" in withApplication(Environment.simple(mode = Mode.Test)) { application =>
+          val javaApplication = application.asJava
+          javaApplication.isTest must beTrue
+          javaApplication.environment().mode() must beEqualTo(play.Mode.TEST)
+        }
+        "dev mode" in withApplication(Environment.simple(mode = Mode.Dev)) { application =>
+          val javaApplication = application.asJava
+          javaApplication.isDev must beTrue
+          javaApplication.environment().mode() must beEqualTo(play.Mode.DEV)
+        }
+        "prod mode" in withApplication(Environment.simple(mode = Mode.Prod)) { application =>
+          val javaApplication = application.asJava
+          javaApplication.isProd must beTrue
+          javaApplication.environment().mode() must beEqualTo(play.Mode.PROD)
+        }
+      }
+
+      "preserve configuration" in withApplicationAndConfig(
+        Environment.simple(),
+        ConfigFactory.parseString("test.config = 10")
+      ) { application =>
+          val javaApplication = application.asJava
+          javaApplication.config().getInt("test.config") must beEqualTo(10)
+        }
+    }
+  }
+}

--- a/framework/src/play/src/test/scala/play/core/test/package.scala
+++ b/framework/src/play/src/test/scala/play/core/test/package.scala
@@ -4,7 +4,9 @@
 
 package play.core
 
+import com.typesafe.config.{ Config, ConfigFactory }
 import play.api._
+import play.api.routing.Router
 
 package object test {
 
@@ -13,7 +15,7 @@ package object test {
    */
   def withApplication[T](block: => T): T = {
     val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple())) with NoHttpFiltersComponents {
-      def router = play.api.routing.Router.empty
+      override def router: Router = play.api.routing.Router.empty
     }.application
     Play.start(app)
     try {
@@ -24,8 +26,20 @@ package object test {
   }
 
   def withApplication[T](block: Application => T): T = {
-    val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple())) with NoHttpFiltersComponents {
-      def router = play.api.routing.Router.empty
+    withApplicationAndConfig(Environment.simple(), ConfigFactory.empty())(block)
+  }
+
+  def withApplication[T](environment: Environment)(block: Application => T): T = {
+    withApplicationAndConfig(environment, ConfigFactory.empty())(block)
+  }
+
+  def withApplicationAndConfig[T](environment: Environment, extraConfig: Config)(block: Application => T): T = {
+    val app = new BuiltInComponentsFromContext(ApplicationLoader.Context.create(environment)) with NoHttpFiltersComponents {
+      override def router: Router = play.api.routing.Router.empty
+      override def configuration: Configuration = {
+        val underlyingConfig = super.configuration.underlying
+        new Configuration(underlyingConfig.withFallback(extraConfig))
+      }
     }.application
     Play.start(app)
     try {


### PR DESCRIPTION
## Fixes

`play.api.application.asJava` was not considering the environment. Notice that while working on some coordinated shutdown refactorings.