### PR TITLE
Start action composition chain with call(req) not with call(ctx)

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -75,7 +75,9 @@ public abstract class Action<T> extends Results {
         if(threadLocalCtx != null) {
             // A previous action did explicitly set a context onto the thread local (via Http.Context.current.set(...))
             // Let's use that context so the user doesn't loose data he/she set onto that ctx (args,...)
-            return call(threadLocalCtx.withRequest(req));
+            Context newCtx = threadLocalCtx.withRequest(req);
+            Context.current.set(newCtx);
+            return call(newCtx);
         } else {
             // A previous action did not set a context explicitly, we simply create a new one to pass on the request
             return call(new Context(req, contextComponents));

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -136,7 +136,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
       })
       logger.debug("### End of action order")
     }
-    val actionFuture: Future[Future[JResult]] = Future { FutureConverters.toScala(firstAction.call(javaContext)) }(trampolineWithContext)
+    val actionFuture: Future[Future[JResult]] = Future { FutureConverters.toScala(firstAction.call(javaContext.request())) }(trampolineWithContext)
     val flattenedActionFuture: Future[JResult] = actionFuture.flatMap(identity)(trampoline)
     val resultFuture: Future[Result] = flattenedActionFuture.map(createResult(javaContext, _))(trampoline)
     resultFuture


### PR DESCRIPTION
Actually it doesn't really matter how we enter the chain since [Action.java](https://github.com/playframework/playframework/blob/be0e28c1e72be0ba02101e09852c3347835d986f/framework/src/play/src/main/java/play/mvc/Action.java#L62-L83) takes care to call the right method anyway.

This is just to make that a bit cleaner - could have been included in #8694 already actually.