### PR TITLE
More logs during Play's evolution

### DIFF
--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -210,7 +210,12 @@ class DatabaseEvolutions(database: Database, schema: String = "") {
         applying = script.evolution.revision
         logBefore(script)
         // Execute script
-        script.statements.foreach(execute)
+        script.statements.foreach { statement =>
+          logger.debug(s"Execute: $statement")
+          val start = System.currentTimeMillis()
+          execute(statement)
+          logger.debug(s"Finished in ${System.currentTimeMillis() - start}ms")
+        }
         logAfter(script)
       }
 


### PR DESCRIPTION
One problem that I have occasionally is that, when an error occurs during Evolution, it's difficult to figure out which statement causes the error.

I'd see an error like: `invalid character at position 61` without any pointer to which statement causes the error. This PR alleviates the problem.

This partly solves #8468. There's also a short discussion here: https://discuss.lightbend.com/t/should-we-add-more-logging-to-plays-evolutions/1460
