### PR TITLE
QueryString- and PathBindable for Java Character

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -355,6 +355,12 @@ object QueryStringBindable {
   }
 
   /**
+   * QueryString binder for Java Character.
+   */
+  implicit def bindableCharacter: QueryStringBindable[java.lang.Character] =
+    bindableChar.transform(c => c, c => c)
+
+  /**
    * QueryString binder for Int.
    */
   implicit object bindableInt extends Parsing[Int](
@@ -611,6 +617,12 @@ object PathBindable {
     }
     def unbind(key: String, value: Char) = value.toString
   }
+
+  /**
+   * Path binder for Java Character.
+   */
+  implicit def bindableCharacter: PathBindable[java.lang.Character] =
+    bindableChar.transform(c => c, c => c)
 
   /**
    * Path binder for Int.

--- a/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -116,9 +116,47 @@ class BindersSpec extends Specification {
     }
   }
 
+  "URL QueryStringBindable Java Character" should {
+    val subject = implicitly[QueryStringBindable[Character]]
+    val char: Character = 'X'
+    val string = "X"
+
+    "Unbind query string char as string" in {
+      subject.unbind("key", char) must equalTo("key=" + char.toString)
+    }
+    "Bind query string as char" in {
+      subject.bind("key", Map("key" -> Seq(string))) must equalTo(Some(Right(char)))
+    }
+    "Fail on length > 1" in {
+      subject.bind("key", Map("key" -> Seq("foo"))) must be_==(Some(Left("Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length.")))
+    }
+    "Be None on empty" in {
+      subject.bind("key", Map("key" -> Seq(""))) must equalTo(None)
+    }
+  }
+
   "URL PathBindable Char" should {
     val subject = implicitly[PathBindable[Char]]
     val char = 'X'
+    val string = "X"
+
+    "Unbind Path char as string" in {
+      subject.unbind("key", char) must equalTo(char.toString)
+    }
+    "Bind Path string as char" in {
+      subject.bind("key", string) must equalTo(Right(char))
+    }
+    "Fail on length > 1" in {
+      subject.bind("key", "foo") must be_==(Left("Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length."))
+    }
+    "Fail on empty" in {
+      subject.bind("key", "") must be_==(Left("Cannot parse parameter key with value '' as Char: key must be exactly one digit in length."))
+    }
+  }
+
+  "URL PathBindable Java Character" should {
+    val subject = implicitly[PathBindable[Character]]
+    val char: Character = 'X'
     val string = "X"
 
     "Unbind Path char as string" in {


### PR DESCRIPTION
During my work on #8859 I realized that we have binders for Scala's `Int` <-> Java's `Integer`, Scala's `Long` <-> Java's `Long` and so on, but not for Java's `Character` type yet (but for the Scala one we have).
This pull request makes the binders complete now :wink: 