### PR TITLE
[2.6.x] Akka 2.5 only for snapshot builds

### DIFF
--- a/framework/bin/scriptLib
+++ b/framework/bin/scriptLib
@@ -19,7 +19,10 @@ EXTRA_OPTS=""
 # Check if it is a scheduled build
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     # `sort` is not necessary, but it is good to make it predictable.
-    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '[0-9]\.[0-9]-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '2\.5-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+
+    echo "Using Akka SNAPSHOT ${AKKA_VERSION}"
+
     EXTRA_OPTS="-Dakka.version=${AKKA_VERSION}"
 fi
 

--- a/framework/bin/test-scala-211
+++ b/framework/bin/test-scala-211
@@ -4,6 +4,13 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
+# We are not running Scala 2.11 job for scheduled builds because they use
+# Akka snapshots which aren't being published for Scala 2.11 anymore.
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    printMessage "SKIPPING TESTS FOR SCALA 2.11"
+    exit
+fi
+
 cd ${FRAMEWORK}
 
 printMessage "RUNNING TESTS FOR SCALA 2.11"


### PR DESCRIPTION
## Fixes

Cron builds for 2.6.x is broken since it is not skipping Scala 2.11 script.

This also limits the Akka snapshot versions to 2.5.