### PR TITLE
Update guava to version 26.0-jre

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -328,9 +328,9 @@ libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.6"
 
 This section lists significant updates made to our dependencies.
 
-### `Guava` version updated to 25.1-jre
+### `Guava` version updated to 26.0-jre
 
-Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 25.1-jre. Lots of changes were made in the library, and you can see the full changelog [here](https://github.com/google/guava/releases).
+Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 26.0-jre. Lots of changes were made in the library, and you can see the full changelog [here](https://github.com/google/guava/releases).
 
 ### specs2 updated to 4.2.0
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -49,7 +49,7 @@ object Dependencies {
   val slf4j = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % slf4jVersion)
   val slf4jSimple = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
-  val guava = "com.google.guava" % "guava" % "25.1-jre"
+  val guava = "com.google.guava" % "guava" % "26.0-jre"
   val findBugs = "com.google.code.findbugs" % "jsr305" % "3.0.2" // Needed by guava
   val mockitoAll = "org.mockito" % "mockito-core" % "2.20.1"
 


### PR DESCRIPTION
## Purpose

Update Guava to the latest version.

## References

https://github.com/google/guava/releases/tag/v26.0
