### PR TITLE
Make sure request and header stay in sync in Http.Context

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -51,7 +51,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
         CSRFActionHelper csrfActionHelper =
             new CSRFActionHelper(sessionConfiguration, config, tokenSigner, tokenProvider);
 
-        RequestHeader request = csrfActionHelper.tagRequestFromHeader(ctx._requestHeader());
+        RequestHeader request = csrfActionHelper.tagRequestFromHeader(ctx.request().asScala());
         // Check for bypass
         if (!csrfActionHelper.requiresCsrfCheck(request)) {
             return delegate.call(ctx);

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -30,7 +30,7 @@ object PlayMagicForJava extends JavaImplicitConversions {
   }
 
   implicit def requestHeader: play.api.mvc.RequestHeader = {
-    ctx._requestHeader
+    ctx.request().asScala
   }
 
   // TODO: After removing Http.Context (and the corresponding methods in this object here) this should be changed to:

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -72,7 +72,6 @@ public class Http {
         //
 
         private final Long id;
-        private final play.api.mvc.RequestHeader header;
         private final Request request;
         private final Response response;
         private final Session session;
@@ -99,11 +98,10 @@ public class Http {
          */
         public Context(Request request, JavaContextComponents components) {
             this.request = request;
-            this.header = request.asScala();
-            this.id = header.id();
+            this.id = this.request.asScala().id();
             this.response = new Response();
-            this.session = new Session(Scala.asJava(header.session().data()));
-            this.flash = new Flash(Scala.asJava(header.flash().data()));
+            this.session = new Session(Scala.asJava(this.request.asScala().session().data()));
+            this.flash = new Flash(Scala.asJava(this.request.asScala().flash().data()));
             this.args = new HashMap<>();
             this.components = components;
         }
@@ -112,7 +110,7 @@ public class Http {
          * Creates a new HTTP context.
          *
          * @param id the unique context ID
-         * @param header the request header
+         * @param header the request header (Not used anymore. You could simply pass null, it doesn't matter)
          * @param request the request with body
          * @param sessionData the session data extracted from the session cookie
          * @param flashData the flash data extracted from the flash cookie
@@ -132,7 +130,7 @@ public class Http {
          * Use this constructor (or withRequest) to copy a context within a Java Action to be passed to a delegate.
          *
          * @param id the unique context ID
-         * @param header the request header
+         * @param header the request header (Not used anymore. You could simply pass null, it doesn't matter)
          * @param request the request with body
          * @param response the response instance to use
          * @param session the session instance to use
@@ -143,7 +141,6 @@ public class Http {
         public Context(Long id, play.api.mvc.RequestHeader header, Request request, Response response,
                 Session session, Flash flash, Map<String,Object> args, JavaContextComponents components) {
             this.id = id;
-            this.header = header;
             this.request = request;
             this.response = response;
             this.session = session;
@@ -205,9 +202,12 @@ public class Http {
          * For internal usage only.
          *
          * @return the original request header.
+         *
+         * @deprecated Use {@link #request()}.asScala() instead. Since 2.7.0.
          */
+        @Deprecated
         public play.api.mvc.RequestHeader _requestHeader() {
-            return header;
+            return request.asScala();
         }
 
         /**
@@ -426,7 +426,7 @@ public class Http {
         /**
          * Create a new context with the given request.
          *
-         * The id, Scala RequestHeader, session, flash and args remain unchanged.
+         * The id, session, flash and args remain unchanged.
          *
          * This method is intended for use within a Java action, to create a new Context to pass to a delegate action.
          *
@@ -449,7 +449,7 @@ public class Http {
          * @param wrapped the context the created instance will wrap
          */
         public WrappedContext(Context wrapped) {
-            super(wrapped.id(), wrapped._requestHeader(), wrapped.request(), wrapped.session(), wrapped.flash(), wrapped.args, wrapped.components);
+            super(wrapped.id(), wrapped.request().asScala(), wrapped.request(), wrapped.session(), wrapped.flash(), wrapped.args, wrapped.components);
             this.args = wrapped.args;
             this.wrapped = wrapped;
         }
@@ -483,9 +483,13 @@ public class Http {
             return wrapped.flash();
         }
 
+        /**
+         * @deprecated Use {@link #request()}.asScala() instead. Since 2.7.0.
+         */
         @Override
+        @Deprecated
         public play.api.mvc.RequestHeader _requestHeader() {
-            return wrapped._requestHeader();
+            return wrapped.request().asScala();
         }
 
         @Override

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -434,7 +434,7 @@ public class Http {
          * @return The new context.
          */
         public Context withRequest(Request request) {
-            return new Context(id, header, request, response, session, flash, args, components);
+            return new Context(id, request.asScala(), request, response, session, flash, args, components);
         }
     }
 


### PR DESCRIPTION
Fixes #8661

At first I just fixed the issue like I suggested in #8661
See the first commit.

However I think the much safer fix is to just remove the `play.api.mvc.RequestHeader header` field. We can simply replace it with `request.asScala()`.
Also what backs my suggestion for that safer fix is that in [`AbstractCSPAction.java`](https://github.com/playframework/playframework/blob/471708da65723353d3045e360ae663b4553a4a63/framework/src/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java#L37-L45) and [`AddCSRFTokenAction.java`](https://github.com/playframework/playframework/blob/471708da65723353d3045e360ae663b4553a4a63/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java#L76-L84) we already have to make sure that `header` and `request` stay in sync:
https://github.com/playframework/playframework/blob/471708da65723353d3045e360ae663b4553a4a63/framework/src/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java#L37-L45
https://github.com/playframework/playframework/blob/471708da65723353d3045e360ae663b4553a4a63/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java#L76-L84
That's why I added the second commit with that safer fix (The `header` param of the two constructors  become useless now of course, they just stay so the constructors are backwards compatible. I will deprecate the whole `Context` soon so that doesn't really matter anyway).

Actually we should backport this.