### PR TITLE
Sync Scala and Java cookie default values

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2130,7 +2130,7 @@ public class Http {
         private String path = "/";
         private String domain;
         private boolean secure = false;
-        private boolean httpOnly = false;
+        private boolean httpOnly = true;
         private SameSite sameSite;
 
         /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -403,7 +403,7 @@ trait CookieBaker[T <: AnyRef] { self: CookieDataCodec =>
   /**
    *  The cookie path.
    */
-  def path: String
+  def path: String = "/"
 
   /**
    * The value of the SameSite attribute of the cookie. Defaults to no SameSite.

--- a/framework/src/play/src/test/java/play/mvc/CookieBuilderTest.java
+++ b/framework/src/play/src/test/java/play/mvc/CookieBuilderTest.java
@@ -19,7 +19,7 @@ public class CookieBuilderTest {
     assertEquals(null, cookie.domain());
     assertEquals(null, cookie.maxAge());
     assertEquals(false, cookie.secure());
-    assertEquals(false, cookie.httpOnly());
+    assertEquals(true, cookie.httpOnly());
   }
 
   @Test
@@ -31,7 +31,7 @@ public class CookieBuilderTest {
     assertEquals(null, cookie.domain());
     assertEquals(null, cookie.maxAge());
     assertEquals(false, cookie.secure());
-    assertEquals(false, cookie.httpOnly());
+    assertEquals(true, cookie.httpOnly());
   }
 
   @Test
@@ -43,7 +43,7 @@ public class CookieBuilderTest {
     assertEquals(".example.com", cookie.domain());
     assertEquals(null, cookie.maxAge());
     assertEquals(false, cookie.secure());
-    assertEquals(false, cookie.httpOnly());
+    assertEquals(true, cookie.httpOnly());
   }
 
   @Test


### PR DESCRIPTION
Usually we set `httpOnly` to true in most places.
And usually `path` is "/".