### PR TITLE
Added sbt 1.2.7 to Play 2.7 migration guide

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -17,15 +17,15 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.x")
 
 Where the "x" in `2.7.x` is the minor version of Play you want to use, for instance `2.7.0`.
 
-### sbt upgrade to 1.1.6
+### sbt upgrade to 1.2.7
 
-Although Play 2.7 still supports sbt 0.13 series, we recommend that you use sbt 1 from now. This new version is actively maintained and supported. To update, change your `project/build.properties` so that it reads:
+Although Play 2.7 still supports sbt 0.13 series, we recommend that you use sbt 1.x from now. This new version is actively maintained and supported. To update, change your `project/build.properties` so that it reads:
 
 ```
-sbt.version=1.1.6
+sbt.version=1.2.7
 ```
 
-At the time of this writing `1.1.6` is the latest version in the sbt 1 family, you may be able to use newer versions too. Check for details in the release notes of your minor version of Play 2.7.x. More information at the list of [sbt releases](https://github.com/sbt/sbt/releases).
+At the time of this writing `1.2.7` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check for details in the release notes of your minor version of Play 2.7.x. More information at the list of [sbt releases](https://github.com/sbt/sbt/releases).
 
 ## Deprecated APIs were removed
 


### PR DESCRIPTION
The 2.7 migration guide stated that at time of writing, sbt 1.1.6 was the latest version. I've updated that to 1.2.7 (and I have run Play on sbt 1.2.7 and everything seems to work with no problems).