### PR TITLE
Fix sbt auto trigger when using sbt 1.1.5+

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -195,12 +195,6 @@ object Dependencies {
     )
   }
 
-  // use partial version so that non-standard scala binary versions from dbuild also work
-  def sbtIO(sbtVersion: String, scalaVersion: String): ModuleID = CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, major)) if major >= 11 => "org.scala-sbt" %% "io" % "0.13.16" % "provided"
-    case _ => "org.scala-sbt" % "io" % sbtVersion % "provided"
-  }
-
   val typesafeConfig = "com.typesafe" % "config" % "1.3.3"
 
   def sbtDependencies(sbtVersion: String, scalaVersion: String) = {

--- a/framework/src/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/run/PlayRunCompat.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/run/PlayRunCompat.scala
@@ -31,4 +31,16 @@ private[run] trait PlayRunCompat {
     val builder = new java.lang.ProcessBuilder(args.asJava)
     Process(builder).!
   }
+
+  def watchCountinously(state: State): Option[Watched] = {
+    // If we have both Watched.Configuration and Watched.ContinuousState
+    // attributes and if Watched.ContinuousState.count is 1 then we assume
+    // we're in ~ run mode
+    val maybeContinuous = for {
+      watched <- state.get(Watched.Configuration)
+      watchState <- state.get(Watched.ContinuousState)
+      if watchState.count == 1
+    } yield watched
+    maybeContinuous
+  }
 }

--- a/framework/src/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/run/PlayRunCompat.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/run/PlayRunCompat.scala
@@ -32,7 +32,7 @@ private[run] trait PlayRunCompat {
     Process(builder).!
   }
 
-  def watchCountinously(state: State): Option[Watched] = {
+  protected def watchContinuously(state: State, sbtVersion: String): Option[Watched] = {
     // If we have both Watched.Configuration and Watched.ContinuousState
     // attributes and if Watched.ContinuousState.count is 1 then we assume
     // we're in ~ run mode

--- a/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/run/PlayRunCompat.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/run/PlayRunCompat.scala
@@ -33,4 +33,12 @@ private[run] trait PlayRunCompat {
 
   def createAndRunProcess(args: Seq[String]) = args.!
 
+  def watchCountinously(state: State): Option[Watched] = {
+    // If we have Watched.ContinuousEventMonitor attribute and its state.count
+    // is > 0 then we assume we're in ~ run mode
+    state.get(Watched.ContinuousEventMonitor)
+      .map(_.state())
+      .filter(_.count > 0)
+      .flatMap(_ => state.get(Watched.Configuration))
+  }
 }

--- a/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/run/PlayRunCompat.scala
+++ b/framework/src/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/run/PlayRunCompat.scala
@@ -33,12 +33,38 @@ private[run] trait PlayRunCompat {
 
   def createAndRunProcess(args: Seq[String]) = args.!
 
-  def watchCountinously(state: State): Option[Watched] = {
-    // If we have Watched.ContinuousEventMonitor attribute and its state.count
-    // is > 0 then we assume we're in ~ run mode
-    state.get(Watched.ContinuousEventMonitor)
-      .map(_.state())
-      .filter(_.count > 0)
-      .flatMap(_ => state.get(Watched.Configuration))
+  def watchContinuously(state: State, sbtVersion: String): Option[Watched] = {
+
+    // sbt 1.1.5+ uses Watched.ContinuousEventMonitor while watching the file system.
+    def watchUsingEvenMonitor = {
+      // If we have Watched.ContinuousEventMonitor attribute and its state.count
+      // is > 0 then we assume we're in ~ run mode
+      state.get(Watched.ContinuousEventMonitor)
+        .map(_.state())
+        .filter(_.count > 0)
+        .flatMap(_ => state.get(Watched.Configuration))
+    }
+
+    // sbt 1.1.4 and earlier uses Watched.ContinuousState while watching the file system.
+    def watchUsingContinuousState = {
+      // If we have both Watched.Configuration and Watched.ContinuousState
+      // attributes and if Watched.ContinuousState.count is 1 then we assume
+      // we're in ~ run mode
+      for {
+        watched <- state.get(Watched.Configuration)
+        watchState <- state.get(Watched.ContinuousState)
+        if watchState.count == 1
+      } yield watched
+    }
+
+    val _ :: minor :: patch :: Nil = sbtVersion.split("\\.").map(_.toInt).toList
+
+    if (minor >= 2) { // sbt 1.2.x and later
+      watchUsingEvenMonitor
+    } else if (minor == 1 && patch >= 5) { // sbt 1.1.5+
+      watchUsingEvenMonitor
+    } else { // sbt 1.1.4 and earlier
+      watchUsingContinuousState
+    }
   }
 }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -106,7 +106,7 @@ object PlayRun extends PlayRunCompat {
         println(Colors.green("(Server started, use Enter to stop and go back to the console...)"))
         println()
 
-        val maybeContinuous: Option[Watched] = watchCountinously(state)
+        val maybeContinuous: Option[Watched] = watchContinuously(state, Keys.sbtVersion.value)
 
         maybeContinuous match {
           case Some(watched) =>

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -106,14 +106,7 @@ object PlayRun extends PlayRunCompat {
         println(Colors.green("(Server started, use Enter to stop and go back to the console...)"))
         println()
 
-        // If we have both Watched.Configuration and Watched.ContinuousState
-        // attributes and if Watched.ContinuousState.count is 1 then we assume
-        // we're in ~ run mode
-        val maybeContinuous = for {
-          watched <- state.get(Watched.Configuration)
-          watchState <- state.get(Watched.ContinuousState)
-          if watchState.count == 1
-        } yield watched
+        val maybeContinuous: Option[Watched] = watchCountinously(state)
 
         maybeContinuous match {
           case Some(watched) =>


### PR DESCRIPTION
## Fixes

Fixes #8458.

## Purpose

This uses the new attribute key `ContinuousEventMonitor` added in sbt 1.1.5. The old one (`ContinuousState`) was deprecated and is not set anymore.

This may be a little tricky to backport: `ContinuousEventMonitor` was introduced in sbt 1.1.5. If we use it in Play 2.6.x, it will break support for 1.1.4 (and prior versions) meaning that users should use at least sbt 1.1.5. So, for all projects using sbt 1.1.4 and earlier, and update to 2.6.18 will break things which is not ideal.

Of course, for Play 2.7, we can put 1.1.5+ as a requirement.