### PR TITLE
Deprecate Http.Context.flash method

### DIFF
--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -280,3 +280,74 @@ public class FooController extends Controller {
     }
 }
 ```
+
+### `Http.Context.flash()` deprecated
+
+That means other methods that depend directly on it were also deprecated:
+
+1. `play.mvc.Controller.flash()`
+1. `play.mvc.Controller.flash(String key, String value)`
+1. `play.mvc.Controller.flash(String key)`
+
+The new way to retrieve the flash of a request is the call the `flash()` method of a `Http.Request` instance.
+The new way to manipulate the flash is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
+
+#### Before
+
+```java
+import play.mvc.Result;
+import play.mvc.Results;
+import play.mvc.Controller;
+
+public class FooController extends Controller {
+    public Result info() {
+        String message = flash("message");
+        return Results.ok("Message: " + message);
+    }
+
+    public Result login() {
+        flash("message", "Login successful");
+        return Results.redirect("/dashboard");
+    }
+
+    public Result logout() {
+        flash().remove("message");
+        return Results.redirect("/");
+    }
+
+    public Result clear() {
+        flash().clear();
+        return Results.redirect("/");
+    }
+}
+```
+
+#### After
+
+```java
+import play.mvc.Result;
+import play.mvc.Results;
+import play.mvc.Controller;
+
+public class FooController extends Controller {
+    public Result info() {
+        String message = request().flash().get("message");
+        return Results.ok("Message: " + message);
+    }
+
+    public Result login() {
+        return Results.redirect("/dashboard")
+            .flashing("message", "Login successful");
+    }
+
+    public Result logout() {
+        return Results.redirect("/")
+            .removingFromFlash("message");
+    }
+
+    public Result clear() {
+        return Results.redirect("/")
+            .withNewFlash();
+    }
+}
+```

--- a/documentation/manual/working/commonGuide/configuration/code/detailedtopics/httpec/MyController.java
+++ b/documentation/manual/working/commonGuide/configuration/code/detailedtopics/httpec/MyController.java
@@ -24,9 +24,7 @@ public class MyController extends Controller {
     public CompletionStage<Result> index() {
         // Use a different task with explicit EC
         return calculateResponse().thenApplyAsync(answer -> {
-            // uses Http.Context
-            ctx().flash().put("info", "Response updated!");
-            return ok("answer was " + answer);
+            return ok("answer was " + answer).flashing("info", "Response updated!");
         }, httpExecutionContext.current());
     }
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -79,7 +79,7 @@ public class JavaSessionFlash extends WithApplication {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-flash
                     public Result index() {
-                        String message = flash("success");
+                        String message = request().flash().get("success");
                         if(message == null) {
                             message = "Welcome!";
                         }
@@ -95,8 +95,7 @@ public class JavaSessionFlash extends WithApplication {
         Flash flash = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#store-flash
             public Result save() {
-                flash("success", "The item has been created");
-                return redirect("/home");
+                return redirect("/home").flashing("success", "The item has been created");
             }
             //#store-flash
         }, fakeRequest(), mat).flash();

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -50,8 +50,7 @@ public class JavaFileUpload extends WithApplication {
                 File file = picture.getFile();
                 return ok("File uploaded");
             } else {
-                flash("error", "Missing file");
-                return badRequest();
+                return badRequest().flashing("error", "Missing file");
             }
         }
         //#syncUpload

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -671,7 +671,10 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.test.Helpers.stubMessagesApi$default$6"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.stubMessagesApi"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.test.StubMessagesFactory.stubMessagesApi$default$6"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.StubMessagesFactory.stubMessagesApi")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.StubMessagesFactory.stubMessagesApi"),
+
+      // Add companion for play.api.mvc.Result
+      ProblemFilters.exclude[MissingTypesProblem]("play.api.mvc.Result$")
   ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play/src/main/java/play/mvc/Controller.java
+++ b/framework/src/play/src/main/java/play/mvc/Controller.java
@@ -145,7 +145,10 @@ public abstract class Controller extends Results implements Status, HeaderNames 
      * Returns the current HTTP flash scope.
      *
      * @return the flash scope
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link Request#flash()} and {@link Result} instead.
      */
+    @Deprecated
     public static Flash flash() {
         return Http.Context.current().flash();
     }
@@ -155,7 +158,10 @@ public abstract class Controller extends Results implements Status, HeaderNames 
      *
      * @param key the key to put into the flash scope
      * @param value the value corresponding to <code>key</code>
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
      */
+    @Deprecated
     public static void flash(String key, String value) {
         flash().put(key, value);
     }
@@ -165,7 +171,10 @@ public abstract class Controller extends Results implements Status, HeaderNames 
      *
      * @param key the key to look up in the flash scope
      * @return the value corresponding to <code>key</code> from the flash scope, or null if there was none
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
      */
+    @Deprecated
     public static String flash(String key) {
         return flash().get(key);
     }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -241,7 +241,10 @@ public class Http {
          * Returns the current flash scope.
          *
          * @return the flash scope
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link Request#flash()} and {@link Result} instead.
          */
+        @Deprecated
         public Flash flash() {
             return flash;
         }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -103,7 +103,7 @@ public class Http {
             this.id = this.request.asScala().id();
             this.response = new Response();
             this.session = new Session(this.request.session());
-            this.flash = new Flash(Scala.asJava(this.request.asScala().flash().data()));
+            this.flash = new Flash(this.request.flash());
             this.args = new HashMap<>();
             this.components = components;
         }
@@ -828,6 +828,14 @@ public class Http {
          */
         default Session session() {
             return attrs().get(RequestAttrKey.Session().asJava()).value().asJava();
+        }
+
+        /**
+         * Parses the Flash cookie and returns the Flash data. The request's flash cookie is stored in an attribute indexed by
+         * {@link RequestAttrKey#Flash()}}. The attribute uses a {@link Cell} to store the flash, to allow it to be evaluated on-demand.
+         */
+        default Flash flash() {
+            return attrs().get(RequestAttrKey.Flash().asJava()).value().asJava();
         }
 
         /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2092,6 +2092,15 @@ public class Http {
             super.clear();
         }
 
+        /**
+         * Convert this flash to a Scala flash.
+         *
+         * @return the Scala flash.
+         */
+        public play.api.mvc.Flash asScala() {
+            return new play.api.mvc.Flash(Scala.asScala(this));
+        }
+
     }
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -230,6 +230,84 @@ public class Result {
     }
 
     /**
+     * Sets a new flash for this result, discarding the existing flash.
+     *
+     * @param flash the flash to set with this result
+     * @return the new result
+     */
+    public Result withFlash(Flash flash) {
+        play.api.mvc.Result.warnFlashingIfNotRedirect(flash.asScala(), header.asScala());
+        return new Result(header, body, session, flash, cookies);
+    }
+
+    /**
+     * Sets a new flash for this result, discarding the existing flash.
+     *
+     * @param flash the flash to set with this result
+     * @return the new result
+     */
+    public Result withFlash(Map<String, String> flash) {
+        return withFlash(new Flash(flash));
+    }
+
+    /**
+     * Discards the existing flash for this result.
+     *
+     * @return the new result
+     */
+    public Result withNewFlash() {
+        return withFlash(Collections.emptyMap());
+    }
+
+    /**
+     * Adds values to the flash.
+     *
+     * @param values A map with values to add to this result’s flash
+     * @return A copy of this result with values added to its flash scope.
+     */
+    public Result flashing(Map<String, String> values) {
+        if(this.flash == null) {
+            return withFlash(values);
+        } else {
+            Map<String, String> newValues = new HashMap<>(this.flash);
+            newValues.putAll(values);
+            return withFlash(newValues);
+        }
+    }
+
+    /**
+     * Adds the given key and value to the flash.
+     *
+     * @param key The key to add to this result’s flash
+     * @param value The value to add to this result’s flash
+     * @return A copy of this result with the key and value added to its flash scope.
+     */
+    public Result flashing(String key, String value) {
+        Map<String, String> newValues = new HashMap<>(1);
+        newValues.put(key, value);
+        return flashing(newValues);
+    }
+
+    /**
+     * Removes values from the flash.
+     *
+     * @param keys Keys to remove from flash
+     * @return A copy of this result with keys removed from its flash scope.
+     */
+    public Result removingFromFlash(String... keys) {
+        if(this.flash == null) {
+            return withNewFlash();
+        }
+        Map<String, String> newValues = new HashMap<>(this.flash);
+        if(keys != null) {
+            for (String key : keys) {
+                newValues.remove(key);
+            }
+        }
+        return withFlash(newValues);
+    }
+
+    /**
      * Extracts the Session of this Result value.
      *
      * @return the session (if it was set)

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -113,7 +113,7 @@ object Flash extends CookieBaker[Flash] with UrlEncodedCookieDataCodec {
 
   val emptyCookie = new Flash
 
-  def fromJavaFlash(javaFlash: play.mvc.Http.Flash): Flash = new Flash(javaFlash.asScala.toMap)
+  def fromJavaFlash(javaFlash: play.mvc.Http.Flash): Flash = javaFlash.asScala
 
   @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
   override val isSigned: Boolean = false

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -222,7 +222,7 @@ trait RequestHeader {
 
   /**
    * Parses the `Flash` cookie and returns the `Flash` data. The request's flash cookie is stored in an attribute indexed by
-   * [[play.api.mvc.request.RequestAttrKey.Flash]]. The attribute uses a [[play.api.mvc.request.Cell]] to store the session, to allow it to be evaluated on-demand.
+   * [[play.api.mvc.request.RequestAttrKey.Flash]]. The attribute uses a [[play.api.mvc.request.Cell]] to store the flash, to allow it to be evaluated on-demand.
    */
   def flash: Flash = attrs(RequestAttrKey.Flash).value
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -144,13 +144,13 @@ trait JavaHelpers {
       .withCookies(cookiesToScalaCookies(javaContext.response.cookies): _*)
 
     if (javaContext.session.isDirty && javaContext.flash.isDirty) {
-      wResult.withSession(javaContext.session.asScala).flashing(Flash(javaContext.flash.asScala.toMap))
+      wResult.withSession(javaContext.session.asScala).flashing(javaContext.flash.asScala)
     } else {
       if (javaContext.session.isDirty) {
         wResult.withSession(javaContext.session.asScala)
       } else {
         if (javaContext.flash.isDirty) {
-          wResult.flashing(Flash(javaContext.flash.asScala.toMap))
+          wResult.flashing(javaContext.flash.asScala)
         } else {
           wResult
         }


### PR DESCRIPTION
This is basically the same as what #8687 was for session.

What was called `addingToSession` is called `flashing` here however (and not `addingToFlash`) to keep naming consistent with the Scala Flash API.
Also that `flashing` does not take a request (like `addingToSession` did), because we don't care about an existing flash in a request - we do not want to send it back to the client. (A flash is only short-lifed between two requests, unlike a session). Therefore `flashing` simply creates a new flash if there isn't one instead of using the `requests` flash.


Ready for review.