### PR TITLE
Update guava to version 23.6.1

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -43,7 +43,7 @@ object Dependencies {
   val slf4j = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % slf4jVersion)
   val slf4jSimple = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
-  val guava = "com.google.guava" % "guava" % "22.0"
+  val guava = "com.google.guava" % "guava" % "23.6.1-jre"
   val findBugs = "com.google.code.findbugs" % "jsr305" % "3.0.2" // Needed by guava
   val mockitoAll = "org.mockito" % "mockito-all" % "1.10.19"
 


### PR DESCRIPTION
## Purpose

Update to version 23.6.1 since it is the closest to 22 which fixes [CVE-2018-10237](https://github.com/google/guava/wiki/CVE-2018-10237). See https://github.com/google/guava/releases/tag/v23.6.1.