### PR TITLE
transientLang methods for RequestBuilder

### DIFF
--- a/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -175,6 +175,51 @@ public class RequestBuilderTest {
     }
 
     @Test
+    public void testAddATransientLangToRequestBuilder() {
+        RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+        Lang lang = new Lang(Locale.GERMAN);
+        Request request = builder.transientLang(lang).build();
+
+        assertTrue(request.transientLang().isPresent());
+        assertEquals(lang, request.attrs().get(Messages.Attrs.CurrentLang));
+    }
+
+    @Test
+    public void testAddATransientLangByCodeToRequestBuilder() {
+        RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+        String lang = "de";
+        Request request = builder.transientLang(lang).build();
+
+        assertTrue(request.transientLang().isPresent());
+        assertEquals(Lang.forCode(lang), request.attrs().get(Messages.Attrs.CurrentLang));
+    }
+
+    @Test
+    public void testAddATransientLangByLocaleToRequestBuilder() {
+        RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+        Locale locale = Locale.GERMAN;
+        Request request = builder.transientLang(locale).build();
+
+        assertTrue(request.transientLang().isPresent());
+        assertEquals(new Lang(locale), request.attrs().get(Messages.Attrs.CurrentLang));
+    }
+
+    @Test
+    public void testClearRequestBuilderTransientLang() {
+        Lang lang = new Lang(Locale.GERMAN);
+        RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/").transientLang(lang);
+
+        assertTrue(builder.build().transientLang().isPresent());
+        assertEquals(Optional.of(lang), builder.transientLang());
+
+        // Language attr should be removed
+        assertFalse(builder.withoutTransientLang().build().transientLang().isPresent());
+    }
+
+    @Test
     public void testFlash() {
         Application app = new GuiceApplicationBuilder().build();
         Play.start(app);

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1748,6 +1748,56 @@ public class Http {
             ));
             return this;
         }
+
+        /**
+         * Sets the transient language.
+         *
+         * @param lang The language to use.
+         * @return the builder instance
+         */
+        public RequestBuilder transientLang(Lang lang) {
+            req = req.withTransientLang(lang);
+            return this;
+        }
+
+        /**
+         * Sets the transient language.
+         *
+         * @param code The language to use.
+         * @return the builder instance
+         */
+        public RequestBuilder transientLang(String code) {
+            req = req.withTransientLang(code);
+            return this;
+        }
+
+        /**
+         * Sets the transient language.
+         *
+         * @param locale The language to use.
+         * @return the builder instance
+         */
+        public RequestBuilder transientLang(Locale locale) {
+            req = req.withTransientLang(locale);
+            return this;
+        }
+
+        /**
+         * Removes the transient language.
+         *
+         * @return the builder instance
+         */
+        public RequestBuilder withoutTransientLang() {
+            req = req.withoutTransientLang();
+            return this;
+        }
+
+        /**
+         * @return The current transient language of this builder instance.
+         */
+        Optional<Lang> transientLang() {
+            return OptionConverters.toJava(req.transientLang()).map(play.api.i18n.Lang::asJava);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #8874 

The methods are named `transientLang` and `withoutTransientLang`. I skipped the `with` prefix because other methods in the request builder do so as well (body,...)