### PR TITLE
Do not promote artifacts automatically

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -72,10 +72,19 @@ object BuildSettings {
       .withWarnDirectEvictions(false)
   )
 
+  // We are not automatically promoting artifacts to Sonatype and
+  // Bintray so that we can have more control of the release process
+  // and do something if somethings fails (for example, if publishing
+  // a artifact times out).
+  def playPublishingPromotionSettings: Seq[Setting[_]] = Seq(
+    playBuildPromoteBintray := false,
+    playBuildPromoteSonatype := false
+  )
+
   /**
    * These settings are used by all projects
    */
-  def playCommonSettings: Seq[Setting[_]] = evictionSettings ++ {
+  def playCommonSettings: Seq[Setting[_]] = evictionSettings ++ playPublishingPromotionSettings ++ {
 
     fileHeaderSettings ++ Seq(
       scalariformAutoformat := true,
@@ -714,7 +723,7 @@ object BuildSettings {
 
       // Allow to disable JPA thread local requires access to configuration
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.db.jpa.DefaultJPAApi#JPAApiProvider.this"),
-    
+
       // Add play.db.Database.withTransaction config
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.Database.withTransaction"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.Database.withTransaction"),


### PR DESCRIPTION
## Purpose

Our release process right now publishes to two services: Sonatype (that will sync to Maven Central) and Bintray (where sbt plugins) lives. That means if one of the services fails for some reason, we may end up in a situation where the release is half done. When that happens, the most secure thing is to do another release increasing the version number.

But this is not ideal and may lead to a confusing situation. For example, right now we have two release candidates for Play 2.7.0 but the second one is RC**8**!

Not promoting the artifacts automatically is not ideal since it adds manual steps to our release process, but for now, it helps us to avoid this situation where we have half-baked releases. We will eventually refactor our release process to make it safer and with minimal manual intervention.

