### PR TITLE
Make sure a new ctx gets set in the Context.current ThreadLocal

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
@@ -45,6 +45,7 @@ public abstract class AbstractCSPAction extends Action<CSP> {
             }
         };
 
+        Http.Context.current.set(newCtx);
         return delegate.call(newCtx).thenApply((Result result) -> {
             Result r = result;
             if (cspResult.nonceHeader()) {

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -67,6 +67,7 @@ public class Security {
             } else {
                 Request usernameReq = ctx.request().addAttr(USERNAME, username);
                 Context usernameCtx = ctx.withRequest(usernameReq);
+                Http.Context.current.set(usernameCtx);
                 return delegate.call(usernameCtx);
             }
         }


### PR DESCRIPTION
Whenever we create a new `Context` and pass it on to the next action we always also have to make sure that this new context is also set as the current one in the Context thread local.

Actually that is how it's done already in another action helper:
https://github.com/playframework/playframework/blob/471708da65723353d3045e360ae663b4553a4a63/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java#L87-L88