### PR TITLE
Guice 4.2.2 with ASM 7 for JDK 11 + JDK 12 support

### DIFF
--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -31,9 +31,9 @@ Coordinated Shutdown internally handles Play 2.7 Play's lifecycle and an instanc
 
 You can find more details on the new section on [[Coordinated Shutdown on the Play manual|Shutdown]], or you can have a look at Akka's [reference docs on Coordinated Shutdown](https://doc.akka.io/docs/akka/2.5/actors.html?languages=scala#coordinated-shutdown).
 
-## Guice was upgraded to 4.2.1
+## Guice was upgraded to 4.2.2
 
-Guice, the default dependency injection framework used by Play, was upgraded to 4.2.1 (from 4.1.0). Have a look at the [4.2.1](https://github.com/google/guice/wiki/Guice421) and the [4.2.0](https://github.com/google/guice/wiki/Guice42) release notes. This new Guice version introduces breaking changes, so make sure you check the [[Play 2.7 Migration Guide|Migration27]].
+Guice, the default dependency injection framework used by Play, was upgraded to 4.2.2 (from 4.1.0). Have a look at the [4.2.2](https://github.com/google/guice/wiki/Guice422), [4.2.1](https://github.com/google/guice/wiki/Guice421) and the [4.2.0](https://github.com/google/guice/wiki/Guice42) release notes. This new Guice version introduces breaking changes, so make sure you check the [[Play 2.7 Migration Guide|Migration27]].
 
 ## Constraint annotations offered for Play Java are now @Repeatable
 

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -82,7 +82,7 @@ The API for body parser was mixing `Integer` and `Long` to define buffer lengths
 
 ## Guice compatibility changes
 
-Guice was upgraded to version [4.2.1](https://github.com/google/guice/wiki/Guice421) (also see [4.2.0 release notes](https://github.com/google/guice/wiki/Guice42)), which causes the following breaking changes:
+Guice was upgraded to version [4.2.2](https://github.com/google/guice/wiki/Guice422) (also see [4.2.1](https://github.com/google/guice/wiki/Guice421) and [4.2.0 release notes](https://github.com/google/guice/wiki/Guice42)), which causes the following breaking changes:
 
  - `play.test.TestBrowser.waitUntil` expects a `java.util.function.Function` instead of a `com.google.common.base.Function` now.
  - In Scala, when overriding the `configure()` method of `AbstractModule`, you need to prefix that method with the `override` identifier now (because it's non-abstract now).

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -137,7 +137,7 @@ object Dependencies {
     logback
   ).map(_ % Test)
 
-  val guiceVersion = "4.2.1"
+  val guiceVersion = "4.2.2"
   val guiceDeps = Seq(
     "com.google.inject" % "guice" % guiceVersion,
     "com.google.inject.extensions" % "guice-assistedinject" % guiceVersion


### PR DESCRIPTION
Check the [diff from 4.2.1.](https://github.com/google/guice/compare/4.2.1...4.2.2)

Most notable Guice upgraded to [ASM 7](https://asm.ow2.io/) and [cglib](https://github.com/cglib/cglib) which bring full JDK11 support (before it was experimental).