### PR TITLE
Add an HttpErrorHandler that selects the client's preferred media type

### DIFF
--- a/documentation/manual/working/javaGuide/main/application/JavaErrorHandling.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaErrorHandling.md
@@ -18,6 +18,16 @@ To use that `HttpErrorHandler` implementation, you should configure the `play.ht
 
     play.http.errorHandler = play.http.JsonHttpErrorHandler
 
+## Using both HTML and JSON, and other content types
+
+If your application uses a mixture of HTML and JSON, as is common in modern web apps, Play offers another error handler that delegates to either the HTML or JSON error handler based on the preferences specified in the client's `Accept` header. This can be specified with:
+
+    play.http.errorHandler = play.http.HtmlOrJsonHttpErrorHandler
+
+This is a suitable default choice of error handler for most applications.
+
+Finally, if you want to support other content types for errors in addition to HTML and JSON, you can extend [`PreferredMediaTypeHttpErrorHandler`](api/java/play/http/PreferredMediaTypeHttpErrorHandler.html) and add error handlers for specific content types, then specify a custom error handler as described below.
+
 ## Supplying a custom error handler
 
 If you're using [`BuiltInComponents`](api/java/play/BuiltInComponents.html) to construct your app, override the `httpRequestHandler` method to return an instance of your custom handler.

--- a/documentation/manual/working/scalaGuide/main/http/ScalaErrorHandling.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaErrorHandling.md
@@ -9,7 +9,7 @@ The interface through which Play handles these errors is [`HttpErrorHandler`](ap
 
 ## Handling errors in a JSON API
 
-By default, Play returns errors in a HTML format. 
+By default, Play returns errors in a HTML format.
 For a JSON API, it's more consistent to return errors in JSON.
 
 Play proposes an alternative `HttpErrorHandler` implementation, named [`JsonHttpErrorHandler`](api/scala/play/api/http/JsonHttpErrorHandler.html), which will return errors formatted in JSON.
@@ -17,6 +17,16 @@ Play proposes an alternative `HttpErrorHandler` implementation, named [`JsonHttp
 To use that `HttpErrorHandler` implementation, you should configure the `play.http.errorHandler` configuration property in `application.conf` like this:
 
     play.http.errorHandler = play.api.http.JsonHttpErrorHandler
+
+## Using both HTML and JSON, and other content types
+
+If your application uses a mixture of HTML and JSON, as is common in modern web apps, Play offers another error handler that delegates to either the HTML or JSON error handler based on the preferences specified in the client's `Accept` header. This can be specified with:
+
+    play.http.errorHandler = play.api.http.HtmlOrJsonHttpErrorHandler
+
+This is a suitable default choice of error handler for most applications.
+
+Finally, if you want to support other content types for errors in addition to HTML and JSON, you can extend [`PreferredMediaTypeHttpErrorHandler`](api/scala/play/api/http/PreferredMediaTypeHttpErrorHandler.html) and specify a custom error handler as described below.
 
 ## Supplying a custom error handler
 
@@ -29,6 +39,12 @@ If you're using runtime dependency injection (e.g. Guice), the error handler can
 If you don't want to place your error handler in the root package, or if you want to be able to configure different error handlers for different environments, you can do this by configuring the `play.http.errorHandler` configuration property in `application.conf`:
 
     play.http.errorHandler = "com.example.ErrorHandler"
+
+If you want to use the error handler for the client's preferred media type and add your own error handler for another media type, you can extend the [`PreferredMediaTypeHttpErrorHandler`](api/scala/play/api/http/PreferredMediaTypeHttpErrorHandler.html):
+
+@[custom-media-type](code/ScalaErrorHandling.scala)
+
+The above example uses the default Play handlers for JSON and HTML and adds a custom handler that will be used if the client prefers plain text, e.g. if the request has `Accept: text/plain`.
 
 ## Extending the default error handler
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -107,3 +107,30 @@ class ErrorHandler @Inject() (
 }
 //#default
 }
+
+package custom {
+
+//#custom-media-type
+import javax.inject._
+import play.api.http._
+
+class MyHttpErrorHandler @Inject() (
+  jsonHandler: JsonHttpErrorHandler,
+  htmlHandler: DefaultHttpErrorHandler,
+  textHandler: MyTextHttpErrorHandler
+) extends PreferredMediaTypeHttpErrorHandler(
+  "application/json" -> jsonHandler,
+  "text/html" -> htmlHandler,
+  "text/plain" -> textHandler
+)
+//#custom-media-type
+
+import play.api.mvc._
+import scala.concurrent._
+
+class MyTextHttpErrorHandler extends HttpErrorHandler {
+  def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = ???
+  def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = ???
+}
+
+}

--- a/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -149,6 +149,44 @@ class HttpErrorHandlerSpec extends Specification {
       }
     }
 
+    "work with a Scala HtmlOrJsonHttpErrorHandler" in {
+      "a request when the client prefers JSON" in {
+        def errorHandler = handler(classOf[HtmlOrJsonHttpErrorHandler].getName, Mode.Prod)
+        "json response" in {
+          val result = errorHandler.onClientError(FakeRequest().withHeaders("Accept" -> "application/json"), 400)
+          await(result).body.contentType must beSome("application/json")
+        }
+        sharedSpecs(errorHandler)
+      }
+      "a request when the client prefers HTML" in {
+        def errorHandler = handler(classOf[HtmlOrJsonHttpErrorHandler].getName, Mode.Prod)
+        "html response" in {
+          val result = errorHandler.onClientError(FakeRequest().withHeaders("Accept" -> "text/html"), 400)
+          await(result).body.contentType must beSome("text/html; charset=utf-8")
+        }
+        sharedSpecs(errorHandler)
+      }
+    }
+
+    "work with a Java HtmlOrJsonHttpErrorHandler" in {
+      "a request when the client prefers JSON" in {
+        def errorHandler = handler(classOf[play.http.HtmlOrJsonHttpErrorHandler].getName, Mode.Prod)
+        "json response" in {
+          val result = errorHandler.onClientError(FakeRequest().withHeaders("Accept" -> "application/json"), 400)
+          await(result).body.contentType must beSome("application/json")
+        }
+        sharedSpecs(errorHandler)
+      }
+      "a request when the client prefers HTML" in {
+        def errorHandler = handler(classOf[play.http.HtmlOrJsonHttpErrorHandler].getName, Mode.Prod)
+        "html response" in {
+          val result = errorHandler.onClientError(FakeRequest().withHeaders("Accept" -> "text/html"), 400)
+          await(result).body.contentType must beSome("text/html; charset=utf-8")
+        }
+        sharedSpecs(errorHandler)
+      }
+    }
+
     "work with a custom scala handler" in {
       val result = handler(classOf[CustomScalaErrorHandler].getName, Mode.Prod).onClientError(FakeRequest(), 400)
       await(result).header.status must_== 200

--- a/framework/src/play/src/main/java/play/http/HtmlOrJsonHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/HtmlOrJsonHttpErrorHandler.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.http;
+
+import javax.inject.Inject;
+import java.util.LinkedHashMap;
+
+/**
+ * An HttpErrorHandler that uses either HTML or JSON in the response depending on the client's preference.
+ */
+public class HtmlOrJsonHttpErrorHandler extends PreferredMediaTypeHttpErrorHandler {
+
+  private static LinkedHashMap<String, HttpErrorHandler> buildMap(
+      DefaultHttpErrorHandler htmlHandler, JsonHttpErrorHandler jsonHandler
+  ) {
+    LinkedHashMap<String, HttpErrorHandler> map = new LinkedHashMap<>();
+    map.put("text/html", htmlHandler);
+    map.put("application/json", jsonHandler);
+    return map;
+  }
+
+  @Inject
+  public HtmlOrJsonHttpErrorHandler(DefaultHttpErrorHandler htmlHandler, JsonHttpErrorHandler jsonHandler) {
+    super(buildMap(htmlHandler, jsonHandler));
+  }
+
+}

--- a/framework/src/play/src/main/java/play/http/PreferredMediaTypeHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/PreferredMediaTypeHttpErrorHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.http;
+
+import play.api.http.MediaRange;
+import play.libs.Scala;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.util.LinkedHashMap;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * An `HttpErrorHandler` that delegates to one of several `HttpErrorHandlers` depending on the client's media type
+ * preference. The order of preference is defined by the client's `Accept` header. The handlers are specified as a
+ * `LinkedHashMap`, and the ordering of the map determines the order in which media types are chosen when they are
+ * equally preferred by a specific media range (e.g. `*\/*`).
+ */
+public class PreferredMediaTypeHttpErrorHandler implements HttpErrorHandler {
+    private LinkedHashMap<String, HttpErrorHandler> errorHandlerMap;
+
+    public PreferredMediaTypeHttpErrorHandler(LinkedHashMap<String, HttpErrorHandler> errorHandlerMap) {
+        if (errorHandlerMap.isEmpty()) {
+            throw new IllegalArgumentException("Map must not be empty!");
+        }
+        this.errorHandlerMap = new LinkedHashMap<>(errorHandlerMap);
+    }
+
+    protected HttpErrorHandler preferred(Http.RequestHeader request) {
+        String preferredContentType = Scala.orNull(MediaRange.preferred(
+                Scala.toSeq(request.acceptedTypes()),
+                Scala.toSeq(errorHandlerMap.keySet().toArray(new String[]{}))
+        ));
+        if (preferredContentType == null) {
+            return errorHandlerMap.values().iterator().next();
+        } else {
+            return errorHandlerMap.get(preferredContentType);
+        }
+    }
+
+    @Override
+    public CompletionStage<Result> onClientError(Http.RequestHeader request, int statusCode, String message) {
+        return preferred(request).onClientError(request, statusCode, message);
+    }
+
+    @Override
+    public CompletionStage<Result> onServerError(Http.RequestHeader request, Throwable exception) {
+        return preferred(request).onServerError(request, exception);
+    }
+}

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -50,6 +50,54 @@ trait HttpErrorHandler {
   def onServerError(request: RequestHeader, exception: Throwable): Future[Result]
 }
 
+/**
+ * An [[HttpErrorHandler]] that uses either HTML or JSON in the response depending on the client's preference.
+ */
+class HtmlOrJsonHttpErrorHandler @Inject() (
+    htmlHandler: DefaultHttpErrorHandler,
+    jsonHandler: JsonHttpErrorHandler
+) extends PreferredMediaTypeHttpErrorHandler(
+  "text/html" -> htmlHandler,
+  "application/json" -> jsonHandler
+)
+
+/**
+ * An [[HttpErrorHandler]] that delegates to one of several [[HttpErrorHandler]]s based on media type preferences.
+ *
+ * For example, to create an error handler that handles JSON and HTML, with JSON preferred by the app as default:
+ * {{{
+ *   override lazy val httpErrorHandler = PreferredMediaTypeHttpErrorHandler(
+ *     "application/json" -> new JsonHttpErrorHandler()
+ *     "text/html" -> new HtmlHttpErrorHandler(),
+ *   )
+ * }}}
+ *
+ * If the client's preferred media range matches multiple media types in the list, then the first match is chosen.
+ */
+class PreferredMediaTypeHttpErrorHandler(val handlers: (String, HttpErrorHandler)*) extends HttpErrorHandler {
+
+  private val supportedTypes: Seq[String] = handlers.map(_._1)
+  private val typeToHandler: Map[String, HttpErrorHandler] = handlers.toMap
+
+  protected val defaultHandler: HttpErrorHandler =
+    handlers.headOption.getOrElse(throw new IllegalArgumentException("handlers must not be empty"))._2
+
+  protected def preferredHandler(request: RequestHeader): HttpErrorHandler = {
+    MediaRange.preferred(request.acceptedTypes, supportedTypes).fold(defaultHandler)(typeToHandler)
+  }
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+    preferredHandler(request).onClientError(request, statusCode, message)
+  }
+  override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+    preferredHandler(request).onServerError(request, exception)
+  }
+}
+
+object PreferredMediaTypeHttpErrorHandler {
+  def apply(handlers: (String, HttpErrorHandler)*) = new PreferredMediaTypeHttpErrorHandler(handlers: _*)
+}
+
 object HttpErrorHandler {
 
   /**

--- a/framework/src/play/src/main/scala/play/api/http/MediaRange.scala
+++ b/framework/src/play/src/main/scala/play/api/http/MediaRange.scala
@@ -92,7 +92,20 @@ object MediaType {
 
 object MediaRange {
 
-  private val logger = Logger(this.getClass())
+  private val logger = Logger(getClass)
+
+  /**
+   * Given a list of acceptable media ranges, find the preferred media type in the list of available media types.
+   *
+   * Note: the media types in the list should be without parameters, e.g. `text/html` not `text/html;charset=utf-8`
+   */
+  def preferred(acceptableRanges: Seq[MediaRange], availableMediaTypes: Seq[String]): Option[String] = {
+    val acceptableTypes = for {
+      mediaRange <- acceptableRanges.sorted.toStream
+      mt <- availableMediaTypes if mediaRange.accepts(mt)
+    } yield mt
+    acceptableTypes.headOption
+  }
 
   /**
    * Function and extractor object for parsing media ranges.

--- a/framework/src/play/src/test/scala/play/api/http/MediaRangeSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/MediaRangeSpec.scala
@@ -5,7 +5,6 @@
 package play.api.http
 
 import org.specs2.mutable._
-import java.net.URLEncoder
 
 class MediaRangeSpec extends Specification {
 
@@ -143,6 +142,29 @@ class MediaRangeSpec extends Specification {
     "gracefully handle invalid q values" in {
       parseSingleMediaRange("foo/bar;q=a") must_== new MediaRange("foo", "bar", Nil, None, Nil)
       parseSingleMediaRange("foo/bar;q=1.01") must_== new MediaRange("foo", "bar", Nil, None, Nil)
+    }
+  }
+
+  "MediaRange.preferred" should {
+    "get preferred media type for a web browser" in {
+      val ranges = MediaRange.parse("text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8")
+      MediaRange.preferred(ranges, Seq("application/json", "text/html")) must beSome("text/html")
+    }
+    "get preferred media type for a JSON API client" in {
+      val ranges = MediaRange.parse("application/json")
+      MediaRange.preferred(ranges, Seq("application/json", "text/html")) must beSome("application/json")
+    }
+    "handle equal preference by returning the first in the list" in {
+      val ranges = MediaRange.parse("text/html, application/json, */*;q=0.5")
+      MediaRange.preferred(ranges, Seq("application/json", "text/html")) must beSome("text/html")
+    }
+    "handle wildcard ranges by returning the first in the list" in {
+      val ranges = MediaRange.parse("application/xml, */*;q=0.5")
+      MediaRange.preferred(ranges, Seq("application/json", "text/html")) must beSome("application/json")
+    }
+    "return None when no type is acceptable" in {
+      val ranges = MediaRange.parse("application/json")
+      MediaRange.preferred(ranges, Seq("application/xml", "text/html")) must beNone
     }
   }
 


### PR DESCRIPTION
This defines a `PreferredMediaTypeHttpErrorHandler` for composing your own error handlers based on error handlers for specific content types, and an `HtmlOrJsonHttpErrorHandler` which does this with the Play-provided HTML and JSON handlers. The handler to use is determined based on the preferences in the `Accept` header. `HtmlOrJsonHttpErrorHandler` is designed to be a suitable default error handler for a web app that has a mixture of HTML and JSON endpoints (most modern web apps).