### PR TITLE
Merge the ctx's flash/session with the result ones

### DIFF
--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -144,13 +144,14 @@ trait JavaHelpers {
       .withCookies(cookiesToScalaCookies(javaContext.response.cookies): _*)
 
     if (javaContext.session.isDirty && javaContext.flash.isDirty) {
-      wResult.withSession(javaContext.session.asScala).flashing(javaContext.flash.asScala)
+      wResult.withSession(Session(wResult.newSession.map(_.data).getOrElse(Map.empty) ++ javaContext.session.asScala.data))
+        .flashing(Flash(wResult.newFlash.map(_.data).getOrElse(Map.empty) ++ javaContext.flash.asScala.data))
     } else {
       if (javaContext.session.isDirty) {
-        wResult.withSession(javaContext.session.asScala)
+        wResult.withSession(Session(wResult.newSession.map(_.data).getOrElse(Map.empty) ++ javaContext.session.asScala.data))
       } else {
         if (javaContext.flash.isDirty) {
-          wResult.flashing(javaContext.flash.asScala)
+          wResult.flashing(Flash(wResult.newFlash.map(_.data).getOrElse(Map.empty) ++ javaContext.flash.asScala.data))
         } else {
           wResult
         }


### PR DESCRIPTION
This is a follow-up to #8687 and #8688.

The scala `Result` methods `wResult.withSession(somevalue)` and `wResult.flashing(somevalue)` do **not** preserve any data - these methods will simply replace it's current `session` and `flash` data, replacing it with `somevalue`.
However we do want to preserve the results' session and flash data when creating the *final* result, like we do for headers and cookies just two lines above:
https://github.com/playframework/playframework/blob/f38e65a2e95e61883069a8cee170e72a2a873668/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala#L143-L144

`withHeaders` and `withCookies` here **do** preserve existing data.