### PR TITLE
Handle null content type as if the header was not set

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -12,9 +12,10 @@ import akka.stream.javadsl.Source
 import akka.util.ByteString
 import com.fasterxml.jackson.databind.JsonNode
 import play.api.Application
+import play.api.http.ContentTypes
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
-import play.api.libs.ws.{ DefaultWSCookie, WSCookie, WSResponse }
+import play.api.libs.ws.WSResponse
 import play.http.HttpEntity
 import play.i18n.{ Lang, MessagesApi }
 import play.it._
@@ -22,10 +23,12 @@ import play.libs.{ Comet, EventSource, Json }
 import play.mvc.Http.{ Cookie, Flash, Session }
 import play.mvc._
 
+import scala.collection.JavaConverters._
+
 class NettyJavaResultsHandlingSpec extends JavaResultsHandlingSpec with NettyIntegrationSpecification
 class AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with AkkaHttpIntegrationSpecification
 
-trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
+trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification with ContentTypes {
 
   sequential
 
@@ -367,8 +370,6 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
     "honor configuration for play.http.session.sameSite" in {
       "when configured to lax" in makeRequest(new MockController {
         def action = {
-          import scala.collection.JavaConverters._
-
           val responseHeader = new ResponseHeader(OK, Map.empty[String, String].asJava)
           val body = HttpEntity.fromString("Hello World", "utf-8")
           val session = new Session(Map.empty[String, String].asJava)
@@ -385,8 +386,6 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
 
       "when configured to strict" in makeRequest(new MockController {
         def action = {
-          import scala.collection.JavaConverters._
-
           val responseHeader = new ResponseHeader(OK, Map.empty[String, String].asJava)
           val body = HttpEntity.fromString("Hello World", "utf-8")
           val session = new Session(Map.empty[String, String].asJava)
@@ -504,7 +503,6 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
 
     "chunk event source results" in makeRequest(new MockController {
       def action = {
-        import scala.collection.JavaConverters._
         val dataSource = akka.stream.javadsl.Source.from(List("a", "b").asJava).map {
           new akka.japi.function.Function[String, EventSource.Event] {
             def apply(t: String) = EventSource.Event.event(t)
@@ -540,6 +538,74 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
       response.header(CONTENT_LENGTH) must beSome("5")
       response.header(TRANSFER_ENCODING) must beNone
       response.body must_== "hello"
+    }
+
+    "when changing the content-type" should {
+      "correct change it for strict entities" in makeRequest(new MockController {
+        def action = {
+          Results.ok("<h1>Hello</h1>").as(HTML)
+        }
+      }) { response =>
+        // Use starts with because there is also the charset
+        response.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/html"))
+        response.body must beEqualTo("<h1>Hello</h1>")
+      }
+
+      "correct change it for chunked entities" in makeRequest(new MockController {
+        def action = {
+          val chunks = List(ByteString("a"), ByteString("b"))
+          val dataSource = akka.stream.javadsl.Source.from(chunks.asJava)
+          Results.ok().chunked(dataSource).as(HTML)
+        }
+      }) { response =>
+        // Use starts with because there is also the charset
+        response.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/html"))
+        response.header(TRANSFER_ENCODING) must beSome("chunked")
+      }
+
+      "correct change it for streamed entities" in makeRequest(new MockController {
+        def action = {
+          val source = akka.stream.javadsl.Source.single(ByteString("entity source"))
+          new Result(
+            new ResponseHeader(200, java.util.Collections.emptyMap()),
+            new HttpEntity.Streamed(source, Optional.empty(), Optional.empty())
+          ).as(HTML) // start without content type, but later change it to HTML
+        }
+      }) { response =>
+        // Use starts with because there is also the charset
+        response.header(CONTENT_TYPE) must beSome.which(_.startsWith("text/html"))
+      }
+
+      "have no content type if set to null in strict entities" in makeRequest(new MockController {
+        def action = {
+          Results.ok("<h1>Hello</h1>").as(null)
+        }
+      }) { response =>
+        response.header(CONTENT_TYPE) must beNone
+        response.body must beEqualTo("<h1>Hello</h1>")
+      }
+
+      "have no content type if set to null in chunked entities" in makeRequest(new MockController {
+        def action = {
+          val chunks = List(ByteString("a"), ByteString("b"))
+          val dataSource = akka.stream.javadsl.Source.from(chunks.asJava)
+          Results.ok().chunked(dataSource).as(null)
+        }
+      }) { response =>
+        response.header(CONTENT_TYPE) must beNone
+      }
+
+      "have no content type if set to null in streamed entities" in makeRequest(new MockController {
+        def action = {
+          val source = akka.stream.javadsl.Source.single(ByteString("entity source"))
+          new Result(
+            new ResponseHeader(200, java.util.Collections.emptyMap()),
+            new HttpEntity.Streamed(source, Optional.empty(), Optional.of(HTML))
+          ).as(null) // start with HTML but later change it to null which means no content type
+        }
+      }) { response =>
+        response.header(CONTENT_TYPE) must beNone
+      }
     }
 
   }

--- a/framework/src/play/src/main/java/play/http/HttpEntity.java
+++ b/framework/src/play/src/main/java/play/http/HttpEntity.java
@@ -143,7 +143,7 @@ public abstract class HttpEntity {
 
         @Override
         public HttpEntity as(String contentType) {
-            return new Strict(data, Optional.of(contentType));
+            return new Strict(data, Optional.ofNullable(contentType));
         }
 
         @Override
@@ -192,7 +192,7 @@ public abstract class HttpEntity {
 
         @Override
         public HttpEntity as(String contentType) {
-            return new Streamed(data, contentLength, Optional.of(contentType));
+            return new Streamed(data, contentLength, Optional.ofNullable(contentType));
         }
 
         @Override
@@ -244,7 +244,7 @@ public abstract class HttpEntity {
 
         @Override
         public HttpEntity as(String contentType) {
-            return new Chunked(chunks, Optional.of(contentType));
+            return new Chunked(chunks, Optional.ofNullable(contentType));
         }
 
         @Override

--- a/framework/src/play/src/main/scala/play/api/http/HttpEntity.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpEntity.scala
@@ -81,7 +81,7 @@ object HttpEntity {
     def dataStream = if (data.isEmpty) Source.empty[ByteString] else Source.single(data)
     override def consumeData(implicit mat: Materializer) = Future.successful(data)
     def asJava = new JHttpEntity.Strict(data, OptionConverters.toJava(contentType))
-    def as(contentType: String) = copy(contentType = Some(contentType))
+    def as(contentType: String) = copy(contentType = Option(contentType))
   }
 
   /**
@@ -99,7 +99,7 @@ object HttpEntity {
       data.asJava,
       OptionConverters.toJava(contentLength.asInstanceOf[Option[java.lang.Long]]),
       OptionConverters.toJava(contentType))
-    def as(contentType: String) = copy(contentType = Some(contentType))
+    def as(contentType: String) = copy(contentType = Option(contentType))
   }
 
   /**
@@ -118,7 +118,7 @@ object HttpEntity {
       case HttpChunk.Chunk(data) => data
     }
     def asJava = new JHttpEntity.Chunked(chunks.asJava, OptionConverters.toJava(contentType))
-    def as(contentType: String) = copy(contentType = Some(contentType))
+    def as(contentType: String) = copy(contentType = Option(contentType))
   }
 }
 


### PR DESCRIPTION
## Fixes

Fixes #8713.

## Purpose

When calling `Result.as` or `HttpEntity.as` with a `null` value, it later fails when doing the model conversion to the server backend. Since the content type can be configured as an `Option`/`Optional`, it makes sense to handle null values as `None` and, instead of failing, just return the response without the header.