### PR TITLE
Make CSRF filter consider either the cookie or the session, but not both

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -389,9 +389,11 @@ class CSRFActionHelper(
    */
   def getTokenToValidate(request: RequestHeader): Option[String] = {
     val attrToken = CSRF.getToken(request).map(_.value)
-    val cookieToken = csrfConfig.cookieName.flatMap(cookie => request.cookies.get(cookie).map(_.value))
-    val sessionToken = request.session.get(csrfConfig.tokenName)
-    cookieToken orElse sessionToken orElse attrToken filter { token =>
+    val cookieOrSessionToken = csrfConfig.cookieName match {
+      case Some(cookieName) => request.cookies.get(cookieName).map(_.value)
+      case None => request.session.get(csrfConfig.tokenName)
+    }
+    cookieOrSessionToken orElse attrToken filter { token =>
       // return None if the token is invalid
       !csrfConfig.signTokens || tokenSigner.extractSignedToken(token).isDefined
     }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -135,6 +135,17 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
         response.cookies must beEmpty
       }
     }
+    "add a cookie token if configured to use a cookie even if a session token already exists" in {
+      buildCsrfAddToken(
+        "play.filters.csrf.cookie.name" -> "csrf",
+        "play.filters.csrf.token.name" -> "csrf"
+      )({ req =>
+          req
+            .addHttpHeaders(ACCEPT -> "text/html")
+            .withSession("csrf" -> signedTokenProvider.generateToken)
+            .get()
+        })(_.cookies must not be empty)
+    }
   }
 
   "a CSRF filter" should {


### PR DESCRIPTION
Fixes #8548.

If configured to use a cookie, the CSRF filter will only check the cookie. If configured to use the Play session, it will only check the session.