### PR TITLE
Improved SBT Cookbook in documentation by adding imports for scala.sys.process.Process

### DIFF
--- a/documentation/manual/working/commonGuide/build/code/runhook.sbt
+++ b/documentation/manual/working/commonGuide/build/code/runhook.sbt
@@ -7,6 +7,7 @@ def Grunt(base: File) = {
   //#grunt-before-started
   import play.sbt.PlayRunHook
   import sbt._
+  import scala.sys.process.Process
 
   object Grunt {
     def apply(base: File): PlayRunHook = {
@@ -34,6 +35,7 @@ def Grunt2(base: File) = {
   import play.sbt.PlayRunHook
   import sbt._
   import java.net.InetSocketAddress
+  import scala.sys.process.Process
 
   object Grunt {
     def apply(base: File): PlayRunHook = {


### PR DESCRIPTION
This is just a minimal update to the documentation: adding Play Run Hooks did no longer work [as described in the documentation](https://www.playframework.com/documentation/2.6.x/SBTCookbook).

Probably, this has something to do with the SBT version (pre/post 1).

In recent SBT, `Process` in the examples is interpreted as the abstract Java class `java.lang.Process`:

```
[error] M:\dev\play-cookbook-process\project\Grunt.scala:10:9: Java class java.lang.Process is not a value
[error]         Process("grunt dist", base).run
[error]         ^
[error] one error found
```

The additional `import scala.sys.process.Process` fixes this problem.

[See this repository for a minimal example to reproduce problem and solution.](https://github.com/aimpulse/play-cookbook-process/commits/master)