### PR TITLE
Also pass config via validation payload

### DIFF
--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -64,6 +64,7 @@ To pass such a payload to a `validate` method just annotate your form with `@Val
 
 ```java
 import java.util.Map;
+import com.typesafe.config.Config;
 import play.data.validation.Constraints.ValidatableWithPayload;
 import play.data.validation.Constraints.ValidateWithPayload;
 import play.data.validation.Constraints.ValidationPayload;
@@ -78,6 +79,7 @@ public class SomeForm implements ValidatableWithPayload<String> {
         Lang lang = payload.getLang();
         Messages messages = payload.getMessages();
         Map<String, Object> ctxArgs = payload.getArgs();
+        Config config = payload.getConfig();
         // ...
     }
 

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -321,7 +321,8 @@ Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]]
 ## Java `Form`, `DynamicForm` and `FormFactory` constructors changed
 
 Constructors of the `Form`, `DynamicForm` and `FormFactory` classes (inside `play.data`) that were using a [`Validator`](https://docs.jboss.org/hibernate/stable/beanvalidation/api/javax/validation/Validator.html) param use a [`ValidatorFactory`](https://docs.jboss.org/hibernate/stable/beanvalidation/api/javax/validation/ValidatorFactory.html) param instead now.
-E.g. `new Form(..., validator)` becomes `new Form(..., validatorFactory)` now.
+In addition to that, these constructors now also need a [`com.typesafe.config.Config`](https://lightbend.github.io/config/latest/api/com/typesafe/config/Config.html) param.
+E.g. `new Form(..., validator)` becomes `new Form(..., validatorFactory, config)` now.
 This change only effects you if you use the constructors to instantiate a form instead of just using `formFactory.form(SomeForm.class)` - most likely in tests.
 
 ## The Java Cache API `get` method has been deprecated in favor of `getOptional`

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
@@ -5,6 +5,7 @@
 package javaguide.forms;
 
 import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
 import org.junit.Test;
 import play.Application;
 import play.core.j.JavaHandlerComponents;
@@ -536,6 +537,8 @@ public class JavaForms extends WithApplication {
     //#payload-validate
     //###insert: import java.util.Map;
 
+    //###insert: import com.typesafe.config.Config;
+
     //###insert: import play.data.validation.Constraints.ValidatableWithPayload;
     //###insert: import play.data.validation.Constraints.ValidateWithPayload;
     //###insert: import play.data.validation.ValidationError;
@@ -555,6 +558,7 @@ public class JavaForms extends WithApplication {
             Lang lang = payload.getLang();
             Messages messages = payload.getMessages();
             Map<String, Object> ctxArgs = payload.getArgs();
+            Config config = payload.getConfig();
             // ...
             //###skip: 1
             return null;

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -580,7 +580,10 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.hosts.AllowedHostsConfig.apply"),
 
       // Add ValidationPayload to Java isValid/validate methods
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.data.FormFactory.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.FormFactory.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.DynamicForm.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.this"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("play.data.FormFactoryComponents.config"),
 
       // Remove JPA class + add more withTransaction(...) methods
       ProblemFilters.exclude[MissingClassProblem]("play.db.jpa.JPA"),

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -4,6 +4,8 @@
 
 package play.data;
 
+import com.typesafe.config.Config;
+
 import javax.validation.ValidatorFactory;
 
 import java.util.ArrayList;
@@ -34,9 +36,10 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param messagesApi    the messagesApi component.
      * @param formatters     the formatters component.
      * @param validatorFactory      the validatorFactory component.
+     * @param config      the config component.
      */
-    public DynamicForm(MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory) {
-        super(DynamicForm.Dynamic.class, messagesApi, formatters, validatorFactory);
+    public DynamicForm(MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config) {
+        super(DynamicForm.Dynamic.class, messagesApi, formatters, validatorFactory, config);
         rawData = new HashMap<>();
     }
 
@@ -49,9 +52,10 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param messagesApi    the messagesApi component.
      * @param formatters     the formatters component.
      * @param validatorFactory      the validatorFactory component.
+     * @param config      the config component.
      */
-    public DynamicForm(Map<String,String> data, List<ValidationError> errors, Optional<Dynamic> value, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory) {
-        super(null, DynamicForm.Dynamic.class, data, errors, value, messagesApi, formatters, validatorFactory);
+    public DynamicForm(Map<String,String> data, List<ValidationError> errors, Optional<Dynamic> value, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config) {
+        super(null, DynamicForm.Dynamic.class, data, errors, value, messagesApi, formatters, validatorFactory, config);
         rawData = new HashMap<>();
         for (Map.Entry<String, String> e : data.entrySet()) {
             rawData.put(asNormalKey(e.getKey()), e.getValue());
@@ -99,7 +103,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public DynamicForm fill(Map<String, Object> value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
-        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory);
+        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory, config);
     }
 
     /**
@@ -137,7 +141,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         data = newData;
 
         Form<Dynamic> form = super.bind(data, allowedFields);
-        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory);
+        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory, config);
     }
 
     /**
@@ -182,7 +186,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     public DynamicForm withError(final String key, final String error, final List<Object> args) {
         final Form<Dynamic> form = super.withError(asDynamicKey(key), error, args);
-        return new DynamicForm(this.rawData, form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory);
+        return new DynamicForm(this.rawData, form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/FormFactory.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/FormFactory.java
@@ -4,6 +4,8 @@
 
 package play.data;
 
+import com.typesafe.config.Config;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.validation.ValidatorFactory;
@@ -22,18 +24,21 @@ public class FormFactory {
 
     private final ValidatorFactory validatorFactory;
 
+    private final Config config;
+
     @Inject
-    public FormFactory(MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory) {
+    public FormFactory(MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config) {
         this.messagesApi = messagesApi;
         this.formatters = formatters;
         this.validatorFactory = validatorFactory;
+        this.config = config;
     }
     
     /**
      * @return a dynamic form.
      */
     public DynamicForm form() {
-        return new DynamicForm(messagesApi, formatters, validatorFactory);
+        return new DynamicForm(messagesApi, formatters, validatorFactory, config);
     }
     
     /**
@@ -42,7 +47,7 @@ public class FormFactory {
      * @return a new form that wraps the specified class.
      */
     public <T> Form<T> form(Class<T> clazz) {
-        return new Form<>(clazz, messagesApi, formatters, validatorFactory);
+        return new Form<>(clazz, messagesApi, formatters, validatorFactory, config);
     }
     
     /**
@@ -52,7 +57,7 @@ public class FormFactory {
      * @return a new form that wraps the specified class.
      */
     public <T> Form<T> form(String name, Class<T> clazz) {
-        return new Form<>(name, clazz, messagesApi, formatters, validatorFactory);
+        return new Form<>(name, clazz, messagesApi, formatters, validatorFactory, config);
     }
     
     /**
@@ -63,7 +68,7 @@ public class FormFactory {
      * @return a new form that wraps the specified class.
      */
     public <T> Form<T> form(String name, Class<T> clazz, Class<?>... groups) {
-        return new Form<>(name, clazz, groups, messagesApi, formatters, validatorFactory);
+        return new Form<>(name, clazz, groups, messagesApi, formatters, validatorFactory, config);
     }
 
     /**
@@ -73,7 +78,7 @@ public class FormFactory {
      * @return a new form that wraps the specified class.
      */
     public <T> Form<T> form(Class<T> clazz, Class<?>... groups) {
-        return new Form<>(null, clazz, groups, messagesApi, formatters, validatorFactory);
+        return new Form<>(null, clazz, groups, messagesApi, formatters, validatorFactory, config);
     }
 
 }

--- a/framework/src/play-java-forms/src/main/java/play/data/FormFactoryComponents.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/FormFactoryComponents.java
@@ -4,6 +4,7 @@
 
 package play.data;
 
+import play.components.ConfigurationComponents;
 import play.i18n.I18nComponents;
 import play.data.format.Formatters;
 import play.data.validation.ValidatorsComponents;
@@ -11,13 +12,13 @@ import play.data.validation.ValidatorsComponents;
 /**
  * Java Components for FormFactory.
  */
-public interface FormFactoryComponents extends ValidatorsComponents, I18nComponents {
+public interface FormFactoryComponents extends ConfigurationComponents, ValidatorsComponents, I18nComponents {
 
     default Formatters formatters() {
         return new Formatters(messagesApi());
     }
 
     default FormFactory formFactory() {
-        return new FormFactory(messagesApi(), formatters(), validatorFactory());
+        return new FormFactory(messagesApi(), formatters(), validatorFactory(), config());
     }
 }

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -4,6 +4,8 @@
 
 package play.data.validation;
 
+import com.typesafe.config.Config;
+
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.data.Form.Display;
@@ -83,11 +85,13 @@ public class Constraints {
         private final Lang lang;
         private final Messages messages;
         private final Map<String, Object> args;
+        private final Config config;
 
-        public ValidationPayload(final Lang lang, final Messages messages, final Map<String, Object> args) {
+        public ValidationPayload(final Lang lang, final Messages messages, final Map<String, Object> args, final Config config) {
             this.lang = lang;
             this.messages = messages;
             this.args = args;
+            this.config = config;
         }
 
         /**
@@ -111,8 +115,18 @@ public class Constraints {
             return this.args;
         }
 
-        public static ValidationPayload empty() {
-            return new ValidationPayload(null, null, null);
+        /**
+         * @return the current application configuration, will always be set, even when accessed outside a Http Request
+         */
+        public Config getConfig() {
+            return this.config;
+        }
+
+        /**
+         * @return a ValidationPayload object which only contains the given config
+         */
+        public static ValidationPayload empty(final Config config) {
+            return new ValidationPayload(null, null, null, config);
         }
     }
 

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -60,7 +60,7 @@ public class HttpFormsTest {
 
     private <T> Form<T> copyFormWithoutRawData(final Form<T> formToCopy, final Application app) {
         return new Form<T>(formToCopy.name(), formToCopy.getBackedType(), null, formToCopy.errors(), formToCopy.value(),
-            (Class[])null, app.injector().instanceOf(MessagesApi.class), app.injector().instanceOf(Formatters.class), app.injector().instanceOf(ValidatorFactory.class));
+            (Class[])null, app.injector().instanceOf(MessagesApi.class), app.injector().instanceOf(Formatters.class), app.injector().instanceOf(ValidatorFactory.class), app.injector().instanceOf(Config.class));
     }
 
     @Test
@@ -130,6 +130,7 @@ public class HttpFormsTest {
             MessagesApi messagesApi = app.injector().instanceOf(MessagesApi.class);
             Formatters formatters = app.injector().instanceOf(Formatters.class);
             ValidatorFactory validatorFactory = app.injector().instanceOf(ValidatorFactory.class);
+            Config config = app.injector().instanceOf(Config.class);
 
             RequestBuilder rb = new RequestBuilder();
             Context ctx = new Context(rb, contextComponents(app));
@@ -142,7 +143,7 @@ public class HttpFormsTest {
             args.add("error.customarg");
             List<ValidationError> errors = new ArrayList<>();
             errors.add(new ValidationError("foo", msgs, args));
-            Form<Money> form = new Form<>(null, Money.class, new HashMap<>(), errors, Optional.empty(), messagesApi, formatters, validatorFactory);
+            Form<Money> form = new Form<>(null, Money.class, new HashMap<>(), errors, Optional.empty(), messagesApi, formatters, validatorFactory, config);
 
             assertThat(form.errorsAsJson().get("foo").toString()).isEqualTo("[\"It looks like something was not correct\"]");
         });

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -4,6 +4,8 @@
 
 package play.data
 
+import com.typesafe.config.ConfigFactory
+
 import javax.validation.Validation
 
 import org.specs2.mutable.Specification
@@ -24,61 +26,62 @@ class DynamicFormSpec extends Specification {
   implicit val messages = messagesApi.preferred(Seq.empty)
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val validatorFactory = FormSpec.validatorFactory()
+  val config = ConfigFactory.empty()
 
   "a dynamic form" should {
 
     "bind values from a request" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.get("foo") must_== "bar"
       form.value("foo").get must_== "bar"
     }
 
     "allow access to raw data values from request" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.rawData().get("foo") must_== "bar"
     }
 
     "display submitted values in template helpers" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       val html = inputText(form("foo")).body
       html must contain("value=\"bar\"")
       html must contain("name=\"foo\"")
     }
 
     "render correctly when no value is submitted in template helpers" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory).bindFromRequest(FormSpec.dummyRequest(Map()))
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).bindFromRequest(FormSpec.dummyRequest(Map()))
       val html = inputText(form("foo")).body
       html must contain("value=\"\"")
       html must contain("name=\"foo\"")
     }
 
     "display errors in template helpers" in {
-      var form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      var form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form = form.withError("foo", "There was an error")
       val html = inputText(form("foo")).body
       html must contain("There was an error")
     }
 
     "display errors when a field is not present" in {
-      var form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory).bindFromRequest(FormSpec.dummyRequest(Map()))
+      var form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).bindFromRequest(FormSpec.dummyRequest(Map()))
       form = form.withError("foo", "Foo is required")
       val html = inputText(form("foo")).body
       html must contain("Foo is required")
     }
 
     "allow access to the property when filled" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form.get("foo") must_== "bar"
       form.value("foo").get must_== "bar"
     }
 
     "allow access to the equivalent of the raw data when filled" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form("foo").value().get() must_== "bar"
     }
 
     "don't throw NullPointerException when all components of form are null" in {
-      val form = new DynamicForm(null, null, null).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
+      val form = new DynamicForm(null, null, null, null).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form("foo").value().get() must_== "bar"
     }
 

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -523,7 +523,7 @@ trait FormSpec extends Specification {
       // Don't use bind, the point here is to have a form with data that isn't bound, otherwise the mapping indexes
       // used come from the form, not the input data
       new Form[JavaForm](null, classOf[JavaForm], map.asJava,
-        List.empty.asJava.asInstanceOf[java.util.List[ValidationError]], Optional.empty[JavaForm], null, null, FormSpec.validatorFactory())
+        List.empty.asJava.asInstanceOf[java.util.List[ValidationError]], Optional.empty[JavaForm], null, null, FormSpec.validatorFactory(), ConfigFactory.empty())
     }
 
     "return the appropriate constraints for the desired validation group(s)" in {

--- a/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -4,6 +4,8 @@
 
 package play.data
 
+import com.typesafe.config.ConfigFactory
+
 import javax.validation.Validation
 
 import org.specs2.mutable.Specification
@@ -19,7 +21,7 @@ class PartialValidationSpec extends Specification {
   val messagesApi = new DefaultMessagesApi()
 
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
-  val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), FormSpec.validatorFactory())
+  val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), FormSpec.validatorFactory(), ConfigFactory.empty())
 
   "partial validation" should {
     "not fail when fields not in the same group fail validation" in {


### PR DESCRIPTION
Just a small enhancement to #8316:
The payload now also provides the config via `payload.getConfig()`.

I didn't include that in the original pull request since this is not a must-have, however every now and then I stumbled over a use-case where I had to access the config during validation. It's just a comfortable addition and since we already have a migration path for the constructors that change, I thought we could just include this feature straight away.