### PR TITLE
Generated html does not have the heading tag

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/scalaguide/http/routing/relative/views/hello.html
+++ b/documentation/manual/working/scalaGuide/main/http/code/scalaguide/http/routing/relative/views/hello.html
@@ -5,6 +5,7 @@
         <title>Bob</title>
     </head>
     <body>
+      <h1>Hello Bob</h1>
       <a href="/hello/Bob">Absolute Link</a>
       <a href="../../hello/Bob">Relative Link</a>
     </body>


### PR DESCRIPTION
The generated html file does not have the heading tag present in the scala template file.

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
