### PR TITLE
Move FileMimeTypesModule to play-java

### DIFF
--- a/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -21,7 +21,7 @@ import play.core.j.{ JavaContextComponents, DefaultJavaContextComponents }
 import play.core.test.{ FakeRequest, Fakes }
 import play.http
 import play.i18n.{ Langs, MessagesApi }
-import play.mvc.{ FileMimeTypes => JFileMimeTypes, FileMimeTypesProvider => JFileMimeTypesProvider }
+import play.mvc.{ FileMimeTypes => JFileMimeTypes }
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future }
@@ -226,7 +226,6 @@ class HttpErrorHandlerSpec extends Specification {
         BindingKey(classOf[HttpConfiguration]).to(httpConfiguration),
         BindingKey(classOf[FileMimeTypesConfiguration]).toProvider[FileMimeTypesConfigurationProvider],
         BindingKey(classOf[FileMimeTypes]).toProvider[DefaultFileMimeTypesProvider],
-        BindingKey(classOf[JFileMimeTypes]).toProvider[JFileMimeTypesProvider].eagerly(),
         BindingKey(classOf[JavaContextComponents]).to[DefaultJavaContextComponents]
       )).instanceOf[HttpErrorHandler]
   }

--- a/framework/src/play-java/src/main/resources/reference.conf
+++ b/framework/src/play-java/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 play {
   modules {
     enabled += "play.inject.BuiltInModule"
+    enabled += "play.core.FileMimeTypesModule"
     enabled += "play.core.ObjectMapperModule"
     enabled += "play.routing.RoutingDslModule"
   }

--- a/framework/src/play-java/src/main/scala/play/core/FileMimeTypesModule.scala
+++ b/framework/src/play-java/src/main/scala/play/core/FileMimeTypesModule.scala
@@ -2,11 +2,12 @@
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package play.mvc
+package play.core
 
 import play.api.inject._
 
 import javax.inject._
+import play.mvc.{ FileMimeTypes, StaticFileMimeTypes }
 
 import scala.concurrent.Future
 

--- a/framework/src/play/src/main/java/play/mvc/FileMimeTypes.java
+++ b/framework/src/play/src/main/java/play/mvc/FileMimeTypes.java
@@ -6,6 +6,7 @@ package play.mvc;
 
 import scala.compat.java8.OptionConverters;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Optional;
 
@@ -14,6 +15,7 @@ public class FileMimeTypes {
 
     private final play.api.http.FileMimeTypes fileMimeTypes;
 
+    @Inject
     public FileMimeTypes(play.api.http.FileMimeTypes fileMimeTypes) {
         this.fileMimeTypes = fileMimeTypes;
     }

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -22,7 +22,6 @@ import play.api.routing.Router
 import play.core.j.JavaRouterAdapter
 import play.core.routing.GeneratedRouter
 import play.libs.concurrent.HttpExecutionContext
-import play.mvc.{ FileMimeTypes => JFileMimeTypes, FileMimeTypesProvider => JFileMimeTypesProvider }
 
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 
@@ -83,8 +82,7 @@ class BuiltinModule extends SimpleModule((env, conf) => {
 
     bind[play.core.j.JavaContextComponents].to[play.core.j.DefaultJavaContextComponents],
     bind[play.core.j.JavaHandlerComponents].to[play.core.j.DefaultJavaHandlerComponents],
-    bind[FileMimeTypes].toProvider[DefaultFileMimeTypesProvider],
-    bind[JFileMimeTypes].toProvider[JFileMimeTypesProvider].eagerly()
+    bind[FileMimeTypes].toProvider[DefaultFileMimeTypesProvider]
   ) ++ dynamicBindings(
       HttpErrorHandler.bindingsFromConfiguration,
       HttpFilters.bindingsFromConfiguration,


### PR DESCRIPTION
...and add it to `reference.conf` instead of loading it via `BuiltinModule` of the `play` project.
Enhances #8724

The key is to keep the `@Inject` on the `FileMimeTypes` constructor so if not using `play-java` (and therefore not the provider defined via `FileMimeTypesModule`) Guice can still instantiate a `FileMimeTypes`. This is needed because the `play` projects runs tests (`play.api.inject.guice.GuiceApplicationBuilderSpec` and `play.api.http.HttpErrorHandlerSpec`) which need an instance of `FileMimeTypes` to work.

Tested, works well.

See https://github.com/playframework/playframework/pull/8724#discussion_r230137950