### PR TITLE
Bumps ssl-config to 0.3.5

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val akkaHttpVersion = "10.1.5"
   val akkaHttpVersion_2_13 = "10.1.3" // akka-http dropped support for Scala 2.13: https://github.com/akka/akka-http/issues/2166
 
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.4"
+  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.5"
 
   val playJsonVersion = "2.6.10"
 

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -19,18 +19,11 @@ import com.typesafe.sslconfig.util.NoopLogger
 object FakeKeyStore {
   private final val FakeKeyStore = new sslconfig.FakeKeyStore(NoopLogger.factory())
 
-  val GeneratedKeyStore: String = sslconfig.FakeKeyStore.GeneratedKeyStore
-  val ExportedCert: String = sslconfig.FakeKeyStore.ExportedCert
-  val TrustedAlias = sslconfig.FakeKeyStore.TrustedAlias
-  val DistinguishedName = sslconfig.FakeKeyStore.DistinguishedName
-  val SignatureAlgorithmName = sslconfig.FakeKeyStore.SignatureAlgorithmName
-  val SignatureAlgorithmOID: ObjectIdentifier = sslconfig.FakeKeyStore.SignatureAlgorithmOID
-
-  object CertificateAuthority {
-    val ExportedCertificate = sslconfig.FakeKeyStore.CertificateAuthority.ExportedCertificate
-    val TrustedAlias = sslconfig.FakeKeyStore.CertificateAuthority.TrustedAlias
-    val DistinguishedName = sslconfig.FakeKeyStore.CertificateAuthority.DistinguishedName
-  }
+  val GeneratedKeyStore: String = sslconfig.FakeKeyStore.KeystoreSettings.GeneratedKeyStore
+  val TrustedAlias = sslconfig.FakeKeyStore.SelfSigned.Alias.trustedCertEntry
+  val DistinguishedName = sslconfig.FakeKeyStore.SelfSigned.DistinguishedName
+  val SignatureAlgorithmName = sslconfig.FakeKeyStore.KeystoreSettings.SignatureAlgorithmName
+  val SignatureAlgorithmOID: ObjectIdentifier = sslconfig.FakeKeyStore.KeystoreSettings.SignatureAlgorithmOID
 
   /**
    * @param appPath a file descriptor to the root folder of the project (the root, not a particular module).

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
@@ -1,7 +1,11 @@
 # runs the devmode and checks that a generated-keystore file is created
+
+# A clean is required to ensure no `target/` folder exists with an obsolete keystore
+> clean
 > run -Dhttps.port=9443
+## an HTTP request to a relative path. The `makeRequest` implementation uses https://localhost:9443 hardcoded
 > makeRequest / 200
 
 # keystore file was generated
-$ exists target/dev-mode/generated.keystore
+$ exists target/dev-mode/selfsigned.keystore
 > playStop


### PR DESCRIPTION
This change reverts the use of CA+userCert on dev mode and falls back to using a self-signed certificate.