### PR TITLE
Update Akka HTTP to version 10.1.6

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.19")
-  val akkaHttpVersion: String = sys.props.getOrElse("akka.http.version", "10.1.5")
+  val akkaHttpVersion: String = sys.props.getOrElse("akka.http.version", "10.1.6")
   val akkaHttpVersion_2_13 = "10.1.3" // akka-http dropped support for Scala 2.13: https://github.com/akka/akka-http/issues/2166
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.7"


### PR DESCRIPTION
## Purpose

Update Akka HTTP version to 10.1.6.

## References

https://akka.io/blog/news/2018/12/19/akka-http-10.1.6-released