### PR TITLE
Update akka 2.5.16

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.5.11"
+  val akkaVersion = "2.5.12"
   val akkaHttpVersion = "10.0.13"
   val playJsonVersion = "2.6.10"
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.5.12"
+  val akkaVersion = "2.5.16"
   val akkaHttpVersion = "10.0.13"
   val playJsonVersion = "2.6.10"
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
@@ -10,6 +10,8 @@ import java.util
 import java.util.Optional
 import java.util.concurrent.{ CompletionStage, TimeUnit }
 
+import akka.NotUsed
+import akka.stream.javadsl
 import akka.stream.scaladsl.{ FileIO, Sink, Source }
 import akka.util.ByteString
 import org.specs2.concurrent.{ ExecutionEnv, FutureAwait }
@@ -138,7 +140,7 @@ trait JavaWSSpec extends PlaySpecification with ServerIntegrationSpecification w
     }
 
     "sending a simple multipart form body" in withServer { ws =>
-      val source = Source.single(new Http.MultipartFormData.DataPart("hello", "world")).asJava
+      val source = Source.single(new Http.MultipartFormData.DataPart("hello", "world")).asJava[Http.MultipartFormData.Part[javadsl.Source[ByteString, _]], NotUsed]
       val res = ws.url("/post").post(source)
       val body = res.toCompletableFuture.get().asJson()
 

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -3,11 +3,12 @@
  */
 package play.api.libs.streams
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.{ Flow, Source, Sink }
-import akka.stream.{ ActorMaterializer, Materializer }
+import java.util.concurrent.CompletionStage
 
-import org.reactivestreams.{ Subscription, Subscriber, Publisher }
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{ Flow, Sink, Source }
+import akka.stream.{ ActorMaterializer, Materializer }
+import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 import org.specs2.mutable.Specification
 
 import scala.compat.java8.FutureConverters
@@ -106,7 +107,7 @@ class AccumulatorSpec extends Specification {
 
     "be compatible with Java accumulator" in {
       "Java asScala" in withMaterializer { implicit m =>
-        await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava).asScala().run(source)) must_== 6
+        await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int, CompletionStage[Int]]).asScala().run(source)) must_== 6
       }
 
       "Scala asJava" in withMaterializer { implicit m =>
@@ -184,7 +185,7 @@ class AccumulatorSpec extends Specification {
 
       "be compatible with Java accumulator" in {
         "Java asScala" in withMaterializer { implicit m =>
-          await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava).asScala().run(source)) must_== 6
+          await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int, CompletionStage[Int]]).asScala().run(source)) must_== 6
         }
 
         "Scala asJava" in withMaterializer { implicit m =>
@@ -232,7 +233,7 @@ class AccumulatorSpec extends Specification {
 
       "be compatible with Java accumulator" in {
         "Java asScala" in withMaterializer { implicit m =>
-          await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava).asScala().run(6)) must_== 6
+          await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int, CompletionStage[Int]]).asScala().run(6)) must_== 6
         }
 
         "Scala asJava" in withMaterializer { implicit m =>

--- a/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -88,7 +88,7 @@ class AccumulatorSpec extends org.specs2.mutable.Specification {
         val fAcc = Accumulator.flatten[Int, Int](completable, m)
         completable complete sum
 
-        await(fAcc.run(errorSource, m)) must throwA[ExecutionException].like {
+        await(fAcc.run(errorSource[Int], m)) must throwA[ExecutionException].like {
           case ex =>
             val cause = ex.getCause
             cause.isInstanceOf[RuntimeException] must beTrue and (


### PR DESCRIPTION
## Note to contributors

Please, do not squash commits here to keep contributors credits.

## Purpose

This backports #8437 and #8589 so that we can have an updated version of Akka in Play 2.6.x.

Akka 2.5.12 introduced a fix that causes source compatibility issues (see https://github.com/akka/akka/pull/24575). This should not affect most of the users though. Also, Akka [2.5.13 brings some API changes](https://akka.io/blog/news/2018/06/08/akka-2.5.13-released) for Akka Typed and if you are using it in your Play application, there are some changes you need to make. These changes are okay according to Akka [binary policy rules](https://doc.akka.io/docs/akka/2.5/common/binary-compatibility-rules.html) since Akka Typed is still market as a ["may change" module](https://doc.akka.io/docs/akka/2.5/common/may-change.html). Internally, Play does not uses Akka Typed, so these changes don't affect us.

## Background Context

We need to update Akka version now because there is a security fix in Akka 2.5.16.

## References

1. https://akka.io/blog/news/2018/04/13/akka-2.5.12-released
1. https://akka.io/blog/news/2018/06/08/akka-2.5.13-released
1. https://akka.io/blog/news/2018/07/13/akka-2.5.14-released
1. https://akka.io/blog/news/2018/08/24/akka-2.5.15-released
1. https://akka.io/blog/news/2018/08/29/akka-2.5.16-security-fix-released