### PR TITLE
Scala 2.12.8 and latest sbt

### DIFF
--- a/framework/bin/test-sbt-plugins-1_0
+++ b/framework/bin/test-sbt-plugins-1_0
@@ -4,8 +4,8 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-SCALA_VERSION="2.12.6"
-SBT_VERSION="1.0.4"
+SCALA_VERSION="2.12.8"
+SBT_VERSION="1.2.8"
 
 cd ${FRAMEWORK}
 


### PR DESCRIPTION
I missed that one in #8863 

Also is there a reason why we don't use latest sbt when running sbt tests for 1.x?
1.2.8 was just released:
https://developer.lightbend.com/blog/2018-12-30-sbt-1-2-8/