### PR TITLE
Allow direct field access in Java Forms

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -17,9 +17,19 @@ The `play.data` package contains several helpers to handle HTTP form data submis
 
 @[user](code/javaguide/forms/u1/User.java)
 
+As you can see, by default, you have to define getter and setter methods so Play is able to access the Form fields. You can however also enable "direct field access" (for all forms) by setting `play.forms.binding.directFieldAccess = true` in `conf/application.conf`. In this mode Play will ignore the getter and setter methods and will try to directly access the fields:
+
+@[user](code/javaguide/forms/u4/User.java)
+
+> **Note:** When using "direct field access" and a field is not accessible to Play during form binding (e.g. if a field or the class containing the field is not defined as `public`) Play will try to make a field accessible via reflection by calling [`field.setAccessible(true)`](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/AccessibleObject.html#setAccessible-boolean-) internally. Depending on the Java version (8+), JVM and the [ Security Manager](https://docs.oracle.com/javase/tutorial/essential/environment/security.html) settings that could cause warnings about *illegal reflective access* or, in the worst case, throw a [`SecurityException`](https://docs.oracle.com/javase/8/docs/api/java/lang/SecurityException.html)
+
 To wrap a class you have to inject a [`play.data.FormFactory`](api/java/play/data/FormFactory.html) into your Controller which then allows you to create the form:
 
 @[create](code/javaguide/forms/JavaForms.java)
+
+Instead of enabling "direct field access" for all forms, you can enable it only for specific ones:
+
+@[create](code/javaguide/forms/JavaFormsDirectFieldAccess.java)
 
 > **Note:** The underlying binding is done using [Spring data binder](https://docs.spring.io/spring/docs/4.2.4.RELEASE/spring-framework-reference/html/validation.html).
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormsDirectFieldAccess.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormsDirectFieldAccess.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package javaguide.forms;
+
+import javaguide.forms.u4.User;
+import org.junit.Test;
+import play.data.Form;
+import play.data.FormFactory;
+import play.i18n.Lang;
+import play.libs.typedmap.TypedMap;
+import play.test.WithApplication;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class JavaFormsDirectFieldAccess extends WithApplication {
+
+    private FormFactory formFactory() {
+        return app.injector().instanceOf(FormFactory.class);
+    }
+
+    @Test
+    public void usingForm() {
+        FormFactory formFactory = formFactory();
+
+        final // sneaky final
+        //#create
+        Form<User> userForm = formFactory.form(User.class).withDirectFieldAccess(true);
+        //#create
+
+        Lang lang = new Lang(Locale.getDefault());
+        TypedMap attrs = TypedMap.empty();
+        Map<String,String> anyData = new HashMap<>();
+        anyData.put("email", "bob@gmail.com");
+        anyData.put("password", "secret");
+
+        User user = userForm.bind(lang, attrs, anyData).get();
+
+        assertThat(user.email, equalTo("bob@gmail.com"));
+        assertThat(user.password, equalTo("secret"));
+    }
+
+}

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/u4/User.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/u4/User.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package javaguide.forms.u4;
+
+//#user
+public class User {
+
+    public String email;
+    public String password;
+
+}
+//#user

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -227,8 +227,8 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     }
 
     @Override
-    public DynamicForm withDirectFieldAccess(Boolean directFieldAccess) {
-        if(directFieldAccess == null || !directFieldAccess) {
+    public DynamicForm withDirectFieldAccess(boolean directFieldAccess) {
+        if(!directFieldAccess) {
             // Just do nothing
             return this;
         }

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -226,6 +226,15 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         return new DynamicForm(super.rawData(), this.errors(), this.value(), this.messagesApi, this.formatters, this.validatorFactory, this.config, lang);
     }
 
+    @Override
+    public DynamicForm withDirectFieldAccess(Boolean directFieldAccess) {
+        if(directFieldAccess == null || !directFieldAccess) {
+            // Just do nothing
+            return this;
+        }
+        throw new RuntimeException("Not possible to enable direct field access for dynamic forms.");
+    }
+
     // -- tools
 
     static String asDynamicKey(String key) {

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -185,7 +185,7 @@ public class Form<T> {
      * @param lang used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)}) and for translations in {@link #errorsAsJson()}
      */
     public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config, Lang lang) {
-        this(rootName, clazz, data, errors, value, groups, messagesApi, formatters, validatorFactory, config, lang, config.getBoolean("play.forms.binding.directFieldAccess"));
+        this(rootName, clazz, data, errors, value, groups, messagesApi, formatters, validatorFactory, config, lang, config != null && config.getBoolean("play.forms.binding.directFieldAccess"));
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -1070,7 +1070,7 @@ public class Form<T> {
      * A copy of this form with the given lang set which is used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)})
      * and for translations in {@link #errorsAsJson()}.
      */
-    public Form withLang(Lang lang) {
+    public Form<T> withLang(Lang lang) {
         return new Form<T>(this.rootName, this.backedType, this.rawData, this.errors, this.value, this.groups, this.messagesApi, this.formatters, this.validatorFactory, this.config, lang, this.directFieldAccess);
     }
 
@@ -1079,7 +1079,7 @@ public class Form<T> {
      *
      * @param directFieldAccess {@code true} enables direct field access during form binding, {@code false} disables it and uses getters instead. If {@code null} falls back to config default.
      */
-    public Form withDirectFieldAccess(boolean directFieldAccess) {
+    public Form<T> withDirectFieldAccess(boolean directFieldAccess) {
         return new Form<T>(this.rootName, this.backedType, this.rawData, this.errors, this.value, this.groups, this.messagesApi, this.formatters, this.validatorFactory, this.config, lang, directFieldAccess);
     }
 

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -100,7 +100,7 @@ public class Form<T> {
     private final Optional<T> value;
     private final Class<?>[] groups;
     private final Lang lang;
-    private final Boolean directFieldAccess;
+    private final boolean directFieldAccess;
     final MessagesApi messagesApi;
     final Formatters formatters;
     final ValidatorFactory validatorFactory;
@@ -185,7 +185,7 @@ public class Form<T> {
      * @param lang used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)}) and for translations in {@link #errorsAsJson()}
      */
     public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config, Lang lang) {
-        this(rootName, clazz, data, errors, value, groups, messagesApi, formatters, validatorFactory, config, lang, null);
+        this(rootName, clazz, data, errors, value, groups, messagesApi, formatters, validatorFactory, config, lang, config.getBoolean("play.forms.binding.directFieldAccess"));
     }
 
     /**
@@ -204,7 +204,7 @@ public class Form<T> {
      * @param lang used for formatting when retrieving a field (via {@link #field(String)} or {@link #apply(String)}) and for translations in {@link #errorsAsJson()}
      * @param directFieldAccess access fields of form directly during binding instead of using getters
      */
-    public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config, Lang lang, Boolean directFieldAccess) {
+    public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, ValidatorFactory validatorFactory, Config config, Lang lang, boolean directFieldAccess) {
         this.rootName = rootName;
         this.backedType = clazz;
         this.rawData = data != null ? new HashMap<>(data) : new HashMap<>();
@@ -466,7 +466,7 @@ public class Form<T> {
         dataBinder.setValidator(validator);
         dataBinder.setConversionService(formatters.conversion);
         dataBinder.setAutoGrowNestedPaths(true);
-        if((this.directFieldAccess != null && this.directFieldAccess) || (this.directFieldAccess == null && this.config.getBoolean("play.forms.binding.directFieldAccess"))) {
+        if(this.directFieldAccess) {
             // FYI: initBeanPropertyAccess() is the default, let's switch to direct field access instead
             dataBinder.initDirectFieldAccess(); // this should happen last, when everything else was set on the dataBinder already
         }
@@ -1079,7 +1079,7 @@ public class Form<T> {
      *
      * @param directFieldAccess {@code true} enables direct field access during form binding, {@code false} disables it and uses getters instead. If {@code null} falls back to config default.
      */
-    public Form withDirectFieldAccess(Boolean directFieldAccess) {
+    public Form withDirectFieldAccess(boolean directFieldAccess) {
         return new Form<T>(this.rootName, this.backedType, this.rawData, this.errors, this.value, this.groups, this.messagesApi, this.formatters, this.validatorFactory, this.config, lang, directFieldAccess);
     }
 

--- a/framework/src/play-java-forms/src/main/resources/reference.conf
+++ b/framework/src/play-java-forms/src/main/resources/reference.conf
@@ -6,8 +6,15 @@ play {
   }
 
   forms {
+
     binding {
+
+      # Enables or disables direct field access during form binding.
+      # If disabled (the default) getter methods will be used to access the form during binding.
       directFieldAccess = false
+
     }
+
   }
+
 }

--- a/framework/src/play-java-forms/src/main/resources/reference.conf
+++ b/framework/src/play-java-forms/src/main/resources/reference.conf
@@ -4,4 +4,10 @@ play {
     enabled += "play.data.format.FormattersModule"
     enabled += "play.data.validation.ValidatorsModule"
   }
+
+  forms {
+    binding {
+      directFieldAccess = false
+    }
+  }
 }

--- a/framework/src/play-java-forms/src/test/java/play/data/Subtask.java
+++ b/framework/src/play-java-forms/src/test/java/play/data/Subtask.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.data;
+
+import play.data.format.Formats.DateTime;
+import play.data.validation.Constraints;
+import play.data.validation.TestConstraints.AnotherI18NConstraint;
+import play.data.validation.TestConstraints.I18Constraint;
+
+import java.util.Date;
+
+public class Subtask {
+
+    @Constraints.Min(10)
+    public Long id;
+
+    @Constraints.Required
+    public String name;
+
+    public Boolean done = true;
+
+    @Constraints.Required
+    @DateTime(pattern = "dd/MM/yyyy")
+    public Date dueDate;
+
+    public Date endDate;
+
+    @I18Constraint(value = "patterns.zip")
+    public String zip;
+
+    @AnotherI18NConstraint(value = "patterns.zip")
+    public String anotherZip;
+
+}

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -87,6 +87,12 @@ class DynamicFormSpec extends Specification {
       }
     }
 
+    "work when switch off direct field access" in {
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).withDirectFieldAccess(false).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      form.get("foo") must_== "bar"
+      form.value("foo").get must_== "bar"
+    }
+
     "don't throw NullPointerException when all components of form are null" in {
       val form = new DynamicForm(null, null, null, null).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form("foo").value().get() must_== "bar"

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -26,7 +26,7 @@ class DynamicFormSpec extends Specification {
   implicit val messages = messagesApi.preferred(Seq.empty)
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val validatorFactory = FormSpec.validatorFactory()
-  val config = ConfigFactory.empty()
+  val config = ConfigFactory.load()
 
   "a dynamic form" should {
 
@@ -78,6 +78,13 @@ class DynamicFormSpec extends Specification {
     "allow access to the equivalent of the raw data when filled" in {
       val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form("foo").value().get() must_== "bar"
+    }
+
+    "fail with exception when trying to switch on direct field access" in {
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      form.withDirectFieldAccess(true) must throwA[RuntimeException].like {
+        case e => e.getMessage must endWith("Not possible to enable direct field access for dynamic forms.")
+      }
     }
 
     "don't throw NullPointerException when all components of form are null" in {

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -294,6 +294,14 @@ trait FormSpec extends Specification {
       myForm hasErrors () must beEqualTo(true)
       myForm.errors("dueDate").get(0).messages().asScala must contain("error.required")
     }
+    "be invalid when only fields (and no getters) exist but direct field access is disabled" in {
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
+
+      formFactory.form(classOf[play.data.Subtask]).bindFromRequest(req) must throwA[IllegalStateException].like {
+        case e: IllegalStateException =>
+          e.getMessage must beMatching("""JSR-303 validated property '.*' does not have a corresponding accessor for data binding - check your DataBinder's configuration \(bean property versus direct field access\)""")
+      }
+    }
     "have an error due to bad value in Id field" in new WithApplication(application()) {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -93,6 +93,12 @@ trait FormSpec extends Specification {
         val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest()
         myForm hasErrors () must beEqualTo(false)
       }
+      "be valid with all fields with direct field access" in {
+        val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891"), "task.name" -> Array("peter"), "task.dueDate" -> Array("15/12/2009"), "task.endDate" -> Array("2008-11-21")))
+
+        val myForm = formFactory.form("task", classOf[play.data.Subtask]).withDirectFieldAccess(true).bindFromRequest(req)
+        myForm hasErrors () must beEqualTo(false)
+      }
       "allow to access the value of an invalid form prefixing fields with the root name" in new WithApplication(application()) {
         val req = FormSpec.dummyRequest(Map("task.id" -> Array("notAnInt"), "task.name" -> Array("peter"), "task.done" -> Array("true"), "task.dueDate" -> Array("15/12/2009")))
         Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
@@ -112,12 +118,31 @@ trait FormSpec extends Specification {
         myForm hasErrors () must beEqualTo(true)
         myForm.errors("task.dueDate").get(0).messages().asScala must contain("error.required")
       }
+      "have an error due to missing required value with direct field access" in new WithApplication(application()) {
+        val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891x"), "task.name" -> Array("peter")))
+
+        val myForm = formFactory.form("task", classOf[play.data.Subtask]).withDirectFieldAccess(true).bindFromRequest(req)
+        myForm hasErrors () must beEqualTo(true)
+        myForm.errors("task.dueDate").get(0).messages().asScala must contain("error.required")
+      }
     }
     "be valid with all fields" in {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11-21")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+    }
+    "be valid with all fields with direct field access" in {
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11-21")))
+
+      val myForm = formFactory.form(classOf[play.data.Subtask]).withDirectFieldAccess(true).bindFromRequest(req)
+      myForm hasErrors () must beEqualTo(false)
+    }
+    "be valid with all fields with direct field access switched on in config" in new WithApplication(application("play.forms.binding.directFieldAccess" -> "true")) {
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11-21")))
+
+      val myForm = formFactory.form(classOf[play.data.Subtask]).bindFromRequest(req)
       myForm hasErrors () must beEqualTo(false)
     }
     "be valid with mandatory params passed" in {
@@ -259,6 +284,13 @@ trait FormSpec extends Specification {
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(true)
+      myForm.errors("dueDate").get(0).messages().asScala must contain("error.required")
+    }
+    "have an error due to missing required value with direct field access" in new WithApplication(application()) {
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
+
+      val myForm = formFactory.form(classOf[play.data.Subtask]).withDirectFieldAccess(true).bindFromRequest(req)
       myForm hasErrors () must beEqualTo(true)
       myForm.errors("dueDate").get(0).messages().asScala must contain("error.required")
     }

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -555,7 +555,7 @@ trait FormSpec extends Specification {
       // Don't use bind, the point here is to have a form with data that isn't bound, otherwise the mapping indexes
       // used come from the form, not the input data
       new Form[JavaForm](null, classOf[JavaForm], map.asJava,
-        List.empty.asJava.asInstanceOf[java.util.List[ValidationError]], Optional.empty[JavaForm], null, null, FormSpec.validatorFactory(), ConfigFactory.empty())
+        List.empty.asJava.asInstanceOf[java.util.List[ValidationError]], Optional.empty[JavaForm], null, null, FormSpec.validatorFactory(), ConfigFactory.load())
     }
 
     "return the appropriate constraints for the desired validation group(s)" in {

--- a/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -21,7 +21,7 @@ class PartialValidationSpec extends Specification {
   val messagesApi = new DefaultMessagesApi()
 
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
-  val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), FormSpec.validatorFactory(), ConfigFactory.empty())
+  val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), FormSpec.validatorFactory(), ConfigFactory.load())
 
   "partial validation" should {
     "not fail when fields not in the same group fail validation" in {


### PR DESCRIPTION
Fixes https://discuss.lightbend.com/t/databinder-field-access-instead-of-using-accessors/2468

Adds `play.forms.binding.directFieldAccess` config to switch on direct field access for all forms. To control specific forms only this pull request adds `form.withDirectFieldAccess(...)` to switch direct field access on or off - or if `null` falls back to config fallback.