### PR TITLE
Minor travis improvements

### DIFF
--- a/framework/bin/publish-local
+++ b/framework/bin/publish-local
@@ -6,8 +6,13 @@
 
 cd ${FRAMEWORK}
 
-printMessage "RUNNING PUBLISH LOCAL"
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
 
-runSbt "publishLocal"
+  printMessage "RUNNING PUBLISH LOCAL"
+  runSbt "publishLocal"
+  printMessage "PUBLISH LOCAL PASSED"
+else
+    printMessage "SKIPPING PUBLISH LOCAL"
+fi
 
-printMessage "PUBLISH LOCAL PASSED"
+

--- a/framework/bin/test-scala-212
+++ b/framework/bin/test-scala-212
@@ -8,7 +8,6 @@ cd ${FRAMEWORK}
 
 printMessage "RUNNING TESTS FOR SCALA 2.12"
 
-# Use sbt-doge for building code https://github.com/sbt/sbt-doge#strict-aggregation
 runSbt "test"
 
 printMessage "ALL TESTS PASSED"

--- a/framework/bin/test-scala-212
+++ b/framework/bin/test-scala-212
@@ -9,6 +9,6 @@ cd ${FRAMEWORK}
 printMessage "RUNNING TESTS FOR SCALA 2.12"
 
 # Use sbt-doge for building code https://github.com/sbt/sbt-doge#strict-aggregation
-runSbt "+++2.12.7 test"
+runSbt "test"
 
 printMessage "ALL TESTS PASSED"


### PR DESCRIPTION
Some minor travis build improvements:

* new publish-local job is only executed on cron jobs
* `test-scala-212` script should not force a version, but let sbt pick the default one