### PR TITLE
Pass ctx.args between actions in chain when thread-local is disabled

### DIFF
--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
@@ -36,7 +36,7 @@ public class ActionCompositionOrderTest {
     @Retention(RetentionPolicy.RUNTIME)
     @interface ActionAnnotation {}
 
-    static class ActionComposition extends Action<ControllerAnnotation> {
+    static class ActionComposition extends Action<ActionAnnotation> {
         @Override
         public CompletionStage<Result> call(Http.Request req) {
             return delegate.call(req).thenApply(result -> {

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
@@ -114,4 +114,46 @@ public class ActionCompositionOrderTest {
             });
         }
     }
+
+    @With(ContextArgsSetAction.class)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ContextArgsSet {}
+
+    static class ContextArgsSetAction extends Action<ContextArgsSet> {
+        @Override
+        public CompletionStage<Result> call(Http.Context ctx) {
+            ctx.args.put("foo", "bar");
+            return delegate.call(ctx);
+        }
+    }
+
+    @With(ContextArgsGetAction.class)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ContextArgsGet {}
+
+    static class ContextArgsGetAction extends Action<ContextArgsGet> {
+        @Override
+        public CompletionStage<Result> call(Http.Context ctx) {
+            return delegate.call(ctx).thenApply(result -> {
+                if("bar".equals(ctx.args.get("foo"))) {
+                    return Results.ok("ctx.args were set");
+                }
+                return Results.ok();
+            });
+        }
+    }
+
+    @With(NoopUsingRequestAction.class)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface NoopUsingRequest {}
+
+    static class NoopUsingRequestAction extends Action<NoopUsingRequest> {
+        @Override
+        public CompletionStage<Result> call(Http.Request req) {
+            return delegate.call(req);
+        }
+    }
 }

--- a/framework/src/play-integration-test/src/test/java/play/it/http/PreserveContextArgsController.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/PreserveContextArgsController.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.it.http;
+
+import play.it.http.ActionCompositionOrderTest.ContextArgsGet;
+import play.it.http.ActionCompositionOrderTest.ContextArgsSet;
+import play.it.http.ActionCompositionOrderTest.NoopUsingRequest;
+import play.mvc.Result;
+import play.mvc.Results;
+
+public class PreserveContextArgsController extends MockController {
+
+    @ContextArgsSet
+    @NoopUsingRequest
+    @ContextArgsGet
+    public Result action() {
+        return Results.ok();
+    }
+
+}

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -5,9 +5,12 @@
 package play.mvc;
 
 import java.lang.reflect.AnnotatedElement;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import play.core.j.JavaContextComponents;
+import play.libs.typedmap.TypedKey;
 import play.mvc.Http.Context;
 import play.mvc.Http.Request;
 
@@ -51,6 +54,8 @@ public abstract class Action<T> extends Results {
      */
     public Action<?> delegate;
 
+    private static final TypedKey<Map<String, Object>> CTX_ARGS = TypedKey.<Map<String, Object>>create("http-context-args");
+
     /**
      * Executes this action with the given HTTP context and returns the result.
      *
@@ -61,7 +66,7 @@ public abstract class Action<T> extends Results {
      */
     @Deprecated // TODO: When you remove this method make call(Request) below abstract
     public CompletionStage<Result> call(Context ctx) {
-        return call(ctx.request());
+        return call(ctx.args != null && !ctx.args.isEmpty() ? ctx.request().addAttr(CTX_ARGS, ctx.args) : ctx.request());
     }
 
     /**
@@ -74,13 +79,15 @@ public abstract class Action<T> extends Results {
         return Context.safeCurrent().map(threadLocalCtx -> {
             // A previous action did explicitly set a context onto the thread local (via Http.Context.current.set(...))
             // Let's use that context so the user doesn't loose data he/she set onto that ctx (args,...)
-            Context newCtx = threadLocalCtx.withRequest(req);
+            Context newCtx = threadLocalCtx.withRequest(req.removeAttr(CTX_ARGS));
             Context.setCurrent(newCtx);
             return call(newCtx);
-        }).orElseGet(() ->
+        }).orElseGet(() -> {
             // A previous action did not set a context explicitly, we simply create a new one to pass on the request
-            call(new Context(req, contextComponents))
-        );
+            Context ctx = new Context(req.removeAttr(CTX_ARGS), contextComponents);
+            ctx.args = req.attrs().getOptional(CTX_ARGS).orElse(new HashMap<>());
+            return call(ctx);
+        });
     }
 
     /**


### PR DESCRIPTION
This is the last fix for the `Http.Context` stuff, I promise :sunglasses: 

To reproduce disable the http context thread-local by setting
```
play.allowHttpContext = false
```
**and**

you have a action composition chain that look like this:
1. `call(ctx)`
1. `call(req)`
1. `call(ctx)`
1. the action method

There is one small bug if you set something into the `ctx.args` in the *first* `call` and want to access/retrieve that `ctx.args` value(s) in the *third* `call` again. Right now `ctx.args` will not contain the elements in that *third* `call` which where set in the *first* call. That's because when converting the `ctx` to a `req` between step 1 and 2 the `ctx.args` will be lost (since a request does not have a `args` field).

What I did is I carry over the `ctx.args` via a request attribute from step 1 to step 2 and use that request attribute as `ctx.args` when stepping from step 2 to step 3.

Again, this only happens when the thread local is disabled already but you still use `call(ctx)` (even though this will rarely be the case because I guess users will migrate to `call(req)` before disabling the thread-local). Also the action method is not effected because, when the the thread-local is disabed, you can not even access the static `Http.Context.current.args` anymore... because... it's  disabled and therefore `current` is `null` of course.

I also clean-up the request attributes everytime to not pollute it with temporary information.

I did manually test this and works perfectly. `ctx.args` are preserved in step 3 :wink: 