### PR TITLE
Adds method to get cookie as optional.

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -23,6 +23,7 @@ import static javaguide.testhelpers.MockJavaActionHelper.*;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static play.mvc.Controller.*;
 import static play.test.Helpers.fakeRequest;
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -130,9 +130,10 @@ public class JavaResponse extends WithApplication {
             }
             //#discard-cookie
         }, fakeRequest(), mat).cookies();
-        Cookie cookie = cookies.get("theme");
-        assertThat(cookie.name(), equalTo("theme"));
-        assertThat(cookie.value(), equalTo(""));
+        Optional<Cookie> cookie = cookies.getCookie("theme");
+        assertTrue(cookie.isPresent());
+        assertThat(cookie.get().name(), equalTo("theme"));
+        assertThat(cookie.get().value(), equalTo(""));
     }
 
     @Test

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -88,7 +88,9 @@ public class JavaResponse extends WithApplication {
             //#set-cookie
         }, fakeRequest(), mat).cookies();
 
-        assertThat(cookies.get("theme").value(), equalTo("blue"));
+        Optional<Cookie> cookie = cookies.getCookie("theme");
+        assertTrue(cookie.isPresent());
+        assertThat(cookie.get().value(), equalTo("blue"));
     }
 
     @Test
@@ -110,7 +112,11 @@ public class JavaResponse extends WithApplication {
             }
             //#detailed-set-cookie
         }, fakeRequest(), mat).cookies();
-        Cookie cookie = cookies.get("theme");
+        Optional<Cookie> cookieOpt = cookies.getCookie("theme");
+
+        assertTrue(cookieOpt.isPresent());
+
+        Cookie cookie = cookieOpt.get();
         assertThat(cookie.name(), equalTo("theme"));
         assertThat(cookie.value(), equalTo("blue"));
         assertThat(cookie.maxAge(), equalTo(3600));

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -652,7 +652,10 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.i18n.Messages.asJava"),
 
       // Change implicit type from Messages to MessagesProvider to fix implicit precedence
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.j.PlayMagicForJava.implicitJavaMessages")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.j.PlayMagicForJava.implicitJavaMessages"),
+
+      // Add play.mvc.Http#Cookies getCookie method
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Cookies.getCookie")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2238,7 +2238,6 @@ public class Http {
          * @return the cookie that is associated with the given name
          * @deprecated Deprecated as of 2.7.0. Use {@link #getCookie(String)}
          */
-
         @Deprecated
         default Cookie get(String name) {
             return getCookie(name).get();

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2236,7 +2236,10 @@ public class Http {
         /**
          * @param name Name of the cookie to retrieve
          * @return the cookie that is associated with the given name
+         * @deprecated Deprecated as of 2.7.0. Use {@link #getCookie(String)}
          */
+
+        @Deprecated
         default Cookie get(String name) {
             return getCookie(name).get();
         }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2237,7 +2237,16 @@ public class Http {
          * @param name Name of the cookie to retrieve
          * @return the cookie that is associated with the given name
          */
-        Cookie get(String name);
+        default Cookie get(String name) {
+            return getCookie(name).get();
+        }
+
+        /**
+         *
+         * @param name Name of the cookie to retrieve
+         * @return the optional cookie that is associated with the given name
+         */
+        Optional<Cookie> getCookie(String name);
 
     }
 

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -238,9 +238,22 @@ public class Result {
      *
      * @param name the cookie's name.
      * @return the cookie (if it was set)
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link getCookie}
      */
+    @Deprecated
     public Cookie cookie(String name) {
         return cookies().get(name);
+    }
+
+    /**
+     * Extracts a Cookie value from this Result value
+     *
+     * @param name the cookie's name.
+     * @return the optional cookie
+     */
+    public Optional<Cookie> getCookie(String name) {
+        return cookies.stream().filter(c -> c.name().equals(name)).findFirst();
     }
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -239,7 +239,7 @@ public class Result {
      * @param name the cookie's name.
      * @return the cookie (if it was set)
      *
-     * @deprecated Deprecated as of 2.7.0. Use {@link getCookie}
+     * @deprecated Deprecated as of 2.7.0. Use {@link #getCookie(String)}
      */
     @Deprecated
     public Cookie cookie(String name) {
@@ -253,7 +253,7 @@ public class Result {
      * @return the optional cookie
      */
     public Optional<Cookie> getCookie(String name) {
-        return cookies.stream().filter(c -> c.name().equals(name)).findFirst();
+        return cookies().getCookie(name);
     }
 
     /**
@@ -264,8 +264,8 @@ public class Result {
     public Cookies cookies() {
         return new Cookies() {
             @Override
-            public Cookie get(String name) {
-                return cookies.stream().filter(c -> c.name().equals(name)).findFirst().get();
+            public Optional<Cookie> getCookie(String name) {
+                return cookies.stream().filter(c -> c.name().equals(name)).findFirst();
             }
 
             @Override

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -37,9 +37,15 @@ trait JavaHelpers {
 
   def cookiesToJavaCookies(cookies: Cookies) = {
     new JCookies {
-      def get(name: String): JCookie = {
+
+      override def get(name: String): JCookie = {
         cookies.get(name).map(_.asJava).orNull
       }
+
+      override def getCookie(name: String): Optional[JCookie] = {
+        Optional.ofNullable(cookies.get(name).map(_.asJava).orNull)
+      }
+
       def iterator: java.util.Iterator[JCookie] = {
         cookies.toIterator.map(_.asJava).asJava
       }

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -182,6 +182,14 @@ public class ResultsTest {
     assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp");
   }
 
+  @Test
+  public void getOptionalCookie() {
+    Result result = Results.ok().withCookies(new Http.Cookie("foo", "1", 1000, "/", "example.com", false, true, null));
+    assertTrue(result.getCookie("foo").isPresent());
+    assertEquals(result.getCookie("foo").get().name(), "foo");
+    assertFalse(result.getCookie("bar").isPresent());
+  }
+
   private void mockRegularFileTypes() {
     HttpConfiguration httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(Configuration.reference(), play.api.Environment.simple(new File("."), Mode.TEST.asScala())).get();
     final DefaultFileMimeTypes defaultFileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes()).get();


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #8644 

## Purpose

Deprecates method to get cookie that throws an exception if cookie not found and introduces new method that returns cookie wrapped in optional.

## Background Context

As discussed in issue.

## References

Are there any relevant issues / PRs / mailing lists discussions?
