### PR TITLE
Adopt lagom keystore generation changes in Play

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -369,3 +369,7 @@ CoordinatedShutdown.Reason reason = CoordinatedShutdown.unknownReason();
 Optional<String> runFromPhase = Optional.of("");
 CoordinatedShutdown.get(actorSystem).run(reason, runFromPhase);
 ```
+
+## Change in self-signed HTTPS certificate
+
+It is now generated under `target/dev-mode/generated.keystore` instead of directly on the root folder.

--- a/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
+++ b/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
@@ -3,7 +3,9 @@
 
 Play can be configured to serve HTTPS.  To enable this, simply tell Play which port to listen to using the `https.port` system property.  For example:
 
-    ./start -Dhttps.port=9443
+```bash
+sbt -Dhttps.port=9443 run
+```
 
 ## Providing configuration
 
@@ -26,30 +28,31 @@ Having created your keystore, the following configuration properties can be used
 
 ### SSL Certificates from a custom SSL Engine
 
-Another alternative to configure the SSL certificates is to provide a custom [SSLEngine](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLEngine.html).  This is also useful in cases where a customized SSLEngine is required, such as in the case of client authentication.
+Another alternative to configure the SSL certificates is to provide a custom [SSLEngine](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLEngine.html).  This is also useful in cases where a customized `SSLEngine` is required, such as in the case of client authentication. In Java, an implementation must be provided for [`play.server.SSLEngineProvider`](api/java/play/server/SSLEngineProvider.html) and in Scala, an implementation must be provided for [`play.server.api.SSLEngineProvider`](api/scala/play/server/api/SSLEngineProvider.html). For example:
 
-#### in Java, an implementation must be provided for [`play.server.SSLEngineProvider`](api/java/play/server/SSLEngineProvider.html)
+Scala
+: @[scalaexample](code/scalaguide/CustomSSLEngineProvider.scala)
 
-@[javaexample](code/javaguide/CustomSSLEngineProvider.java)
-
-#### in Scala, an implementation must be provided for [`play.server.api.SSLEngineProvider`](api/scala/play/server/api/SSLEngineProvider.html)
-
-@[scalaexample](code/scalaguide/CustomSSLEngineProvider.scala)
+Java:
+: @[javaexample](code/javaguide/CustomSSLEngineProvider.java)
 
 Having created an implementation for `play.server.SSLEngineProvider` or `play.server.api.SSLEngineProvider`, the following system property configures Play to use it:
 
-* **play.server.https.engineProvider** - The path to the class implementing `play.server.SSLEngineProvider` or `play.server.api.SSLEngineProvider`:
+* **`play.server.https.engineProvider`** - The path to the class implementing `play.server.SSLEngineProvider` or `play.server.api.SSLEngineProvider`:
 
 Example:
 
-    ./start -Dhttps.port=9443 -Dplay.server.https.engineProvider=mypackage.CustomSSLEngineProvider
-
+```bash
+sbt -Dhttps.port=9443 -Dplay.server.https.engineProvider=mypackage.CustomSSLEngineProvider run
+```
 
 ## Turning HTTP off
 
 To disable binding on the HTTP port, set the `http.port` system property to be `disabled`, eg:
 
-    ./start -Dhttp.port=disabled -Dhttps.port=9443 -Dplay.server.https.keyStore.path=/path/to/keystore -Dplay.server.https.keyStore.password=changeme
+```bash
+sbt -Dhttp.port=disabled -Dhttps.port=9443 -Dplay.server.https.keyStore.path=/path/to/keystore -Dplay.server.https.keyStore.password=changeme run
+```
 
 ## Production usage of HTTPS
 

--- a/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
+++ b/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
@@ -4,7 +4,7 @@
 Play can be configured to serve HTTPS.  To enable this, simply tell Play which port to listen to using the `https.port` system property.  For example:
 
 ```bash
-sbt -Dhttps.port=9443 run
+./bin/your-app -Dhttps.port=9443
 ```
 
 ## Providing configuration
@@ -43,7 +43,7 @@ Having created an implementation for `play.server.SSLEngineProvider` or `play.se
 Example:
 
 ```bash
-sbt -Dhttps.port=9443 -Dplay.server.https.engineProvider=mypackage.CustomSSLEngineProvider run
+./bin/your-app -Dhttps.port=9443 -Dplay.server.https.engineProvider=mypackage.CustomSSLEngineProvider
 ```
 
 ## Turning HTTP off
@@ -51,7 +51,7 @@ sbt -Dhttps.port=9443 -Dplay.server.https.engineProvider=mypackage.CustomSSLEngi
 To disable binding on the HTTP port, set the `http.port` system property to be `disabled`, eg:
 
 ```bash
-sbt -Dhttp.port=disabled -Dhttps.port=9443 -Dplay.server.https.keyStore.path=/path/to/keystore -Dplay.server.https.keyStore.password=changeme run
+./bin/your-app -Dhttp.port=disabled -Dhttps.port=9443 -Dplay.server.https.keyStore.path=/path/to/keystore -Dplay.server.https.keyStore.password=changeme
 ```
 
 ## Production usage of HTTPS

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -562,7 +562,12 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.concurrent.ActorSystemProvider.start"),
       // Removed private[play] class CloseableLazy
       ProblemFilters.exclude[MissingClassProblem]("play.core.ClosableLazy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.concurrent.ActorSystemProvider.lazyStart")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.concurrent.ActorSystemProvider.lazyStart"),
+
+      // Merge Lagom changes to KeyStore generation
+      // https://github.com/playframework/playframework/pull/8574
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ssl.FakeKeyStore.DnName"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ssl.FakeKeyStore.createSelfSignedCertificate")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
@@ -24,7 +24,7 @@ object CertificateGenerator {
    * Generates a certificate using RSA (which is available in 1.6).
    */
   def generateRSAWithSHA256(keySize: Int = 2048, from: Instant = Instant.now, duration: Duration = Duration.ofDays(365)): X509Certificate = {
-    val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
+    val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Play Base 1, ST=Cyberspace, C=CY"
     val to = from.plus(duration)
 
     val keyGen = KeyPairGenerator.getInstance("RSA")
@@ -34,7 +34,7 @@ object CertificateGenerator {
   }
 
   def generateRSAWithSHA1(keySize: Int = 2048, from: Instant = Instant.now, duration: Duration = Duration.ofDays(365)): X509Certificate = {
-    val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
+    val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Play Base 1, ST=Cyberspace, C=CY"
     val to = from.plus(duration)
 
     val keyGen = KeyPairGenerator.getInstance("RSA")
@@ -55,7 +55,7 @@ object CertificateGenerator {
   }
 
   def generateRSAWithMD5(keySize: Int = 2048, from: Instant = Instant.now, duration: Duration = Duration.ofDays(365)): X509Certificate = {
-    val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
+    val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Play Base 1, ST=Cyberspace, C=CY"
     val to = from.plus(duration)
 
     val keyGen = KeyPairGenerator.getInstance("RSA")

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
@@ -58,7 +58,7 @@ class DefaultSSLEngineProvider(serverConfig: ServerConfig, appProvider: Applicat
       }
     } else {
       // Load a generated key store
-      logger.warn("Using generated key with self signed certificate for HTTPS. This should not be used in production.")
+      logger.warn("Using generated key with self signed certificate for HTTPS. This should NOT be used in production.")
       FakeKeyStore.keyManagerFactory(serverConfig.rootDir)
     }
 

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -78,7 +78,7 @@ object FakeKeyStore {
   }
 
   def createKeyStore(appPath: File): KeyStore = {
-    val keyStoreFile = new File(appPath, GeneratedKeyStore)
+    val keyStoreFile = getKeyStoreFilePath(appPath)
     val keyStoreDir = keyStoreFile.getParentFile
 
     createKeystoreParentDirectory(keyStoreDir)

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -96,16 +96,9 @@ object FakeKeyStore {
       freshKeyStore
     } else {
       // Load a KeyStore from a file
-      val loadedKeystore: KeyStore = KeyStore.getInstance("JKS")
-      val in = java.nio.file.Files.newInputStream(keyStoreFile.toPath)
-      try {
-        loadedKeystore.load(in, Array.emptyCharArray)
-      } finally {
-        PlayIO.closeQuietly(in)
-      }
-
+      val loadedKeyStore = loadKeyStore(keyStoreFile)
       logger.info(s"HTTPS key pair generated in ${keyStoreFile.getAbsolutePath}.")
-      loadedKeystore
+      loadedKeyStore
     }
     keyStore
   }

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -38,7 +38,7 @@ object FakeKeyStore {
     val DistinguishedName = "CN=localhost-CA, OU=Unit Testing, O=Mavericks, L=Play Base 1, ST=Cyberspace, C=CY"
   }
 
-  def fileInDevModeDir(filename: String): String = {
+  private def fileInDevModeDir(filename: String): String = {
     "target" + File.separatorChar + "dev-mode" + File.separatorChar + filename
   }
 
@@ -166,7 +166,7 @@ object FakeKeyStore {
     keyStore
   }
 
-  def createSelfSignedCertificate(keyPair: KeyPair, certificateAuthorityKeyPair: KeyPair): X509Certificate = {
+  private def createSelfSignedCertificate(keyPair: KeyPair, certificateAuthorityKeyPair: KeyPair): X509Certificate = {
     val certInfo = new X509CertInfo()
 
     // Serial number and version

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -5,27 +5,45 @@
 package play.core.server.ssl
 
 import play.api.Logger
-import java.security.{ KeyStore, SecureRandom, KeyPairGenerator, KeyPair }
+import java.security.{ KeyPair, KeyPairGenerator, KeyStore, SecureRandom }
+
 import sun.security.x509._
 import java.util.Date
 import java.math.BigInteger
 import java.security.cert.X509Certificate
 import java.io.File
+
 import javax.net.ssl.KeyManagerFactory
 import play.utils.PlayIO
 import java.security.interfaces.RSAPublicKey
+
+import sun.security.util.ObjectIdentifier
 
 /**
  * A fake key store
  */
 object FakeKeyStore {
   private val logger = Logger(FakeKeyStore.getClass)
-  val GeneratedKeyStore = "generated.keystore"
-  val DnName = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
-  val SignatureAlgorithmOID = AlgorithmId.sha256WithRSAEncryption_oid
-  val SignatureAlgorithmName = "SHA256withRSA"
 
-  def shouldGenerate(keyStoreFile: File): Boolean = {
+  val GeneratedKeyStore = "target/dev-mode/generated.keystore"
+  val ExportedCert = "target/dev-mode/service.crt"
+  val TrustedAlias = "playgeneratedtrusted"
+  val DistinguishedName = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Play Base 1, ST=Cyberspace, C=CY"
+  val SignatureAlgorithmName = "SHA256withRSA"
+  val SignatureAlgorithmOID: ObjectIdentifier = AlgorithmId.sha256WithRSAEncryption_oid
+
+  object CertificateAuthority {
+    val ExportedCertificate = "target/dev-mode/ca.crt"
+    val TrustedAlias = "playgeneratedCAtrusted"
+    val DistinguishedName = "CN=localhost-CA, OU=Unit Testing, O=Mavericks, L=Play Base 1, ST=Cyberspace, C=CY"
+  }
+
+  /**
+   * @param appPath a file descriptor to the root folder of the project (the root, not a particular module).
+   */
+  def getKeyStoreFilePath(appPath: File) = new File(appPath, GeneratedKeyStore)
+
+  private[play] def shouldGenerate(keyStoreFile: File): Boolean = {
     import scala.collection.JavaConverters._
 
     if (!keyStoreFile.exists()) {
@@ -33,32 +51,41 @@ object FakeKeyStore {
     }
 
     // Should regenerate if we find an unacceptably weak key in there.
-    val store = KeyStore.getInstance("JKS")
-    val in = java.nio.file.Files.newInputStream(keyStoreFile.toPath)
-    try {
-      store.load(in, "".toCharArray)
-    } finally {
-      PlayIO.closeQuietly(in)
-    }
+    val store = loadKeyStore(keyStoreFile)
     store.aliases().asScala.exists { alias =>
       Option(store.getCertificate(alias)).exists(c => certificateTooWeak(c))
     }
   }
 
-  def certificateTooWeak(c: java.security.cert.Certificate): Boolean = {
+  private def loadKeyStore(file: File): KeyStore = {
+    val keyStore: KeyStore = KeyStore.getInstance("JKS")
+    val in = java.nio.file.Files.newInputStream(file.toPath)
+    try {
+      keyStore.load(in, Array.emptyCharArray)
+    } finally {
+      PlayIO.closeQuietly(in)
+    }
+    keyStore
+  }
+
+  private[play] def certificateTooWeak(c: java.security.cert.Certificate): Boolean = {
     val key: RSAPublicKey = c.getPublicKey.asInstanceOf[RSAPublicKey]
     key.getModulus.bitLength < 2048 || c.asInstanceOf[X509CertImpl].getSigAlgName != SignatureAlgorithmName
   }
 
-  def keyManagerFactory(appPath: File): KeyManagerFactory = {
+  def createKeyStore(appPath: File): KeyStore = {
     val keyStoreFile = new File(appPath, GeneratedKeyStore)
+
+    // Ensure directory for keystore exists
+    keyStoreFile.getParentFile.mkdirs()
+
     val keyStore: KeyStore = if (shouldGenerate(keyStoreFile)) {
-      logger.info("Generating HTTPS key pair in " + keyStoreFile.getAbsolutePath + " - this may take some time. If nothing happens, try moving the mouse/typing on the keyboard to generate some entropy.")
+      logger.info(s"Generating HTTPS key pair in ${keyStoreFile.getAbsolutePath} - this may take some time. If nothing happens, try moving the mouse/typing on the keyboard to generate some entropy.")
 
       val freshKeyStore: KeyStore = generateKeyStore
       val out = java.nio.file.Files.newOutputStream(keyStoreFile.toPath)
       try {
-        freshKeyStore.store(out, "".toCharArray)
+        freshKeyStore.store(out, Array.emptyCharArray)
       } finally {
         PlayIO.closeQuietly(out)
       }
@@ -68,16 +95,23 @@ object FakeKeyStore {
       val loadedKeystore: KeyStore = KeyStore.getInstance("JKS")
       val in = java.nio.file.Files.newInputStream(keyStoreFile.toPath)
       try {
-        loadedKeystore.load(in, "".toCharArray)
+        loadedKeystore.load(in, Array.emptyCharArray)
       } finally {
         PlayIO.closeQuietly(in)
       }
+
+      logger.info(s"HTTPS key pair generated in ${keyStoreFile.getAbsolutePath}.")
       loadedKeystore
     }
+    keyStore
+  }
+
+  private[play] def keyManagerFactory(appPath: File): KeyManagerFactory = {
+    val keyStore = createKeyStore(appPath)
 
     // Load the key and certificate into a key manager factory
     val kmf = KeyManagerFactory.getInstance("SunX509")
-    kmf.init(keyStore, "".toCharArray)
+    kmf.init(keyStore, Array.emptyCharArray)
     kmf
   }
 
@@ -96,18 +130,22 @@ object FakeKeyStore {
     val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
     keyPairGenerator.initialize(2048) // 2048 is the NIST acceptable key length until 2030
     val keyPair = keyPairGenerator.generateKeyPair()
+    val certificateAuthorityKeyPair = keyPairGenerator.generateKeyPair()
 
+    val cacert: X509Certificate = createCertificateAuthority(certificateAuthorityKeyPair)
     // Generate a self signed certificate
-    val cert: X509Certificate = createSelfSignedCertificate(keyPair)
+    val cert: X509Certificate = createSelfSignedCertificate(keyPair, certificateAuthorityKeyPair)
 
     // Create the key store, first set the store pass
-    keyStore.load(null, "".toCharArray)
-    keyStore.setKeyEntry("playgenerated", keyPair.getPrivate, "".toCharArray, Array(cert))
-    keyStore.setCertificateEntry("playgeneratedtrusted", cert)
+    keyStore.load(null, Array.emptyCharArray)
+    keyStore.setKeyEntry("playgeneratedCA", keyPair.getPrivate, Array.emptyCharArray, Array(cacert))
+    keyStore.setCertificateEntry(CertificateAuthority.TrustedAlias, cacert)
+    keyStore.setKeyEntry("playgenerated", keyPair.getPrivate, Array.emptyCharArray, Array(cert))
+    keyStore.setCertificateEntry(TrustedAlias, cert)
     keyStore
   }
 
-  def createSelfSignedCertificate(keyPair: KeyPair): X509Certificate = {
+  def createSelfSignedCertificate(keyPair: KeyPair, certificateAuthorityKeyPair: KeyPair): X509Certificate = {
     val certInfo = new X509CertInfo()
 
     // Serial number and version
@@ -121,7 +159,44 @@ object FakeKeyStore {
     certInfo.set(X509CertInfo.VALIDITY, validity)
 
     // Subject and issuer
-    val owner = new X500Name(DnName)
+    val certificateAuthorityName = new X500Name(CertificateAuthority.DistinguishedName)
+    certInfo.set(X509CertInfo.ISSUER, certificateAuthorityName)
+    val owner = new X500Name(DistinguishedName)
+    certInfo.set(X509CertInfo.SUBJECT, owner)
+
+    // Key and algorithm
+    certInfo.set(X509CertInfo.KEY, new CertificateX509Key(keyPair.getPublic))
+    val algorithm = new AlgorithmId(SignatureAlgorithmOID)
+    certInfo.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithm))
+
+    // Create a new certificate and sign it
+    val cert = new X509CertImpl(certInfo)
+    cert.sign(keyPair.getPrivate, SignatureAlgorithmName)
+
+    // Since the signature provider may have a different algorithm ID to what we think it should be,
+    // we need to reset the algorithm ID, and resign the certificate
+    val actualAlgorithm = cert.get(X509CertImpl.SIG_ALG).asInstanceOf[AlgorithmId]
+    certInfo.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, actualAlgorithm)
+    val newCert = new X509CertImpl(certInfo)
+    newCert.sign(certificateAuthorityKeyPair.getPrivate, SignatureAlgorithmName)
+    newCert
+  }
+
+  private def createCertificateAuthority(keyPair: KeyPair): X509Certificate = {
+    val certInfo = new X509CertInfo()
+
+    // Serial number and version
+    certInfo.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(new BigInteger(64, new SecureRandom())))
+    certInfo.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3))
+
+    // Validity
+    val validFrom = new Date()
+    val validTo = new Date(validFrom.getTime + 50l * 365l * 24l * 60l * 60l * 1000l)
+    val validity = new CertificateValidity(validFrom, validTo)
+    certInfo.set(X509CertInfo.VALIDITY, validity)
+
+    // Subject and issuer
+    val owner = new X500Name(CertificateAuthority.DistinguishedName)
     certInfo.set(X509CertInfo.SUBJECT, owner)
     certInfo.set(X509CertInfo.ISSUER, owner)
 
@@ -129,6 +204,11 @@ object FakeKeyStore {
     certInfo.set(X509CertInfo.KEY, new CertificateX509Key(keyPair.getPublic))
     val algorithm = new AlgorithmId(SignatureAlgorithmOID)
     certInfo.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithm))
+
+    val caExtension =
+      new CertificateExtensions
+    caExtension.set(BasicConstraintsExtension.NAME, new BasicConstraintsExtension( /* isCritical */ true, /* isCA */ true, 0))
+    certInfo.set(X509CertInfo.EXTENSIONS, caExtension)
 
     // Create a new certificate and sign it
     val cert = new X509CertImpl(certInfo)

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -172,7 +172,7 @@ class ServerResultUtilsSpec extends Specification {
       resultUtils.validateHeaderNameChars("!#$%&'*+-.^_`|~01239azAZ") must not(throwAn[IllegalArgumentException])
     }
     "not accept control characters" in {
-      resultUtils.validateHeaderNameChars("\0") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars("\u0000") must (throwAn[IllegalArgumentException])
       resultUtils.validateHeaderNameChars("\u0001") must (throwAn[IllegalArgumentException])
       resultUtils.validateHeaderNameChars("\u001f") must (throwAn[IllegalArgumentException])
       resultUtils.validateHeaderNameChars("\u00ff") must (throwAn[IllegalArgumentException])
@@ -197,7 +197,7 @@ class ServerResultUtilsSpec extends Specification {
       resultUtils.validateHeaderValueChars(" \t") must not(throwAn[IllegalArgumentException])
     }
     "not accept control characters" in {
-      resultUtils.validateHeaderValueChars("\0") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars("\u0000") must (throwAn[IllegalArgumentException])
       resultUtils.validateHeaderValueChars("\u0001") must (throwAn[IllegalArgumentException])
       resultUtils.validateHeaderValueChars("\u001f") must (throwAn[IllegalArgumentException])
       resultUtils.validateHeaderValueChars("\u007f") must (throwAn[IllegalArgumentException])

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
@@ -1,5 +1,7 @@
 # runs the devmode and checks that a generated-keystore file is created
 > run -Dhttps.port=9443
 > makeRequest / 200
-$ exists generated.keystore
+
+# keystore file was generated
+$ exists target/dev-mode/generated.keystore
 > playStop


### PR DESCRIPTION
## Purpose

Lagom has a copy of our local certificate generation, but with some adjustments. See https://github.com/lagom/lagom/pull/1443.

Refs https://github.com/lagom/lagom/issues/1507

This brings most of the changes made there so that both frameworks can use the same code.

## Missing tasks

- [x] Documentation (migration guide)