### PR TITLE
DocumentationHandler small typo

### DIFF
--- a/framework/src/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
@@ -31,7 +31,7 @@ class DocumentationHandler(repo: FileRepository, apiRepo: FileRepository, toClos
       "js" -> "application/javascript",
       "ico" -> "application/javascript",
       "jpg" -> "image/jpeg",
-      "ico" -> "ico=image/x-icon"
+      "ico" -> "image/x-icon"
     ))
     new DefaultFileMimeTypes(mimeTypesConfiguration)
   }


### PR DESCRIPTION
While digging into source, found what looks like a typo in the `ico` MIME Type.
Note also that `ico` is there twice (line 32)...

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?
