### PR TITLE
Make logging configuration code reusable for compile-time DI

### DIFF
--- a/framework/src/play/src/main/java/play/ConfiguredLogging.java
+++ b/framework/src/play/src/main/java/play/ConfiguredLogging.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play;
+
+import com.typesafe.config.Config;
+import org.slf4j.ILoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+public interface ConfiguredLogging
+{
+    Environment environment();
+
+    default ILoggerFactory configureLoggerFactory(final Config configuration) {
+        final Environment environment = environment();
+        final ILoggerFactory loggerFactory = LoggerConfigurator.apply(environment.classLoader()).map(lc -> {
+            lc.configure(environment, configuration);
+            return lc.loggerFactory();
+        }).orElseGet(org.slf4j.LoggerFactory::getILoggerFactory);
+
+        if (shouldDisplayLoggerDeprecationMessage(configuration)) {
+            loggerFactory
+                    .getLogger("application")
+                    .warn("Logger configuration in conf files is deprecated and has no effect. Use a logback configuration file instead.");
+        }
+
+        return loggerFactory;
+    }
+
+    default boolean shouldDisplayLoggerDeprecationMessage(final Config configuration) {
+        return configuration.hasPath("logger") && isDeprecated(
+                configuration.getAnyRef("logger"),
+                Arrays.asList("DEBUG", "WARN", "ERROR", "INFO", "TRACE", "OFF")
+        );
+    }
+
+    default boolean hasDeprecatedValue(final Map<String, Object> config, final Collection<String> deprecatedValues) {
+        return config.values().stream().map(value -> isDeprecated(value, deprecatedValues)).findAny().orElse(false);
+    }
+
+    @SuppressWarnings("unchecked")
+    default Boolean isDeprecated(Object value, Collection<String> deprecatedValues) {
+        if (value instanceof String) {
+            return deprecatedValues.contains(value);
+        } else if (value instanceof Map) {
+            return hasDeprecatedValue((Map<String, Object>) value, deprecatedValues);
+        } else {
+            return false;
+        }
+    }
+}

--- a/framework/src/play/src/main/scala/play/api/ConfiguredLogging.scala
+++ b/framework/src/play/src/main/scala/play/api/ConfiguredLogging.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api
+
+import org.slf4j.ILoggerFactory
+
+trait ConfiguredLogging {
+
+  val environment: Environment
+
+  /**
+   * Configures the SLF4J logger factory.  This is where LoggerConfigurator is
+   * called from.
+   *
+   * @param configuration play.api.Configuration
+   * @return the app wide ILoggerFactory.  Useful for testing and DI.
+   */
+  def configureLoggerFactory(configuration: Configuration): ILoggerFactory = {
+    val loggerFactory: ILoggerFactory = LoggerConfigurator(environment.classLoader).map { lc =>
+      lc.configure(environment, configuration, Map.empty)
+      lc.loggerFactory
+    }.getOrElse(org.slf4j.LoggerFactory.getILoggerFactory)
+
+    if (shouldDisplayLoggerDeprecationMessage(configuration)) {
+      val logger = loggerFactory.getLogger("application")
+      logger.warn("Logger configuration in conf files is deprecated and has no effect. Use a logback configuration file instead.")
+    }
+
+    loggerFactory
+  }
+
+  /**
+   * Checks if the path contains the logger path
+   * and whether or not one of the keys contains a deprecated value
+   *
+   * @param appConfiguration The app configuration
+   * @return Returns true if one of the keys contains a deprecated value, otherwise false
+   */
+  def shouldDisplayLoggerDeprecationMessage(appConfiguration: Configuration): Boolean = {
+    import scala.collection.JavaConverters._
+    import scala.collection.mutable
+
+    val deprecatedValues = List("DEBUG", "WARN", "ERROR", "INFO", "TRACE", "OFF")
+
+    // Recursively checks each key to see if it contains a deprecated value
+    def hasDeprecatedValue(values: mutable.Map[String, AnyRef]): Boolean = {
+      values.exists {
+        case (_, value: String) if deprecatedValues.contains(value) =>
+          true
+        case (_, value: java.util.Map[_, _]) =>
+          val v = value.asInstanceOf[java.util.Map[String, AnyRef]]
+          hasDeprecatedValue(v.asScala)
+        case _ =>
+          false
+      }
+    }
+
+    if (appConfiguration.underlying.hasPath("logger")) {
+      appConfiguration.underlying.getAnyRef("logger") match {
+        case value: String =>
+          hasDeprecatedValue(mutable.Map("logger" -> value))
+        case value: java.util.Map[_, _] =>
+          val v = value.asInstanceOf[java.util.Map[String, AnyRef]]
+          hasDeprecatedValue(v.asScala)
+        case _ =>
+          false
+      }
+    } else {
+      false
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)? - No, there was no issue.
* [X] Have you added copyright headers to new files?
* [X] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [X] Have you added tests for any changed functionality? - No functionality has changed, only moved to trait so it's covered by existing tests

# Helpful things

## Purpose

What is this for? When you don't like runtime and wish that you do/check at compile time as much as possible you use [Compile time DI](https://www.playframework.com/documentation/2.7.0-M4/JavaCompileTimeDependencyInjection) and then you go to [logging documentation](https://www.playframework.com/documentation/2.7.0-M4/SettingsLogger#Custom-configuration) and find out that framework gives you amazing ability - to use custom logging configuration. You try to use it but nothing works - default configuration gets used over and over again. You investigate it and find out that only people with guice get `LoggingConfigurator.configure` called.
This PR changes it - now you can code your `AppLoader with ConfiguredLogging` and get things done.
**Note**: this works only for people that pass logger through DI as a parameter. Any way people that use
```
Logger.debug(s"message")
```
or
```
val logger: Logger = Logger(this.getClass())
```
inside client code don't ever substitute anything - you just can't substitute static coupling.

## Background Context

Why did you take this approach? - Minimal code change, 1:1 methods move, 1:1 interpretation to Java.

## References

Are there any relevant issues / PRs / mailing lists discussions? - No.
