### PR TITLE
Fix PhantomReference approach for TempFileCreator.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -173,10 +173,10 @@ object Files {
     }
 
     private def createReference(tempFile: TemporaryFile) = {
+      val path = tempFile.path
       val reference = new FinalizablePhantomReference[TemporaryFile](tempFile, frq) {
         override def finalizeReferent(): Unit = {
           references.remove(this)
-          val path = tempFile.path
           deletePath(path)
         }
       }


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Should fix problem with TempFile objects not being released in memory (including proper deletion of underlining file). 

## Purpose

Remove tempFile from closure (to avoid strong reference to tempFile object preventing GC from triggering finalizeReferent of phantom reference).
As a result finalizeReferent method with deletePath is proper called when GC collects TempFile after usage.

## Background Context

This issue was found as a result of memory leak investigation (all TempFile objects created are held in memory while play application is alive).

## References

N/A
