### PR TITLE
Fixed extremely small typo in ScalaBodyParsers.md

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
@@ -27,7 +27,7 @@ Most typical web apps will not need to use custom body parsers, they can simply 
 
 ### The default body parser
 
-The default body parser that's used if you do not explicitly select a body parser will look at the incoming `Content-Type` header, and parses the body accordingly.  So for example, a `Content-Type` of type `application/json` will be parsed as a `JsValue`, while a `Content-Type` of `application/x-www-form-urlencoded` will be parsed as a `Map[String, Seq[String]]`.
+The default body parser that's used if you do not explicitly select a body parser will look at the incoming `Content-Type` header, and parse the body accordingly.  So for example, a `Content-Type` of type `application/json` will be parsed as a `JsValue`, while a `Content-Type` of `application/x-www-form-urlencoded` will be parsed as a `Map[String, Seq[String]]`.
 
 The default body parser produces a body of type [`AnyContent`](api/scala/play/api/mvc/AnyContent.html).  The various types supported by `AnyContent` are accessible via `as` methods, such as `asJson`, which returns an `Option` of the body type:
 


### PR DESCRIPTION
From ScalaBodyParsers.md:

"The default body parser that’s used if you do not explicitly select a body parser will look at the incoming Content-Type header, and parses the body accordingly. "

The first half of the sentence is in the future progressive tense while the second is in the present tense. If the body parser *will* take an action in the future all the other actions it takes after that will also be in the future.

It's a small thing I know but it was bothering me as I was reading. 