### PR TITLE
Don't deprecate whole play.Logger, but only the static Logger singleton

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -87,9 +87,35 @@ Guice was upgraded to version [4.2.2](https://github.com/google/guice/wiki/Guice
  - `play.test.TestBrowser.waitUntil` expects a `java.util.function.Function` instead of a `com.google.common.base.Function` now.
  - In Scala, when overriding the `configure()` method of `AbstractModule`, you need to prefix that method with the `override` identifier now (because it's non-abstract now).
 
-## `play.Logger` deprecated
+## Static `Logger` singletons deprecated
 
-`play.Logger` has been deprecated in favor of using SLF4J directly. You can create an SLF4J logger with `private static final Logger logger = LoggerFactory.getLogger(YourClass.class);`. If you'd like a more concise solution, you may also consider [Project Lombok's `@Slf4j` annotation](https://projectlombok.org/features/log).
+Most `static` methods of `play.Logger` and also almost all methods of the `play.api.Logger` singleton have been deprecated. You shouldn't use those static singletons anymore, but instead create and use instances of those classes:
+
+Java
+: ```java
+private static final play.Logger.ALogger logger = play.Logger.of(YourClass.class);
+```
+
+Scala
+: ```scala
+private val logger = play.api.Logger(YourClass.class)
+```
+
+Of course you can also just use [SLF4J](https://www.slf4j.org/) directly:
+
+Java
+: ```java
+private static final Logger logger = LoggerFactory.getLogger(YourClass.class);
+```
+
+Scala
+: ```scala
+private val logger = LoggerFactory.getLogger(YourClass.class);
+```
+
+If you'd like a more concise solution when using SLF4J directly, you may also consider [Project Lombok's `@Slf4j` annotation](https://projectlombok.org/features/log).
+
+> **NOTE**: `org.slf4j.Logger`, the logging interface of SLF4J, does [not yet](https://jira.qos.ch/browse/SLF4J-371) provide logging methods which accept lambda expression as parameters for lazy evaluation. `play.Logger` and `play.api.Logger`, which are mostly simple wrappers for `org.slf4j.Logger`, provide such methods however.
 
 If you have a `logger` entry in your logback.xml referencing the `application` logger, you may remove it.
 

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/User.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/User.scala
@@ -7,7 +7,7 @@ package scalaguide.binder.models
 import scala.Left
 import scala.Right
 import play.api.mvc.PathBindable
-import play.Logger
+import play.api.Logger
 
 //#declaration
 case class User(id: Int, name: String) {}
@@ -17,7 +17,7 @@ object User {
   // stubbed test 
 	// designed to be lightweight operation
   def findById(id: Int): Option[User] = {
-    Logger.info("findById: " + id.toString)
+    Logger(getClass).info("findById: " + id.toString)
     if (id > 3) None
     var user = new User(id, "User " + String.valueOf(id))
     Some(user)

--- a/documentation/manual/working/scalaGuide/main/application/code/EssentialFilter.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/EssentialFilter.scala
@@ -25,7 +25,7 @@ class LoggingFilter @Inject() (implicit ec: ExecutionContext) extends EssentialF
         val endTime = System.currentTimeMillis
         val requestTime = endTime - startTime
 
-        Logger.info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")
+        Logger(getClass).info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")
         result.withHeaders("Request-Time" -> requestTime.toString)
 
       }

--- a/documentation/manual/working/scalaGuide/main/application/code/FiltersRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/FiltersRouting.scala
@@ -24,7 +24,7 @@ class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionCont
       val endTime = System.currentTimeMillis
       val requestTime = endTime - startTime
 
-      Logger.info(s"${action} took ${requestTime}ms and returned ${result.header.status}")
+      Logger(getClass).info(s"${action} took ${requestTime}ms and returned ${result.header.status}")
 
       result.withHeaders("Request-Time" -> requestTime.toString)
     }

--- a/documentation/manual/working/scalaGuide/main/application/code/ScalaHttpFilters.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/ScalaHttpFilters.scala
@@ -25,7 +25,7 @@ class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionCont
       val endTime = System.currentTimeMillis
       val requestTime = endTime - startTime
 
-      Logger.info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")
+      Logger(getClass).info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")
 
       result.withHeaders("Request-Time" -> requestTime.toString)
     }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -43,7 +43,7 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
 
       class LoggingAction @Inject() (parser: BodyParsers.Default)(implicit ec: ExecutionContext) extends ActionBuilderImpl(parser) {
         override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
-          Logger.info("Calling action")
+          Logger(getClass).info("Calling action")
           block(request)
         }
       }
@@ -81,7 +81,7 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       case class Logging[A](action: Action[A]) extends Action[A] {
 
         def apply(request: Request[A]): Future[Result] = {
-          Logger.info("Calling action")
+          Logger(getClass).info("Calling action")
           action(request)
         }
 
@@ -133,7 +133,7 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       //###skip:1
       val Action = actionBuilder
       def logging[A](action: Action[A]) = Action.async(action.parser) { request =>
-        Logger.info("Calling action")
+        Logger(getClass).info("Calling action")
         action(request)
       }
       //#actions-def-wrapping

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -39,7 +39,7 @@ class ScalaOpenIdSpec extends PlaySpecification {
           Form(single(
             "openid" -> nonEmptyText
           )).bindFromRequest.fold({ error =>
-            Logger.info(s"bad request ${error.toString}")
+            Logger(getClass).info(s"bad request ${error.toString}")
             Future.successful(BadRequest(error.toString))
           }, { openId =>
             openIdClient.redirectURL(openId, routes.Application.openIdCallback.absoluteURL())

--- a/framework/src/play/src/main/java/play/Logger.java
+++ b/framework/src/play/src/main/java/play/Logger.java
@@ -39,12 +39,13 @@ import java.util.function.Supplier;
  * overhead.  For more complex needs, the underlying() methods may be used to get the underlying SLF4J logger, or
  * SLF4J may be used directly.
  *
- * @deprecated Deprecated as of 2.7.0. Use slf4j directly.
- * For more details see https://github.com/playframework/playframework/issues/1669
  */
-@Deprecated
 public class Logger {
 
+    /**
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     */
+    @Deprecated
     private static final ALogger logger = of("application");
 
     /**
@@ -71,7 +72,10 @@ public class Logger {
      * Get the underlying application SLF4J logger.
      *
      * @return the underlying logger
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static org.slf4j.Logger underlying() {
         return logger.underlying();
     }
@@ -80,7 +84,10 @@ public class Logger {
      * Returns <code>true</code> if the logger instance enabled for the TRACE level?
      *
      * @return <code>true</code> if the logger instance enabled for the TRACE level?
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static boolean isTraceEnabled() {
         return logger.isTraceEnabled();
     }
@@ -89,7 +96,10 @@ public class Logger {
      * Returns <code>true</code> if the logger instance enabled for the DEBUG level?
      *
      * @return <code>true</code> if the logger instance enabled for the DEBUG level?
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static boolean isDebugEnabled() {
         return logger.isDebugEnabled();
     }
@@ -98,7 +108,10 @@ public class Logger {
      * Returns <code>true</code> if the logger instance enabled for the INFO level?
      *
      * @return <code>true</code> if the logger instance enabled for the INFO level?
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static boolean isInfoEnabled() {
         return logger.isInfoEnabled();
     }
@@ -107,7 +120,10 @@ public class Logger {
      * Returns <code>true</code> if the logger instance enabled for the WARN level?
      *
      * @return <code>true</code> if the logger instance enabled for the WARN level?
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static boolean isWarnEnabled() {
         return logger.isWarnEnabled();
     }
@@ -116,7 +132,10 @@ public class Logger {
      * Returns <code>true</code> if the logger instance enabled for the ERROR level?
      *
      * @return <code>true</code> if the logger instance enabled for the ERROR level?
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static boolean isErrorEnabled() {
         return logger.isWarnEnabled();
     }
@@ -125,7 +144,10 @@ public class Logger {
      * Log a message with the TRACE level.
      *
      * @param message message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void trace(String message) {
         logger.trace(message);
     }
@@ -134,7 +156,10 @@ public class Logger {
      * Log a message with the TRACE level.
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void trace(Supplier<String> msgSupplier) {
         logger.trace(msgSupplier);
     }
@@ -144,7 +169,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args The arguments to apply to the message String
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void trace(String message, Object... args) {
         logger.trace(message, args);
     }
@@ -154,7 +182,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void trace(String message, Supplier<?>... args) {
         logger.trace(message, args);
     }
@@ -164,7 +195,10 @@ public class Logger {
      *
      * @param message message to log
      * @param error associated exception
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void trace(String message, Throwable error) {
         logger.trace(message, error);
     }
@@ -173,7 +207,10 @@ public class Logger {
      * Log a message with the DEBUG level.
      *
      * @param message message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void debug(String message) {
         logger.debug(message);
     }
@@ -182,7 +219,10 @@ public class Logger {
      * Log a message with the DEBUG level.
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void debug(Supplier<String> msgSupplier) {
         logger.debug(msgSupplier);
     }
@@ -192,7 +232,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args The arguments to apply to the message String
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void debug(String message, Object... args) {
         logger.debug(message, args);
     }
@@ -202,7 +245,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void debug(String message, Supplier<?>... args) {
         logger.debug(message, args);
     }
@@ -212,7 +258,10 @@ public class Logger {
      *
      * @param message message to log
      * @param error associated exception
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void debug(String message, Throwable error) {
         logger.debug(message, error);
     }
@@ -221,7 +270,10 @@ public class Logger {
      * Log a message with the INFO level.
      *
      * @param message message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void info(String message) {
         logger.info(message);
     }
@@ -230,7 +282,10 @@ public class Logger {
      * Log a message with the INFO level.
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void info(Supplier<String> msgSupplier) {
         logger.info(msgSupplier);
     }
@@ -240,7 +295,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args The arguments to apply to the message string
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void info(String message, Object... args) {
         logger.info(message, args);
     }
@@ -250,7 +308,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void info(String message, Supplier<?>... args) {
         logger.info(message, args);
     }
@@ -260,7 +321,10 @@ public class Logger {
      *
      * @param message message to log
      * @param error associated exception
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void info(String message, Throwable error) {
         logger.info(message, error);
     }
@@ -269,7 +333,10 @@ public class Logger {
      * Log a message with the WARN level.
      *
      * @param message message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void warn(String message) {
         logger.warn(message);
     }
@@ -278,7 +345,10 @@ public class Logger {
      * Log a message with the WARN level.
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void warn(Supplier<String> msgSupplier) {
         logger.warn(msgSupplier);
     }
@@ -288,7 +358,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args The arguments to apply to the message string
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void warn(String message, Object... args) {
         logger.warn(message, args);
     }
@@ -298,7 +371,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void warn(String message, Supplier<?>... args) {
         logger.warn(message, args);
     }
@@ -308,7 +384,10 @@ public class Logger {
      *
      * @param message message to log
      * @param error associated exception
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void warn(String message, Throwable error) {
         logger.warn(message, error);
     }
@@ -317,7 +396,10 @@ public class Logger {
      * Log a message with the ERROR level.
      *
      * @param message message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void error(String message) {
         logger.error(message);
     }
@@ -326,7 +408,10 @@ public class Logger {
      * Log a message with the ERROR level.
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void error(Supplier<String> msgSupplier) {
         logger.error(msgSupplier);
     }
@@ -336,7 +421,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args The arguments to apply to the message string
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void error(String message, Object... args) {
         logger.error(message, args);
     }
@@ -346,7 +434,10 @@ public class Logger {
      *
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void error(String message, Supplier<?> args) {
         logger.error(message, args);
     }
@@ -356,7 +447,10 @@ public class Logger {
      *
      * @param message message to log
      * @param error associated exception
+     *
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
      */
+    @Deprecated
     public static void error(String message, Throwable error) {
         logger.error(message, error);
     }

--- a/framework/src/play/src/main/java/play/Logger.java
+++ b/framework/src/play/src/main/java/play/Logger.java
@@ -43,7 +43,7 @@ import java.util.function.Supplier;
 public class Logger {
 
     /**
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     private static final ALogger logger = of("application");
@@ -73,7 +73,7 @@ public class Logger {
      *
      * @return the underlying logger
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static org.slf4j.Logger underlying() {
@@ -85,7 +85,7 @@ public class Logger {
      *
      * @return <code>true</code> if the logger instance enabled for the TRACE level?
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static boolean isTraceEnabled() {
@@ -97,7 +97,7 @@ public class Logger {
      *
      * @return <code>true</code> if the logger instance enabled for the DEBUG level?
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static boolean isDebugEnabled() {
@@ -109,7 +109,7 @@ public class Logger {
      *
      * @return <code>true</code> if the logger instance enabled for the INFO level?
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static boolean isInfoEnabled() {
@@ -121,7 +121,7 @@ public class Logger {
      *
      * @return <code>true</code> if the logger instance enabled for the WARN level?
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static boolean isWarnEnabled() {
@@ -133,7 +133,7 @@ public class Logger {
      *
      * @return <code>true</code> if the logger instance enabled for the ERROR level?
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static boolean isErrorEnabled() {
@@ -145,7 +145,7 @@ public class Logger {
      *
      * @param message message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void trace(String message) {
@@ -157,7 +157,7 @@ public class Logger {
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void trace(Supplier<String> msgSupplier) {
@@ -170,7 +170,7 @@ public class Logger {
      * @param message message to log
      * @param args The arguments to apply to the message String
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void trace(String message, Object... args) {
@@ -183,7 +183,7 @@ public class Logger {
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void trace(String message, Supplier<?>... args) {
@@ -196,7 +196,7 @@ public class Logger {
      * @param message message to log
      * @param error associated exception
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void trace(String message, Throwable error) {
@@ -208,7 +208,7 @@ public class Logger {
      *
      * @param message message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void debug(String message) {
@@ -220,7 +220,7 @@ public class Logger {
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void debug(Supplier<String> msgSupplier) {
@@ -233,7 +233,7 @@ public class Logger {
      * @param message message to log
      * @param args The arguments to apply to the message String
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void debug(String message, Object... args) {
@@ -246,7 +246,7 @@ public class Logger {
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void debug(String message, Supplier<?>... args) {
@@ -259,7 +259,7 @@ public class Logger {
      * @param message message to log
      * @param error associated exception
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void debug(String message, Throwable error) {
@@ -271,7 +271,7 @@ public class Logger {
      *
      * @param message message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void info(String message) {
@@ -283,7 +283,7 @@ public class Logger {
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void info(Supplier<String> msgSupplier) {
@@ -296,7 +296,7 @@ public class Logger {
      * @param message message to log
      * @param args The arguments to apply to the message string
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void info(String message, Object... args) {
@@ -309,7 +309,7 @@ public class Logger {
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void info(String message, Supplier<?>... args) {
@@ -322,7 +322,7 @@ public class Logger {
      * @param message message to log
      * @param error associated exception
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void info(String message, Throwable error) {
@@ -334,7 +334,7 @@ public class Logger {
      *
      * @param message message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void warn(String message) {
@@ -346,7 +346,7 @@ public class Logger {
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void warn(Supplier<String> msgSupplier) {
@@ -359,7 +359,7 @@ public class Logger {
      * @param message message to log
      * @param args The arguments to apply to the message string
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void warn(String message, Object... args) {
@@ -372,7 +372,7 @@ public class Logger {
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void warn(String message, Supplier<?>... args) {
@@ -385,7 +385,7 @@ public class Logger {
      * @param message message to log
      * @param error associated exception
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void warn(String message, Throwable error) {
@@ -397,7 +397,7 @@ public class Logger {
      *
      * @param message message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void error(String message) {
@@ -409,7 +409,7 @@ public class Logger {
      *
      * @param msgSupplier <code>Supplier</code> that contains message to log
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void error(Supplier<String> msgSupplier) {
@@ -422,7 +422,7 @@ public class Logger {
      * @param message message to log
      * @param args The arguments to apply to the message string
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void error(String message, Object... args) {
@@ -435,7 +435,7 @@ public class Logger {
      * @param message message to log
      * @param args Suppliers that contain arguments to apply to the message String
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void error(String message, Supplier<?> args) {
@@ -448,7 +448,7 @@ public class Logger {
      * @param message message to log
      * @param error associated exception
      *
-     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use it's same method. Or use SLF4J directly.
+     * @deprecated Deprecated as of 2.7.0. Create an instance of {@link ALogger} via {@link #of(String)} / {@link #of(Class)} and use the same-named method. Or use SLF4J directly.
      */
     @Deprecated
     public static void error(String message, Throwable error) {

--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -334,55 +334,55 @@ object Logger extends Logger(LoggerFactory.getLogger("application")) { // TODO: 
 
   // ### Deprecate inherited methods from Logger and LoggerLike
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def enabled: Boolean = super.enabled
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def forMode(mode: Mode*): Logger = super.forMode(mode: _*)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def isTraceEnabled(implicit mc: MarkerContext): Boolean = super.isTraceEnabled
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def isDebugEnabled(implicit mc: MarkerContext): Boolean = super.isDebugEnabled
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def isInfoEnabled(implicit mc: MarkerContext): Boolean = super.isInfoEnabled
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def isWarnEnabled(implicit mc: MarkerContext): Boolean = super.isWarnEnabled
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def isErrorEnabled(implicit mc: MarkerContext): Boolean = super.isErrorEnabled
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def trace(message: => String)(implicit mc: MarkerContext): Unit = super.trace(message)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def trace(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.trace(message, error)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def debug(message: => String)(implicit mc: MarkerContext): Unit = super.debug(message)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def debug(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.debug(message, error)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def info(message: => String)(implicit mc: MarkerContext): Unit = super.info(message)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def info(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.info(message, error)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def warn(message: => String)(implicit mc: MarkerContext): Unit = super.warn(message)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def warn(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.warn(message, error)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def error(message: => String)(implicit mc: MarkerContext): Unit = super.error(message)
 
-  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  @deprecated("Create an instance of via Logger(...) and use the same-named method. Or use SLF4J directly.", "2.7.0")
   override def error(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.error(message, error)
 }
 

--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -274,7 +274,7 @@ class Logger private (val logger: Slf4jLogger, isEnabled: => Boolean) extends Lo
  * Logger("my.logger").info("Hello!")
  * }}}
  */
-object Logger extends Logger(LoggerFactory.getLogger("application")) {
+object Logger extends Logger(LoggerFactory.getLogger("application")) { // TODO: After Play 2.7 this should simply become: object Logger {
 
   private[this] val log: Slf4jLogger = LoggerFactory.getLogger(getClass)
 
@@ -332,6 +332,58 @@ object Logger extends Logger(LoggerFactory.getLogger("application")) {
    */
   def apply(clazz: Class[_]): Logger = new Logger(LoggerFactory.getLogger(clazz.getName.stripSuffix("$")))
 
+  // ### Deprecate inherited methods from Logger and LoggerLike
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def enabled: Boolean = super.enabled
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def forMode(mode: Mode*): Logger = super.forMode(mode: _*)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def isTraceEnabled(implicit mc: MarkerContext): Boolean = super.isTraceEnabled
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def isDebugEnabled(implicit mc: MarkerContext): Boolean = super.isDebugEnabled
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def isInfoEnabled(implicit mc: MarkerContext): Boolean = super.isInfoEnabled
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def isWarnEnabled(implicit mc: MarkerContext): Boolean = super.isWarnEnabled
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def isErrorEnabled(implicit mc: MarkerContext): Boolean = super.isErrorEnabled
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def trace(message: => String)(implicit mc: MarkerContext): Unit = super.trace(message)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def trace(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.trace(message, error)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def debug(message: => String)(implicit mc: MarkerContext): Unit = super.debug(message)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def debug(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.debug(message, error)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def info(message: => String)(implicit mc: MarkerContext): Unit = super.info(message)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def info(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.info(message, error)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def warn(message: => String)(implicit mc: MarkerContext): Unit = super.warn(message)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def warn(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.warn(message, error)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def error(message: => String)(implicit mc: MarkerContext): Unit = super.error(message)
+
+  @deprecated("Create an instance of via Logger(...) and use it's same method. Or use SLF4J directly.", "2.7.0")
+  override def error(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = super.error(message, error)
 }
 
 /**


### PR DESCRIPTION
In RC3 `play.Logger` [is deprecated](https://www.playframework.com/documentation/2.7.0-RC3/Migration27#play.Logger-deprecated). I get [the idea](https://github.com/playframework/playframework/issues/1669) why using that class introduces some problems. However I think we should not deprecate the class itself, but only it's `static` methods. The same for `play.api.Logger` - we should only deprecate the usage of the singleton. But for both cases it's totally OK to use its instances, there is nothing wrong with them IMHO.
The advantage of using those wrapper classes instead of SLF4J itself is that right now SLF4J [does not provide logging methods which accept lambda expression](https://jira.qos.ch/browse/SLF4J-371) as parameters (for lazy evaluation). That's why I would still keep `Play.Logger` and `play.api.Logger` for now (and finally deprecate them once SLF4J introduces that lambda parameters.) See #7082 which added lazy logging via suppliers to `play.Logger`.