### PR TITLE
Add tests for HttpEntity.Streamed content length header 

### DIFF
--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -150,32 +150,6 @@ See more details at [[GzipEncoding]].
 
 Here are some of the relevant API additions we made for Play 2.7.0.
 
-### Isolation level for Database transactions
-
-You can now chose an isolation level when using `Database.withTransaction` API. For example:
-
-Java
-: ```java
-public void someDatabaseOperation() {
-    database.withTransaction(TransactionIsolationLevel.ReadUncommitted, connection -> {
-        ResultSet resultSet = connection.prepareStatement("select * from users where id = 10").executeQuery();
-        // consume the resultSet and return some value
-    });
-}
-```
-
-Scala
-: ```scala
-def someDatabaseOperation(): Unit = {
-  database.withTransaction(TransactionIsolationLevel.ReadUncommitted) { connection =>
-    val resultSet: ResultSet = connection.prepareStatement("select * from users where id = 10").executeQuery();
-    // consume the resultSet and return some value
-  }
-}
-```
-
-The available transaction isolation levels mimic what is defined in `java.sql.Connection`.
-
 ### Result `HttpEntity` streamed methods
 
 Previous versions of Play had convenient methods to stream results using HTTP chunked transfer encoding:

--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -178,7 +178,7 @@ The available transaction isolation levels mimic what is defined in `java.sql.Co
 
 ### Result `HttpEntity` streamed methods
 
-We had methods to more easily return `chunked` results:
+Previous versions of Play had convenient methods to stream results using HTTP chunked transfer encoding:
 
 Java
 : ```java
@@ -196,7 +196,7 @@ def chunked = Action {
 }
 ```
 
-But the APIs to return a streamed result were a little more verbose:
+In Play 2.6, there was no convenient method to return a streamed Result in the same way without using HTTP chunked encoding. You instead had to write this:
 
 Java
 : ```java
@@ -214,7 +214,7 @@ def streamed = Action {
 }
 ```
 
-We then add new APIs to make it as much straightforward as `chunked`:
+Play 2.7 fixes this by adding a new streamed method on results, that works similar to `chunked`:
 
 Java
 : ```java

--- a/framework/src/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
@@ -156,6 +156,13 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
       response.header(CONTENT_LENGTH) must beNone
     }
 
+    "Keep Content-Length for streamed responses" in withServer { client =>
+      val response = await(client.url("/stream/10").head())
+
+      response.body must_== ""
+      response.header(CONTENT_LENGTH) must beSome("10")
+    }
+
   }
 
 }

--- a/framework/src/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -86,6 +86,26 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
       response.body must_== "Hello world"
     }
 
+    "add Content-Length for streamed results" in makeRequest(new MockController {
+      def action = {
+        val body = Source.single(ByteString.fromString("1234567890"))
+        Results.ok().streamed(body, Optional.of(10L), Optional.empty())
+      }
+    }) { response =>
+      response.header(CONTENT_LENGTH) must beSome("10")
+      response.body must_== "1234567890"
+    }
+
+    "not add Content-Length for streamed results when it is not specified" in makeRequest(new MockController {
+      def action = {
+        val body = Source.single(ByteString.fromString("1234567890"))
+        Results.ok().streamed(body, Optional.empty(), Optional.empty())
+      }
+    }) { response =>
+      response.header(CONTENT_LENGTH) must beNone
+      response.body must_== "1234567890"
+    }
+
     "support responses with custom Content-Types" in makeRequest(new MockController {
       def action = {
         val entity = new HttpEntity.Strict(ByteString(0xff.toByte), Optional.of("schmitch/foo; bar=bax"))

--- a/framework/src/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -94,6 +94,20 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       response.body must_== "Hello world"
     }
 
+    "add Content-Length header for streamed results when specified" in makeRequest {
+      Results.Ok.streamed(Source.single("1234567890"), Some(10))
+    } { response =>
+      response.header(CONTENT_LENGTH) must beSome("10")
+      response.body must_== "1234567890"
+    }
+
+    "not have Content-Length header for streamed results when not specified" in makeRequest {
+      Results.Ok.streamed(Source.single("1234567890"), None)
+    } { response =>
+      response.header(CONTENT_LENGTH) must beNone
+      response.body must_== "1234567890"
+    }
+
     def emptyStreamedEntity = Results.Ok.sendEntity(HttpEntity.Streamed(Source.empty[ByteString], Some(0), None))
 
     "not fail when sending an empty entity with a known size zero" in makeRequest(emptyStreamedEntity) {

--- a/framework/src/play-integration-test/src/it/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/it/scala/play/it/tools/HttpBin.scala
@@ -8,6 +8,8 @@ import java.nio.charset.StandardCharsets
 
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.http.HttpEntity
 import play.api.libs.Files
 import play.api.libs.json.{ JsObject, _ }
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -16,7 +18,7 @@ import play.api.mvc._
 import play.api.routing.Router.Routes
 import play.api.routing.SimpleRouter
 import play.api.routing.sird._
-import play.api.{ ApplicationLoader, BuiltInComponentsFromContext, Environment, NoHttpFiltersComponents }
+import play.api._
 import play.filters.gzip.GzipFilter
 
 /**
@@ -36,7 +38,7 @@ object HttpBinApplication {
     )
   }
 
-  private def requestWriter[A] = new Writes[Request[A]] {
+  private def requestWriter[A]: Writes[Request[A]] = new Writes[Request[A]] {
     def readFileToString(ref: Files.TemporaryFile): String = {
       new String(java.nio.file.Files.readAllBytes(ref), StandardCharsets.UTF_8)
     }
@@ -122,7 +124,7 @@ object HttpBinApplication {
 
   private def gzipFilter(mat: Materializer) = new GzipFilter()(mat)
 
-  def gzip(implicit mat: Materializer, Action: DefaultActionBuilder) = Seq("GET", "PATCH", "POST", "PUT", "DELETE").map { method =>
+  def gzip(implicit mat: Materializer, Action: DefaultActionBuilder): Routes = Seq("GET", "PATCH", "POST", "PUT", "DELETE").map { method =>
     val route: Routes = {
       case r @ p"/gzip" if r.method == method =>
         gzipFilter(mat)(Action { request =>
@@ -210,14 +212,10 @@ object HttpBinApplication {
 
   def stream(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/stream/$param<[0-9]+>") =>
-      Action { request =>
-        val body = requestHeaderWriter.writes(request).as[JsObject]
-
-        val content = 0.to(param.toInt).map { index =>
-          body ++ Json.obj("id" -> index)
-        }
-
-        Ok.chunked(Source(content)).as("application/json")
+      Action {
+        val contentLength = param.toInt
+        val content = (0 to contentLength).map(ByteString(_))
+        Ok.sendEntity(HttpEntity.Streamed(Source(content), Option(contentLength), Option("application/json")))
       }
   }
 
@@ -327,10 +325,10 @@ object HttpBinApplication {
       }
   }
 
-  def app = {
+  def app: Application = {
     new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple())) with AhcWSComponents with NoHttpFiltersComponents {
       override implicit lazy val Action = defaultActionBuilder
-      def router = SimpleRouter(
+      override def router = SimpleRouter(
         PartialFunction.empty
           .orElse(getIp)
           .orElse(getUserAgent)

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -478,7 +478,7 @@ public class StatusHeader extends Result {
     }
 
     /**
-     * Send a stremed response with the given source.
+     * Send a streamed response with the given source.
      *
      * @param body the source to send
      * @param contentLength the entity content length.

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -478,6 +478,18 @@ public class StatusHeader extends Result {
     }
 
     /**
+     * Send a stremed response with the given source.
+     *
+     * @param body the source to send
+     * @param contentLength the entity content length.
+     * @param contentType the entity content type.
+     * @return a '200 OK' response with the given body.
+     */
+    public Result streamed(Source<ByteString, ?> body, Optional<Long> contentLength, Optional<String> contentType) {
+        return new Result(status(), new HttpEntity.Streamed(body, contentLength, contentType));
+    }
+
+    /**
      * Send a json result.
      *
      * @param json the json node to send

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -513,6 +513,23 @@ trait Results {
     }
 
     /**
+     * Feed the content as the response, using a streamed entity.
+     *
+     * It will use the given Content-Type, but if is not present, then it fallsback
+     * to use the [[Writeable]] contentType.
+     *
+     * @param content Source providing the content to stream.
+     * @param contentLength an optional content length.
+     * @param contentType an optional content type.
+     */
+    def streamed[C](content: Source[C, _], contentLength: Option[Long], contentType: Option[String] = None)(implicit writeable: Writeable[C]): Result = {
+      Result(
+        header = header,
+        body = HttpEntity.Streamed(content.map(c => writeable.transform(c)), contentLength, contentType.orElse(writeable.contentType))
+      )
+    }
+
+    /**
      * Send an HTTP entity with this status.
      */
     def sendEntity(entity: HttpEntity): Result = {


### PR DESCRIPTION
## Fixes

Fixes #8853.

## Purpose

Add new tests to ensure `HttpEntity.Streamed` sends `Content-Length` when it is defined.