### PR TITLE
Deprecate Java Form methods that depend on Http.Context

### DIFF
--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -481,3 +481,19 @@ public class FooController extends Controller {
     }
 }
 ```
+
+### Changes in Java Forms related to `Http.Context`
+
+When retrieving the [`Field`](api/java/play/data/Form.Field.html) of a [`Form`](api/java/play/data/Form.html) (e.g. via `myform.field("username")` or just `myform("username")` inside templates) the language of the current `Http.Context` was used to format the value of the field.
+Starting with Play 2.7 however this isn't the case anymore.
+Instead you can now explicitly set the language the form should use when retrieving a field:
+```java
+myForm.setLang(lang);
+```
+To make things simple and to not force you to explicitly set the language for every form Play does set it during binding already:
+```java
+Form<MyForm> form = formFactory().form(MyForm.class).bindFromRequest(request);
+```
+In this example the language of the form will be set to the preferred language of the request.
+
+Be aware that changing the language of the the current `Http.Context` (e.g. via `Http.Context.current().changeLang(...)` or `Http.Context.current().setTransientLang(...)`) does not have an effect on the language used to retrieve the field value of a form anymore - as explained, use `form.setLang(...)` instead.

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -487,13 +487,17 @@ public class FooController extends Controller {
 When retrieving the [`Field`](api/java/play/data/Form.Field.html) of a [`Form`](api/java/play/data/Form.html) (e.g. via `myform.field("username")` or just `myform("username")` inside templates) the language of the current `Http.Context` was used to format the value of the field.
 Starting with Play 2.7 however this isn't the case anymore.
 Instead you can now explicitly set the language the form should use when retrieving a field:
+
 ```java
-myForm.setLang(lang);
+Form<User> formWithNewLang = currentForm.withLang(lang);
 ```
+
 To make things simple and to not force you to explicitly set the language for every form Play does set it during binding already:
+
 ```java
-Form<MyForm> form = formFactory().form(MyForm.class).bindFromRequest(request);
+Form<User> form = formFactory().form(User.class).bindFromRequest(request);
 ```
+
 In this example the language of the form will be set to the preferred language of the request.
 
-Be aware that changing the language of the the current `Http.Context` (e.g. via `Http.Context.current().changeLang(...)` or `Http.Context.current().setTransientLang(...)`) does not have an effect on the language used to retrieve the field value of a form anymore - as explained, use `form.setLang(...)` instead.
+Be aware that changing the language of the the current `Http.Context` (e.g. via `Http.Context.current().changeLang(...)` or `Http.Context.current().setTransientLang(...)`) does not have an effect on the language used to retrieve the field value of a form anymore - as explained, use `form.withLang(...)` instead.

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
@@ -58,12 +58,13 @@ public class JavaForms extends WithApplication {
         Form<User> userForm = formFactory.form(User.class);
         //#create
 
+        Lang lang = null;
         //#bind
         Map<String,String> anyData = new HashMap<>();
         anyData.put("email", "bob@gmail.com");
         anyData.put("password", "secret");
 
-        User user = userForm.bind(anyData).get();
+        User user = userForm.bind(lang, anyData).get();
         //#bind
 
         assertThat(user.getEmail(), equalTo("bob@gmail.com"));
@@ -83,10 +84,10 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
+        public Result index(Http.Request request) {
             Form<User> userForm = formFactory().form(User.class);
             //#bind-from-request
-            User user = userForm.bindFromRequest().get();
+            User user = userForm.bindFromRequest(request).get();
             //#bind-from-request
 
             return ok(user.getEmail());
@@ -96,7 +97,7 @@ public class JavaForms extends WithApplication {
     @Test
     public void constraints() {
         Form<javaguide.forms.u2.User> userForm = formFactory().form(javaguide.forms.u2.User.class);
-        assertThat(userForm.bind(ImmutableMap.of("password", "p")).hasErrors(), equalTo(true));
+        assertThat(userForm.bind(null, ImmutableMap.of("password", "p")).hasErrors(), equalTo(true));
     }
 
     @Test
@@ -114,8 +115,8 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
-            Form<javaguide.forms.u3.User> userForm = formFactory().form(javaguide.forms.u3.User.class).bindFromRequest();
+        public Result index(Http.Request request) {
+            Form<javaguide.forms.u3.User> userForm = formFactory().form(javaguide.forms.u3.User.class).bindFromRequest(request);
 
             if (userForm.hasErrors()) {
                 return badRequest(javaguide.forms.html.view.render(userForm));
@@ -191,8 +192,8 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
-            Form<SignUpForm> userForm = formFactory().form(SignUpForm.class).bindFromRequest();
+        public Result index(Http.Request request) {
+            Form<SignUpForm> userForm = formFactory().form(SignUpForm.class).bindFromRequest(request);
 
             if (userForm.hasErrors()) {
                 return badRequest(javaguide.forms.html.view.render(userForm));
@@ -259,8 +260,8 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
-            Form<LoginForm> adminForm = formFactory().form(LoginForm.class).bindFromRequest();
+        public Result index(Http.Request request) {
+            Form<LoginForm> adminForm = formFactory().form(LoginForm.class).bindFromRequest(request);
 
             if (adminForm.hasErrors()) {
                 return badRequest(javaguide.forms.html.view.render(adminForm));
@@ -296,8 +297,8 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
-            Form<User> userForm = formFactory().form(User.class).bindFromRequest();
+        public Result index(Http.Request request) {
+            Form<User> userForm = formFactory().form(User.class).bindFromRequest(request);
             //#handle-errors
             if (userForm.hasErrors()) {
                 return badRequest(views.html.form.render(userForm));
@@ -341,8 +342,8 @@ public class JavaForms extends WithApplication {
         }
 
         //#dynamic
-        public Result hello() {
-            DynamicForm requestData = formFactory.form().bindFromRequest();
+        public Result hello(Http.Request request) {
+            DynamicForm requestData = formFactory.form().bindFromRequest(request);
             String firstname = requestData.get("firstname");
             String lastname = requestData.get("lastname");
             return ok("Hello " + firstname + " " + lastname);
@@ -357,7 +358,7 @@ public class JavaForms extends WithApplication {
             .build();
 
         Form<WithLocalTime> form = application.injector().instanceOf(FormFactory.class).form(WithLocalTime.class);
-        WithLocalTime obj = form.bind(ImmutableMap.of("time", "23:45")).get();
+        WithLocalTime obj = form.bind(null, ImmutableMap.of("time", "23:45")).get();
         assertThat(obj.getTime(), equalTo(LocalTime.of(23, 45)));
         assertThat(form.fill(obj).field("time").value().get(), equalTo("23:45"));
     }
@@ -404,9 +405,9 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
+        public Result index(Http.Request request) {
             //#partial-validate-signup
-            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, SignUpCheck.class).bindFromRequest();
+            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, SignUpCheck.class).bindFromRequest(request);
             //#partial-validate-signup
 
             if (form.hasErrors()) {
@@ -433,9 +434,9 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
+        public Result index(Http.Request request) {
             //#partial-validate-login
-            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, LoginCheck.class).bindFromRequest();
+            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, LoginCheck.class).bindFromRequest(request);
             //#partial-validate-login
 
             if (form.hasErrors()) {
@@ -462,9 +463,9 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
+        public Result index(Http.Request request) {
             //#partial-validate-default
-            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, Default.class).bindFromRequest();
+            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, Default.class).bindFromRequest(request);
             //#partial-validate-default
 
             if (form.hasErrors()) {
@@ -491,9 +492,9 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
+        public Result index(Http.Request request) {
             //#partial-validate-nogroup
-            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class).bindFromRequest();
+            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class).bindFromRequest(request);
             //#partial-validate-nogroup
 
             if (form.hasErrors()) {
@@ -520,9 +521,9 @@ public class JavaForms extends WithApplication {
             super(javaHandlerComponents);
         }
 
-        public Result index() {
+        public Result index(Http.Request request) {
             //#ordered-group-sequence-validate
-            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, OrderedChecks.class).bindFromRequest();
+            Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, OrderedChecks.class).bindFromRequest(request);
             //#ordered-group-sequence-validate
 
             if (form.hasErrors()) {

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
@@ -58,7 +58,7 @@ public class JavaForms extends WithApplication {
         Form<User> userForm = formFactory.form(User.class);
         //#create
 
-        Lang lang = null;
+        Lang lang = new Lang(Locale.getDefault());
         //#bind
         Map<String,String> anyData = new HashMap<>();
         anyData.put("email", "bob@gmail.com");

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide.ws.routes
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide.ws.routes
@@ -1,6 +1,6 @@
 # #ws-openid-routes
 GET     /openID/login               controllers.OpenIDController.login()
-POST    /openID/login               controllers.OpenIDController.loginPost()
+POST    /openID/login               controllers.OpenIDController.loginPost(request: Request)
 GET     /openID/callback            controllers.OpenIDController.openIDCallback(request: Request)
 # #ws-openid-routes
 

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/OpenIDController.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/OpenIDController.java
@@ -28,10 +28,10 @@ public class OpenIDController extends Controller {
         return ok(views.html.login.render(""));
     }
 
-    public CompletionStage<Result> loginPost() {
+    public CompletionStage<Result> loginPost(Http.Request request) {
 
         // Form data
-        DynamicForm requestData = formFactory.form().bindFromRequest();
+        DynamicForm requestData = formFactory.form().bindFromRequest(request);
         String openID = requestData.get("openID");
 
         CompletionStage<String> redirectUrlPromise =

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -112,7 +112,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public DynamicForm fill(Map<String, Object> value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
-        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory, config);
+        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory, config, lang().orElse(null));
     }
 
     @Override
@@ -170,13 +170,13 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     public DynamicForm withError(final ValidationError error) {
         final Form<Dynamic> form = super.withError(new ValidationError(asDynamicKey(error.key()), error.messages(), error.arguments()));
-        return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config);
+        return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config, lang().orElse(null));
     }
 
     @Override
     public DynamicForm withError(final String key, final String error, final List<Object> args) {
         final Form<Dynamic> form = super.withError(asDynamicKey(key), error, args);
-        return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config);
+        return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config, lang().orElse(null));
     }
 
     @Override
@@ -187,7 +187,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     public DynamicForm withGlobalError(final String error, final List<Object> args) {
         final Form<Dynamic> form = super.withGlobalError(error, args);
-        return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config);
+        return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config, lang().orElse(null));
     }
 
     @Override
@@ -198,7 +198,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     public DynamicForm discardingErrors() {
         final Form<Dynamic> form = super.discardingErrors();
-        return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config);
+        return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config, lang().orElse(null));
     }
 
     @Override

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -116,25 +116,40 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     }
 
     @Override
+    @Deprecated
     public DynamicForm bindFromRequest(String... allowedFields) {
-        return bind(requestData(play.mvc.Controller.request()), allowedFields);
+        return bind(play.mvc.Controller.ctx().messages().lang(), requestData(play.mvc.Controller.request()), allowedFields);
     }
 
     @Override
     public DynamicForm bindFromRequest(Http.Request request, String... allowedFields) {
-        return bind(requestData(request), allowedFields);
+        return bind(this.messagesApi.preferred(request).lang(), requestData(request), allowedFields);
     }
 
     @Override
+    @Deprecated
     public DynamicForm bindFromRequest(Map<String,String[]> requestData, String... allowedFields) {
+        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
+        return bindFromRequest(ctx != null ? ctx.messages().lang() : null, requestData, allowedFields);
+    }
+
+    @Override
+    public DynamicForm bindFromRequest(Lang lang, Map<String,String[]> requestData, String... allowedFields) {
         Map<String,String> data = new HashMap<>();
         fillDataWith(data, requestData);
-        return bind(data, allowedFields);
+        return bind(lang, data, allowedFields);
     }
 
     @Override
+    @Deprecated
     public DynamicForm bind(JsonNode data, String... allowedFields) {
-        return bind(
+        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
+        return bind(ctx != null ? ctx.messages().lang() : null, data, allowedFields);
+    }
+
+    @Override
+    public DynamicForm bind(Lang lang, JsonNode data, String... allowedFields) {
+        return bind(lang,
             play.libs.Scala.asJava(
                 play.api.data.FormUtils.fromJson("",
                     play.api.libs.json.Json.parse(
@@ -147,9 +162,16 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     }
 
     @Override
+    @Deprecated
     public DynamicForm bind(Map<String,String> data, String... allowedFields) {
-        Form<Dynamic> form = super.bind(data.entrySet().stream().collect(Collectors.toMap(e -> asDynamicKey(e.getKey()), e -> e.getValue())), allowedFields);
-        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory, config);
+        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
+        return bind(ctx != null ? ctx.messages().lang() : null, data, allowedFields);
+    }
+
+    @Override
+    public DynamicForm bind(Lang lang, Map<String,String> data, String... allowedFields) {
+        Form<Dynamic> form = super.bind(lang, data.entrySet().stream().collect(Collectors.toMap(e -> asDynamicKey(e.getKey()), e -> e.getValue())), allowedFields);
+        return new DynamicForm(form.rawData(), form.errors(), form.value(), messagesApi, formatters, validatorFactory, config, lang);
     }
 
     @Override

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 import play.data.format.Formatters;
 import play.data.validation.ValidationError;
+import play.i18n.Lang;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
 
@@ -55,7 +56,23 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param config      the config component.
      */
     public DynamicForm(Map<String,String> data, List<ValidationError> errors, Optional<Dynamic> value, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config) {
-        super(null, DynamicForm.Dynamic.class, data, errors, value, messagesApi, formatters, validatorFactory, config);
+        this(data, errors, value, messagesApi, formatters, validatorFactory, config, null);
+    }
+
+    /**
+     * Creates a new dynamic form.
+     *
+     * @param data the current form data (used to display the form)
+     * @param errors the collection of errors associated with this form
+     * @param value optional concrete value if the form submission was successful
+     * @param messagesApi    the messagesApi component.
+     * @param formatters     the formatters component.
+     * @param validatorFactory      the validatorFactory component.
+     * @param config      the config component.
+     * @param lang used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)}) and for translations in {@link #errorsAsJson()}
+     */
+    public DynamicForm(Map<String,String> data, List<ValidationError> errors, Optional<Dynamic> value, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config, Lang lang) {
+        super(null, DynamicForm.Dynamic.class, data, errors, value, null, messagesApi, formatters, validatorFactory, config, lang);
     }
 
     /**
@@ -182,6 +199,11 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     public DynamicForm discardingErrors() {
         final Form<Dynamic> form = super.discardingErrors();
         return new DynamicForm(super.rawData(), form.errors(), form.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config);
+    }
+
+    @Override
+    public DynamicForm withLang(Lang lang) {
+        return new DynamicForm(super.rawData(), this.errors(), this.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config, lang);
     }
 
     // -- tools

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -129,11 +129,11 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     @Deprecated
     public DynamicForm bindFromRequest(Map<String,String[]> requestData, String... allowedFields) {
-        return bindFromRequest(ctxLang(), requestData, allowedFields);
+        return bindFromRequestData(ctxLang(), requestData, allowedFields);
     }
 
     @Override
-    public DynamicForm bindFromRequest(Lang lang, Map<String,String[]> requestData, String... allowedFields) {
+    public DynamicForm bindFromRequestData(Lang lang, Map<String,String[]> requestData, String... allowedFields) {
         Map<String,String> data = new HashMap<>();
         fillDataWith(data, requestData);
         return bind(lang, data, allowedFields);

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -129,8 +129,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     @Deprecated
     public DynamicForm bindFromRequest(Map<String,String[]> requestData, String... allowedFields) {
-        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
-        return bindFromRequest(ctx != null ? ctx.messages().lang() : null, requestData, allowedFields);
+        return bindFromRequest(ctxLang(), requestData, allowedFields);
     }
 
     @Override
@@ -143,8 +142,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     @Deprecated
     public DynamicForm bind(JsonNode data, String... allowedFields) {
-        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
-        return bind(ctx != null ? ctx.messages().lang() : null, data, allowedFields);
+        return bind(ctxLang(), data, allowedFields);
     }
 
     @Override
@@ -164,8 +162,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     @Override
     @Deprecated
     public DynamicForm bind(Map<String,String> data, String... allowedFields) {
-        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
-        return bind(ctx != null ? ctx.messages().lang() : null, data, allowedFields);
+        return bind(ctxLang(), data, allowedFields);
     }
 
     @Override

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -153,10 +153,10 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     }
 
     @Override
-    public Form.Field field(String key) {
+    public Form.Field field(String key, Lang lang) {
         // #1310: We specify inner class as Form.Field rather than Field because otherwise,
         // javadoc cannot find the static inner class.
-        Field field = super.field(asDynamicKey(key));
+        Field field = super.field(asDynamicKey(key), lang);
         return new Field(this, key, field.constraints(), field.format(), field.errors(),
             field.value().orElse((String)value(key).orElse(null))
         );

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -588,7 +588,8 @@ public class Form<T> {
                 messagesApi,
                 formatters,
                 validatorFactory,
-                config
+                config,
+                lang
         );
     }
 
@@ -759,7 +760,7 @@ public class Form<T> {
         }
         final List<ValidationError> copiedErrors = new ArrayList<>(this.errors);
         copiedErrors.add(error);
-        return new Form<T>(this.rootName, this.backedType, this.rawData, copiedErrors, this.value, this.groups, this.messagesApi, this.formatters, this.validatorFactory, this.config);
+        return new Form<T>(this.rootName, this.backedType, this.rawData, copiedErrors, this.value, this.groups, this.messagesApi, this.formatters, this.validatorFactory, this.config, this.lang);
     }
 
     /**
@@ -806,7 +807,7 @@ public class Form<T> {
      * @return a copy of this form but with the errors discarded.
      */
     public Form<T> discardingErrors() {
-        return new Form<T>(this.rootName, this.backedType, this.rawData, new ArrayList<>(), this.value, this.groups, this.messagesApi, this.formatters, this.validatorFactory, this.config);
+        return new Form<T>(this.rootName, this.backedType, this.rawData, new ArrayList<>(), this.value, this.groups, this.messagesApi, this.formatters, this.validatorFactory, this.config, this.lang);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -801,8 +801,21 @@ public class Form<T> {
      * @return the concrete value.
      */
     public T get() {
+        return this.get(this.lang);
+    }
+
+    /**
+     * Gets the concrete value only if the submission was a success.
+     * If the form is invalid because of validation errors this method will throw an exception.
+     * If you want to retrieve the value even when the form is invalid use {@link #value()} instead.
+     *
+     * @param lang if an IllegalStateException gets thrown it's used to translate the form errors within that exception
+     * @throws IllegalStateException if there are errors binding the form, including the errors as JSON in the message
+     * @return the concrete value.
+     */
+    public T get(Lang lang) {
         if (!errors.isEmpty()) {
-            throw new IllegalStateException("Error(s) binding form: " + errorsAsJson());
+            throw new IllegalStateException("Error(s) binding form: " + errorsAsJson(lang));
         }
         return value.get();
     }

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -247,6 +247,15 @@ public class Form<T> {
     }
 
     /**
+     * @deprecated Deprecated as of 2.7.0.
+     */
+    @Deprecated
+    protected Lang ctxLang() {
+        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
+        return ctx != null ? ctx.messages().lang() : null;
+    }
+
+    /**
      * Binds request data to this form - that is, handles form submission.
      *
      * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
@@ -281,8 +290,7 @@ public class Form<T> {
      */
     @Deprecated
     public Form<T> bindFromRequest(Map<String,String[]> requestData, String... allowedFields) {
-        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
-        return bindFromRequest(ctx != null ? ctx.messages().lang() : null, requestData, allowedFields);
+        return bindFromRequest(ctxLang(), requestData, allowedFields);
     }
 
     /**
@@ -312,8 +320,7 @@ public class Form<T> {
      */
     @Deprecated
     public Form<T> bind(JsonNode data, String... allowedFields) {
-        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
-        return bind(ctx != null ? ctx.messages().lang() : null, data, allowedFields);
+        return bind(ctxLang(), data, allowedFields);
     }
 
     /**
@@ -554,8 +561,7 @@ public class Form<T> {
     @SuppressWarnings("unchecked")
     @Deprecated
     public Form<T> bind(Map<String,String> data, String... allowedFields) {
-        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
-        return bind(ctx != null ? ctx.messages().lang() : null, data, allowedFields);
+        return bind(ctxLang(), data, allowedFields);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -251,9 +251,12 @@ public class Form<T> {
      *
      * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
      * @return a copy of this form filled with the new data
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #bindFromRequest(Http.Request, String...)} instead.
      */
+    @Deprecated
     public Form<T> bindFromRequest(String... allowedFields) {
-        return bind(requestData(play.mvc.Controller.request()), allowedFields);
+        return bind(play.mvc.Controller.ctx().messages().lang(), requestData(play.mvc.Controller.request()), allowedFields);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -506,6 +506,22 @@ public class Form<T> {
     /**
      * Binds data to this form - that is, handles form submission.
      *
+     * @param data data to submit
+     * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
+     * @return a copy of this form filled with the new data
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #bind(Lang, Map, String...)} instead.
+     */
+    @SuppressWarnings("unchecked")
+    @Deprecated
+    public Form<T> bind(Map<String,String> data, String... allowedFields) {
+        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
+        return bind(ctx != null ? ctx.messages().lang() : null, data, allowedFields);
+    }
+
+    /**
+     * Binds data to this form - that is, handles form submission.
+     *
      * @param lang used for validators and formatters during binding and is part of {@link ValidationPayload}.
      *             Later also used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)})
      *             and for translations in {@link #errorsAsJson()}. For these methods the lang can be change via {@link #withLang(Lang)}.

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -1196,13 +1196,23 @@ public class Form<T> {
          * @return the subfield corresponding to the key.
          */
         public Field sub(String key) {
+            return sub(key, form.lang);
+        }
+
+        /**
+         * Get a sub-field, with a key relative to the current field.
+         * @param key    the key
+         * @param lang used for formatting
+         * @return the subfield corresponding to the key.
+         */
+        public Field sub(String key, Lang lang) {
             String subKey;
             if (key.startsWith("[")) {
                 subKey = name + key;
             } else {
                 subKey = name + "." + key;
             }
-            return form.field(subKey);
+            return form.field(subKey, lang);
         }
 
         public String toString() {

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -286,11 +286,11 @@ public class Form<T> {
      * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
      * @return a copy of this form filled with the new data
      *
-     * @deprecated Deprecated as of 2.7.0. Use {@link #bindFromRequest(Lang, Map, String...)} instead.
+     * @deprecated Deprecated as of 2.7.0. Use {@link #bindFromRequestData(Lang, Map, String...)} instead.
      */
     @Deprecated
     public Form<T> bindFromRequest(Map<String,String[]> requestData, String... allowedFields) {
-        return bindFromRequest(ctxLang(), requestData, allowedFields);
+        return bindFromRequestData(ctxLang(), requestData, allowedFields);
     }
 
     /**
@@ -303,7 +303,7 @@ public class Form<T> {
      * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
      * @return a copy of this form filled with the new data
      */
-    public Form<T> bindFromRequest(Lang lang, Map<String,String[]> requestData, String... allowedFields) {
+    public Form<T> bindFromRequestData(Lang lang, Map<String,String[]> requestData, String... allowedFields) {
         Map<String,String> data = new HashMap<>();
         fillDataWith(data, requestData);
         return bind(lang, data, allowedFields);

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -307,9 +307,27 @@ public class Form<T> {
      * @param data data to submit
      * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
      * @return a copy of this form filled with the new data
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #bind(Lang, JsonNode, String...)} instead.
      */
+    @Deprecated
     public Form<T> bind(JsonNode data, String... allowedFields) {
-        return bind(
+        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
+        return bind(ctx != null ? ctx.messages().lang() : null, data, allowedFields);
+    }
+
+    /**
+     * Binds Json data to this form - that is, handles form submission.
+     *
+     * @param lang used for validators and formatters during binding and is part of {@link ValidationPayload}.
+     *             Later also used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)})
+     *             and for translations in {@link #errorsAsJson()}. For these methods the lang can be change via {@link #withLang(Lang)}.
+     * @param data data to submit
+     * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
+     * @return a copy of this form filled with the new data
+     */
+    public Form<T> bind(Lang lang, JsonNode data, String... allowedFields) {
+        return bind(lang,
             play.libs.Scala.asJava(
                 play.api.data.FormUtils.fromJson("",
                     play.api.libs.json.Json.parse(

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -276,11 +276,29 @@ public class Form<T> {
      * @param requestData      the map of data to bind from
      * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
      * @return a copy of this form filled with the new data
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #bindFromRequest(Lang, Map, String...)} instead.
      */
+    @Deprecated
     public Form<T> bindFromRequest(Map<String,String[]> requestData, String... allowedFields) {
+        final Http.Context ctx = Http.Context.current != null ? Http.Context.current.get() : null;
+        return bindFromRequest(ctx != null ? ctx.messages().lang() : null, requestData, allowedFields);
+    }
+
+    /**
+     * Binds request data to this form - that is, handles form submission.
+     *
+     * @param lang used for validators and formatters during binding and is part of {@link ValidationPayload}.
+     *             Later also used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)})
+     *             and for translations in {@link #errorsAsJson()}. For these methods the lang can be change via {@link #withLang(Lang)}.
+     * @param requestData      the map of data to bind from
+     * @param allowedFields    the fields that should be bound to the form, all fields if not specified.
+     * @return a copy of this form filled with the new data
+     */
+    public Form<T> bindFromRequest(Lang lang, Map<String,String[]> requestData, String... allowedFields) {
         Map<String,String> data = new HashMap<>();
         fillDataWith(data, requestData);
-        return bind(data, allowedFields);
+        return bind(lang, data, allowedFields);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -264,7 +264,7 @@ public class Form<T> {
      * @return a copy of this form filled with the new data
      */
     public Form<T> bindFromRequest(Http.Request request, String... allowedFields) {
-        return bind(requestData(request), allowedFields);
+        return bind(this.messagesApi.preferred(request).lang(), requestData(request), allowedFields);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -97,6 +97,7 @@ public class Form<T> {
     private final List<ValidationError> errors;
     private final Optional<T> value;
     private final Class<?>[] groups;
+    private final Lang lang;
     final MessagesApi messagesApi;
     final Formatters formatters;
     final ValidatorFactory validatorFactory;
@@ -162,6 +163,25 @@ public class Form<T> {
      * @param config the config component.
      */
     public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config) {
+        this(rootName, clazz, data, errors, value, groups, messagesApi, formatters, validatorFactory, config, null);
+    }
+
+    /**
+     * Creates a new <code>Form</code>.  Consider using a {@link FormFactory} rather than this constructor.
+     *
+     * @param rootName    the root name.
+     * @param clazz wrapped class
+     * @param data the current form data (used to display the form)
+     * @param errors the collection of errors associated with this form
+     * @param value optional concrete value of type <code>T</code> if the form submission was successful
+     * @param groups    the array of classes with the groups.
+     * @param messagesApi needed to look up various messages
+     * @param formatters used for parsing and printing form fields
+     * @param validatorFactory the validatorFactory component.
+     * @param config the config component.
+     * @param lang used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)}) and for translations in {@link #errorsAsJson()}
+     */
+    public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config, Lang lang) {
         this.rootName = rootName;
         this.backedType = clazz;
         this.rawData = data != null ? new HashMap<>(data) : new HashMap<>();
@@ -172,6 +192,7 @@ public class Form<T> {
         this.formatters = formatters;
         this.validatorFactory = validatorFactory;
         this.config = config;
+        this.lang = lang;
     }
 
     protected Map<String,String> requestData(Http.Request request) {
@@ -898,6 +919,22 @@ public class Form<T> {
         }
 
         return new Field(this, key, constraints, format, errors(key), fieldValue);
+    }
+
+    /**
+     * @return the lang used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)})
+     * and for translations in {@link #errorsAsJson()}. For these methods the lang can be change via {@link #withLang(Lang)}.
+     */
+    public Optional<Lang> lang() {
+        return Optional.ofNullable(this.lang);
+    }
+
+    /**
+     * A copy of this form with the given lang set which is used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)})
+     * and for translations in {@link #errorsAsJson()}.
+     */
+    public Form withLang(Lang lang) {
+        return new Form<T>(this.rootName, this.backedType, this.rawData, this.errors, this.value, this.groups, this.messagesApi, this.formatters, this.validatorFactory, this.config, lang);
     }
 
     public String toString() {

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -827,6 +827,16 @@ public class Form<T> {
      * Retrieves a field.
      *
      * @param key field name
+     * @return the field (even if the field does not exist you get a field)
+     */
+    public Field field(final String key) {
+        return field(key, this.lang);
+    }
+
+    /**
+     * Retrieves a field.
+     *
+     * @param key field name
      * @param lang used for formatting
      * @return the field (even if the field does not exist you get a field)
      */

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -820,7 +820,18 @@ public class Form<T> {
      * @return the field (even if the field does not exist you get a field)
      */
     public Field apply(String key) {
-        return field(key);
+        return apply(key, this.lang);
+    }
+
+    /**
+     * Retrieves a field.
+     *
+     * @param key field name
+     * @param lang the language to use for the formatter
+     * @return the field (even if the field does not exist you get a field)
+     */
+    public Field apply(String key, Lang lang) {
+        return field(key, lang);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -750,7 +750,7 @@ public class Form<T> {
      * @return the form errors serialized as Json.
      */
     public JsonNode errorsAsJson() {
-        return errorsAsJson(Http.Context.current() != null ? Http.Context.current().lang() : null);
+        return errorsAsJson(this.lang);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -121,13 +121,6 @@ public class Constraints {
         public Config getConfig() {
             return this.config;
         }
-
-        /**
-         * @return a ValidationPayload object which only contains the given config
-         */
-        public static ValidationPayload empty(final Config config) {
-            return new ValidationPayload(null, null, null, config);
-        }
     }
 
     /**

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -14,6 +14,7 @@ import play.data.*;
 import play.data.format.Formatters;
 import play.data.Task;
 import play.data.validation.ValidationError;
+import play.i18n.Lang;
 import play.i18n.MessagesApi;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http.Context;
@@ -60,7 +61,7 @@ public class HttpFormsTest {
 
     private <T> Form<T> copyFormWithoutRawData(final Form<T> formToCopy, final Application app) {
         return new Form<T>(formToCopy.name(), formToCopy.getBackedType(), null, formToCopy.errors(), formToCopy.value(),
-            (Class[])null, app.injector().instanceOf(MessagesApi.class), app.injector().instanceOf(Formatters.class), app.injector().instanceOf(ValidatorFactory.class), app.injector().instanceOf(Config.class));
+            (Class[])null, app.injector().instanceOf(MessagesApi.class), app.injector().instanceOf(Formatters.class), app.injector().instanceOf(ValidatorFactory.class), app.injector().instanceOf(Config.class), formToCopy.lang().orElse(null));
     }
 
     @Test
@@ -132,9 +133,7 @@ public class HttpFormsTest {
             ValidatorFactory validatorFactory = app.injector().instanceOf(ValidatorFactory.class);
             Config config = app.injector().instanceOf(Config.class);
 
-            RequestBuilder rb = new RequestBuilder();
-            Context ctx = new Context(rb, contextComponents(app));
-            Context.current.set(ctx);
+            Lang lang = messagesApi.preferred(new RequestBuilder().build()).lang();
 
             List<String> msgs = new ArrayList<>();
             msgs.add("error.generalcustomerror");
@@ -143,7 +142,8 @@ public class HttpFormsTest {
             args.add("error.customarg");
             List<ValidationError> errors = new ArrayList<>();
             errors.add(new ValidationError("foo", msgs, args));
-            Form<Money> form = new Form<>(null, Money.class, new HashMap<>(), errors, Optional.empty(), messagesApi, formatters, validatorFactory, config);
+
+            Form<Money> form = new Form<>(null, Money.class, new HashMap<>(), errors, Optional.empty(), null, messagesApi, formatters, validatorFactory, config, lang);
 
             assertThat(form.errorsAsJson().get("foo").toString()).isEqualTo("[\"It looks like something was not correct\"]");
         });


### PR DESCRIPTION
There is just one thing you should know when reviewing this:

If you have a very simple template like...
```html
@(myForm: Form[User])

@helper.form(action = routes.Application.submit()) {
    @helper.inputText(myForm("email"))
}
```
...the problem here is that `myForm("email")` - which actually calls `myForm.apply(String key)` - uses `Http.Context` internally to retrieve the language - which is then used to format the field value (important for numbers, dates, etc.)

So instead of having to pass a language every time within templates like e.g. `myForm("email", lang)`  (and to stay backwards compatible as well) I solved this by internally - inside the form instance - saving the language that was used during form binding and use it later inside `apply(key)` and `field(key)`.
Just have a look at the `apply(...)` and `field(...)` methods I changed and added (and it's javadocs).
I also added the method `form.withLang(Lang lang)` so a user is able to update the form language (gives you a copy of the form of course). (However I doubt this method will be used a lot since I am pretty sure you usually just want to keep the language that was used during binding - and most of the time you just bind from the current request, which provides you the lang, anyway).