### PR TITLE
Update Logger documentation and add Logging trait

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -103,13 +103,13 @@ To define the logger in each class, you can define:
 
 Java
 : ```java
-private static final play.Logger.ALogger logger = play.Logger.of(YourClass.class);
+import play.Logger;
+private static final Logger.ALogger logger = Logger.of(YourClass.class);
 ```
 
 Scala
 : ```scala
 import play.api.Logger
-
 private val logger = Logger(YourClass.class)
 ```
 
@@ -140,7 +140,7 @@ If you'd like a more concise solution when using SLF4J directly for Java, you ma
 
 > **NOTE**: `org.slf4j.Logger`, the logging interface of SLF4J, does [not yet](https://jira.qos.ch/browse/SLF4J-371) provide logging methods which accept lambda expression as parameters for lazy evaluation. `play.Logger` and `play.api.Logger`, which are mostly simple wrappers for `org.slf4j.Logger`, provide such methods however.
 
-Once you have migrated away from using the `application` logger, you can remove the `logger` entry in your logback.xml referencing it:
+Once you have migrated away from using the `application` logger, you can remove the `logger` entry in your `logback.xml` referencing it:
 
     <logger name="application" level="DEBUG" />
 

--- a/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
+++ b/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
@@ -44,7 +44,7 @@ First import the `Logger` class:
 
 @[logging-import](code/javaguide/logging/JavaLogging.java)
 
-### Creating your own loggers
+### Creating loggers
 
 You can create a new logger using the `LoggerFactory` with a `name` argument:
 

--- a/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
+++ b/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
@@ -13,7 +13,7 @@ Your application can define loggers to send log message requests. Each logger ha
 
 Loggers follow a hierarchical inheritance structure based on their naming. A logger is said to be an ancestor of another logger if its name followed by a dot is the prefix of descendant logger name. For example, a logger named "com.foo" is the ancestor of a logger named "com.foo.bar.Baz." All loggers inherit from a root logger. Logger inheritance allows you to configure a set of loggers by configuring a common ancestor.
 
-Play applications are provided a default logger named "application" or you can create your own loggers. The Play libraries use a logger named "play", and some third party libraries will have loggers with their own names.
+We recommend creating separately-named loggers for each class. Following this convention, the Play libraries use loggers namespaced under "play", and many third party libraries will have loggers based on their class names.
 
 #### Log levels
 
@@ -44,17 +44,25 @@ First import the `Logger` class:
 
 @[logging-import](code/javaguide/logging/JavaLogging.java)
 
-### The default Logger
+### Creating your own loggers
 
-You can then use the `Logger` to write log request statements:
+You can create a new logger using the `LoggerFactory` with a `name` argument:
 
-@[logging-default-logger](code/javaguide/logging/JavaLogging.java)
+@[logging-create-logger-name](code/javaguide/logging/JavaLogging.java)
+
+A common strategy for logging application events is to use a distinct logger per class using the class name. The logging API supports this with a factory method that takes a class argument:
+
+@[logging-create-logger-class](code/javaguide/logging/JavaLogging.java)
+
+You can then use the `Logger` to write log statements:
+
+@[logging-example](code/javaguide/logging/JavaLogging.java)
 
 Using Play's default logging configuration, these statements will produce console output similar to this:
 
 ```
-[debug] application - Attempting risky calculation.
-[error] application - Exception with riskyCalculation
+[debug] c.e.s.MyClass - Attempting risky calculation.
+[error] c.e.s.MyClass - Exception with riskyCalculation
 java.lang.ArithmeticException: / by zero
     at controllers.Application.riskyCalculation(Application.java:20) ~[classes/:na]
     at controllers.Application.index(Application.java:11) ~[classes/:na]
@@ -63,19 +71,9 @@ java.lang.ArithmeticException: / by zero
     at play.core.Router$HandlerInvoker$$anon$8$$anon$2.invocation(Router.scala:203) [play_2.10-2.3-M1.jar:2.3-M1]
 ```
 
-Note that the messages have the log level, logger name, message, and stack trace if a Throwable was used in the log request.
+Note that the messages have the log level, logger name (in this case the class name, displayed in abbreviated form), message, and stack trace if a `Throwable` was used in the log request.
 
-### Creating your own loggers
-
-Although it may be tempting to use the default logger everywhere, it's generally a bad design practice. Creating your own loggers with distinct names allows for flexible configuration, filtering of log output, and pinpointing the source of log messages.
-
-You can create a new logger using the `LoggerFactory` with a name argument:
-
-@[logging-create-logger-name](code/javaguide/logging/JavaLogging.java)
-
-A common strategy for logging application events is to use a distinct logger per class using the class name. The logging API supports this with a factory method that takes a class argument:
-
-@[logging-create-logger-class](code/javaguide/logging/JavaLogging.java)
+There are also `play.Logger` static methods that allow you to access a logger named `application`, but their use is deprecated in Play 2.7.0 and above. You should declare your own logger instances using one of the strategies defined above.
 
 ### Using Markers
 

--- a/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/JavaLogging.java
+++ b/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/JavaLogging.java
@@ -21,7 +21,7 @@ public class JavaLogging {
 
   public void testDefaultLogger() {
 
-    //#logging-default-logger
+    //#logging-example
     // Log some debug info
     logger.debug("Attempting risky calculation.");
 
@@ -34,7 +34,7 @@ public class JavaLogging {
       // Log error with message and Throwable.
       logger.error("Exception with riskyCalculation", t);
     }
-    //#logging-default-logger
+    //#logging-example
 
   }
 

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/User.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/User.scala
@@ -7,17 +7,17 @@ package scalaguide.binder.models
 import scala.Left
 import scala.Right
 import play.api.mvc.PathBindable
-import play.api.Logger
+import play.api.Logging
 
 //#declaration
 case class User(id: Int, name: String) {}
 //#declaration
-object User {
-  
-  // stubbed test 
+object User extends Logging {
+
+  // stubbed test
 	// designed to be lightweight operation
   def findById(id: Int): Option[User] = {
-    Logger(getClass).info("findById: " + id.toString)
+    logger.info("findById: " + id.toString)
     if (id > 3) None
     var user = new User(id, "User " + String.valueOf(id))
     Some(user)

--- a/documentation/manual/working/scalaGuide/main/application/code/EssentialFilter.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/EssentialFilter.scala
@@ -7,12 +7,12 @@ package scalaguide.advanced.filters.essential
 // #essential-filter-example
 import javax.inject.Inject
 import akka.util.ByteString
-import play.api.Logger
+import play.api.Logging
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import scala.concurrent.ExecutionContext
 
-class LoggingFilter @Inject() (implicit ec: ExecutionContext) extends EssentialFilter {
+class LoggingFilter @Inject() (implicit ec: ExecutionContext) extends EssentialFilter with Logging {
   def apply(nextFilter: EssentialAction) = new EssentialAction {
     def apply(requestHeader: RequestHeader) = {
 
@@ -25,7 +25,7 @@ class LoggingFilter @Inject() (implicit ec: ExecutionContext) extends EssentialF
         val endTime = System.currentTimeMillis
         val requestTime = endTime - startTime
 
-        Logger(getClass).info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")
+        logger.info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")
         result.withHeaders("Request-Time" -> requestTime.toString)
 
       }

--- a/documentation/manual/working/scalaGuide/main/application/code/FiltersRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/FiltersRouting.scala
@@ -8,11 +8,11 @@ package scalaguide.advanced.filters.routing
 import javax.inject.Inject
 import akka.stream.Materializer
 import play.api.mvc.{Result, RequestHeader, Filter}
-import play.api.Logger
+import play.api.Logging
 import play.api.routing.{HandlerDef, Router}
 import scala.concurrent.{Future, ExecutionContext}
 
-class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionContext) extends Filter with Logging {
   def apply(nextFilter: RequestHeader => Future[Result])
            (requestHeader: RequestHeader): Future[Result] = {
 
@@ -24,7 +24,7 @@ class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionCont
       val endTime = System.currentTimeMillis
       val requestTime = endTime - startTime
 
-      Logger(getClass).info(s"${action} took ${requestTime}ms and returned ${result.header.status}")
+      logger.info(s"${action} took ${requestTime}ms and returned ${result.header.status}")
 
       result.withHeaders("Request-Time" -> requestTime.toString)
     }

--- a/documentation/manual/working/scalaGuide/main/application/code/ScalaHttpFilters.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/ScalaHttpFilters.scala
@@ -9,11 +9,11 @@ package simple {
 // #simple-filter
 import javax.inject.Inject
 import akka.stream.Materializer
-import play.api.Logger
+import play.api.Logging
 import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
-class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionContext) extends Filter with Logging {
 
   def apply(nextFilter: RequestHeader => Future[Result])
            (requestHeader: RequestHeader): Future[Result] = {
@@ -25,7 +25,7 @@ class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionCont
       val endTime = System.currentTimeMillis
       val requestTime = endTime - startTime
 
-      Logger(getClass).info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")
+      logger.info(s"${requestHeader.method} ${requestHeader.uri} took ${requestTime}ms and returned ${result.header.status}")
 
       result.withHeaders("Request-Time" -> requestTime.toString)
     }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -15,6 +15,7 @@ import org.specs2.mutable.Specification
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import play.api.Logger
+import play.api.Logging
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
@@ -41,9 +42,10 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       //#basic-logging
       import play.api.mvc._
 
-      class LoggingAction @Inject() (parser: BodyParsers.Default)(implicit ec: ExecutionContext) extends ActionBuilderImpl(parser) {
+      class LoggingAction @Inject() (parser: BodyParsers.Default)(implicit ec: ExecutionContext)
+          extends ActionBuilderImpl(parser) with Logging {
         override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
-          Logger(getClass).info("Calling action")
+          logger.info("Calling action")
           block(request)
         }
       }
@@ -78,10 +80,10 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       //#actions-class-wrapping
       import play.api.mvc._
 
-      case class Logging[A](action: Action[A]) extends Action[A] {
+      case class Logging[A](action: Action[A]) extends Action[A] with play.api.Logging {
 
         def apply(request: Request[A]): Future[Result] = {
-          Logger(getClass).info("Calling action")
+          logger.info("Calling action")
           action(request)
         }
 
@@ -130,10 +132,11 @@ class ScalaActionsCompositionSpec extends Specification with ControllerHelpers {
       //#actions-def-wrapping
       import play.api.mvc._
 
-      //###skip:1
+      //###skip:2
+      val logger = Logger(getClass)
       val Action = actionBuilder
       def logging[A](action: Action[A]) = Action.async(action.parser) { request =>
-        Logger(getClass).info("Calling action")
+        logger.info("Calling action")
         action(request)
       }
       //#actions-def-wrapping

--- a/documentation/manual/working/scalaGuide/main/logging/ScalaLogging.md
+++ b/documentation/manual/working/scalaGuide/main/logging/ScalaLogging.md
@@ -12,7 +12,7 @@ Your application can define [`Logger`](api/scala/play/api/Logger.html) instances
 
 Loggers follow a hierarchical inheritance structure based on their naming. A logger is said to be an ancestor of another logger if its name followed by a dot is the prefix of descendant logger name. For example, a logger named "com.foo" is the ancestor of a logger named "com.foo.bar.Baz." All loggers inherit from a root logger. Logger inheritance allows you to configure a set of loggers by configuring a common ancestor.
 
-Play applications are provided a default logger named "application" or you can create your own loggers. The Play libraries use a logger named "play", and some third party libraries will have loggers with their own names.
+We recommend creating separately-named loggers for each class. Following this convention, the Play libraries use loggers namespaced under "play", and many third party libraries will have loggers based on their class names.
 
 #### Log levels
 Log levels are used to classify the severity of log messages. When you write a log request statement you will specify the severity and this will appear in generated log messages.
@@ -40,38 +40,40 @@ First import the `Logger` class and companion object:
 
 @[logging-import](code/ScalaLoggingSpec.scala)
 
-### The default Logger
+### Creating loggers
 
-The `Logger` object is your default logger and uses the name "application." You can use it to write log request statements:
-
-@[logging-default-logger](code/ScalaLoggingSpec.scala)
-
-Using Play's default logging configuration, these statements will produce console output similar to this:
-
-```text
-[debug] application - Attempting risky calculation.
-[error] application - Exception with riskyCalculation
-java.lang.ArithmeticException: / by zero
-    at controllers.Application$.controllers$Application$$riskyCalculation(Application.scala:32) ~[classes/:na]
-    at controllers.Application$$anonfun$test$1.apply(Application.scala:18) [classes/:na]
-    at controllers.Application$$anonfun$test$1.apply(Application.scala:12) [classes/:na]
-    at play.api.mvc.ActionBuilder$$anonfun$apply$17.apply(Action.scala:390) [play_2.10-2.3-M1.jar:2.3-M1]
-    at play.api.mvc.ActionBuilder$$anonfun$apply$17.apply(Action.scala:390) [play_2.10-2.3-M1.jar:2.3-M1]
-```
-
-Note that the messages have the log level, logger name, message, and stack trace if a Throwable was used in the log request.
-
-### Creating your own loggers
-
-Although it may be tempting to use the default logger everywhere, it's generally a bad design practice. Creating your own loggers with distinct names allows for flexible configuration, filtering of log output, and pinpointing the source of log messages.
-
-You can create a new logger using the `Logger.apply` factory method with a name argument:
+You can create a new logger using the `Logger.apply` factory method with a `name` argument:
 
 @[logging-create-logger-name](code/ScalaLoggingSpec.scala)
 
 A common strategy for logging application events is to use a distinct logger per class using the class name. The logging API supports this with a factory method that takes a class argument:
 
 @[logging-create-logger-class](code/ScalaLoggingSpec.scala)
+
+There is also a `Logging` trait that does this for you automatically and exposes a `protected val logger`:
+
+@[logging-trait](code/ScalaLoggingSpec.scala)
+
+Once you have a `Logger` set up, you can use it to write log statements:
+
+@[logging-example](code/ScalaLoggingSpec.scala)
+
+Using Play's default logging configuration, these statements will produce console output similar to this:
+
+```
+[debug] c.e.s.MyClass - Attempting risky calculation.
+[error] c.e.s.MyClass - Exception with riskyCalculation
+java.lang.ArithmeticException: / by zero
+    at controllers.Application.riskyCalculation(Application.java:20) ~[classes/:na]
+    at controllers.Application.index(Application.java:11) ~[classes/:na]
+    at Routes$$anonfun$routes$1$$anonfun$applyOrElse$1$$anonfun$apply$1.apply(routes_routing.scala:69) [classes/:na]
+    at Routes$$anonfun$routes$1$$anonfun$applyOrElse$1$$anonfun$apply$1.apply(routes_routing.scala:69) [classes/:na]
+    at play.core.Router$HandlerInvoker$$anon$8$$anon$2.invocation(Router.scala:203) [play_2.10-2.3-M1.jar:2.3-M1]
+```
+
+Note that the messages have the log level, logger name (in this case the class name, displayed in abbreviated form), message, and stack trace if a `Throwable` was used in the log request.
+
+There is also a `play.api.Logger` singleton object that allows you to access a logger named `application`, but its use is deprecated in Play 2.7.0 and above. You should declare your own logger instances using one of the strategies defined above.
 
 ### Using Markers and Marker Contexts
 

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -27,37 +27,37 @@ class ScalaLoggingSpec extends Specification with Mockito {
     10 / scala.util.Random.nextInt(2)
   }
 
-  "The default Logger" should {
+  "The logger" should {
     "properly log" in {
 
-      object Logger extends play.api.LoggerLike {
+      val logger = new play.api.LoggerLike {
         // Mock underlying logger implementation
         val logger = mock[org.slf4j.Logger].smart
         logger.isDebugEnabled() returns true
         logger.isErrorEnabled() returns true
       }
 
-      //#logging-default-logger
+      //#logging-example
       // Log some debug info
-      Logger.debug("Attempting risky calculation.")
+      logger.debug("Attempting risky calculation.")
 
       try {
         val result = riskyCalculation
 
         // Log result if successful
-        Logger.debug(s"Result=$result")
+        logger.debug(s"Result=$result")
       } catch {
         case t: Throwable => {
           // Log error with message and Throwable.
-          Logger.error("Exception with riskyCalculation", t)
+          logger.error("Exception with riskyCalculation", t)
         }
       }
-      //#logging-default-logger
+      //#logging-example
 
-      there was atLeastOne(Logger.logger).isDebugEnabled()
-      there was atLeastOne(Logger.logger).debug(anyString)
-      there was atMostOne(Logger.logger).isErrorEnabled()
-      there was atMostOne(Logger.logger).error(anyString, any[Throwable])
+      there was atLeastOne(logger.logger).isDebugEnabled()
+      there was atLeastOne(logger.logger).debug(anyString)
+      there was atMostOne(logger.logger).isErrorEnabled()
+      there was atMostOne(logger.logger).error(anyString, any[Throwable])
     }
 
   }
@@ -83,6 +83,20 @@ class ScalaLoggingSpec extends Specification with Mockito {
       //#logging-create-logger-class
 
       logger.underlyingLogger.getName must equalTo("scalaguide.logging.ScalaLoggingSpec")
+    }
+
+    "use Logging trait" in {
+
+      //#logging-trait
+      import play.api.Logging
+
+      class MyClassWithLogging extends Logging {
+        logger.info("Using the trait")
+      }
+      //#logging-trait
+
+      new MyClassWithLogging()
+      success
     }
 
     "allow for using multiple loggers" in {

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -29,7 +29,7 @@ class ScalaOpenIdSpec extends PlaySpecification {
 
   "Scala OpenId" should {
     "be injectable" in new WithApplication() with Injecting {
-      val controller = new IdController(inject[OpenIdClient], inject[ControllerComponents])(inject[ExecutionContext]) {
+      val controller = new IdController(inject[OpenIdClient], inject[ControllerComponents])(inject[ExecutionContext]) with Logging {
         //#flow
         def login = Action {
           Ok(views.html.login())
@@ -39,7 +39,7 @@ class ScalaOpenIdSpec extends PlaySpecification {
           Form(single(
             "openid" -> nonEmptyText
           )).bindFromRequest.fold({ error =>
-            Logger(getClass).info(s"bad request ${error.toString}")
+            logger.info(s"bad request ${error.toString}")
             Future.successful(BadRequest(error.toString))
           }, { openId =>
             openIdClient.redirectURL(openId, routes.Application.openIdCallback.absoluteURL())

--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -238,6 +238,13 @@ trait LoggerLike {
 }
 
 /**
+ * A trait that can mixed into a class or trait to add a `logger` named based on the class name.
+ */
+trait Logging {
+  protected val logger: Logger = Logger(getClass)
+}
+
+/**
  * A Play logger.
  *
  * @param logger the underlying SL4FJ logger


### PR DESCRIPTION
 - Updates Logger documentation to de-emphasize the global logger and mention that it is now deprecated.
 - Clarifies different migration paths in the migration guide.
 - Updates example code to use a locally-defined logger val where possible.
 - Adds a `Logging` trait to make it much easier to use a logger per class in Scala.