### PR TITLE
Remove redundant backtick from ScalaDoc

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPProcessor.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPProcessor.scala
@@ -16,7 +16,7 @@ import play.api.mvc.request.RequestAttrKey
  */
 trait CSPProcessor {
   /**
-   * Inspects the request header, and returns a CSPResult iff the
+   * Inspects the request header, and returns a CSPResult if the
    * request should be subject to CSP processing.
    *
    * If the request header has a CSP Nonce already defined,

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
@@ -30,7 +30,7 @@ object CSPResultProcessor {
  * depending on config.reportOnly.
  *
  * If `cspResult.nonceHeader` is defined then
- * `play.api.http.HeaderNames.X_CONTENT_SECURITY_POLICY_NONCE_HEADER``
+ * `play.api.http.HeaderNames.X_CONTENT_SECURITY_POLICY_NONCE_HEADER`
  * is set as an additional header.
  */
 class DefaultCSPResultProcessor @Inject() (cspProcessor: CSPProcessor)


### PR DESCRIPTION
## Purpose

Remove redundant backtick (`) from ScalaDoc
