### PR TITLE
New APIs to discard headers on results

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/ResponseHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/ResponseHeader.java
@@ -50,6 +50,12 @@ public class ResponseHeader {
         return Collections.unmodifiableMap(headers);
     }
 
+    public ResponseHeader discardHeader(String name) {
+        Map<String, String> updatedHeaders = copyCurrentHeaders();
+        updatedHeaders.remove(name);
+        return new ResponseHeader(status, updatedHeaders, reasonPhrase);
+    }
+
     public ResponseHeader withHeader(String name, String value) {
         Map<String, String> updatedHeaders = copyCurrentHeaders();
         updatedHeaders.put(name, value);

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -523,6 +523,16 @@ public class Result {
     }
 
     /**
+     * Discard a HTTP header in this result.
+     *
+     * @param name the header name
+     * @return the transformed copy
+     */
+    public Result discardHeader(String name) {
+        return new Result(header.discardHeader(name), body, session, flash, cookies);
+    }
+
+    /**
      * Return a copy of the result with a different Content-Type header.
      *
      * @param contentType the content type to set

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -136,6 +136,21 @@ case class Result(header: ResponseHeader, body: HttpEntity,
   }
 
   /**
+   * Discards headers to this result.
+   *
+   * For example:
+   * {{{
+   * Ok("Hello world").discardingHeader(ETAG)
+   * }}}
+   *
+   * @param header the headers to discard from this result.
+   * @return the new result
+   */
+  def discardingHeader(name: String): Result = {
+    copy(header = header.copy(headers = header.headers - name))
+  }
+
+  /**
    * Adds cookies to this result. If the result already contains cookies then cookies with the same name in the new
    * list will override existing ones.
    *


### PR DESCRIPTION
## Fixes

Fixes #8734.

## Purpose

Add new APIs to discard a cookie from results.
