### PR TITLE
Add copy methods to temporary files

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -114,6 +114,70 @@ if (picture != null) {
 }
 ```
 
+### Differentiate `moveTo` and `copyTo` in `TemporaryFile`
+
+Until Play 2.5, `moveTo` method was actually making a copy of the file to the destination and deleting the source. There was a subtle change in Play 2.6 where the file was instead being moved atomically depending on certain conditions. For such cases, both the source and destination end up using the same [`inode`](https://en.wikipedia.org/wiki/Inode) and then deleting the source implies that the destination will be deleted too.
+
+To make the API more clear around this, there are now `moveTo` and `copyTo` methods where `copyTo` always create a copy that does not share the same `inode`. So, if the application is configured to clean up temporary files (see documentation for [[Scala|ScalaFileUpload#Cleaning-up-temporary-files]] or [[Java|JavaFileUpload#Cleaning-up-temporary-files]]) and you want to retain the destination, then use `copyTo` instead of `moveTo`. For example:
+
+Java
+: ```java
+package controllers;
+
+import play.libs.Files;
+import play.mvc.*;
+
+import java.nio.file.Paths;
+
+public class UploadController extends Controller {
+
+    public Result upload(Http.Request request) {
+        Http.MultipartFormData<Files.TemporaryFile> body = request.body().asMultipartFormData();
+        Http.MultipartFormData.FilePart<Files.TemporaryFile> picture = body.getFile("picture");
+        if (picture != null) {
+            String fileName = picture.getFilename();
+            String contentType = picture.getContentType();
+            Files.TemporaryFile file = picture.getRef();
+
+            // Use copyTo if you want to retain the file for sure when using the temporary file
+            // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
+            file.copyTo(Paths.get("/tmp/picture/destination.jgp"), true);
+            return ok("File uploaded");
+        } else {
+            return badRequest().flashing("error", "Missing file");
+        }
+    }
+
+}
+```
+
+Scala
+: ```scala
+package controllers
+
+import java.nio.file.Paths
+
+import javax.inject.Inject
+import play.api.mvc._
+
+class UploadController @Inject()(val controllerComponents: ControllerComponents) extends BaseController {
+
+  def upload = Action(parse.multipartFormData) { request =>
+    request.body.file("picture").map { picture =>
+
+      val filename = Paths.get(picture.filename).getFileName
+
+      // Use copyTo if you want to retain the file for sure when using the temporary file
+      // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
+      picture.ref.copyTo(Paths.get(s"/tmp/picture/$filename"), replace = true)
+      Ok("File uploaded")
+    }.getOrElse {
+      Redirect(routes.HomeController.index).flashing("error" -> "Missing file")
+    }
+  }
+}
+```
+
 ### Guice compatibility changes
 
 Guice was upgraded to version [4.2.2](https://github.com/google/guice/wiki/Guice422) (also see [4.2.1](https://github.com/google/guice/wiki/Guice421) and [4.2.0 release notes](https://github.com/google/guice/wiki/Guice42)), which causes the following breaking changes:

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -141,7 +141,7 @@ public class UploadController extends Controller {
 
             // Use copyTo if you want to retain the file for sure when using the temporary file
             // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
-            file.copyTo(Paths.get("/tmp/picture/destination.jgp"), true);
+            file.copyTo(Paths.get("/tmp/picture/destination.jpg"), true);
             return ok("File uploaded");
         } else {
             return badRequest().flashing("error", "Missing file");

--- a/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/controllers/HomeController.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/controllers/HomeController.java
@@ -10,6 +10,8 @@ import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
 
+import java.nio.file.Paths;
+
 public class HomeController extends Controller {
 
     public Result upload(Http.Request request) {
@@ -19,6 +21,7 @@ public class HomeController extends Controller {
             String fileName = picture.getFilename();
             String contentType = picture.getContentType();
             TemporaryFile file = picture.getRef();
+            file.copyTo(Paths.get("/tmp/picture/destination.jgp"), true);
             return ok("File uploaded");
         } else {
             return badRequest().flashing("error", "Missing file");

--- a/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/controllers/HomeController.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/controllers/HomeController.java
@@ -21,7 +21,7 @@ public class HomeController extends Controller {
             String fileName = picture.getFilename();
             String contentType = picture.getContentType();
             TemporaryFile file = picture.getRef();
-            file.copyTo(Paths.get("/tmp/picture/destination.jgp"), true);
+            file.copyTo(Paths.get("/tmp/picture/destination.jpg"), true);
             return ok("File uploaded");
         } else {
             return badRequest().flashing("error", "Missing file");

--- a/framework/src/play/src/main/java/play/libs/Files.java
+++ b/framework/src/play/src/main/java/play/libs/Files.java
@@ -8,6 +8,7 @@ import scala.util.Try;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.nio.file.CopyOption;
 import java.nio.file.Path;
 
 /**
@@ -40,26 +41,79 @@ public final class Files {
         TemporaryFileCreator temporaryFileCreator();
 
         /**
-         * Move the file using a {@link java.io.File}.
+         * Copy the temporary file to the specified destination.
          *
-         * @param to the path to the destination file
+         * @param destination the file destination.
+         *
+         * @see #copyTo(Path, boolean)
          */
-        default TemporaryFile moveTo(File to) {
-            return moveTo(to, false);
+        default TemporaryFile copyTo(File destination) {
+            return copyTo(destination, false);
         }
+
+        /**
+         * Copy the file to the specified destination and, if the destination exists, decide if replace it
+         * based on the {@code replace} parameter.
+         *
+         * @param destination the file destination.
+         * @param replace if it should replace an existing file.
+         *
+         * @see #copyTo(Path, boolean)
+         */
+        default TemporaryFile copyTo(File destination, boolean replace) {
+            return copyTo(destination.toPath(), replace);
+        }
+
+        /**
+         * Copy the file to the specified path destination.
+         *
+         * @param destination the path destination.
+         *
+         * @see #copyTo(Path, boolean)
+         */
+        default TemporaryFile copyTo(Path destination) {
+            return copyTo(destination, false);
+        }
+
+        /**
+         * Copy the file to the specified path destination and, if the destination exists, decide if replace it
+         * based on the {@code replace} parameter.
+         *
+         * @param destination the path destination.
+         * @param replace if it should replace an existing file.
+         */
+        TemporaryFile copyTo(Path destination, boolean replace);
 
         /**
          * Move the file using a {@link java.io.File}.
          *
-         * @param to the path to the destination file
+         * @param destination the path to the destination file
+         *
+         * @see #moveTo(Path, boolean)
+         */
+        default TemporaryFile moveTo(File destination) {
+            return moveTo(destination, false);
+        }
+
+        /**
+         * Move the file to the specified destination {@link java.io.File}. In some cases, the source and destination file
+         * may point to the same {@code inode} meaning that deleting the source will result in the destination being deleted
+         * too. See the documentation for {@link java.nio.file.Files#move(Path, Path, CopyOption...)} to see more details.
+         *
+         * This behavior is especially relevant if you are also using the {@link play.api.libs.Files.TemporaryFileReaper}
+         * which deletes temporary files.
+         *
+         * @param destination the path to the destination file
          * @param replace true if an existing file should be replaced, false otherwise.
          */
-        TemporaryFile moveTo(File to, boolean replace);
+        TemporaryFile moveTo(File destination, boolean replace);
 
         /**
          * Move the file using a {@link java.nio.file.Path}.
          *
-         * @param to the path to the destination file
+         * @param to the path to the destination file.
+         *
+         * @see #moveTo(Path, boolean)
          */
         default TemporaryFile moveTo(Path to) {
             return moveTo(to, false);
@@ -70,6 +124,8 @@ public final class Files {
          *
          * @param to the path to the destination file
          * @param replace true if an existing file should be replaced, false otherwise.
+         *
+         * @see #moveTo(Path, boolean)
          */
         default TemporaryFile moveTo(Path to, boolean replace) {
             return moveTo(to.toFile(), replace);
@@ -163,6 +219,11 @@ public final class Files {
         @Override
         public TemporaryFile moveTo(File to, boolean replace) {
             return new DelegateTemporaryFile(temporaryFile.moveTo(to, replace), this.temporaryFileCreator);
+        }
+
+        @Override
+        public TemporaryFile copyTo(Path destination, boolean replace) {
+            return new DelegateTemporaryFile(temporaryFile.copyTo(destination, replace), this.temporaryFileCreator);
         }
 
         @Override

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -77,7 +77,37 @@ object Files {
     def temporaryFileCreator: TemporaryFileCreator
 
     /**
-     * Move the file using a [[java.io.File]].
+     * Copy the file to the specified path destination and, if the destination exists, decide if replace it
+     * based on the `replace` parameter.
+     *
+     * @param to the destination file.
+     * @param replace if it should replace an existing file.
+     */
+    def copyTo(to: java.io.File, replace: Boolean = false): TemporaryFile = copyTo(to.toPath, replace)
+
+    /**
+     * Copy the file to the specified path destination and, if the destination exists, decide if replace it
+     * based on the `replace` parameter.
+     *
+     * @param to the path destination.
+     * @param replace if it should replace an existing file.
+     */
+    def copyTo(to: Path, replace: Boolean): TemporaryFile = {
+      val destination = try
+        if (replace) JFiles.copy(path, to, StandardCopyOption.REPLACE_EXISTING)
+        else if (!to.toFile.exists()) JFiles.copy(path, to)
+        else to
+      catch {
+        case _: FileAlreadyExistsException => to
+      }
+
+      temporaryFileCreator.create(destination)
+    }
+
+    /**
+     * Move the file to the specified destination [[java.io.File]]. In some cases, the source and destination file
+     * may point to the same `inode` meaning that deleting the source will result in the destination being deleted
+     * too. See the documentation for [[java.nio.file.Files.move()]] to see more details.
      *
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
@@ -93,7 +123,7 @@ object Files {
      * @param replace true if an existing file should be replaced, false otherwise.
      */
     def moveTo(to: Path, replace: Boolean): TemporaryFile = {
-      try {
+      val destination = try {
         if (replace)
           JFiles.move(path, to, StandardCopyOption.REPLACE_EXISTING)
         else if (!to.toFile.exists())
@@ -103,7 +133,7 @@ object Files {
         case ex: FileAlreadyExistsException => to
       }
 
-      temporaryFileCreator.create(to)
+      temporaryFileCreator.create(destination)
     }
 
     /**

--- a/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -101,49 +101,191 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       success
     }
 
-    "replace file when moving with replace enabled" in new WithScope() {
-      val lifecycle = new DefaultApplicationLifecycle
-      val reaper = mock[TemporaryFileReaper]
-      val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+    "when copying file" in {
 
-      val file = parentDirectory.resolve("move.txt")
-      writeFile(file, "file to be moved")
+      "copy when destination does not exists and replace disabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
 
-      val destination = parentDirectory.resolve("destination.txt")
-      creator.create(file).moveTo(destination, replace = true)
+        val file = parentDirectory.resolve("copy.txt")
+        val destination = parentDirectory.resolve("does-not-exists.txt")
 
-      JFiles.exists(file) must beFalse
-      JFiles.exists(destination) must beTrue
+        // Create a source file, but not the destination
+        writeFile(file, "file to be copied")
+
+        // do the copy
+        creator.create(file).copyTo(destination, replace = false)
+
+        // Both source and destination must exist
+        JFiles.exists(file) must beTrue
+        JFiles.exists(destination) must beTrue
+
+        // Both must have the same content
+        val sourceContent = new String(java.nio.file.Files.readAllBytes(file))
+        val destinationContent = new String(java.nio.file.Files.readAllBytes(destination))
+
+        destinationContent must beEqualTo(sourceContent)
+      }
+
+      "copy when destination does not exists and replace enabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+
+        val file = parentDirectory.resolve("copy.txt")
+        val destination = parentDirectory.resolve("destination.txt")
+
+        // Create source file only
+        writeFile(file, "file to be copied")
+
+        creator.create(file).copyTo(destination, replace = true)
+
+        // Both source and destination must exist
+        JFiles.exists(file) must beTrue
+        JFiles.exists(destination) must beTrue
+
+        // Both must have the same content
+        val sourceContent = new String(java.nio.file.Files.readAllBytes(file))
+        val destinationContent = new String(java.nio.file.Files.readAllBytes(destination))
+
+        destinationContent must beEqualTo(sourceContent)
+      }
+
+      "copy when destination exists and replace enabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+
+        val file = parentDirectory.resolve("copy.txt")
+        val destination = parentDirectory.resolve("destination.txt")
+
+        // Create both files
+        writeFile(file, "file to be copied")
+        writeFile(destination, "the destination file")
+
+        creator.create(file).copyTo(destination, replace = true)
+
+        // Both source and destination must exist
+        JFiles.exists(file) must beTrue
+        JFiles.exists(destination) must beTrue
+
+        // Both must have the same content
+        val sourceContent = new String(java.nio.file.Files.readAllBytes(file))
+        val destinationContent = new String(java.nio.file.Files.readAllBytes(destination))
+
+        destinationContent must beEqualTo(sourceContent)
+      }
+
+      "do not copy when destination exists and replace disabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+
+        val file = parentDirectory.resolve("do-not-replace.txt")
+        val destination = parentDirectory.resolve("already-exists.txt")
+
+        writeFile(file, "file that won't be replaced")
+        writeFile(destination, "already exists")
+
+        val to = creator.create(file).copyTo(destination, replace = false)
+        new String(java.nio.file.Files.readAllBytes(to.toPath)) must contain("already exists")
+      }
     }
 
-    "do not replace file when moving with replace disabled" in new WithScope() {
-      val lifecycle = new DefaultApplicationLifecycle
-      val reaper = mock[TemporaryFileReaper]
-      val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+    "when moving file" in {
 
-      val file = parentDirectory.resolve("do-not-replace.txt")
-      val destination = parentDirectory.resolve("already-exists.txt")
+      "move when destination does not exists and replace disabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
 
-      writeFile(file, "file that won't be replaced")
-      writeFile(destination, "already exists")
+        val file = parentDirectory.resolve("move.txt")
+        val destination = parentDirectory.resolve("does-not-exists.txt")
 
-      val to = creator.create(file).moveTo(destination, replace = false)
-      new String(java.nio.file.Files.readAllBytes(to.toPath)) must contain("already exists")
-    }
+        // Create a source file, but not the destination
+        writeFile(file, "file to be moved")
 
-    "move a file atomically with replace enabled" in new WithScope() {
-      val lifecycle = new DefaultApplicationLifecycle
-      val reaper = mock[TemporaryFileReaper]
-      val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        // move the file
+        creator.create(file).moveTo(destination, replace = false)
 
-      val file = parentDirectory.resolve("move.txt")
-      writeFile(file, "file to be moved")
+        JFiles.exists(file) must beFalse
+        JFiles.exists(destination) must beTrue
 
-      val destination = parentDirectory.resolve("destination.txt")
-      creator.create(file).atomicMoveWithFallback(destination)
+        val destinationContent = new String(java.nio.file.Files.readAllBytes(destination))
+        destinationContent must beEqualTo("file to be moved")
+      }
 
-      JFiles.exists(file) must beFalse
-      JFiles.exists(destination) must beTrue
+      "move when destination does not exists and replace enabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+
+        val file = parentDirectory.resolve("move.txt")
+        val destination = parentDirectory.resolve("destination.txt")
+
+        // Create source file only
+        writeFile(file, "file to be moved")
+
+        creator.create(file).moveTo(destination, replace = true)
+
+        JFiles.exists(file) must beFalse
+        JFiles.exists(destination) must beTrue
+
+        val destinationContent = new String(java.nio.file.Files.readAllBytes(destination))
+        destinationContent must beEqualTo("file to be moved")
+      }
+
+      "move when destination exists and replace enabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+
+        val file = parentDirectory.resolve("move.txt")
+        val destination = parentDirectory.resolve("destination.txt")
+
+        // Create both files
+        writeFile(file, "file to be moved")
+        writeFile(destination, "the destination file")
+
+        creator.create(file).moveTo(destination, replace = true)
+
+        JFiles.exists(file) must beFalse
+        JFiles.exists(destination) must beTrue
+
+        val destinationContent = new String(java.nio.file.Files.readAllBytes(destination))
+        destinationContent must beEqualTo("file to be moved")
+      }
+
+      "do not move when destination exists and replace disabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+
+        val file = parentDirectory.resolve("do-not-replace.txt")
+        val destination = parentDirectory.resolve("already-exists.txt")
+
+        writeFile(file, "file that won't be replaced")
+        writeFile(destination, "already exists")
+
+        val to = creator.create(file).moveTo(destination, replace = false)
+        new String(java.nio.file.Files.readAllBytes(to.toPath)) must contain("already exists")
+      }
+
+      "move a file atomically with replace enabled" in new WithScope() {
+        val lifecycle = new DefaultApplicationLifecycle
+        val reaper = mock[TemporaryFileReaper]
+        val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
+
+        val file = parentDirectory.resolve("move.txt")
+        writeFile(file, "file to be moved")
+
+        val destination = parentDirectory.resolve("destination.txt")
+        creator.create(file).atomicMoveWithFallback(destination)
+
+        JFiles.exists(file) must beFalse
+        JFiles.exists(destination) must beTrue
+      }
     }
 
     "works when using compile time dependency injection" in {


### PR DESCRIPTION
## Fixes

Fixes #8885.

## Purpose

Add `copyTo` methods to temporary files and better document the differences between copying and moving files.

## References

Depends on #8891.