### PR TITLE
Update Akka to version 2.5.15

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.5.14"
+  val akkaVersion = "2.5.15"
   val akkaHttpVersion = "10.1.3"
   val playJsonVersion = "2.6.9"
 


### PR DESCRIPTION
## Purpose

Update Akka to version 2.5.15

## References

https://akka.io/blog/news/2018/08/24/akka-2.5.15-released
