### PR TITLE
Scala Async sample code for non-blocking futures notes CustomExecutionContext binding

### DIFF
--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -39,6 +39,7 @@ class ScalaAsyncSpec extends PlaySpecification {
 //#my-execution-context
 import play.api.libs.concurrent.CustomExecutionContext
 
+// Make sure to bind the new context class to this trait using one of the custom binding techniques listed on the "Scala Dependency Injection" documentation page
 trait MyExecutionContext extends ExecutionContext
 
 class MyExecutionContextImpl @Inject()(system: ActorSystem)

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -39,7 +39,8 @@ class ScalaAsyncSpec extends PlaySpecification {
 //#my-execution-context
 import play.api.libs.concurrent.CustomExecutionContext
 
-// Make sure to bind the new context class to this trait using one of the custom binding techniques listed on the "Scala Dependency Injection" documentation page
+// Make sure to bind the new context class to this trait using one of the custom
+// binding techniques listed on the "Scala Dependency Injection" documentation page
 trait MyExecutionContext extends ExecutionContext
 
 class MyExecutionContextImpl @Inject()(system: ActorSystem)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

The [Scala Async non-blocking actions demo code](https://www.playframework.com/documentation/2.6.x/ScalaAsync#Creating-non-blocking-actions) does not indicate that the `CustomExecutionContext` created needs to be specifically bound before use. The demo does not mention that it is not a fully-runnable snippet, so this documentation addition should help other Scala users from spending time to figure out what is missing.
