### PR TITLE
Missing hyperlinks to ScalaTest and specs2 pages

### DIFF
--- a/documentation/manual/working/javaGuide/main/tests/JavaTestingWithDatabases.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTestingWithDatabases.md
@@ -3,7 +3,7 @@
 
 While it is possible to write [[functional tests|JavaFunctionalTest]] that test database access code by starting up a full application including the database, starting up a full application is not often desirable, due to the complexity of having many more components started and running just to test one small part of your application.
 
-Play provides a number of utilities for helping to test database access code that allow it to be tested with a database but in isolation from the rest of your app.  These utilities can easily be used with either ScalaTest or specs2, and can make your database tests much closer to lightweight and fast running unit tests than heavy weight and slow functional tests.
+Play provides a number of utilities for helping to test database access code that allow it to be tested with a database but in isolation from the rest of your app.  These utilities can easily be used with either [[ScalaTest|ScalaFunctionalTestingWithScalaTest]] or [[specs2|ScalaFunctionalTestingWithSpecs2]], and can make your database tests much closer to lightweight and fast running unit tests than heavy weight and slow functional tests.
 
 ## Using a database
 


### PR DESCRIPTION
The JavaTesting page does not have any hyperlinks to the above 2 pages, so if we would like the ScalaTest and specs2 libraries to be used by Java Developers, it may be useful to have links to them.

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
Yes
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
Yes
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
Yes
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
NA
* [ ] Have you added copyright headers to new files?
NA
* [ ] Have you checked that both Scala and Java APIs are updated?
NA
* [ ] Have you updated the documentation for both Scala and Java sections?
Yes this is update in the Java section of the doc
* [ ] Have you added tests for any changed functionality?
NA

# Helpful things

## Fixes

Fixes missing links in the Java sections of the doc.

## Purpose

The JavaTesting page does not have any hyperlinks to the above 2 pages, so if we would like the ScalaTest and specs2 libraries to be used by Java Developers, it may be useful to have links to them.


## Background Context

While referring to this documentation page, I could not find where the 2 framework pages referenced are, until I went to the scala section of the doc where the links were maintained. This can save some effort on the part of java developers who may want to explore these libraries. 

## References

NA
