### PR TITLE
SBTSubProjects.md: fix contradiction about per-project build.sbt

### DIFF
--- a/documentation/manual/working/commonGuide/build/SBTSubProjects.md
+++ b/documentation/manual/working/commonGuide/build/SBTSubProjects.md
@@ -3,7 +3,7 @@
 
 A complex project is not necessarily composed of a single Play application. You may want to split a large project into several smaller applications, or even extract some logic into a standard Java or Scala library that has nothing to do with a Play application.
 
-It will be helpful to read the [SBT documentation on multi-project builds](https://www.scala-sbt.org/release/docs/Getting-Started/Multi-Project).  Sub-projects do not have their own build file, but share the parent project's build file.
+It will be helpful to read the [SBT documentation on multi-project builds](https://www.scala-sbt.org/release/docs/Getting-Started/Multi-Project).  Sub-projects be fully defined in the parent project's build file, although here we put sub-projects' settings in their own build file. 
 
 ## Adding a simple library sub-project
 

--- a/documentation/manual/working/commonGuide/build/SBTSubProjects.md
+++ b/documentation/manual/working/commonGuide/build/SBTSubProjects.md
@@ -3,7 +3,7 @@
 
 A complex project is not necessarily composed of a single Play application. You may want to split a large project into several smaller applications, or even extract some logic into a standard Java or Scala library that has nothing to do with a Play application.
 
-It will be helpful to read the [SBT documentation on multi-project builds](https://www.scala-sbt.org/release/docs/Getting-Started/Multi-Project).  Sub-projects be fully defined in the parent project's build file, although here we put sub-projects' settings in their own build file. 
+It will be helpful to read the [SBT documentation on multi-project builds](https://www.scala-sbt.org/release/docs/Getting-Started/Multi-Project).  Sub-projects can be fully defined in the parent project's build file, although here we put sub-projects' settings in their own build file. 
 
 ## Adding a simple library sub-project
 


### PR DESCRIPTION
Really per-project build.sbt is not recommended, but it was easier to fix the false statement than to change all the examples.

Also, I think subproject shouldn't be hyphenated but I used the spelling of the rest of the file.
