### PR TITLE
Use the same version of play-file-watch for sbt 0.13 and 1

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -183,17 +183,14 @@ object Dependencies {
     Defaults.sbtPluginExtra(moduleId, CrossVersion.binarySbtVersion(sbtVersion), CrossVersion.binaryScalaVersion(scalaVersion))
   }
 
-  def playFileWatch(sbtVersion: String): ModuleID = CrossVersion.binarySbtVersion(sbtVersion) match {
-    case "1.0" => "com.lightbend.play" %% "play-file-watch" % "1.1.7"
-    case "0.13" => "com.lightbend.play" %% "play-file-watch" % "1.0.0"
-  }
+  val playFileWatch = "com.lightbend.play" %% "play-file-watch" % "1.1.7"
 
   def runSupportDependencies(sbtVersion: String): Seq[ModuleID] = {
     (CrossVersion.binarySbtVersion(sbtVersion) match {
       case "1.0" => specs2Deps.map(_ % Test)
       case "0.13" => specs2DepsForSbt.map(_ % Test)
     }) ++ Seq(
-      playFileWatch(sbtVersion),
+      playFileWatch,
       logback % Test
     )
   }
@@ -213,7 +210,7 @@ object Dependencies {
       "org.scala-lang" % "scala-reflect" % scalaVersion % "provided",
       typesafeConfig,
       slf4jSimple,
-      playFileWatch(sbtVersion),
+      playFileWatch,
       sbtDep("com.typesafe.sbt" % "sbt-twirl" % BuildInfo.sbtTwirlVersion),
       sbtDep("com.typesafe.sbt" % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
       sbtDep("com.lightbend.sbt" % "sbt-javaagent" % BuildInfo.sbtJavaAgentVersion),

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
     scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6"),
     PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
 
-    PlayKeys.fileWatchService := FileWatchServiceInitializer.initialFileWatchService,
+    PlayKeys.fileWatchService := DevModeBuild.initialFileWatchService,
 
     TaskKey[Unit]("resetReloads") := {
       (target.value / "reload.log").delete()

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
@@ -11,6 +11,8 @@ import scala.util.Properties
 
 object DevModeBuild {
 
+  lazy val initialFileWatchService = play.dev.filewatch.FileWatchService.polling(500)
+
   def jdk7WatchService = Def.setting {
     FileWatchService.jdk7(Keys.sLog.value)
   }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/scala-sbt-0.13/Compat.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/scala-sbt-0.13/Compat.scala
@@ -1,6 +1,0 @@
-/*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
- */
-object FileWatchServiceInitializer {
-  lazy val initialFileWatchService = play.dev.filewatch.FileWatchService.sbt(500)
-}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/scala-sbt-1.0/Compat.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/scala-sbt-1.0/Compat.scala
@@ -1,6 +1,0 @@
-/*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
- */
-object FileWatchServiceInitializer {
-  lazy val initialFileWatchService = play.dev.filewatch.FileWatchService.polling(500)
-}


### PR DESCRIPTION
## Purpose

This changes how play-file-watch is added for both sbt 0.13 and sbt 1. Now the same version is used for both.