### PR TITLE
Simply use ctx.withRequest instead of a new WrappedContext

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
@@ -33,17 +33,7 @@ public abstract class AbstractCSPAction extends Action<CSP> {
         Http.Request newRequest = toJava(cspResult.nonce())
                 .map(n -> request.addAttr(RequestAttrKey.CSPNonce().asJava(), n))
                 .orElseGet(() -> request);
-        Http.Context newCtx = new Http.WrappedContext(ctx) {
-            @Override
-            public Http.Request request() {
-                return newRequest;
-            }
-
-            @Override
-            public play.api.mvc.RequestHeader _requestHeader() {
-                return newRequest.asScala();
-            }
-        };
+        Http.Context newCtx = ctx.withRequest(newRequest);
 
         return delegate.call(newCtx).thenApply((Result result) -> {
             Result r = result;

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -72,17 +72,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 
         final play.api.mvc.Request<RequestBody> newRequest = request;
         // Methods returning requests should return the tagged request
-        Http.Context newCtx = new Http.WrappedContext(ctx) {
-            @Override
-            public Request request() {
-                return new RequestImpl(newRequest);
-            }
-
-            @Override
-            public play.api.mvc.RequestHeader _requestHeader() {
-                return newRequest;
-            }
-        };
+        Http.Context newCtx = ctx.withRequest(new RequestImpl(newRequest));
 
         Http.Context.current.set(newCtx);
         return delegate.call(newCtx);


### PR DESCRIPTION
Has the same effect but simpler.
Actually I am wondering why we even have `WrappedContext` (probably was here before we added the `withRequest` method).