### PR TITLE
Preparations to make Java Session and Flash immutable

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -66,10 +66,13 @@ public class JavaWebSockets {
         //#actor-reject
         public WebSocket socket(Http.Request req) {
             return WebSocket.Text.acceptOrResult(request ->
-                CompletableFuture.completedFuture(req.session().getOptional("user")
-                    .map(user -> F.Either.<Result, Flow<String, String, ?>>Right(ActorFlow.actorRef(MyWebSocketActor::props,
-                        actorSystem, materializer)))
-                    .orElseGet(() -> F.Either.Left(forbidden()))
+                CompletableFuture.completedFuture(
+                        req.session()
+                           .getOptional("user")
+                           .map(user ->
+                               F.Either.<Result, Flow<String, String, ?>>Right(ActorFlow.actorRef(MyWebSocketActor::props, actorSystem, materializer))
+                           )
+                           .orElseGet(() -> F.Either.Left(forbidden()))
                 )
             );
         }

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -65,7 +65,7 @@ public class JavaWebSockets {
         //#actor-reject
         public WebSocket socket(Http.Request req) {
             return WebSocket.Text.acceptOrResult(request -> {
-                if (req.session().get("user") != null) {
+                if (req.session().getOptional("user").isPresent()) {
                     return CompletableFuture.completedFuture(
                             F.Either.Right(ActorFlow.actorRef(MyWebSocketActor::props,
                                     actorSystem, materializer)));

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -76,7 +76,7 @@ public class JavaSessionFlash extends WithApplication {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-flash
                     public Result index(Http.Request request) {
-                        return ok(request.flash().getOptional("success").map(message -> message).orElse("Welcome!"));
+                        return ok(request.flash().getOptional("success").orElse("Welcome!"));
                     }
                     //#read-flash
                 }, fakeRequest().flash("success", "hi"), mat)),

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -26,7 +26,8 @@ public class JavaSessionFlash extends WithApplication {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-session
                     public Result index(Http.Request request) {
-                        return request.session().getOptional("connected")
+                        return request.session()
+                            .getOptional("connected")
                             .map(user -> ok("Hello " + user))
                             .orElseGet(() -> unauthorized("Oops, you are not connected"));
                     }

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -26,12 +26,9 @@ public class JavaSessionFlash extends WithApplication {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-session
                     public Result index(Http.Request request) {
-                        String user = request.session().get("connected");
-                        if(user != null) {
-                            return ok("Hello " + user);
-                        } else {
-                            return unauthorized("Oops, you are not connected");
-                        }
+                        return request.session().getOptional("connected")
+                            .map(user -> ok("Hello " + user))
+                            .orElseGet(() -> unauthorized("Oops, you are not connected"));
                     }
                     //#read-session
                 }, fakeRequest().session("connected", "foo"), mat)),
@@ -47,7 +44,7 @@ public class JavaSessionFlash extends WithApplication {
             }
             //#store-session
         }, fakeRequest(), mat).session();
-        assertThat(session.get("connected"), equalTo("user@gmail.com"));
+        assertThat(session.getOptional("connected").get(), equalTo("user@gmail.com"));
     }
 
     @Test
@@ -59,7 +56,7 @@ public class JavaSessionFlash extends WithApplication {
             }
             //#remove-from-session
         }, fakeRequest().session("connected", "foo"), mat).session();
-        assertThat(session.get("connected"), nullValue());
+        assertFalse(session.getOptional("connected").isPresent());
     }
 
     @Test
@@ -71,7 +68,7 @@ public class JavaSessionFlash extends WithApplication {
             }
             //#discard-whole-session
         }, fakeRequest().session("connected", "foo"), mat).session();
-        assertThat(session.get("connected"), nullValue());
+        assertFalse(session.getOptional("connected").isPresent());
     }
 
     @Test
@@ -79,11 +76,7 @@ public class JavaSessionFlash extends WithApplication {
         assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-flash
                     public Result index(Http.Request request) {
-                        String message = request.flash().get("success");
-                        if(message == null) {
-                            message = "Welcome!";
-                        }
-                        return ok(message);
+                        return ok(request.flash().getOptional("success").map(message -> message).orElse("Welcome!"));
                     }
                     //#read-flash
                 }, fakeRequest().flash("success", "hi"), mat)),
@@ -99,7 +92,7 @@ public class JavaSessionFlash extends WithApplication {
             }
             //#store-flash
         }, fakeRequest(), mat).flash();
-        assertThat(flash.get("success"), equalTo("The item has been created"));
+        assertThat(flash.getOptional("success").get(), equalTo("The item has been created"));
     }
 
     @Test

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/views/index.scala.html
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/views/index.scala.html
@@ -1,8 +1,4 @@
 @(flash: play.mvc.Http.Flash)
 @* #flash-template *@
-@if(flash.containsKey("success")) {
-  @flash.get("success")
-} else {
-  Welcome!
-}
+@flash.getOptional("success").orElse("Welcome!")
 @* #flash-template *@

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/views/index.scala.html
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/views/index.scala.html
@@ -1,4 +1,4 @@
 @(flash: play.mvc.Http.Flash)
 @* #flash-template *@
-@flash.getOptional("success").orElse("Welcome!")
+@flash("success").orElse("Welcome!")
 @* #flash-template *@

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/Twitter.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/Twitter.java
@@ -69,10 +69,7 @@ public class Twitter extends Controller {
     }
 
     private Optional<RequestToken> getSessionTokenPair(Http.Request request) {
-        if (request.session().containsKey("token")) {
-            return Optional.ofNullable(new RequestToken(request.session().get("token"), request.session().get("secret")));
-        }
-        return Optional.empty();
+        return request.session().getOptional("token").map(token -> new RequestToken(token, request.session().getOptional("secret").get()));
     }
 
 }

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -696,7 +696,11 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.clearTransientLang"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.withTransientLang"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.clearTransientLang"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.withTransientLang")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.withTransientLang"),
+
+      // Added Java @varargs annotation
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.mvc.Session.-"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.mvc.Flash.-")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2202,7 +2202,7 @@ public class Http {
          * Removes any value from the session.
          */
         public Session removing(String... keys) {
-            return new play.api.mvc.Session(Scala.asScala(this)).$minus(keys).asJava();
+            return new play.api.mvc.Session(Scala.asScala(this)).remove(keys).asJava();
         }
 
         /**
@@ -2519,7 +2519,7 @@ public class Http {
          * Removes any value from the flash scope.
          */
         public Flash removing(String... keys) {
-            return new play.api.mvc.Flash(Scala.asScala(this)).$minus(keys).asJava();
+            return new play.api.mvc.Flash(Scala.asScala(this)).remove(keys).asJava();
         }
 
         /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2268,7 +2268,7 @@ public class Http {
         // ### Let's deprecate all of HashMap
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         public Session(int initialCapacity, float loadFactor) {
@@ -2276,7 +2276,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         public Session(int initialCapacity) {
@@ -2284,7 +2284,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2293,7 +2293,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2302,7 +2302,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2311,7 +2311,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2320,7 +2320,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2329,7 +2329,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2338,7 +2338,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2347,7 +2347,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2356,7 +2356,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2365,7 +2365,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2374,7 +2374,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2383,7 +2383,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2392,7 +2392,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2401,7 +2401,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2410,7 +2410,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2419,7 +2419,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2428,7 +2428,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2437,7 +2437,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Session} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2585,7 +2585,7 @@ public class Http {
         // ### Let's deprecate all of HashMap
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         public Flash(int initialCapacity, float loadFactor) {
@@ -2593,7 +2593,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         public Flash(int initialCapacity) {
@@ -2601,7 +2601,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2610,7 +2610,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2619,7 +2619,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2628,7 +2628,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2637,7 +2637,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2646,7 +2646,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2655,7 +2655,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2664,7 +2664,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2673,7 +2673,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2682,7 +2682,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2691,7 +2691,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2700,7 +2700,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2709,7 +2709,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2718,7 +2718,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2727,7 +2727,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2736,7 +2736,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2745,7 +2745,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override
@@ -2754,7 +2754,7 @@ public class Http {
         }
 
         /**
-         * @deprecated Deprecated as of 2.7.0.
+         * @deprecated Deprecated as of 2.7.0. {@link Flash} will not be a subclass of {@link HashMap} in future Play releases.
          */
         @Deprecated
         @Override

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2189,7 +2189,7 @@ public class Http {
         /**
          * Removes the specified value from the session.
          *
-         * @deprecated Deprecated as of 2.7.0. Use {@link #removing(String...)} instead.
+         * @deprecated Deprecated as of 2.7.0. Use {@link #remove(String...)} instead.
          */
         @Deprecated
         @Override
@@ -2201,7 +2201,7 @@ public class Http {
         /**
          * Removes any value from the session.
          */
-        public Session removing(String... keys) {
+        public Session remove(String... keys) {
             return new play.api.mvc.Session(Scala.asScala(this)).remove(keys).asJava();
         }
 
@@ -2506,7 +2506,7 @@ public class Http {
         /**
          * Removes the specified value from the flash scope.
          *
-         * @deprecated Deprecated as of 2.7.0. Use {@link #removing(String...)} instead.
+         * @deprecated Deprecated as of 2.7.0. Use {@link #remove(String...)} instead.
          */
         @Deprecated
         @Override
@@ -2518,7 +2518,7 @@ public class Http {
         /**
          * Removes any value from the flash scope.
          */
-        public Flash removing(String... keys) {
+        public Flash remove(String... keys) {
             return new play.api.mvc.Flash(Scala.asScala(this)).remove(keys).asJava();
         }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2233,7 +2233,7 @@ public class Http {
          * Adds a value to the session, and returns a new session.
          */
         public Session adding(String key, String value) {
-            return new play.api.mvc.Session(Scala.asScala(this)).$plus(Scala.Tuple(key, value)).asJava();
+            return new play.api.mvc.Session(Scala.asScala(this)).add(Scala.Tuple(key, value)).asJava();
         }
 
         /**
@@ -2241,7 +2241,7 @@ public class Http {
          * and returns a new session with the added elements.
          */
         public Session adding(Map<String, String> values) {
-            return new play.api.mvc.Session(Scala.asScala(this)).$plus$plus(Scala.asScala(values)).asJava();
+            return new play.api.mvc.Session(Scala.asScala(this)).addAll(Scala.asScala(values)).asJava();
         }
 
         /**
@@ -2550,7 +2550,7 @@ public class Http {
          * Adds a value to the flash scope, and returns a new flash scope.
          */
         public Flash adding(String key, String value) {
-            return new play.api.mvc.Flash(Scala.asScala(this)).$plus(Scala.Tuple(key, value)).asJava();
+            return new play.api.mvc.Flash(Scala.asScala(this)).add(Scala.Tuple(key, value)).asJava();
         }
 
         /**
@@ -2558,7 +2558,7 @@ public class Http {
          * and returns a new flash scope with the added elements.
          */
         public Flash adding(Map<String, String> values) {
-            return new play.api.mvc.Flash(Scala.asScala(this)).$plus$plus(Scala.asScala(values)).asJava();
+            return new play.api.mvc.Flash(Scala.asScala(this)).addAll(Scala.asScala(values)).asJava();
         }
 
         /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -46,6 +46,9 @@ import java.time.Duration;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -2133,15 +2136,55 @@ public class Http {
      */
     public static class Session extends HashMap<String,String>{
 
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
         public boolean isDirty = false;
 
         public Session(Map<String,String> data) {
             super(data);
         }
 
+        public Session(play.api.mvc.Session underlying) {
+            this(Scala.asJava(underlying.data()));
+        }
+
+        public Map<String, String> data() {
+            return Collections.unmodifiableMap(this);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0. Use {@link #getOptional(String)} instead.
+         */
+        @Deprecated
+        @Override
+        public boolean containsKey(Object key) {
+            return super.containsKey(key);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0. Use {@link #getOptional(String)} instead.
+         */
+        @Deprecated
+        @Override
+        public String get(Object key) {
+            return super.get(key);
+        }
+
+        /**
+         * Optionally returns the session value associated with a key.
+         */
+        public Optional<String> getOptional(String key) {
+            return Optional.ofNullable(super.get(key));
+        }
+
         /**
          * Removes the specified value from the session.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #removing(String...)} instead.
          */
+        @Deprecated
         @Override
         public String remove(Object key) {
             isDirty = true;
@@ -2149,8 +2192,18 @@ public class Http {
         }
 
         /**
-         * Adds the given value to the session.
+         * Removes any value from the session.
          */
+        public Session removing(String... keys) {
+            return new play.api.mvc.Session(Scala.asScala(this)).$minus(keys).asJava();
+        }
+
+        /**
+         * Adds the given value to the session.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #adding(String, String)} instead.
+         */
+        @Deprecated
         @Override
         public String put(String key, String value) {
             isDirty = true;
@@ -2159,7 +2212,10 @@ public class Http {
 
         /**
          * Adds the given values to the session.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #adding(Map)} instead.
          */
+        @Deprecated
         @Override
         public void putAll(Map<? extends String,? extends String> values) {
             isDirty = true;
@@ -2167,8 +2223,26 @@ public class Http {
         }
 
         /**
-         * Clears the session.
+         * Adds a value to the session, and returns a new session.
          */
+        public Session adding(String key, String value) {
+            return new play.api.mvc.Session(Scala.asScala(this)).$plus(Scala.Tuple(key, value)).asJava();
+        }
+
+        /**
+         * Adds a number of elements provided by the given map object
+         * and returns a new session with the added elements.
+         */
+        public Session adding(Map<String, String> values) {
+            return new play.api.mvc.Session(Scala.asScala(this)).$plus$plus(Scala.asScala(values)).asJava();
+        }
+
+        /**
+         * Clears the session.
+         *
+         * @deprecated Deprecated as of 2.7.0. Just create a new instance instead.
+         */
+        @Deprecated
         @Override
         public void clear() {
             isDirty = true;
@@ -2184,6 +2258,185 @@ public class Http {
             return new play.api.mvc.Session(Scala.asScala(this));
         }
 
+        // ### Let's deprecate all of HashMap
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        public Session(int initialCapacity, float loadFactor) {
+            super(initialCapacity, loadFactor);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        public Session(int initialCapacity) {
+            super(initialCapacity);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public int size() {
+            return super.size();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public boolean isEmpty() {
+            return super.isEmpty();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public boolean containsValue(Object value) {
+            return super.containsValue(value);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public Set<String> keySet() {
+            return super.keySet();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public Collection<String> values() {
+            return super.values();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public Set<Entry<String, String>> entrySet() {
+            return super.entrySet();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String getOrDefault(Object key, String defaultValue) {
+            return super.getOrDefault(key, defaultValue);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String putIfAbsent(String key, String value) {
+            return super.putIfAbsent(key, value);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public boolean remove(Object key, Object value) {
+            return super.remove(key, value);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public boolean replace(String key, String oldValue, String newValue) {
+            return super.replace(key, oldValue, newValue);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String replace(String key, String value) {
+            return super.replace(key, value);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String computeIfAbsent(String key, Function<? super String, ? extends String> mappingFunction) {
+            return super.computeIfAbsent(key, mappingFunction);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String computeIfPresent(String key, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+            return super.computeIfPresent(key, remappingFunction);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String compute(String key, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+            return super.compute(key, remappingFunction);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String merge(String key, String value, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+            return super.merge(key, value, remappingFunction);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public void forEach(BiConsumer<? super String, ? super String> action) {
+            super.forEach(action);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public void replaceAll(BiFunction<? super String, ? super String, ? extends String> function) {
+            super.replaceAll(function);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public Object clone() {
+            return super.clone();
+        }
     }
 
     /**
@@ -2193,15 +2446,55 @@ public class Http {
      */
     public static class Flash extends HashMap<String,String>{
 
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
         public boolean isDirty = false;
 
         public Flash(Map<String,String> data) {
             super(data);
         }
 
+        public Flash(play.api.mvc.Flash underlying) {
+            this(Scala.asJava(underlying.data()));
+        }
+
+        public Map<String, String> data() {
+            return Collections.unmodifiableMap(this);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0. Use {@link #getOptional(String)} instead.
+         */
+        @Deprecated
+        @Override
+        public boolean containsKey(Object key) {
+            return super.containsKey(key);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0. Use {@link #getOptional(String)} instead.
+         */
+        @Deprecated
+        @Override
+        public String get(Object key) {
+            return super.get(key);
+        }
+
+        /**
+         * Optionally returns the flash scope value associated with a key.
+         */
+        public Optional<String> getOptional(String key) {
+            return Optional.ofNullable(super.get(key));
+        }
+
         /**
          * Removes the specified value from the flash scope.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #removing(String...)} instead.
          */
+        @Deprecated
         @Override
         public String remove(Object key) {
             isDirty = true;
@@ -2209,8 +2502,18 @@ public class Http {
         }
 
         /**
-         * Adds the given value to the flash scope.
+         * Removes any value from the flash scope.
          */
+        public Flash removing(String... keys) {
+            return new play.api.mvc.Flash(Scala.asScala(this)).$minus(keys).asJava();
+        }
+
+        /**
+         * Adds the given value to the flash scope.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #adding(String, String)} instead.
+         */
+        @Deprecated
         @Override
         public String put(String key, String value) {
             isDirty = true;
@@ -2219,7 +2522,10 @@ public class Http {
 
         /**
          * Adds the given values to the flash scope.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #adding(Map)} instead.
          */
+        @Deprecated
         @Override
         public void putAll(Map<? extends String,? extends String> values) {
             isDirty = true;
@@ -2227,8 +2533,26 @@ public class Http {
         }
 
         /**
-         * Clears the flash scope.
+         * Adds a value to the flash scope, and returns a new flash scope.
          */
+        public Flash adding(String key, String value) {
+            return new play.api.mvc.Flash(Scala.asScala(this)).$plus(Scala.Tuple(key, value)).asJava();
+        }
+
+        /**
+         * Adds a number of elements provided by the given map object
+         * and returns a new flash scope with the added elements.
+         */
+        public Flash adding(Map<String, String> values) {
+            return new play.api.mvc.Flash(Scala.asScala(this)).$plus$plus(Scala.asScala(values)).asJava();
+        }
+
+        /**
+         * Clears the flash scope.
+         *
+         * @deprecated Deprecated as of 2.7.0. Just create a new instance instead.
+         */
+        @Deprecated
         @Override
         public void clear() {
             isDirty = true;
@@ -2244,6 +2568,185 @@ public class Http {
             return new play.api.mvc.Flash(Scala.asScala(this));
         }
 
+        // ### Let's deprecate all of HashMap
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        public Flash(int initialCapacity, float loadFactor) {
+            super(initialCapacity, loadFactor);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        public Flash(int initialCapacity) {
+            super(initialCapacity);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public int size() {
+            return super.size();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public boolean isEmpty() {
+            return super.isEmpty();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public boolean containsValue(Object value) {
+            return super.containsValue(value);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public Set<String> keySet() {
+            return super.keySet();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public Collection<String> values() {
+            return super.values();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public Set<Entry<String, String>> entrySet() {
+            return super.entrySet();
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String getOrDefault(Object key, String defaultValue) {
+            return super.getOrDefault(key, defaultValue);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String putIfAbsent(String key, String value) {
+            return super.putIfAbsent(key, value);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public boolean remove(Object key, Object value) {
+            return super.remove(key, value);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public boolean replace(String key, String oldValue, String newValue) {
+            return super.replace(key, oldValue, newValue);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String replace(String key, String value) {
+            return super.replace(key, value);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String computeIfAbsent(String key, Function<? super String, ? extends String> mappingFunction) {
+            return super.computeIfAbsent(key, mappingFunction);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String computeIfPresent(String key, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+            return super.computeIfPresent(key, remappingFunction);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String compute(String key, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+            return super.compute(key, remappingFunction);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public String merge(String key, String value, BiFunction<? super String, ? super String, ? extends String> remappingFunction) {
+            return super.merge(key, value, remappingFunction);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public void forEach(BiConsumer<? super String, ? super String> action) {
+            super.forEach(action);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public void replaceAll(BiFunction<? super String, ? super String, ? extends String> function) {
+            super.replaceAll(function);
+        }
+
+        /**
+         * @deprecated Deprecated as of 2.7.0.
+         */
+        @Deprecated
+        @Override
+        public Object clone() {
+            return super.clone();
+        }
     }
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2175,6 +2175,13 @@ public class Http {
         /**
          * Optionally returns the session value associated with a key.
          */
+        public Optional<String> apply(String key) {
+            return getOptional(key);
+        }
+
+        /**
+         * Optionally returns the session value associated with a key.
+         */
         public Optional<String> getOptional(String key) {
             return Optional.ofNullable(super.get(key));
         }
@@ -2480,6 +2487,13 @@ public class Http {
         @Override
         public String get(Object key) {
             return super.get(key);
+        }
+
+        /**
+         * Optionally returns the session value associated with a key.
+         */
+        public Optional<String> apply(String key) {
+            return getOptional(key);
         }
 
         /**

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -269,9 +269,7 @@ public class Result {
         if(this.flash == null) {
             return withFlash(values);
         } else {
-            Map<String, String> newValues = new HashMap<>(this.flash);
-            newValues.putAll(values);
-            return withFlash(newValues);
+            return withFlash(this.flash.adding(values));
         }
     }
 
@@ -298,13 +296,7 @@ public class Result {
         if(this.flash == null) {
             return withNewFlash();
         }
-        Map<String, String> newValues = new HashMap<>(this.flash);
-        if(keys != null) {
-            for (String key : keys) {
-                newValues.remove(key);
-            }
-        }
-        return withFlash(newValues);
+        return withFlash(this.flash.removing(keys));
     }
 
     /**
@@ -364,9 +356,7 @@ public class Result {
      * @return A copy of this result with values added to its session scope.
      */
     public Result addingToSession(Http.Request request, Map<String, String> values) {
-        Map<String, String> newValues = new HashMap<>(session(request));
-        newValues.putAll(values);
-        return withSession(newValues);
+        return withSession(session(request).adding(values));
     }
 
     /**
@@ -389,13 +379,7 @@ public class Result {
      * @return A copy of this result with keys removed from its session scope.
      */
     public Result removingFromSession(Http.Request request, String... keys) {
-        Map<String, String> newValues = new HashMap<>(session(request));
-        if(keys != null) {
-            for (String key : keys) {
-                newValues.remove(key);
-            }
-        }
-        return withSession(newValues);
+        return withSession(session(request).removing(keys));
     }
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -296,7 +296,7 @@ public class Result {
         if(this.flash == null) {
             return withNewFlash();
         }
-        return withFlash(this.flash.removing(keys));
+        return withFlash(this.flash.remove(keys));
     }
 
     /**
@@ -379,7 +379,7 @@ public class Result {
      * @return A copy of this result with keys removed from its session scope.
      */
     public Result removingFromSession(Http.Request request, String... keys) {
-        return withSession(session(request).removing(keys));
+        return withSession(session(request).remove(keys));
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -46,10 +46,28 @@ case class Flash(data: Map[String, String] = Map.empty[String, String]) {
   }
 
   /**
+   * Adds a value to the flash scope, and returns a new flash scope.
+   *
+   * This is an alias method to [[+]].
+   *
+   * @param kv the key-value pair to add
+   * @return the modified flash scope
+   */
+  def add(kv: (String, String)): Flash = this + kv
+
+  /**
    * Adds a number of elements provided by the given map object
    * and returns a new flash scope with the added elements.
    */
-  def ++(kvs: Map[String, String]): Flash = {
+  def ++(kvs: (String, String)*): Flash = {
+    copy(data ++ kvs)
+  }
+
+  /**
+   * Adds a number of elements provided by the given map object
+   * and returns a new flash scope with the added elements.
+   */
+  def addAll(kvs: Map[String, String]): Flash = {
     copy(data ++ kvs)
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -54,17 +54,25 @@ case class Flash(data: Map[String, String] = Map.empty[String, String]) {
   }
 
   /**
-   * Removes a value from the flash scope.
+   * Removes values from the flash scope.
    *
    * For example:
    * {{{
    * flash - "success"
    * }}}
    *
-   * @param key the key to remove
+   * @param keys the keys to remove
    * @return the modified flash scope
    */
-  @varargs def -(key: String*): Flash = copy(data -- key)
+  def -(keys: String*): Flash = remove(keys: _*)
+
+  /**
+   * Removes values from the flash scope.
+   *
+   * @param keys the keys to remove
+   * @return the modified flash scope
+   */
+  @varargs def remove(keys: String*): Flash = copy(data -- keys)
 
   /**
    * Retrieves the flash value that is associated with the given key.

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -10,7 +10,7 @@ import play.api.http.{ FlashConfiguration, HttpConfiguration, SecretConfiguratio
 import play.api.libs.crypto.{ CookieSigner, CookieSignerProvider }
 import play.mvc.Http
 
-import scala.collection.JavaConverters._
+import scala.annotation.varargs
 
 /**
  * HTTP Flash scope.
@@ -46,6 +46,14 @@ case class Flash(data: Map[String, String] = Map.empty[String, String]) {
   }
 
   /**
+   * Adds a number of elements provided by the given map object
+   * and returns a new flash scope with the added elements.
+   */
+  def ++(kvs: Map[String, String]): Flash = {
+    copy(data ++ kvs)
+  }
+
+  /**
    * Removes a value from the flash scope.
    *
    * For example:
@@ -56,14 +64,14 @@ case class Flash(data: Map[String, String] = Map.empty[String, String]) {
    * @param key the key to remove
    * @return the modified flash scope
    */
-  def -(key: String): Flash = copy(data - key)
+  @varargs def -(key: String*): Flash = copy(data -- key)
 
   /**
    * Retrieves the flash value that is associated with the given key.
    */
   def apply(key: String): String = data(key)
 
-  lazy val asJava: Http.Flash = new Http.Flash(data.asJava)
+  lazy val asJava: Http.Flash = new Http.Flash(this)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -54,17 +54,25 @@ case class Session(data: Map[String, String] = Map.empty[String, String]) {
   }
 
   /**
-   * Removes any value from the session.
+   * Removes values from the session.
    *
    * For example:
    * {{{
    * session - "username"
    * }}}
    *
-   * @param key the key to remove
+   * @param keys the keys to remove
    * @return the modified session
    */
-  @varargs def -(key: String*): Session = copy(data -- key)
+  def -(keys: String*): Session = remove(keys: _*)
+
+  /**
+   * Removes values from the session.
+   *
+   * @param keys the keys to remove
+   * @return the modified session
+   */
+  @varargs def remove(keys: String*): Session = copy(data -- keys)
 
   /**
    * Retrieves the session value which is associated with the given key.

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -46,10 +46,28 @@ case class Session(data: Map[String, String] = Map.empty[String, String]) {
   }
 
   /**
+   * Adds a value to the session, and returns a new session.
+   *
+   * This is an alias method to [[+]].
+   *
+   * @param kv the key-value pair to add
+   * @return the modified session
+   */
+  def add(kv: (String, String)): Session = this + kv
+
+  /**
    * Adds a number of elements provided by the given map object
    * and returns a new session with the added elements.
    */
-  def ++(kvs: Map[String, String]): Session = {
+  def ++(kvs: (String, String)*): Session = {
+    copy(data ++ kvs)
+  }
+
+  /**
+   * Adds a number of elements provided by the given map object
+   * and returns a new session with the added elements.
+   */
+  def addAll(kvs: Map[String, String]): Session = {
     copy(data ++ kvs)
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -10,7 +10,7 @@ import play.api.http.{ HttpConfiguration, SecretConfiguration, SessionConfigurat
 import play.api.libs.crypto.{ CookieSigner, CookieSignerProvider }
 import play.mvc.Http
 
-import scala.collection.JavaConverters._
+import scala.annotation.varargs
 
 /**
  * HTTP Session.
@@ -46,6 +46,14 @@ case class Session(data: Map[String, String] = Map.empty[String, String]) {
   }
 
   /**
+   * Adds a number of elements provided by the given map object
+   * and returns a new session with the added elements.
+   */
+  def ++(kvs: Map[String, String]): Session = {
+    copy(data ++ kvs)
+  }
+
+  /**
    * Removes any value from the session.
    *
    * For example:
@@ -56,14 +64,14 @@ case class Session(data: Map[String, String] = Map.empty[String, String]) {
    * @param key the key to remove
    * @return the modified session
    */
-  def -(key: String): Session = copy(data - key)
+  @varargs def -(key: String*): Session = copy(data -- key)
 
   /**
    * Retrieves the session value which is associated with the given key.
    */
   def apply(key: String): String = data(key)
 
-  lazy val asJava: Http.Session = new Http.Session(data.asJava)
+  lazy val asJava: Http.Session = new Http.Session(this)
 }
 
 /**


### PR DESCRIPTION
Java's `Session` and `Flash` are mutable right now... extending `HashMap`...

Let's make it like the Scala ones.
That's what they will look like after Play 2.7 when all the deprecations are removed: https://gist.github.com/mkurz/6878b1f8b0b7a352fcd4683385faff06
(`getOptional` will be renamed back to `get`)