### PR TITLE
Update heroku deploying docs (declaring java version)

### DIFF
--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -133,11 +133,11 @@ $ heroku buildpacks:set heroku/scala
 The [Scala buildpack](https://github.com/heroku/heroku-buildpack-scala) will use the `build.sbt` file in your repo to build the app.
 
 
-## Deploying Java 9 application
+## Deploying applications that use latest java versions
 
-Heroku uses OpenJDK 8 to run Java applications by default. It cannot automatically determine if another version is needed, so deploying a Java 9 application will lead to a compilation error on the server. If you use a newer version than Java 8, you should declare it in your `system.properties` file in the project root directory:
+Heroku uses OpenJDK 8 to run Java applications by default. It cannot automatically determine if another version is needed, so deploying an application that uses newer java version leads to a compilation error on the server. If you use a newer version than Java 8, you should declare it in your `system.properties` file in the project root directory, for example:
 ```txt
-java.runtime.version=9
+java.runtime.version=11
 ```
 
 See the [heroku documentation](https://devcenter.heroku.com/articles/java-support#specifying-a-java-version) for more details.


### PR DESCRIPTION

## Purpose

PR updates outdated fragment of heroku deployment documentations. After the java 11 LTS was released, there are not many reasons for using java 9/10(which are end-of-premier-support now) in both new and existing projects, especially since migration to java 11 is trivial. However, if someone needs to use java 9 or 10 for some reasons, the link to heroku documentation can help.
