### PR TITLE
fromJsonValidationError did not expand varargs, fixes #8560

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/validation/Validation.scala
+++ b/framework/src/play/src/main/scala/play/api/data/validation/Validation.scala
@@ -261,7 +261,7 @@ object ValidationError {
    * Conversion from a JsonValidationError to a Play ValidationError.
    */
   def fromJsonValidationError(jve: JsonValidationError): ValidationError = {
-    ValidationError(jve.message, jve.args)
+    ValidationError(jve.message, jve.args: _*)
   }
 
   def apply(message: String, args: Any*) = new ValidationError(Seq(message), args: _*)

--- a/framework/src/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
@@ -11,6 +11,8 @@ import play.api.data.Forms._
 import play.api.data.format.Formats._
 import play.api.data.validation.Constraints._
 
+import play.api.libs.json.JsonValidationError
+
 class ValidationSpec extends Specification {
 
   "text" should {
@@ -235,6 +237,15 @@ class ValidationSpec extends Specification {
       val expected = Invalid(List(ValidationError("error.minLength", 1), ValidationError("error.maxLength", 10)))
 
       ParameterValidator(constraints, values: _*) must equalTo(expected)
+    }
+
+    "ValidationError" should {
+      "Preserve varargs when converting a JsonValidationError to a Play ValidationError" in {
+        val jsonError = JsonValidationError("Testing, testing {1} {2} {3}", "one", "two", "three")
+        val validationError = ValidationError.fromJsonValidationError(jsonError)
+        jsonError.args(2) must equalTo("three")
+        validationError.args(2) must equalTo("three")
+      }
     }
   }
 


### PR DESCRIPTION
Fixes an issue with ValidationError and varargs when converting to a JsonValidationError.   Replaces an earlier pull request that was getting messy due to CLA/GitHub email address confusion.

## Fixes

Fixes #8560 
