### PR TITLE
[2.6.x] Fix incomplete sentence in JPA doc

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -93,15 +93,15 @@ database.dispatcher {
 
 ### Running JPA transactions
 
-The following methods are available to execute arbitrary code inside a JPA transaction, but 
+The `JPAApi` provides you various `withTransaction(...)` methods to execute arbitrary code inside a JPA transaction. These methods however do not include a custom execution context and therefore must be wrapped inside a `CompletableFuture` with an IO bound execution context:
 
 ### Examples:
 
-Using [`JPAApi.withTransaction(Function<EntityManager, T>)`](api/java/play/db/jpa/JPAApi.html#withTransaction-java.util.function.Function-.html):
+Using [`JPAApi.withTransaction(Function<EntityManager, T>)`](api/java/play/db/jpa/JPAApi.html#withTransaction-java.util.function.Function-):
 
 @[jpa-withTransaction-function](code/JPARepository.java)
 
-Using [`JPAApi.withTransaction(Runnable)`](api/java/play/db/jpa/JPAApi.html#withTransaction-java.lang.Runnable-.html) to run a batch update:
+Using [`JPAApi.withTransaction(Runnable)`](api/java/play/db/jpa/JPAApi.html#withTransaction-java.lang.Runnable-) to run a batch update:
 
 @[jpa-withTransaction-runnable](code/JPARepository.java)
 


### PR DESCRIPTION
Backports #8617 + fixed two links which are going to be fixed in #8616 for the master branch already.