### PR TITLE
Fix ambiguous @lang, @flash and @session

### DIFF
--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -54,7 +54,7 @@ object PlayMagicForJava extends JavaImplicitConversions {
   @implicitNotFound("No Http.Request implicit parameter found when accessing flash. You must add it as a template parameter like @(arg1, arg2,...)(implicit request: Http.Request).")
   implicit def request2Flash(implicit request: Http.Request): Http.Flash = request.flash()
 
-  // Interferes with implicitJavaLang method above
+  // TODO: Uncomment when the implicitJavaLang method above gets removed (methods interfere)
   //@implicitNotFound("No play.api.i18n.MessagesProvider implicit parameter found when accessing lang. You must add it as a template parameter like @(arg1, arg2,...)(implicit messages: play.i18n.Messages).")
   //implicit def messagesProvider2Lang(implicit msg: play.api.i18n.MessagesProvider): play.api.i18n.Lang = msg.messages.lang
 

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -49,12 +49,13 @@ object PlayMagicForJava extends JavaImplicitConversions {
   }
 
   @implicitNotFound("No Http.Request implicit parameter found when accessing session. You must add it as a template parameter like @(arg1, arg2,...)(implicit request: Http.Request).")
-  def session(implicit request: Http.Request): Http.Session = request.session()
+  implicit def request2Session(implicit request: Http.Request): Http.Session = request.session()
 
   @implicitNotFound("No Http.Request implicit parameter found when accessing flash. You must add it as a template parameter like @(arg1, arg2,...)(implicit request: Http.Request).")
-  def flash(implicit request: Http.Request): Http.Flash = request.flash()
+  implicit def request2Flash(implicit request: Http.Request): Http.Flash = request.flash()
 
-  @implicitNotFound("No play.api.i18n.MessagesProvider implicit parameter found when accessing lang. You must add it as a template parameter like @(arg1, arg2,...)(implicit messages: play.i18n.Messages).")
-  def lang(implicit msg: play.api.i18n.MessagesProvider): play.api.i18n.Lang = msg.messages.lang
+  // Interferes with implicitJavaLang method above
+  //@implicitNotFound("No play.api.i18n.MessagesProvider implicit parameter found when accessing lang. You must add it as a template parameter like @(arg1, arg2,...)(implicit messages: play.i18n.Messages).")
+  //implicit def messagesProvider2Lang(implicit msg: play.api.i18n.MessagesProvider): play.api.i18n.Lang = msg.messages.lang
 
 }

--- a/framework/src/play-java/src/test/scala/play/mvc/MixTemplateAndHttpImplicits.scala
+++ b/framework/src/play-java/src/test/scala/play/mvc/MixTemplateAndHttpImplicits.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.mvc
+
+import play.core.j.PlayMagicForJava._
+import play.mvc.Http.Context.Implicit._
+
+/**
+ * Test for GH #8866, just to makes sure it compiles
+ */
+object MixTemplateAndHttpImplicits {
+  def apply() {
+    flash
+    session
+    lang
+  }
+}


### PR DESCRIPTION
Fixes #8866

First of all [I forgot](https://github.com/playframework/playframework/pull/8756/commits/bc48f82fcde3ad6176a4c6c8a92440e2f8f80174) to actually make the three methods `implicit`. Fixed that, however when doing so the new lang method now interferes with the `implicitJavaLang` method (which is also defined in the `PlayMagicForJava` object):

```
[error] framework/src/play-java/src/test/scala/play/mvc/NoImplicitLang.scala:11: ambiguous implicit values:
[error]  both method implicitJavaLang in object PlayMagicForJava of type => play.api.i18n.Lang
[error]  and method messagesProvider2Lang in object PlayMagicForJava of type (implicit msg: play.api.i18n.MessagesProvider)play.api.i18n.Lang
[error]  match expected type play.api.i18n.Lang
[error]     ImplicitLangInclude()
[error]                        ^
[error] one error found
```
Therefore we just shouldn't add the new lang method for now, until `implicitJavaLang` is removed. That's ok, since I just added it for convenience.

Of course I still had to rename the methods to fix the original issue. Added a "test" file to make sure it compiles.