### PR TITLE
Fixes #6275 Support rfc2184 extended attribute in multipart disposition

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -355,20 +355,20 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
       result.get must equalTo("partName")
     }
 
-    "ignore extended name in content disposition" in {
+    "parse extended name in content disposition" in {
       val result = PartInfoMatcher.unapply(
         Map("content-disposition" -> """form-data; name=partName; name*=utf8'en'extendedName""")
       )
       result must not(beEmpty)
-      result.get must equalTo("partName")
+      result.get must equalTo("extendedName")
     }
 
-    "ignore extended filename in content disposition" in {
+    "parse extended filename in content disposition" in {
       val result = FileInfoMatcher.unapply(
-        Map("content-disposition" -> """form-data; name=document; filename=hello.txt; filename*=utf-8''ignored.txt""")
+        Map("content-disposition" -> """form-data; name=document; filename=hello.txt; filename*=utf-8''%E4%BD%A0%E5%A5%BD.txt""")
       )
       result must not(beEmpty)
-      result.get must equalTo(("document", "hello.txt", None, "form-data"))
+      result.get must equalTo(("document", "你好.txt", None, "form-data"))
     }
 
     "accept also 'Content-Disposition: file' for file as used in webhook callbacks of some scanners (see issue #8527)" in {

--- a/core/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/core/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -37,8 +37,8 @@ import play.core.Execution.Implicits.trampoline
 object Multipart {
 
   private final val maxHeaderBuffer = 4096
-  private val KeyValue = """^([a-zA-Z_0-9]+)="?(.*?)"?$""".r
-  private val ExtendedKeyValue = """^([a-zA-Z_0-9]+)\*=(.*?)'.*'(.*?)$""".r
+  private val KeyValue              = """^([a-zA-Z_0-9]+)="?(.*?)"?$""".r
+  private val ExtendedKeyValue      = """^([a-zA-Z_0-9]+)\*=(.*?)'.*'(.*?)$""".r
 
   /**
    * Parses the stream into a stream of [[play.api.mvc.MultipartFormData.Part]] to be handled by `partHandler`.
@@ -239,7 +239,7 @@ object Multipart {
                 case KeyValue(key, v) => (key, v)
                 case ExtendedKeyValue(key, encoding, value) =>
                   (key, URLDecoder.decode(value, encoding))
-                case key              => (key.trim, "")
+                case key => (key.trim, "")
               }
               .toMap
           )

--- a/core/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/core/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -37,6 +37,8 @@ import play.core.Execution.Implicits.trampoline
 object Multipart {
 
   private final val maxHeaderBuffer = 4096
+  private val KeyValue = """^([a-zA-Z_0-9]+)="?(.*?)"?$""".r
+  private val ExtendedKeyValue = """^([a-zA-Z_0-9]+)\*=(.*?)'.*'(.*?)$""".r
 
   /**
    * Parses the stream into a stream of [[play.api.mvc.MultipartFormData.Part]] to be handled by `partHandler`.
@@ -200,10 +202,6 @@ object Multipart {
     }
 
     def unapply(headers: Map[String, String]): Option[(String, String, Option[String], String)] = {
-
-      val KeyValue = """^([a-zA-Z_0-9]+)="?(.*?)"?$""".r
-      val ExtendedKeyValue = """^([a-zA-Z_0-9]+)\*=(.*?)'.*'(.*?)$""".r
-
       for {
         values <- headers
           .get("content-disposition")
@@ -231,10 +229,6 @@ object Multipart {
 
   private[play] object PartInfoMatcher {
     def unapply(headers: Map[String, String]): Option[String] = {
-
-      val KeyValue = """^([a-zA-Z_0-9]+)="?(.*?)"?$""".r
-      val ExtendedKeyValue = """^([a-zA-Z_0-9]+)\*=(.*?)'.*'(.*?)$""".r
-
       for {
         values <- headers
           .get("content-disposition")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #6275

## Purpose

When uploading a file with a non ASCII character name, [rfc2184](https://tools.ietf.org/html/rfc2184) should be used. This RFC defines how to encode non ASCII characters in content disposition header. The format is: `key*=charset'language'url-encoded-value`.

The browsers (nor curl) don't use this standard and let the server guess which charset is used to encode filename. The Python (request library) uses extended attribute format if the filename contains non ASCII chars. This make the upload fails.

This PR add the support of the extended attributes in content disposition. Charset is used to decode the value but the language is ignored.

This PR doesn't include the support of value continuation (line wrapping when value is long).

This PR also remove some unnecessary `trim` in key (which can't contain whitespace according to regex) and in value (why an attribute value should not start or end with a whitespace ?)