### PR TITLE
Fix ambiguous import for Java 11

### DIFF
--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/playlib/HelloModule.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/playlib/HelloModule.java
@@ -11,7 +11,8 @@ import com.typesafe.config.Config;
 import java.util.Arrays;
 import java.util.List;
 import play.Environment;
-import play.inject.*;
+import play.inject.Binding;
+import play.inject.Module;
 
 public class HelloModule extends Module {
     @Override


### PR DESCRIPTION
When running with Java 11 fixes this problem:
```
[error] documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/playlib/HelloModule.java:16: reference to Module is ambiguous
[error]   both class play.inject.Module in play.inject and class java.lang.Module in java.lang match
```