### PR TITLE
Remove dead code

### DIFF
--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -10,6 +10,10 @@ Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]
 Therefore the `args` map of a `Http.Context` instance no longer contains these removed request tags as well.
 Instead you can use the `contextObj.request().attrs()` method now, which provides you the equivalent request attributes.
 
+### CSRF tokens removed from `args`
+
+The `@AddCSRFToken` action annotation added two entries named `CSRF_TOKEN` and `CSRF_TOKEN_NAME` to the `args` map of a `Http.Context` instance. These entries have been removed.
+
 ### `Http.Response` deprecated
 
 `Http.Response` was deprecated with other accesses methods to it. It was mainly used to add headers and cookies, but these are already available in `play.mvc.Result` and then the API got a little confused. For Play 2.7, you should migrate code like:

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -13,7 +13,7 @@ Instead you can use the `contextObj.request().attrs()` method now, which provide
 ### CSRF tokens removed from `args`
 
 The `@AddCSRFToken` action annotation added two entries named `CSRF_TOKEN` and `CSRF_TOKEN_NAME` to the `args` map of a `Http.Context` instance. These entries have been removed.
-Alternative methods of getting the token can be found [[here|JavaCsrf#Getting-the-current-token]].
+Use an [[alternative method of getting the token|JavaCsrf#Getting-the-current-token]].
 
 ### `Http.Response` deprecated
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -13,6 +13,7 @@ Instead you can use the `contextObj.request().attrs()` method now, which provide
 ### CSRF tokens removed from `args`
 
 The `@AddCSRFToken` action annotation added two entries named `CSRF_TOKEN` and `CSRF_TOKEN_NAME` to the `args` map of a `Http.Context` instance. These entries have been removed.
+Alternative methods of getting the token can be found [[here|JavaCsrf#Getting-the-current-token]].
 
 ### `Http.Response` deprecated
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -13,7 +13,7 @@ Instead you can use the `contextObj.request().attrs()` method now, which provide
 ### CSRF tokens removed from `args`
 
 The `@AddCSRFToken` action annotation added two entries named `CSRF_TOKEN` and `CSRF_TOKEN_NAME` to the `args` map of a `Http.Context` instance. These entries have been removed.
-Use an [[alternative method of getting the token|JavaCsrf#Getting-the-current-token]].
+Use [[the new correct way to get the token|JavaCsrf#Getting-the-current-token]].
 
 ### `Http.Response` deprecated
 

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -35,9 +35,6 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 
     private final CSRF.Token$ Token = CSRF.Token$.MODULE$;
 
-    private static final String CSRF_TOKEN = "CSRF_TOKEN";
-    private static final String CSRF_TOKEN_NAME = "CSRF_TOKEN_NAME";
-
     @Override
     public CompletionStage<Result> call(Http.Context ctx) {
 
@@ -50,10 +47,6 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
         if (helper.getTokenToValidate(request).isEmpty()) {
             // No token in header and we have to create one if not found, so create a new token
             CSRF.Token newToken = helper.generateToken();
-
-            // Place this token into the context
-            ctx.args.put(CSRF_TOKEN, newToken.value());
-            ctx.args.put(CSRF_TOKEN_NAME, newToken.name());
 
             // Create a new Scala RequestHeader with the token
             request = helper.tagRequest(request, newToken);


### PR DESCRIPTION
I don't know why we put the csrf token in context args. Doesn't make any sense. Also it's Java API only.