### PR TITLE
Revert "Corrected SBT Cross-Building command (#8613)"

### DIFF
--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -38,7 +38,7 @@ This will build and publish Play for the default Scala version (currently 2.11.1
 Or to publish for a specific Scala version:
 
 ```bash
-> +++2.11.12 publishLocal
+> +++ 2.11.12 publishLocal
 ```
 
 ## Build the documentation

--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -38,7 +38,7 @@ This will build and publish Play for the default Scala version (currently 2.11.1
 Or to publish for a specific Scala version:
 
 ```bash
-> ++2.11.12 publishLocal
+> +++2.11.12 publishLocal
 ```
 
 ## Build the documentation


### PR DESCRIPTION
## Purpose

Play is still using sbt-doge to cross run publish tasks. So we need `+++` instead of `++`. So this reverts #8613.