### PR TITLE
Forms - add support for IndexedSeq and Vector bindings

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -512,6 +512,30 @@ object Forms {
   def set[A](mapping: Mapping[A]): Mapping[Set[A]] = RepeatedMapping(mapping).transform(_.toSet, _.toList)
 
   /**
+   * Defines a repeated mapping with the IndexedSeq semantic.
+   * {{{
+   * Form(
+   *   "name" -> indexedSeq(text)
+   * )
+   * }}}
+   *
+   * @param mapping The mapping to make repeated.
+   */
+  def indexedSeq[A](mapping: Mapping[A]): Mapping[IndexedSeq[A]] = RepeatedMapping(mapping).transform(_.toIndexedSeq, _.toList)
+
+  /**
+   * Defines a repeated mapping with the Vector semantic.
+   * {{{
+   * Form(
+   *   "name" -> vector(text)
+   * )
+   * }}}
+   *
+   * @param mapping The mapping to make repeated.
+   */
+  def vector[A](mapping: Mapping[A]): Mapping[Vector[A]] = RepeatedMapping(mapping).transform(_.toVector, _.toList)
+
+  /**
    * Constructs a simple mapping for a date field.
    *
    * For example:

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -300,6 +300,24 @@ class FormSpec extends Specification {
     ScalaForms.repeatedFormWithSet.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com", "kiki@gmail.com"))).get must equalTo(("Kiki", Set("kiki@gmail.com")))
   }
 
+  "support repeated values with indexedSeq" in {
+    ScalaForms.repeatedFormWithIndexedSeq.bindFromRequest(Map("name" -> Seq("Kiki"))).get must equalTo(("Kiki", IndexedSeq()))
+    ScalaForms.repeatedFormWithIndexedSeq.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com"))).get must equalTo(("Kiki", IndexedSeq("kiki@gmail.com")))
+    ScalaForms.repeatedFormWithIndexedSeq.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com"), "emails[1]" -> Seq("kiki@zen.com"))).get must equalTo(("Kiki", IndexedSeq("kiki@gmail.com", "kiki@zen.com")))
+    ScalaForms.repeatedFormWithIndexedSeq.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[0]" -> Seq(), "emails[1]" -> Seq("kiki@zen.com"))).hasErrors must equalTo(true)
+    ScalaForms.repeatedFormWithIndexedSeq.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com"))).get must equalTo(("Kiki", IndexedSeq("kiki@gmail.com")))
+    ScalaForms.repeatedFormWithIndexedSeq.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com", "kiki@zen.com"))).get must equalTo(("Kiki", IndexedSeq("kiki@gmail.com", "kiki@zen.com")))
+  }
+
+  "support repeated values with vector" in {
+    ScalaForms.repeatedFormWithVector.bindFromRequest(Map("name" -> Seq("Kiki"))).get must equalTo(("Kiki", Vector()))
+    ScalaForms.repeatedFormWithVector.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com"))).get must equalTo(("Kiki", Vector("kiki@gmail.com")))
+    ScalaForms.repeatedFormWithVector.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com"), "emails[1]" -> Seq("kiki@zen.com"))).get must equalTo(("Kiki", Vector("kiki@gmail.com", "kiki@zen.com")))
+    ScalaForms.repeatedFormWithVector.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[0]" -> Seq(), "emails[1]" -> Seq("kiki@zen.com"))).hasErrors must equalTo(true)
+    ScalaForms.repeatedFormWithVector.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com"))).get must equalTo(("Kiki", Vector("kiki@gmail.com")))
+    ScalaForms.repeatedFormWithVector.bindFromRequest(Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com", "kiki@zen.com"))).get must equalTo(("Kiki", Vector("kiki@gmail.com", "kiki@zen.com")))
+  }
+
   "render a form with max 18 fields" in {
     ScalaForms.helloForm.bind(Map("name" -> "foo", "repeat" -> "1")).get.toString must equalTo("(foo,1,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None)")
   }
@@ -512,6 +530,20 @@ object ScalaForms {
     tuple(
       "name" -> nonEmptyText,
       "emails" -> set(nonEmptyText)
+    )
+  )
+
+  val repeatedFormWithIndexedSeq = Form(
+    tuple(
+      "name" -> nonEmptyText,
+      "emails" -> indexedSeq(nonEmptyText)
+    )
+  )
+
+  val repeatedFormWithVector = Form(
+    tuple(
+      "name" -> nonEmptyText,
+      "emails" -> vector(nonEmptyText)
     )
   )
 


### PR DESCRIPTION
This introduces default bindings for IndexedSeq and Vector collection types.
In Play 2.6 the default Form bindings for repeated elements are: seq, list and set. However there are many use cases where Vector collection type is preferable due to its overall performance (such as for RandomAccess) if compared to List, it’s also considered one of the most popular and versatile collections in Scala. This change introduces a default binding for Vector and IndexedSeq in play.api.data.Forms as these types are not yet supported.

Pull request provided in response to lightbend discussion:
https://discuss.lightbend.com/t/feature-request-default-binding-for-vector-or-indexedseq-in-play-api-data-forms/2423
Tests added to existing test class: playframework/framework/src/play/src/test/scala/play/api/data/FormSpec.scala

