### PR TITLE
DiscardingCookie never sends "HTTPOnly"

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -13,6 +13,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import play.api.http.HttpConfiguration;
 import play.api.libs.json.JsValue;
+import play.api.mvc.DiscardingCookie;
 import play.api.mvc.Headers$;
 import play.api.mvc.request.*;
 import play.core.j.JavaContextComponents;
@@ -29,6 +30,7 @@ import play.libs.XML;
 import play.libs.typedmap.TypedKey;
 import play.libs.typedmap.TypedMap;
 import play.mvc.Http.Cookie.SameSite;
+import scala.Option;
 import scala.collection.immutable.Map$;
 import scala.compat.java8.OptionConverters;
 
@@ -1861,7 +1863,7 @@ public class Http {
          * @param secure Whether the cookie to discard is secure
          */
         public void discardCookie(String name, String path, String domain, boolean secure) {
-            cookies.add(new Cookie(name, "", play.api.mvc.Cookie.DiscardedMaxAge(), path, domain, secure, false, null));
+            cookies.add(new DiscardingCookie(name, path, Option.apply(domain), secure).toCookie().asJava());
         }
 
         public Collection<Cookie> cookies() {

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -13,10 +13,12 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import play.api.mvc.DiscardingCookie;
 import play.core.j.JavaHelpers$;
 import play.core.j.JavaResultExtractor;
 import play.http.HttpEntity;
 import play.libs.Scala;
+import scala.Option;
 
 import static play.mvc.Http.Cookie;
 import static play.mvc.Http.Cookies;
@@ -316,7 +318,7 @@ public class Result {
      * @param secure Whether the cookie to discard is secure
      */
     public Result discardCookie(String name, String path, String domain, boolean secure) {
-        return withCookies(new Cookie(name, "", play.api.mvc.Cookie.DiscardedMaxAge(), path, domain, secure, false, null));
+        return withCookies(new DiscardingCookie(name, path, Option.apply(domain), secure).toCookie().asJava());
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -113,7 +113,7 @@ object Cookie {
  * @param secure whether this cookie is secured
  */
 case class DiscardingCookie(name: String, path: String = "/", domain: Option[String] = None, secure: Boolean = false) {
-  def toCookie = Cookie(name, "", Some(Cookie.DiscardedMaxAge), path, domain, secure)
+  def toCookie = Cookie(name, "", Some(Cookie.DiscardedMaxAge), path, domain, secure, false)
 }
 
 /**


### PR DESCRIPTION
See motivation and explanation in [this comment](https://github.com/playframework/playframework/pull/8546#discussion_r221903842).

Shouldn't it be OK to just *never* send the `HTTPOnly` flag when discarding a cookie - no matter if the flag was or was not send when creating the cookie?