### PR TITLE
Enable travis to run cron jobs using Akka snapshots

### DIFF
--- a/framework/bin/scriptLib
+++ b/framework/bin/scriptLib
@@ -14,6 +14,15 @@ DOCUMENTATION=${BASEDIR}/documentation
 
 export CURRENT_BRANCH=${TRAVIS_BRANCH}
 
+EXTRA_OPTS=""
+
+# Check if it is a scheduled build
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    # `sort` is not necessary, but it is good to make it predictable.
+    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '[0-9]\.[0-9]-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+    EXTRA_OPTS="-Dakka.version=${AKKA_VERSION}"
+fi
+
 printMessage() {
   echo "[info]"
   echo "[info] ---- $1"
@@ -21,9 +30,9 @@ printMessage() {
 }
 
 runSbt() {
-  sbt --warn -jvm-opts ${BASEDIR}/.travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
+  sbt ${EXTRA_OPTS} --warn -jvm-opts ${BASEDIR}/.travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
 }
 
 runSbtNoisy() {
-  sbt -jvm-opts ${BASEDIR}/.travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
+  sbt ${EXTRA_OPTS} -jvm-opts ${BASEDIR}/.travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
 }

--- a/framework/bin/test-scala-213
+++ b/framework/bin/test-scala-213
@@ -4,11 +4,17 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-cd ${FRAMEWORK}
+# We are not running Scala 2.13 job for scheduled builds because they use
+# Akka snapshots which aren't being published for Scala 2.13 yet.
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    printMessage "SKIPPING TESTS FOR SCALA 2.13.0-M3"
+else
+    cd ${FRAMEWORK}
 
-printMessage "RUNNING TESTS FOR SCALA 2.13.0-M3"
+    printMessage "RUNNING TESTS FOR SCALA 2.13.0-M3"
 
-# Use sbt-doge for building code https://github.com/sbt/sbt-doge#strict-aggregation
-runSbt "+++2.13.0-M3 test"
+    # Use sbt-doge for building code https://github.com/sbt/sbt-doge#strict-aggregation
+    runSbt "+++2.13.0-M3 test"
 
-printMessage "ALL TESTS PASSED"
+    printMessage "ALL TESTS PASSED"
+fi

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -4,16 +4,14 @@
 import BuildSettings._
 import Dependencies._
 import Generators._
-import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaReportBinaryIssues}
-import interplay.ScalaVersions._
-import interplay.PlayBuildBase.autoImport._
-import sbt.Keys.parallelExecution
 import com.lightbend.sbt.javaagent.JavaAgent.JavaAgentKeys.{javaAgents, resolvedJavaAgents}
-import com.lightbend.sbt.javaagent.JavaAgent.ResolvedAgent
+import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaReportBinaryIssues}
+import interplay.PlayBuildBase.autoImport._
+import interplay.ScalaVersions._
 import pl.project13.scala.sbt.JmhPlugin.generateJmhSourcesAndResources
+import sbt.Keys.parallelExecution
 import sbt.ScriptedPlugin._
 import sbt._
-import sbt.complete.Parser
 
 lazy val BuildLinkProject = PlayNonCrossBuiltProject("Build-Link", "build-link")
     .dependsOn(PlayExceptionsProject)

--- a/framework/project/AkkaSnapshotRepositories.scala
+++ b/framework/project/AkkaSnapshotRepositories.scala
@@ -1,0 +1,19 @@
+import sbt.Keys._
+import sbt._
+
+/**
+ * This plugins adds Akka snapshot repositories when running a nightly build.
+ */
+object AkkaSnapshotRepositories extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def projectSettings: Seq[Def.Setting[_]] = {
+    // If this is a cron job in Travis:
+    // https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+    resolvers ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+      case Some(_) => Seq("akka-snapshot-repository" at "https://repo.akka.io/snapshots")
+      case None => Seq.empty
+    })
+  }
+}

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -630,7 +630,7 @@ object BuildSettings {
    */
   def PlayCrossBuiltProject(name: String, dir: String): Project = {
     Project(name, file("src/" + dir))
-        .enablePlugins(PlayLibrary, AutomateHeaderPlugin)
+        .enablePlugins(PlayLibrary, AutomateHeaderPlugin, AkkaSnapshotRepositories)
         .settings(playRuntimeSettings: _*)
         .settings(omnidocSettings: _*)
         .settings(

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.5.16"
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.16")
   val akkaHttpVersion = "10.1.3"
   val playJsonVersion = "2.6.10"
 


### PR DESCRIPTION
## Purpose

The purpose is to discover Akka integration problems sooner. This enables us to configure a nightly build in Travis to test against Akka snapshots.
