### PR TITLE
Assign content type when specific `withXXXBody` methods are called.

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -16,7 +16,6 @@ import play.api.mvc._
 import play.api.mvc.request._
 import play.core.parsers.FormUrlEncodedParser
 
-import scala.concurrent.Future
 import scala.xml.NodeSeq
 
 /**
@@ -98,21 +97,21 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
    * Adds a JSON body to the request.
    */
   def withJsonBody(json: JsValue): FakeRequest[AnyContentAsJson] = {
-    withBody(body = AnyContentAsJson(json))
+    withBody(body = AnyContentAsJson(json)).withHeaders(HeaderNames.CONTENT_TYPE -> Helpers.JSON)
   }
 
   /**
    * Adds an XML body to the request.
    */
   def withXmlBody(xml: NodeSeq): FakeRequest[AnyContentAsXml] = {
-    withBody(body = AnyContentAsXml(xml))
+    withBody(body = AnyContentAsXml(xml)).withHeaders(HeaderNames.CONTENT_TYPE -> Helpers.XML)
   }
 
   /**
    * Adds a text body to the request.
    */
   def withTextBody(text: String): FakeRequest[AnyContentAsText] = {
-    withBody(body = AnyContentAsText(text))
+    withBody(body = AnyContentAsText(text)).withHeaders(HeaderNames.CONTENT_TYPE -> Helpers.TEXT)
   }
 
   /**

--- a/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -9,6 +9,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.specs2.mutable._
+import play.api.libs.json.Json
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.test.Helpers._
@@ -148,6 +149,14 @@ class HelpersSpec extends Specification {
       "return an empty map when there is no query string parameters" in {
         val request = FakeRequest("GET", "/uri", FakeHeaders(), AnyContentAsEmpty)
         request.queryString must beEmpty
+      }
+      "have application/json Content-Type when withJsonBody is called" in {
+        val request = FakeRequest().withJsonBody(Json.obj())
+        request.contentType must beSome(JSON)
+      }
+      "have application/json Content-Type when withJsonBody is called with explicit headers [compatibility check]" in {
+        val request = FakeRequest().withJsonBody(Json.obj()).withHeaders(CONTENT_TYPE -> JSON)
+        request.contentType must beSome(JSON)
       }
     }
   }


### PR DESCRIPTION
## Fixes

Fixes #7878 

## Purpose

Enhances `FakeRequest` with assigning proper `Content-Type` for specific `withXXXBody` methods.

## Background Context

Simplify API testing.
