### PR TITLE
Correctly handle lang in WrappedContext

### DIFF
--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -237,6 +237,33 @@ public class HttpTest {
     }
 
     @Test
+    public void testWrappedCtxLang() {
+        withApplication((app) -> {
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
+            Context ctx = new Context(new RequestBuilder(), contextComponents);
+
+            // Lets change the lang to something that is not the default
+            ctx.setTransientLang("fr");
+
+            // Make sure the context did set that lang correctly
+            assertThat(ctx.lang().code()).isEqualTo("fr");
+
+            // Now let's copy the context - only with a new request set, the rest should stay the same
+            Context newCtx = new Http.WrappedContext(ctx) {};
+
+            // Make sure the new context correctly set its internal lang variable
+            assertThat(newCtx.lang().code()).isEqualTo("fr");
+
+            // Now change the lang on the new context to something not default
+            newCtx.setTransientLang("en-US");
+
+            // Make sure the new context correctly set its internal lang variable
+            assertThat(newCtx.lang().code()).isEqualTo("en-US");
+        });
+    }
+
+    @Test
     public void testTemplateMagicForJavaNoImplicitMessages() {
         withApplication((app) -> {
             Context ctx = new Context(new RequestBuilder(), app.injector().instanceOf(JavaContextComponents.class));

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -497,7 +497,7 @@ public class Http {
          * @param wrapped the context the created instance will wrap
          */
         public WrappedContext(Context wrapped) {
-            super(wrapped.id(), wrapped.request().asScala(), wrapped.request(), wrapped.session(), wrapped.flash(), wrapped.args, wrapped.components);
+            super(wrapped.id(), wrapped.request().asScala(), wrapped.request(), wrapped.session(), wrapped.flash(), wrapped.args, wrapped.lang, wrapped.components);
             this.args = wrapped.args;
             this.wrapped = wrapped;
         }
@@ -558,6 +558,26 @@ public class Http {
         @Override
         public void clearLang() {
             wrapped.clearLang();
+        }
+
+        @Override
+        public void setTransientLang(String code) {
+            wrapped.setTransientLang(code);
+        }
+
+        @Override
+        public void setTransientLang(Lang lang) {
+            wrapped.setTransientLang(lang);
+        }
+
+        @Override
+        public void clearTransientLang() {
+            wrapped.clearTransientLang();
+        }
+
+        @Override
+        public Messages messages() {
+            return wrapped.messages();
         }
     }
 


### PR DESCRIPTION
Similar to #8675 `WrappedContext` didn't handle the language correctly.

To fix that the language related methods needed to be overriden. Now **all** methods from `Context` are overriden by `WrappedContext`.

(We are not using `WrappedContext` in Play's codebase anymore, this is just for users who still rely on it.)