### PR TITLE
Don't send additional data in the compressed request test

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -61,7 +61,7 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       val compressedDataLength = compressor.deflate(output)
 
       val client = new BasicHttpClient(port, false)
-      val response = client.sendRaw(output, Map("Content-Type" -> "text/plain", "Content-Length" -> compressedDataLength.toString, "Content-Encoding" -> "deflate"))
+      val response = client.sendRaw(output.take(compressedDataLength), Map("Content-Type" -> "text/plain", "Content-Length" -> compressedDataLength.toString, "Content-Encoding" -> "deflate"))
       response.status must_== 200
       response.body.left.get must_== bodyString
     }


### PR DESCRIPTION
This is what caused the failure in #8597

