### PR TITLE
Bumps ssl-config to 0.3.6

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val akkaHttpVersion = "10.1.5"
   val akkaHttpVersion_2_13 = "10.1.3" // akka-http dropped support for Scala 2.13: https://github.com/akka/akka-http/issues/2166
 
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.5"
+  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.6"
 
   val playJsonVersion = "2.6.10"
 


### PR DESCRIPTION
`0.3.5` defaulted to `PKCS12` format for the auto-generated key stores. The `ssl-config` library doesn't support setting the trustStore password which is required in `PKCS12` format to read the trusted certificates. As a consequence generated stores could not be used as truststores.