### PR TITLE
Update Akka HTTP to 10.1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   matrix:
     - SCRIPT=test-scala-211
     - SCRIPT=test-scala-212
-  # - SCRIPT=test-scala-213 # akka-http doesn't support Scala 2.13: https://github.com/akka/akka-http/issues/2166
+    - SCRIPT=test-scala-213
     - SCRIPT=test-docs
     - SCRIPT=test-sbt-plugins-0_13
     - SCRIPT=test-sbt-plugins-1_0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   matrix:
     - SCRIPT=test-scala-211
     - SCRIPT=test-scala-212
-    - SCRIPT=test-scala-213
+  # - SCRIPT=test-scala-213 # akka-http doesn't support Scala 2.13: https://github.com/akka/akka-http/issues/2166
     - SCRIPT=test-docs
     - SCRIPT=test-sbt-plugins-0_13
     - SCRIPT=test-sbt-plugins-1_0

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
 
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.16")
   val akkaHttpVersion = "10.1.5"
+  val akkaHttpVersion_2_13 = "10.1.3" // akka-http dropped support for Scala 2.13: https://github.com/akka/akka-http/issues/2166
   val playJsonVersion = "2.6.10"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
@@ -330,11 +331,17 @@ object Dependencies {
 
         project.dependsOn(withConfig)
       } else {
-        val dep = "com.typesafe.akka" %% module % Dependencies.akkaHttpVersion
-        val withConfig =
-          if (config == "") dep
-          else dep % config
-        project.settings(libraryDependencies += withConfig)
+        project.settings(libraryDependencies += {
+          val akkaHttpVersion = CrossVersion.partialVersion(scalaVersion.value) match {
+            case Some((2, 13)) => Dependencies.akkaHttpVersion_2_13
+            case _ => Dependencies.akkaHttpVersion
+          }
+          val dep = "com.typesafe.akka" %% module % akkaHttpVersion
+          val withConfig =
+            if (config == "") dep
+            else dep % config
+          withConfig
+        })
       }
   }
 }

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion = "2.5.16"
-  val akkaHttpVersion = "10.1.3"
+  val akkaHttpVersion = "10.1.5"
   val playJsonVersion = "2.6.10"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"


### PR DESCRIPTION
## Purpose

Update Akka HTTP to the latest version.

## References

https://akka.io/blog/news/2018/09/06/akka-http-10.1.5-10.0.14-security-fix-released

This version of Akka HTTP fixes a [vulnerability](https://doc.akka.io/docs/akka-http/current/security/2018-09-05-denial-of-service-via-decodeRequest.html?_ga=2.123987082.1025615845.1536248761-1450633930.1536073782) but we find Play is not affected at all since the content length validation is done by BodyParsers.