### PR TITLE
Quick publish when running scripted tests for sbt 1

### DIFF
--- a/framework/bin/test-sbt-plugins-1_0
+++ b/framework/bin/test-sbt-plugins-1_0
@@ -10,7 +10,7 @@ SBT_VERSION="1.0.4"
 cd ${FRAMEWORK}
 
 printMessage "PUBLISHING PLAY LOCALLY FOR SBT ${SBT_VERSION}"
-runSbt "+++ ${SCALA_VERSION} publishLocal"
+runSbt ++${SCALA_VERSION} quickPublish publishLocal
 
 printMessage "RUNNING SCRIPTED TESTS FOR SBT ${SBT_VERSION}"
 runSbtNoisy "++${SCALA_VERSION} scripted"

--- a/framework/project/Tasks.scala
+++ b/framework/project/Tasks.scala
@@ -2,9 +2,8 @@
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
-import sbt._
 import sbt.Keys._
-import sbt.complete.Parsers
+import sbt._
 
 object Generators {
   // Generates a scala file that contains the play version for use at runtime.
@@ -39,7 +38,7 @@ object Generators {
 }
 
 object Commands {
-  val quickPublish = Command("quickPublish", Help.more("quickPublish", "Toggles quick publish mode, disabling/enabling build of documentation/source jars"))(_ => Parsers.EOF) { (state, _) =>
+  val quickPublish = Command.command("quickPublish", Help.more("quickPublish", "Toggles quick publish mode, disabling/enabling build of documentation/source jars")) { state =>
     val x = Project.extract(state)
     import x._
 


### PR DESCRIPTION
## Purpose

We can use `quickPublish` to speed up scripted tests for sbt 1 too.