### PR TITLE
Honor play settings on AkkaHttpServer for client auth in SSL

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -188,7 +188,6 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     }
   }
 
-
   if (http2Enabled) {
     logger.info(s"Enabling HTTP/2 on Akka HTTP server...")
     if (httpsServerBinding.isEmpty) {


### PR DESCRIPTION
## Fixes

`AkkaHttpServer` didn't honour some HTTPS-related settings:

````
play {
  server {
    # HTTPS configuration
    https {
      # Whether JSSE want client auth mode should be used. This means, the server
      # will request a client certificate, but won't fail if one isn't provided.
      wantClientAuth = false

      # Whether JSSE need client auth mode should be used. This means, the server
      # will request a client certificate, and will fail and terminate the session
      # if one isn't provided.
      needClientAuth = false
    }
  }
}
```

