### PR TITLE
Lookup form helpers' _label and _name attributes in messages

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -43,13 +43,13 @@ package views.html.helper {
     }
 
     def label: Any = {
-      args.get('_label).getOrElse(p.messages(field.label))
+      args.get('_label).map(l => p.messages(l.toString)).getOrElse(p.messages(field.label))
     }
 
     def hasName: Boolean = args.get('_name).isDefined
 
     def name: Any = {
-      args.get('_name).getOrElse(p.messages(field.label))
+      args.get('_name).map(n => p.messages(n.toString)).getOrElse(p.messages(field.label))
     }
 
     private def translateMsgArg(msgArg: Any) = msgArg match {

--- a/framework/src/play/src/test/resources/messages
+++ b/framework/src/play/src/test/resources/messages
@@ -8,3 +8,6 @@ constraint.customarg=custom constraint
 
 format.custom=Look at me! I am a {0}
 format.customarg=custom format pattern
+
+myfieldlabel=I am the label of the field
+myfieldname=I am the name of the field

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -201,5 +201,13 @@ class HelpersSpec extends Specification {
       body must contain("""<dd class="info">I am a custom constraint</dd>""")
       body must contain("""<dd class="info">Look at me! I am a custom format pattern</dd>""")
     }
+
+    "correctly lookup _label in messages" in {
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_label -> "myfieldlabel").body must contain("I am the label of the field")
+    }
+
+    "correctly lookup _name in messages" in {
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_name -> "myfieldname").body must contain("I am the name of the field")
+    }
   }
 }


### PR DESCRIPTION
Actually I thought that was happening already - like it's done for the `getOrElse` part as well, however it looks like I forgot that when I added the `translateMsgArg` method and other i18n stuff to the helpers.
(Actually I don't use the Play built-in helpers myself, most of the time [play-bootstrap](https://github.com/adrianhurt/play-bootstrap) - which *does* look up these attributes in the messages - therefore I did not recognize earlier).

We can backport as well.