### PR TITLE
Keep Jetty ALPN version in sync

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -128,6 +128,6 @@ object PlayAkkaHttp2Support extends AutoPlugin {
 
   override def projectSettings = Seq(
     libraryDependencies += "com.typesafe.play" %% "play-akka-http2-support" % play.core.PlayVersion.current,
-    javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.7" % "compile;test"
+    javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % play.core.PlayVersion.jettyAlpnAgentVersion % "compile;test"
   )
 }


### PR DESCRIPTION
## Purpose

Keep `PlayAkkaHttp2Support` version of Jetty ALPN in sync with the version used to build and test Play.
