### PR TITLE
Corrected SBT Cross-Building command

### DIFF
--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -38,7 +38,7 @@ This will build and publish Play for the default Scala version (currently 2.11.1
 Or to publish for a specific Scala version:
 
 ```bash
-> +++2.11.12 publishLocal
+> ++2.11.12 publishLocal
 ```
 
 ## Build the documentation


### PR DESCRIPTION
In the Play framework documentation, command is wrong to Cross-Building a Project with specific version. Corrected and submitted PR to community.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

N/A.

## Purpose

In Play Framework document SBT command is wrong to build application with different Scala version. 

## Background Context

N/A. It is a document correction PR.

## References

Are there any relevant issues / PRs / mailing lists discussions?
