### PR TITLE
Add exception handling around synchronous lifecycle stop hook execution

### DIFF
--- a/framework/src/play/src/test/scala/play/api/inject/ApplicationLifecycleSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/ApplicationLifecycleSpec.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package play.api.inject
+
+import java.util.concurrent.Callable
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import org.specs2.mutable.Specification
+import play.libs.F
+
+class ApplicationLifecycleSpec extends Specification {
+  "ApplicationLifecycle.stop" should {
+    "not return a failed future when one of the stop hooks returns a null promise" in {
+      val lifecycle = new DefaultApplicationLifecycle
+      lifecycle.addStopHook(new Callable[F.Promise[Void]] {
+        override def call(): F.Promise[Void] = null
+      })
+
+      val stopFuture = lifecycle.stop()
+
+      Await.result(stopFuture, Duration(1, MINUTES)) must not(throwA[Throwable])
+    }
+  }
+}


### PR DESCRIPTION
Add unit test to verify synchronous exceptions do not cause the
 lifecycle stop hook future to fail
Resolve: https://github.com/playframework/playframework/issues/8624

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [In progress] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [X] Have you added copyright headers to new files?
* [N/A] Have you checked that both Scala and Java APIs are updated?
* [N/A] Have you updated the documentation for both Scala and Java sections?
* [X] Have you added tests for any changed functionality?

# Helpful things

## Fixes

https://github.com/playframework/playframework/issues/8624

## Purpose

Fixes bug https://github.com/playframework/playframework/issues/8624

## Background Context

The existing implementation only used `recover` to handle failure which assumes all failures happen on the asynchronous path. However, a method that returns `Future` is not guaranteed to only throw an exception on the asynchronous path, so we need to handle exceptions on both the synchronous and asynchronous paths - hence the addition of the `try ... catch`

## References

None
