### PR TITLE
New FilePart.getRef() exposes Java's TemporaryFile for uploaded files

### DIFF
--- a/documentation/manual/working/javaGuide/main/upload/JavaFileUpload.md
+++ b/documentation/manual/working/javaGuide/main/upload/JavaFileUpload.md
@@ -3,25 +3,23 @@
 
 ## Uploading files in a form using `multipart/form-data`
 
-The standard way to upload files in a web application is to use a form with a special `multipart/form-data` encoding, which allows mixing of standard form data with file attachments. Please note: the HTTP method for the form has to be POST (not GET).
+The standard way to upload files in a web application is to use a form with a special `multipart/form-data` encoding, which lets you mix standard form data with file attachment data.
+
+> **Note:** The HTTP method used to submit the form must be `POST` (not `GET`).
 
 Start by writing an HTML form:
 
-```
-@form(action = routes.Application.upload, 'enctype -> "multipart/form-data") {
+@[file-upload-form](code/javaguide/fileupload/views/uploadForm.scala.html)
 
-    <input type="file" name="picture">
+Now define the `upload` action:
 
-    <p>
-        <input type="submit">
-    </p>
+@[syncUpload](code/javaguide/fileupload/controllers/HomeController.java)
 
-}
-```
+The [`getRef()`](api/java/play/mvc/Http.MultipartFormData.FilePart.html#getRef--) method gives you a reference to a [`TemporaryFile`](api/java/play/libs/Files.TemporaryFile.html). This is the default way Play handles file uploads.
 
-Now let’s define the `upload` action:
+At last, add a `POST` router
 
-@[syncUpload](code/JavaFileUpload.java)
+@[application-upload-routes](code/javaguide.upload.fileupload.routes)
 
 ### Testing the file upload
 
@@ -50,7 +48,7 @@ Using a custom file part handler also means that behavior can be injected, so a 
 
 ## Cleaning up temporary files
 
-Uploading files uses a [`TemporaryFile`](api/java/play/libs/Files.TemporaryFile.html) API which relies on storing files in a temporary filesystem.  All [`TemporaryFile`](api/java/play/libs/Files.TemporaryFile.html) references come from a [`TemporaryFileCreator`](api/java/play/libs/Files.TemporaryFileCreator.html) trait, and the implementation can be swapped out as necessary, and there's now an [`atomicMoveWithFallback`](api/java/play/libs/Files.TemporaryFile.html#temporaryFileCreator--) method that uses `StandardCopyOption.ATOMIC_MOVE` if available.
+Uploading files uses a [`TemporaryFile`](api/java/play/libs/Files.TemporaryFile.html) API which relies on storing files in a temporary filesystem, accessible through the [`getRef()`](api/java/play/mvc/Http.MultipartFormData.FilePart.html#getRef--) method.  All [`TemporaryFile`](api/java/play/libs/Files.TemporaryFile.html) references come from a [`TemporaryFileCreator`](api/java/play/libs/Files.TemporaryFileCreator.html) trait, and the implementation can be swapped out as necessary, and there's now an [`atomicMoveWithFallback`](api/java/play/libs/Files.TemporaryFile.html#temporaryFileCreator--) method that uses `StandardCopyOption.ATOMIC_MOVE` if available.
 
 Uploading files is an inherently dangerous operation, because unbounded file upload can cause the filesystem to fill up -- as such, the idea behind [`TemporaryFile`](api/java/play/libs/Files.TemporaryFile.html) is that it's only in scope at completion and should be moved out of the temporary file system as soon as possible.  Any temporary files that are not moved are deleted. 
 

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import play.api.http.HttpErrorHandler;
 import play.core.j.JavaHandlerComponents;
 import play.core.parsers.Multipart;
+import play.libs.Files.TemporaryFile;
 import play.libs.streams.Accumulator;
 import play.mvc.BodyParser;
 import play.mvc.Controller;
@@ -42,12 +43,12 @@ public class JavaFileUpload extends WithApplication {
     static class SyncUpload extends Controller {
         //#syncUpload
         public Result upload(Http.Request request) {
-            Http.MultipartFormData<File> body = request.body().asMultipartFormData();
-            Http.MultipartFormData.FilePart<File> picture = body.getFile("picture");
+            Http.MultipartFormData<TemporaryFile> body = request.body().asMultipartFormData();
+            Http.MultipartFormData.FilePart<TemporaryFile> picture = body.getFile("picture");
             if (picture != null) {
                 String fileName = picture.getFilename();
                 String contentType = picture.getContentType();
-                File file = picture.getFile();
+                TemporaryFile file = picture.getRef();
                 return ok("File uploaded");
             } else {
                 return badRequest().flashing("error", "Missing file");
@@ -123,7 +124,7 @@ public class JavaFileUpload extends WithApplication {
                     public Result uploadCustomMultiPart(Http.Request request) throws Exception {
                         final Http.MultipartFormData<File> formData = request.body().asMultipartFormData();
                         final Http.MultipartFormData.FilePart<File> filePart = formData.getFile("name");
-                        final File file = filePart.getFile();
+                        final File file = filePart.getRef();
                         final long size = Files.size(file.toPath());
                         Files.deleteIfExists(file.toPath());
                         return ok("Got: file size = " + size + "");

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -40,23 +40,6 @@ import static javaguide.testhelpers.MockJavaActionHelper.*;
 
 public class JavaFileUpload extends WithApplication {
 
-    static class SyncUpload extends Controller {
-        //#syncUpload
-        public Result upload(Http.Request request) {
-            Http.MultipartFormData<TemporaryFile> body = request.body().asMultipartFormData();
-            Http.MultipartFormData.FilePart<TemporaryFile> picture = body.getFile("picture");
-            if (picture != null) {
-                String fileName = picture.getFilename();
-                String contentType = picture.getContentType();
-                TemporaryFile file = picture.getRef();
-                return ok("File uploaded");
-            } else {
-                return badRequest().flashing("error", "Missing file");
-            }
-        }
-        //#syncUpload
-    }
-
     static class AsyncUpload extends Controller {
         //#asyncUpload
         public Result upload(Http.Request request) {

--- a/documentation/manual/working/javaGuide/main/upload/code/javaguide.upload.fileupload.routes
+++ b/documentation/manual/working/javaGuide/main/upload/code/javaguide.upload.fileupload.routes
@@ -1,0 +1,3 @@
+# #application-upload-routes
+POST  /          controllers.HomeController.upload(request: Request)
+# #application-upload-routes

--- a/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/controllers/HomeController.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/controllers/HomeController.java
@@ -1,0 +1,24 @@
+package javaguide.upload.fileupload.controllers;
+
+//#syncUpload
+import play.libs.Files.TemporaryFile;
+import play.mvc.Controller;
+import play.mvc.Http;
+import play.mvc.Result;
+
+public class HomeController extends Controller {
+
+    public Result upload(Http.Request request) {
+        Http.MultipartFormData<TemporaryFile> body = request.body().asMultipartFormData();
+        Http.MultipartFormData.FilePart<TemporaryFile> picture = body.getFile("picture");
+        if (picture != null) {
+            String fileName = picture.getFilename();
+            String contentType = picture.getContentType();
+            TemporaryFile file = picture.getRef();
+            return ok("File uploaded");
+        } else {
+            return badRequest().flashing("error", "Missing file");
+        }
+    }
+}
+//#syncUpload

--- a/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/views/uploadForm.scala.html
+++ b/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/views/uploadForm.scala.html
@@ -1,12 +1,12 @@
-@import scalaguide.upload.fileupload.controllers._
+@import javaguide.upload.fileupload.controllers._
 @* #file-upload-form *@
 @helper.form(action = routes.HomeController.upload, 'enctype -> "multipart/form-data") {
-    
+
     <input type="file" name="picture">
-    
+
     <p>
         <input type="submit">
     </p>
-    
+
 }
 @* #file-upload-form *@

--- a/documentation/manual/working/scalaGuide/main/upload/ScalaFileUpload.md
+++ b/documentation/manual/working/scalaGuide/main/upload/ScalaFileUpload.md
@@ -1,9 +1,9 @@
 <!--- Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com> -->
 # Handling file upload
 
-## Uploading files in a form using multipart/form-data
+## Uploading files in a form using `multipart/form-data`
 
-The standard way to upload files in a web application is to use a form with a special `multipart/form-data` encoding, which lets you mix standard form data with file attachment data. 
+The standard way to upload files in a web application is to use a form with a special `multipart/form-data` encoding, which lets you mix standard form data with file attachment data.
 
 > **Note:** The HTTP method used to submit the form must be `POST` (not `GET`).
 
@@ -15,7 +15,7 @@ Now define the `upload` action using a `multipartFormData` body parser:
 
 @[upload-file-action](code/ScalaFileUpload.scala)
 
-The `ref` attribute give you a reference to a `TemporaryFile`. This is the default way the `multipartFormData` parser handles file upload.
+The [`ref`](api/scala/play/api/mvc/MultipartFormData$$FilePart.html#ref:A) attribute gives you a reference to a [`TemporaryFile`](api/scala/play/api/libs/Files$$TemporaryFile.html). This is the default way the `multipartFormData` parser handles file uploads.
 
 > **Note:** As always, you can also use the `anyContent` body parser and retrieve it as `request.body.asMultipartFormData`.
 
@@ -25,7 +25,7 @@ At last, add a `POST` router
 
 ## Direct file upload
 
-Another way to send files to the server is to use Ajax to upload the file asynchronously in a form. In this case the request body will not have been encoded as `multipart/form-data`, but will just contain the plain file content.
+Another way to send files to the server is to use Ajax to upload files asynchronously from a form. In this case, the request body will not be encoded as `multipart/form-data`, but will just contain the plain file contents.
 
 In this case we can just use a body parser to store the request body content in a file. For this example, let’s use the `temporaryFile` body parser:
 
@@ -41,13 +41,13 @@ If you want to use `multipart/form-data` encoding, you can still use the default
 
 ## Cleaning up temporary files
 
-Uploading files uses a [`TemporaryFile`](api/scala/play/api/libs/Files$$TemporaryFile.html) API which relies on storing files in a temporary filesystem, accessible through the `ref` attribute.  All [`TemporaryFile`](api/scala/play/api/libs/Files$$TemporaryFile.html) references come from a [`TemporaryFileCreator`](api/scala/play/api/libs/Files$$TemporaryFileCreator.html) trait, and the implementation can be swapped out as necessary, and there's now an [`atomicMoveWithFallback`](api/scala/play/api/libs/Files$$TemporaryFile.html#atomicMoveWithFallback\(to:java.nio.file.Path\):play.api.libs.Files.TemporaryFile) method that uses `StandardCopyOption.ATOMIC_MOVE` if available.
+Uploading files uses a [`TemporaryFile`](api/scala/play/api/libs/Files$$TemporaryFile.html) API which relies on storing files in a temporary filesystem, accessible through the [`ref`](api/scala/play/api/mvc/MultipartFormData$$FilePart.html#ref:A) attribute.  All [`TemporaryFile`](api/scala/play/api/libs/Files$$TemporaryFile.html) references come from a [`TemporaryFileCreator`](api/scala/play/api/libs/Files$$TemporaryFileCreator.html) trait, and the implementation can be swapped out as necessary, and there's now an [`atomicMoveWithFallback`](api/scala/play/api/libs/Files$$TemporaryFile.html#atomicMoveWithFallback\(to:java.nio.file.Path\):play.api.libs.Files.TemporaryFile) method that uses `StandardCopyOption.ATOMIC_MOVE` if available.
 
 Uploading files is an inherently dangerous operation, because unbounded file upload can cause the filesystem to fill up -- as such, the idea behind [`TemporaryFile`](api/scala/play/api/libs/Files$$TemporaryFile.html) is that it's only in scope at completion and should be moved out of the temporary file system as soon as possible.  Any temporary files that are not moved are deleted. 
 
 However, under [certain conditions](https://github.com/playframework/playframework/issues/5545), garbage collection does not occur in a timely fashion.  As such, there's also a [`play.api.libs.Files.TemporaryFileReaper`](api/scala/play/api/libs/Files$$DefaultTemporaryFileReaper.html) that can be enabled to delete temporary files on a scheduled basis using the Akka scheduler, distinct from the garbage collection method.
 
-The reaper is disabled by default, and is enabled through `application.conf`:
+The reaper is disabled by default, and is enabled through configuration of `application.conf`:
 
 ```
 play.temporaryFile {

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -54,7 +54,7 @@ package scalaguide.upload.fileupload {
             picture.ref.moveTo(Paths.get(s"/tmp/picture/$filename"), replace = true)
             Ok("File uploaded")
           }.getOrElse {
-            Redirect(routes.ScalaFileUploadController.index).flashing("error" -> "Missing file")
+            Redirect(routes.HomeController.index).flashing("error" -> "Missing file")
           }
         }
 
@@ -84,7 +84,7 @@ package scalaguide.upload.fileupload {
         val request = FakeRequest().withBody(tf)
 
         val controllerComponents = app.injector.instanceOf[ControllerComponents]
-        testAction(new controllers.ScalaFileUploadController(controllerComponents).upload, request)
+        testAction(new controllers.HomeController(controllerComponents).upload, request)
 
         uploaded.delete()
         success
@@ -107,7 +107,7 @@ package scalaguide.upload.fileupload {
   }
   package controllers {
 
-    class ScalaFileUploadController(controllerComponents: ControllerComponents)(implicit ec: ExecutionContext) extends AbstractController(controllerComponents) {
+    class HomeController(controllerComponents: ControllerComponents)(implicit ec: ExecutionContext) extends AbstractController(controllerComponents) {
 
       //#upload-file-directly-action
         def upload = Action(parse.temporaryFile) { request =>

--- a/documentation/manual/working/scalaGuide/main/upload/code/scalaguide.upload.fileupload.routes
+++ b/documentation/manual/working/scalaGuide/main/upload/code/scalaguide.upload.fileupload.routes
@@ -1,5 +1,5 @@
-GET   /          controllers.ScalaFileUploadController.index()
+GET   /          controllers.HomeController.index()
 
 # #application-upload-routes
-POST  /          controllers.ScalaFileUploadController.upload()
+POST  /          controllers.HomeController.upload()
 # #application-upload-routes

--- a/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -12,6 +12,7 @@ import play.api.inject.guice.GuiceApplicationBuilder;
 import play.core.j.JavaContextComponents;
 import play.i18n.Lang;
 import play.i18n.Messages;
+import play.libs.Files;
 import play.libs.Files.TemporaryFileCreator;
 import play.libs.typedmap.TypedKey;
 import play.mvc.Http.Context;
@@ -298,7 +299,7 @@ public class RequestBuilderTest {
                 .bodyMultipart(Collections.singletonList(dp), temporaryFileCreator, app.materializer())
                 .build();
 
-        Optional<Http.MultipartFormData<File>> parts = app.injector().instanceOf(BodyParser.MultipartFormData.class)
+        Optional<Http.MultipartFormData<Files.TemporaryFile>> parts = app.injector().instanceOf(BodyParser.MultipartFormData.class)
                .apply(request)
                .run(Source.single(request.body().asBytes()), app.materializer())
                .toCompletableFuture()

--- a/framework/src/play/src/main/java/play/libs/Files.java
+++ b/framework/src/play/src/main/java/play/libs/Files.java
@@ -90,7 +90,7 @@ public final class Files {
         private final play.api.libs.Files.TemporaryFile temporaryFile;
         private final TemporaryFileCreator temporaryFileCreator;
 
-        DelegateTemporaryFile(play.api.libs.Files.TemporaryFile temporaryFile) {
+        public DelegateTemporaryFile(play.api.libs.Files.TemporaryFile temporaryFile) {
             this.temporaryFile = temporaryFile;
             this.temporaryFileCreator = new DelegateTemporaryFileCreator(temporaryFile.temporaryFileCreator());
         }

--- a/framework/src/play/src/main/java/play/libs/Files.java
+++ b/framework/src/play/src/main/java/play/libs/Files.java
@@ -39,13 +39,63 @@ public final class Files {
 
         TemporaryFileCreator temporaryFileCreator();
 
+        /**
+         * Move the file using a {@link java.io.File}.
+         *
+         * @param to the path to the destination file
+         */
         default TemporaryFile moveTo(File to) {
             return moveTo(to, false);
         }
 
+        /**
+         * Move the file using a {@link java.io.File}.
+         *
+         * @param to the path to the destination file
+         * @param replace true if an existing file should be replaced, false otherwise.
+         */
         TemporaryFile moveTo(File to, boolean replace);
 
+        /**
+         * Move the file using a {@link java.nio.file.Path}.
+         *
+         * @param to the path to the destination file
+         */
+        default TemporaryFile moveTo(Path to) {
+            return moveTo(to, false);
+        }
+
+        /**
+         * Move the file using a {@link java.nio.file.Path}.
+         *
+         * @param to the path to the destination file
+         * @param replace true if an existing file should be replaced, false otherwise.
+         */
+        default TemporaryFile moveTo(Path to, boolean replace) {
+            return moveTo(to.toFile(), replace);
+        }
+
+        /**
+         * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+         *
+         * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+         * existent files or not, considering that it will always replaces, makes the API more predictable.
+         *
+         * @param to the path to the destination file
+         */
         TemporaryFile atomicMoveWithFallback(File to);
+
+        /**
+         * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+         *
+         * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+         * existent files or not, considering that it will always replaces, makes the API more predictable.
+         *
+         * @param to the path to the destination file
+         */
+        default TemporaryFile atomicMoveWithFallback(Path to) {
+            return atomicMoveWithFallback(to.toFile());
+        }
     }
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -413,7 +413,7 @@ public interface BodyParser<A> {
     /**
      * Parse the body as multipart form-data without checking the Content-Type.
      */
-    class MultipartFormData extends DelegatingBodyParser<Http.MultipartFormData<File>, play.api.mvc.MultipartFormData<Files.TemporaryFile>> {
+    class MultipartFormData extends DelegatingBodyParser<Http.MultipartFormData<play.libs.Files.TemporaryFile>, play.api.mvc.MultipartFormData<Files.TemporaryFile>> {
         @Inject
         public MultipartFormData(PlayBodyParsers parsers) {
             super(parsers.multipartFormData(), JavaParsers::toJavaMultipartFormData);

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1880,18 +1880,18 @@ public class Http {
             final String key;
             final String filename;
             final String contentType;
-            final A file;
+            final A ref;
             final String dispositionType;
 
-            public FilePart(String key, String filename, String contentType, A file) {
-                this(key, filename, contentType, file, "form-data");
+            public FilePart(String key, String filename, String contentType, A ref) {
+                this(key, filename, contentType, ref, "form-data");
             }
 
-            public FilePart(String key, String filename, String contentType, A file, String dispositionType) {
+            public FilePart(String key, String filename, String contentType, A ref, String dispositionType) {
                 this.key = key;
                 this.filename = filename;
                 this.contentType = contentType;
-                this.file = file;
+                this.ref = ref;
                 this.dispositionType = dispositionType;
             }
 
@@ -1926,9 +1926,25 @@ public class Http {
              * The File.
              *
              * @return the file
+             *
+             * @deprecated Deprecated as of 2.7.0. Use {@link #getRef()} instead
              */
+            @Deprecated
             public A getFile() {
-                return file;
+                if (ref instanceof Files.TemporaryFile) {
+                    // For backwards compatibility
+                    return (A)((Files.TemporaryFile) ref).path().toFile();
+                }
+                return ref;
+            }
+
+            /**
+             * The File.
+             *
+             * @return the file
+             */
+            public A getRef() {
+                return ref;
             }
 
             /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1927,7 +1927,9 @@ public class Http {
              *
              * @return the file
              *
-             * @deprecated Deprecated as of 2.7.0. Use {@link #getRef()} instead
+             * @deprecated Deprecated as of 2.7.0. Use {@link #getRef()} instead, which however (when using the default Play {@code BodyParser})
+             * will give you a {@link play.libs.Files.TemporaryFile} instance instead of a {@link java.io.File} one.
+             * <a href="https://www.playframework.com/documentation/latest/Migration27#Javas-FilePart-exposes-the-TemporaryFile-for-uploaded-files">See migration guide.</a>
              */
             @Deprecated
             public A getFile() {

--- a/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
+++ b/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
@@ -31,8 +31,8 @@ public class MultipartFormatter {
                 return (MultipartFormData.Part) new MultipartFormData.DataPart(dp.getKey(), dp.getValue());
             } else if (part instanceof Http.MultipartFormData.FilePart) {
                 Http.MultipartFormData.FilePart fp = (Http.MultipartFormData.FilePart) part;
-                if (fp.file instanceof Source) {
-                    Source ref = (Source) fp.file;
+                if (fp.ref instanceof Source) {
+                    Source ref = (Source) fp.ref;
                     Option<String> ct = Option.apply(fp.getContentType());
                     return (MultipartFormData.Part)new MultipartFormData.FilePart<akka.stream.scaladsl.Source<ByteString, ?>>(fp.getKey(), fp.getFilename(), ct, ref.asScala(), fp.getDispositionType());
                 }

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -114,6 +114,16 @@ object Files {
      *
      * @param to the path to the destination file
      */
+    def atomicMoveWithFallback(to: File): TemporaryFile = atomicMoveWithFallback(to.toPath)
+
+    /**
+     * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+     *
+     * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+     * existent files or not, considering that it will always replaces, makes the API more predictable.
+     *
+     * @param to the path to the destination file
+     */
     // see https://github.com/apache/kafka/blob/d345d53/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L608-L626
     def atomicMoveWithFallback(to: Path): TemporaryFile = {
       try {

--- a/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -13,6 +13,7 @@ import akka.stream.Materializer
 
 import scala.collection.JavaConverters._
 import play.api.mvc._
+import play.libs.Files.{ DelegateTemporaryFile, TemporaryFile => JTemporaryFile }
 
 /**
  * provides Java centric BodyParsers
@@ -23,15 +24,15 @@ object JavaParsers {
   @deprecated("Inject PlayBodyParsers instead", "2.6.0")
   val parse = BodyParsers.parse
 
-  def toJavaMultipartFormData[A](multipart: MultipartFormData[TemporaryFile]): play.mvc.Http.MultipartFormData[File] = {
-    new play.mvc.Http.MultipartFormData[File] {
+  def toJavaMultipartFormData[A](multipart: MultipartFormData[TemporaryFile]): play.mvc.Http.MultipartFormData[JTemporaryFile] = {
+    new play.mvc.Http.MultipartFormData[JTemporaryFile] {
       lazy val asFormUrlEncoded = {
         multipart.asFormUrlEncoded.mapValues(_.toArray).asJava
       }
       lazy val getFiles = {
         multipart.files.map { file =>
           new play.mvc.Http.MultipartFormData.FilePart(
-            file.key, file.filename, file.contentType.orNull, file.ref.path.toFile, file.dispositionType)
+            file.key, file.filename, file.contentType.orNull, new DelegateTemporaryFile(file.ref).asInstanceOf[JTemporaryFile], file.dispositionType)
         }.asJava
       }
     }


### PR DESCRIPTION
When [uploading a file in Play Scala](https://www.playframework.com/documentation/2.6.x/ScalaFileUpload#Uploading-files-in-a-form-using-multipart/form-data) you get direct access to the `TemporaryFile` and it methods via `FilePart.ref`.

In Play Java you only get access the `java.io.File` object via `FilePart.getFile()` (but not to the temporary file)

This pull request adds `FilePart.getRef()` to the Java API to get access to Java's `TemporaryFile` ([which was added just recently in Play 2.6](https://github.com/playframework/playframework/pull/6759/files#diff-2c9a81fe543674bc8f14c5d6369685d7R33)) as well.
Have a look at the migration notes I added for further explanation.