### PR TITLE
Update WsSSL.md to reflect differences between play and typesafe SSL configuration object

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/WsSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/WsSSL.md
@@ -10,6 +10,9 @@ unlimited strength java cryptography extension.  You can download the policy fil
 
 ## Table of Contents
 
+> **NOTE**: The links below are relative to the `Typesafe SSLConfig`, which uses the `ssl-config` as a prefix for ssl properties.<br>
+> Play uses the `play.ws.ssl` prefix, so that, for instance the `ssl-config.loose.acceptAnyCertificate` becomes `play.ws.ssl.loose.acceptAnyCertificate` for your play `WSClient` configuration.
+
 The Play WS configuration is based on [Typesafe SSLConfig](https://lightbend.github.io/ssl-config).  For convenience, a table of contents to SSLConfig is provided:
 
 - [Quick Start to WS SSL](https://lightbend.github.io/ssl-config/WSQuickStart.html)


### PR DESCRIPTION
Added note on difference between underlying Typesafe SSLConfig and play's.

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
