### PR TITLE
Move ServerEndpoint to play.core.server

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -14,6 +14,7 @@ import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
 import play.api.test._
+import play.core.server.ServerEndpoint
 import play.it.test.{ EndpointIntegrationSpecification, OkHttpEndpointSupport }
 
 import scala.collection.JavaConverters

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
@@ -10,7 +10,8 @@ import play.api.BuiltInComponents
 import play.api.mvc._
 import play.api.routing.Router
 import play.api.routing.sird
-import play.api.test.{ ApplicationFactories, PlaySpecification, ServerEndpoint }
+import play.api.test.{ ApplicationFactories, PlaySpecification }
+import play.core.server.ServerEndpoint
 import play.it.test._
 
 class UriHandlingSpec extends PlaySpecification with EndpointIntegrationSpecification with OkHttpEndpointSupport with ApplicationFactories {

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -39,7 +39,7 @@ trait EndpointIntegrationSpecification
     def withEndpoints[A: AsResult](endpoints: Seq[ServerEndpointRecipe])(block: ServerEndpoint => A): Fragment = {
       endpoints.map { endpointRecipe: ServerEndpointRecipe =>
         s"with ${endpointRecipe.description}" >> {
-          ServerEndpoint.withEndpoint(endpointRecipe, appFactory)(block)
+          ServerEndpointRecipe.withEndpoint(endpointRecipe, appFactory)(block)
         }
       }.last
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -8,7 +8,8 @@ import org.specs2.execute.{ AsResult, PendingUntilFixed, Result, ResultExecution
 import org.specs2.mutable.SpecLike
 import org.specs2.specification.core.Fragment
 
-import play.api.test.{ ApplicationFactory, ApplicationFactories, ServerEndpoint, ServerEndpointRecipe }
+import play.api.test.{ ApplicationFactories, ApplicationFactory, ServerEndpointRecipe }
+import play.core.server.ServerEndpoint
 
 /**
  * Mixin class for integration tests that want to run over different

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -9,7 +9,8 @@ import javax.net.ssl.{ HostnameVerifier, SSLSession }
 import okhttp3.{ OkHttpClient, Request, Response }
 import org.specs2.execute.AsResult
 import org.specs2.specification.core.Fragment
-import play.api.test.{ ApplicationFactory, ServerEndpoint, ServerEndpointRecipe }
+import play.api.test.{ ApplicationFactory, ServerEndpointRecipe }
+import play.core.server.ServerEndpoint
 
 /**
  * Provides a similar interface to [[play.api.test.WsTestClient]], but

--- a/framework/src/play-integration-test/src/test/scala/play/it/test/WSEndpointSupport.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/test/WSEndpointSupport.scala
@@ -16,7 +16,8 @@ import play.api.Configuration
 import play.api.libs.ws.ahc.{ AhcWSClient, AhcWSClientConfig }
 import play.api.libs.ws.{ WSClient, WSClientConfig, WSRequest, WSResponse }
 import play.api.mvc.Call
-import play.api.test.{ ApplicationFactory, DefaultAwaitTimeout, FutureAwaits, ServerEndpoint }
+import play.api.test.{ ApplicationFactory, DefaultAwaitTimeout, FutureAwaits }
+import play.core.server.ServerEndpoint
 
 import scala.annotation.implicitNotFound
 import scala.concurrent.duration.Duration

--- a/framework/src/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/framework/src/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -48,7 +48,7 @@ class HelloWorldBenchmark {
       case "ak-20-enc" => ServerEndpointRecipe.AkkaHttp20Encrypted
 
     }
-    val startResult = ServerEndpoint.startEndpoint(endpointRecipe, appFactory)
+    val startResult = ServerEndpointRecipe.startEndpoint(endpointRecipe, appFactory)
     serverEndpoint = startResult._1
     endpointCloseable = startResult._2
   }

--- a/framework/src/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/framework/src/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -9,7 +9,8 @@ import java.util.concurrent.TimeUnit
 import okhttp3.{ OkHttpClient, Protocol, Request, Response }
 import org.openjdk.jmh.annotations._
 import play.api.mvc.Results
-import play.api.test.{ ApplicationFactory, ServerEndpoint, ServerEndpointRecipe }
+import play.api.test.{ ApplicationFactory, ServerEndpointRecipe }
+import play.core.server.ServerEndpoint
 import play.microbenchmark.it.HelloWorldBenchmark.ThreadState
 
 import scala.util.Random

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package play.api.test
+package play.core.server
 
 import java.security.KeyStore
 import javax.net.ssl._
@@ -11,9 +11,8 @@ import com.typesafe.sslconfig.ssl.{ FakeKeyStore, FakeSSLTools }
 
 import akka.annotation.ApiMayChange
 
-import play.api.test.ServerEndpoint.ClientSsl
 import play.core.ApplicationProvider
-import play.core.server.ServerConfig
+import play.core.server.ServerEndpoint.ClientSsl
 import play.server.api.SSLEngineProvider
 
 /**

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerEndpoints.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerEndpoints.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package play.api.test
+package play.core.server
 
 import akka.annotation.ApiMayChange
 

--- a/framework/src/play-test/src/main/scala/play/api/test/RunningServer.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/RunningServer.scala
@@ -7,6 +7,7 @@ package play.api.test
 import akka.annotation.ApiMayChange
 
 import play.api.Application
+import play.core.server.ServerEndpoints
 
 /**
  * Contains information about a running TestServer. This object can be

--- a/framework/src/play-test/src/main/scala/play/api/test/ServerEndpoint.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/ServerEndpoint.scala
@@ -94,11 +94,6 @@ import scala.util.control.NonFatal
     }
   }
 
-  def withEndpoint[A](endpointRecipe: ServerEndpointRecipe, appFactory: ApplicationFactory)(block: ServerEndpoint => A): A = {
-    val (endpoint, endpointCloseable) = startEndpoint(endpointRecipe, appFactory)
-    try block(endpoint) finally endpointCloseable.close()
-  }
-
   /**
    * An SSLEngineProvider which simply references the values in the
    * SelfSigned object.

--- a/framework/src/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -48,7 +48,7 @@ import scala.util.control.NonFatal
    * can be queried to create an endpoint. Usually this just involves asking
    * the server what port it is using.
    */
-  def createEndpointFromServer(runningTestServer: play.api.test.TestServer): ServerEndpoint
+  def createEndpointFromServer(runningTestServer: TestServer): ServerEndpoint
 
 }
 
@@ -65,7 +65,7 @@ import scala.util.control.NonFatal
   override val configuredHttpsPort: Option[Int] = None
   override val serverConfiguration: Configuration = extraServerConfiguration
 
-  override def createEndpointFromServer(runningServer: play.api.test.TestServer): ServerEndpoint = {
+  override def createEndpointFromServer(runningServer: TestServer): ServerEndpoint = {
     ServerEndpoint(
       description = recipe.description,
       scheme = "http",
@@ -99,7 +99,7 @@ import scala.util.control.NonFatal
     "play.server.https.engineProvider" -> classOf[ServerEndpoint.SelfSignedSSLEngineProvider].getName
   ) ++ extraServerConfiguration
 
-  override def createEndpointFromServer(runningServer: play.api.test.TestServer): ServerEndpoint = {
+  override def createEndpointFromServer(runningServer: TestServer): ServerEndpoint = {
     ServerEndpoint(
       description = recipe.description,
       scheme = "https",
@@ -161,9 +161,7 @@ import scala.util.control.NonFatal
     }
 
     // Initialize and start the TestServer
-    val testServer: play.api.test.TestServer = new play.api.test.TestServer(
-      serverConfig, application, Some(endpointRecipe.serverProvider)
-    )
+    val testServer = new TestServer(serverConfig, application, Some(endpointRecipe.serverProvider))
 
     val runSynchronized = application.globalApplicationEnabled
     if (runSynchronized) {

--- a/framework/src/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -7,8 +7,8 @@ package play.api.test
 import akka.annotation.ApiMayChange
 
 import play.api.{ Application, Configuration, Mode }
-import play.api.test.ServerEndpoint.ClientSsl
-import play.core.server.{ AkkaHttpServer, NettyServer, ServerConfig, ServerProvider }
+import play.core.server.ServerEndpoint.ClientSsl
+import play.core.server.{ AkkaHttpServer, NettyServer, ServerConfig, ServerEndpoint, ServerProvider }
 
 import scala.util.control.NonFatal
 

--- a/framework/src/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -15,7 +15,7 @@ import play.core.server.{ AkkaHttpServer, NettyServer, ServerProvider }
  * when describing which tests to run. The recipe can be used to start
  * servers with the correct [[ServerEndpoint]]s.
  *
- * @see [[ServerEndpoint.withEndpoint()]]
+ * @see [[ServerEndpointRecipe.withEndpoint()]]
  */
 @ApiMayChange sealed trait ServerEndpointRecipe {
 
@@ -137,4 +137,10 @@ import play.core.server.{ AkkaHttpServer, NettyServer, ServerProvider }
     AkkaHttp11Encrypted,
     AkkaHttp20Encrypted
   )
+
+  def withEndpoint[A](endpointRecipe: ServerEndpointRecipe, appFactory: ApplicationFactory)(block: ServerEndpoint => A): A = {
+    val (endpoint, endpointCloseable) = ServerEndpoint.startEndpoint(endpointRecipe, appFactory)
+    try block(endpoint) finally endpointCloseable.close()
+  }
+
 }

--- a/framework/src/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -6,9 +6,11 @@ package play.api.test
 
 import akka.annotation.ApiMayChange
 
-import play.api.Configuration
+import play.api.{ Application, Configuration, Mode }
 import play.api.test.ServerEndpoint.ClientSsl
-import play.core.server.{ AkkaHttpServer, NettyServer, ServerProvider }
+import play.core.server.{ AkkaHttpServer, NettyServer, ServerConfig, ServerProvider }
+
+import scala.util.control.NonFatal
 
 /**
  * A recipe for making a [[ServerEndpoint]]. Recipes are often used
@@ -138,8 +140,56 @@ import play.core.server.{ AkkaHttpServer, NettyServer, ServerProvider }
     AkkaHttp20Encrypted
   )
 
+  /**
+   * Starts a server by following a [[ServerEndpointRecipe]] and using the
+   * application provided by an [[ApplicationFactory]]. The server's endpoint
+   * is passed to the given `block` of code.
+   */
+  def startEndpoint[A](endpointRecipe: ServerEndpointRecipe, appFactory: ApplicationFactory): (ServerEndpoint, AutoCloseable) = {
+    val application: Application = appFactory.create()
+
+    // Create a ServerConfig with dynamic ports and using a self-signed certificate
+    val serverConfig = {
+      val sc: ServerConfig = ServerConfig(
+        port = endpointRecipe.configuredHttpPort,
+        sslPort = endpointRecipe.configuredHttpsPort,
+        mode = Mode.Test,
+        rootDir = application.path
+      )
+      val patch = endpointRecipe.serverConfiguration
+      sc.copy(configuration = sc.configuration ++ patch)
+    }
+
+    // Initialize and start the TestServer
+    val testServer: play.api.test.TestServer = new play.api.test.TestServer(
+      serverConfig, application, Some(endpointRecipe.serverProvider)
+    )
+
+    val runSynchronized = application.globalApplicationEnabled
+    if (runSynchronized) {
+      PlayRunners.mutex.lock()
+    }
+    val stopEndpoint = new AutoCloseable {
+      override def close(): Unit = {
+        testServer.stop()
+        if (runSynchronized) {
+          PlayRunners.mutex.unlock()
+        }
+      }
+    }
+    try {
+      testServer.start()
+      val endpoint: ServerEndpoint = endpointRecipe.createEndpointFromServer(testServer)
+      (endpoint, stopEndpoint)
+    } catch {
+      case NonFatal(e) =>
+        stopEndpoint.close()
+        throw e
+    }
+  }
+
   def withEndpoint[A](endpointRecipe: ServerEndpointRecipe, appFactory: ApplicationFactory)(block: ServerEndpoint => A): A = {
-    val (endpoint, endpointCloseable) = ServerEndpoint.startEndpoint(endpointRecipe, appFactory)
+    val (endpoint, endpointCloseable) = startEndpoint(endpointRecipe, appFactory)
     try block(endpoint) finally endpointCloseable.close()
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

 # Helpful things

 ## Purpose

Moves `ServerEndpoint{,s}` to `play.core.server`, from `play.api.test`.

Subset of #8689