### PR TITLE
Update interplay to version 2.0.5

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -14,7 +14,7 @@ val Versions = new {
   val webjarsLocatorCore = "0.36"
   val sbtHeader = "5.0.0"
   val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.4.0-RC4")
-  val interplay: String = sys.props.getOrElse("interplay.version", "2.0.4")
+  val interplay: String = sys.props.getOrElse("interplay.version", "2.0.5")
 }
 
 buildInfoKeys := Seq[BuildInfoKey](


### PR DESCRIPTION
## Purpose

This version brings Scala 2.12.8.

## References

- https://github.com/playframework/interplay/pull/55
- #8863 
