### PR TITLE
New APIS to avoid Http.Context when using RoutingDsl

### DIFF
--- a/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/FiltersTest.java
+++ b/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/FiltersTest.java
@@ -23,7 +23,7 @@ public class FiltersTest extends WithApplication {
     @Test
     public void testRequestBuilder() {
         Router router = new RoutingDsl(instanceOf(play.mvc.BodyParser.Default.class), instanceOf(JavaContextComponents.class))
-                .GET("/xx/Kiwi").routeTo(() -> Results.ok("success"))
+                .GET("/xx/Kiwi").routingTo(request -> Results.ok("success"))
                 .build();
 
         // #test-with-request-builder
@@ -39,7 +39,7 @@ public class FiltersTest extends WithApplication {
     @Test
     public void test() {
         Router router = new RoutingDsl(instanceOf(play.mvc.BodyParser.Default.class), instanceOf(JavaContextComponents.class))
-                .POST("/xx/Kiwi").routeTo(() -> Results.ok("success"))
+                .POST("/xx/Kiwi").routingTo(request -> Results.ok("success"))
                 .build();
 
         // #test-with-addCSRFToken

--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
@@ -31,7 +31,7 @@ public class JavaEmbeddingPlay {
         //#simple
         Server server = Server.forRouter((components) ->
             RoutingDsl.fromComponents(components)
-                .GET("/hello/:to").routeTo(to ->
+                .GET("/hello/:to").routingTo((request, to) ->
                     ok("Hello " + to)
                 )
                 .build()
@@ -63,7 +63,7 @@ public class JavaEmbeddingPlay {
         //#config
         Server server = Server.forRouter((components) ->
             RoutingDsl.fromComponents(components)
-                .GET("/hello/:to").routeTo(to ->
+                .GET("/hello/:to").routingTo((request, to) ->
                     ok("Hello " + to)
                 )
                 .build()

--- a/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
@@ -5,7 +5,7 @@ Play provides a DSL for routers directly in code.  This DSL has many uses, inclu
 
 The DSL uses a path pattern syntax similar to Play's compiled routes files, extracting parameters out, and invoking actions implemented using lambdas.
 
-The DSL is provided by [`RoutingDsl`](api/java/play/routing/RoutingDsl.html).  Since you will be implementing actions, you may want to import the static methods from [`Controller`](api/java/play/mvc/Controller.html), which includes factory methods for creating results, accessing the request, response and session.  So typically you will want at least the following imports:
+The DSL is provided by [`RoutingDsl`](api/java/play/routing/RoutingDsl.html).  Since you will be implementing actions, you may want to import the static methods from [`Results`](api/java/play/mvc/Results.html), which includes factory methods for creating results. The DSL gives you access to the current [Http.Request](api/java/play/mvc/Http.Request.html) and you can use it to access the session, cookies, etc. So typically you will want at least the following imports:
 
 @[imports](code/javaguide/advanced/routing/JavaRoutingDsl.java)
 
@@ -21,7 +21,9 @@ A simple example of the DSL's use is:
 
 @[simple](code/javaguide/advanced/routing/JavaRoutingDsl.java)
 
-The `:to` parameter is extracted out and passed as the first parameter to the router.  Note that the name you give to parameters in the path pattern is irrelevant, the important thing is that parameters in the path are in the same order as parameters in your lambda.  You can have anywhere from 0 to 3 parameters in the path pattern, and other HTTP methods, such as `POST`, `PUT` and `DELETE` are supported.
+The first parameter to the action block is an [Http.Request](api/java/play/mvc/Http.Request.html). Then the `:to` parameter is extracted out and passed as the first parameter to the router.  Note that the name you give to parameters in the path pattern is irrelevant, the important thing is that parameters in the path are in the same order as parameters in your lambda.  You can have anywhere from 0 to 3 parameters in the path pattern, and other HTTP methods, such as `POST`, `PUT` and `DELETE` are supported.
+
+> **Note**: it is important to notice that when using the DSL, the first parameter will always be the `Http.Request`. The next parameters are the ones you actually declared at your route pattern.
 
 Like Play's compiled router, the DSL also supports matching multi path segment parameters, this is done by prefixing the parameter with `*`:
 
@@ -37,7 +39,7 @@ In the above examples, the type of the parameters in the lambdas is undeclared, 
 
 Supported types include `Integer`, `Long`, `Float`, `Double`, `Boolean`, and any type that extends [`PathBindable`](api/java/play/mvc/PathBindable.html).
 
-Asynchronous actions are of course also supported, using the `routeAsync` method:
+Asynchronous actions are of course also supported, using the `routingAsync` method:
 
 @[async](code/javaguide/advanced/routing/JavaRoutingDsl.java)
 
@@ -67,4 +69,4 @@ and in the application loader:
 
 ### Overriding binding
 
-A router can also be provided using e.g. GuiceApplicationBuilder in the application loader to override with custom router binding or module as detailed in [[Bindings and Modules|JavaTestingWithGuice#Override-bindings]] 
+A router can also be provided using e.g. [`GuiceApplicationBuilder`](api/java/play/inject/guice/GuiceApplicationBuilder.html) in the application loader to override with custom router binding or module as detailed in [[Bindings and Modules|JavaTestingWithGuice#Override-bindings]]

--- a/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.java
@@ -26,7 +26,7 @@ class MyComponents extends RoutingDslComponentsFromContext
     @Override
     public Router router() {
         return routingDsl()
-                .GET("/hello/:to").routeTo(to -> ok("Hello " + to))
+                .GET("/hello/:to").routingTo((request, to) -> ok("Hello " + to))
                 .build();
     }
 }

--- a/documentation/manual/working/javaGuide/advanced/routing/code/GuiceRouterProvider.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/GuiceRouterProvider.java
@@ -24,7 +24,7 @@ public class GuiceRouterProvider implements Provider<play.api.routing.Router> {
     @Override
     public play.api.routing.Router get() {
         return routingDsl
-                .GET("/hello/:to").routeTo(to -> ok("Hello " + to))
+                .GET("/hello/:to").routingTo((request, to) -> ok("Hello " + to))
                 .build()
                 .asScala();
     }

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/advanced/routing/JavaRoutingDsl.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/advanced/routing/JavaRoutingDsl.java
@@ -133,8 +133,8 @@ public class JavaRoutingDsl extends WithApplication {
         RoutingDsl routingDsl = new RoutingDsl(bodyParser, javaContextComponents);
         //#new-routing-dsl
         Router router = routingDsl
-                .GET("/hello/:to").routeTo(to ->
-                        ok("Hello " + to)
+                .GET("/hello/:to").routingTo((request, to) ->
+                    ok("Hello " + to)
                 )
                 .build();
 

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/advanced/routing/JavaRoutingDsl.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/advanced/routing/JavaRoutingDsl.java
@@ -14,6 +14,7 @@ import play.api.mvc.AnyContent;
 import play.api.mvc.BodyParser;
 import play.api.mvc.PlayBodyParsers;
 import play.core.j.JavaContextComponents;
+import play.mvc.Http;
 import play.routing.Router;
 import play.routing.RoutingDsl;
 import java.util.concurrent.CompletableFuture;
@@ -41,8 +42,8 @@ public class JavaRoutingDsl extends WithApplication {
     public void simple() {
         //#simple
         Router router = routingDsl
-            .GET("/hello/:to").routeTo(to ->
-                    ok("Hello " + to)
+            .GET("/hello/:to").routingTo( (request, to) ->
+                ok("Hello " + to)
             )
             .build();
         //#simple
@@ -54,7 +55,7 @@ public class JavaRoutingDsl extends WithApplication {
     public void fullPath() {
         //#full-path
         Router router = routingDsl
-            .GET("/assets/*file").routeTo(file ->
+            .GET("/assets/*file").routingTo( (request, file) ->
                 ok("Serving " + file)
             )
             .build();
@@ -67,7 +68,7 @@ public class JavaRoutingDsl extends WithApplication {
     public void regexp() {
         //#regexp
         Router router = routingDsl
-            .GET("/api/items/$id<[0-9]+>").routeTo(id ->
+            .GET("/api/items/$id<[0-9]+>").routingTo( (request, id) ->
                 ok("Getting item " + id)
             )
             .build();
@@ -80,7 +81,7 @@ public class JavaRoutingDsl extends WithApplication {
     public void integer() {
         //#integer
         Router router = routingDsl
-            .GET("/api/items/:id").routeTo((Integer id) ->
+            .GET("/api/items/:id").routingTo((Http.Request request, Integer id) ->
                 ok("Getting item " + id)
             )
             .build();
@@ -93,7 +94,7 @@ public class JavaRoutingDsl extends WithApplication {
     public void async() {
         //#async
         Router router = routingDsl
-            .GET("/api/items/:id").routeAsync((Integer id) ->
+            .GET("/api/items/:id").routingAsync((Http.Request request, Integer id) ->
                 CompletableFuture.completedFuture(ok("Getting item " + id))
             )
             .build();

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
@@ -106,7 +106,7 @@ public class CompileTimeDependencyInjection {
         public Router router() {
             // routingDsl method is provided by RoutingDslComponentsFromContext
             return routingDsl()
-                    .GET("/path").routeTo(() -> Results.ok("The content"))
+                    .GET("/path").routingTo(request -> Results.ok("The content"))
                     .build();
         }
     }

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
@@ -28,7 +28,7 @@ public class GitHubClientTest {
     @Before
     public void setup() {
         server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
-                .GET("/repositories").routeTo(() -> {
+                .GET("/repositories").routingTo(request -> {
                     ArrayNode repos = Json.newArray();
                     ObjectNode repo = Json.newObject();
                     repo.put("full_name", "octocat/Hello-World");

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
@@ -24,7 +24,7 @@ public class JavaTestingWebServiceClients {
     public void mockService() {
         //#mock-service
         Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
-                .GET("/repositories").routeTo(() -> {
+                .GET("/repositories").routingTo(request -> {
                     ArrayNode repos = Json.newArray();
                     ObjectNode repo = Json.newObject();
                     repo.put("full_name", "octocat/Hello-World");
@@ -41,7 +41,7 @@ public class JavaTestingWebServiceClients {
     public void sendResource() throws Exception {
         //#send-resource
         Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
-                .GET("/repositories").routeTo(() ->
+                .GET("/repositories").routingTo(request ->
                         ok().sendResource("github/repositories.json")
                 )
                 .build()

--- a/framework/src/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
@@ -16,7 +16,6 @@ import play.mvc.Results;
 
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.*;

--- a/framework/src/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
@@ -12,8 +12,11 @@ import play.libs.XML;
 import play.mvc.Http;
 import play.mvc.PathBindable;
 import play.mvc.Result;
+import play.mvc.Results;
 
 import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -36,7 +39,215 @@ public abstract class AbstractRoutingDslTest {
     }
 
     @Test
+    public void shouldProvideJavaRequestToActionWithoutParameters() {
+        Router router = router(routingDsl -> routingDsl.GET("/with-request")
+                .routingTo(request ->
+                        request.header("X-Test")
+                            .map(Results::ok)
+                            .orElse(Results.notFound())).build());
+
+        String result = makeRequest(
+                router,
+                "GET",
+                "/with-request",
+                rb -> rb.header("X-Test", "Header value")
+        );
+        assertThat(result, equalTo("Header value"));
+    }
+
+    @Test
+    public void shouldProvideJavaRequestToActionWithSingleParameter() {
+        Router router = router(routingDsl -> routingDsl.GET("/with-request/:p1")
+                .routingTo((request, number) ->
+                        request.header("X-Test")
+                            .map(header -> Results.ok(header + " - " + number))
+                            .orElse(Results.notFound())).build());
+
+        String result = makeRequest(
+                router,
+                "GET",
+                "/with-request/10",
+                rb -> rb.header("X-Test", "Header value")
+        );
+        assertThat(result, equalTo("Header value - 10"));
+    }
+
+    @Test
+    public void shouldProvideJavaRequestToActionWith2Parameters() {
+        Router router = router(routingDsl -> routingDsl.GET("/with-request/:p1/:p2")
+                .routingTo((request, n1, n2) ->
+                        request.header("X-Test")
+                            .map(header -> Results.ok(header + " - " + n1 + " - " + n2))
+                            .orElse(Results.notFound())).build());
+
+        String result = makeRequest(
+                router,
+                "GET",
+                "/with-request/10/20",
+                rb -> rb.header("X-Test", "Header value")
+        );
+        assertThat(result, equalTo("Header value - 10 - 20"));
+    }
+
+    @Test
+    public void shouldProvideJavaRequestToActionWith3Parameters() {
+        Router router = router(routingDsl -> routingDsl.GET("/with-request/:p1/:p2/:p3")
+                .routingTo((request, n1, n2, n3) ->
+                        request.header("X-Test")
+                                .map(header -> Results.ok(header + " - " + n1 + " - " + n2 + " - " + n3))
+                                .orElse(Results.notFound())).build());
+
+        String result = makeRequest(
+                router,
+                "GET",
+                "/with-request/10/20/30",
+                rb -> rb.header("X-Test", "Header value")
+        );
+        assertThat(result, equalTo("Header value - 10 - 20 - 30"));
+    }
+
+    @Test
+    public void shouldProvideJavaRequestToAsyncActionWithoutParameters() {
+        Router router = router(routingDsl -> routingDsl.GET("/with-request")
+                .routingAsync(request ->
+                    CompletableFuture.completedFuture(
+                        request.header("X-Test")
+                            .map(Results::ok)
+                            .orElse(Results.notFound())
+                    )
+                ).build());
+
+        String result = makeRequest(
+                router,
+                "GET",
+                "/with-request",
+                rb -> rb.header("X-Test", "Header value")
+        );
+        assertThat(result, equalTo("Header value"));
+    }
+
+    @Test
+    public void shouldProvideJavaRequestToAsyncActionWithSingleParameter() {
+        Router router = router(routingDsl -> routingDsl.GET("/with-request/:p1")
+                .routingAsync((request, number) ->
+                    CompletableFuture.completedFuture(
+                        request.header("X-Test")
+                            .map(header -> Results.ok(header + " - " + number))
+                            .orElse(Results.notFound())
+                    )
+                ).build());
+
+        String result = makeRequest(
+                router,
+                "GET",
+                "/with-request/10",
+                rb -> rb.header("X-Test", "Header value")
+        );
+        assertThat(result, equalTo("Header value - 10"));
+    }
+
+    @Test
+    public void shouldProvideJavaRequestToAsyncActionWith2Parameters() {
+        Router router = router(routingDsl -> routingDsl.GET("/with-request/:p1/:p2")
+                .routingAsync((request, n1, n2) ->
+                    CompletableFuture.completedFuture(
+                        request.header("X-Test")
+                            .map(header -> Results.ok(header + " - " + n1 + " - " + n2))
+                            .orElse(Results.notFound())
+                    )
+                ).build());
+
+        String result = makeRequest(
+                router,
+                "GET",
+                "/with-request/10/20",
+                rb -> rb.header("X-Test", "Header value")
+        );
+        assertThat(result, equalTo("Header value - 10 - 20"));
+    }
+
+    @Test
+    public void shouldProvideJavaRequestToAsyncActionWith3Parameters() {
+        Router router = router(routingDsl -> routingDsl.GET("/with-request/:p1/:p2/:p3")
+                .routingAsync((request, n1, n2, n3) ->
+                    CompletableFuture.completedFuture(
+                        request.header("X-Test")
+                            .map(header -> Results.ok(header + " - " + n1 + " - " + n2 + " - " + n3))
+                            .orElse(Results.notFound())
+                        )
+                ).build());
+
+        String result = makeRequest(
+                router,
+                "GET",
+                "/with-request/10/20/30",
+                rb -> rb.header("X-Test", "Header value")
+        );
+        assertThat(result, equalTo("Header value - 10 - 20 - 30"));
+    }
+
+    @Test
     public void shouldPreserveRequestBodyAsText() {
+        Router router = router(routingDsl -> routingDsl.POST("/with-body")
+                .routingTo(request -> Results.ok(request.body().asText()))
+                .build());
+
+        String result = makeRequest(
+                router,
+                "POST",
+                "/with-body",
+                rb -> rb.bodyText("The Body")
+        );
+        assertThat(result, equalTo("The Body"));
+    }
+
+    @Test
+    public void shouldPreserveRequestBodyAsJson() {
+        Router router = router(routingDsl -> routingDsl.POST("/with-body")
+                .routingTo(request -> Results.ok(request.body().asJson()))
+                .build());
+
+        String result = makeRequest(
+                router,
+                "POST",
+                "/with-body",
+                requestBuilder -> requestBuilder.bodyJson(Json.parse("{ \"a\": \"b\" }"))
+        );
+        assertThat(result, equalTo("{\"a\":\"b\"}"));
+    }
+
+    @Test
+    public void shouldPreserveRequestBodyAsXml() {
+        Router router = router(routingDsl -> routingDsl.POST("/with-body")
+                .routingTo(request -> ok(XML.toBytes(request.body().asXml()).utf8String()))
+                .build());
+
+        String result = makeRequest(
+                router,
+                "POST",
+                "/with-body",
+                requestBuilder -> requestBuilder.bodyXml(XML.fromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>"))
+        );
+        assertThat(result, equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>"));
+    }
+
+    @Test
+    public void shouldPreserveRequestBodyAsRawBuffer() {
+        Router router = router(routingDsl -> routingDsl.POST("/with-body")
+                .routingTo(request -> ok(request.body().asRaw().asBytes().utf8String()))
+                .build());
+
+        String result = makeRequest(
+                router,
+                "POST",
+                "/with-body",
+                requestBuilder -> requestBuilder.bodyRaw(ByteString.fromString("The Raw Body"))
+        );
+        assertThat(result, equalTo("The Raw Body"));
+    }
+
+    @Test
+    public void shouldPreserveRequestBodyAsTextWhenUsingHttpContext() {
         Router router = router(routingDsl -> routingDsl.POST("/with-body")
             .routeTo(() -> {
                 // This better emulates how users will access the request object
@@ -54,7 +265,7 @@ public abstract class AbstractRoutingDslTest {
     }
 
     @Test
-    public void shouldPreserveRequestBodyAsJson() {
+    public void shouldPreserveRequestBodyAsJsonWhenUsingHttpContext() {
         Router router = router(routingDsl -> routingDsl.POST("/with-body")
                 .routeTo(() -> {
                     // This better emulates how users will access the request object
@@ -72,7 +283,7 @@ public abstract class AbstractRoutingDslTest {
     }
 
     @Test
-    public void shouldPreserveRequestBodyAsXml() {
+    public void shouldPreserveRequestBodyAsXmlWhenUsingHttpContext() {
         Router router = router(routingDsl -> routingDsl.POST("/with-body")
                 .routeTo(() -> {
                     // This better emulates how users will access the request object
@@ -90,7 +301,7 @@ public abstract class AbstractRoutingDslTest {
     }
 
     @Test
-    public void shouldPreserveRequestBodyAsRawBuffer() {
+    public void shouldPreserveRequestBodyAsRawBufferWhenUsingHttpContext() {
         Router router = router(routingDsl -> routingDsl.POST("/with-body")
                 .routeTo(() -> {
                     // This better emulates how users will access the request object

--- a/framework/src/play-java/src/main/java/play/routing/RequestFunctions.java
+++ b/framework/src/play-java/src/main/java/play/routing/RequestFunctions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.routing;
+
+import play.libs.F;
+import play.mvc.Http;
+
+import java.util.function.Function;
+
+/**
+ * Define functions to be used with {@link RoutingDsl}. The functions here always declared the first parameter as an
+ * {@link Http.Request} so that the blocks have access to the request made.
+ */
+public class RequestFunctions {
+
+    /**
+     * This is used to "tag" the functions which requires a request to execute.
+     */
+    public interface RequestFunction {}
+
+    /**
+     * A function that receives a {@link Http.Request}, no parameters, and return a result type. Results are typically
+     * {@link play.mvc.Result} or a {@link java.util.concurrent.CompletionStage} that produces a Result.
+     *
+     * @param <R> the result type.
+     */
+    public interface Params0<R> extends Function<Http.Request, R>, RequestFunction {}
+
+    /**
+     * A function that receives a {@link Http.Request}, a single parameter, and return a result type. Results are typically
+     * {@link play.mvc.Result} or a {@link java.util.concurrent.CompletionStage} that produces a Result.
+     *
+     * @param <P> the parameter type.
+     * @param <R> the result type.
+     */
+    public interface Params1<P, R> extends java.util.function.BiFunction<Http.Request, P, R>, RequestFunction {}
+
+    /**
+     * A function that receives a {@link Http.Request}, two parameters, and return a result type. Results are typically
+     * {@link play.mvc.Result} or a {@link java.util.concurrent.CompletionStage} that produces a Result.
+     *
+     * @param <P1> the first parameter type.
+     * @param <P2> the second parameter type.
+     * @param <R> the result type.
+     */
+    public interface Params2<P1, P2, R> extends F.Function3<Http.Request, P1, P2, R>, RequestFunction {}
+
+    /**
+     * A function that receives a {@link Http.Request}, three parameters, and return a result type. Results are typically
+     * {@link play.mvc.Result} or a {@link java.util.concurrent.CompletionStage} that produces a Result.
+     *
+     * @param <P1> the first parameter type.
+     * @param <P2> the second parameter type.
+     * @param <P3> the third parameter type.
+     * @param <R> the result type.
+     */
+    public interface Params3<P1, P2, P3, R> extends F.Function4<Http.Request, P1, P2, P3, R>, RequestFunction {}
+}

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -247,14 +247,14 @@ public class RoutingDsl {
 
         Method actionMethod = null;
         for (Method m : actionFunction.getMethods()) {
-        	// Here I assume that we are always passing a `actionFunction` type that:
-        	// 1) defines exactly one abstract method, and
-        	// 2) the abstract method is the method that we want to invoke.
-        	// This works fine with the current implementation of `PathPatternMatcher`, but I wouldn't be
-        	// surprised if it breaks in the future, which is why this comment exists.
-        	// Also, the former implementation (which was checking for the first non default method), was
-        	// not working when using a `java.util.function.Function` type (Function.identity was being
-        	// returned, instead of Function.apply).
+            // Here I assume that we are always passing a `actionFunction` type that:
+            // 1) defines exactly one abstract method, and
+            // 2) the abstract method is the method that we want to invoke.
+            // This works fine with the current implementation of `PathPatternMatcher`, but I wouldn't be
+            // surprised if it breaks in the future, which is why this comment exists.
+            // Also, the former implementation (which was checking for the first non default method), was
+            // not working when using a `java.util.function.Function` type (Function.identity was being
+            // returned, instead of Function.apply).
             if (Modifier.isAbstract(m.getModifiers())) {
                 actionMethod = m;
             }
@@ -324,11 +324,106 @@ public class RoutingDsl {
         private final String pathPattern;
 
         /**
-         * Route with no parameters.
+         * Route with the request and no parameters.
+         *
+         * @param action the action to execute
+         * @return this router builder.
+         */
+        public RoutingDsl routingTo(RequestFunctions.Params0<Result> action) {
+            return build(0, action, RequestFunctions.Params0.class);
+        }
+
+        /**
+         * Route with the request and a single parameter.
+         *
+         * @param action the action to execute.
+         * @param <P1> the first parameter type.
+         * @return this router builder.
+         */
+        public <P1> RoutingDsl routingTo(RequestFunctions.Params1<P1, Result> action) {
+            return build(1, action, RequestFunctions.Params1.class);
+        }
+
+        /**
+         * Route with the request and two parameter.
+         *
+         * @param action the action to execute.
+         * @param <P1> the first parameter type.
+         * @param <P2> the second parameter type.
+         * @return this router builder.
+         */
+        public <P1, P2> RoutingDsl routingTo(RequestFunctions.Params2<P1, P2, Result> action) {
+            return build(2, action, RequestFunctions.Params2.class);
+        }
+
+        /**
+         * Route with the request and three parameter.
+         *
+         * @param action the action to execute.
+         * @param <P1> the first parameter type.
+         * @param <P2> the second parameter type.
+         * @param <P3> the third  parameter type.
+         * @return this router builder.
+         */
+        public <P1, P2, P3> RoutingDsl routingTo(RequestFunctions.Params3<P1, P2, P3, Result> action) {
+            return build(3, action, RequestFunctions.Params3.class);
+        }
+
+        /**
+         * Route async with the request and no parameters.
          *
          * @param action The action to execute.
          * @return This router builder.
          */
+        public RoutingDsl routingAsync(RequestFunctions.Params0<? extends CompletionStage<Result>> action) {
+            return build(0, action, RequestFunctions.Params0.class);
+        }
+
+        /**
+         * Route async with request and a single parameter.
+         *
+         * @param <P1> the first type parameter
+         * @param action The action to execute.
+         * @return This router builder.
+         */
+        public <P1> RoutingDsl routingAsync(RequestFunctions.Params1<P1, ? extends CompletionStage<Result>> action) {
+            return build(1, action, RequestFunctions.Params1.class);
+        }
+
+        /**
+         * Route async with request and two parameters.
+         *
+         * @param <P1> the first type parameter
+         * @param <P2> the second type parameter
+         * @param action The action to execute.
+         * @return This router builder.
+         */
+        public <P1, P2> RoutingDsl routingAsync(RequestFunctions.Params2<P1, P2, ? extends CompletionStage<Result>> action) {
+            return build(2, action, RequestFunctions.Params2.class);
+        }
+
+        /**
+         * Route async with request and three parameters.
+         *
+         * @param <A1> the first type parameter
+         * @param <A2> the second type parameter
+         * @param <A3> the third type parameter
+         * @param action The action to execute.
+         * @return This router builder.
+         */
+        public <A1, A2, A3> RoutingDsl routingAsync(RequestFunctions.Params3<A1, A2, A3, ? extends CompletionStage<Result>> action) {
+            return build(3, action, RequestFunctions.Params3.class);
+        }
+
+        /**
+         * Route with no parameters.
+         *
+         * @param action The action to execute.
+         * @return This router builder.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #routingTo(RequestFunctions.Params0)} instead.
+         */
+        @Deprecated
         public RoutingDsl routeTo(Supplier<Result> action) {
             return build(0, action, Supplier.class);
         }
@@ -339,7 +434,10 @@ public class RoutingDsl {
          * @param <A1> the first type parameter
          * @param action The action to execute.
          * @return This router builder.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #routingTo(RequestFunctions.Params1)} instead.
          */
+        @Deprecated
         public <A1> RoutingDsl routeTo(Function<A1, Result> action) {
             return build(1, action, Function.class);
         }
@@ -351,7 +449,10 @@ public class RoutingDsl {
          * @param <A2> the second type parameter
          * @param action The action to execute.
          * @return This router builder.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #routingTo(RequestFunctions.Params2)} instead.
          */
+        @Deprecated
         public <A1, A2> RoutingDsl routeTo(BiFunction<A1, A2, Result> action) {
             return build(2, action, BiFunction.class);
         }
@@ -364,7 +465,10 @@ public class RoutingDsl {
          * @param <A3> the third type parameter
          * @param action The action to execute.
          * @return This router builder.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #routingTo(RequestFunctions.Params3)} instead.
          */
+        @Deprecated
         public <A1, A2, A3> RoutingDsl routeTo(F.Function3<A1, A2, A3, Result> action) {
             return build(3, action, F.Function3.class);
         }
@@ -374,7 +478,10 @@ public class RoutingDsl {
          *
          * @param action The action to execute.
          * @return This router builder.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #routingAsync(RequestFunctions.Params0)} instead.
          */
+        @Deprecated
         public RoutingDsl routeAsync(Supplier<? extends CompletionStage<Result>> action) {
             return build(0, action, Supplier.class);
         }
@@ -385,7 +492,10 @@ public class RoutingDsl {
          * @param <A1> the first type parameter
          * @param action The action to execute.
          * @return This router builder.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #routingAsync(RequestFunctions.Params1)} instead.
          */
+        @Deprecated
         public <A1> RoutingDsl routeAsync(Function<A1, ? extends CompletionStage<Result>> action) {
             return build(1, action, Function.class);
         }
@@ -397,7 +507,10 @@ public class RoutingDsl {
          * @param <A2> the second type parameter
          * @param action The action to execute.
          * @return This router builder.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #routingAsync(RequestFunctions.Params2)} instead.
          */
+        @Deprecated
         public <A1, A2> RoutingDsl routeAsync(BiFunction<A1, A2, ? extends CompletionStage<Result>> action) {
             return build(2, action, BiFunction.class);
         }
@@ -410,7 +523,10 @@ public class RoutingDsl {
          * @param <A3> the third type parameter
          * @param action The action to execute.
          * @return This router builder.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #routingAsync(RequestFunctions.Params3)} instead.
          */
+        @Deprecated
         public <A1, A2, A3> RoutingDsl routeAsync(F.Function3<A1, A2, A3, ? extends CompletionStage<Result>> action) {
             return build(3, action, F.Function3.class);
         }

--- a/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -14,7 +14,7 @@ import play.utils.UriEncoding
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 private[routing] class RouterBuilderHelper(bodyParser: BodyParser[RequestBody], contextComponents: JavaContextComponents) {
 
@@ -25,7 +25,34 @@ private[routing] class RouterBuilderHelper(bodyParser: BodyParser[RequestBody], 
     play.api.routing.Router.from(Function.unlift { requestHeader =>
 
       // Find the first route that matches
-      routes.collectFirst(Function.unlift(route =>
+      routes.collectFirst(Function.unlift(route => {
+
+        def handleUsingRequest(parameters: Seq[AnyRef], request: Request[RequestBody])(implicit executionContext: ExecutionContext) = {
+          val actionParameters = request.asJava +: parameters
+          val javaResultFuture = route.actionMethod.invoke(route.action, actionParameters: _*) match {
+            case result: Result => Future.successful(result)
+            case promise: CompletionStage[_] =>
+              val p = promise.asInstanceOf[CompletionStage[Result]]
+              FutureConverters.toScala(p)
+          }
+          javaResultFuture.map(_.asScala())
+        }
+
+        def handleUsingHttpContext(parameters: Seq[AnyRef], request: Request[RequestBody])(implicit executionContext: ExecutionContext) = {
+          val ctx = JavaHelpers.createJavaContext(request, contextComponents)
+          try {
+            Context.current.set(ctx)
+            val javaResultFuture = route.actionMethod.invoke(route.action, parameters: _*) match {
+              case result: Result => Future.successful(result)
+              case promise: CompletionStage[_] =>
+                val p = promise.asInstanceOf[CompletionStage[Result]]
+                FutureConverters.toScala(p)
+            }
+            javaResultFuture.map(JavaHelpers.createResult(ctx, _))
+          } finally {
+            Context.current.remove()
+          }
+        }
 
         // First check method
         if (requestHeader.method == route.method) {
@@ -61,19 +88,10 @@ private[routing] class RouterBuilderHelper(bodyParser: BodyParser[RequestBody], 
               case Left(error) => ActionBuilder.ignoringBody(Results.BadRequest(error))
               case Right(parameters) =>
                 import play.core.Execution.Implicits.trampoline
-                ActionBuilder.ignoringBody.async(bodyParser) { request =>
-                  val ctx = JavaHelpers.createJavaContext(request, contextComponents)
-                  try {
-                    Context.current.set(ctx)
-                    val javaResultFuture = route.actionMethod.invoke(route.action, parameters: _*) match {
-                      case result: Result => Future.successful(result)
-                      case promise: CompletionStage[_] =>
-                        val p = promise.asInstanceOf[CompletionStage[Result]]
-                        FutureConverters.toScala(p)
-                    }
-                    javaResultFuture.map(JavaHelpers.createResult(ctx, _))
-                  } finally {
-                    Context.current.remove()
+                ActionBuilder.ignoringBody.async(bodyParser) { request: Request[RequestBody] =>
+                  route.action match {
+                    case _: RequestFunctions.RequestFunction => handleUsingRequest(parameters, request)
+                    case _ => handleUsingHttpContext(parameters, request)
                   }
                 }
             }
@@ -81,7 +99,7 @@ private[routing] class RouterBuilderHelper(bodyParser: BodyParser[RequestBody], 
             Some(action)
           } else None
         } else None
-      ))
+      }))
     }).asJava
   }
 }

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -23,6 +23,13 @@ public class F {
     }
 
     /**
+     * A Function with 4 arguments.
+     */
+    public interface Function4<A,B,C,D,R> {
+        R apply(A a, B b, C c, D d) throws Throwable;
+    }
+
+    /**
      * Exception thrown when an operation times out. This class provides an
      * unchecked alternative to Java's TimeoutException.
      */

--- a/framework/src/play/src/main/scala/play/api/mvc/Request.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Request.scala
@@ -9,6 +9,7 @@ import java.util.Locale
 import play.api.i18n.{ Lang, Messages }
 import play.api.libs.typedmap.{ TypedKey, TypedMap }
 import play.api.mvc.request.{ RemoteConnection, RequestTarget }
+import play.mvc.Http
 
 import scala.annotation.{ implicitNotFound, tailrec }
 
@@ -70,6 +71,14 @@ trait Request[+A] extends RequestHeader {
     withTransientLang(Lang(locale))
   override def clearTransientLang(): Request[A] =
     removeAttr(Messages.Attrs.CurrentLang)
+
+  override def asJava: Http.Request = this match {
+    case req: Request[Http.RequestBody] =>
+      // This will preserve the parsed body since it is already using the Java body wrapper
+      new Http.RequestImpl(req)
+    case _ =>
+      new Http.RequestImpl(this)
+  }
 }
 
 object Request {


### PR DESCRIPTION
## Purpose

RoutingDsl was able only to access the request using `Http.Context`. This PR fix it.