### PR TITLE
Add some missing deprecated annotations and docs

### DIFF
--- a/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -104,6 +104,7 @@ public class AhcWSRequest implements WSRequest {
     }
 
     @Override
+    @Deprecated
     public CompletionStage<WSResponse> post(InputStream is) {
         return request.post(writables.body(() -> is)).thenApply(responseFunction);
     }
@@ -139,6 +140,7 @@ public class AhcWSRequest implements WSRequest {
     }
 
     @Override
+    @Deprecated
     public CompletionStage<WSResponse> put(InputStream is) {
         return request.put(writables.body(() -> is)).thenApply(responseFunction);
     }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -103,7 +103,7 @@ public class DefaultJPAApi implements JPAApi {
      *
      * @return EntityManager for the specified persistence unit name
      *
-     * @deprecated The EntityManager is supplied as lambda parameter instead when using {@link #withTransaction(Function)}
+     * @deprecated Deprecated as of 2.7.0. The EntityManager is supplied as lambda parameter instead when using {@link #withTransaction(Function)}
      */
     @Deprecated
     public EntityManager em() {
@@ -242,7 +242,7 @@ public class DefaultJPAApi implements JPAApi {
      *
      * @param block Block of code to execute
      *
-     * @deprecated Use {@link #withTransaction(Function)}
+     * @deprecated Deprecated as of 2.7.0. Use {@link #withTransaction(Function)} instead.
      */
     @Deprecated
     public <T> T withTransaction(Supplier<T> block) {
@@ -254,7 +254,7 @@ public class DefaultJPAApi implements JPAApi {
      *
      * @param block Block of code to execute
      *
-     * @deprecated Use {@link #withTransaction(Consumer)}
+     * @deprecated Deprecated as of 2.7.0. Use {@link #withTransaction(Consumer)} instead.
      */
     @Deprecated
     public void withTransaction(final Runnable block) {
@@ -275,7 +275,7 @@ public class DefaultJPAApi implements JPAApi {
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute
      *
-     * @deprecated Use {@link #withTransaction(String, boolean, Function)}
+     * @deprecated Deprecated as of 2.7.0. Use {@link #withTransaction(String, boolean, Function)} instead.
      */
     @Deprecated
     public <T> T withTransaction(String name, boolean readOnly, Supplier<T> block) {

--- a/framework/src/play-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -80,7 +80,10 @@ public interface WSRequest extends StandaloneWSRequest {
      *
      * @param body represented as an InputStream
      * @return a promise to the response
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #patch(BodyWritable)} instead.
      */
+    @Deprecated
     CompletionStage<WSResponse> patch(InputStream body);
 
     /**
@@ -138,9 +141,10 @@ public interface WSRequest extends StandaloneWSRequest {
     /**
      * Perform a POST on the request asynchronously.
      *
-     * @deprecated use {@link #post(BodyWritable)}
      * @param body represented as an InputStream
      * @return a promise to the response
+     *
+     * @deprecated Deprecated as of 2.6.0. Use {@link #post(BodyWritable)} instead.
      */
     @Deprecated
     CompletionStage<WSResponse> post(InputStream body);
@@ -203,7 +207,10 @@ public interface WSRequest extends StandaloneWSRequest {
      *
      * @param body represented as an InputStream
      * @return a promise to the response
+     *
+     * @deprecated Deprecated as of 2.7.0. Use {@link #put(BodyWritable)} instead.
      */
+    @Deprecated
     CompletionStage<WSResponse> put(InputStream body);
 
     /**
@@ -316,9 +323,10 @@ public interface WSRequest extends StandaloneWSRequest {
     /**
      * Set the body this request should use.
      *
-     * @deprecated use {@link #setBody(BodyWritable)}
-     * @param body Deprecated
-     * @return Deprecated
+     * @param body the request body.
+     * @return the modified WSRequest.
+     *
+     * @deprecated Deprecated as of 2.6.0. Use {@link #setBody(BodyWritable)} instead.
      */
     @Deprecated
     WSRequest setBody(InputStream body);

--- a/framework/src/play/src/main/java/play/DefaultApplication.java
+++ b/framework/src/play/src/main/java/play/DefaultApplication.java
@@ -68,6 +68,7 @@ public class DefaultApplication implements Application {
      * @return the underlying application
      */
     @Override
+    @Deprecated
     public play.api.Application getWrappedApplication() {
       return application;
     }

--- a/framework/src/play/src/main/java/play/server/ApplicationProvider.java
+++ b/framework/src/play/src/main/java/play/server/ApplicationProvider.java
@@ -41,7 +41,10 @@ public class ApplicationProvider {
     /**
      * Handle a request directly, without using the application.
      * @param requestHeader the request made.
+     *
+     * @deprecated Deprecated as of 2.7.0. WebCommands are now handled by the DefaultHttpRequestHandler.
      */
+    @Deprecated
     public Optional<Result> handleWebCommand(Http.RequestHeader requestHeader) {
         return OptionConverters
                 .toJava(this.underlying.handleWebCommand(requestHeader.asScala()))


### PR DESCRIPTION
## Purpose

Some of them were missing for Play 2.6 already. But market them as Play 2.7 deprecations since it is the version were we are effectively adding the deprecation annotation and docs.