### PR TITLE
Disable test-scala-211 on nightly

### DIFF
--- a/framework/bin/test-scala-211
+++ b/framework/bin/test-scala-211
@@ -7,7 +7,7 @@
 # We are not running Scala 2.11 job for scheduled builds because they use
 # Akka snapshots which aren't being published for Scala 2.11 anymore.
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-    printMessage "SKIPPING TESTS FOR SCALA 2.13.0-M3"
+    printMessage "SKIPPING TESTS FOR SCALA 2.11"
     exit
 fi
 

--- a/framework/bin/test-scala-211
+++ b/framework/bin/test-scala-211
@@ -4,6 +4,13 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
+# We are not running Scala 2.11 job for scheduled builds because they use
+# Akka snapshots which aren't being published for Scala 2.11 anymore.
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    printMessage "SKIPPING TESTS FOR SCALA 2.13.0-M3"
+    exit
+fi
+
 cd ${FRAMEWORK}
 
 printMessage "RUNNING TESTS FOR SCALA 2.11"


### PR DESCRIPTION
See:

* https://travis-ci.org/playframework/playframework/jobs/427334869
* https://repo.akka.io/snapshots/com/typesafe/akka/akka-stream_2.11/
* https://repo.akka.io/snapshots/com/typesafe/akka/akka-stream_2.12/

There are no recent snapshot builds of akka-stream for 2.11.

 # Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?