### PR TITLE
Implement allowed hosts filter route modifiers

### DIFF
--- a/documentation/manual/working/commonGuide/filters/AllowedHostsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/AllowedHostsFilter.md
@@ -34,6 +34,38 @@ play.filters.hosts {
 }
 ```
 
+## Applying to routes via route modifiers
+
+You may find that some of your routes can not be used properly with allowed hosts filtering. This is commonly the case for load balancer health checks, which often use the IP address of the server as the host name. Rather than completely disabling this important safety feature, you can use the route modifier whitelist to exclude the problematic routes from the filter while leaving it on by default.
+
+For example, the default configuration defines an `anyhost` route tag, which can be used to exclude one or more routes from the filter.
+
+```
+play.filters.hosts.routeModifiers.whiteList = [anyhost]
+```
+
+With this configuration, routes tagged with `anyhost` will be exempt from the allowed hosts filter, for instance, your routes file may look like this:
+
+```
++anyhost
+GET           /healthcheck          controllers.HealthController.healthcheck
+```
+
+If the whitelist is empty and the blacklist is defined, the allowed hosts filter will only be applied to hosts defined in the blacklist. For example, the following config will only apply the allowed hosts filter to routes tagged with `external`.
+
+```
+play.filters.hosts.routeModifiers.whiteList = []
+play.filters.hosts.routeModifiers.blackList = [external]
+```
+
+With this configuration,  your routes file might look like this:
+
+```
++external
+GET           /                     controllers.HomeController.index
+GET           /healthcheck          controllers.HealthController.healthcheck
+```
+
 ## Testing 
 
 Because the AllowedHostsFilter filter is added automatically, functional tests need to have the Host HTTP header added.

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -571,7 +571,13 @@ object BuildSettings {
 
       // Simplify ReloadableServer interface
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.core.server.Server.mainAddress"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ReloadableServer.mainAddress")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ReloadableServer.mainAddress"),
+
+      // Add route modifier whitelist / blacklist to AllowedHostsFilter
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.hosts.AllowedHostsConfig.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.hosts.AllowedHostsConfig.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.hosts.AllowedHostsConfig.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.hosts.AllowedHostsConfig.apply")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -212,6 +212,17 @@ play.filters {
     # Note that ".example.com" will match example.com and any subdomain of example.com, with or without a trailing dot.
     # "." matches all domains, and "" matches an empty or nonexistent host.
     allowed = ["localhost", ".local"]
+
+    routeModifiers {
+      # If non empty, then requests will be checked if the route does not have this modifier. This is how we enable the
+      # anyhost modifier, but you may choose to use a different modifier (such as "api") if you plan to check the
+      # modifier in your code for other purposes.
+      whiteList = ["anyhost"]
+
+      # If non empty, then requests will be checked if the route contains this modifier
+      # The black list is used only if the white list is empty
+      blackList = []
+    }
   }
 
   # CORS filter configuration

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -11,7 +11,7 @@ import play.api.{ Configuration, Logger }
 import play.api.http.{ HttpErrorHandler, Status }
 import play.api.inject._
 import play.api.libs.streams.Accumulator
-import play.api.mvc.{ EssentialAction, EssentialFilter }
+import play.api.mvc.{ EssentialAction, EssentialFilter, RequestHeader }
 import play.core.j.{ JavaContextComponents, JavaHttpErrorHandlerAdapter }
 
 /**
@@ -30,7 +30,7 @@ case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandle
   private val hostMatchers: Seq[HostMatcher] = config.allowed map HostMatcher.apply
 
   override def apply(next: EssentialAction) = EssentialAction { req =>
-    if (hostMatchers.exists(_(req.host))) {
+    if (!config.shouldProtect(req) || hostMatchers.exists(_(req.host))) {
       next(req)
     } else {
       logger.warn(s"Host not allowed: ${req.host}")(SecurityMarkerContext)
@@ -65,13 +65,14 @@ private[hosts] case class HostMatcher(pattern: String) {
   }
 }
 
-case class AllowedHostsConfig(allowed: Seq[String]) {
-  def this() {
-    this(Seq.empty)
-  }
-
+case class AllowedHostsConfig(allowed: Seq[String], shouldProtect: RequestHeader => Boolean = _ => true) {
   import scala.collection.JavaConverters._
-  def withHostPatterns(hosts: java.util.List[String]): AllowedHostsConfig = copy(hosts.asScala.toSeq)
+  import play.mvc.Http.{ RequestHeader => JRequestHeader }
+  import scala.compat.java8.FunctionConverters._
+
+  def withHostPatterns(hosts: java.util.List[String]): AllowedHostsConfig = copy(allowed = hosts.asScala)
+  def withShouldProtect(shouldProtect: java.util.function.Predicate[JRequestHeader]): AllowedHostsConfig =
+    copy(shouldProtect = shouldProtect.asScala.compose(_.asJava))
 }
 
 object AllowedHostsConfig {
@@ -79,7 +80,21 @@ object AllowedHostsConfig {
    * Parses out the AllowedHostsConfig from play.api.Configuration (usually this means application.conf).
    */
   def fromConfiguration(conf: Configuration): AllowedHostsConfig = {
-    AllowedHostsConfig(conf.get[Seq[String]]("play.filters.hosts.allowed"))
+    val whiteListRouteModifiers = conf.get[Seq[String]]("play.filters.hosts.routeModifiers.whiteList")
+    val blackListRouteModifiers = conf.get[Seq[String]]("play.filters.hosts.routeModifiers.blackList")
+
+    @inline def shouldProtectViaRouteModifiers(rh: RequestHeader): Boolean = {
+      import play.api.routing.Router.RequestImplicits._
+      if (whiteListRouteModifiers.nonEmpty)
+        !whiteListRouteModifiers.exists(rh.hasRouteModifier)
+      else
+        blackListRouteModifiers.isEmpty || blackListRouteModifiers.exists(rh.hasRouteModifier)
+    }
+
+    AllowedHostsConfig(
+      allowed = conf.get[Seq[String]]("play.filters.hosts.allowed"),
+      shouldProtect = shouldProtectViaRouteModifiers
+    )
   }
 }
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [X] Have you added copyright headers to new files?
* [X] Have you checked that both Scala and Java APIs are updated?
* [X] Have you updated the documentation for both Scala and Java sections?
* [X] Have you added tests for any changed functionality?

## Purpose
In some cases requests cannot always be validated against a fixed list of Allowed Hosts. Specifically, autoscaling groups using AWS application load balancers require http host checks, and will always use the dynamically assigned IP address of the instance as the host. This PR allows the allowed hosts filter to be applied to or filtered out of specific routes (such as health check urls) if desired. 

## Background Context
This PR adds a the ability to whitelist or blacklist route modifiers from the AllowedHostsFilter. The basic premise mirrors that of the CSRFilter. 
