### PR TITLE
Better organize migration guide

### DIFF
--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -110,7 +110,7 @@ The CSP filter uses Google's [Strict CSP policy](https://csp.withgoogle.com/docs
 
 ## HikariCP upgraded
 
-[HikariCP](https://github.com/brettwooldridge/HikariCP) was updated to its latest major version. Have a look at the [[Migration Guide|Migration27#HikariCP]] to see what changed.
+[HikariCP](https://github.com/brettwooldridge/HikariCP) was updated to its latest major version. Have a look at the [[Migration Guide|Migration27#HikariCP-update]] to see what changed.
 
 ## Play WS `curl` filter for Java
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -8,7 +8,7 @@ Regarding the API modeling, there are some duplicated concepts (like `play.mvc.R
 
 Since `play.mvc.Http.Context` is a central part of the existing APIs, deprecating it had an impact on multiple places that were depending on it, take for example `play.mvc.Controller`. This page documents these changes and how to migrate, but you can see the deprecated Javadocs for each methods too.
 
-### `Http.Context.current()` and `Http.Context.request()` deprecated
+## `Http.Context.current()` and `Http.Context.request()` deprecated
 
 That means other methods that depend directly on these two were also deprecated:
 
@@ -21,7 +21,7 @@ With Play 2.7 you can now access the current request by just adding it as a para
 
 For example, the routes files contain:
 
-```
+```routes
 GET     /       controllers.HomeController.index(request: Request)
 ```
 
@@ -47,7 +47,7 @@ Play will automatically detect a route param of type `Request` (which is an impo
 
 If you use `Http.Context.current()` in other places besides controllers you have to pass the desired data via method parameters to these places now. Look at this example which checks if the current request's remote address is on a blacklist:
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Http;
@@ -77,7 +77,7 @@ public class HomeController extends Controller {
 }
 ```
 
-#### After
+### After
 
 ```java
 public class SecurityHelper {
@@ -104,11 +104,11 @@ public class HomeController extends Controller {
 }
 ```
 
-### `Action.call(Context)` deprecated
+## `Action.call(Context)` deprecated
 
 If you are using [[action composition|JavaActionsComposition]] you have to update your actions to avoid `Http.Context`.
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Action;
@@ -124,7 +124,7 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-#### After
+### After
 
 ```java
 import play.mvc.Action;
@@ -140,7 +140,7 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-### `Http.Context.response()` and `Http.Response` class deprecated
+## `Http.Context.response()` and `Http.Response` class deprecated
 
 That means other methods that depend directly on these were also deprecated:
 
@@ -148,7 +148,7 @@ That means other methods that depend directly on these were also deprecated:
 
 `Http.Response` was deprecated with other accesses methods to it. It was mainly used to add headers and cookies, but these are already available in `play.mvc.Result` and then the API got a little confused. For Play 2.7, you should migrate code like:
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Http;
@@ -168,7 +168,7 @@ public class FooController extends Controller {
 }
 ```
 
-#### After
+### After
 
 The code above should be written as:
 
@@ -192,7 +192,7 @@ public class FooController extends Controller {
 
 If you have action composition that depends on `Http.Context.response`, you can also rewrite it like the code below:
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Action;
@@ -212,7 +212,7 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-#### After
+### After
 
 The code above should be written as:
 
@@ -233,7 +233,7 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-### Lang and Messages methods in `Http.Context` deprecated
+## Lang and Messages methods in `Http.Context` deprecated
 
 The following methods have been deprecated:
 
@@ -255,7 +255,7 @@ That means other methods that depend directly on these were also deprecated:
 
 The new way of changing lang now is to have an instance of [`play.i18n.MessagesApi`](api/java/play/i18n/MessagesApi.html) injected and call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Result;
@@ -272,7 +272,7 @@ public class FooController extends Controller {
 }
 ```
 
-#### After
+### After
 
 ```java
 import play.mvc.Result;
@@ -296,7 +296,7 @@ public class FooController extends Controller {
 
 If you are using `changeLang` to change the `Lang` used to render a template, you should now pass the `Messages` itself as a parameter. This will make the template clearer and easier to read. For example, in an action method, you have to create a `Messages` instance like:
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Result;
@@ -310,7 +310,7 @@ public class MyController extends Controller {
 }
 ```
 
-#### After
+### After
 
 ```java
 import javax.inject.Inject;
@@ -321,14 +321,14 @@ import play.mvc.Result;
 import play.mvc.Controller;
 
 public class MyController extends Controller {
-    
+
     private final MessagesApi messagesApi;
-    
+
     @Inject
     public MyController(MessagesApi messagesApi) {
         this.messagesApi = messagesApi;
     }
-    
+
     public Result action() {
         Messages messages = this.messagesApi.preferred(Lang.forCode("es"));
         return ok(myview.render(messages));
@@ -347,17 +347,17 @@ import play.mvc.Result;
 import play.mvc.Controller;
 
 public class MyController extends Controller {
-    
+
     private final MessagesApi messagesApi;
-    
+
     @Inject
     public MyController(MessagesApi messagesApi) {
         this.messagesApi = messagesApi;
     }
-    
+
     public Result action() {
         Lang lang = Lang.forCode("es");
-        
+
         // Get a Message instance based on the spanish locale, however if that isn't available
         // try to choose the best fitting language based on the current request
         Messages messages = this.messagesApi.preferred(request.withTransientLang(lang));
@@ -379,7 +379,7 @@ Now the template:
 
 And the same applies to `clearLang`:
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Result;
@@ -396,7 +396,7 @@ public class FooController extends Controller {
 }
 ```
 
-#### After
+### After
 
 ```java
 import play.mvc.Result;
@@ -418,7 +418,7 @@ public class FooController extends Controller {
 }
 ```
 
-### `Http.Context.session()` deprecated
+## `Http.Context.session()` deprecated
 
 That means other methods that depend directly on it were also deprecated:
 
@@ -428,7 +428,7 @@ That means other methods that depend directly on it were also deprecated:
 
 The new way to retrieve the session of a request is to call the `session()` method of an `Http.Request` instance. The new way to manipulate the session is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Result;
@@ -458,7 +458,7 @@ public class FooController extends Controller {
 }
 ```
 
-#### After
+### After
 
 ```java
 import play.mvc.Http;
@@ -492,7 +492,7 @@ public class FooController extends Controller {
 }
 ```
 
-### `Http.Context.flash()` deprecated
+## `Http.Context.flash()` deprecated
 
 That means other methods that depend directly on it were also deprecated:
 
@@ -502,7 +502,7 @@ That means other methods that depend directly on it were also deprecated:
 
 The new way to retrieve the flash of a request is to call the `flash()` method of a `Http.Request` instance. The new way to manipulate the flash is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Result;
@@ -532,7 +532,7 @@ public class FooController extends Controller {
 }
 ```
 
-#### After
+### After
 
 ```java
 import play.mvc.Http;
@@ -563,11 +563,11 @@ public class FooController extends Controller {
 }
 ```
 
-### Template helper methods deprecated
+## Template helper methods deprecated
 
 Inside templates, Play offered you various helper methods which rely on `Http.Context` internally. These methods are deprecated starting with Play 2.7. Instead, you have to explicitly pass the desired object to your templates now.
 
-#### Before
+### Before
 
 ```html
 @()
@@ -581,7 +581,7 @@ Inside templates, Play offered you various helper methods which rely on `Http.Co
 @Messages("some_msg_key")
 ```
 
-#### After
+### After
 
 ```html
 @(Http.Request request, Lang lang, Messages messages)
@@ -595,7 +595,7 @@ Inside templates, Play offered you various helper methods which rely on `Http.Co
 
 There is no direct replacement for `ctx()` and `response()`.
 
-### Some template tags need an implicit `Request`, `Messages` or `Lang` instance
+## Some template tags need an implicit `Request`, `Messages` or `Lang` instance
 
 Some template tags need to access a `Request`, `Messages` or `Lang` instance in order to work correctly. Until now these tags just made use of `Http.Context.current()` to retrieve such instances.
 
@@ -649,7 +649,7 @@ Play itself does not provide tags that need a `Lang` instance to be present, thi
 
 Third-party tags will automatically use the implicit messages passed to this template.
 
-### Changes in Java Forms related to `Http.Context`
+## Changes in Java Forms related to `Http.Context`
 
 When retrieving the [`Field`](api/java/play/data/Form.Field.html) of a [`Form`](api/java/play/data/Form.html) (e.g. via `myform.field("username")` or just `myform("username")` inside templates) the language of the current `Http.Context` was used to format the value of the field. Starting with Play 2.7 however this isn't the case anymore. Instead you can now explicitly set the language the form should use when retrieving a field. To make things simple and to not force you to set the language for every form explicitly, Play sets it during binding already:
 
@@ -662,16 +662,16 @@ import play.data.Form;
 import play.data.FormFactory;
 
 public class MyController extends Controller {
-    
+
     private final FormFactory formFactory;
-    
+
     @Inject
     public MyController(FormFactory formFactory) {
         this.formFactory = formFactory;
     }
-    
+
     public Result action(Http.Request request) {
-        // In this example, the language of the form will be set 
+        // In this example, the language of the form will be set
         // to the preferred language of the request.
         Form<User> form = formFactory.form(User.class).bindFromRequest(request);
         return ok(views.form.render(form));
@@ -690,18 +690,18 @@ import play.data.Form;
 import play.data.FormFactory;
 
 public class MyController extends Controller {
-    
+
     private final FormFactory formFactory;
-    
+
     @Inject
     public MyController(FormFactory formFactory) {
         this.formFactory = formFactory;
     }
-    
+
     public Result action(Http.Request request) {
         // There is first the lang from request
         Form<User> form = formFactory.form(User.class).bindFromRequest(request);
-        
+
         // Let's change the language to `es`.
         Lang lang = Lang.forCode("es");
         Form<User> formWithNewLang = form.withLang(lang);
@@ -712,19 +712,19 @@ public class MyController extends Controller {
 
 > **Note:** changing the language of the the current `Http.Context` (e.g. via `Http.Context.current().changeLang(...)` or `Http.Context.current().setTransientLang(...)`) does not have an effect on the language used to retrieve the field value of a form anymore - as explained, use `form.withLang(...)` instead.
 
-### `Http.Context` Request tags removed from `args`
+## `Http.Context` Request tags removed from `args`
 
 Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]] in Play 2.6, have finally been removed in Play 2.7. Therefore the `args` map of an `Http.Context` instance no longer contains these removed request tags as well. Instead you can use the `request.attrs()` method now, which provides you the same request attributes.
 
-### CSRF tokens removed from `args`
+## CSRF tokens removed from `args`
 
 The `@AddCSRFToken` action annotation added two entries named `CSRF_TOKEN` and `CSRF_TOKEN_NAME` to the `args` map of an `Http.Context` instance. These entries have been removed. Use [[the new correct way to get the token|JavaCsrf#Getting-the-current-token]].
 
-### RoutingDSL changes
+## RoutingDSL changes
 
 Until Play 2.6, when using Java [[routing DSL|JavaRoutingDsl]], there is no other way to access the current `request` besides `Http.Context.current()`. Now the DSL has new methods where a request will be passed to the block.
 
-#### Before
+### Before
 
 ```java
 import play.mvc.Http;
@@ -758,7 +758,7 @@ public class MyRouter {
 
 In the example above, we need to use `Http.Context.current()` to access the request. From now on, you can instead write the code like below:
 
-#### After
+### After
 
 ```java
 import play.routing.Router;
@@ -790,18 +790,18 @@ public class MyRouter {
 
 An important aspect to note is that, in the new API, `Http.Request` will always be the first parameter for the function blocks.
 
-### Disabling the `Http.Context` and JPA thread local
+## Disabling the `Http.Context` and JPA thread local
 
 If you followed the above migration notes and changed all your code so it doesn't make use of API's that rely on `Http.Context` (meaning you don't get compiler warnings anymore) you can disable the `Http.Context` thread local.
 
 Just add the following line to your `application.conf` file:
 
-```
+```hocon
 play.allowHttpContext = false
 ```
 
 To also disable the [`play.db.jpa.JPAEntityManagerContext`](api/java/play/db/jpa/JPAEntityManagerContext.html) thread local add:
 
-```
+```hocon
 play.jpa.allowJPAEntityManagerContext = false
 ```

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -275,6 +275,8 @@ public class FooController extends Controller {
 ### After
 
 ```java
+import javax.inject.Inject;
+
 import play.mvc.Result;
 import play.mvc.Results;
 import play.mvc.Controller;
@@ -284,6 +286,7 @@ import play.i18n.MessagesApi;
 public class FooController extends Controller {
     private final MessagesApi messagesApi;
 
+    @Inject
     public FooController(MessagesApi messagesApi) {
         this.messagesApi = messagesApi;
     }
@@ -399,6 +402,8 @@ public class FooController extends Controller {
 ### After
 
 ```java
+import javax.inject.Inject;
+
 import play.mvc.Result;
 import play.mvc.Results;
 import play.mvc.Controller;
@@ -408,6 +413,7 @@ import play.i18n.MessagesApi;
 public class FooController extends Controller {
     private final MessagesApi messagesApi;
 
+    @Inject
     public FooController(MessagesApi messagesApi) {
         this.messagesApi = messagesApi;
     }

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -743,7 +743,13 @@ public class SomeController extends Controller {
 }
 ```
 
-> **Note:** some of these features were previously provided by `PlayMagicForJava` and were heavily depending on `Http.Context.current()`. Passing the parameters to your view will make it more clear what is happening and where your view is depending on other data.
+> **Note:** some of these features were previously provided by `PlayMagicForJava` and were heavily depending on `Http.Context.current()`. That is why you will see warnings like:
+>
+> ```
+> method implicitXXX in object PlayMagicForJava is deprecated (since 2.7.0): See https://www.playframework.com/documentation/latest/JavaHttpContextMigration27
+> ```
+>
+> Passing the parameters to your view will make it more clear what is happening and where your view is depending on other data.
 
 Play itself does not provide tags that need a `Lang` instance to be present, third-party modules however may do:
 

--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -24,6 +24,7 @@ For example, the routes files contain:
 ```
 GET     /       controllers.HomeController.index(request: Request)
 ```
+
 And the corresponding action method:
 
 ```java
@@ -35,7 +36,6 @@ public class HomeController extends Controller {
         return ok("Hello, your request path " + request.path());
     }
 }
-
 ```
 
 Play will automatically detect a route param of type `Request` (which is an import for `play.mvc.Http.Request`) and will pass the actual request into the corresponding action method's param.
@@ -45,8 +45,7 @@ Play will automatically detect a route param of type `Request` (which is an impo
 >
 >     GET    /        controllers.HomeController.index(myRequest: com.mycompany.Request)
 
-If you use `Http.Context.current()` in other places besides controllers you have to pass the desired data via method parameters to these places now.
-Look at this example which checks if the current request's remote address is on a blacklist:
+If you use `Http.Context.current()` in other places besides controllers you have to pass the desired data via method parameters to these places now. Look at this example which checks if the current request's remote address is on a blacklist:
 
 #### Before
 
@@ -76,7 +75,6 @@ public class HomeController extends Controller {
         return ok("Hello, your request path " + request().path());
     }
 }
-
 ```
 
 #### After
@@ -104,7 +102,6 @@ public class HomeController extends Controller {
         return ok("Hello, your request path " + request.path());
     }
 }
-
 ```
 
 ### `Action.call(Context)` deprecated
@@ -151,6 +148,8 @@ That means other methods that depend directly on these were also deprecated:
 
 `Http.Response` was deprecated with other accesses methods to it. It was mainly used to add headers and cookies, but these are already available in `play.mvc.Result` and then the API got a little confused. For Play 2.7, you should migrate code like:
 
+#### Before
+
 ```java
 import play.mvc.Http;
 import play.mvc.Result;
@@ -169,7 +168,9 @@ public class FooController extends Controller {
 }
 ```
 
-Should be written as:
+#### After
+
+The code above should be written as:
 
 ```java
 import play.mvc.Http;
@@ -191,6 +192,8 @@ public class FooController extends Controller {
 
 If you have action composition that depends on `Http.Context.response`, you can also rewrite it like the code below:
 
+#### Before
+
 ```java
 import play.mvc.Action;
 import play.mvc.Http;
@@ -209,7 +212,9 @@ public class MyAction extends Action.Simple {
 }
 ```
 
-Should be written as:
+#### After
+
+The code above should be written as:
 
 ```java
 import play.mvc.Action;
@@ -291,18 +296,76 @@ public class FooController extends Controller {
 
 If you are using `changeLang` to change the `Lang` used to render a template, you should now pass the `Messages` itself as a parameter. This will make the template clearer and easier to read. For example, in an action method, you have to create a `Messages` instance like:
 
+#### Before
+
 ```java
-Messages messages = this.messagesApi.preferred(Lang.forCode("es"));
-return ok(myview.render(messages));
+import play.mvc.Result;
+import play.mvc.Controller;
+
+public class MyController extends Controller {
+    public Result action() {
+        changeLang(Lang.forCode("es"));
+        return ok(myview.render(messages));
+    }
+}
 ```
+
+#### After
+
+```java
+import javax.inject.Inject;
+import play.i18n.Messages;
+import play.i18n.MessagesApi;
+
+import play.mvc.Result;
+import play.mvc.Controller;
+
+public class MyController extends Controller {
+    
+    private final MessagesApi messagesApi;
+    
+    @Inject
+    public MyController(MessagesApi messagesApi) {
+        this.messagesApi = messagesApi;
+    }
+    
+    public Result action() {
+        Messages messages = this.messagesApi.preferred(Lang.forCode("es"));
+        return ok(myview.render(messages));
+    }
+}
+```
+
 Or if you want to have a fallback to the languages of the request you can do that as well:
+
 ```java
-Lang lang = Lang.forCode("es");
-// Get a Message instance based on the spanish locale, however if that isn't available
-// try to choose the best fitting language based on the current request
-Messages messages = this.messagesApi.preferred(request.withTransientLang(lang));
-return ok(myview.render(messages));
+import javax.inject.Inject;
+import play.i18n.Messages;
+import play.i18n.MessagesApi;
+
+import play.mvc.Result;
+import play.mvc.Controller;
+
+public class MyController extends Controller {
+    
+    private final MessagesApi messagesApi;
+    
+    @Inject
+    public MyController(MessagesApi messagesApi) {
+        this.messagesApi = messagesApi;
+    }
+    
+    public Result action() {
+        Lang lang = Lang.forCode("es");
+        
+        // Get a Message instance based on the spanish locale, however if that isn't available
+        // try to choose the best fitting language based on the current request
+        Messages messages = this.messagesApi.preferred(request.withTransientLang(lang));
+        return ok(myview.render(messages));
+    }
+}
 ```
+
 > **Note**: To not repeat that code again and again inside each action method you could e.g. create the `Messages` instance in an action of the [[action composition chain|JavaActionsComposition]] and save that instance in a request Attribute so you can access it later.
 
 Now the template:
@@ -363,8 +426,7 @@ That means other methods that depend directly on it were also deprecated:
 1. `play.mvc.Controller.session(String key, String value)`
 1. `play.mvc.Controller.session(String key)`
 
-The new way to retrieve the session of a request is to call the `session()` method of an `Http.Request` instance.
-The new way to manipulate the session is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
+The new way to retrieve the session of a request is to call the `session()` method of an `Http.Request` instance. The new way to manipulate the session is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
 
 #### Before
 
@@ -404,9 +466,12 @@ import play.mvc.Result;
 import play.mvc.Results;
 import play.mvc.Controller;
 
+import java.util.Optional;
+
 public class FooController extends Controller {
     public Result info(Http.Request request) {
-        String user = request.session().get("current_user");
+        // Get the current user or then fallback to guest
+        String user = request.session().getOptional("current_user").orElse("guest");
         return Results.ok("Hello " + user);
     }
 
@@ -435,8 +500,7 @@ That means other methods that depend directly on it were also deprecated:
 1. `play.mvc.Controller.flash(String key, String value)`
 1. `play.mvc.Controller.flash(String key)`
 
-The new way to retrieve the flash of a request is to call the `flash()` method of a `Http.Request` instance.
-The new way to manipulate the flash is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
+The new way to retrieve the flash of a request is to call the `flash()` method of a `Http.Request` instance. The new way to manipulate the flash is to call corresponding [`play.mvc.Result`](api/java/play/mvc/Result.html) methods. For example:
 
 #### Before
 
@@ -478,7 +542,7 @@ import play.mvc.Controller;
 
 public class FooController extends Controller {
     public Result info(Http.Request request) {
-        String message = request.flash().get("message");
+        String message = request.flash().getOptional("message").orElse("The default message");
         return Results.ok("Message: " + message);
     }
 
@@ -501,9 +565,7 @@ public class FooController extends Controller {
 
 ### Template helper methods deprecated
 
-Inside templates, Play offered you various helper methods which rely on `Http.Context` internally.
-These methods are deprecated starting with Play 2.7.
-Instead, you have to explicitly pass the desired object to your templates now.
+Inside templates, Play offered you various helper methods which rely on `Http.Context` internally. These methods are deprecated starting with Play 2.7. Instead, you have to explicitly pass the desired object to your templates now.
 
 #### Before
 
@@ -535,13 +597,12 @@ There is no direct replacement for `ctx()` and `response()`.
 
 ### Some template tags need an implicit `Request`, `Messages` or `Lang` instance
 
-Some template tags need to access a `Request`, `Messages` or `Lang` instance in order to work correctly.
-Until now these tags just made use of `Http.Context.current()` to retrieve such instances.
+Some template tags need to access a `Request`, `Messages` or `Lang` instance in order to work correctly. Until now these tags just made use of `Http.Context.current()` to retrieve such instances.
 
-Because `Http.Context` is deprecated however, such instances should now be passed as `implicit` parameters to templates which make use of such tags.
-By marking the parameter as `implicit` you don't always have to pass it on to the tag which actually needs it, but the tag can retrieve it from the implicit scope automatically.
+Because `Http.Context` is deprecated however, such instances should now be passed as `implicit` parameters to templates which make use of such tags. By marking the parameter as `implicit` you don't always have to pass it on to the tag which actually needs it, but the tag can retrieve it from the implicit scope automatically.
 
 Following tags need an implicit `Request` instance to be present:
+
 ```html
 @(arg1, arg2,...)(implicit request: play.mvc.Http.Request)
 
@@ -563,6 +624,7 @@ These tags will automatically use the implicit request passed to this template:
 ```
 
 Following tags need an implicit `Messages` instance to be present:
+
 ```html
 @(arg1, arg2,...)(implicit messages: play.i18n.Messages)
 
@@ -583,40 +645,80 @@ Play itself does not provide tags that need a `Lang` instance to be present, thi
 
 ```html
 @(arg1, arg2,...)(implicit lang: play.i18n.Lang)
+```
 
 Third-party tags will automatically use the implicit messages passed to this template.
-```
 
 ### Changes in Java Forms related to `Http.Context`
 
-When retrieving the [`Field`](api/java/play/data/Form.Field.html) of a [`Form`](api/java/play/data/Form.html) (e.g. via `myform.field("username")` or just `myform("username")` inside templates) the language of the current `Http.Context` was used to format the value of the field.
-Starting with Play 2.7 however this isn't the case anymore.
-Instead you can now explicitly set the language the form should use when retrieving a field:
+When retrieving the [`Field`](api/java/play/data/Form.Field.html) of a [`Form`](api/java/play/data/Form.html) (e.g. via `myform.field("username")` or just `myform("username")` inside templates) the language of the current `Http.Context` was used to format the value of the field. Starting with Play 2.7 however this isn't the case anymore. Instead you can now explicitly set the language the form should use when retrieving a field. To make things simple and to not force you to set the language for every form explicitly, Play sets it during binding already:
 
 ```java
-Form<User> formWithNewLang = currentForm.withLang(lang);
+import play.mvc.Http;
+import play.mvc.Result;
+import play.mvc.Controller;
+
+import play.data.Form;
+import play.data.FormFactory;
+
+public class MyController extends Controller {
+    
+    private final FormFactory formFactory;
+    
+    @Inject
+    public MyController(FormFactory formFactory) {
+        this.formFactory = formFactory;
+    }
+    
+    public Result action(Http.Request request) {
+        // In this example, the language of the form will be set 
+        // to the preferred language of the request.
+        Form<User> form = formFactory.form(User.class).bindFromRequest(request);
+        return ok(views.form.render(form));
+    }
+}
 ```
 
-To make things simple and to not force you to set the language for every form explicitly, Play sets it during binding already:
+You can also change the language of an existing form if you need:
 
 ```java
-Form<User> form = formFactory().form(User.class).bindFromRequest(request);
+import play.mvc.Result;
+import play.mvc.Controller;
+
+import play.i18n.Lang;
+import play.data.Form;
+import play.data.FormFactory;
+
+public class MyController extends Controller {
+    
+    private final FormFactory formFactory;
+    
+    @Inject
+    public MyController(FormFactory formFactory) {
+        this.formFactory = formFactory;
+    }
+    
+    public Result action(Http.Request request) {
+        // There is first the lang from request
+        Form<User> form = formFactory.form(User.class).bindFromRequest(request);
+        
+        // Let's change the language to `es`.
+        Lang lang = Lang.forCode("es");
+        Form<User> formWithNewLang = form.withLang(lang);
+        return ok(views.form.render(formWithNewLang));
+    }
+}
 ```
 
-In this example, the language of the form will be set to the preferred language of the request.
-
-Be aware that changing the language of the the current `Http.Context` (e.g. via `Http.Context.current().changeLang(...)` or `Http.Context.current().setTransientLang(...)`) does not have an effect on the language used to retrieve the field value of a form anymore - as explained, use `form.withLang(...)` instead.
+> **Note:** changing the language of the the current `Http.Context` (e.g. via `Http.Context.current().changeLang(...)` or `Http.Context.current().setTransientLang(...)`) does not have an effect on the language used to retrieve the field value of a form anymore - as explained, use `form.withLang(...)` instead.
 
 ### `Http.Context` Request tags removed from `args`
 
-Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]] in Play 2.6, have finally been removed in Play 2.7.
-Therefore the `args` map of an `Http.Context` instance no longer contains these removed request tags as well.
-Instead you can use the `request.attrs()` method now, which provides you the same request attributes.
+Request tags, which [[have been deprecated|Migration26#Request-tags-deprecation]] in Play 2.6, have finally been removed in Play 2.7. Therefore the `args` map of an `Http.Context` instance no longer contains these removed request tags as well. Instead you can use the `request.attrs()` method now, which provides you the same request attributes.
 
 ### CSRF tokens removed from `args`
 
-The `@AddCSRFToken` action annotation added two entries named `CSRF_TOKEN` and `CSRF_TOKEN_NAME` to the `args` map of an `Http.Context` instance. These entries have been removed.
-Use [[the new correct way to get the token|JavaCsrf#Getting-the-current-token]].
+The `@AddCSRFToken` action annotation added two entries named `CSRF_TOKEN` and `CSRF_TOKEN_NAME` to the `args` map of an `Http.Context` instance. These entries have been removed. Use [[the new correct way to get the token|JavaCsrf#Getting-the-current-token]].
 
 ### RoutingDSL changes
 

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -17,77 +17,85 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.x")
 
 Where the "x" in `2.7.x` is the minor version of Play you want to use, for instance `2.7.0`.
 
-### sbt upgrade to 1.1.6
+### sbt upgrade to 1.2.6
 
 Although Play 2.7 still supports sbt 0.13 series, we recommend that you use sbt 1 from now. This new version is actively maintained and supported. To update, change your `project/build.properties` so that it reads:
 
 ```
-sbt.version=1.1.6
+sbt.version=1.2.6
 ```
 
-At the time of this writing `1.1.6` is the latest version in the sbt 1 family, you may be able to use newer versions too. Check for details in the release notes of your minor version of Play 2.7.x. More information at the list of [sbt releases](https://github.com/sbt/sbt/releases).
+At the time of this writing `1.2.6` is the latest version in the sbt 1 family, you may be able to use newer versions too. Check for details in the release notes of your minor version of Play 2.7.x. More information at the list of [sbt releases](https://github.com/sbt/sbt/releases).
 
-## Deprecated APIs were removed
+## API Changes
 
-Many deprecated APIs were removed in Play 2.7. If you are still using them, we recommend migrating to the new APIs before upgrading to Play 2.7. Both Javadocs and Scaladocs usually have proper documentation on how to migrate.
+Multiple APIs changes were made following our policy of deprecating the existing APIs before removing them. This section details these changes.
 
-## `play.allowGlobalApplication` defaults to `false`
+### Deprecated APIs were removed
 
-`play.allowGlobalApplication = false` is set by default in Play 2.7.0. This means `Play.current` will throw an exception when called. You can set this to `true` to make `Play.current` and other deprecated static helpers work again, but be aware that this feature will be removed in future versions.
+Many APIs that deprecated in earlier versions were removed in Play 2.7. If you are still using them, we recommend migrating to the new APIs before upgrading to Play 2.7. Both Javadocs and Scaladocs usually have proper documentation on how to migrate. See the [[migration guide for Play 2.6|Migration26]] for more information.
 
-In the future, if you still need to use static instances of application components, you can use [static injection](https://github.com/google/guice/wiki/Injections#static-injections) to inject them using Guice, or manually set static fields on startup in your application loader. These approaches should be forward compatible with future versions of Play, as long as you are careful never to run apps concurrently (e.g., in tests).
+### StaticRoutesGenerator removed
 
-Since `Play.current` is still called by some deprecated APIs, when using such APIs, you need to add the following line to your `application.conf` file:
-
-```hocon
-play.allowGlobalApplication = true
-```
-
-For example, when using `play.api.mvc.Action` object with embedded Play and [[Scala Sird Router|ScalaSirdRouter]], it access the global state:
+The `StaticRoutesGenerator`, which was deprecated in 2.6.0, has been removed. If you are still using it, you will likely have to remove a line like this from your `build.sbt` file:
 
 ```scala
-import play.api.mvc._
-import play.api.routing.sird._
-import play.core.server._
-
-// It can also be NettyServer
-val server = AkkaHttpServer.fromRouter() {
-  // `Action` in this case is the `Action` object which access global state
-  case GET(p"/") => Action {
-    Results.Ok(s"Hello World")
-  }
-}
+routesGenerator := StaticRoutesGenerator
 ```
 
-The example above either needs you to configure `play.allowGlobalApplication = true` as explained before, or to be rewritten to:
+### Java `Http.Context` changes
 
-```scala
-import play.api._
-import play.api.mvc._
-import play.api.routing.sird._
-import play.core.server._
+See changes made in `play.mvc.Http.Context` APIs. This is only relevant for Java users: [[Java `Http.Context` changes|JavaHttpContextMigration27]].
 
-// It can also be NettyServer
-val server = AkkaHttpServer.fromRouterWithComponents() { components: BuiltInComponents => {
-    case GET(p"/") => components.defaultActionBuilder {
-      Results.Ok(s"Hello World")
-    }
-  }
-}
+### Play WS API Changes
+
+In Play 2.6, we extracted most of Play-WS into a [standalone project](https://github.com/playframework/play-ws) that has an independent release cycle. Play-WS now has a significant release that requires some changes in Play itself.
+
+#### Scala API
+
+1. `play.api.libs.ws.WSRequest.requestTimeout` now returns an `Option[Duration]` instead of an `Option[Int]`.
+
+#### Java API:
+
+1. `play.libs.ws.WSRequest.getUsername` now returns an `Optional<String>` instead of a `String`.
+1. `play.libs.ws.WSRequest.getContentType` now returns an `Optional<String>` instead of a `String`.
+1. `play.libs.ws.WSRequest.getPassword` now returns an `Optional<String>` instead of a `String`.
+1. `play.libs.ws.WSRequest.getScheme` now returns an `Optional<WSScheme` instead of a `WSScheme`.
+1. `play.libs.ws.WSRequest.getCalculator` now returns an `Optional<WSSignatureCalculator>` instead of a `WSSignatureCalculator`.
+1. `play.libs.ws.WSRequest.getRequestTimeout` now returns an `Optional<Duration>` instead of a `long`.
+1. `play.libs.ws.WSRequest.getRequestTimeoutDuration` was removed in favor of using `play.libs.ws.WSRequest.getRequestTimeout`.
+1. `play.libs.ws.WSRequest.getFollowRedirects` now returns an `Optional<Boolean>` instead of a `boolean`.
+
+Some new methods were added to improve the Java API too:
+
+New method `play.libs.ws.WSResponse.getBodyAsSource` converts a response body into `Source<ByteString, ?>`. For example:
+
+```java
+wsClient.url("https://www.playframework.com")
+    .stream() // this returns a CompletionStage<StandaloneWSResponse>
+    .thenApply(StandaloneWSResponse::getBodyAsSource);
 ```
 
-## BodyParsers API consistency
+Other methods that were added to improve Java API:
+
+1. `play.libs.ws.WSRequest.getBody` returns the body configured for that request. It can be useful when implementing `play.libs.ws.WSRequestFilter`
+1. `play.libs.ws.WSRequest.getMethod` returns the method configured for that request.
+1. `play.libs.ws.WSRequest.getAuth` returns the `WSAuth`.
+1. `play.libs.ws.WSRequest.setAuth` sets the `WSAuth` for that request.
+1. `play.libs.ws.WSResponse.getUri` gets the `URI` for that response.
+
+### BodyParsers API consistency
 
 The API for body parser was mixing `Integer` and `Long` to define buffer lengths which could lead to overflow of values. The configuration is now uniformed to use `Long`. It means that if you are depending on `play.api.mvc.PlayBodyParsers.DefaultMaxTextLength` for example, you then need to use a `Long`. As such, `play.api.http.ParserConfiguration.maxMemoryBuffer` is now a `Long` too.
 
-## Guice compatibility changes
+### Guice compatibility changes
 
 Guice was upgraded to version [4.2.2](https://github.com/google/guice/wiki/Guice422) (also see [4.2.1](https://github.com/google/guice/wiki/Guice421) and [4.2.0 release notes](https://github.com/google/guice/wiki/Guice42)), which causes the following breaking changes:
 
  - `play.test.TestBrowser.waitUntil` expects a `java.util.function.Function` instead of a `com.google.common.base.Function` now.
  - In Scala, when overriding the `configure()` method of `AbstractModule`, you need to prefix that method with the `override` identifier now (because it's non-abstract now).
 
-## Static `Logger` singletons deprecated
+### Static `Logger` singletons deprecated
 
 Most `static` methods of the Java `play.Logger` and almost all methods of the Scala `play.api.Logger` singleton object have been deprecated. These singletons wrote to the `application` logger, which is referenced in `logback.xml` as:
 
@@ -142,113 +150,11 @@ If you'd like a more concise solution when using SLF4J directly for Java, you ma
 
 Once you have migrated away from using the `application` logger, you can remove the `logger` entry in your `logback.xml` referencing it:
 
-    <logger name="application" level="DEBUG" />
-
-## Evolutions comment syntax changes
-
-Play Evolutions now correctly supports SQL92 comment syntax. This means you can write evolutions using `--` at the beginning of a line instead of `#` wherever you choose. Newly generated evolutions using the Evolutions API will now also use SQL92-style comment syntax in all areas. Documentation has also been updated accordingly to prefer the SQL92 style, though the older comment style is still fully supported.
-
-## StaticRoutesGenerator removed
-
-The `StaticRoutesGenerator`, which was deprecated in 2.6.0, has been removed. If you are still using it, you will likely have to remove a line like this, so your build compiles:
-
-```scala
-routesGenerator := StaticRoutesGenerator
+```xml
+<logger name="application" level="DEBUG" />
 ```
 
-Then you should migrate your static controllers to use classes with instance methods.
-
-If you were using the `StaticRoutesGenerator` with dependency-injected controllers, you likely want to remove the `@` prefix from the controller names. The `@` is only needed if you wish to have a new controller instance created on each request using a `Provider`, instead of having a single instance injected into the router.
-
-
-### `application/javascript` as default content type for JavaScript
-
-`application/javascript` is now the default content-type returned for JavaScript instead of `text/javascript`. For generated `<script>` tags, we are now also omitting the `type` attribute. See more details about omitting `type` attribute at the [HTML 5 specification](https://www.w3.org/TR/html51/semantics-scripting.html#element-attrdef-script-type).  
-
-## `Router#withPrefix` should always add a prefix
-
-Previously, `router.withPrefix(prefix)` was meant to add a prefix to a router, but still allowed "legacy implementations" to update their existing prefix. Play's `SimpleRouter` and other classes followed this behavior. Now all implementations have been updated to add the prefix, so `router.withPrefix(prefix)` should always return a router that routes `s"$prefix/$path"` the same way `router` routes `path`.
-
-By default, routers are unprefixed, so this will only cause a change in behavior if you are calling `withPrefix` on a router that has already been returned by `withPrefix`. To replace a prefix that has already been set on a router, you must call `withPrefix` on the original unprefixed router rather than the prefixed version.
-
-## Play WS Updates
-
-In Play 2.6, we extracted most of Play-WS into a [standalone project](https://github.com/playframework/play-ws) that has an independent release cycle. Play-WS now has a significant release that requires some changes in Play itself.
-
-## Run Hooks
-
-`RunHook.afterStarted()` no longer takes an `InetSocketAddress` as a parameter.
-
-### Scala API
-
-1. `play.api.libs.ws.WSRequest.requestTimeout` now returns an `Option[Duration]` instead of an `Option[Int]`.
-
-### Java API:
-
-1. `play.libs.ws.WSRequest.getUsername` now returns an `Optional<String>` instead of a `String`.
-1. `play.libs.ws.WSRequest.getContentType` now returns an `Optional<String>` instead of a `String`.
-1. `play.libs.ws.WSRequest.getPassword` now returns an `Optional<String>` instead of a `String`.
-1. `play.libs.ws.WSRequest.getScheme` now returns an `Optional<WSScheme` instead of a `WSScheme`.
-1. `play.libs.ws.WSRequest.getCalculator` now returns an `Optional<WSSignatureCalculator>` instead of a `WSSignatureCalculator`.
-1. `play.libs.ws.WSRequest.getRequestTimeout` now returns an `Optional<Duration>` instead of a `long`.
-1. `play.libs.ws.WSRequest.getRequestTimeoutDuration` was removed in favor of using `play.libs.ws.WSRequest.getRequestTimeout`.
-1. `play.libs.ws.WSRequest.getFollowRedirects` now returns an `Optional<Boolean>` instead of a `boolean`.
-
-Some new methods were added to improve the Java API too:
-
-New method `play.libs.ws.WSResponse.getBodyAsSource` converts a response body into `Source<ByteString, ?>`. For example:
-
-```java
-wsClient.url("https://www.playframework.com")
-    .stream() // this returns a CompletionStage<StandaloneWSResponse>
-    .thenApply(StandaloneWSResponse::getBodyAsSource);
-```
-
-Other methods that were added to improve Java API:
-
-1. `play.libs.ws.WSRequest.getBody` returns the body configured for that request. It can be useful when implementing `play.libs.ws.WSRequestFilter`
-1. `play.libs.ws.WSRequest.getMethod` returns the method configured for that request.
-1. `play.libs.ws.WSRequest.getAuth` returns the `WSAuth`.
-1. `play.libs.ws.WSRequest.setAuth` sets the `WSAuth` for that request.
-1. `play.libs.ws.WSResponse.getUri` gets the `URI` for that response. 
-
-## HikariCP update and new configuration
-
-HikariCP was updated to the latest version which finally removed the configuration `initializationFailFast`, replaced by `initializationFailTimeout`. See [HikariCP changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) and [documentation for `initializationFailTimeout`](https://github.com/brettwooldridge/HikariCP#infrequently-used) to better understand how to use this configuration.
-
-### HikariCP will not fail fast
-
-Play 2.7 changes the default value for HikariCP's `initializationFailTimeout` to `-1`. That means your application will start even if the database is not available. You can revert to the old behavior by configuring `initializationFailTimeout` to `1` which will make the pool to fail fast.
-
-If the application is using database [[Evolutions]], then a connection is requested at application startup to verify if there are new evolutions to apply. So this will make the startup fail if the database is not available since a connection is being required. The timeout then will be defined by `connectionTimeout` (default to 30 seconds).
-
-See more details at [[SettingsJDBC]].
-
-## BoneCP removed
-
-BoneCP is removed. If your application is configured to use BoneCP, you need to switch to [HikariCP](http://brettwooldridge.github.io/HikariCP/) which is the default JDBC connection pool.
-
-```
-play.db.pool = "default"  # Use the default connection pool provided by the platform (HikariCP)
-play.db.pool = "hikaricp" # Use HikariCP
-
-```
-
-You may need to reconfigure the pool to use HikariCP. For example, if you want to configure the maximum number of connections for HikariCP, it would be as follows.
-
-```
-play.db.prototype.hikaricp.maximumPoolSize = 15
-```
-
-For more details, see [[JDBC configuration section|SettingsJDBC]].
-
-Also, you can use your own pool that implements `play.api.db.ConnectionPool` by specifying the fully-qualified class name.
-
-```
-play.db.pool=your.own.ConnectionPool
-```
-
-## Application Loader API changes
+### Application Loader API changes
 
 If you are using a custom `ApplicationLoader` there is a chance you are manually creating instances of this loader when running the tests. To do that, you first need to create an instance of `ApplicationLoader.Context`, for example:
 
@@ -274,7 +180,7 @@ val loader = new GreetingApplicationLoader()
 val application = loader.load(context)
 ```
 
-## JPA removals and deprecations
+### JPA removals and deprecations
 
 The class `play.db.jpa.JPA`, which has been deprecated in Play 2.6 already, has finally been removed. Have a look at the [[Play 2.6 JPA Migration notes|JPAMigration26]] if you haven't yet.
 
@@ -288,25 +194,31 @@ With this Play release even more JPA related methods and annotations have been d
 
 Like already mentioned in the Play 2.6 JPA migration notes, please use a `JPAApi` injected instance as described in [[Using play.db.jpa.JPAApi|JavaJPA#Using-play.db.jpa.JPAApi]] instead of these deprecated methods and annotations.
 
-## Java `Http.Context` changes
+### `Router#withPrefix` should always add a prefix
 
-See changes made in `play.mvc.Http.Context` APIs. This is only relevant for Java users: [[Java `Http.Context` changes|JavaHttpContextMigration27]].
+Previously, `router.withPrefix(prefix)` was meant to add a prefix to a router, but still allowed "legacy implementations" to update their existing prefix. Play's `SimpleRouter` and other classes followed this behavior. Now all implementations have been updated to add the prefix, so `router.withPrefix(prefix)` should always return a router that routes `s"$prefix/$path"` the same way `router` routes `path`.
 
-## All Java form `validate` methods need to be migrated to class-level constraints
+By default, routers are unprefixed, so this will only cause a change in behavior if you are calling `withPrefix` on a router that has already been returned by `withPrefix`. To replace a prefix that has already been set on a router, you must call `withPrefix` on the original unprefixed router rather than the prefixed version.
+
+### Run Hooks
+
+`RunHook.afterStarted()` no longer takes an `InetSocketAddress` as a parameter.
+
+### All Java form `validate` methods need to be migrated to class-level constraints
 
 The "old" `validate` methods of a Java form will not be executed anymore.
 Like announced in the [[Play 2.6 Migration Guide|Migration26#Java-Form-Changes]] you have to migrate such `validate` methods to [[class-level constraints|JavaForms#advanced-validation]].
 
 > **Important**: When upgrading to Play 2.7 you will not see any compiler warnings indicating that you have to migrate your `validate` methods (because Play executed them via reflection).
 
-## Java `Form`, `DynamicForm` and `FormFactory` constructors changed
+### Java `Form`, `DynamicForm` and `FormFactory` constructors changed
 
 Constructors of the `Form`, `DynamicForm` and `FormFactory` classes (inside `play.data`) that were using a [`Validator`](https://docs.jboss.org/hibernate/stable/beanvalidation/api/javax/validation/Validator.html) param use a [`ValidatorFactory`](https://docs.jboss.org/hibernate/stable/beanvalidation/api/javax/validation/ValidatorFactory.html) param instead now.
 In addition to that, these constructors now also need a [`com.typesafe.config.Config`](https://lightbend.github.io/config/latest/api/com/typesafe/config/Config.html) param.
 E.g. `new Form(..., validator)` becomes `new Form(..., validatorFactory, config)` now.
 This change only effects you if you use the constructors to instantiate a form instead of just using `formFactory.form(SomeForm.class)` - most likely in tests.
 
-## The Java Cache API `get` method has been deprecated in favor of `getOptional`
+### The Java Cache API `get` method has been deprecated in favor of `getOptional`
 
 The `getOptional` methods of the Java `cacheApi` return their results wrapped in an `Optional`.
 
@@ -322,46 +234,12 @@ Changes in `play.cache.AsyncCacheApi`:
 |------------------------------------------|----------------------------------------------------
 | `<T> CompletionStage<T> get(String key)` | `<T> CompletionStage<Optional<T>> getOptional(String key)`
 
-## SecurityHeadersFilter's contentSecurityPolicy deprecated for CSPFilter
 
-The [[SecurityHeaders filter|SecurityHeaders]] has a `contentSecurityPolicy` property: this is deprecated in 2.7.0.  `contentSecurityPolicy` has been changed from `default-src 'self'` to `null` -- the default setting of `null` means that a `Content-Security-Policy` header will not be added to HTTP responses from the SecurityHeaders filter.  Please use the new [[CSPFilter|CspFilter]] to enable CSP functionality.
+### `Server.getHandlerFor` has moved to `Server#getHandlerFor`
 
-If `play.filters.headers.contentSecurityPolicy` is not `null`, you will receive a warning.  It is technically possible to have `contentSecurityPolicy` and the new `CSPFilter` active at the same time, but this is not recommended.
+The `getHandlerFor` method on the `Server` trait was used internally by the Play server code when routing requests. It has been removed and replaced with a method of the same name on the `Server` object.
 
-You can enable the new `CSPFilter` by adding it to the `play.filters.enabled` property:
-
-```hocon
-play.filters.enabled += play.filters.csp.CSPFilter
-```
-
-> **NOTE**: You will want to review the Content Security Policy closely to ensure it meets your needs.  The new `CSPFilter` is notably more permissive than `default-src ‘self’`, and is based off the Google Strict CSP configuration.  You can use the `report-only` functionality with a [[CSP report controller|CspFilter#Configuring-CSP-Report-Only]] to review policy violations.
-
-Please see the documentation in [[CSPFilter|CspFilter]] for more information.
-
-## SameSite attribute for CSRF and language cookie
-
-With Play 2.6 the `SameSite` cookie attribute [[was enabled|Migration26#SameSite-attribute,-enabled-for-session-and-flash]] for session and flash by default.
-The same is true for the CSRF and the language cookie starting with Play 2.7. By default, the `SameSite` attribute of the CSRF cookie will have the same value like the session cookie has and the language cookie will use `SameSite=Lax` by default.
-You can tweak this using configuration. For example:
-
-```
-play.filters.csrf.cookie.sameSite = null // no same-site for csrf cookie
-play.i18n.langCookieSameSite = "strict" // strict same-site for language cookie
-```
-
-## play.mvc.Results.TODO moved to play.mvc.Controller.TODO
-
-All Play's error pages have been updated to render a CSP nonce if the [[CSPFilter|CspFilter]] is present.  This means that the error page templates must take a request as a parameter.  In 2.6.x, the `TODO` field was previously rendered as a static result instead of an action with an HTTP context, and so may have been called outside the controller.  In 2.7.0, the `TODO` field has been removed, and there is now a `TODO(Http.Request request)` method in `play.mvc.Controller` instead:
-
-```java
-public abstract class Controller extends Results implements Status, HeaderNames {
-    public static Result TODO(play.mvc.Http.Request request) {
-        return status(NOT_IMPLEMENTED, views.html.defaultpages.todo.render(request.asScala()));
-    }
-}
-```
-
-## Java DI-agnostic Play `Module` API support added and all built-in Java `Module`s type changed
+### Java DI-agnostic Play `Module` API support added and all built-in Java `Module`s type changed
 
 You can now create DI-agnostic Play `Module` with Java by extending `play.inject.Module`, which is more Java friendly as it is using Java APIs and coded in Java as well. Besides, all the existing built-in Java `Module`s, for example, `play.inject.BuiltInModule` and `play.libs.ws.ahc.AhcWSModule`, are no longer extending Scala `play.api.inject.Module` but Java `play.inject.Module`.
 
@@ -379,61 +257,80 @@ public class MyModule extends play.inject.Module {
 }
 ```
 
-## Removed libraries
+### play.mvc.Results.TODO moved to play.mvc.Controller.TODO
 
-To make the default play distribution a bit smaller we removed some libraries. The following libraries are no longer dependencies in Play 2.7, so you will need to add them manually to your build if you use them.
+All Play's error pages have been updated to render a CSP nonce if the [[CSPFilter|CspFilter]] is present.  This means that the error page templates must take a request as a parameter.  In 2.6.x, the `TODO` field was previously rendered as a static result instead of an action with an HTTP context, and so may have been called outside the controller.  In 2.7.0, the `TODO` field has been removed, and there is now a `TODO(Http.Request request)` method in `play.mvc.Controller` instead:
 
-### Apache Commons (`commons-lang3` and `commons-codec`)
-
-Play had some internal uses of `commons-codec` and `commons-lang3` if you used it in your project you need to add it to your `build.sbt`:
-
-```scala
-libraryDependencies += "commons-codec" % "commons-codec" % "1.10"
+```java
+public abstract class Controller extends Results implements Status, HeaderNames {
+    public static Result TODO(play.mvc.Http.Request request) {
+        return status(NOT_IMPLEMENTED, views.html.defaultpages.todo.render(request.asScala()));
+    }
+}
 ```
 
-or:
-
-```scala
-libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.6"
-```
-
-## Other libraries updates
-
-This section lists significant updates made to our dependencies.
-
-### `Guava` version updated to 27.0-jre
-
-Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 27.0-jre. Lots of changes were made in the library, and you can see the full changelog [here](https://github.com/google/guava/releases).
-
-### specs2 updated to 4.2.0
-
-The previous version was `3.8.x`. There are many changes and improvements, so we recommend that you read [the release notes](https://github.com/etorreborre/specs2/releases) for the recent versions of Specs2. The used version updated the [Mockito](https://site.mockito.org/) version used to `2.18.x`, so we also have updated it.
-
-### Jackson updated to 2.9
-
-Jackson version was updated from 2.8 to 2.9. The release notes for this version are [here](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9). It is a release that keeps compatibility, so your application should not be affected. But you may be interested in the new features.
-
-### Hibernate Validator updated to 6.0
-
-[Hibernate Validator](http://hibernate.org/validator/) was updated to version 6.0 which is now compatible with [Bean Validation](https://beanvalidation.org/) 2.0. See what is new [here](http://hibernate.org/validator/releases/6.0/#whats-new) or read [this detailed blog post](http://in.relation.to/2017/08/07/and-here-comes-hibernate-validator-60/) about the new version.
-
-> **Note**: Keep in mind that this version may not be fully compatible with other Hibernate dependencies you may have in your project. For example, if you are using [hibernate-jpamodelgen](https://mvnrepository.com/artifact/org.hibernate/hibernate-jpamodelgen) it is required that you use the latest version to ensure everything will work together:
->
-> ```scala
-> libraryDependencies += "org.hibernate" % "hibernate-jpamodelgen" % "5.3.6.Final" % "provided"
-> ```
-
-## Internal changes
+### Internal changes
 
 Many changes have been made to Play's internal APIs. These APIs are used internally and don't follow a normal deprecation process. Changes may be mentioned below to help those who integrate directly with Play internal APIs.
 
-### `Server.getHandlerFor` has moved to `Server#getHandlerFor`
+## Configuration changes
 
-The `getHandlerFor` method on the `Server` trait was used internally by the Play server code when routing requests. It has been removed and replaced with a method of the same name on the `Server` object.
+### `play.allowGlobalApplication` defaults to `false`
 
-## CoordinatedShutdown `play.akka.run-cs-from-phase` configuration
+`play.allowGlobalApplication = false` is set by default in Play 2.7.0. This means `Play.current` will throw an exception when called. You can set this to `true` to make `Play.current` and other deprecated static helpers work again, but be aware that this feature will be removed in future versions.
 
-The configuration `akka.coordinated-shutdown.exit-jvm` is not supported anymore. When that setting is enabled Play will not start, and an error will be logged. Play ships with default values for `akka.coordinated-shutdown.*` which should be suitable for most scenarios so it's unlikely you'll need to override them. 
+In the future, if you still need to use static instances of application components, you can use [static injection](https://github.com/google/guice/wiki/Injections#static-injections) to inject them using Guice, or manually set static fields on startup in your application loader. These approaches should be forward compatible with future versions of Play, as long as you are careful never to run apps concurrently (e.g., in tests).
+
+Since `Play.current` is still called by some deprecated APIs, when using such APIs, you need to add the following line to your `application.conf` file:
+
+```hocon
+play.allowGlobalApplication = true
+```
+
+For example, when using `play.api.mvc.Action` object with embedded Play and [[Scala Sird Router|ScalaSirdRouter]], it access the global state:
+
+```scala
+import play.api.mvc._
+import play.api.routing.sird._
+import play.core.server._
+
+// It can also be NettyServer
+val server = AkkaHttpServer.fromRouter() {
+  // `Action` in this case is the `Action` object which access global state
+  case GET(p"/") => Action {
+    Results.Ok(s"Hello World")
+  }
+}
+```
+
+The example above either needs you to configure `play.allowGlobalApplication = true` as explained before, or to be rewritten to:
+
+```scala
+import play.api._
+import play.api.mvc._
+import play.api.routing.sird._
+import play.core.server._
+
+// It can also be NettyServer
+val server = AkkaHttpServer.fromRouterWithComponents() { components: BuiltInComponents => {
+    case GET(p"/") => components.defaultActionBuilder {
+      Results.Ok(s"Hello World")
+    }
+  }
+}
+```
+
+### HikariCP will not fail fast
+
+Play 2.7 changes the default value for HikariCP's `initializationFailTimeout` to `-1`. That means your application will start even if the database is not available. You can revert to the old behavior by configuring `initializationFailTimeout` to `1` which will make the pool to fail fast.
+
+If the application is using database [[Evolutions]], then a connection is requested at application startup to verify if there are new evolutions to apply. So this will make the startup fail if the database is not available since a connection is being required. The timeout then will be defined by `connectionTimeout` (default to 30 seconds).
+
+See more details at [[SettingsJDBC]].
+
+### CoordinatedShutdown `play.akka.run-cs-from-phase` configuration
+
+The configuration `akka.coordinated-shutdown.exit-jvm` is not supported anymore. When that setting is enabled Play will not start, and an error will be logged. Play ships with default values for `akka.coordinated-shutdown.*` which should be suitable for most scenarios so it's unlikely you'll need to override them.
 
 The configuration `play.akka.run-cs-from-phase` is not supported anymore and adding it does not affect the application shutdown. A warning is logged if it is present. Play now runs all the phases to ensure that all hooks registered in `ApplicationLifecycle` and all the tasks added to coordinated shutdown are executed. If you need to run `CoordinatedShutdown` from a specific phase, you can always do it manually:
 
@@ -487,18 +384,136 @@ class Shutdown {
 }
 ```
 
-## Change in self-signed HTTPS certificate
-
-It is now generated under `target/dev-mode/generated.keystore` instead of directly on the root folder.
-
-## Application Secret is checked for minimum length
+### Application Secret is checked for minimum length
 
 The [[application secret|ApplicationSecret]] configuration `play.http.secret.key` is checked for a minimum length in production.  If the key is fifteen characters or fewer, a warning will be logged.  If the key is eight characters or fewer, then an error is thrown and the configuration is invalid.  You can resolve this error by setting the secret to at least 32 bytes of completely random input, such as `head -c 32 /dev/urandom | base64` or by the application secret generator, using `playGenerateSecret` or `playUpdateSecret`.
 
 The [[application secret|ApplicationSecret]] is used as the key for ensuring that a Play session cookie is valid, i.e. has been generated by the server as opposed to spoofed by an attacker.  However, the secret only specifies a string, and does not determine the amount of entropy in that string.  Anyhow, it is possible to put an upper bound on the amount of entropy in the secret simply by measuring how short it is: if the secret is eight characters long, that is at most 64 bits of entropy, which is insufficient by modern standards.
 
-## Change in default character set on "text/plain" Content Types
+### `play.filters.headers.contentSecurityPolicy` deprecated for CSPFilter
 
-The Text and Tolerant Text body parsers now use "US-ASCII" as the default charset, replacing the previous default of `ISO-8859-1`.
+The [[SecurityHeaders filter|SecurityHeaders]] has a `contentSecurityPolicy` property: this is deprecated in 2.7.0.  `contentSecurityPolicy` has been changed from `default-src 'self'` to `null` -- the default setting of `null` means that a `Content-Security-Policy` header will not be added to HTTP responses from the SecurityHeaders filter.  Please use the new [[CSPFilter|CspFilter]] to enable CSP functionality.
+
+If `play.filters.headers.contentSecurityPolicy` is not `null`, you will receive a warning.  It is technically possible to have `contentSecurityPolicy` and the new `CSPFilter` active at the same time, but this is not recommended.
+
+You can enable the new `CSPFilter` by adding it to the `play.filters.enabled` property:
+
+```hocon
+play.filters.enabled += play.filters.csp.CSPFilter
+```
+
+> **NOTE**: You will want to review the Content Security Policy closely to ensure it meets your needs.  The new `CSPFilter` is notably more permissive than `default-src ‘self’`, and is based off the Google Strict CSP configuration.  You can use the `report-only` functionality with a [[CSP report controller|CspFilter#Configuring-CSP-Report-Only]] to review policy violations.
+
+Please see the documentation in [[CSPFilter|CspFilter]] for more information.
+
+### SameSite attribute for CSRF and language cookie
+
+With Play 2.6 the `SameSite` cookie attribute [[was enabled|Migration26#SameSite-attribute,-enabled-for-session-and-flash]] for session and flash by default.
+The same is true for the CSRF and the language cookie starting with Play 2.7. By default, the `SameSite` attribute of the CSRF cookie will have the same value like the session cookie has and the language cookie will use `SameSite=Lax` by default.
+You can tweak this using configuration. For example:
+
+```
+play.filters.csrf.cookie.sameSite = null // no same-site for csrf cookie
+play.i18n.langCookieSameSite = "strict" // strict same-site for language cookie
+```
+
+## Defaults changes
+
+Some of the default values used by Play had changed and that can have an impact on your application. This section details the default changes.
+
+### `application/javascript` as default content type for JavaScript
+
+`application/javascript` is now the default content-type returned for JavaScript instead of `text/javascript`. For generated `<script>` tags, we are now also omitting the `type` attribute. See more details about omitting `type` attribute at the [HTML 5 specification](https://www.w3.org/TR/html51/semantics-scripting.html#element-attrdef-script-type).
+
+### Change in self-signed HTTPS certificate
+
+It is now generated under `target/dev-mode/generated.keystore` instead of directly on the root folder.
+
+### Change in default character set on `text/plain` Content Types
+
+The Text and Tolerant Text body parsers now use `US-ASCII` as the default charset, replacing the previous default of `ISO-8859-1`.
 
 This is because of some newer HTTP standards, specifically [RFC 7231, appendix B](https://tools.ietf.org/html/rfc7231#appendix-B), which states "The default charset of ISO-8859-1 for text media types has been removed; the default is now whatever the media type definition says."  The `text/plain` media type definition is defined by [RFC 6657, section 4](https://tools.ietf.org/html/rfc6657#section-4), which specifies US-ASCII.  The Text and Tolerant Text Body parsers use `text/plain` as the content type, so now default appropriately.
+
+
+## Updated libraries
+
+This section lists significant updates made to our dependencies.
+
+### HikariCP update
+
+HikariCP was updated to the latest version which finally removed the configuration `initializationFailFast`, replaced by `initializationFailTimeout`. See [HikariCP changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) and [documentation for `initializationFailTimeout`](https://github.com/brettwooldridge/HikariCP#infrequently-used) to better understand how to use this configuration.
+
+### `Guava` version updated to 27.0-jre
+
+Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 27.0-jre. Lots of changes were made in the library, and you can see the full changelog [here](https://github.com/google/guava/releases).
+
+### specs2 updated to 4.3.5
+
+The previous version was `3.8.x`. There are many changes and improvements, so we recommend that you read [the release notes](https://github.com/etorreborre/specs2/releases) for the recent versions of Specs2. The used version updated the [Mockito](https://site.mockito.org/) version used to `2.18.x`, so we also have updated it.
+
+### Jackson updated to 2.9
+
+Jackson version was updated from 2.8 to 2.9. The release notes for this version are [here](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9). It is a release that keeps compatibility, so your application should not be affected. But you may be interested in the new features.
+
+### Hibernate Validator updated to 6.0
+
+[Hibernate Validator](http://hibernate.org/validator/) was updated to version 6.0 which is now compatible with [Bean Validation](https://beanvalidation.org/) 2.0. See what is new [here](http://hibernate.org/validator/releases/6.0/#whats-new) or read [this detailed blog post](http://in.relation.to/2017/08/07/and-here-comes-hibernate-validator-60/) about the new version.
+
+> **Note**: Keep in mind that this version may not be fully compatible with other Hibernate dependencies you may have in your project. For example, if you are using [hibernate-jpamodelgen](https://mvnrepository.com/artifact/org.hibernate/hibernate-jpamodelgen) it is required that you use the latest version to ensure everything will work together:
+>
+> ```scala
+> // Visit https://mvnrepository.com/artifact/org.hibernate/hibernate-jpamodelgen to see the list of versions available
+> libraryDependencies += "org.hibernate" % "hibernate-jpamodelgen" % "5.3.7.Final" % "provided"
+> ```
+
+## Removed libraries
+
+To make the default play distribution a bit smaller we removed some libraries. The following libraries are no longer dependencies in Play 2.7, so you will need to add them manually to your build if you use them.
+
+### BoneCP removed
+
+BoneCP is removed. If your application is configured to use BoneCP, you need to switch to [HikariCP](http://brettwooldridge.github.io/HikariCP/) which is the default JDBC connection pool.
+
+```
+play.db.pool = "default"  # Use the default connection pool provided by the platform (HikariCP)
+play.db.pool = "hikaricp" # Use HikariCP
+
+```
+
+You may need to reconfigure the pool to use HikariCP. For example, if you want to configure the maximum number of connections for HikariCP, it would be as follows.
+
+```
+play.db.prototype.hikaricp.maximumPoolSize = 15
+```
+
+For more details, see [[JDBC configuration section|SettingsJDBC]].
+
+Also, you can use your own pool that implements `play.api.db.ConnectionPool` by specifying the fully-qualified class name.
+
+```
+play.db.pool=your.own.ConnectionPool
+```
+
+### Apache Commons (`commons-lang3` and `commons-codec`)
+
+Play had some internal uses of `commons-codec` and `commons-lang3` if you used it in your project you need to add it to your `build.sbt`:
+
+```scala
+// Visit https://mvnrepository.com/artifact/commons-codec/commons-codec to see the list of versions available
+libraryDependencies += "commons-codec" % "commons-codec" % "1.11"
+```
+
+And for commons-lang3:
+
+```scala
+// Visit https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 to see the list of versions available
+libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.8.1"
+
+```
+
+## Other important changes
+
+### Evolutions comment syntax
+
+Play Evolutions now correctly supports SQL92 comment syntax. This means you can write evolutions using `--` at the beginning of a line instead of `#` wherever you choose. Newly generated evolutions using the Evolutions API will now also use SQL92-style comment syntax in all areas. Documentation has also been updated accordingly to prefer the SQL92 style, though the older comment style is still fully supported.

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play 2.7 Migration Guide
 
 This is a guide for migrating from Play 2.6 to Play 2.7. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.6 Migration Guide|Migration26]].
@@ -21,7 +22,7 @@ Where the "x" in `2.7.x` is the minor version of Play you want to use, for insta
 
 Although Play 2.7 still supports sbt 0.13 series, we recommend that you use sbt 1 from now. This new version is actively maintained and supported. To update, change your `project/build.properties` so that it reads:
 
-```
+```properties
 sbt.version=1.2.6
 ```
 
@@ -55,7 +56,7 @@ In Play 2.6, we extracted most of Play-WS into a [standalone project](https://gi
 
 1. `play.api.libs.ws.WSRequest.requestTimeout` now returns an `Option[Duration]` instead of an `Option[Int]`.
 
-#### Java API:
+#### Java API
 
 1. `play.libs.ws.WSRequest.getUsername` now returns an `Optional<String>` instead of a `String`.
 1. `play.libs.ws.WSRequest.getContentType` now returns an `Optional<String>` instead of a `String`.
@@ -146,7 +147,7 @@ private val logger = LoggerFactory.getLogger(YourClass.class);
 
 If you'd like a more concise solution when using SLF4J directly for Java, you may also consider [Project Lombok's `@Slf4j` annotation](https://projectlombok.org/features/log).
 
-> **NOTE**: `org.slf4j.Logger`, the logging interface of SLF4J, does [not yet](https://jira.qos.ch/browse/SLF4J-371) provide logging methods which accept lambda expression as parameters for lazy evaluation. `play.Logger` and `play.api.Logger`, which are mostly simple wrappers for `org.slf4j.Logger`, provide such methods however.
+> **Note**: `org.slf4j.Logger`, the logging interface of SLF4J, does [not yet](https://jira.qos.ch/browse/SLF4J-371) provide logging methods which accept lambda expression as parameters for lazy evaluation. `play.Logger` and `play.api.Logger`, which are mostly simple wrappers for `org.slf4j.Logger`, provide such methods however.
 
 Once you have migrated away from using the `application` logger, you can remove the `logger` entry in your `logback.xml` referencing it:
 
@@ -186,11 +187,11 @@ The class `play.db.jpa.JPA`, which has been deprecated in Play 2.6 already, has 
 
 With this Play release even more JPA related methods and annotations have been deprecated:
 
-* `@play.db.jpa.Transactional`
-* `play.db.jpa.JPAApi.em()`
-* `play.db.jpa.JPAApi.withTransaction(final Runnable block)`
-* `play.db.jpa.JPAApi.withTransaction(Supplier<T> block)`
-* `play.db.jpa.JPAApi.withTransaction(String name, boolean readOnly, Supplier<T> block)`
+- `@play.db.jpa.Transactional`
+- `play.db.jpa.JPAApi.em()`
+- `play.db.jpa.JPAApi.withTransaction(final Runnable block)`
+- `play.db.jpa.JPAApi.withTransaction(Supplier<T> block)`
+- `play.db.jpa.JPAApi.withTransaction(String name, boolean readOnly, Supplier<T> block)`
 
 Like already mentioned in the Play 2.6 JPA migration notes, please use a `JPAApi` injected instance as described in [[Using play.db.jpa.JPAApi|JavaJPA#Using-play.db.jpa.JPAApi]] instead of these deprecated methods and annotations.
 
@@ -402,7 +403,7 @@ You can enable the new `CSPFilter` by adding it to the `play.filters.enabled` pr
 play.filters.enabled += play.filters.csp.CSPFilter
 ```
 
-> **NOTE**: You will want to review the Content Security Policy closely to ensure it meets your needs.  The new `CSPFilter` is notably more permissive than `default-src ‘self’`, and is based off the Google Strict CSP configuration.  You can use the `report-only` functionality with a [[CSP report controller|CspFilter#Configuring-CSP-Report-Only]] to review policy violations.
+> **Note**: You will want to review the Content Security Policy closely to ensure it meets your needs.  The new `CSPFilter` is notably more permissive than `default-src ‘self’`, and is based off the Google Strict CSP configuration.  You can use the `report-only` functionality with a [[CSP report controller|CspFilter#Configuring-CSP-Report-Only]] to review policy violations.
 
 Please see the documentation in [[CSPFilter|CspFilter]] for more information.
 
@@ -412,7 +413,7 @@ With Play 2.6 the `SameSite` cookie attribute [[was enabled|Migration26#SameSite
 The same is true for the CSRF and the language cookie starting with Play 2.7. By default, the `SameSite` attribute of the CSRF cookie will have the same value like the session cookie has and the language cookie will use `SameSite=Lax` by default.
 You can tweak this using configuration. For example:
 
-```
+```hocon
 play.filters.csrf.cookie.sameSite = null // no same-site for csrf cookie
 play.i18n.langCookieSameSite = "strict" // strict same-site for language cookie
 ```
@@ -475,7 +476,7 @@ To make the default play distribution a bit smaller we removed some libraries. T
 
 BoneCP is removed. If your application is configured to use BoneCP, you need to switch to [HikariCP](http://brettwooldridge.github.io/HikariCP/) which is the default JDBC connection pool.
 
-```
+```hocon
 play.db.pool = "default"  # Use the default connection pool provided by the platform (HikariCP)
 play.db.pool = "hikaricp" # Use HikariCP
 
@@ -483,7 +484,7 @@ play.db.pool = "hikaricp" # Use HikariCP
 
 You may need to reconfigure the pool to use HikariCP. For example, if you want to configure the maximum number of connections for HikariCP, it would be as follows.
 
-```
+```hocon
 play.db.prototype.hikaricp.maximumPoolSize = 15
 ```
 
@@ -491,7 +492,7 @@ For more details, see [[JDBC configuration section|SettingsJDBC]].
 
 Also, you can use your own pool that implements `play.api.db.ConnectionPool` by specifying the fully-qualified class name.
 
-```
+```hocon
 play.db.pool=your.own.ConnectionPool
 ```
 

--- a/documentation/manual/releases/release27/migration27/index.toc
+++ b/documentation/manual/releases/release27/migration27/index.toc
@@ -1,2 +1,2 @@
 Migration27:Migration Guide
-JavaHttpContextMigration27: Java `Http.Context` changes
+JavaHttpContextMigration27: Java Http.Context changes

--- a/framework/src/run-support/src/main/scala/play/runsupport/RunHook.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/RunHook.scala
@@ -4,7 +4,6 @@
 
 package play.runsupport
 
-import java.net.InetSocketAddress
 import scala.collection.mutable.LinkedHashMap
 import scala.util.control.NonFatal
 


### PR DESCRIPTION
## Purpose

The major sections for the migration guide are now:

- How to migrate
- API Changes
- Configuration changes
- Defaults changes
- Updated libraries
- Removed libraries
- Other important changes

This better groups sections that are related but weren't close to each other. It also adds complete code samples for the Http.Context migration guide and do some formatting changes there.

_review using [?w=1](https://github.com/playframework/playframework/pull/8843/files?w=1)_.