### PR TITLE
Deprecate Http.Response

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -182,11 +182,77 @@ val loader = new GreetingApplicationLoader()
 val application = loader.load(context)
 ```
 
-## Java `Http.Context` changed
+## Java `Http` changes
+
+Multiple changes were made to `Http.Context`.
+
+### `Http.Context` Request tags removed from `args` 
 
 Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]] in Play 2.6, have finally been removed in Play 2.7.
 Therefore the `args` map of a `Http.Context` instance no longer contains these removed request tags as well.
 Instead you can use the `contextObj.request().attrs()` method now, which provides you the equivalent request attributes.
+
+### `Http.Response` deprecated
+
+`Http.Response` was deprecated with other accesses methods to it. It was mainly used to add headers and cookies, but these are already available in `play.mvc.Result` and then the API got a little confused. For Play 2.7, you should migrate code like:
+
+```java
+// This uses the deprecated response() APIs
+public Result index1() {
+    response().setHeader("Header", "Value");
+    response().setCookie(Http.Cookie.builder("Cookie", "cookie value").build());
+    response().discardCookie("CookieName");
+    return ok("Hello World");
+}
+```
+
+Should be written as:
+```java
+public Result index2() {
+    return ok("Hello World")
+            .withHeader("Header", "value")
+            .withCookies(Http.Cookie.builder("Cookie", "cookie value").build())
+            .discardCookie("CookieName");
+}
+```
+
+If you have action composition that depends on `Http.Context.response`, you can also rewrite it like. For example, the code below:
+
+```java
+import play.mvc.Action;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.util.concurrent.CompletionStage;
+
+public class MyAction extends Action.Simple {
+
+    @Override
+    public CompletionStage<Result> call(Http.Context ctx) {
+        ctx.response().setHeader("Name", "Value");
+        return delegate.call(ctx);
+    }
+}
+```
+
+Should be written as:
+
+```java
+import play.mvc.Action;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.util.concurrent.CompletionStage;
+
+public class MyAction extends Action.Simple {
+
+    @Override
+    public CompletionStage<Result> call(Http.Context ctx) {
+        return delegate.call(ctx)
+                .thenApply(result -> result.withHeader("Name", "Value"));
+    }
+}
+```
 
 ## All Java form `validate` methods need to be migrated to class-level constraints
 

--- a/framework/src/play/src/main/java/play/mvc/Controller.java
+++ b/framework/src/play/src/main/java/play/mvc/Controller.java
@@ -85,7 +85,10 @@ public abstract class Controller extends Results implements Status, HeaderNames 
      * Returns the current HTTP response.
      *
      * @return the response
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
      */
+    @Deprecated
     public static Response response() {
         return Http.Context.current().response();
     }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import play.api.http.HttpConfiguration;
-import play.api.i18n.Messages$;
 import play.api.libs.json.JsValue;
 import play.api.mvc.Headers$;
 import play.api.mvc.request.*;
@@ -40,7 +39,6 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
@@ -176,7 +174,10 @@ public class Http {
          * Returns the current response.
          *
          * @return the response
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
          */
+        @Deprecated
         public Response response() {
             return response;
         }
@@ -353,7 +354,10 @@ public class Http {
              * Returns the current response.
              *
              * @return the current response.
+             *
+             * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
              */
+            @Deprecated
             public static Response response() {
                 return Context.current().response();
             }
@@ -460,7 +464,11 @@ public class Http {
             return wrapped.request();
         }
 
+        /**
+         * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
+         */
         @Override
+        @Deprecated
         public Response response() {
             return wrapped.response();
         }
@@ -1771,7 +1779,10 @@ public class Http {
 
     /**
      * The HTTP response.
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead which has methods to add headers and cookies.
      */
+    @Deprecated
     public static class Response implements HeaderNames {
 
         private final Map<String, String> headers = new TreeMap<>((Comparator<String>) String::compareToIgnoreCase);
@@ -1858,7 +1869,7 @@ public class Http {
         }
 
         public Optional<Cookie> cookie(String name) {
-            return cookies.stream().filter(x -> { return x.name().equals(name); }).findFirst();
+            return cookies.stream().filter(x -> x.name().equals(name)).findFirst();
         }
 
     }

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -290,7 +290,7 @@ public class Result {
      * Discard a cookie on the given path with no domain and not that's secure.
      *
      * @param name The name of the cookie to discard, must not be null
-     * @param path The path of the cookie te discard, may be null
+     * @param path The path of the cookie to discard, may be null
      */
     public Result discardCookie(String name, String path) {
         return discardCookie(name, path, null, false);

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -278,6 +278,48 @@ public class Result {
     }
 
     /**
+     * Discard a cookie on the default path ("/") with no domain and that's not secure.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     */
+    public Result discardCookie(String name) {
+        return discardCookie(name, "/", null, false);
+    }
+
+    /**
+     * Discard a cookie on the given path with no domain and not that's secure.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie te discard, may be null
+     */
+    public Result discardCookie(String name, String path) {
+        return discardCookie(name, path, null, false);
+    }
+
+    /**
+     * Discard a cookie on the given path and domain that's not secure.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie te discard, may be null
+     * @param domain The domain of the cookie to discard, may be null
+     */
+    public Result discardCookie(String name, String path, String domain) {
+        return discardCookie(name, path, domain, false);
+    }
+
+    /**
+     * Discard a cookie in this result
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie te discard, may be null
+     * @param domain The domain of the cookie to discard, may be null
+     * @param secure Whether the cookie to discard is secure
+     */
+    public Result discardCookie(String name, String path, String domain, boolean secure) {
+        return withCookies(new Cookie(name, "", play.api.mvc.Cookie.DiscardedMaxAge(), path, domain, secure, false, null));
+    }
+
+    /**
      * Return a copy of this result with the given header.
      *
      * @param name the header name

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -198,7 +198,7 @@ public class StatusHeader extends Result {
         }
         try {
             return doSendResource(
-                    FileIO.fromFile(path.toFile()),
+                    FileIO.fromPath(path),
                     Optional.of(Files.size(path)),
                     Optional.of(filename),
                     inline
@@ -230,7 +230,7 @@ public class StatusHeader extends Result {
             throw new NullPointerException("null file");
         }
         return doSendResource(
-                FileIO.fromFile(file),
+                FileIO.fromPath(file.toPath()),
                 Optional.of(file.length()),
                 Optional.of(file.getName()),
                 inline
@@ -261,7 +261,7 @@ public class StatusHeader extends Result {
             throw new NullPointerException("null file");
         }
         return doSendResource(
-                FileIO.fromFile(file),
+                FileIO.fromPath(file.toPath()),
                 Optional.of(file.length()),
                 Optional.of(fileName),
                 inline


### PR DESCRIPTION
## Purpose

The main purpose here is to deprecate `Http.Response` which is a confusing API since we have `Result`. ~~There is also a deprecation warning for `Http.Context.args` but I'm not sure this should be part of this PR since we still don't have a substitute to it (the ideal solution is to add request attributes, but this would require to change action composition to call using a request instead of a context)~~.

Edit: This now focuses exclusively on deprecating `Http.Response`.

## References

This is a less ambitious PR than #8312 by @mkurz.
