### PR TITLE
Make CoordinatedShutdoownSupport public but internal

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -23,7 +23,7 @@ import com.typesafe.config.{ Config, ConfigMemorySize }
 import javax.net.ssl._
 import play.api._
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
-import play.api.libs.concurrent.CoordinatedShutdownSupport
+import play.api.internal.libs.concurrent.CoordinatedShutdownSupport
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.mvc.akkahttp.AkkaHttpHandler

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -24,7 +24,7 @@ import io.netty.handler.logging.{ LogLevel, LoggingHandler }
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.timeout.IdleStateHandler
 import play.api._
-import play.api.libs.concurrent.CoordinatedShutdownSupport
+import play.api.internal.libs.concurrent.CoordinatedShutdownSupport
 import play.api.routing.Router
 import play.core._
 import play.core.server.Server.ServerStoppedReason

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -13,8 +13,9 @@ import play.api.ApplicationLoader.DevContext
 import play.api.http._
 import play.api.i18n.I18nComponents
 import play.api.inject.{ ApplicationLifecycle, _ }
+import play.api.internal.libs.concurrent.CoordinatedShutdownSupport
 import play.api.libs.Files._
-import play.api.libs.concurrent.{ ActorSystemProvider, CoordinatedShutdownProvider, CoordinatedShutdownSupport }
+import play.api.libs.concurrent.{ ActorSystemProvider, CoordinatedShutdownProvider }
 import play.api.libs.crypto._
 import play.api.mvc._
 import play.api.mvc.request.{ DefaultRequestFactory, RequestFactory }

--- a/framework/src/play/src/main/scala/play/api/internal/libs/concurrent/CoordinatedShutdownSupport.scala
+++ b/framework/src/play/src/main/scala/play/api/internal/libs/concurrent/CoordinatedShutdownSupport.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.internal.libs.concurrent
+
+import java.util.concurrent.TimeUnit
+
+import akka.Done
+import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.annotation.InternalApi
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future, TimeoutException }
+
+/**
+ * INTERNAL API: provides ways to call Akka's CoordinatedShutdown.
+ *
+ * This should not be necessary by user code and it is an internal API subject to change without following our
+ * deprecation policy.
+ */
+// This is public so that it can be used in Lagom without any hacks or copy-and-paste.
+@InternalApi
+object CoordinatedShutdownSupport {
+
+  /**
+   * Shuts down the provided `ActorSystem` asynchronously, starting from the configured phase.
+   *
+   * @param actorSystem the actor system to shut down
+   * @param reason the reason the actor system is shutting down
+   * @return a future that completes with `Done` when the actor system has fully shut down
+   */
+  def asyncShutdown(actorSystem: ActorSystem, reason: CoordinatedShutdown.Reason): Future[Done] = {
+    // CoordinatedShutdown may be invoked many times over the same actorSystem but
+    // only the first invocation runs the tasks (later invocations are noop).
+    CoordinatedShutdown(actorSystem).run(reason)
+  }
+
+  /**
+   * Shuts down the provided `ActorSystem` synchronously, starting from the configured phase. This method blocks until
+   * the actor system has fully shut down, or the duration exceeds timeouts for all coordinated shutdown phases.
+   *
+   * @param actorSystem the actor system to shut down
+   * @param reason      the reason the actor system is shutting down
+   * @throws InterruptedException if the current thread is interrupted while waiting
+   * @throws TimeoutException if after waiting for the specified time `awaitable` is still not ready
+   */
+  @throws(classOf[TimeoutException])
+  @throws(classOf[InterruptedException])
+  def syncShutdown(actorSystem: ActorSystem, reason: CoordinatedShutdown.Reason): Unit = {
+    // The await operation should last at most the total timeout of the coordinated shutdown.
+    // We're adding a few extra seconds of margin (5 sec) to make sure the coordinated shutdown
+    // has enough room to complete and yet we will timeout in case something goes wrong (invalid setup,
+    // failed task, bug, etc...) preventing the coordinated shutdown from completing.
+    val shutdownTimeout = CoordinatedShutdown(actorSystem).totalTimeout() + Duration(5, TimeUnit.SECONDS)
+    Await.result(
+      asyncShutdown(actorSystem, reason),
+      shutdownTimeout
+    )
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -225,7 +225,14 @@ class ActorRefProvider[T <: Actor: ClassTag](name: String, props: Props => Props
   }
 }
 
-private[play] object CoordinatedShutdownSupport {
+/**
+ * INTERNAL API: provides ways to call Akka's CoordinatedShutdown.
+ *
+ * This should not be necessary by user code and it is an internal API subject to change without following our
+ * deprecation policy.
+ */
+// This is public so that it can be used in Lagom without any hacks or copy-and-paste.
+object CoordinatedShutdownSupport {
 
   private[play] lazy val logger = LoggerFactory.getLogger(classOf[CoordinatedShutdownProvider])
 

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -4,8 +4,6 @@
 
 package play.api.libs.concurrent
 
-import java.util.concurrent.TimeUnit
-
 import akka.Done
 import akka.actor.setup.{ ActorSystemSetup, Setup }
 import akka.actor.{ CoordinatedShutdown, _ }
@@ -125,7 +123,7 @@ object ActorSystemProvider {
 
   type StopHook = () => Future[_]
 
-  private val logger = Logger(classOf[ActorSystemProvider])
+  private val logger = LoggerFactory.getLogger(classOf[ActorSystemProvider])
 
   case object ApplicationShutdownReason extends CoordinatedShutdown.Reason
 
@@ -225,53 +223,8 @@ class ActorRefProvider[T <: Actor: ClassTag](name: String, props: Props => Props
   }
 }
 
-/**
- * INTERNAL API: provides ways to call Akka's CoordinatedShutdown.
- *
- * This should not be necessary by user code and it is an internal API subject to change without following our
- * deprecation policy.
- */
-// This is public so that it can be used in Lagom without any hacks or copy-and-paste.
-object CoordinatedShutdownSupport {
-
-  private[play] lazy val logger = LoggerFactory.getLogger(classOf[CoordinatedShutdownProvider])
-
-  /**
-   * Shuts down the provided `ActorSystem` asynchronously, starting from the configured phase.
-   *
-   * @param actorSystem the actor system to shut down
-   * @param reason the reason the actor system is shutting down
-   * @return a future that completes with `Done` when the actor system has fully shut down
-   */
-  def asyncShutdown(actorSystem: ActorSystem, reason: CoordinatedShutdown.Reason): Future[Done] = {
-    // CoordinatedShutdown may be invoked many times over the same actorSystem but
-    // only the first invocation runs the tasks (later invocations are noop).
-    CoordinatedShutdown(actorSystem).run(reason)
-  }
-
-  /**
-   * Shuts down the provided `ActorSystem` synchronously, starting from the configured phase. This method blocks until
-   * the actor system has fully shut down, or the duration exceeds timeouts for all coordinated shutdown phases.
-   *
-   * @param actorSystem the actor system to shut down
-   * @param reason      the reason the actor system is shutting down
-   * @throws InterruptedException if the current thread is interrupted while waiting
-   * @throws TimeoutException if after waiting for the specified time `awaitable` is still not ready
-   */
-  @throws(classOf[TimeoutException])
-  @throws(classOf[InterruptedException])
-  def syncShutdown(actorSystem: ActorSystem, reason: CoordinatedShutdown.Reason): Unit = {
-    // The await operation should last at most the total timeout of the coordinated shutdown.
-    // We're adding a few extra seconds of margin (5 sec) to make sure the coordinated shutdown
-    // has enough room to complete and yet we will timeout in case something goes wrong (invalid setup,
-    // failed task, bug, etc...) preventing the coordinated shutdown from completing.
-    val shutdownTimeout = CoordinatedShutdown(actorSystem).totalTimeout() + Duration(5, TimeUnit.SECONDS)
-    Await.result(
-      asyncShutdown(actorSystem, reason),
-      shutdownTimeout
-    )
-  }
-
+private object CoordinatedShutdownProvider {
+  private val logger = LoggerFactory.getLogger(classOf[CoordinatedShutdownProvider])
 }
 
 /**
@@ -280,7 +233,7 @@ object CoordinatedShutdownSupport {
 @Singleton
 class CoordinatedShutdownProvider @Inject() (actorSystem: ActorSystem, applicationLifecycle: ApplicationLifecycle) extends Provider[CoordinatedShutdown] {
 
-  import CoordinatedShutdownSupport.logger
+  import CoordinatedShutdownProvider.logger
 
   lazy val get: CoordinatedShutdown = {
 

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -12,6 +12,7 @@ import akka.actor.CoordinatedShutdown._
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.specs2.mutable.Specification
 import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
+import play.api.internal.libs.concurrent.CoordinatedShutdownSupport
 import play.api.{ Configuration, Environment }
 
 import scala.concurrent.{ Await, Future }


### PR DESCRIPTION
## Purpose

The API needs to be public so that we can better use it in Lagom. But it is not supposed to be used in users code.