### PR TITLE
Use Akka HTTP snapshots for our cron builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: true
 group: beta
 jdk:
   - oraclejdk8
+addons:
+  apt:
+    packages:
+      # Install xmllint used to get Akka HTTP version
+      - libxml2-utils
 stages:
   - validations
   - test

--- a/framework/bin/scriptLib
+++ b/framework/bin/scriptLib
@@ -20,10 +20,11 @@ EXTRA_OPTS=""
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     # `sort` is not necessary, but it is good to make it predictable.
     AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '2\.5-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+    AKKA_HTTP_VERSION=$(curl -s https://dl.bintray.com/akka/maven/com/typesafe/akka/akka-http-core_2.12/maven-metadata.xml | xmllint --xpath '//latest/text()' -)
 
-    echo "Using Akka SNAPSHOT ${AKKA_VERSION}"
+    echo "Using Akka SNAPSHOT ${AKKA_VERSION} and Akka HTTP SNAPSHOT ${AKKA_HTTP_VERSION}"
 
-    EXTRA_OPTS="-Dakka.version=${AKKA_VERSION}"
+    EXTRA_OPTS="-Dakka.version=${AKKA_VERSION} -Dakka.http.version=${AKKA_HTTP_VERSION}"
 fi
 
 printMessage() {

--- a/framework/project/AkkaSnapshotRepositories.scala
+++ b/framework/project/AkkaSnapshotRepositories.scala
@@ -12,7 +12,10 @@ object AkkaSnapshotRepositories extends AutoPlugin {
     // If this is a cron job in Travis:
     // https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
     resolvers ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
-      case Some(_) => Seq("akka-snapshot-repository" at "https://repo.akka.io/snapshots")
+      case Some(_) => Seq(
+        "akka-snapshot-repository" at "https://repo.akka.io/snapshots",
+        "akka-http-snapshot-repository" at "https://dl.bintray.com/akka/maven/"
+      )
       case None => Seq.empty
     })
   }

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.19")
-  val akkaHttpVersion = "10.1.5"
+  val akkaHttpVersion: String = sys.props.getOrElse("akka.http.version", "10.1.5")
   val akkaHttpVersion_2_13 = "10.1.3" // akka-http dropped support for Scala 2.13: https://github.com/akka/akka-http/issues/2166
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.7"


### PR DESCRIPTION
## Purpose

The purpose is to discover Akka HTTP integration problems sooner. This enables us to configure a nightly build in Travis to test against Akka HTTP snapshots. Basically the same we did for Akka in #8601.