### PR TITLE
Handle multipart form upload with empty filename as BadPart

### DIFF
--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -193,7 +193,7 @@ object Multipart {
 
         _ <- values.get("form-data").orElse(values.get("file"))
         partName <- values.get("name")
-        fileName <- values.get("filename").filter(!_.trim.isEmpty)
+        fileName <- values.get("filename").filter(_.trim.nonEmpty)
         contentType = headers.get("content-type")
       } yield (partName, fileName, contentType)
     }
@@ -211,7 +211,7 @@ object Multipart {
             case key => (key.trim, "")
           }(breakOut): Map[String, String])
         _ <- values.get("form-data")
-        _ <- Option(values.keySet.contains("filename")).filter(_ == false)
+        _ <- Option(values.contains("filename")).filter(_ == false)
         partName <- values.get("name")
       } yield partName
     }

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -193,7 +193,7 @@ object Multipart {
 
         _ <- values.get("form-data").orElse(values.get("file"))
         partName <- values.get("name")
-        fileName <- values.get("filename")
+        fileName <- values.get("filename").filter(!_.trim.isEmpty)
         contentType = headers.get("content-type")
       } yield (partName, fileName, contentType)
     }
@@ -211,6 +211,7 @@ object Multipart {
             case key => (key.trim, "")
           }(breakOut): Map[String, String])
         _ <- values.get("form-data")
+        _ <- Option(values.keySet.contains("filename")).filter(_ == false)
         partName <- values.get("name")
       } yield partName
     }


### PR DESCRIPTION
Fixes #8727 and #6203

This restores the behavior we had in Play 2.4 and before: When submitting a form and leaving a file field empty, the `filename` is empty. Like in Play 2.4, we should handle this as failure.
[This line](https://github.com/playframework/playframework/pull/5037/files#diff-a41a1796efe45be8ecc6d68806de1b81L151) - which was removed - took care for this in Play 2.4 and below. Plus, as you can see in the comments of #8727 and #6203 people work around this problem by checking for an empty file name as well.

(After this pull request I will provide another one which actually also checks for the file itself if it's empty, not just the filename)