### PR TITLE
Decouple scala-reflect library from Play dependencies

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -158,7 +158,7 @@ object Dependencies {
       "javax.transaction" % "jta" % "1.1",
       "javax.inject" % "javax.inject" % "1",
 
-      "org.scala-lang" % "scala-reflect" % scalaVersion,
+      "org.scala-lang" % "scala-reflect" % scalaVersion % "provided",
       scalaJava8Compat,
 
       sslConfig

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -85,6 +85,7 @@ object Dependencies {
     "org.hibernate" % "hibernate-core" % "5.3.7.Final" % "test"
   )
 
+  def scalaReflect(scalaVersion: String) = "org.scala-lang" % "scala-reflect" % scalaVersion % "provided"
   val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0"
   def scalaParserCombinators(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, major)) if major >= 11 => Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1")
@@ -158,7 +159,7 @@ object Dependencies {
       "javax.transaction" % "jta" % "1.1",
       "javax.inject" % "javax.inject" % "1",
 
-      "org.scala-lang" % "scala-reflect" % scalaVersion % "provided",
+      scalaReflect(scalaVersion),
       scalaJava8Compat,
 
       sslConfig
@@ -207,7 +208,7 @@ object Dependencies {
     def sbtDep(moduleId: ModuleID) = sbtPluginDep(moduleId, sbtVersion, scalaVersion)
 
     Seq(
-      "org.scala-lang" % "scala-reflect" % scalaVersion % "provided",
+      scalaReflect(scalaVersion),
       typesafeConfig,
       slf4jSimple,
       playFileWatch,


### PR DESCRIPTION
## Purpose

Adds the provided classifier to scala-reflect, so that the Scala version provided by the project is used.

## References

Implements https://github.com/playframework/playframework/issues/1459