### PR TITLE
Avoid publishing microbenchmarks and integration tests artifacts

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -34,7 +34,7 @@ lazy val RoutesCompilerProject = PlayDevelopmentProject("Routes-Compiler", "rout
       //
       // See also:
       // 1. the root project at build.sbt file.
-      // 2. project/BuildSettings.scala 
+      // 2. project/BuildSettings.scala
       crossScalaVersions := Seq(scala211, scala212),
       TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")
     )
@@ -249,9 +249,10 @@ lazy val PlayFiltersHelpersProject = PlayCrossBuiltProject("Filters-Helpers", "p
     ).dependsOn(PlayProject, PlayTestProject % "test",
         PlayJavaProject % "test", PlaySpecs2Project % "test", PlayAhcWsProject % "test")
 
-// This project is just for testing Play, not really a public artifact
 lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Test", "play-integration-test")
     .enablePlugins(JavaAgent)
+    // This project is just for testing Play, not really a public artifact
+    .settings(disablePublishing)
     .settings(
       libraryDependencies += okHttp % Test,
       parallelExecution in Test := false,
@@ -274,10 +275,11 @@ lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Te
     .dependsOn(PlayAkkaHttp2SupportProject)
     .dependsOn(PlayNettyServerProject)
 
-// This project is just for microbenchmarking Play. Not published.
 // NOTE: this project depends on JMH, which is GPLv2.
 lazy val PlayMicrobenchmarkProject = PlayCrossBuiltProject("Play-Microbenchmark", "play-microbenchmark")
     .enablePlugins(JmhPlugin, JavaAgent)
+    // This project is just for microbenchmarking Play. Not published.
+    .settings(disablePublishing)
     .settings(
       // Change settings so that IntelliJ can handle dependencies
       // from JMH to the integration tests. We can't use "compile->test"
@@ -366,7 +368,13 @@ lazy val PlayDocsSbtPlugin = PlaySbtPluginProject("Play-Docs-SBT-Plugin", "play-
       libraryDependencies ++= playDocsSbtPluginDependencies
     ).dependsOn(SbtPluginProject)
 
-lazy val publishedProjects = Seq[ProjectReference](
+// These projects are aggregate by the root project and every
+// task (compile, test, publish, etc) executed for the root
+// project will also be executed for them:
+// https://www.scala-sbt.org/1.x/docs/Multi-Project.html#Aggregation
+//
+// Keep in mind that specific configurations (like skip in publish) will be respected.
+lazy val aggreatedProjects = Seq[ProjectReference](
   PlayProject,
   PlayGuiceProject,
   BuildLinkProject,
@@ -387,6 +395,7 @@ lazy val publishedProjects = Seq[ProjectReference](
   PlayJavaJdbcProject,
   PlayJpaProject,
   PlayNettyServerProject,
+  PlayMicrobenchmarkProject,
   PlayServerProject,
   PlayLogback,
   PlayWsProject,
@@ -417,7 +426,7 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
       // we decide that we could release to M5, than we can re-add scala213 to it
       //
       // See also:
-      // 1. project/BuildSettings.scala 
+      // 1. project/BuildSettings.scala
       // 2. RoutesCompilerProject project
       crossScalaVersions := Seq(scala211, scala212),
       playBuildRepoName in ThisBuild := "playframework",
@@ -428,4 +437,4 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
       mimaReportBinaryIssues := (),
       commands += Commands.quickPublish
     ).settings(Release.settings: _*)
-    .aggregate(publishedProjects: _*)
+    .aggregate(aggreatedProjects: _*)

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -374,7 +374,7 @@ lazy val PlayDocsSbtPlugin = PlaySbtPluginProject("Play-Docs-SBT-Plugin", "play-
 // https://www.scala-sbt.org/1.x/docs/Multi-Project.html#Aggregation
 //
 // Keep in mind that specific configurations (like skip in publish) will be respected.
-lazy val aggreatedProjects = Seq[ProjectReference](
+lazy val aggregatedProjects = Seq[ProjectReference](
   PlayProject,
   PlayGuiceProject,
   BuildLinkProject,
@@ -437,4 +437,4 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
       mimaReportBinaryIssues := (),
       commands += Commands.quickPublish
     ).settings(Release.settings: _*)
-    .aggregate(aggreatedProjects: _*)
+    .aggregate(aggregatedProjects: _*)

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -1,21 +1,23 @@
 /*
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
-import sbt.ScriptedPlugin._
-import sbt._
-import Keys.{version, _}
+import java.util.regex.Pattern
+
+import bintray.BintrayPlugin.autoImport._
+import com.typesafe.sbt.SbtScalariform.autoImport._
+import com.typesafe.sbt.pgp.PgpKeys
 import com.typesafe.tools.mima.core.{ProblemFilters, _}
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import com.typesafe.tools.mima.plugin.MimaPlugin._
 import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
-import scalariform.formatter.preferences._
-import com.typesafe.sbt.SbtScalariform.autoImport._
-import bintray.BintrayPlugin.autoImport._
-import interplay._
 import interplay.Omnidoc.autoImport._
 import interplay.PlayBuildBase.autoImport._
-import java.util.regex.Pattern
+import interplay._
+import sbt.Keys.{version, _}
+import sbt.ScriptedPlugin._
+import sbt.{Resolver, _}
+import scalariform.formatter.preferences._
 
 import scala.util.control.NonFatal
 
@@ -714,7 +716,7 @@ object BuildSettings {
 
       // Allow to disable JPA thread local requires access to configuration
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.db.jpa.DefaultJPAApi#JPAApiProvider.this"),
-    
+
       // Add play.db.Database.withTransaction config
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.Database.withTransaction"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.Database.withTransaction"),
@@ -828,6 +830,18 @@ object BuildSettings {
   def playFullScriptedSettings: Seq[Setting[_]] = ScriptedPlugin.scriptedSettings ++ Seq(
     ScriptedPlugin.scriptedLaunchOpts += s"-Dproject.version=${version.value}"
   ) ++ playScriptedSettings
+
+  def disablePublishing = Seq[Setting[_]](
+    // This setting will work for sbt 1, but not 0.13. For 0.13 it only affects
+    // `compile` and `update` tasks.
+    skip in publish := true,
+
+    // For sbt 0.13 this is what we need to avoid publishing. These settings can
+    // be removed when we move to sbt 1.
+    PgpKeys.publishSigned := {},
+    publish := {},
+    publishLocal := {}
+  )
 
   /**
    * A project that runs in the SBT runtime


### PR DESCRIPTION
Microbenchmarks weren't being published anymore, but they weren't also
being aggregated. This aggregates the project again but configures it not to release artifacts.

Integration tests on the other side are still being published, but this
is not intentional since this is an internal artifact used only to test
Play itself.

Fixes #7743.
