### PR TITLE
Java Form and DynamicForm cleanup

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -82,9 +82,6 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         return super.value().map(v -> v.getData().get(asNormalKey(key)));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Map<String, String> rawData() {
         return Collections.unmodifiableMap(super.rawData().entrySet().stream().collect(Collectors.toMap(e -> asNormalKey(e.getKey()), e -> e.getValue())));
@@ -100,44 +97,22 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory, config);
     }
 
-    /**
-     * Binds request data to this form - that is, handles form submission.
-     *
-     * @return a copy of this form filled with the new data
-     */
     @Override
     public DynamicForm bindFromRequest(String... allowedFields) {
         return bind(requestData(play.mvc.Controller.request()), allowedFields);
     }
 
-    /**
-     * Binds request data to this form - that is, handles form submission.
-     *
-     * @return a copy of this form filled with the new data
-     */
     @Override
     public DynamicForm bindFromRequest(Http.Request request, String... allowedFields) {
         return bind(requestData(request), allowedFields);
     }
 
-    /**
-     * Binds data to this form - that is, handles form submission.
-     *
-     * @param data data to submit
-     * @return a copy of this form filled with the new data
-     */
     @Override
     public DynamicForm bind(Map<String,String> data, String... allowedFields) {
         Form<Dynamic> form = super.bind(data.entrySet().stream().collect(Collectors.toMap(e -> asDynamicKey(e.getKey()), e -> e.getValue())), allowedFields);
         return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory, config);
     }
 
-    /**
-     * Retrieves a field.
-     *
-     * @param key field name
-     * @return the field - even if the field does not exist you get a field
-     */
     @Override
     public Form.Field field(String key) {
         // #1310: We specify inner class as Form.Field rather than Field because otherwise,
@@ -148,44 +123,23 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         );
     }
 
-    /**
-     * Retrieve an error by key.
-     *
-     * @deprecated Deprecated as of 2.7.0. Method has been renamed to {@link #error(String)}.
-     */
     @Override
     @Deprecated
     public Optional<ValidationError> getError(String key) {
         return error(key);
     }
 
-    /**
-     * Retrieve an error by key.
-     */
     @Override
     public Optional<ValidationError> error(String key) {
         return super.error(asDynamicKey(key));
     }
 
-    /**
-     * @param key the error key
-     * @param error the error message
-     * @param args the error arguments
-     *
-     * @return a copy of this form with the given error added.
-     */
     @Override
     public DynamicForm withError(final String key, final String error, final List<Object> args) {
         final Form<Dynamic> form = super.withError(asDynamicKey(key), error, args);
         return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config);
     }
 
-    /**
-     * @param key the error key
-     * @param error the error message
-     *
-     * @return a copy of this form with the given error added.
-     */
     @Override
     public DynamicForm withError(final String key, final String error) {
         return withError(key, error, new ArrayList<>());

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -124,12 +124,6 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     }
 
     @Override
-    @Deprecated
-    public Optional<ValidationError> getError(String key) {
-        return error(key);
-    }
-
-    @Override
     public Optional<ValidationError> error(String key) {
         return super.error(asDynamicKey(key));
     }

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import play.data.format.Formatters;
 import play.data.validation.ValidationError;
 import play.i18n.MessagesApi;
+import play.mvc.Http;
 
 /**
  * A dynamic form. This form is backed by a simple <code>HashMap&lt;String,String&gt;</code>
@@ -115,7 +116,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @return a copy of this form filled with the new data
      */
     @Override
-    public DynamicForm bindFromRequest(play.mvc.Http.Request request, String... allowedFields) {
+    public DynamicForm bindFromRequest(Http.Request request, String... allowedFields) {
         return bind(requestData(request), allowedFields);
     }
 

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -138,6 +138,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param key field name
      * @return the field - even if the field does not exist you get a field
      */
+    @Override
     public Form.Field field(String key) {
         // #1310: We specify inner class as Form.Field rather than Field because otherwise,
         // javadoc cannot find the static inner class.
@@ -152,6 +153,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      *
      * @deprecated Deprecated as of 2.7.0. Method has been renamed to {@link #error(String)}.
      */
+    @Override
     @Deprecated
     public Optional<ValidationError> getError(String key) {
         return error(key);
@@ -160,6 +162,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     /**
      * Retrieve an error by key.
      */
+    @Override
     public Optional<ValidationError> error(String key) {
         return super.error(asDynamicKey(key));
     }

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -4,6 +4,7 @@
 
 package play.data;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import org.hibernate.validator.HibernateValidatorFactory;
@@ -23,6 +24,7 @@ import play.data.format.Formatters;
 import play.data.validation.Constraints;
 import play.data.validation.Constraints.ValidationPayload;
 import play.data.validation.ValidationError;
+import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.libs.AnnotationUtils;
@@ -32,7 +34,6 @@ import play.mvc.Http.HttpVerbs;
 import javax.validation.ConstraintViolation;
 import javax.validation.groups.Default;
 import javax.validation.metadata.BeanDescriptor;
-import javax.validation.metadata.ConstraintDescriptor;
 import javax.validation.metadata.PropertyDescriptor;
 import javax.validation.ValidatorFactory;
 import javax.validation.Validator;
@@ -264,7 +265,7 @@ public class Form<T> {
      * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
      * @return a copy of this form filled with the new data
      */
-    public Form<T> bind(com.fasterxml.jackson.databind.JsonNode data, String... allowedFields) {
+    public Form<T> bind(JsonNode data, String... allowedFields) {
         return bind(
             play.libs.Scala.asJava(
                 play.api.data.FormUtils.fromJson("",
@@ -668,7 +669,7 @@ public class Form<T> {
     /**
      * @return the form errors serialized as Json.
      */
-    public com.fasterxml.jackson.databind.JsonNode errorsAsJson() {
+    public JsonNode errorsAsJson() {
         return errorsAsJson(Http.Context.current() != null ? Http.Context.current().lang() : null);
     }
 
@@ -677,7 +678,7 @@ public class Form<T> {
      * @param lang    the language to use.
      * @return the JSON node containing the errors.
      */
-    public com.fasterxml.jackson.databind.JsonNode errorsAsJson(play.i18n.Lang lang) {
+    public JsonNode errorsAsJson(Lang lang) {
         Map<String, List<String>> allMessages = new HashMap<>();
         errors.forEach(error -> {
             if (error != null) {
@@ -695,7 +696,7 @@ public class Form<T> {
         return play.libs.Json.toJson(allMessages);
     }
 
-    private Object translateMsgArg(List<Object> arguments, MessagesApi messagesApi, play.i18n.Lang lang) {
+    private Object translateMsgArg(List<Object> arguments, MessagesApi messagesApi, Lang lang) {
         if (arguments != null) {
             return arguments.stream().map(arg -> {
                     if (arg instanceof String) {

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -211,7 +211,7 @@ public class Form<T> {
         return data;
     }
 
-    private void fillDataWith(Map<String, String> data, Map<String, String[]> urlFormEncoded) {
+    protected void fillDataWith(Map<String, String> data, Map<String, String[]> urlFormEncoded) {
         urlFormEncoded.forEach((key, values) -> {
             if (key.endsWith("[]")) {
                 String k = key.substring(0, key.length() - 2);


### PR DESCRIPTION
Preparations for an upcoming pull requests that deprecates `Http.Context` related stuff inside Java Forms.

Reviewing [per commit](https://github.com/playframework/playframework/pull/8731/commits) should be the easiest.