### PR TITLE
Rename bodyMultipart(...) which actually saves a RawBuffer

### DIFF
--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -114,7 +114,7 @@ public class JavaFileUpload extends WithApplication {
                         Files.deleteIfExists(file.toPath());
                         return ok("Got: file size = " + size + "");
                     }
-                }, fakeRequest("POST", "/").bodyMultipart(Collections.singletonList(dp), tfc, mat), mat)),
+                }, fakeRequest("POST", "/").bodyRaw(Collections.singletonList(dp), tfc, mat), mat)),
                 equalTo("Got: file size = 3"));
     }
 }

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
@@ -41,7 +41,7 @@ public class JavaFileUploadTest extends WithApplication {
         Http.RequestBuilder request = Helpers.fakeRequest().uri("/upload")
                 .method("POST")
                 .header(Http.HeaderNames.CONTENT_TYPE, "multipart/form-data")
-                .bodyMultipart(
+                .bodyRaw(
                         Collections.singletonList(part),
                         play.libs.Files.singletonTemporaryFileCreator(),
                         app.asScala().materializer()

--- a/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -296,7 +296,7 @@ public class RequestBuilderTest {
         TemporaryFileCreator temporaryFileCreator = app.injector().instanceOf(TemporaryFileCreator.class);
         Http.MultipartFormData.DataPart dp = new Http.MultipartFormData.DataPart("hello", "world");
         final Request request = new RequestBuilder().uri("http://playframework.com/")
-                .bodyMultipart(Collections.singletonList(dp), temporaryFileCreator, app.materializer())
+                .bodyRaw(Collections.singletonList(dp), temporaryFileCreator, app.materializer())
                 .build();
 
         Optional<Http.MultipartFormData<Files.TemporaryFile>> parts = app.injector().instanceOf(BodyParser.MultipartFormData.class)

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1313,14 +1313,29 @@ public class Http {
         }
 
         /**
-         * Set a Multipart Form url encoded body to this request.
+         * Set a Multipart Form url encoded body to this request saving it as a raw body.
+         *
+         * @param data the multipart-form parameters
+         * @param temporaryFileCreator the temporary file creator.
+         * @param mat a Akka Streams Materializer
+         * @return the modified builder
+         *
+         * @deprecated Deprecated as of 2.7.0. Renamed to {@link #bodyRaw(List, Files.TemporaryFileCreator, Materializer)}.
+         */
+        @Deprecated
+        public RequestBuilder bodyMultipart(List<MultipartFormData.Part<Source<ByteString, ?>>> data, Files.TemporaryFileCreator temporaryFileCreator, Materializer mat) {
+            return bodyRaw(data, temporaryFileCreator, mat);
+        }
+
+        /**
+         * Set a Multipart Form url encoded body to this request saving it as a raw body.
          *
          * @param data the multipart-form parameters
          * @param temporaryFileCreator the temporary file creator.
          * @param mat a Akka Streams Materializer
          * @return the modified builder
          */
-        public RequestBuilder bodyMultipart(List<MultipartFormData.Part<Source<ByteString, ?>>> data, Files.TemporaryFileCreator temporaryFileCreator, Materializer mat) {
+        public RequestBuilder bodyRaw(List<MultipartFormData.Part<Source<ByteString, ?>>> data, Files.TemporaryFileCreator temporaryFileCreator, Materializer mat) {
             String boundary = MultipartFormatter.randomBoundary();
             try {
                 ByteString materializedData = MultipartFormatter


### PR DESCRIPTION
Fixes #8895.

Also see #8913 for further details.

I think the name of the method is very confusing because it does not actually save a `MultipartFormData` instance.