### PR TITLE
Deprecate remaining methods that depend on Http.Context

### DIFF
--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -359,7 +359,7 @@ That means other methods that depend directly on it were also deprecated:
 1. `play.mvc.Controller.session(String key, String value)`
 1. `play.mvc.Controller.session(String key)`
 
-The new way to retrieve the session of a request is the call the `session()` method of a `Http.Request` instance.
+The new way to retrieve the session of a request is to call the `session()` method of a `Http.Request` instance.
 The new way to manipulate the session is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
 
 #### Before
@@ -431,7 +431,7 @@ That means other methods that depend directly on it were also deprecated:
 1. `play.mvc.Controller.flash(String key, String value)`
 1. `play.mvc.Controller.flash(String key)`
 
-The new way to retrieve the flash of a request is the call the `flash()` method of a `Http.Request` instance.
+The new way to retrieve the flash of a request is to call the `flash()` method of a `Http.Request` instance.
 The new way to manipulate the flash is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
 
 #### Before

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -495,6 +495,38 @@ public class FooController extends Controller {
 }
 ```
 
+### Template helper methods deprecated
+
+Inside templates Play offered you various helper methods which rely on `Http.Context` internally.
+These methods are deprecated starting with Play 2.7.
+Instead you have to explicitly pass a desired object to your templates now.
+
+#### Before
+
+```html
+@()
+@ctx()
+@request()
+@response()
+@flash()
+@session()
+@lang()
+@messages()
+```
+
+#### After
+
+```html
+@(Http.Request request, Http.Flash flash, Http.Session session, Lang lang, Messages messages)
+@request
+@flash
+@session
+@lang
+@messages
+```
+
+There is no direct replacement for `ctx()` and `response()`.
+
 ### Changes in Java Forms related to `Http.Context`
 
 When retrieving the [`Field`](api/java/play/data/Form.Field.html) of a [`Form`](api/java/play/data/Form.html) (e.g. via `myform.field("username")` or just `myform("username")` inside templates) the language of the current `Http.Context` was used to format the value of the field.

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -237,6 +237,17 @@ public class MyAction extends Action.Simple {
 
 ### Lang and Messages methods in `Http.Context` deprecated
 
+The following methods have been deprecated:
+
+1. `Http.Context.lang()`
+1. `Http.Context.changeLang(Lang lang)`
+1. `Http.Context.changeLang(String code)`
+1. `Http.Context.clearLang()`
+1. `Http.Context.setTransientLang(Lang lang)`
+1. `Http.Context.setTransientLang(String code)`
+1. `Http.Context.clearTransientLang()`
+1. `Http.Context.messages()`
+
 That means other methods that depend directly on these were also deprecated:
 
 1. `play.mvc.Controller.lang()`

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -285,7 +285,7 @@ Or if you want to have a fallback to the languages of the request you can do tha
 Lang lang = Lang.forCode("es");
 // Get a Message instance based on the spanish locale, however if that isn't available
 // try to choose the best fitting language based on the current request
-Messages messages = this.messagesApi.preferred(request.addAttr(Messages.Attrs.CurrentLang, lang));
+Messages messages = this.messagesApi.preferred(request.withTransientLang(lang));
 return ok(myview.render(messages));
 ```
 > **Note**: To not repeat that code again and again inside each action method you could e.g. create the `Messages` instance in an action of the [[action composition chain|JavaActionsComposition]] and save that instance in a request Attribute so you can access it later.

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -15,7 +15,7 @@ Instead you can use the `request.attrs()` method now, which provides you the equ
 The `@AddCSRFToken` action annotation added two entries named `CSRF_TOKEN` and `CSRF_TOKEN_NAME` to the `args` map of a `Http.Context` instance. These entries have been removed.
 Use [[the new correct way to get the token|JavaCsrf#Getting-the-current-token]].
 
-### `Http.Context.current()` deprecated
+### `Http.Context.current()` and `Http.Context.request()` deprecated
 
 Before Play 2.7, when using Play with Java, the only way to access the `Http.Request` was `Http.Context.current()` which was used internally by `Controller.request()` method. The problem with `Http.Context.current()` is that it is implemented using a thread local, which is harder to test, to keep in sync with changes made by other places and makes it harder to access the request in other threads.
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -150,7 +150,11 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-### `Http.Response` deprecated
+### `Http.Context.response()` and `Http.Response` class deprecated
+
+That means other methods that depend directly on these were also deprecated:
+
+1. `play.mvc.Controller.response()`
 
 `Http.Response` was deprecated with other accesses methods to it. It was mainly used to add headers and cookies, but these are already available in `play.mvc.Result` and then the API got a little confused. For Play 2.7, you should migrate code like:
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -529,10 +529,10 @@ Instead you have to explicitly pass a desired object to your templates now.
 #### After
 
 ```html
-@(Http.Request request, Http.Flash flash, Http.Session session, Lang lang, Messages messages)
+@(Http.Request request, Lang lang, Messages messages)
 @request
-@flash
-@session
+@request.flash()
+@request.session()
 @lang
 @messages
 @messages("some_msg_key")

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -226,7 +226,7 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-### `Http.Context.changeLang` and `Http.Context.clearLang` deprecated
+### `Http.Context.changeLang(...)` and `Http.Context.clearLang()` deprecated
 
 That means other methods that depend directly on these two were also deprecated:
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -512,6 +512,7 @@ Instead you have to explicitly pass a desired object to your templates now.
 @session()
 @lang()
 @messages()
+@Messages("some_msg_key")
 ```
 
 #### After
@@ -523,6 +524,7 @@ Instead you have to explicitly pass a desired object to your templates now.
 @session
 @lang
 @messages
+@messages("some_msg_key")
 ```
 
 There is no direct replacement for `ctx()` and `response()`.

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -235,12 +235,14 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-### `Http.Context.changeLang(...)` and `Http.Context.clearLang()` deprecated
+### `lang()`, `changeLang(...)`, `clearLang()`, `setTransientLang(...)`, `clearTransientLang()` and `messages()` of `Http.Context` deprecated
 
-That means other methods that depend directly on these two were also deprecated:
+That means other methods that depend directly on these were also deprecated:
 
-1. `play.mvc.Controller.changeLang`
-1. `play.mvc.Controller.clearLang`
+1. `play.mvc.Controller.lang()`
+1. `play.mvc.Controller.changeLang(Lang lang)`
+1. `play.mvc.Controller.changeLang(String code)`
+1. `play.mvc.Controller.clearLang()`
 
 The new way of changing lang now is to have a instance of [`play.i18n.MessagesApi`](api/java/play/i18n/MessagesApi.html) injected and call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -235,7 +235,7 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-### `lang()`, `changeLang(...)`, `clearLang()`, `setTransientLang(...)`, `clearTransientLang()` and `messages()` of `Http.Context` deprecated
+### Lang and Messages methods in `Http.Context` deprecated
 
 That means other methods that depend directly on these were also deprecated:
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -17,6 +17,11 @@ Use [[the new correct way to get the token|JavaCsrf#Getting-the-current-token]].
 
 ### `Http.Context.current()` and `Http.Context.request()` deprecated
 
+That means other methods that depend directly on these two were also deprecated:
+
+1. `play.mvc.Controller.ctx()`
+1. `play.mvc.Controller.request()`
+
 Before Play 2.7, when using Play with Java, the only way to access the `Http.Request` was `Http.Context.current()` which was used internally by `Controller.request()` method. The problem with `Http.Context.current()` is that it is implemented using a thread local, which is harder to test, to keep in sync with changes made by other places and makes it harder to access the request in other threads.
 
 With Play 2.7 you can now access the current request by simply adding it as a param to your routes and actions.

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -8,7 +8,7 @@ Multiple changes were made to `Http.Context`. The idea is to move more and more 
 
 Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]] in Play 2.6, have finally been removed in Play 2.7.
 Therefore the `args` map of a `Http.Context` instance no longer contains these removed request tags as well.
-Instead you can use the `contextObj.request().attrs()` method now, which provides you the equivalent request attributes.
+Instead you can use the `request.attrs()` method now, which provides you the equivalent request attributes.
 
 ### CSRF tokens removed from `args`
 
@@ -285,7 +285,7 @@ Or if you want to have a fallback to the languages of the request you can do tha
 Lang lang = Lang.forCode("es");
 // Get a Message instance based on the spanish locale, however if that isn't available
 // try to choose the best fitting language based on the current request
-Messages messages = this.messagesApi.preferred(request().addAttr(Messages.Attrs.CurrentLang, lang));
+Messages messages = this.messagesApi.preferred(request.addAttr(Messages.Attrs.CurrentLang, lang));
 return ok(myview.render(messages));
 ```
 > **Note**: To not repeat that code again and again inside each action method you could e.g. create the `Messages` instance in an action of the [[action composition chain|JavaActionsComposition]] and save that instance in a request Attribute so you can access it later.
@@ -384,24 +384,25 @@ public class FooController extends Controller {
 #### After
 
 ```java
+import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
 import play.mvc.Controller;
 
 public class FooController extends Controller {
-    public Result info() {
-        String user = request().session().get("current_user");
+    public Result info(Http.Request request) {
+        String user = request.session().get("current_user");
         return Results.ok("Hello " + user);
     }
 
-    public Result login() {
+    public Result login(Http.Request request) {
         return Results.ok("Hello")
-            .addingToSession(request(), "current_user", "user@gmail.com");
+            .addingToSession(request, "current_user", "user@gmail.com");
     }
 
-    public Result logout() {
+    public Result logout(Http.Request request) {
         return Results.ok("Hello")
-            .removingFromSession(request(), "current_user");
+            .removingFromSession(request, "current_user");
     }
 
     public Result clear() {
@@ -455,13 +456,14 @@ public class FooController extends Controller {
 #### After
 
 ```java
+import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
 import play.mvc.Controller;
 
 public class FooController extends Controller {
-    public Result info() {
-        String message = request().flash().get("message");
+    public Result info(Http.Request request) {
+        String message = request.flash().get("message");
         return Results.ok("Message: " + message);
     }
 

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -295,12 +295,11 @@ Please see the documentation in [[CSPFilter]] for more information.
 
 ## play.mvc.Results.TODO moved to play.mvc.Controller.TODO
 
-All Play's error pages have been updated to render a CSP nonce if the [[CSP filter|CSPFilter]] is present.  This means that the error page templates must take a request as a parameter.  In 2.6.x, the `TODO` field was previously rendered as a static result instead of an action with an HTTP context, and so may have been called outside the controller.  In 2.7.0, the `TODO` field has been removed, and there is now a `TODO()` method in `play.mvc.Controller` instead:
+All Play's error pages have been updated to render a CSP nonce if the [[CSP filter|CSPFilter]] is present.  This means that the error page templates must take a request as a parameter.  In 2.6.x, the `TODO` field was previously rendered as a static result instead of an action with an HTTP context, and so may have been called outside the controller.  In 2.7.0, the `TODO` field has been removed, and there is now a `TODO(Http.Request request)` method in `play.mvc.Controller` instead:
 
 ```java
 public abstract class Controller extends Results implements Status, HeaderNames {
-    public static Result TODO() {
-        play.mvc.Http.Request request = Http.Context.current().request();
+    public static Result TODO(play.mvc.Http.Request request) {
         return status(NOT_IMPLEMENTED, views.html.defaultpages.todo.render(request.asScala()));
     }
 }

--- a/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/csp/CSPReportController.java
+++ b/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/csp/CSPReportController.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import play.filters.csp.*;
 import play.mvc.BodyParser;
 import play.mvc.Controller;
+import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
 
@@ -17,8 +18,8 @@ public class CSPReportController extends Controller {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @BodyParser.Of(CSPReportBodyParser.class)
-    public Result cspReport() {
-        JavaCSPReport cspReport = request().body().as(JavaCSPReport.class);
+    public Result cspReport(Http.Request request) {
+        JavaCSPReport cspReport = request.body().as(JavaCSPReport.class);
         logger.warn("CSP violation: violatedDirective = {}, blockedUri = {}, originalPolicy = {}",
                 cspReport.violatedDirective(),
                 cspReport.blockedUri(),

--- a/documentation/manual/working/commonGuide/server/code/SomeJavaController.java
+++ b/documentation/manual/working/commonGuide/server/code/SomeJavaController.java
@@ -3,6 +3,7 @@
  */
 
 import play.mvc.Controller;
+import play.mvc.Http;
 import play.mvc.Result;
 import java.util.Optional;
 //#server-request-attribute
@@ -10,8 +11,8 @@ import play.api.mvc.request.RequestAttrKey;
 
 public class SomeJavaController extends Controller {
 
-  public Result index() {
-    assert(request().attrs().getOptional(RequestAttrKey.Server().asJava()).equals(Optional.of("netty")));
+  public Result index(Http.Request request) {
+    assert(request.attrs().getOptional(RequestAttrKey.Server().asJava()).equals(Optional.of("netty")));
     // ...
     //###skip: 1
     return ok("");

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaEmbeddedRouter.scala.html
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaEmbeddedRouter.scala.html
@@ -1,5 +1,5 @@
 @* #javascript-embedded-router *@
-@()
+@(implicit request: play.mvc.Http.Request)
 
 @* ###skip: 2 *@
 @import javaguide.binder.controllers.routes

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -67,12 +67,6 @@ object MockJavaActionHelper {
   def callWithStringBody(action: Action[Http.RequestBody], requestBuilder: play.mvc.Http.RequestBuilder, body: String)(implicit mat: Materializer): Result = {
     Helpers.await(Helpers.call(action, requestBuilder.build().asScala, body)).asJava
   }
-
-  def setContext(request: play.mvc.Http.RequestBuilder, contextComponents: JavaContextComponents): Unit = {
-    Http.Context.current.set(new Http.Context(request.build(), contextComponents))
-  }
-
-  def removeContext: Unit = Http.Context.current.remove()
 }
 
 /**

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -7,6 +7,7 @@ package javaguide.async;
 import akka.actor.*;
 import akka.stream.Materializer;
 import play.libs.streams.ActorFlow;
+import play.mvc.Http;
 import play.mvc.WebSocket;
 import play.libs.F;
 
@@ -62,9 +63,9 @@ public class JavaWebSockets {
         private Materializer materializer;
 
         //#actor-reject
-        public WebSocket socket() {
+        public WebSocket socket(Http.Request req) {
             return WebSocket.Text.acceptOrResult(request -> {
-                if (request().session().get("user") != null) {
+                if (req.session().get("user") != null) {
                     return CompletableFuture.completedFuture(
                             F.Either.Right(ActorFlow.actorRef(MyWebSocketActor::props,
                                     actorSystem, materializer)));

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
@@ -11,6 +11,7 @@ import play.filters.csrf.AddCSRFToken;
 import play.filters.csrf.CSRF;
 import play.filters.csrf.RequireCSRFCheck;
 import play.libs.crypto.CSRFTokenSigner;
+import play.mvc.Http;
 import play.mvc.Result;
 import play.test.WithApplication;
 
@@ -37,9 +38,9 @@ public class JavaCsrf extends WithApplication {
         String token = tokenSigner().generateSignedToken();
         String body = contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             @AddCSRFToken
-            public Result index() {
+            public Result index(Http.Request request) {
                 //#get-token
-                Optional<CSRF.Token> token = CSRF.getToken(request());
+                Optional<CSRF.Token> token = CSRF.getToken(request);
                 //#get-token
                 return ok(token.map(CSRF.Token::value).orElse(""));
             }
@@ -106,8 +107,8 @@ public class JavaCsrf extends WithApplication {
 
         //#csrf-add-token
         @AddCSRFToken
-        public Result get() {
-            return ok(CSRF.getToken(request()).map(CSRF.Token::value).orElse("no token"));
+        public Result get(Http.Request request) {
+            return ok(CSRF.getToken(request).map(CSRF.Token::value).orElse("no token"));
         }
         //#csrf-add-token
     }

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
@@ -53,8 +53,8 @@ public class JavaCsrf extends WithApplication {
         CSRF.Token token = new CSRF.Token("csrfToken", tokenSigner().generateSignedToken());
         String body = contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             @AddCSRFToken
-            public Result index() {
-                return ok(javaguide.forms.html.csrf.render());
+            public Result index(Http.Request request) {
+                return ok(javaguide.forms.html.csrf.render(request));
             }
         }, fakeRequest("GET", "/").session("csrfToken", token.value()), mat));
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
@@ -8,10 +8,8 @@ import play.api.Application
 import play.api.test.{PlaySpecification, WithApplication}
 import javaguide.forms.html.{User, UserForm}
 
-import play.mvc.Http.{Context => JContext}
 import java.util
 
-import play.core.j.JavaContextComponents
 import play.mvc.Http
 
 class JavaFormHelpers extends PlaySpecification {
@@ -19,13 +17,10 @@ class JavaFormHelpers extends PlaySpecification {
   "java form helpers" should {
     def withFormFactory[A](block: (play.data.FormFactory, play.i18n.Messages) => A)(implicit app: Application): A = {
       val requestBuilder = new Http.RequestBuilder()
-      val components: JavaContextComponents = app.injector.instanceOf[JavaContextComponents]
       val request = requestBuilder.build()
-      val ctx = new JContext(request, components)
-      JContext.current.set(ctx)
       val formFactory = app.injector.instanceOf[play.data.FormFactory]
       val messagesApi = app.injector.instanceOf[play.i18n.MessagesApi]
-      try block(formFactory, messagesApi.preferred(request)) finally JContext.current.set(null)
+      block(formFactory, messagesApi.preferred(request))
     }
     {
       def segment(name: String)(implicit app: Application) = {

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
@@ -21,6 +21,7 @@ import play.data.validation.Constraints.ValidationPayload;
 import play.data.validation.ValidationError;
 import play.i18n.Lang;
 import play.i18n.Messages;
+import play.i18n.MessagesApi;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.*;
 import play.test.WithApplication;
@@ -102,7 +103,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void adhocValidation() {
-        Result result = call(new U3UserController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
+        Result result = call(new U3UserController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of("email", "e", "password", "p")), mat);
 
         // Run it through the template
@@ -111,15 +112,19 @@ public class JavaForms extends WithApplication {
 
     public class U3UserController extends MockJavaAction {
 
-        U3UserController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        U3UserController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
 
         public Result index(Http.Request request) {
             Form<javaguide.forms.u3.User> userForm = formFactory().form(javaguide.forms.u3.User.class).bindFromRequest(request);
+            Messages messages = this.messagesApi.preferred(request);
 
             if (userForm.hasErrors()) {
-                return badRequest(javaguide.forms.html.view.render(userForm));
+                return badRequest(javaguide.forms.html.view.render(userForm, messages));
             } else {
                 javaguide.forms.u3.User user = userForm.get();
                 return ok("Got user " + user);
@@ -133,7 +138,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void listValidation() {
-        Result result = call(new ListValidationController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
+        Result result = call(new ListValidationController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of("email", "e")), mat);
 
         // Run it through the template
@@ -188,15 +193,19 @@ public class JavaForms extends WithApplication {
 
     public class ListValidationController extends MockJavaAction {
 
-        ListValidationController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        ListValidationController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
 
         public Result index(Http.Request request) {
             Form<SignUpForm> userForm = formFactory().form(SignUpForm.class).bindFromRequest(request);
+            Messages messages = this.messagesApi.preferred(request);
 
             if (userForm.hasErrors()) {
-                return badRequest(javaguide.forms.html.view.render(userForm));
+                return badRequest(javaguide.forms.html.view.render(userForm, messages));
             } else {
                 SignUpForm user = userForm.get();
                 return ok("Got user " + user);
@@ -206,7 +215,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void objectValidation() {
-        Result result = call(new ObjectValidationController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
+        Result result = call(new ObjectValidationController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of("email", "e")), mat);
 
         // Run it through the template
@@ -256,15 +265,19 @@ public class JavaForms extends WithApplication {
 
     public class ObjectValidationController extends MockJavaAction {
 
-        ObjectValidationController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        ObjectValidationController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
 
         public Result index(Http.Request request) {
             Form<LoginForm> adminForm = formFactory().form(LoginForm.class).bindFromRequest(request);
+            Messages messages = this.messagesApi.preferred(request);
 
             if (adminForm.hasErrors()) {
-                return badRequest(javaguide.forms.html.view.render(adminForm));
+                return badRequest(javaguide.forms.html.view.render(adminForm, messages));
             } else {
                 LoginForm user = adminForm.get();
                 return ok("Got user " + user);
@@ -392,7 +405,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void partialFormSignupValidation() {
-        Result result = call(new PartialFormSignupController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
+        Result result = call(new PartialFormSignupController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of()), mat);
 
         // Run it through the template
@@ -401,8 +414,11 @@ public class JavaForms extends WithApplication {
 
     public class PartialFormSignupController extends MockJavaAction {
 
-        PartialFormSignupController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        PartialFormSignupController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
 
         public Result index(Http.Request request) {
@@ -410,8 +426,10 @@ public class JavaForms extends WithApplication {
             Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, SignUpCheck.class).bindFromRequest(request);
             //#partial-validate-signup
 
+            Messages messages = this.messagesApi.preferred(request);
+
             if (form.hasErrors()) {
-                return badRequest(javaguide.forms.html.view.render(form));
+                return badRequest(javaguide.forms.html.view.render(form, messages));
             } else {
                 PartialUserForm user = form.get();
                 return ok("Got user " + user);
@@ -421,7 +439,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void partialFormLoginValidation() {
-        Result result = call(new PartialFormLoginController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
+        Result result = call(new PartialFormLoginController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of()), mat);
 
         // Run it through the template
@@ -430,17 +448,23 @@ public class JavaForms extends WithApplication {
 
     public class PartialFormLoginController extends MockJavaAction {
 
-        PartialFormLoginController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        PartialFormLoginController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
+
 
         public Result index(Http.Request request) {
             //#partial-validate-login
             Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, LoginCheck.class).bindFromRequest(request);
             //#partial-validate-login
 
+            Messages messages = this.messagesApi.preferred(request);
+
             if (form.hasErrors()) {
-                return badRequest(javaguide.forms.html.view.render(form));
+                return badRequest(javaguide.forms.html.view.render(form, messages));
             } else {
                 PartialUserForm user = form.get();
                 return ok("Got user " + user);
@@ -450,7 +474,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void partialFormDefaultValidation() {
-        Result result = call(new PartialFormDefaultController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
+        Result result = call(new PartialFormDefaultController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of()), mat);
 
         // Run it through the template
@@ -459,8 +483,11 @@ public class JavaForms extends WithApplication {
 
     public class PartialFormDefaultController extends MockJavaAction {
 
-        PartialFormDefaultController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        PartialFormDefaultController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
 
         public Result index(Http.Request request) {
@@ -468,8 +495,10 @@ public class JavaForms extends WithApplication {
             Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, Default.class).bindFromRequest(request);
             //#partial-validate-default
 
+            Messages messages = this.messagesApi.preferred(request);
+
             if (form.hasErrors()) {
-                return badRequest(javaguide.forms.html.view.render(form));
+                return badRequest(javaguide.forms.html.view.render(form, messages));
             } else {
                 PartialUserForm user = form.get();
                 return ok("Got user " + user);
@@ -479,7 +508,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void partialFormNoGroupValidation() {
-        Result result = call(new PartialFormNoGroupController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
+        Result result = call(new PartialFormNoGroupController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of()), mat);
 
         // Run it through the template
@@ -488,8 +517,11 @@ public class JavaForms extends WithApplication {
 
     public class PartialFormNoGroupController extends MockJavaAction {
 
-        PartialFormNoGroupController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        PartialFormNoGroupController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
 
         public Result index(Http.Request request) {
@@ -497,8 +529,10 @@ public class JavaForms extends WithApplication {
             Form<PartialUserForm> form = formFactory().form(PartialUserForm.class).bindFromRequest(request);
             //#partial-validate-nogroup
 
+            Messages messages = this.messagesApi.preferred(request);
+
             if (form.hasErrors()) {
-                return badRequest(javaguide.forms.html.view.render(form));
+                return badRequest(javaguide.forms.html.view.render(form, messages));
             } else {
                 PartialUserForm user = form.get();
                 return ok("Got user " + user);
@@ -508,7 +542,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void OrderedGroupSequenceValidation() {
-        Result result = call(new OrderedGroupSequenceController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
+        Result result = call(new OrderedGroupSequenceController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of()), mat);
 
         // Run it through the template
@@ -517,8 +551,11 @@ public class JavaForms extends WithApplication {
 
     public class OrderedGroupSequenceController extends MockJavaAction {
 
-        OrderedGroupSequenceController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        OrderedGroupSequenceController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
 
         public Result index(Http.Request request) {
@@ -526,8 +563,10 @@ public class JavaForms extends WithApplication {
             Form<PartialUserForm> form = formFactory().form(PartialUserForm.class, OrderedChecks.class).bindFromRequest(request);
             //#ordered-group-sequence-validate
 
+            Messages messages = this.messagesApi.preferred(request);
+
             if (form.hasErrors()) {
-                return badRequest(javaguide.forms.html.view.render(form));
+                return badRequest(javaguide.forms.html.view.render(form, messages));
             } else {
                 PartialUserForm user = form.get();
                 return ok("Got user " + user);

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf.scala.html
@@ -1,4 +1,4 @@
-
+@(implicit request: play.mvc.Http.Request)
 @* #csrf-call *@
 @import helper._
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/fullform.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/fullform.scala.html
@@ -1,5 +1,5 @@
 @* #full-form *@
-@(myForm: Form[User])
+@(myForm: Form[User])(implicit messages: play.i18n.Messages)
 
 @helper.form(action = routes.Application.submit()) {
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/fullform.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/fullform.scala.html
@@ -1,5 +1,5 @@
 @* #full-form *@
-@(myForm: Form[User])(implicit messages: play.i18n.Messages)
+@(myForm: play.data.Form[User])(implicit messages: play.i18n.Messages)
 
 @helper.form(action = routes.Application.submit()) {
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/helpers.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/helpers.scala.html
@@ -1,4 +1,4 @@
-@(myForm: Form[User], userForm: Form[UserForm])
+@(myForm: Form[User], userForm: Form[UserForm])(implicit messages: play.i18n.Messages)
 
 <span class="form">
 @* #form *@

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/helpers.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/helpers.scala.html
@@ -1,4 +1,4 @@
-@(myForm: Form[User], userForm: Form[UserForm])(implicit messages: play.i18n.Messages)
+@(myForm: play.data.Form[User], userForm: Form[UserForm])(implicit messages: play.i18n.Messages)
 
 <span class="form">
 @* #form *@

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/view.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/view.scala.html
@@ -1,10 +1,10 @@
-@(form: Form[_])
+@(form: Form[_], messages: play.i18n.Messages)
 
 @* #global-errors *@
 @if(form.hasGlobalErrors) {
     <p class="error">
         @for(error <- form.globalErrors) {
-            <p>@error.format(messages())</p>
+            <p>@error.format(messages)</p>
         }
     </p>
 }
@@ -12,6 +12,6 @@
 
 @* #field-errors *@
 @for(error <- form("email").errors) {
-    <p>@error.format(messages())</p>
+    <p>@error.format(messages)</p>
 }
 @* #field-errors *@

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/view.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/view.scala.html
@@ -1,4 +1,4 @@
-@(form: Form[_], messages: play.i18n.Messages)
+@(form: play.data.Form[_], messages: play.i18n.Messages)
 
 @* #global-errors *@
 @if(form.hasGlobalErrors) {

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/withFieldConstructor.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/withFieldConstructor.scala.html
@@ -1,4 +1,4 @@
-@(myForm: Form[User])(implicit messages: play.i18n.Messages)
+@(myForm: play.data.Form[User])(implicit messages: play.i18n.Messages)
 
 @import helper._
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/withFieldConstructor.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/withFieldConstructor.scala.html
@@ -1,4 +1,4 @@
-@(myForm: Form[User])
+@(myForm: Form[User])(implicit messages: play.i18n.Messages)
 
 @import helper._
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.relative.routes
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.relative.routes
@@ -1,4 +1,4 @@
 #relative-hello
-GET     /foo/bar/hello              controllers.Relative.helloview
+GET     /foo/bar/hello              controllers.Relative.helloview(request: Request)
 GET     /hello/:name                controllers.Relative.hello(name)
 #relative-hello

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActions.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActions.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletionStage;
 import org.junit.Test;
 import play.core.j.JavaHandlerComponents;
 import play.mvc.Controller;
+import play.mvc.Http;
 import play.mvc.Result;
 
 import javaguide.testhelpers.MockJavaAction;
@@ -26,8 +27,8 @@ public class JavaActions extends WithApplication {
     public void simpleAction() {
         assertThat(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#simple-action
-            public Result index() {
-                return ok("Got request " + request() + "!");
+            public Result index(Http.Request request) {
+                return ok("Got request " + request + "!");
             }
             //#simple-action
         }, fakeRequest(), mat).status(), equalTo(200));

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
@@ -99,8 +99,8 @@ public class JavaActionsComposition extends Controller {
 
     // #pass-arg-action-index
     @With(PassArgAction.class)
-    public static Result passArgIndex() {
-        User user = request().attrs().get(Attrs.USER);
+    public static Result passArgIndex(Http.Request request) {
+        User user = request.attrs().get(Attrs.USER);
         return ok(Json.toJson(user));
     }
     // #pass-arg-action-index

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
@@ -37,8 +37,8 @@ public class JavaBodyParsers extends WithApplication {
     public void accessRequestBody() {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#access-json-body
-            public Result index() {
-                JsonNode json = request().body().asJson();
+            public Result index(Http.Request request) {
+                JsonNode json = request.body().asJson();
                 return ok("Got name: " + json.get("name").asText());
             }
             //#access-json-body
@@ -50,8 +50,8 @@ public class JavaBodyParsers extends WithApplication {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#particular-body-parser
                     @BodyParser.Of(BodyParser.Text.class)
-                    public Result index() {
-                        RequestBody body = request().body();
+                    public Result index(Http.Request request) {
+                        RequestBody body = request.body();
                         return ok("Got text: " + body.asText());
                     }
                     //#particular-body-parser
@@ -110,8 +110,8 @@ public class JavaBodyParsers extends WithApplication {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                 //#composing-access
                 @BodyParser.Of(UserBodyParser.class)
-                public Result save() {
-                    RequestBody body = request().body();
+                public Result save(Http.Request request) {
+                    RequestBody body = request.body();
                     User user = body.as(User.class);
 
                     return ok("Got: " + user.name);
@@ -147,8 +147,8 @@ public class JavaBodyParsers extends WithApplication {
         }
 
         @BodyParser.Of(Text10Kb.class)
-        public Result index() {
-            return ok("Got body: " + request().body().asText());
+        public Result index(Http.Request request) {
+            return ok("Got body: " + request.body().asText());
         }
         //#max-length
     }
@@ -218,8 +218,8 @@ public class JavaBodyParsers extends WithApplication {
     public void testCsv() {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                 @BodyParser.Of(CsvBodyParser.class)
-                public Result uploadCsv() {
-                    String value = ((List<List<String>>) request().body().as(List.class)).get(1).get(2);
+                public Result uploadCsv(Http.Request request) {
+                    String value = ((List<List<String>>) request.body().as(List.class)).get(1).get(2);
                     return ok("Got: " + value);
                 }
             }, fakeRequest().bodyText("1,2\n3,4,foo\n5,6"), mat)),

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaContentNegotiation.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaContentNegotiation.java
@@ -25,9 +25,9 @@ public class JavaContentNegotiation extends WithApplication {
     public void negotiateContent() {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#negotiate-content
-                    public Result list() {
+                    public Result list(Http.Request request) {
                         List<Item> items = Item.find.all();
-                        if (request().accepts("text/html")) {
+                        if (request.accepts("text/html")) {
                             return ok(views.html.Application.list.render(items));
                         } else {
                             return ok(Json.toJson(items));

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -25,8 +25,8 @@ public class JavaSessionFlash extends WithApplication {
     public void readSession() {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-session
-                    public Result index() {
-                        String user = request().session().get("connected");
+                    public Result index(Http.Request request) {
+                        String user = request.session().get("connected");
                         if(user != null) {
                             return ok("Hello " + user);
                         } else {
@@ -42,8 +42,8 @@ public class JavaSessionFlash extends WithApplication {
     public void storeSession() {
         Session session = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#store-session
-            public Result login() {
-                return ok("Welcome!").addingToSession(request(), "connected", "user@gmail.com");
+            public Result login(Http.Request request) {
+                return ok("Welcome!").addingToSession(request, "connected", "user@gmail.com");
             }
             //#store-session
         }, fakeRequest(), mat).session();
@@ -54,8 +54,8 @@ public class JavaSessionFlash extends WithApplication {
     public void removeFromSession() {
         Session session = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#remove-from-session
-            public Result logout() {
-                return ok("Bye").removingFromSession(request(), "connected");
+            public Result logout(Http.Request request) {
+                return ok("Bye").removingFromSession(request, "connected");
             }
             //#remove-from-session
         }, fakeRequest().session("connected", "foo"), mat).session();
@@ -78,8 +78,8 @@ public class JavaSessionFlash extends WithApplication {
     public void readFlash() {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-flash
-                    public Result index() {
-                        String message = request().flash().get("success");
+                    public Result index(Http.Request request) {
+                        String message = request.flash().get("success");
                         if(message == null) {
                             message = "Welcome!";
                         }

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -105,8 +105,8 @@ public class JavaSessionFlash extends WithApplication {
     @Test
     public void accessFlashInTemplate() {
         MockJavaAction index = new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
-            public Result index() {
-                return ok(javaguide.http.views.html.index.render());
+            public Result index(Http.Request request) {
+                return ok(javaguide.http.views.html.index.render(request.flash()));
             }
         };
         assertThat(contentAsString(call(index, fakeRequest(), mat)).trim(), equalTo("Welcome!"));

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/routing/relative/controllers/Relative.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/routing/relative/controllers/Relative.java
@@ -11,9 +11,9 @@ import play.mvc.*;
 
 public class Relative extends Controller {
 
-    public Result helloview() {
-        //###replace:         ok(views.html.hello.render("Bob", request()));
-        return ok(javaguide.http.routing.relative.views.html.hello.render("Bob", request()));
+    public Result helloview(Http.Request request) {
+        //###replace:         ok(views.html.hello.render("Bob", request));
+        return ok(javaguide.http.routing.relative.views.html.hello.render("Bob", request));
     }
 
     public Result hello(String name) {

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/views/index.scala.html
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/views/index.scala.html
@@ -1,4 +1,4 @@
-@()
+@(flash: play.mvc.Http.Flash)
 @* #flash-template *@
 @if(flash.containsKey("success")) {
   @flash.get("success")

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
@@ -120,7 +120,7 @@ public class JavaI18N extends WithApplication {
         //#change-lang-render
         public Result index(Http.Request request) {
             Lang lang = Lang.forCode("fr");
-            Messages messages = messagesApi.preferred(request.addAttr(Messages.Attrs.CurrentLang, lang));
+            Messages messages = messagesApi.preferred(request.withTransientLang(lang));
             return ok(hellotemplate.render(messages)).withLang(lang, messagesApi); // "bonjour"
         }
         //#change-lang-render

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
@@ -76,18 +76,22 @@ public class JavaI18N extends WithApplication {
 
     @Test
     public void checkDefaultScalaHello() {
-        Result result = MockJavaActionHelper.call(new DefaultScalaLangController(instanceOf(JavaHandlerComponents.class)), fakeRequest("GET", "/"), mat);
+        Result result = MockJavaActionHelper.call(new DefaultScalaLangController(instanceOf(JavaHandlerComponents.class), instanceOf(MessagesApi.class)), fakeRequest("GET", "/"), mat);
         assertThat(contentAsString(result), containsString("hello"));
     }
 
     public static class DefaultScalaLangController extends MockJavaAction {
 
-        DefaultScalaLangController(JavaHandlerComponents javaHandlerComponents) {
+        private final MessagesApi messagesApi;
+
+        DefaultScalaLangController(JavaHandlerComponents javaHandlerComponents, MessagesApi messagesApi) {
             super(javaHandlerComponents);
+            this.messagesApi = messagesApi;
         }
 
-        public Result index() {
-            return ok(helloscalatemplate.render()); // "hello"
+        public Result index(Http.Request request) {
+            Messages messages = this.messagesApi.preferred(request);
+            return ok(helloscalatemplate.render(messages)); // "hello"
         }
     }
 
@@ -129,11 +133,14 @@ public class JavaI18N extends WithApplication {
             super(javaHandlerComponents);
         }
 
+        @javax.inject.Inject
+        private MessagesApi messagesApi;
+
         //#show-context-messages
-        public Result index() {
-            Messages messages = Http.Context.current().messages();
+        public Result index(Http.Request request) {
+            Messages messages = this.messagesApi.preferred(request);
             String hello = messages.at("hello");
-            return ok(indextemplate.render());
+            return ok(indextemplate.render(messages));
         }
         //#show-context-messages
     }

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
@@ -181,8 +181,8 @@ public class JavaI18N extends WithApplication {
         }
 
         // #accepted-languages
-        public Result index() {
-            List<Lang> langs = request().acceptLanguages();
+        public Result index(Http.Request request) {
+            List<Lang> langs = request.acceptLanguages();
             String codes = langs.stream().map(Lang::code).collect(joining(","));
             return ok(codes);
         }

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/explicitjavatemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/explicitjavatemplate.scala.html
@@ -1,4 +1,4 @@
 @* #template *@
-@(implicit messages: play.i18n.Messages)
+@(messages: play.i18n.Messages)
 @messages.at("hello")
 @* #template *@

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/helloscalatemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/helloscalatemplate.scala.html
@@ -1,3 +1,4 @@
 @* #template *@
-@Messages("hello")
+@(messages: play.i18n.Messages)
+@messages("hello")
 @* #template *@

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/hellotemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/hellotemplate.scala.html
@@ -1,4 +1,4 @@
 @* #template *@
-@(implicit messages: play.i18n.Messages)
+@(messages: play.i18n.Messages)
 @{messages.at("hello")}
 @* #template *@

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/indextemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/indextemplate.scala.html
@@ -1,4 +1,4 @@
 @* #template *@
-@()
-@{messages().at("hello")}
+@(messages: play.i18n.Messages)
+@{messages.at("hello")}
 @* #template *@

--- a/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
+++ b/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import play.core.j.JavaHandlerComponents;
+import play.mvc.Http;
 import play.mvc.Result;
 import play.libs.Json;
 
@@ -99,8 +100,8 @@ public class JavaJsonActions extends WithApplication {
         }
 
         //#json-request-as-anycontent
-        public Result sayHello() {
-            JsonNode json = request().body().asJson();
+        public Result sayHello(Http.Request request) {
+            JsonNode json = request.body().asJson();
             if(json == null) {
                 return badRequest("Expecting Json data");
             } else {
@@ -122,8 +123,8 @@ public class JavaJsonActions extends WithApplication {
         }
 
         //#json-request-as-anyclazz
-        public Result sayHello() {
-            Optional<Person> person = request().body().parseJson(Person.class);
+        public Result sayHello(Http.Request request) {
+            Optional<Person> person = request.body().parseJson(Person.class);
             return person
               .map(p -> ok("Hello, " + p.firstName))
               .orElse(badRequest("Expecting Json data"));
@@ -139,8 +140,8 @@ public class JavaJsonActions extends WithApplication {
 
         //#json-request-as-json
         @BodyParser.Of(BodyParser.Json.class)
-        public Result sayHello() {
-            JsonNode json = request().body().asJson();
+        public Result sayHello(Http.Request request) {
+            JsonNode json = request.body().asJson();
             String name = json.findPath("name").textValue();
             if (name == null) {
                 return badRequest("Missing parameter [name]");

--- a/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/JavaMarkerController.java
+++ b/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/JavaMarkerController.java
@@ -31,22 +31,21 @@ public class JavaMarkerController extends Controller {
     // #logging-log-info-with-request-context
     // ###insert: import static net.logstash.logback.marker.Markers.append;
 
-    private Marker requestMarker() {
-        Http.Request request = Http.Context.current().request();
+    private Marker requestMarker(Http.Request request) {
         return append("host", request.host())
                 .and(append("path", request.path()));
     }
 
-    public Result index() {
-        logger.info(requestMarker(), "Rendering index()");
+    public Result index(Http.Request request) {
+        logger.info(requestMarker(request), "Rendering index()");
         return ok("foo");
     }
     // #logging-log-info-with-request-context
 
     // #logging-log-info-with-async-request-context
-    public CompletionStage<Result> asyncIndex() {
+    public CompletionStage<Result> asyncIndex(Http.Request request) {
         return CompletableFuture.supplyAsync(() -> {
-            logger.info(requestMarker(), "Rendering asyncIndex()");
+            logger.info(requestMarker(request), "Rendering asyncIndex()");
             return ok("foo");
         }, httpExecutionContext.current());
     }

--- a/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/JavaTracerController.java
+++ b/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/JavaTracerController.java
@@ -20,8 +20,7 @@ public class JavaTracerController extends Controller {
 
     private static final Marker tracerMarker = org.slf4j.MarkerFactory.getMarker("TRACER");
 
-    private Marker tracer() {
-        Http.Request request = Http.Context.current().request();
+    private Marker tracer(Http.Request request) {
         Marker marker = MarkerFactory.getDetachedMarker("dynamic"); // base do-nothing marker...
         if (request.getQueryString("trace") != null) {
             marker.add(tracerMarker);
@@ -29,8 +28,8 @@ public class JavaTracerController extends Controller {
         return marker;
     }
 
-    public Result index() {
-        logger.trace(tracer(), "Only logged if queryString contains trace=true");
+    public Result index(Http.Request request) {
+        logger.trace(tracer(request), "Only logged if queryString contains trace=true");
         return ok("hello world");
     }
 }

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -41,8 +41,8 @@ public class JavaFileUpload extends WithApplication {
 
     static class SyncUpload extends Controller {
         //#syncUpload
-        public Result upload() {
-            Http.MultipartFormData<File> body = request().body().asMultipartFormData();
+        public Result upload(Http.Request request) {
+            Http.MultipartFormData<File> body = request.body().asMultipartFormData();
             Http.MultipartFormData.FilePart<File> picture = body.getFile("picture");
             if (picture != null) {
                 String fileName = picture.getFilename();
@@ -58,8 +58,8 @@ public class JavaFileUpload extends WithApplication {
 
     static class AsyncUpload extends Controller {
         //#asyncUpload
-        public Result upload() {
-            File file = request().body().asRaw().asFile();
+        public Result upload(Http.Request request) {
+            File file = request.body().asRaw().asFile();
             return ok("File uploaded");
         }
         //#asyncUpload
@@ -118,8 +118,8 @@ public class JavaFileUpload extends WithApplication {
         Http.MultipartFormData.FilePart<Source<ByteString, ?>> dp = new Http.MultipartFormData.FilePart<>("name", "filename", "text/plain", source);
         assertThat(contentAsString(call(new javaguide.testhelpers.MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     @BodyParser.Of(MultipartFormDataWithFileBodyParser.class)
-                    public Result uploadCustomMultiPart() throws Exception {
-                        final Http.MultipartFormData<File> formData = request().body().asMultipartFormData();
+                    public Result uploadCustomMultiPart(Http.Request request) throws Exception {
+                        final Http.MultipartFormData<File> formData = request.body().asMultipartFormData();
                         final Http.MultipartFormData.FilePart<File> filePart = formData.getFile("name");
                         final File file = filePart.getFile();
                         final long size = Files.size(file.toPath());

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide.ws.routes
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide.ws.routes
@@ -5,6 +5,6 @@ GET     /openID/callback            controllers.OpenIDController.openIDCallback(
 # #ws-openid-routes
 
 # #ws-oauth-routes
-GET     /twitter/homeTimeline controllers.Twitter.homeTimeline()
-GET     /twitter/auth         controllers.Twitter.auth()
+GET     /twitter/homeTimeline controllers.Twitter.homeTimeline(request: Request)
+GET     /twitter/auth         controllers.Twitter.auth(request: Request)
 # #ws-oauth-routes

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/OpenIDController.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/OpenIDController.java
@@ -35,7 +35,7 @@ public class OpenIDController extends Controller {
         String openID = requestData.get("openID");
 
         CompletionStage<String> redirectUrlPromise =
-                openIdClient.redirectURL(openID, routes.OpenIDController.openIDCallback().absoluteURL(request()));
+                openIdClient.redirectURL(openID, routes.OpenIDController.openIDCallback().absoluteURL(request));
 
         return redirectUrlPromise
                 .thenApply(Controller::redirect)
@@ -74,7 +74,7 @@ class OpenIDSamples extends Controller {
 
     static OpenIdClient openIdClient;
 
-    public static void extendedAttributes() {
+    public static void extendedAttributes(Http.Request request) {
 
         String openID = "";
 
@@ -84,7 +84,7 @@ class OpenIDSamples extends Controller {
 
         CompletionStage<String> redirectUrlPromise = openIdClient.redirectURL(
                 openID,
-                routes.OpenIDController.openIDCallback().absoluteURL(request()),
+                routes.OpenIDController.openIDCallback().absoluteURL(request),
                 attributes
         );
         //#ws-openid-extended-attributes

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/Twitter.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/Twitter.java
@@ -12,6 +12,7 @@ import play.libs.oauth.OAuth.RequestToken;
 import play.libs.oauth.OAuth.ServiceInfo;
 import play.libs.ws.WSClient;
 import play.mvc.Controller;
+import play.mvc.Http;
 import play.mvc.Result;
 
 import com.google.common.base.Strings;
@@ -39,8 +40,8 @@ public class Twitter extends Controller {
         this.ws = ws;
     }
 
-    public CompletionStage<Result> homeTimeline() {
-        Optional<RequestToken> sessionTokenPair = getSessionTokenPair();
+    public CompletionStage<Result> homeTimeline(Http.Request request) {
+        Optional<RequestToken> sessionTokenPair = getSessionTokenPair(request);
         if (sessionTokenPair.isPresent()) {
             return ws.url("https://api.twitter.com/1.1/statuses/home_timeline.json")
                     .sign(new OAuthCalculator(Twitter.KEY, sessionTokenPair.get()))
@@ -50,26 +51,26 @@ public class Twitter extends Controller {
         return CompletableFuture.completedFuture(redirect(routes.Twitter.auth()));
     }
 
-    public Result auth() {
-        String verifier = request().getQueryString("oauth_verifier");
+    public Result auth(Http.Request request) {
+        String verifier = request.getQueryString("oauth_verifier");
         if (Strings.isNullOrEmpty(verifier)) {
-            String url = routes.Twitter.auth().absoluteURL(request());
+            String url = routes.Twitter.auth().absoluteURL(request);
             RequestToken requestToken = TWITTER.retrieveRequestToken(url);
             return redirect(TWITTER.redirectUrl(requestToken.token))
-                    .addingToSession(request(), "token", requestToken.token)
-                    .addingToSession(request(), "secret", requestToken.secret);
+                    .addingToSession(request, "token", requestToken.token)
+                    .addingToSession(request, "secret", requestToken.secret);
         } else {
-            RequestToken requestToken = getSessionTokenPair().get();
+            RequestToken requestToken = getSessionTokenPair(request).get();
             RequestToken accessToken = TWITTER.retrieveAccessToken(requestToken, verifier);
             return redirect(routes.Twitter.homeTimeline())
-                    .addingToSession(request(), "token", accessToken.token)
-                    .addingToSession(request(), "secret", accessToken.secret);
+                    .addingToSession(request, "token", accessToken.token)
+                    .addingToSession(request, "secret", accessToken.secret);
         }
     }
 
-    private Optional<RequestToken> getSessionTokenPair() {
-        if (request().session().containsKey("token")) {
-            return Optional.ofNullable(new RequestToken(request().session().get("token"), request().session().get("secret")));
+    private Optional<RequestToken> getSessionTokenPair(Http.Request request) {
+        if (request.session().containsKey("token")) {
+            return Optional.ofNullable(new RequestToken(request.session().get("token"), request.session().get("secret")));
         }
         return Optional.empty();
     }

--- a/documentation/manual/working/javaGuide/main/xml/code/javaguide/xml/JavaXmlRequests.java
+++ b/documentation/manual/working/javaGuide/main/xml/code/javaguide/xml/JavaXmlRequests.java
@@ -8,12 +8,13 @@ import org.w3c.dom.Document;
 import play.libs.XPath;
 import play.mvc.BodyParser;
 import play.mvc.Controller;
+import play.mvc.Http;
 import play.mvc.Result;
 
 public class JavaXmlRequests extends Controller {
     //#xml-hello
-    public Result sayHello() {
-        Document dom = request().body().asXml();
+    public Result sayHello(Http.Request request) {
+        Document dom = request.body().asXml();
         if (dom == null) {
             return badRequest("Expecting Xml data");
         } else {
@@ -29,8 +30,8 @@ public class JavaXmlRequests extends Controller {
 
     //#xml-hello-bodyparser
     @BodyParser.Of(BodyParser.Xml.class)
-    public Result sayHelloBP() {
-        Document dom = request().body().asXml();
+    public Result sayHelloBP(Http.Request request) {
+        Document dom = request.body().asXml();
         if (dom == null) {
             return badRequest("Expecting Xml data");
         } else {
@@ -46,8 +47,8 @@ public class JavaXmlRequests extends Controller {
 
     //#xml-reply
     @BodyParser.Of(BodyParser.Xml.class)
-    public Result replyHello() {
-        Document dom = request().body().asXml();
+    public Result replyHello(Http.Request request) {
+        Document dom = request.body().asXml();
         if (dom == null) {
             return badRequest("Expecting Xml data");
         } else {

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -690,8 +690,14 @@ object BuildSettings {
       // Allow to remove request attributes
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.removeAttr"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.removeAttr"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.-")
-  ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.-"),
+
+      // Add withTransientLang and clearTransientLang to Request
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.clearTransientLang"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.withTransientLang"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.clearTransientLang"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.withTransientLang")
+    ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"
     },

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -8,6 +8,7 @@ import java.util.Optional
 
 import play.mvc.Http
 
+import scala.annotation.implicitNotFound
 import scala.util.control.NonFatal
 
 /** Defines a magic helper for Play templates in a Java context. */
@@ -46,5 +47,14 @@ object PlayMagicForJava extends JavaImplicitConversions {
   implicit def implicitJavaMessages: play.api.i18n.MessagesProvider = {
     ctx.messages().asScala
   }
+
+  @implicitNotFound("No Http.Request implicit parameter found when accessing session. You must add it as a template parameter like @(implicit request: Http.Request).")
+  def session(implicit request: play.mvc.Http.Request): play.mvc.Http.Session = request.session()
+
+  @implicitNotFound("No Http.Request implicit parameter found when accessing flash. You must add it as a template parameter like @(implicit request: Http.Request).")
+  def flash(implicit request: play.mvc.Http.Request): play.mvc.Http.Flash = request.flash()
+
+  @implicitNotFound("No play.api.i18n.MessagesProvider implicit parameter found when accessing lang. You must add it as a template parameter like @(implicit messages: play.i18n.Messages).")
+  def lang(implicit msg: play.api.i18n.MessagesProvider): play.api.i18n.Lang = msg.messages.lang
 
 }

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -19,8 +19,10 @@ object PlayMagicForJava extends JavaImplicitConversions {
   /** Transforms a Play Java `Optional` to a proper Scala `Option`. */
   implicit def javaOptionToScala[T](x: Optional[T]): Option[T] = x.asScala
 
+  @deprecated("See https://www.playframework.com/documentation/latest/JavaHttpContextMigration27", "2.7.0")
   private def ctx = Http.Context.current()
 
+  @deprecated("See https://www.playframework.com/documentation/latest/JavaHttpContextMigration27", "2.7.0")
   implicit def implicitJavaLang: play.api.i18n.Lang = {
     try {
       ctx.lang
@@ -29,6 +31,7 @@ object PlayMagicForJava extends JavaImplicitConversions {
     }
   }
 
+  @deprecated("See https://www.playframework.com/documentation/latest/JavaHttpContextMigration27", "2.7.0")
   implicit def requestHeader: play.api.mvc.RequestHeader = {
     ctx.request().asScala
   }
@@ -39,6 +42,7 @@ object PlayMagicForJava extends JavaImplicitConversions {
     r.asScala()
   }
 
+  @deprecated("See https://www.playframework.com/documentation/latest/JavaHttpContextMigration27", "2.7.0")
   implicit def implicitJavaMessages: play.api.i18n.MessagesProvider = {
     ctx.messages().asScala
   }

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -38,8 +38,8 @@ object PlayMagicForJava extends JavaImplicitConversions {
   }
 
   // TODO: After removing Http.Context (and the corresponding methods in this object here) this should be changed to:
-  // implicit def javaRequestHeader2ScalaRequestHeader(implicit r: play.mvc.Http.RequestHeader): play.api.mvc.RequestHeader = {
-  implicit def javaRequest2ScalaRequest(implicit r: play.mvc.Http.Request): play.api.mvc.Request[_] = {
+  // implicit def javaRequestHeader2ScalaRequestHeader(implicit r: Http.RequestHeader): play.api.mvc.RequestHeader = {
+  implicit def javaRequest2ScalaRequest(implicit r: Http.Request): play.api.mvc.Request[_] = {
     r.asScala()
   }
 
@@ -49,10 +49,10 @@ object PlayMagicForJava extends JavaImplicitConversions {
   }
 
   @implicitNotFound("No Http.Request implicit parameter found when accessing session. You must add it as a template parameter like @(implicit request: Http.Request).")
-  def session(implicit request: play.mvc.Http.Request): play.mvc.Http.Session = request.session()
+  def session(implicit request: Http.Request): Http.Session = request.session()
 
   @implicitNotFound("No Http.Request implicit parameter found when accessing flash. You must add it as a template parameter like @(implicit request: Http.Request).")
-  def flash(implicit request: play.mvc.Http.Request): play.mvc.Http.Flash = request.flash()
+  def flash(implicit request: Http.Request): Http.Flash = request.flash()
 
   @implicitNotFound("No play.api.i18n.MessagesProvider implicit parameter found when accessing lang. You must add it as a template parameter like @(implicit messages: play.i18n.Messages).")
   def lang(implicit msg: play.api.i18n.MessagesProvider): play.api.i18n.Lang = msg.messages.lang

--- a/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -10,6 +10,8 @@ import play.api.Application;
 import play.api.Play;
 import play.api.inject.guice.GuiceApplicationBuilder;
 import play.core.j.JavaContextComponents;
+import play.i18n.Lang;
+import play.i18n.Messages;
 import play.libs.Files.TemporaryFileCreator;
 import play.libs.typedmap.TypedKey;
 import play.mvc.Http.Context;
@@ -18,6 +20,7 @@ import play.mvc.Http.RequestBuilder;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -115,6 +118,26 @@ public class RequestBuilderTest {
         assertEquals(Optional.of(6L), req7.attrs().getOptional(NUMBER));
         assertEquals((Long) 6L, req7.attrs().get(NUMBER));
         assertFalse(req7.attrs().containsKey(COLOR));
+    }
+
+    @Test
+    public void testTransientLang() {
+        RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+        assertFalse(builder.attrs().containsKey(Messages.Attrs.CurrentLang));
+
+        Request req1 = builder.build();
+        assertFalse(req1.transientLang().isPresent());
+        assertFalse(req1.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
+
+        Request req2 = req1.withTransientLang(new Lang(Locale.GERMAN));
+        assertNotEquals(req1, req2);
+        assertEquals(new Lang(Locale.GERMAN), req2.transientLang().get());
+        assertEquals(new Lang(Locale.GERMAN), req2.attrs().get(Messages.Attrs.CurrentLang));
+
+        Request req3 = req2.clearTransientLang();
+        assertNotEquals(req2, req3);
+        assertFalse(req3.transientLang().isPresent());
+        assertFalse(req3.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
     }
 
     @Test

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -111,7 +111,10 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @param callable the callable block to run.
      * @param <V> the return type.
      * @return the value from {@code callable}.
+     *
+     * @deprecated Deprecated as of 2.7.0. See <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">migration guide</a>.
      */
+    @Deprecated
     public static <V> V invokeWithContext(RequestBuilder requestBuilder, JavaContextComponents contextComponents, Callable<V> callable) {
         try {
             Context.current.set(new Context(requestBuilder, contextComponents));
@@ -153,7 +156,10 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Builds a new Http.Context from a new request
      * @return a new Http.Context using the default request
+     *
+     * @deprecated Deprecated as of 2.7.0. See <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">migration guide</a>.
      */
+    @Deprecated
     public static Http.Context httpContext() {
         return httpContext(new Http.RequestBuilder().build());
     }
@@ -162,7 +168,10 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Builds a new Http.Context for a specific request
      * @param request the Request you want to use for this Context
      * @return a new Http.Context for this request
+     *
+     * @deprecated Deprecated as of 2.7.0. See <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">migration guide</a>.
      */
+    @Deprecated
     public static Http.Context httpContext(Http.Request request) {
         return new Http.Context(request, contextComponents());
     }

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -39,6 +39,32 @@ public interface Messages extends MessagesProvider {
      * @param args the message arguments
      * @return the formatted message or a default rendering if the key wasn't defined
      */
+    default String apply(String key, Object... args) {
+        return at(key, args);
+    }
+
+    /**
+     * Get the message at the first defined key.
+     *
+     * Uses `java.text.MessageFormat` internally to format the message.
+     *
+     * @param keys the messages keys
+     * @param args the message arguments
+     * @return the formatted message or a default rendering if the key wasn't defined
+     */
+    default String apply(List<String> keys, Object... args) {
+        return at(keys, args);
+    }
+
+    /**
+     * Get the message at the given key.
+     *
+     * Uses `java.text.MessageFormat` internally to format the message.
+     *
+     * @param key the message key
+     * @param args the message arguments
+     * @return the formatted message or a default rendering if the key wasn't defined
+     */
     public String at(String key, Object... args);
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/Controller.java
+++ b/framework/src/play/src/main/java/play/mvc/Controller.java
@@ -22,9 +22,18 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Generates a 501 NOT_IMPLEMENTED simple result.
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #TODO(Request)} instead.
      */
+    @Deprecated
     public static Result TODO() {
-        play.mvc.Http.Request request = Http.Context.current().request();
+        return TODO(Http.Context.current().request());
+    }
+
+    /**
+     * Generates a 501 NOT_IMPLEMENTED simple result.
+     */
+    public static Result TODO(Request request) {
         return status(NOT_IMPLEMENTED, views.html.defaultpages.todo.render(request.asScala()));
     }
 
@@ -32,7 +41,10 @@ public abstract class Controller extends Results implements Status, HeaderNames 
      * Returns the current HTTP context.
      *
      * @return the context
+     *
+     * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
      */
+    @Deprecated
     public static Context ctx() {
         return Http.Context.current();
     }
@@ -41,7 +53,10 @@ public abstract class Controller extends Results implements Status, HeaderNames 
      * Returns the current HTTP request.
      *
      * @return the request
+     *
+     * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
      */
+    @Deprecated
     public static Request request() {
         return Http.Context.current().request();
     }
@@ -50,7 +65,10 @@ public abstract class Controller extends Results implements Status, HeaderNames 
      * Returns the current lang.
      *
      * @return the language
+     *
+     * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
      */
+    @Deprecated
     public static Lang lang() {
         return Http.Context.current().lang();
     }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -296,7 +296,7 @@ public class Http {
          */
         @Deprecated
         public Messages messages() {
-            Request request = lang != null ? request().addAttr(Messages.Attrs.CurrentLang, lang) : request();
+            Request request = lang != null ? request().withTransientLang(lang) : request();
             return messagesApi().preferred(request);
         }
 
@@ -964,6 +964,49 @@ public class Http {
         Optional<List<X509Certificate>> clientCertificateChain();
 
         /**
+         * Create a new versions of this object with the given transient language set.
+         * The transient language will be taken into account when using {@link MessagesApi#preferred(RequestHeader)}} (It will take precedence over any other language).
+         *
+         * @param lang The language to use.
+         * @return The new version of this object with the given transient language set.
+         */
+        RequestHeader withTransientLang(Lang lang);
+
+        /**
+         * Create a new versions of this object with the given transient language set.
+         * The transient language will be taken into account when using {@link MessagesApi#preferred(RequestHeader)}} (It will take precedence over any other language).
+         *
+         * @param code The language to use.
+         * @return The new version of this object with the given transient language set.
+         */
+        RequestHeader withTransientLang(String code);
+
+        /**
+         * Create a new versions of this object with the given transient language set.
+         * The transient language will be taken into account when using {@link MessagesApi#preferred(RequestHeader)}} (It will take precedence over any other language).
+         *
+         * @param locale The language to use.
+         * @return The new version of this object with the given transient language set.
+         */
+        RequestHeader withTransientLang(Locale locale);
+
+        /**
+         * Create a new versions of this object with the given transient language removed.
+         *
+         * @return The new version of this object with the transient language removed.
+         */
+        RequestHeader clearTransientLang();
+
+        /**
+         * The transient language will be taken into account when using {@link MessagesApi#preferred(RequestHeader)}} (It will take precedence over any other language).
+         *
+         * @return The current transient language of this request.
+         */
+        default Optional<Lang> transientLang() {
+            return attrs().getOptional(Messages.Attrs.CurrentLang).map(lang -> lang.asJava());
+        }
+
+        /**
          * Return the Scala version of the request header.
          *
          * @return the Scala version for this request header.
@@ -994,6 +1037,18 @@ public class Http {
 
         // Override return type
         Request removeAttr(TypedKey<?> key);
+
+        // Override return type
+        Request withTransientLang(Lang lang);
+
+        // Override return type
+        Request withTransientLang(String code);
+
+        // Override return type
+        Request withTransientLang(Locale locale);
+
+        // Override return type
+        Request clearTransientLang();
 
         /**
          * Return the Scala version of the request

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -64,7 +64,10 @@ public class Http {
          * Retrieves the current HTTP context, for the current thread.
          *
          * @return the context
+         *
+         * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">Use a request instead</a>.
          */
+        @Deprecated
         public static Context current() {
             Context c = current.get();
             if(c == null) {
@@ -210,7 +213,10 @@ public class Http {
          * Returns the current request.
          *
          * @return the request
+         *
+         * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
          */
+        @Deprecated
         public Request request() {
             return request;
         }
@@ -268,7 +274,10 @@ public class Http {
          * The current lang
          *
          * @return the current lang
+         *
+         * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
          */
+        @Deprecated
         public Lang lang() {
             if (lang != null) {
                 return lang;
@@ -279,7 +288,10 @@ public class Http {
 
         /**
          * @return the messages for the current lang
+         *
+         * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
          */
+        @Deprecated
         public Messages messages() {
             Request request = lang != null ? request().addAttr(Messages.Attrs.CurrentLang, lang) : request();
             return messagesApi().preferred(request);
@@ -365,7 +377,10 @@ public class Http {
          * @param code the language code to set (e.g. "en-US")
          * @throws IllegalArgumentException If the given language
          * is not supported by the application.
+         *
+         * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
          */
+        @Deprecated
         public void setTransientLang(String code) {
             setTransientLang(Lang.forCode(code));
         }
@@ -379,7 +394,10 @@ public class Http {
          * @param lang the language to set
          * @throws IllegalArgumentException If the given language
          * is not supported by the application.
+         *
+         * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
          */
+        @Deprecated
         public void setTransientLang(Lang lang) {
             final Langs langs = components.langs();
             if (langs.availables().contains(lang)) {
@@ -394,7 +412,10 @@ public class Http {
          * change the language cookie. This means the language
          * will be cleared for this request (so a default will be
          * used), but will not change for future requests.
+         *
+         * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
          */
+        @Deprecated
         public void clearTransientLang() {
             this.lang = null;
         }
@@ -414,7 +435,10 @@ public class Http {
 
         /**
          * Import in templates to get implicit HTTP context.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
          */
+        @Deprecated
         public static class Implicit {
 
             /**
@@ -433,7 +457,10 @@ public class Http {
              * Returns the current request.
              *
              * @return the current request.
+             *
+             * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
              */
+            @Deprecated
             public static Request request() {
                 return Context.current().request();
             }
@@ -442,7 +469,10 @@ public class Http {
              * Returns the current flash scope.
              *
              * @return the current flash scope.
+             *
+             * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
              */
+            @Deprecated
             public static Flash flash() {
                 return Context.current().flash();
             }
@@ -451,7 +481,10 @@ public class Http {
              * Returns the current session.
              *
              * @return the current session.
+             *
+             * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
              */
+            @Deprecated
             public static Session session() {
                 return Context.current().session();
             }
@@ -460,14 +493,20 @@ public class Http {
              * Returns the current lang.
              *
              * @return the current lang.
+             *
+             * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
              */
+            @Deprecated
             public static Lang lang() {
                 return Context.current().lang();
             }
 
             /**
              * @return the messages for the current lang
+             *
+             * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
              */
+            @Deprecated
             public static Messages messages() {
                 return Context.current().messages();
             }
@@ -476,7 +515,10 @@ public class Http {
              * Returns the current context.
              *
              * @return the current context.
+             *
+             * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
              */
+            @Deprecated
             public static Context ctx() {
                 return Context.current();
             }
@@ -499,7 +541,10 @@ public class Http {
          *
          * @param request The request to create the new header from.
          * @return The new context.
+         *
+         * @deprecated Deprecated as of 2.7.0. <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">See migration guide.</a>.
          */
+        @Deprecated
         public Context withRequest(Request request) {
             return new Context(id, request.asScala(), request, response, session, flash, args, lang, components);
         }
@@ -522,18 +567,17 @@ public class Http {
         }
 
         @Override
+        @Deprecated
         public Long id() {
             return wrapped.id();
         }
 
         @Override
+        @Deprecated
         public Request request() {
             return wrapped.request();
         }
 
-        /**
-         * @deprecated Deprecated as of 2.7.0. Use {@link Result} instead.
-         */
         @Override
         @Deprecated
         public Response response() {
@@ -541,18 +585,17 @@ public class Http {
         }
 
         @Override
+        @Deprecated
         public Session session() {
             return wrapped.session();
         }
 
         @Override
+        @Deprecated
         public Flash flash() {
             return wrapped.flash();
         }
 
-        /**
-         * @deprecated Use {@link #request()}.asScala() instead. Since 2.7.0.
-         */
         @Override
         @Deprecated
         public play.api.mvc.RequestHeader _requestHeader() {
@@ -560,41 +603,49 @@ public class Http {
         }
 
         @Override
+        @Deprecated
         public Lang lang() {
             return wrapped.lang();
         }
 
         @Override
+        @Deprecated
         public boolean changeLang(String code) {
             return wrapped.changeLang(code);
         }
 
         @Override
+        @Deprecated
         public boolean changeLang(Lang lang) {
             return wrapped.changeLang(lang);
         }
 
         @Override
+        @Deprecated
         public void clearLang() {
             wrapped.clearLang();
         }
 
         @Override
+        @Deprecated
         public void setTransientLang(String code) {
             wrapped.setTransientLang(code);
         }
 
         @Override
+        @Deprecated
         public void setTransientLang(Lang lang) {
             wrapped.setTransientLang(lang);
         }
 
         @Override
+        @Deprecated
         public void clearTransientLang() {
             wrapped.clearTransientLang();
         }
 
         @Override
+        @Deprecated
         public Messages messages() {
             return wrapped.messages();
         }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -55,7 +55,10 @@ public class Http {
 
     /**
      * The global HTTP context.
+     *
+     * @deprecated Deprecated as of 2.7.0. See <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">migration guide</a>.
      */
+    @Deprecated
     public static class Context {
 
         public static ThreadLocal<Context> current = new ThreadLocal<>();
@@ -553,7 +556,10 @@ public class Http {
     /**
      * A wrapped context.
      * Use this to modify the context in some way.
+     *
+     * @deprecated Deprecated as of 2.7.0. See <a href="https://www.playframework.com/documentation/latest/JavaHttpContextMigration27">migration guide</a>.
      */
+    @Deprecated
     public static abstract class WrappedContext extends Context {
         private final Context wrapped;
 

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -482,7 +482,7 @@ class DefaultMessagesApi @Inject() (
   }
 
   override def preferred(request: RequestHeader): Messages = {
-    val maybeLangFromRequest = request.attrs.get(Messages.Attrs.CurrentLang)
+    val maybeLangFromRequest = request.transientLang()
     val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
     val lang = langs.preferred(maybeLangFromRequest.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
     MessagesImpl(lang, this)

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -482,9 +482,9 @@ class DefaultMessagesApi @Inject() (
   }
 
   override def preferred(request: RequestHeader): Messages = {
-    val maybeLangFromContext = request.attrs.get(Messages.Attrs.CurrentLang)
+    val maybeLangFromRequest = request.attrs.get(Messages.Attrs.CurrentLang)
     val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
-    val lang = langs.preferred(maybeLangFromContext.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
+    val lang = langs.preferred(maybeLangFromRequest.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
     MessagesImpl(lang, this)
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Request.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Request.scala
@@ -4,6 +4,9 @@
 
 package play.api.mvc
 
+import java.util.Locale
+
+import play.api.i18n.{ Lang, Messages }
 import play.api.libs.typedmap.{ TypedKey, TypedMap }
 import play.api.mvc.request.{ RemoteConnection, RequestTarget }
 
@@ -59,6 +62,14 @@ trait Request[+A] extends RequestHeader {
     withAttrs(attrs.updated(key, value))
   override def removeAttr(key: TypedKey[_]): Request[A] =
     withAttrs(attrs - key)
+  override def withTransientLang(lang: Lang): Request[A] =
+    addAttr(Messages.Attrs.CurrentLang, lang)
+  override def withTransientLang(code: String): Request[A] =
+    withTransientLang(Lang(code))
+  override def withTransientLang(locale: Locale): Request[A] =
+    withTransientLang(Lang(locale))
+  override def clearTransientLang(): Request[A] =
+    removeAttr(Messages.Attrs.CurrentLang)
 }
 
 object Request {

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -5,9 +5,10 @@
 package play.api.mvc
 
 import java.security.cert.X509Certificate
+import java.util.Locale
 
 import play.api.http.{ HeaderNames, MediaRange, MediaType }
-import play.api.i18n.Lang
+import play.api.i18n.{ Lang, Messages }
 import play.api.libs.typedmap.{ TypedKey, TypedMap }
 import play.api.mvc.request._
 
@@ -268,6 +269,52 @@ trait RequestHeader {
    */
   def withBody[A](body: A): Request[A] =
     new RequestImpl[A](connection, method, target, version, headers, attrs, body)
+
+  /**
+   * Create a new versions of this object with the given transient language set.
+   * The transient language will be taken into account when using [[play.api.i18n.MessagesApi.preferred()]] (It will take precedence over any other language).
+   *
+   * @param lang The language to use.
+   * @return The new version of this object with the given transient language set.
+   */
+  def withTransientLang(lang: Lang): RequestHeader =
+    addAttr(Messages.Attrs.CurrentLang, lang)
+
+  /**
+   * Create a new versions of this object with the given transient language set.
+   * The transient language will be taken into account when using [[play.api.i18n.MessagesApi.preferred()]] (It will take precedence over any other language).
+   *
+   * @param code The language to use.
+   * @return The new version of this object with the given transient language set.
+   */
+  def withTransientLang(code: String): RequestHeader =
+    withTransientLang(Lang(code))
+
+  /**
+   * Create a new versions of this object with the given transient language set.
+   * The transient language will be taken into account when using [[play.api.i18n.MessagesApi.preferred()]] (It will take precedence over any other language).
+   *
+   * @param locale The language to use.
+   * @return The new version of this object with the given transient language set.
+   */
+  def withTransientLang(locale: Locale): RequestHeader =
+    withTransientLang(Lang(locale))
+
+  /**
+   * Create a new versions of this object with the given transient language removed.
+   *
+   * @return The new version of this object with the transient language removed.
+   */
+  def clearTransientLang(): RequestHeader =
+    removeAttr(Messages.Attrs.CurrentLang)
+
+  /**
+   * The transient language will be taken into account when using [[play.api.i18n.MessagesApi.preferred()]] (It will take precedence over any other language).
+   *
+   * @return The current transient language of this request.
+   */
+  def transientLang(): Option[Lang] =
+    attrs.get(Messages.Attrs.CurrentLang)
 
   override def toString: String = {
     method + " " + uri

--- a/framework/src/play/src/main/scala/play/core/j/HttpExecutionContext.scala
+++ b/framework/src/play/src/main/scala/play/core/j/HttpExecutionContext.scala
@@ -45,7 +45,16 @@ object HttpExecutionContext {
  * Manages execution to ensure that the given context ClassLoader and Http.Context are set correctly
  * in the current thread. Actual execution is performed by a delegate ExecutionContext.
  */
-class HttpExecutionContext(contextClassLoader: ClassLoader, httpContext: Http.Context, delegate: ExecutionContext) extends ExecutionContextExecutor {
+class HttpExecutionContext(contextClassLoader: ClassLoader, delegate: ExecutionContext) extends ExecutionContextExecutor {
+
+  var httpContext: Http.Context = null
+
+  @deprecated("See https://www.playframework.com/documentation/latest/JavaHttpContextMigration27", "2.7.0")
+  def this(contextClassLoader: ClassLoader, httpContext: Http.Context, delegate: ExecutionContext) = {
+    this(contextClassLoader, delegate)
+    this.httpContext = httpContext
+  }
+
   override def execute(runnable: Runnable) = delegate.execute(new Runnable {
     def run(): Unit = {
       val thread = Thread.currentThread()

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -7,7 +7,7 @@ package play.core.j
 import java.net.{ InetAddress, URI, URLDecoder }
 import java.security.cert.X509Certificate
 import java.util
-import java.util.Optional
+import java.util.{ Locale, Optional }
 import java.util.concurrent.CompletionStage
 
 import play.api.http.{ DefaultFileMimeTypesProvider, FileMimeTypes, HttpConfiguration, MediaRange }
@@ -332,6 +332,14 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def charset(): Optional[String] = OptionConverters.toJava(header.charset)
 
+  override def withTransientLang(lang: play.i18n.Lang): JRequestHeader = addAttr(i18n.Messages.Attrs.CurrentLang, lang)
+
+  override def withTransientLang(code: String): JRequestHeader = withTransientLang(play.i18n.Lang.forCode(code))
+
+  override def withTransientLang(locale: Locale): JRequestHeader = withTransientLang(new play.i18n.Lang(locale))
+
+  override def clearTransientLang(): JRequestHeader = removeAttr(i18n.Messages.Attrs.CurrentLang)
+
   override def toString: String = header.toString
 
   override lazy val getHeaders: Http.Headers = header.headers.asJava
@@ -352,4 +360,13 @@ class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(reque
   override def body: RequestBody = request.body
   override def hasBody: Boolean = request.hasBody
   override def withBody(body: RequestBody): JRequest = new RequestImpl(request.withBody(body))
+
+  override def withTransientLang(lang: play.i18n.Lang): JRequest =
+    addAttr(i18n.Messages.Attrs.CurrentLang, lang)
+  override def withTransientLang(code: String): JRequest =
+    withTransientLang(play.i18n.Lang.forCode(code))
+  override def withTransientLang(locale: Locale): JRequest =
+    withTransientLang(new play.i18n.Lang(locale))
+  override def clearTransientLang(): JRequest =
+    removeAttr(i18n.Messages.Attrs.CurrentLang)
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -4,12 +4,12 @@
 
 package play.api.mvc
 
-import java.security.cert.X509Certificate
+import java.util.Locale
 
 import org.specs2.mutable.Specification
 import play.api.http.HeaderNames._
 import play.api.http.HttpConfiguration
-import play.api.i18n.Lang
+import play.api.i18n.{ Lang, Messages }
 import play.api.libs.typedmap.{ TypedKey, TypedMap }
 import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestTarget }
 
@@ -86,6 +86,21 @@ class RequestHeaderSpec extends Specification {
         req.attrs.get(x) must beNone
         req.attrs.get(y) must beNone
       }
+    }
+    "handle transient lang" in {
+      val req1 = dummyRequestHeader()
+      req1.transientLang() must beNone
+      req1.attrs.get(Messages.Attrs.CurrentLang) must beNone
+
+      val req2 = req1.withTransientLang(new Lang(Locale.GERMAN))
+      req1 mustNotEqual req2
+      req2.transientLang() must beSome(new Lang(Locale.GERMAN))
+      req2.attrs.get(Messages.Attrs.CurrentLang) must beSome(new Lang(Locale.GERMAN))
+
+      val req3 = req2.clearTransientLang()
+      req2 mustNotEqual req3
+      req3.transientLang() must beNone
+      req3.attrs.get(Messages.Attrs.CurrentLang) must beNone
     }
 
     "handle host" in {


### PR DESCRIPTION
This should be the last really relevent pull request for that topic.

I know documentation needs some updates now - however I will do that in another pull request tomorrow.