### PR TITLE
[master]: Added Java APIs for general dependency-injection to be DI framework agnostic

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -373,6 +373,24 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 }
 ```
 
+## Java DI-agnostic Play `Module` API support added and all built-in Java `Module`s type changed
+
+You can now create DI-agnostic Play `Module` with Java by extending `play.inject.Module`, which is more Java friendly as it is using Java APIs and coded in Java as well. Besides, all the existing built-in Java `Module`s, for example, `play.inject.BuiltInModule` and `play.libs.ws.ahc.AhcWSModule`, are no longer extending Scala `play.api.inject.Module` but Java `play.inject.Module`.
+
+Since Java `play.inject.Module` is a subclass of Scala `play.api.inject.Module`, the `Module` instances can still be used in the same way, except the interface is a little different:
+
+```java
+public class MyModule extends play.inject.Module {
+    @Override
+    public java.util.List<play.inject.Binding<?>> bindings(final play.Environment environment, final com.typesafe.config.Config config) {
+        return java.util.Collections.singletonList(
+            // Note: it is bindClass() but not bind()
+            bindClass(MyApi.class).toProvider(MyApiProvider.class)
+        );
+    }
+}
+```
+
 ## Removed libraries
 
 To make the default play distribution a bit smaller we removed some libraries. The following libraries are no longer dependencies in Play 2.7, so you will need to add them manually to your build if you use them.

--- a/documentation/manual/working/javaGuide/advanced/extending/JavaPlayModules.md
+++ b/documentation/manual/working/javaGuide/advanced/extending/JavaPlayModules.md
@@ -7,7 +7,7 @@
 
 A [[module|JavaDependencyInjection#Play-libraries]] can be written using any dependency injection framework.  However, when you want to extend Play, you need to avoid dependencies on a specific framework so that your extension can work independently of the dependency injection.  Play previously used the `play.Plugin` system for this purpose, but in 2.5.x, Plugins have been replaced with Play modules.
  
- A Play module is a class that extends [`play.api.inject.Module`](api/scala/play/api/inject/Module.html) and can be registered with Play without relying explicitly on a particular dependency injection framework.  This allows everyone to use Play modules.
+ A Play module is a class that extends [`play.inject.Module`](api/java/play/inject/Module.html) and can be registered with Play without relying explicitly on a particular dependency injection framework.  This allows everyone to use Play modules.
 
 A list of Play modules are available in the [[module directory|ModuleDirectory]].
 
@@ -52,6 +52,27 @@ Please see [[Testing with Guice|JavaTestingWithGuice#Bindings-and-Modules]] for 
 
 The [`Modules.locate(env, conf)`](api/scala/play/api/inject/Modules$.html) method will display a list of all available Play modules in an application.  There is no corresponding Java class.
 
-## Overriding built-in modules
+## Overriding Built-In Modules
 
-There are some cases where Play provides a built-in module that must be overridden.  In these cases, the Java implementation is a wrapper over the Scala one, and so it's usually more convenient to override the Scala implementation directly.
+There are some cases where Play provides a built-in module that must be overridden.  
+
+For example, [[WSClient|JavaWS]] functionality is implemented by the [WSClient interface](api/java/play/libs/ws/WSClient.html) and backed by [AhcWSClientProvider](api/java/play/libs/ws/ahc/AhcWSModule.AhcWSClientProvider.html).  If you write a replacement class `MyWSClient` that extends `WSClient`, you can bind it with:
+
+@[builtin-module-definition](code/javaguide/advanced/extending/MyWSModule.java)
+
+### Testing Overrides
+
+Testing the application should be done using the `overrides` method to replace the existing implementation: 
+
+@[builtin-module-overrides](code/javaguide/advanced/extending/JavaExtendingPlay.java)
+
+### Registration Overrides
+
+Because the `AhcWSModule` is loaded automatically in `reference.conf`, you must first [[disable|JavaDependencyInjection#Excluding-modules]] the default module before adding the replacement module:
+
+```
+play.modules.disabled += "play.libs.ws.ahc.AhcWSModule"
+play.modules.enabled += "modules.MyWSModule"
+```
+
+You should not disable existing modules in `reference.conf` when publishing a Play module, as it may have unexpected consequences.  Please see the [[migration page|PluginsToModules#Wire-it-up]] for details.

--- a/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/JavaExtendingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/JavaExtendingPlay.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
+import play.libs.ws.WSClient;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -24,6 +25,18 @@ public class JavaExtendingPlay {
         MyApi api = application.injector().instanceOf(MyApi.class);
 
         assertNotNull(api);
+    }
+
+    @Test
+    public void testOverride() throws Exception {
+        // #builtin-module-overrides
+        Application application = new GuiceApplicationBuilder()
+                .overrides(new MyWSModule())
+                .build();
+        // #builtin-module-overrides
+        WSClient wsClient = application.injector().instanceOf(WSClient.class);
+
+        assertThat(wsClient, instanceOf(MyWSClient.class));
     }
 
 }

--- a/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/MyWSClient.java
+++ b/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/MyWSClient.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package javaguide.advanced.extending;
+
+import java.io.IOException;
+import play.libs.ws.WSClient;
+import play.libs.ws.WSRequest;
+
+public class MyWSClient implements WSClient {
+    @Override
+    public Object getUnderlying() {
+        return null;
+    }
+
+    @Override
+    public play.api.libs.ws.WSClient asScala() {
+        return null;
+    }
+
+    @Override
+    public WSRequest url(String url) {
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/MyWSClientProvider.java
+++ b/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/MyWSClientProvider.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package javaguide.advanced.extending;
+
+import play.libs.ws.WSClient;
+
+public class MyWSClientProvider implements javax.inject.Provider<WSClient> {
+    @Override
+    public WSClient get() {
+        return new MyWSClient();
+    }
+}

--- a/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/MyWSModule.java
+++ b/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/MyWSModule.java
@@ -9,13 +9,14 @@ import java.util.Collections;
 import java.util.List;
 import play.Environment;
 import play.inject.Binding;
+import play.libs.ws.WSClient;
 
-// #module-class-definition
-public class MyModule extends play.inject.Module {
+// #builtin-module-definition
+public class MyWSModule extends play.inject.Module {
     public List<Binding<?>> bindings(Environment environment, Config config) {
         return Collections.singletonList(
-            bindClass(MyApi.class).toSelf()
+            bindClass(WSClient.class).toProvider(MyWSClientProvider.class)
         );
     }
 }
-// #module-class-definition
+// #builtin-module-definition

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/playlib/HelloModule.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/playlib/HelloModule.java
@@ -7,16 +7,18 @@ package javaguide.di.playlib;
 import javaguide.di.*;
 
 //#play-module
-import play.api.*;
-import play.api.inject.*;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import java.util.Arrays;
+import java.util.List;
+import play.Environment;
+import play.inject.*;
 
 public class HelloModule extends Module {
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-            bind(Hello.class).qualifiedWith("en").to(EnglishHello.class),
-            bind(Hello.class).qualifiedWith("de").to(GermanHello.class)
+    public List<Binding<?>> bindings(Environment environment, Config config) {
+        return Arrays.asList(
+            bindClass(Hello.class).qualifiedWith("en").to(EnglishHello.class),
+            bindClass(Hello.class).qualifiedWith("de").to(GermanHello.class)
         );
     }
 }

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -627,7 +627,16 @@ object BuildSettings {
 
       // Remove JPA class + add more withTransaction(...) methods
       ProblemFilters.exclude[MissingClassProblem]("play.db.jpa.JPA"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.jpa.JPAApi.withTransaction")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.jpa.JPAApi.withTransaction"),
+
+      // Add play.api.inject.BindingTarget asJava method
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.inject.BindingTarget.asJava"),
+
+      // Add play.api.inject.QualifierAnnotation asJava method
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.inject.QualifierAnnotation.asJava"),
+
+      // Rewrite Java modules to extend play.inject.Module
+      ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.inject.Module.bindings")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSModule.java
+++ b/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSModule.java
@@ -5,17 +5,18 @@
 package play.libs.ws.ahc;
 
 import akka.stream.Materializer;
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
 import play.libs.ws.WSClient;
 import play.shaded.ahc.org.asynchttpclient.AsyncHttpClient;
-import scala.collection.Seq;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * The Play module to provide Java bindings for WS to an AsyncHTTPClient implementation.
@@ -26,10 +27,10 @@ import javax.inject.Singleton;
 public class AhcWSModule extends Module {
 
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Collections.singletonList(
             // AsyncHttpClientProvider is added by the Scala API
-            bind(WSClient.class).toProvider(AhcWSClientProvider.class)
+            bindClass(WSClient.class).toProvider(AhcWSClientProvider.class)
         );
     }
 

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -6,21 +6,33 @@ package play.api.inject
 package guice
 
 import javax.inject.{ Inject, Provider, Singleton }
+import java.util.Collections
 
 import com.google.inject.{ CreationException, ProvisionException }
+import com.typesafe.config.Config
 import org.specs2.mutable.Specification
+import play.{ Environment => JavaEnvironment }
 import play.api.i18n.I18nModule
 import play.api.mvc.CookiesModule
 import play.api.{ Configuration, Environment }
+import play.inject.{ Module => JavaModule }
 
 class GuiceApplicationBuilderSpec extends Specification {
 
   "GuiceApplicationBuilder" should {
 
-    "add bindings" in {
+    "add bindings with Scala" in {
+      addBindings(new GuiceApplicationBuilderSpec.AModule)
+    }
+
+    "add bindings with Java" in {
+      addBindings(new GuiceApplicationBuilderSpec.JavaAModule)
+    }
+
+    def addBindings(module: Module) = {
       val injector = new GuiceApplicationBuilder()
         .bindings(
-          new GuiceApplicationBuilderSpec.AModule,
+          module,
           bind[GuiceApplicationBuilderSpec.B].to[GuiceApplicationBuilderSpec.B1])
         .injector()
 
@@ -28,9 +40,17 @@ class GuiceApplicationBuilderSpec extends Specification {
       injector.instanceOf[GuiceApplicationBuilderSpec.B] must beAnInstanceOf[GuiceApplicationBuilderSpec.B1]
     }
 
-    "override bindings" in {
+    "override bindings with Scala" in {
+      overrideBindings(new GuiceApplicationBuilderSpec.AModule)
+    }
+
+    "override bindings with Java" in {
+      overrideBindings(new GuiceApplicationBuilderSpec.JavaAModule)
+    }
+
+    def overrideBindings(module: Module) = {
       val app = new GuiceApplicationBuilder()
-        .bindings(new GuiceApplicationBuilderSpec.AModule)
+        .bindings(module)
         .overrides(
           bind[Configuration] to new GuiceApplicationBuilderSpec.ExtendConfiguration("a" -> 1),
           bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A2])
@@ -40,10 +60,18 @@ class GuiceApplicationBuilderSpec extends Specification {
       app.injector.instanceOf[GuiceApplicationBuilderSpec.A] must beAnInstanceOf[GuiceApplicationBuilderSpec.A2]
     }
 
-    "disable modules" in {
+    "disable modules with Scala" in {
+      disableModules(new GuiceApplicationBuilderSpec.AModule)
+    }
+
+    "disable modules with Java" in {
+      disableModules(new GuiceApplicationBuilderSpec.JavaAModule)
+    }
+
+    def disableModules(module: Module) = {
       val injector = new GuiceApplicationBuilder()
-        .bindings(new GuiceApplicationBuilderSpec.AModule)
-        .disable(classOf[GuiceApplicationBuilderSpec.AModule])
+        .bindings(module)
+        .disable(module.getClass)
         .injector()
 
       injector.instanceOf[GuiceApplicationBuilderSpec.A] must throwA[com.google.inject.ConfigurationException]
@@ -143,6 +171,10 @@ object GuiceApplicationBuilderSpec {
   @Singleton
   class C1 extends C {
     throw new EagerlyLoadedException
+  }
+
+  class JavaAModule extends JavaModule {
+    override def bindings(environment: JavaEnvironment, config: Config) = Collections.singletonList(JavaModule.bindClass(classOf[A]).to(classOf[A1]))
   }
 
   class EagerlyLoadedException extends RuntimeException

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -7,32 +7,53 @@ package guice
 
 import java.io.File
 import java.net.URLClassLoader
+import java.util.Collections
+import java.util.function.Supplier
 
 import com.google.inject.AbstractModule
+import com.typesafe.config.Config
 import org.specs2.mutable.Specification
+import play.{ Environment => JavaEnvironment }
 import play.api.inject._
-import play.api.{ Configuration, Environment, Mode, inject }
+import play.api.{ Configuration, Environment, Mode }
+import play.inject.{ Module => JavaModule }
 
 class GuiceInjectorBuilderSpec extends Specification {
 
   "GuiceInjectorBuilder" should {
 
-    "set environment" in {
+    "set environment with Scala" in {
+      setEnvironment(new GuiceInjectorBuilderSpec.EnvironmentModule)
+    }
+
+    "set environment with Java" in {
+      setEnvironment(new GuiceInjectorBuilderSpec.JavaEnvironmentModule)
+    }
+
+    def setEnvironment(environmentModule: Module) = {
       val env = new GuiceInjectorBuilder()
         .in(Environment.simple(mode = Mode.Dev))
-        .bindings(new GuiceInjectorBuilderSpec.EnvironmentModule)
+        .bindings(environmentModule)
         .injector().instanceOf[Environment]
 
       env.mode must_== Mode.Dev
     }
 
-    "set environment values" in {
+    "set environment values with Scala" in {
+      setEnvironmentValues(new GuiceInjectorBuilderSpec.EnvironmentModule)
+    }
+
+    "set environment values with Java" in {
+      setEnvironmentValues(new GuiceInjectorBuilderSpec.JavaEnvironmentModule)
+    }
+
+    def setEnvironmentValues(environmentModule: Module) = {
       val classLoader = new URLClassLoader(Array.empty)
       val env = new GuiceInjectorBuilder()
         .in(new File("test"))
         .in(Mode.Dev)
         .in(classLoader)
-        .bindings(new GuiceInjectorBuilderSpec.EnvironmentModule)
+        .bindings(environmentModule)
         .injector().instanceOf[Environment]
 
       env.rootPath must_== new File("test")
@@ -50,13 +71,21 @@ class GuiceInjectorBuilderSpec extends Specification {
       classLoaderAware.constructionClassLoader must_== classLoader
     }
 
-    "set configuration" in {
+    "set configuration with Scala" in {
+      setConfiguration(new GuiceInjectorBuilderSpec.ConfigurationModule)
+    }
+
+    "set configuration with Java" in {
+      setConfiguration(new GuiceInjectorBuilderSpec.JavaConfigurationModule)
+    }
+
+    def setConfiguration(configurationModule: Module) = {
       val conf = new GuiceInjectorBuilder()
         .configure(Configuration("a" -> 1))
         .configure(Map("b" -> 2))
         .configure("c" -> 3)
         .configure("d.1" -> 4, "d.2" -> 5)
-        .bindings(new GuiceInjectorBuilderSpec.ConfigurationModule)
+        .bindings(configurationModule)
         .injector().instanceOf[Configuration]
 
       conf.subKeys must contain(allOf("a", "b", "c", "d"))
@@ -67,11 +96,19 @@ class GuiceInjectorBuilderSpec extends Specification {
       conf.get[Int]("d.2") must_== 5
     }
 
-    "support various bindings" in {
+    "support various bindings with Scala" in {
+      supportVariousBindings(new GuiceInjectorBuilderSpec.EnvironmentModule, new GuiceInjectorBuilderSpec.ConfigurationModule)
+    }
+
+    "support various bindings with Java" in {
+      supportVariousBindings(new GuiceInjectorBuilderSpec.JavaEnvironmentModule, new GuiceInjectorBuilderSpec.JavaConfigurationModule)
+    }
+
+    def supportVariousBindings(environmentModule: Module, configurationModule: Module) = {
       val injector = new GuiceInjectorBuilder()
         .bindings(
-          new GuiceInjectorBuilderSpec.EnvironmentModule,
-          Seq(new GuiceInjectorBuilderSpec.ConfigurationModule),
+          environmentModule,
+          Seq(configurationModule),
           new GuiceInjectorBuilderSpec.AModule,
           Seq(new GuiceInjectorBuilderSpec.BModule))
         .bindings(
@@ -87,13 +124,21 @@ class GuiceInjectorBuilderSpec extends Specification {
       injector.instanceOf[GuiceInjectorBuilderSpec.D] must beAnInstanceOf[GuiceInjectorBuilderSpec.D1]
     }
 
-    "override bindings" in {
+    "override bindings with Scala" in {
+      overrideBindings(new GuiceInjectorBuilderSpec.EnvironmentModule, new GuiceInjectorBuilderSpec.ConfigurationModule)
+    }
+
+    "override bindings with Java" in {
+      overrideBindings(new GuiceInjectorBuilderSpec.JavaEnvironmentModule, new GuiceInjectorBuilderSpec.JavaConfigurationModule)
+    }
+
+    def overrideBindings(environmentModule: Module, configurationModule: Module) = {
       val injector = new GuiceInjectorBuilder()
         .in(Mode.Dev)
         .configure("a" -> 1)
         .bindings(
-          new GuiceInjectorBuilderSpec.EnvironmentModule,
-          new GuiceInjectorBuilderSpec.ConfigurationModule)
+          environmentModule,
+          configurationModule)
         .overrides(
           bind[Environment] to Environment.simple(),
           new GuiceInjectorBuilderSpec.SetConfigurationModule(Configuration("b" -> 2)))
@@ -106,16 +151,25 @@ class GuiceInjectorBuilderSpec extends Specification {
       conf.get[Int]("b") must_== 2
     }
 
-    "disable modules" in {
+    "disable modules with Scala" in {
+      disableModules(new GuiceInjectorBuilderSpec.EnvironmentModule, new GuiceInjectorBuilderSpec.ConfigurationModule)
+    }
+
+    "disable modules with Java" in {
+      disableModules(new GuiceInjectorBuilderSpec.JavaEnvironmentModule, new GuiceInjectorBuilderSpec.JavaConfigurationModule)
+    }
+
+    def disableModules(environmentModule: Module, configurationModule: Module) = {
       val injector = new GuiceInjectorBuilder()
         .bindings(
-          new GuiceInjectorBuilderSpec.EnvironmentModule,
-          new GuiceInjectorBuilderSpec.ConfigurationModule,
+          environmentModule,
+          configurationModule,
           new GuiceInjectorBuilderSpec.AModule,
           new GuiceInjectorBuilderSpec.BModule,
           bind[GuiceInjectorBuilderSpec.C].to[GuiceInjectorBuilderSpec.C1],
           bind[GuiceInjectorBuilderSpec.D] to new GuiceInjectorBuilderSpec.D1)
         .disable[GuiceInjectorBuilderSpec.EnvironmentModule]
+        .disable[GuiceInjectorBuilderSpec.JavaEnvironmentModule]
         .disable(classOf[GuiceInjectorBuilderSpec.AModule], classOf[GuiceInjectorBuilderSpec.CModule]) // C won't be disabled
         .injector()
 
@@ -151,6 +205,18 @@ object GuiceInjectorBuilderSpec {
   class EnvironmentModule extends SimpleModule((env, _) => Seq(bind[Environment] to env))
 
   class ConfigurationModule extends SimpleModule((_, conf) => Seq(bind[Configuration] to conf))
+
+  class JavaEnvironmentModule extends JavaModule {
+    override def bindings(environment: JavaEnvironment, config: Config) = Collections.singletonList(JavaModule.bindClass(classOf[Environment]).to(new Supplier[Environment] {
+      override def get(): Environment = environment.asScala()
+    }))
+  }
+
+  class JavaConfigurationModule extends JavaModule {
+    override def bindings(environment: JavaEnvironment, config: Config) = Collections.singletonList(JavaModule.bindClass(classOf[Configuration]).to(new Supplier[Configuration] {
+      override def get(): Configuration = Configuration(config)
+    }))
+  }
 
   class SetConfigurationModule(conf: Configuration) extends AbstractModule {
     override def configure() = bind(classOf[Configuration]) toInstance conf

--- a/framework/src/play-java-forms/src/main/java/play/data/FormFactoryModule.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/FormFactoryModule.java
@@ -4,18 +4,20 @@
 
 package play.data;
 
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
+
+import java.util.Collections;
+import java.util.List;
 
 public class FormFactoryModule extends Module {
 
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-            bind(FormFactory.class).toSelf()
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Collections.singletonList(
+            bindClass(FormFactory.class).toSelf()
         );
     }
 

--- a/framework/src/play-java-forms/src/main/java/play/data/format/FormattersModule.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/format/FormattersModule.java
@@ -4,19 +4,21 @@
 
 package play.data.format;
 
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
 import play.data.format.Formatters;
-import scala.collection.Seq;
+
+import java.util.Collections;
+import java.util.List;
 
 public class FormattersModule extends Module {
 
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-            bind(Formatters.class).toSelf()
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Collections.singletonList(
+            bindClass(Formatters.class).toSelf()
         );
     }
 

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorsModule.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorsModule.java
@@ -4,22 +4,24 @@
 
 package play.data.validation;
 
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
 
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import java.util.Arrays;
+import java.util.List;
 
-public class ValidatorsModule extends play.api.inject.Module {
+public class ValidatorsModule extends Module {
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-                bind(ConstraintValidatorFactory.class).to(DefaultConstraintValidatorFactory.class),
-                bind(Validator.class).toProvider(ValidatorProvider.class),
-                bind(ValidatorFactory.class).toProvider(ValidatorFactoryProvider.class)
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Arrays.asList(
+                bindClass(ConstraintValidatorFactory.class).to(DefaultConstraintValidatorFactory.class),
+                bindClass(Validator.class).toProvider(ValidatorProvider.class),
+                bindClass(ValidatorFactory.class).toProvider(ValidatorFactoryProvider.class)
         );
     }
 }

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DBModule.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DBModule.java
@@ -5,16 +5,15 @@
 package play.db;
 
 import com.google.common.collect.ImmutableList;
+import com.typesafe.config.Config;
 import play.Logger;
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import play.libs.Scala;
-import scala.collection.Seq;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -23,29 +22,29 @@ import java.util.Set;
 public final class DBModule extends Module {
 
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        String dbKey = configuration.underlying().getString("play.db.config");
-        String defaultDb = configuration.underlying().getString("play.db.default");
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        String dbKey = config.getString("play.db.config");
+        String defaultDb = config.getString("play.db.default");
 
         ImmutableList.Builder<Binding<?>> list = new ImmutableList.Builder<Binding<?>>();
 
-        list.add(bind(ConnectionPool.class).to(DefaultConnectionPool.class));
-        list.add(bind(DBApi.class).to(DefaultDBApi.class));
+        list.add(bindClass(ConnectionPool.class).to(DefaultConnectionPool.class));
+        list.add(bindClass(DBApi.class).to(DefaultDBApi.class));
 
         try {
-            Set<String> dbs = configuration.underlying().getConfig(dbKey).root().keySet();
+            Set<String> dbs = config.getConfig(dbKey).root().keySet();
             for (String db : dbs) {
-                list.add(bind(Database.class).qualifiedWith(named(db)).to(new NamedDatabaseProvider(db)));
+                list.add(bindClass(Database.class).qualifiedWith(named(db)).to(new NamedDatabaseProvider(db)));
             }
 
             if (dbs.contains(defaultDb)) {
-                list.add(bind(Database.class).to(bind(Database.class).qualifiedWith(named(defaultDb))));
+                list.add(bindClass(Database.class).to(bindClass(Database.class).qualifiedWith(named(defaultDb))));
             }
         } catch (com.typesafe.config.ConfigException.Missing ex) {
             Logger.warn("Configuration not found for database: {}", ex.getMessage());
         }
 
-        return Scala.toSeq(list.build());
+        return list.build();
     }
 
     private NamedDatabase named(String name) {

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAModule.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAModule.java
@@ -4,11 +4,13 @@
 
 package play.db.jpa;
 
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Injection module with default JPA components.
@@ -16,10 +18,10 @@ import scala.collection.Seq;
 public class JPAModule extends Module {
 
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-            bind(JPAApi.class).toProvider(DefaultJPAApi.JPAApiProvider.class),
-            bind(JPAConfig.class).toProvider(DefaultJPAConfig.JPAConfigProvider.class)
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Arrays.asList(
+            bindClass(JPAApi.class).toProvider(DefaultJPAApi.JPAApiProvider.class),
+            bindClass(JPAConfig.class).toProvider(DefaultJPAConfig.JPAConfigProvider.class)
         );
     }
 

--- a/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
+++ b/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
@@ -4,27 +4,28 @@
 
 package play.inject;
 
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
+import com.typesafe.config.Config;
+import play.Environment;
 import play.libs.Files;
 import play.libs.concurrent.DefaultFutures;
 import play.libs.concurrent.Futures;
 import play.libs.crypto.CookieSigner;
 import play.libs.crypto.DefaultCookieSigner;
 import play.mvc.FileMimeTypes;
-import scala.collection.Seq;
 
-public class BuiltInModule extends play.api.inject.Module {
+import java.util.Arrays;
+import java.util.List;
+
+public class BuiltInModule extends Module {
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-            bind(ApplicationLifecycle.class).to(DelegateApplicationLifecycle.class),
-            bind(play.Environment.class).toSelf(),
-            bind(CookieSigner.class).to(DefaultCookieSigner.class),
-            bind(Files.TemporaryFileCreator.class).to(Files.DelegateTemporaryFileCreator.class),
-            bind(FileMimeTypes.class).toSelf(),
-            bind(Futures.class).to(DefaultFutures.class)
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Arrays.asList(
+            bindClass(ApplicationLifecycle.class).to(DelegateApplicationLifecycle.class),
+            bindClass(play.Environment.class).toSelf(),
+            bindClass(CookieSigner.class).to(DefaultCookieSigner.class),
+            bindClass(Files.TemporaryFileCreator.class).to(Files.DelegateTemporaryFileCreator.class),
+            bindClass(FileMimeTypes.class).toSelf(),
+            bindClass(Futures.class).to(DefaultFutures.class)
         );
     }
 }

--- a/framework/src/play-openid/src/main/java/play/libs/openid/OpenIdModule.java
+++ b/framework/src/play-openid/src/main/java/play/libs/openid/OpenIdModule.java
@@ -4,18 +4,20 @@
 
 package play.libs.openid;
 
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
+
+import java.util.Collections;
+import java.util.List;
 
 public class OpenIdModule extends Module {
 
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-                bind(OpenIdClient.class).to(DefaultOpenIdClient.class)
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Collections.singletonList(
+                bindClass(OpenIdClient.class).to(DefaultOpenIdClient.class)
         );
     }
 }

--- a/framework/src/play/src/main/java/play/inject/Binding.java
+++ b/framework/src/play/src/main/java/play/inject/Binding.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+import scala.compat.java8.OptionConverters;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+/**
+ * A binding.
+ *
+ * Bindings are used to bind classes, optionally qualified by a JSR-330 qualifier annotation, to instances, providers or
+ * implementation classes.
+ *
+ * Bindings may also specify a JSR-330 scope.  If, and only if that scope is
+ * <a href="http://docs.oracle.com/javase/8/docs/api/javax/inject/Singleton">javax.inject.Singleton</a>, then the
+ * binding may declare itself to be eagerly instantiated.  In which case, it should be eagerly instantiated when Play
+ * starts up.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public final class Binding<T> {
+    private final play.api.inject.Binding<T> underlying;
+
+    /**
+     * @param key The binding key.
+     * @param target The binding target.
+     * @param scope The JSR-330 scope.
+     * @param eager Whether the binding should be eagerly instantiated.
+     * @param source Where this object was bound. Used in error reporting.
+     */
+    public Binding(final BindingKey<T> key, final Optional<BindingTarget<T>> target,
+            final Optional<Class<? extends Annotation>> scope, final Boolean eager, final Object source) {
+        this(play.api.inject.Binding.apply(key.asScala(), OptionConverters.toScala(target.map(BindingTarget::asScala)),
+            OptionConverters.toScala(scope), eager, source));
+    }
+
+    public Binding(final play.api.inject.Binding<T> underlying) {
+        this.underlying = underlying;
+    }
+
+    public BindingKey<T> getKey() {
+        return underlying.key().asJava();
+    }
+
+    public Optional<BindingTarget<T>> getTarget() {
+        return OptionConverters.toJava(underlying.target()).map(play.api.inject.BindingTarget::asJava);
+    }
+
+    public Optional<Class<? extends Annotation>> getScope() {
+        return OptionConverters.toJava(underlying.scope());
+    }
+
+    public Boolean getEager() {
+        return underlying.eager();
+    }
+
+    public Object getSource() {
+        return underlying.source();
+    }
+
+    /**
+     * Configure the scope for this binding.
+     */
+    public <A extends Annotation> Binding<T> in(final Class<A> scope) {
+        return underlying.in(scope).asJava();
+    }
+
+    /**
+     * Eagerly instantiate this binding when Play starts up.
+     */
+    public Binding<T> eagerly() {
+        return underlying.eagerly().asJava();
+    }
+
+    @Override
+    public String toString() {
+        return underlying.toString();
+    }
+
+    public play.api.inject.Binding<T> asScala() {
+        return underlying;
+    }
+}

--- a/framework/src/play/src/main/java/play/inject/BindingKey.java
+++ b/framework/src/play/src/main/java/play/inject/BindingKey.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+import scala.compat.java8.functionConverterImpls.FromJavaSupplier;
+import scala.compat.java8.OptionConverters;
+
+import javax.inject.Provider;
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * A binding key.
+ *
+ * A binding key consists of a class and zero or more JSR-330 qualifiers.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public final class BindingKey<T> {
+    private final play.api.inject.BindingKey<T> underlying;
+
+    /**
+     * A binding key.
+     *
+     * A binding key consists of a class and zero or more JSR-330 qualifiers.
+     *
+     * See the {@link Module} class for information on how to provide bindings.
+     *
+     * @param clazz The class to bind.
+     * @param qualifier An optional qualifier.
+     */
+    public BindingKey(final Class<T> clazz, final Optional<QualifierAnnotation> qualifier) {
+        this(play.api.inject.BindingKey.apply(clazz, OptionConverters.toScala(qualifier.map(QualifierAnnotation::asScala))));
+    }
+
+    public BindingKey(final play.api.inject.BindingKey<T> underlying) {
+        this.underlying = underlying;
+    }
+
+    public BindingKey(final Class<T> clazz) {
+        this(clazz, Optional.empty());
+    }
+
+    public Class<T> getClazz() {
+        return underlying.clazz();
+    }
+
+    public Optional<QualifierAnnotation> getQualifier() {
+        return OptionConverters.toJava(underlying.qualifier()).map(play.api.inject.QualifierAnnotation::asJava);
+    }
+
+    /**
+     * Qualify this binding key with the given instance of an annotation.
+     *
+     * This can be used to specify bindings with annotations that have particular values.
+     */
+    public <A extends Annotation> BindingKey<T> qualifiedWith(final A instance) {
+        return underlying.qualifiedWith(instance).asJava();
+    }
+
+    /**
+     * Qualify this binding key with the given annotation.
+     *
+     * For example, you may have both a cached implementation, and a direct implementation of a service. To differentiate
+     * between them, you may define a Cached annotation:
+     *
+     * <pre>
+     * {@code
+     *   bindClass(Foo.class).qualifiedWith(Cached.class).to(FooCached.class),
+     *   bindClass(Foo.class).to(FooImpl.class)
+     *
+     *   ...
+     *
+     *   class MyController {
+     *     {@literal @}Inject
+     *     MyController({@literal @}Cached Foo foo) {
+     *       ...
+     *     }
+     *     ...
+     *   }
+     * }
+     * </pre>
+     *
+     * In the above example, the controller will get the cached {@code Foo} service.
+     */
+    public <A extends Annotation> BindingKey<T> qualifiedWith(final Class<A> annotation) {
+        return underlying.qualifiedWith(annotation).asJava();
+    }
+
+    /**
+     * Qualify this binding key with the given name.
+     *
+     * For example, you may have both a cached implementation, and a direct implementation of a service. To differentiate
+     * between them, you may decide to name the cached one:
+     *
+     * <pre>
+     * {@code
+     *   bindClass(Foo.class).qualifiedWith("cached").to(FooCached.class),
+     *   bindClass(Foo.class).to(FooImpl.class)
+     *
+     *   ...
+     *
+     *   class MyController {
+     *     {@literal @}Inject
+     *     MyController({@literal @}Named("cached") Foo foo) {
+     *       ...
+     *     }
+     *     ...
+     *   }
+     * }
+     * </pre>
+     *
+     * In the above example, the controller will get the cached `Foo` service.
+     */
+    public BindingKey<T> qualifiedWith(final String name) {
+        return underlying.qualifiedWith(name).asJava();
+    }
+
+    /**
+     * Bind this binding key to the given implementation class.
+     *
+     * This class will be instantiated and injected by the injection framework.
+     */
+    public Binding<T> to(final Class<? extends T> implementation) {
+        return underlying.to(implementation).asJava();
+    }
+
+    /**
+     * Bind this binding key to the given provider instance.
+     *
+     * This provider instance will be invoked to obtain the implementation for the key.
+     */
+    public Binding<T> to(final Provider<? extends T> provider) {
+        return underlying.to(provider).asJava();
+    }
+
+    /**
+     * Bind this binding key to the given instance.
+     */
+    public <A extends T> Binding<T> to(final Supplier<A> instance) {
+        return underlying.to(new FromJavaSupplier<>(instance)).asJava();
+    }
+
+    /**
+     * Bind this binding key to another binding key.
+     */
+    public Binding<T> to(final BindingKey<? extends T> key) {
+        return underlying.to(key.asScala()).asJava();
+    }
+
+    /**
+     * Bind this binding key to the given provider class.
+     *
+     * The dependency injection framework will instantiate and inject this provider, and then invoke its `get` method
+     * whenever an instance of the class is needed.
+     */
+    public <P extends Provider<? extends T>> Binding<T> toProvider(final Class<P> provider) {
+        return underlying.toProvider(provider).asJava();
+    }
+
+    /**
+     * Bind this binding key to the given instance.
+     */
+    public Binding<T> toInstance(final T instance) {
+        return underlying.toInstance(instance).asJava();
+    }
+
+    /**
+     * Bind this binding key to itself.
+     */
+    public Binding<T> toSelf() {
+        return underlying.toSelf().asJava();
+    }
+
+    @Override
+    public String toString() {
+        return underlying.toString();
+    }
+
+    public play.api.inject.BindingKey<T> asScala() {
+        return underlying;
+    }
+}

--- a/framework/src/play/src/main/java/play/inject/BindingKeyTarget.java
+++ b/framework/src/play/src/main/java/play/inject/BindingKeyTarget.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+/**
+ * A binding target that is provided by another key - essentially an alias.
+ */
+public final class BindingKeyTarget<T> extends BindingTarget<T> {
+    private final play.api.inject.BindingKeyTarget<T> underlying;
+
+    public BindingKeyTarget(final BindingKey<? extends T> key) {
+        this(play.api.inject.BindingKeyTarget.apply(key.asScala()));
+    }
+
+    public BindingKeyTarget(final play.api.inject.BindingKeyTarget<T> underlying) {
+        super();
+        this.underlying = underlying;
+    }
+
+    public BindingKey<? extends T> getKey() {
+        return underlying.key().asJava();
+    }
+
+    @Override
+    public play.api.inject.BindingKeyTarget<T> asScala() {
+        return underlying;
+    }
+}

--- a/framework/src/play/src/main/java/play/inject/BindingTarget.java
+++ b/framework/src/play/src/main/java/play/inject/BindingTarget.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+/**
+ * A binding target.
+ *
+ * This abstract class captures the four possible types of targets.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public abstract class BindingTarget<T> {
+    BindingTarget() {
+    }
+
+    public abstract play.api.inject.BindingTarget<T> asScala();
+}

--- a/framework/src/play/src/main/java/play/inject/ConstructionTarget.java
+++ b/framework/src/play/src/main/java/play/inject/ConstructionTarget.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+/**
+ * A binding target that is provided by a class.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public final class ConstructionTarget<T> extends BindingTarget<T> {
+    private final play.api.inject.ConstructionTarget<T> underlying;
+
+    public ConstructionTarget(final Class<? extends T> implementation) {
+        this(play.api.inject.ConstructionTarget.apply(implementation));
+    }
+
+    public ConstructionTarget(final play.api.inject.ConstructionTarget<T> underlying) {
+        super();
+        this.underlying = underlying;
+    }
+
+    public Class<? extends T> getImplementation() {
+        return underlying.implementation();
+    }
+
+    @Override
+    public play.api.inject.ConstructionTarget<T> asScala() {
+        return underlying;
+    }
+}

--- a/framework/src/play/src/main/java/play/inject/Module.java
+++ b/framework/src/play/src/main/java/play/inject/Module.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+import com.typesafe.config.Config;
+import play.Environment;
+import scala.collection.JavaConverters;
+import scala.collection.immutable.Seq;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A Play dependency injection module.
+ *
+ * Dependency injection modules can be used by Play plugins to provide bindings for JSR-330 compliant
+ * ApplicationLoaders.  Any plugin that wants to provide components that a Play application can use may implement
+ * one of these.
+ *
+ * Providing custom modules can be done by appending their fully qualified class names to `play.modules.enabled` in
+ * `application.conf`, for example
+ *
+ * <pre> <code>
+ * play.modules.enabled += "com.example.FooModule"
+ * play.modules.enabled += "com.example.BarModule"
+ * </code> </pre>
+ *
+ * It is strongly advised that in addition to providing a module for JSR-330 DI, that plugins also provide a Scala
+ * trait that constructs the modules manually.  This allows for use of the module without needing a runtime dependency
+ * injection provider.
+ *
+ * The `bind` methods are provided only as a DSL for specifying bindings. For example:
+ *
+ * <pre> <code>
+ * {@literal @}Override
+ * public List&lt;Binding&lt;?&gt;&gt; bindings(Environment environment, Config config) {
+ *     return Arrays.asList(
+ *         bindClass(Foo.class).to(FooImpl.class),
+ *         bindClass(Bar.class).to(() -&gt; new Bar()),
+ *         bindClass(Foo.class).qualifiedWith(SomeQualifier.class).to(OtherFoo.class)
+ *     );
+ * }
+ * </code> </pre>
+ */
+public abstract class Module extends play.api.inject.Module {
+    public abstract List<Binding<?>> bindings(final Environment environment, final Config config);
+
+    @Override
+    public final Seq<play.api.inject.Binding<?>> bindings(final play.api.Environment environment,
+            final play.api.Configuration configuration) {
+        List<play.api.inject.Binding<?>> list = bindings(environment.asJava(), configuration.underlying()).stream()
+            .map(Binding::asScala)
+            .collect(Collectors.toList());
+        return JavaConverters.collectionAsScalaIterableConverter(list).asScala().toList();
+    }
+
+    /**
+     * Create a binding key for the given class.
+     */
+    public static <T> BindingKey<T> bindClass(final Class<T> clazz) {
+        return new BindingKey<>(clazz);
+    }
+}

--- a/framework/src/play/src/main/java/play/inject/ProviderConstructionTarget.java
+++ b/framework/src/play/src/main/java/play/inject/ProviderConstructionTarget.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+import javax.inject.Provider;
+
+/**
+ * A binding target that is provided by a provider class.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public final class ProviderConstructionTarget<T> extends BindingTarget<T> {
+    private final play.api.inject.ProviderConstructionTarget<T> underlying;
+
+    public ProviderConstructionTarget(final Class<? extends Provider<? extends T>> provider) {
+        this(play.api.inject.ProviderConstructionTarget.apply(provider));
+    }
+
+    public ProviderConstructionTarget(final play.api.inject.ProviderConstructionTarget<T> underlying) {
+        super();
+        this.underlying = underlying;
+    }
+
+    public Class<? extends Provider<? extends T>> getProvider() {
+        return underlying.provider();
+    }
+
+    @Override
+    public play.api.inject.ProviderConstructionTarget<T> asScala() {
+        return underlying;
+    }
+}

--- a/framework/src/play/src/main/java/play/inject/ProviderTarget.java
+++ b/framework/src/play/src/main/java/play/inject/ProviderTarget.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+import javax.inject.Provider;
+
+/**
+ * A binding target that is provided by a provider instance.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public final class ProviderTarget<T> extends BindingTarget<T> {
+    private final play.api.inject.ProviderTarget<T> underlying;
+
+    public ProviderTarget(final Provider<? extends T> provider) {
+        this(play.api.inject.ProviderTarget.apply(provider));
+    }
+
+    public ProviderTarget(final play.api.inject.ProviderTarget<T> underlying) {
+        super();
+        this.underlying = underlying;
+    }
+
+    public Provider<? extends T> getProvider() {
+        return underlying.provider();
+    }
+
+    @Override
+    public play.api.inject.ProviderTarget<T> asScala() {
+        return underlying;
+    }
+}

--- a/framework/src/play/src/main/java/play/inject/QualifierAnnotation.java
+++ b/framework/src/play/src/main/java/play/inject/QualifierAnnotation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+/**
+ * A qualifier annotation.
+ *
+ * Since bindings may specify either annotations, or instances of annotations, this abstraction captures either of
+ * those two possibilities.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public abstract class QualifierAnnotation {
+    QualifierAnnotation() {
+    }
+
+    public abstract play.api.inject.QualifierAnnotation asScala();
+}

--- a/framework/src/play/src/main/java/play/inject/QualifierClass.java
+++ b/framework/src/play/src/main/java/play/inject/QualifierClass.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A qualifier annotation instance.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public final class QualifierClass<T extends Annotation> extends QualifierAnnotation {
+    private final play.api.inject.QualifierClass<T> underlying;
+
+    public QualifierClass(final Class<T> clazz) {
+        this(play.api.inject.QualifierClass.apply(clazz));
+    }
+
+    public QualifierClass(final play.api.inject.QualifierClass<T> underlying) {
+        super();
+        this.underlying = underlying;
+    }
+
+    public Class<T> getClazz() {
+        return underlying.clazz();
+    }
+
+    @Override
+    public play.api.inject.QualifierClass asScala() {
+        return underlying;
+    }
+}

--- a/framework/src/play/src/main/java/play/inject/QualifierInstance.java
+++ b/framework/src/play/src/main/java/play/inject/QualifierInstance.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A qualifier annotation instance.
+ *
+ * See the {@link Module} class for information on how to provide bindings.
+ */
+public final class QualifierInstance<T extends Annotation> extends QualifierAnnotation {
+    private final play.api.inject.QualifierInstance<T> underlying;
+
+    public QualifierInstance(final T instance) {
+        this(play.api.inject.QualifierInstance.apply(instance));
+    }
+
+    public QualifierInstance(final play.api.inject.QualifierInstance<T> underlying) {
+        super();
+        this.underlying = underlying;
+    }
+
+    public T getInstance() {
+        return underlying.instance();
+    }
+
+    @Override
+    public play.api.inject.QualifierInstance asScala() {
+        return underlying;
+    }
+}

--- a/framework/src/play/src/main/scala/play/api/inject/Binding.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Binding.scala
@@ -55,6 +55,8 @@ final case class Binding[T](key: BindingKey[T], target: Option[BindingTarget[T]]
     val eagerDesc = if (eager) " eagerly" else ""
     s"$source:\nBinding($key to ${target.getOrElse("self")}${scope.fold("")(" in " + _)}$eagerDesc)"
   }
+
+  def asJava: play.inject.Binding[T] = new play.inject.Binding[T](this)
 }
 
 /**
@@ -236,6 +238,8 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
     s"$clazz${qualifier.fold("")(" qualified with " + _)}"
   }
 
+  def asJava: play.inject.BindingKey[T] = new play.inject.BindingKey[T](this)
+
   private def validateTargetNonAbstract[T](target: Class[T]): Class[T] = {
     if (target.isInterface || Modifier.isAbstract(target.getModifiers)) {
       throw new PlayException(
@@ -254,33 +258,43 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
  *
  * @see The [[Module]] class for information on how to provide bindings.
  */
-sealed trait BindingTarget[T]
+sealed trait BindingTarget[T] {
+  def asJava: play.inject.BindingTarget[T]
+}
 
 /**
  * A binding target that is provided by a provider instance.
  *
  * @see The [[Module]] class for information on how to provide bindings.
  */
-final case class ProviderTarget[T](provider: Provider[_ <: T]) extends BindingTarget[T]
+final case class ProviderTarget[T](provider: Provider[_ <: T]) extends BindingTarget[T] {
+  override def asJava: play.inject.ProviderTarget[T] = new play.inject.ProviderTarget[T](this)
+}
 
 /**
  * A binding target that is provided by a provider class.
  *
  * @see The [[Module]] class for information on how to provide bindings.
  */
-final case class ProviderConstructionTarget[T](provider: Class[_ <: Provider[_ <: T]]) extends BindingTarget[T]
+final case class ProviderConstructionTarget[T](provider: Class[_ <: Provider[_ <: T]]) extends BindingTarget[T] {
+  override def asJava: play.inject.ProviderConstructionTarget[T] = new play.inject.ProviderConstructionTarget[T](this)
+}
 
 /**
  * A binding target that is provided by a class.
  *
  * @see The [[play.api.inject.Module]] class for information on how to provide bindings.
  */
-final case class ConstructionTarget[T](implementation: Class[_ <: T]) extends BindingTarget[T]
+final case class ConstructionTarget[T](implementation: Class[_ <: T]) extends BindingTarget[T] {
+  override def asJava: play.inject.ConstructionTarget[T] = new play.inject.ConstructionTarget[T](this)
+}
 
 /**
  * A binding target that is provided by another key - essentially an alias.
  */
-final case class BindingKeyTarget[T](key: BindingKey[_ <: T]) extends BindingTarget[T]
+final case class BindingKeyTarget[T](key: BindingKey[_ <: T]) extends BindingTarget[T] {
+  override def asJava: play.inject.BindingKeyTarget[T] = new play.inject.BindingKeyTarget[T](this)
+}
 
 /**
  * A qualifier annotation.
@@ -290,21 +304,27 @@ final case class BindingKeyTarget[T](key: BindingKey[_ <: T]) extends BindingTar
  *
  * @see The [[Module]] class for information on how to provide bindings.
  */
-sealed trait QualifierAnnotation
+sealed trait QualifierAnnotation {
+  def asJava: play.inject.QualifierAnnotation
+}
 
 /**
  * A qualifier annotation instance.
  *
  * @see The [[Module]] class for information on how to provide bindings.
  */
-final case class QualifierInstance[T <: Annotation](instance: T) extends QualifierAnnotation
+final case class QualifierInstance[T <: Annotation](instance: T) extends QualifierAnnotation {
+  override def asJava: play.inject.QualifierInstance[T] = new play.inject.QualifierInstance[T](this)
+}
 
 /**
  * A qualifier annotation class.
  *
  * @see The [[Module]] class for information on how to provide bindings.
  */
-final case class QualifierClass[T <: Annotation](clazz: Class[T]) extends QualifierAnnotation
+final case class QualifierClass[T <: Annotation](clazz: Class[T]) extends QualifierAnnotation {
+  override def asJava: play.inject.QualifierClass[T] = new play.inject.QualifierClass[T](this)
+}
 
 private object SourceLocator {
   val provider = SourceProvider.DEFAULT_INSTANCE.plusSkippedClasses(this.getClass, classOf[BindingKey[_]], classOf[Binding[_]])

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -63,6 +63,7 @@ abstract class Module {
   /**
    * Create a binding key for the given class.
    */
+  @deprecated("Use play.inject.Module.bindClass instead if the Module is coded in Java. Scala modules can use play.api.inject.bind[T: ClassTag]", "2.7.0")
   final def bind[T](clazz: Class[T]): BindingKey[T] = play.api.inject.bind(clazz)
 
   /**
@@ -75,6 +76,7 @@ abstract class Module {
    *
    * For Java compatibility.
    */
+  @deprecated("Use play.inject.Module instead if the Module is coded in Java.", "2.7.0")
   @varargs
   final def seq(bindings: Binding[_]*): Seq[Binding[_]] = bindings
 }


### PR DESCRIPTION
…gnostic

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Java API did not support `Module` or `Binding`, if people want to write module, they have to either use Scala API, which is awkward sometimes, or use Guice API, which binds to Guice framework.

Using this can make Java API symmetric to Scala API and agnostic to DI framework.

On a side note, we are in the process of making pure Java Play projects (for the purpose of escaping cross-building together with our Scala dynamic resolution). Lacking of this is an important blocker, as many libraries need to expose `Module`.

## Background Context

There are two thoughts. One is to make Java `Module` not subclass Scala `Module`, this leads to touching a lot of things in `play-guice`. The other is the current implementation, Java `Module` extends Scala `Module`. This works very well - you can also see I replaced all the Java source modules previously using Scala `Module`, and just works. Except, 1) it has to exposes Scala `Module`'s `bind` APIs, this is not critical, since it is not very usable in the Java `Module`, 2) I had to rename Java `bind` to `bindClass` (better name?), not ideal but acceptable.

The Java APIs are translated from `Module.scala` and `Binding.scala`. As I explained above, because all the bindings/tests work, it means replace Scala `Module` with Java `Module` functional, so I didn't include tests.

TODO: Play documentation needs to change accordingly. And backport to 2.6 is needed.

Please let me know if you spot any issue or have any feedback. Thanks!