### PR TITLE
No need to set header, will be set automatically

### DIFF
--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
@@ -40,7 +40,6 @@ public class JavaFileUploadTest extends WithApplication {
         //###replace:     Http.RequestBuilder request = Helpers.fakeRequest().uri(routes.MyController.upload().url())
         Http.RequestBuilder request = Helpers.fakeRequest().uri("/upload")
                 .method("POST")
-                .header(Http.HeaderNames.CONTENT_TYPE, "multipart/form-data")
                 .bodyMultipart(
                         Collections.singletonList(part),
                         play.libs.Files.singletonTemporaryFileCreator(),


### PR DESCRIPTION
There is absolutely no need to set this header here because it will be set in the `body(...)` method anyway
https://github.com/playframework/playframework/blob/8017eb596b9f732a573f37aaf9343cd8fc975b27/framework/src/play/src/main/java/play/mvc/Http.java#L1215-L1216 which itself gets called by the `bodyMultipart(...)` method: https://github.com/playframework/playframework/blob/8017eb596b9f732a573f37aaf9343cd8fc975b27/framework/src/play/src/main/java/play/mvc/Http.java#L1333
(Also that header was wrong actually because it should include the boundary: `multipart/form-data; boundary=...`)