### PR TITLE
Update dependencies

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.5.13"
+  val akkaVersion = "2.5.14"
   val akkaHttpVersion = "10.1.3"
   val playJsonVersion = "2.6.9"
 
@@ -51,21 +51,17 @@ object Dependencies {
 
   val guava = "com.google.guava" % "guava" % "25.1-jre"
   val findBugs = "com.google.code.findbugs" % "jsr305" % "3.0.2" // Needed by guava
-  val mockitoAll = "org.mockito" % "mockito-core" % "2.18.3"
+  val mockitoAll = "org.mockito" % "mockito-core" % "2.20.1"
 
   val h2database = "com.h2database" % "h2" % "1.4.197"
   val derbyDatabase = "org.apache.derby" % "derby" % "10.13.1.1"
 
-  val acolyteVersion = "1.0.47"
+  val acolyteVersion = "1.0.48"
   val acolyte = "org.eu.acolyte" % "jdbc-driver" % acolyteVersion
 
   val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.7"
 
-  val jjwt = "io.jsonwebtoken" % "jjwt" % "0.9.0"
-  // currently jjwt needs the JAXB Api package in JDK 9+
-  // since it actually uses javax/xml/bind/DatatypeConverter
-  // See: https://github.com/jwtk/jjwt/issues/317
-  val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.0"
+  val jjwt = "io.jsonwebtoken" % "jjwt" % "0.10.0"
 
   val jdbcDeps = Seq(
     "com.zaxxer" % "HikariCP" % "3.2.0",
@@ -78,7 +74,7 @@ object Dependencies {
 
   val jpaDeps = Seq(
     "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.2.Final",
-    "org.hibernate" % "hibernate-core" % "5.3.1.Final" % "test"
+    "org.hibernate" % "hibernate-core" % "5.3.3.Final" % "test"
   )
 
   val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0"
@@ -87,7 +83,7 @@ object Dependencies {
     case _ => Nil
   }
 
-  val springFrameworkVersion = "5.0.7.RELEASE"
+  val springFrameworkVersion = "5.0.8.RELEASE"
 
   val javaDeps = Seq(
     scalaJava8Compat,
@@ -103,7 +99,7 @@ object Dependencies {
 
   val javaFormsDeps = Seq(
 
-    "org.hibernate" % "hibernate-validator" % "6.0.10.Final",
+    "org.hibernate" % "hibernate-validator" % "6.0.11.Final",
 
     ("org.springframework" % "spring-context" % springFrameworkVersion)
       .exclude("org.springframework", "spring-aop")
@@ -149,7 +145,6 @@ object Dependencies {
 
       guava,
       jjwt,
-      jaxbApi,
 
       "javax.transaction" % "jta" % "1.1",
       "javax.inject" % "javax.inject" % "1",
@@ -169,7 +164,7 @@ object Dependencies {
 
   val jimfs = "com.google.jimfs" % "jimfs" % "1.1"
 
-  val okHttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"
+  val okHttp = "com.squareup.okhttp3" % "okhttp" % "3.11.0"
 
   def routesCompilerDependencies(scalaVersion: String) = {
     val deps = CrossVersion.partialVersion(scalaVersion) match {
@@ -246,10 +241,10 @@ object Dependencies {
     logback % Test
   )
 
-  val fluentleniumVersion = "3.5.2"
+  val fluentleniumVersion = "3.6.1"
   // This is the selenium version compatible with the FluentLenium version declared above.
   // See http://mvnrepository.com/artifact/org.fluentlenium/fluentlenium-core/3.5.2
-  val seleniumVersion = "3.9.1"
+  val seleniumVersion = "3.13.0"
 
   val testDependencies = Seq(junit, junitInterface, guava, findBugs, logback) ++ Seq(
     "org.fluentlenium" % "fluentlenium-core" % fluentleniumVersion exclude("org.jboss.netty", "netty"),

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -153,7 +153,7 @@ object Dependencies {
       scalaJava8Compat
     ) ++ scalaParserCombinators(scalaVersion) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
 
-  val nettyVersion = "4.1.25.Final"
+  val nettyVersion = "4.1.28.Final"
 
   val netty = Seq(
     "com.typesafe.netty" % "netty-reactive-streams-http" % "2.0.0",

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -149,6 +149,7 @@ object Dependencies {
 
       guava,
       jjwt,
+      jaxbApi,
 
       "javax.transaction" % "jta" % "1.1",
       "javax.inject" % "javax.inject" % "1",

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -61,7 +61,11 @@ object Dependencies {
 
   val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.7"
 
-  val jjwt = "io.jsonwebtoken" % "jjwt" % "0.10.0"
+  val jjwt = "io.jsonwebtoken" % "jjwt" % "0.9.0"
+  // currently jjwt needs the JAXB Api package in JDK 9+
+  // since it actually uses javax/xml/bind/DatatypeConverter
+  // See: https://github.com/jwtk/jjwt/issues/317
+  val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.0"
 
   val jdbcDeps = Seq(
     "com.zaxxer" % "HikariCP" % "3.2.0",


### PR DESCRIPTION
## Purpose

Main updates are:

1.  Akka to version 2.5.14
2. jjwt to version 0.10.0

There are some other significant jumps like the selenium version.

## References

https://github.com/jwtk/jjwt/blob/master/CHANGELOG.md#0100
