### PR TITLE
Update to Akka 2.5.17

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -47,7 +47,7 @@ lazy val SbtRoutesCompilerProject = PlaySbtProject("SBT-Routes-Compiler", "route
     )
 
 lazy val StreamsProject = PlayCrossBuiltProject("Play-Streams", "play-streams")
-    .settings(libraryDependencies ++= streamsDependencies)
+    .settings(libraryDependencies ++= streamsDependencies.value)
 
 lazy val PlayExceptionsProject = PlayNonCrossBuiltProject("Play-Exceptions", "play-exceptions")
 

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -47,7 +47,7 @@ lazy val SbtRoutesCompilerProject = PlaySbtProject("SBT-Routes-Compiler", "route
     )
 
 lazy val StreamsProject = PlayCrossBuiltProject("Play-Streams", "play-streams")
-    .settings(libraryDependencies ++= streamsDependencies.value)
+    .settings(libraryDependencies ++= streamsDependencies)
 
 lazy val PlayExceptionsProject = PlayNonCrossBuiltProject("Play-Exceptions", "play-exceptions")
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.17")
   val akkaHttpVersion = "10.1.5"
   val akkaHttpVersion_2_13 = "10.1.3" // akka-http dropped support for Scala 2.13: https://github.com/akka/akka-http/issues/2166
+  val akkaStreamVersion_2_13 = "2.5.16" // it would appear akka-stream also dropped support for Scala 2.13..
   val playJsonVersion = "2.6.10"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
@@ -227,11 +228,16 @@ object Dependencies {
     "com.typesafe.play" %% "play-doc" % playDocVersion
   ) ++ playdocWebjarDependencies
 
-  val streamsDependencies = Seq(
+  val streamsDependencies = Def.setting(Seq(
     "org.reactivestreams" % "reactive-streams" % "1.0.2",
-    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-stream" % (
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 13)) => akkaStreamVersion_2_13
+        case _ => akkaVersion
+      }
+    ),
     scalaJava8Compat
-  ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
+  ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps)
 
   val playServerDependencies = specs2Deps.map(_ % Test) ++ Seq(
     guava % Test,

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -11,7 +11,6 @@ object Dependencies {
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.17")
   val akkaHttpVersion = "10.1.5"
   val akkaHttpVersion_2_13 = "10.1.3" // akka-http dropped support for Scala 2.13: https://github.com/akka/akka-http/issues/2166
-  val akkaStreamVersion_2_13 = "2.5.16" // it would appear akka-stream also dropped support for Scala 2.13..
   val playJsonVersion = "2.6.10"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
@@ -228,16 +227,11 @@ object Dependencies {
     "com.typesafe.play" %% "play-doc" % playDocVersion
   ) ++ playdocWebjarDependencies
 
-  val streamsDependencies = Def.setting(Seq(
+  val streamsDependencies = Seq(
     "org.reactivestreams" % "reactive-streams" % "1.0.2",
-    "com.typesafe.akka" %% "akka-stream" % (
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 13)) => akkaStreamVersion_2_13
-        case _ => akkaVersion
-      }
-    ),
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
     scalaJava8Compat
-  ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps)
+  ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
 
   val playServerDependencies = specs2Deps.map(_ % Test) ++ Seq(
     guava % Test,

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.16")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.17")
   val akkaHttpVersion = "10.1.5"
   val akkaHttpVersion_2_13 = "10.1.3" // akka-http dropped support for Scala 2.13: https://github.com/akka/akka-http/issues/2166
   val playJsonVersion = "2.6.10"


### PR DESCRIPTION
## References

https://akka.io/blog/news/2018/09/27/akka-2.5.17-released
