### PR TITLE
Fix HttpErrorHandlerSpec and make JsonHttpErrorHandler injectable

### DIFF
--- a/framework/src/play/src/main/java/play/http/JsonHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/JsonHttpErrorHandler.java
@@ -44,6 +44,11 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
 
     @Override
     public CompletionStage<Result> onClientError(RequestHeader request, int statusCode, String message) {
+        if (!play.api.http.Status$.MODULE$.isClientError(statusCode)) {
+            throw new IllegalArgumentException(
+                "onClientError invoked with non client error status code " + statusCode + ": " + message);
+        }
+
         ObjectNode result = Json.newObject();
         result.put("requestId", request.asScala().id());
         result.put("message", message);


### PR DESCRIPTION
I noticed that we are not actually running the `HttpErrorHandlerSpec`, because an exception was happening while the class was being constructed. We actually get an error like:

```
[trace] Stack trace suppressed: run last Play-Guice/test:testOnly for the full output.
```
but it doesn't actually fail the test.

I changed the test so that it actually fails, which led to discovering some issues, including that `JsonHttpErrorHandler` is not injectable using runtime DI. I fixed those issues as well in this pull request.

Ideally we also should fail the build if a spec fails on initialization.