### PR TITLE
Update Text Body Parser with US-ASCII as default charset

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -397,3 +397,9 @@ CoordinatedShutdown.get(actorSystem).run(reason, runFromPhase);
 ## Change in self-signed HTTPS certificate
 
 It is now generated under `target/dev-mode/generated.keystore` instead of directly on the root folder.
+
+## Change in default character set on "text/plain" Content Types
+
+The Text and Tolerant Text body parsers now use "US-ASCII" as the default charset, replacing the previous default of `ISO-8859-1`.
+
+This is because of some newer HTTP standards, specifically [RFC 7231, appendix B](https://tools.ietf.org/html/rfc7231#appendix-B), which states "The default charset of ISO-8859-1 for text media types has been removed; the default is now whatever the media type definition says."  The `text/plain` media type definition is defined by [RFC 6657, section 4](https://tools.ietf.org/html/rfc6657#section-4), which specifies US-ASCII.  The Text and Tolerant Text Body parsers use `text/plain` as the content type, so now default appropriately.

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -223,7 +223,9 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$X_CONTENT_SECURITY_POLICY_NONCE_HEADER_="),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.CONTENT_SECURITY_POLICY_REPORT_ONLY"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$CONTENT_SECURITY_POLICY_REPORT_ONLY_="),
-
+      
+      ProblemFilters.exclude[MissingTypesProblem]("play.mvc.BodyParser$Text"),
+        
       ProblemFilters.exclude[MissingFieldProblem]("play.mvc.Results.TODO"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Controller.TODO"),
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
@@ -34,9 +34,10 @@ class TextBodyParserSpec extends PlaySpecification {
       parse("bär", Some("text/plain; charset=iso-8859-1"), "iso-8859-1") must beRight("bär")
     }
 
-    "default to iso-8859-1 encoding" in new WithApplication() {
-      parse("bär", Some("text/plain"), "iso-8859-1") must beRight("bär")
-      parse("bär", None, "iso-8859-1") must beRight("bär")
+    "default to us-ascii encoding" in new WithApplication() {
+      parse("bär", Some("text/plain"), "us-ascii") must beRight("b?r")
+      parse("bär", None, "us-ascii") must beRight("b?r")
+      parse("bär", None, "us-ascii") must beRight("b?r")
     }
 
     "accept text/plain content type" in new WithApplication() {

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -313,7 +313,7 @@ public interface BodyParser<A> {
                     CharsetDecoder decoder = encodingToTry.newDecoder().onMalformedInput(CodingErrorAction.REPORT);
                     return F.Either.Right(decoder.decode(byteBuffer).toString());
                 } catch (CharacterCodingException e) {
-                    String msg = String.format("Parser tried to parse request %s as text body with charset %s, but it contains invalid characters!", request.asScala().id(), encodingToTry);
+                    String msg = String.format("Parser tried to parse request %s as text body with charset %s, but it contains invalid characters!", request.id(), encodingToTry);
                     logger.warn(msg);
                     return F.Either.Left(e);
                 } catch (Exception e) {

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -254,7 +254,7 @@ public interface BodyParser<A> {
 
         @Inject
         public Text(HttpConfiguration httpConfiguration, HttpErrorHandler errorHandler) {
-            super(httpConfiguration, errorHandler, "Error decoding text body");
+            super(httpConfiguration, errorHandler, "Error decoding text/plain body");
             this.errorHandler = errorHandler;
         }
 

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -248,7 +248,7 @@ public interface BodyParser<A> {
         private final HttpErrorHandler errorHandler;
 
         public Text(long maxLength, HttpErrorHandler errorHandler) {
-            super(maxLength, errorHandler, "Error decoding text body");
+            super(maxLength, errorHandler, "Error decoding text/plain body");
             this.errorHandler = errorHandler;
         }
 

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -273,7 +273,13 @@ public interface BodyParser<A> {
 
         @Override
         protected String parse(Http.RequestHeader request, ByteString bytes) throws Exception {
-            String charset = request.charset().orElse("ISO-8859-1");
+            // Per RFC 7231:
+            // The default charset of ISO-8859-1 for text media types has been removed; the default is now
+            // whatever the media type definition says.
+            // Per RFC 6657:
+            // The default "charset" parameter value for "text/plain" is unchanged from [RFC2046] and remains as "US-ASCII".
+            // https://tools.ietf.org/html/rfc6657#section-4
+            String charset = request.charset().orElse("US-ASCII");
             return bytes.decodeString(charset);
         }
     }

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -282,7 +282,7 @@ public interface BodyParser<A> {
                 logger.warn(msg);
                 return bytes.decodeString(charset); // parse and return with unmappable characters.
             } catch (Exception e) {
-                String msg = "Unexpected exception!";
+                String msg = "Unexpected exception while parsing text/plain body";
                 logger.error(msg, e);
                 return bytes.decodeString(charset);
             }

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -278,7 +278,7 @@ public interface BodyParser<A> {
                 CharsetDecoder decoder = charset.newDecoder().onMalformedInput(CodingErrorAction.REPORT);
                 return decoder.decode(bytes.toByteBuffer()).toString();
             } catch (CharacterCodingException e) {
-                String msg = String.format("Parser tried to parse request %s as text body with charset %s, but it contains invalid characters!", request.asScala().id(), charset);
+                String msg = String.format("Parser tried to parse request %s as text body with charset %s, but it contains invalid characters!", request.id(), charset);
                 logger.warn(msg);
                 return bytes.decodeString(charset); // parse and return with unmappable characters.
             } catch (Exception e) {

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -9,6 +9,7 @@ import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
 import org.w3c.dom.Document;
 import play.api.http.HttpConfiguration;
 import play.api.http.Status$;
@@ -37,12 +38,17 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.*;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -235,17 +241,17 @@ public interface BodyParser<A> {
     /**
      * Parse the body as text if the Content-Type is text/plain.
      */
-    class Text extends TolerantText {
+    class Text extends BufferingBodyParser<String> {
         private final HttpErrorHandler errorHandler;
 
         public Text(long maxLength, HttpErrorHandler errorHandler) {
-            super(maxLength, errorHandler);
+            super(maxLength, errorHandler, "Error decoding text body");
             this.errorHandler = errorHandler;
         }
 
         @Inject
         public Text(HttpConfiguration httpConfiguration, HttpErrorHandler errorHandler) {
-            super(httpConfiguration, errorHandler);
+            super(httpConfiguration, errorHandler, "Error decoding text body");
             this.errorHandler = errorHandler;
         }
 
@@ -254,21 +260,6 @@ public interface BodyParser<A> {
             return BodyParsers.validateContentType(errorHandler, request, "Expected text/plain",
                 ct -> ct.equalsIgnoreCase("text/plain"), super::apply
             );
-        }
-    }
-
-    /**
-     * Parse the body as text without checking the Content-Type.
-     */
-    class TolerantText extends BufferingBodyParser<String> {
-
-        public TolerantText(long maxLength, HttpErrorHandler errorHandler) {
-            super(maxLength, errorHandler, "Error decoding text body");
-        }
-
-        @Inject
-        public TolerantText(HttpConfiguration httpConfiguration, HttpErrorHandler errorHandler) {
-            super(httpConfiguration, errorHandler, "Error decoding text body");
         }
 
         @Override
@@ -281,6 +272,66 @@ public interface BodyParser<A> {
             // https://tools.ietf.org/html/rfc6657#section-4
             String charset = request.charset().orElse("US-ASCII");
             return bytes.decodeString(charset);
+        }
+    }
+
+    /**
+     * Parse the body as text without checking the Content-Type.
+     */
+    class TolerantText extends BufferingBodyParser<String> {
+
+        private static final Logger logger = org.slf4j.LoggerFactory.getLogger(TolerantText.class);
+
+        public TolerantText(long maxLength, HttpErrorHandler errorHandler) {
+            super(maxLength, errorHandler, "Error decoding text body");
+        }
+
+        @Inject
+        public TolerantText(HttpConfiguration httpConfiguration, HttpErrorHandler errorHandler) {
+            super(httpConfiguration, errorHandler, "Error decoding text body");
+        }
+
+        @Override
+        protected String parse(Http.RequestHeader request, ByteString bytes) throws Exception {
+            ByteBuffer byteBuffer = bytes.toByteBuffer();
+            final Function<Charset, F.Either<Exception, String>> decode = (Charset encodingToTry) -> {
+                try {
+                    CharsetDecoder decoder = encodingToTry.newDecoder().onMalformedInput(CodingErrorAction.REPORT);
+                    return F.Either.Right(decoder.decode(byteBuffer).toString());
+                } catch (CharacterCodingException e) {
+                    String msg = String.format("Parser tried to parse request body with charset %s, but it contains invalid characters!", encodingToTry);
+                    logger.warn(msg);
+                    return F.Either.Left(e);
+                } catch (Exception e) {
+                    String msg = "Unexpected Exception!";
+                    logger.error(msg, e);
+                    return F.Either.Left(e);
+                }
+            };
+
+            // Run through a common set of encoders to get an idea of the best character encoding.
+
+            // Per RFC 7231:
+            // The default charset of ISO-8859-1 for text media types has been removed; the default is now
+            // whatever the media type definition says.
+            // Per RFC 6657:
+            // The default "charset" parameter value for "text/plain" is unchanged from [RFC2046] and remains as "US-ASCII".
+            // https://tools.ietf.org/html/rfc6657#section-4
+            Charset charset = Charset.forName(request.charset().orElse("US-ASCII"));
+            return decode.apply(charset).right.orElseGet(
+                    () -> {
+                        // Fallback to UTF-8 if user supplied charset doesn't work...
+                        return decode.apply(StandardCharsets.UTF_8).right.orElseGet(
+                                () -> {
+                                    // Fallback to ISO_8859_1 if UTF-8 doesn't decode right...
+                                    return decode.apply(StandardCharsets.ISO_8859_1).right.orElseGet(
+                                            () -> {
+                                                // We can't get a decent charset.
+                                                // Parse as US-ASCII, using ? for any untranslatable characters.
+                                                return bytes.decodeString(charset);
+                                            });
+                                });
+                    });
         }
     }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1182,13 +1182,13 @@ public class Http {
 
         /**
          * Set a Text to this request.
-         * The <tt>Content-Type</tt> header of the request is set to <tt>text/plain; charset=utf-8</tt>.
+         * The <tt>Content-Type</tt> header of the request is set to <tt>text/plain</tt>.
          *
-         * @param text the text, assumed to be encoded in UTF-8 format.
+         * @param text the text, assumed to be encoded in US_ASCII format, per https://tools.ietf.org/html/rfc6657#section-4
          * @return this builder, updated
          */
         public RequestBuilder bodyText(String text) {
-            return bodyText(text, StandardCharsets.UTF_8);
+            return body(new RequestBody(text), "text/plain");
         }
 
         /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -39,6 +39,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.*;
@@ -1180,13 +1182,25 @@ public class Http {
 
         /**
          * Set a Text to this request.
-         * The <tt>Content-Type</tt> header of the request is set to <tt>text/plain</tt>.
+         * The <tt>Content-Type</tt> header of the request is set to <tt>text/plain; charset=utf-8</tt>.
          *
-         * @param text the text
+         * @param text the text, assumed to be encoded in UTF-8 format.
          * @return this builder, updated
          */
         public RequestBuilder bodyText(String text) {
-            return body(new RequestBody(text), "text/plain");
+            return bodyText(text, StandardCharsets.UTF_8);
+        }
+
+        /**
+         * Set a Text to this request.
+         * The <tt>Content-Type</tt> header of the request is set to <tt>text/plain; charset=$charset</tt>.
+         *
+         * @param text the text, which is assumed to be already encoded in the format defined by charset.
+         * @param charset the character set that the request is encoded in.
+         * @return this builder, updated
+         */
+        public RequestBuilder bodyText(String text, Charset charset) {
+            return body(new RequestBody(text), "text/plain; charset=" + charset.name());
         }
 
         /**

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -472,8 +472,11 @@ trait PlayBodyParsers extends BodyParserUtils {
    */
   def tolerantText(maxLength: Long): BodyParser[String] = {
     tolerantBodyParser("text", maxLength, "Error decoding text body") { (request, bytes) =>
-      // Encoding notes: RFC-2616 section 3.7.1 mandates ISO-8859-1 as the default charset if none is specified.
-      bytes.decodeString(request.charset.getOrElse("ISO-8859-1"))
+      // Per RFC-7321, "The default charset of ISO-8859-1 for text media types has been removed; the default is now
+      // whatever the media type definition says." and
+      // The default "charset" parameter value for "text/plain" is unchanged from [RFC2046] and remains as "US-ASCII".
+      // https://tools.ietf.org/html/rfc6657#section-4
+      bytes.decodeString(request.charset.getOrElse("US-ASCII"))
     }
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -14,22 +14,22 @@ import java.util.Locale
 import javax.inject.Inject
 import akka.actor.ActorSystem
 import akka.stream._
-import akka.stream.scaladsl.{Flow, Sink, StreamConverters}
+import akka.stream.scaladsl.{ Flow, Sink, StreamConverters }
 import akka.stream.stage._
 import akka.util.ByteString
 import play.api._
 import play.api.data.Form
 import play.api.http.Status._
 import play.api.http._
-import play.api.libs.Files.{SingletonTemporaryFileCreator, TemporaryFile, TemporaryFileCreator}
+import play.api.libs.Files.{ SingletonTemporaryFileCreator, TemporaryFile, TemporaryFileCreator }
 import play.api.libs.json._
 import play.api.libs.streams.Accumulator
 import play.api.mvc.MultipartFormData._
 import play.core.parsers.Multipart
 import play.utils.PlayIO
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
 import scala.xml._
 

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -489,7 +489,7 @@ trait PlayBodyParsers extends BodyParserUtils {
           logger.warn(s"TolerantText body parser tried to parse request ${request.id} as text body with charset $encodingToTry, but it contains invalid characters!")
           Failure(e)
         case e: Exception =>
-          logger.error("Unexpected exception decoding document!", e)
+          logger.error("Unexpected exception while decoding text/plain body", e)
           Failure(e)
       }
     }

--- a/framework/src/play/src/test/scala/play/api/mvc/TextBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/TextBodyParserSpec.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc
+
+import java.nio.charset.{ Charset, StandardCharsets }
+import java.nio.charset.StandardCharsets.UTF_8
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.util.ByteString
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+import play.api.http.{ DefaultHttpErrorHandler, ParserConfiguration, Status }
+import play.api.libs.Files.SingletonTemporaryFileCreator
+import play.api.libs.streams.Accumulator
+import play.api.{ Configuration, Environment }
+import play.core.test.FakeRequest
+import play.libs.F
+import play.mvc.Http
+import play.mvc.Http.RequestBody
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future, Promise }
+import scala.util.{ Failure, Try }
+
+/**
+ *
+ */
+class TextBodyParserSpec extends Specification with AfterAll {
+
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+  val parse = PlayBodyParsers()
+
+  override def afterAll: Unit = {
+    system.terminate()
+  }
+
+  def tolerantParse(request: RequestHeader, byteString: ByteString) = {
+    val parser: BodyParser[String] = parse.tolerantText
+    Await.result(parser(request).run(Source.single(byteString)), Duration.Inf)
+  }
+
+  def strictParse(request: RequestHeader, byteString: ByteString) = {
+    val parser: BodyParser[String] = parse.text
+    Await.result(parser(request).run(Source.single(byteString)), Duration.Inf)
+  }
+
+  "Text Body Parser" should {
+    "parse text" >> {
+
+      "as UTF-8 if defined" in {
+        val body = ByteString("©".getBytes(UTF_8))
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain; charset=utf-8")
+        strictParse(postRequest, body) must beRight.like {
+          case text => text must beEqualTo("©")
+        }
+      }
+
+      "as the declared charset if defined" in {
+        // http://kunststube.net/encoding/
+        val charset = StandardCharsets.UTF_16
+        val body = ByteString("エンコーディングは難しくない".getBytes(charset))
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain; charset=utf-16")
+        strictParse(postRequest, body) must beRight.like {
+          case text =>
+            text must beEqualTo("エンコーディングは難しくない")
+        }
+      }
+
+      "as US-ASCII if not defined" in {
+        val body = ByteString("lorem ipsum")
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain")
+        strictParse(postRequest, body) must beRight.like {
+          case text => text must beEqualTo("lorem ipsum")
+        }
+      }
+
+      "as US-ASCII if not defined even if UTF-8 characters are provided" in {
+        val body = ByteString("©".getBytes(UTF_8))
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain")
+        strictParse(postRequest, body) must beRight.like {
+          case text => text must beEqualTo("��")
+        }
+      }
+    }
+  }
+
+  "TolerantText Body Parser" should {
+    "parse text" >> {
+
+      "as the declared charset if defined" in {
+        // http://kunststube.net/encoding/
+        val charset = StandardCharsets.UTF_16
+        val body = ByteString("エンコーディングは難しくない".getBytes(charset))
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain; charset=utf-16")
+        tolerantParse(postRequest, body) must beRight.like {
+          case text =>
+            text must beEqualTo("エンコーディングは難しくない")
+        }
+      }
+
+      "as US-ASCII if charset is not explicitly defined" in {
+        val body = ByteString("lorem ipsum")
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain")
+        tolerantParse(postRequest, body) must beRight.like {
+          case text => text must beEqualTo("lorem ipsum")
+        }
+      }
+
+      "as UTF-8 for undefined if ASCII encoding is insufficient" in {
+        // http://kermitproject.org/utf8.html
+        val body = ByteString("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ")
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain")
+        tolerantParse(postRequest, body) must beRight.like {
+          case text => text must beEqualTo("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ")
+        }
+      }
+
+      "as ISO-8859-1 for undefined if UTF-8 is insufficient" in {
+        val body = ByteString(0xa9) // copyright sign encoded with ISO-8859-1
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain")
+        tolerantParse(postRequest, body) must beRight.like {
+          case text => text must beEqualTo("©")
+        }
+      }
+
+      "as UTF-8 even if the guessed encoding is utterly wrong" in {
+        // This is not a full solution, so anything where we have a potentially valid encoding is seized on, even
+        // when it's not the best one.
+        val body = ByteString("エンコーディングは難しくない".getBytes(Charset.forName("Shift-JIS")))
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain")
+        tolerantParse(postRequest, body) must beRight.like {
+          case text =>
+            // utter gibberish, but we have no way of knowing the format.
+            text must beEqualTo("\u0083G\u0083\u0093\u0083R\u0081[\u0083f\u0083B\u0083\u0093\u0083O\u0082Í\u0093ï\u0082µ\u0082\u00AD\u0082È\u0082¢")
+        }
+      }
+    }
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/mvc/TextBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/TextBodyParserSpec.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.mvc
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.charset.{ Charset, StandardCharsets }
+import java.util.concurrent.CompletionStage
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.javadsl.Source
+import akka.util.ByteString
+import org.specs2.matcher.MustMatchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+import play.api.http.{ HttpConfiguration, ParserConfiguration }
+import play.http.HttpErrorHandler
+import play.libs.F
+import play.mvc.Http.RequestBody
+
+class TextBodyParserSpec extends Specification with AfterAll with MustMatchers {
+  "Java TextBodyParserSpec" title
+
+  implicit val system = ActorSystem("text-body-parser-spec")
+  implicit val materializer = ActorMaterializer()
+
+  def afterAll(): Unit = {
+    materializer.shutdown()
+    system.terminate()
+  }
+
+  val config = ParserConfiguration()
+  @inline def req(r: play.api.mvc.Request[Http.RequestBody]) = new Http.RequestImpl(r)
+
+  val httpConfiguration = HttpConfiguration()
+
+  val httpErrorHandler: HttpErrorHandler = new HttpErrorHandler {
+    override def onClientError(request: Http.RequestHeader, statusCode: Int, message: String): CompletionStage[Result] = ???
+    override def onServerError(request: Http.RequestHeader, exception: Throwable): CompletionStage[Result] = ???
+  }
+
+  def tolerantParse(request: Http.Request, byteString: ByteString): Either[Result, String] = {
+    val parser: BodyParser[String] = new BodyParser.TolerantText(httpConfiguration, httpErrorHandler)
+    val disj: F.Either[Result, String] = parser(request).run(Source.single(byteString), materializer).toCompletableFuture.get
+    if (disj.left.isPresent) {
+      Left(disj.left.get)
+    } else Right(disj.right.get)
+  }
+
+  def strictParse(request: Http.Request, byteString: ByteString): Either[Result, String] = {
+    val parser: BodyParser[String] = new BodyParser.Text(httpConfiguration, httpErrorHandler)
+    val disj: F.Either[Result, String] = parser(request).run(Source.single(byteString), materializer).toCompletableFuture.get
+    if (disj.left.isPresent) {
+      Left(disj.left.get)
+    } else Right(disj.right.get)
+  }
+
+  "Text Body Parser" should {
+    "parse text" >> {
+      "as US-ASCII if not defined" in {
+        val body = ByteString("lorem ipsum")
+        val postRequest = new Http.RequestBuilder().method("POST").body(new RequestBody(body.toString()), "text/plain").req
+        strictParse(req(postRequest), body) must beRight.like {
+          case text => text must beEqualTo("lorem ipsum")
+        }
+      }
+      "as UTF-8 if defined" in {
+        val body = ByteString("©".getBytes(UTF_8))
+        val postRequest = new Http.RequestBuilder().method("POST").body(new RequestBody(body.toString()), "text/plain; charset=utf-8").req
+        strictParse(req(postRequest), body) must beRight.like {
+          case text => text must beEqualTo("©")
+        }
+      }
+      "as US-ASCII if not defined even if UTF-8 characters are provided" in {
+        val body = ByteString("©".getBytes(UTF_8))
+        val postRequest = new Http.RequestBuilder().method("POST").body(new RequestBody(body.toString()), "text/plain").req
+        strictParse(req(postRequest), body) must beRight.like {
+          case text => text must beEqualTo("��")
+        }
+      }
+    }
+  }
+
+  "TolerantText Body Parser" should {
+    "parse text" >> {
+
+      "as the declared charset if defined" in {
+        // http://kunststube.net/encoding/
+        val charset = StandardCharsets.UTF_16
+        val body = ByteString("エンコーディングは難しくない".getBytes(charset))
+        val postRequest = new Http.RequestBuilder().method("POST").bodyText(body.toString(), charset).req
+        tolerantParse(req(postRequest), body) must beRight.like {
+          case text =>
+            text must beEqualTo("エンコーディングは難しくない")
+        }
+      }
+
+      "as US-ASCII if charset is not explicitly defined" in {
+        val body = ByteString("lorem ipsum")
+        val postRequest = new Http.RequestBuilder().method("POST").body(new RequestBody(body.toString()), "text/plain").req
+        tolerantParse(req(postRequest), body) must beRight.like {
+          case text => text must beEqualTo("lorem ipsum")
+        }
+      }
+
+      "as UTF-8 for undefined if ASCII encoding is insufficient" in {
+        // http://kermitproject.org/utf8.html
+        val body = ByteString("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ")
+        val postRequest = new Http.RequestBuilder().method("POST").body(new RequestBody(body.toString()), "text/plain").req
+        tolerantParse(req(postRequest), body) must beRight.like {
+          case text => text must beEqualTo("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ")
+        }
+      }
+
+      "as ISO-8859-1 for undefined if UTF-8 is insufficient" in {
+        val body = ByteString(0xa9) // copyright sign encoded with ISO-8859-1
+        val postRequest = new Http.RequestBuilder().method("POST").body(new RequestBody(body.toString()), "text/plain").req
+        tolerantParse(req(postRequest), body) must beRight.like {
+          case text => text must beEqualTo("©")
+        }
+      }
+
+      "as UTF-8 even if the guessed encoding is utterly wrong" in {
+        // This is not a full solution, so anything where we have a potentially valid encoding is seized on, even
+        // when it's not the best one.
+        val body = ByteString("エンコーディングは難しくない".getBytes(Charset.forName("Shift-JIS")))
+        val postRequest = new Http.RequestBuilder().method("POST").bodyText(body.toString()).req
+        tolerantParse(req(postRequest), body) must beRight.like {
+          case text =>
+            // utter gibberish, but we have no way of knowing the format.
+            text must beEqualTo("\u0083G\u0083\u0093\u0083R\u0081[\u0083f\u0083B\u0083\u0093\u0083O\u0082Í\u0093ï\u0082µ\u0082\u00AD\u0082È\u0082¢")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Fixes

Fixes https://github.com/playframework/playframework/issues/4997

## Purpose

Changes "text/plain" Text and Tolerant Text parser to use "US-ASCII" as the default charset.

## Background Context

Per tools.ietf.org/html/rfc6657#section-4 the default for "text/plain" should be "US-ASCII", since that's what it's defined as in the media type definition at https://tools.ietf.org/html/rfc6657#section-4
