### PR TITLE
Remove deprecated APIs usage from docs

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -10,6 +10,9 @@ import sbt._
 
 lazy val main = Project("Play-Documentation", file(".")).enablePlugins(PlayDocsPlugin).disablePlugins(PlayEnhancer)
     .settings(
+      // Avoid the use of deprecated APIs in the docs
+      scalacOptions ++= Seq("-deprecation", "-Xfatal-warnings"),
+      javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-parameters", "-Xlint:unchecked", "-Xlint:deprecation"),
 
       // We need to publishLocal playDocs since its jar file is
       // a dependency of `docsJarFile` setting.

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaComet.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaComet.java
@@ -4,12 +4,14 @@
 
 package javaguide.async;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import javaguide.testhelpers.MockJavaAction;
 import javaguide.testhelpers.MockJavaActionHelper;
 import org.junit.Test;
 
 //#comet-imports
+import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import play.core.j.JavaHandlerComponents;
 import play.libs.Comet;
@@ -38,7 +40,9 @@ public class JavaComet extends WithApplication {
 
         //#comet-string
         public static Result index() {
-            final Source source = Source.from(Arrays.asList("kiki", "foo", "bar"));
+            final Source<String, NotUsed> source = Source.from(
+                Arrays.asList("kiki", "foo", "bar")
+            );
             return ok().chunked(source.via(Comet.string("parent.cometMessage"))).as(Http.MimeTypes.HTML);
         }
         //#comet-string
@@ -54,7 +58,7 @@ public class JavaComet extends WithApplication {
         public static Result index() {
             final ObjectNode objectNode = Json.newObject();
             objectNode.put("foo", "bar");
-            final Source source = Source.from(Collections.singletonList(objectNode));
+            final Source<JsonNode, NotUsed> source = Source.from(Collections.singletonList(objectNode));
             return ok().chunked(source.via(Comet.json("parent.cometMessage"))).as(Http.MimeTypes.HTML);
         }
         //#comet-json

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
@@ -214,7 +214,7 @@ public class JavaBodyParsers extends WithApplication {
     }
     //#csv
 
-    @Test
+    @Test @SuppressWarnings("unchecked")
     public void testCsv() {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                 @BodyParser.Of(CsvBodyParser.class)

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaErrorHandling.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaErrorHandling.scala
@@ -5,9 +5,8 @@
 package javaguide.http
 
 import javaguide.application.`def`.ErrorHandler
-
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.mvc.Action
+import play.api.mvc.DefaultActionBuilder
 import play.api.test._
 
 import scala.reflect.ClassTag
@@ -17,8 +16,11 @@ class JavaErrorHandling extends PlaySpecification with WsTestClient {
   def fakeApp[A](implicit ct: ClassTag[A]) = {
     GuiceApplicationBuilder()
       .configure("play.http.errorHandler" -> ct.runtimeClass.getName)
-      .routes {
-        case (_, "/error") => Action(_ => throw new RuntimeException("foo"))
+      .appRoutes { app =>
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        ({
+          case (_, "/error") => Action(_ => throw new RuntimeException("foo"))
+        })
       }
       .build()
   }

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/MockitoTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/MockitoTest.java
@@ -15,18 +15,18 @@ import java.util.List;
 import org.junit.Test;
 
 public class MockitoTest {
-  
-  @Test
+
+  @Test @SuppressWarnings("unchecked")
   public void testMockList() {
-    
+
     //#test-mockito
     // Create and train mock
     List<String> mockedList = mock(List.class);
     when(mockedList.get(0)).thenReturn("first");
-    
+
     // check value
     assertEquals("first", mockedList.get(0));
-    
+
     // verify interaction
     verify(mockedList).get(0);
     //#test-mockito

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -85,7 +85,7 @@ public class JavaFileUpload extends WithApplication {
                 final String contentType = fileInfo.contentType().getOrElse(null);
                 final File file = generateTempFile();
 
-                final Sink<ByteString, CompletionStage<IOResult>> sink = FileIO.toFile(file);
+                final Sink<ByteString, CompletionStage<IOResult>> sink = FileIO.toPath(file.toPath());
                 return Accumulator.fromSink(
                         sink.mapMaterializedValue(completionStage ->
                                 completionStage.thenApplyAsync(results ->
@@ -115,8 +115,8 @@ public class JavaFileUpload extends WithApplication {
     @Test
     public void testCustomMultipart() throws IOException {
         play.libs.Files.TemporaryFileCreator tfc = play.libs.Files.singletonTemporaryFileCreator();
-        Source source = FileIO.fromPath(Files.createTempFile("temp", "txt"));
-        Http.MultipartFormData.FilePart dp = new Http.MultipartFormData.FilePart<Source>("name", "filename", "text/plain", source);
+        Source<ByteString, ?> source = FileIO.fromPath(Files.createTempFile("temp", "txt"));
+        Http.MultipartFormData.FilePart<Source<ByteString, ?>> dp = new Http.MultipartFormData.FilePart<>("name", "filename", "text/plain", source);
         assertThat(contentAsString(call(new javaguide.testhelpers.MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     @BodyParser.Of(MultipartFormDataWithFileBodyParser.class)
                     public Result uploadCustomMultiPart() throws Exception {

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
@@ -35,7 +35,7 @@ public class JavaFileUploadTest extends WithApplication {
     @Test
     public void testFileUpload() throws IOException {
         File file = getFile();
-        Http.MultipartFormData.Part<Source<ByteString, ?>> part = new Http.MultipartFormData.FilePart<>("picture", "file.pdf", "application/pdf", FileIO.fromFile(file));
+        Http.MultipartFormData.Part<Source<ByteString, ?>> part = new Http.MultipartFormData.FilePart<>("picture", "file.pdf", "application/pdf", FileIO.fromPath(file.toPath()));
 
         //###replace:     Http.RequestBuilder request = Helpers.fakeRequest().uri(routes.MyController.upload().url())
         Http.RequestBuilder request = Helpers.fakeRequest().uri("/upload")

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
@@ -90,7 +90,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
         override lazy val httpErrorHandler = new DefaultHttpErrorHandler(
           environment,
           configuration,
-          sourceMapper,
+          devContext.map(_.sourceMapper),
           Some(router)
         ) {
 

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSimpleRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSimpleRouter.scala
@@ -14,7 +14,7 @@ import play.api.routing.sird._
 import play.api.routing.{ Router, SimpleRouter }
 
 //#load-guice
-class ScalaSimpleRouter @Inject()() extends SimpleRouter {
+class ScalaSimpleRouter @Inject()(val Action: DefaultActionBuilder) extends SimpleRouter {
 
   override def routes: Routes = {
     case GET(p"/") => Action {

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
@@ -4,7 +4,6 @@
 
 package scalaguide.advanced.routing
 
-import controllers.Assets
 import org.specs2.mutable.Specification
 import play.api.test.{FakeRequest, WithApplication}
 
@@ -20,6 +19,7 @@ class ScalaSirdRouter extends Specification {
 
   "sird router" should {
     "allow a simple match" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#simple
       val router = Router.from {
         case GET(p"/hello/$to") => Action {
@@ -33,6 +33,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow a full path match" in new WithApplication {
+      val Assets = app.injector.instanceOf[controllers.Assets]
       //#full-path
       val router = Router.from {
         case GET(p"/assets/$file*") =>
@@ -45,6 +46,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow a regex match" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#regexp
       val router = Router.from {
         case GET(p"/items/$id<[0-9]+>") => Action {
@@ -58,6 +60,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow extracting required query parameters" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#required
       val router = Router.from {
         case GET(p"/search" ? q"query=$query") => Action {
@@ -71,6 +74,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow extracting optional query parameters" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#optional
       val router = Router.from {
         case GET(p"/items" ? q_o"page=$page") => Action {
@@ -85,6 +89,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow extracting multi value query parameters" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#many
       val router = Router.from {
         case GET(p"/items" ? q_s"tag=$tags") => Action {
@@ -99,6 +104,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow extracting multiple query parameters" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#multiple
       val router = Router.from {
         case GET(p"/items" ? q_o"page=$page"
@@ -116,6 +122,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow sub extractor" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#int
       val router = Router.from {
         case GET(p"/items/${int(id)}") => Action {
@@ -129,6 +136,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow sub extractor on a query parameter" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#query-int
       val router = Router.from {
         case GET(p"/items" ? q_o"page=${int(page)}") => Action {
@@ -144,6 +152,7 @@ class ScalaSirdRouter extends Specification {
     }
 
     "allow complex extractors" in new WithApplication {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
       //#complex
       val router = Router.from {
         case rh @ GET(p"/items/${idString @ int(id)}" ?

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -17,7 +17,7 @@ class CompileTimeDependencyInjection extends Specification {
 
   "compile time dependency injection" should {
     "allow creating an application with the built in components from context" in {
-      val context = ApplicationLoader.createContext(environment,
+      val context = ApplicationLoader.Context.create(environment,
         Map("play.application.loader" -> classOf[basic.MyApplicationLoader].getName)
       )
       val components = new messages.MyComponents(context)
@@ -26,13 +26,13 @@ class CompileTimeDependencyInjection extends Specification {
       components.router.documentation must beEmpty
     }
     "allow using other components" in {
-      val context = ApplicationLoader.createContext(environment)
+      val context = ApplicationLoader.Context.create(environment)
       val components = new messages.MyComponents(context)
       components.application must beAnInstanceOf[Application]
       components.myComponent must beAnInstanceOf[messages.MyComponent]
     }
     "allow declaring a custom router" in {
-      val context = ApplicationLoader.createContext(environment)
+      val context = ApplicationLoader.Context.create(environment)
       val components = new routers.MyComponents(context)
       components.application must beAnInstanceOf[Application]
       components.router must beAnInstanceOf[scalaguide.dependencyinjection.Routes]

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -252,8 +252,9 @@ class HelloModule extends Module {
 //#eager-play-module
 }
 package injected.controllers {
+  import javax.inject.Inject
   import play.api.mvc._
-  class Application {
+  class Application @Inject()(val controllerComponents: ControllerComponents) extends BaseController {
     def index = Action(Results.Ok)
   }
 }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -144,8 +144,9 @@ object ScalaRoutingSpec extends Specification {
       contentOf(FakeRequest("GET", "/api/list-all?version=3.0")) must_== "version Some(3.0)"
     }
     "support reverse routing" in {
-      import reverse.controllers.routes
       import Results.Redirect
+      import reverse.controllers.routes
+      val Action = Helpers.stubControllerComponents().actionBuilder
       // #reverse-router
       // Redirect to /hello/Bob
       def helloBob = Action {

--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
@@ -5,24 +5,24 @@
 package scalaguide.json
 
 import javax.inject.Inject
-
-import scala.concurrent.Future
 import org.junit.runner.RunWith
-import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import play.api.mvc._
 import play.api.test._
+
+import scala.concurrent.Future
 
 @RunWith(classOf[JUnitRunner])
 class ScalaJsonHttpSpec extends PlaySpecification with Results {
 
   "JSON with HTTP" should {
-    "allow serving JSON" in {
+    "allow serving JSON" in new WithApplication() with Injecting {
+      val Action = inject[DefaultActionBuilder]
 
       //#serve-json-imports
       //###insert: import play.api.mvc._
-      import play.api.libs.json._
       import play.api.libs.functional.syntax._
+      import play.api.libs.json._
       //#serve-json-imports
 
       //#serve-json-implicits
@@ -50,11 +50,13 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
       contentAsString(result) === """[{"name":"Sandleford","location":{"lat":51.377797,"long":-1.318965}},{"name":"Watership Down","location":{"lat":51.235685,"long":-1.309197}}]"""
     }
 
-    "allow handling JSON" in {
+    "allow handling JSON" in new WithApplication() with Injecting {
+
+      val Action = inject[DefaultActionBuilder]
 
       //#handle-json-imports
-      import play.api.libs.json._
       import play.api.libs.functional.syntax._
+      import play.api.libs.json._
       //#handle-json-imports
 
       //#handle-json-implicits
@@ -107,8 +109,8 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
 
     "allow handling JSON with BodyParser" in new WithApplication() with Injecting {
 
-      import play.api.libs.json._
       import play.api.libs.functional.syntax._
+      import play.api.libs.json._
 
       implicit val locationReads: Reads[Location] = (
         (JsPath \ "lat").read[Double] and
@@ -121,6 +123,7 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
       )(Place.apply _)
 
       val parse = inject[PlayBodyParsers]
+      val Action = inject[DefaultActionBuilder]
 
       //#handle-json-bodyparser
       def savePlace = Action(parse.json) { request =>
@@ -158,11 +161,12 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
       import scala.concurrent.ExecutionContext.Implicits.global
 
       val parse = inject[PlayBodyParsers]
+      val Action = inject[DefaultActionBuilder]
 
       //#handle-json-bodyparser-concise
-      import play.api.libs.json._
-      import play.api.libs.json.Reads._
       import play.api.libs.functional.syntax._
+      import play.api.libs.json.Reads._
+      import play.api.libs.json._
 
       implicit val locationReads: Reads[Location] = (
         (JsPath \ "lat").read[Double](min(-90.0) keepAnd max(90.0)) and
@@ -239,8 +243,6 @@ object Place {
 
 //#controller
 import play.api.mvc._
-import play.api.libs.json._
-import play.api.libs.functional.syntax._
 
 class HomeController @Inject()(cc:ControllerComponents) extends AbstractController(cc)  {
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
@@ -4,14 +4,10 @@
 
 package scalaguide.tests.specs2
 
-import javax.inject.{Inject, Provider}
-
 import org.specs2.mutable.Specification
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import play.api.mvc._
-import play.api.routing._
-import play.api.routing.sird._
 
 // #scalafunctionaltest-imports
 import play.api.test._
@@ -137,7 +133,7 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
       val ws = app.injector.instanceOf[WSClient]
 
       // await is from play.api.test.FutureAwaits
-      val response = await(ws.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
+      val response = await(ws.url(testPaymentGatewayURL).withQueryStringParameters("callbackURL" -> callbackURL).get())
 
       response.status must equalTo(OK)
     }

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -34,7 +34,7 @@ import akka.util.ByteString
 
 import scala.concurrent.ExecutionContext
 
-class Application @Inject() (ws: WSClient) extends Controller {
+class Application @Inject() (ws: WSClient, val controllerComponents: ControllerComponents) extends BaseController {
 
 }
 //#dependency


### PR DESCRIPTION
## Purpose

Removes deprecated APIs usage from our docs.

It also uses (almost) the same compiler configuration used by Lagom so that we can better know when docs are using deprecated APIs.