### PR TITLE
[Travis CI] fast_finish: true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
       name: "Run tests for Scala 2.12 and Java 11"
 
 matrix:
+  fast_finish: true
   allow_failures:
     # We are not fully validating for Java 11 yet, so we allow this to
     # failure until we tackle all the problems. Anyway, having it at the


### PR DESCRIPTION
I think that makes sense, so we don't have to wait for the Java 11 build to finish because it has `allow_failures` set anyway.

See

- https://docs.travis-ci.com/user/customizing-the-build/#fast-finishing
- https://blog.travis-ci.com/2013-11-27-fast-finishing-builds