### PR TITLE
Using Files.size(...) should be safer than file.length()

### DIFF
--- a/core/play/src/main/java/play/mvc/StatusHeader.java
+++ b/core/play/src/main/java/play/mvc/StatusHeader.java
@@ -456,12 +456,16 @@ public class StatusHeader extends Result {
     if (file == null) {
       throw new NullPointerException("null file");
     }
-    return doSendResource(
-        FileIO.fromPath(file.toPath()),
-        Optional.of(file.length()),
-        Optional.of(file.getName()),
-        inline,
-        fileMimeTypes);
+    try {
+      return doSendResource(
+          FileIO.fromPath(file.toPath()),
+          Optional.of(Files.size(file.toPath())),
+          Optional.of(file.getName()),
+          inline,
+          fileMimeTypes);
+    } catch (final IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
   }
 
   /**
@@ -514,12 +518,16 @@ public class StatusHeader extends Result {
     if (file == null) {
       throw new NullPointerException("null file");
     }
-    return doSendResource(
-        FileIO.fromPath(file.toPath()),
-        Optional.of(file.length()),
-        Optional.of(fileName),
-        inline,
-        fileMimeTypes);
+    try {
+      return doSendResource(
+          FileIO.fromPath(file.toPath()),
+          Optional.of(Files.size(file.toPath())),
+          Optional.of(fileName),
+          inline,
+          fileMimeTypes);
+    } catch (final IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
   }
 
   private Result doSendResource(

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -279,7 +279,7 @@ case class RawBuffer(
    * Buffer size.
    */
   def size: Long = {
-    if (inMemory != null) inMemory.size else backedByTemporaryFile.length
+    if (inMemory != null) inMemory.size else Files.size(backedByTemporaryFile)
   }
 
   /**

--- a/core/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/core/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -4,6 +4,8 @@
 
 package play.api.mvc
 
+import java.nio.file.Files
+
 import akka.NotUsed
 import akka.stream.Attributes
 import akka.stream.FlowShape
@@ -24,7 +26,7 @@ import play.core.utils.HttpHeaderParameterEncoding
 // Long should be good enough to represent even very large files
 // considering that Long.MAX_VALUE is 9223372036854775807 which
 // would be enough to represent Petabytes files. Also, consider
-// that File.length() returns a long value.
+// that Files.size(...) returns a long value.
 private[mvc] case class ByteRange(start: Long, end: Long) extends Ordered[ByteRange] {
 
   override def compare(that: ByteRange): Int = {
@@ -356,7 +358,7 @@ object RangeResult {
       contentType: Option[String]
   ): Result = {
     val source = FileIO.fromPath(path)
-    ofSource(path.toFile.length(), source, rangeHeader, Option(fileName), contentType)
+    ofSource(Files.size(path), source, rangeHeader, Option(fileName), contentType)
   }
 
   /**
@@ -380,7 +382,7 @@ object RangeResult {
    */
   def ofFile(file: java.io.File, rangeHeader: Option[String], fileName: String, contentType: Option[String]): Result = {
     val source = FileIO.fromPath(file.toPath)
-    ofSource(file.length(), source, rangeHeader, Option(fileName), contentType)
+    ofSource(Files.size(file.toPath), source, rangeHeader, Option(fileName), contentType)
   }
 
   def ofSource(

--- a/core/play/src/test/java/play/mvc/RangeResultsTest.java
+++ b/core/play/src/test/java/play/mvc/RangeResultsTest.java
@@ -76,7 +76,7 @@ public class RangeResultsTest {
       throws IOException {
     this.mockRangeRequest();
     try (InputStream stream = Files.newInputStream(path)) {
-      Result result = RangeResults.ofStream(stream, path.toFile().length(), "file.txt", HTML);
+      Result result = RangeResults.ofStream(stream, Files.size(path), "file.txt", HTML);
       assertEquals(result.status(), PARTIAL_CONTENT);
       assertEquals(HTML, result.body().contentType().orElse(""));
     }
@@ -86,7 +86,7 @@ public class RangeResultsTest {
   public void shouldReturnRangeResultForInputStreamWithCustomFilename() throws IOException {
     this.mockRangeRequest();
     try (InputStream stream = Files.newInputStream(path)) {
-      Result result = RangeResults.ofStream(stream, path.toFile().length(), "file.txt");
+      Result result = RangeResults.ofStream(stream, Files.size(path), "file.txt");
       assertEquals(result.status(), PARTIAL_CONTENT);
       assertEquals(
           "attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
@@ -98,7 +98,7 @@ public class RangeResultsTest {
       throws IOException {
     this.mockRegularRequest();
     try (InputStream stream = Files.newInputStream(path)) {
-      Result result = RangeResults.ofStream(stream, path.toFile().length(), "file.txt");
+      Result result = RangeResults.ofStream(stream, Files.size(path), "file.txt");
       assertEquals(result.status(), OK);
       assertEquals(BINARY, result.body().contentType().orElse(""));
       assertEquals(
@@ -110,9 +110,9 @@ public class RangeResultsTest {
   public void shouldReturnPartialContentForInputStreamWithGivenEntityLength() throws IOException {
     this.mockRangeRequest();
     try (InputStream stream = Files.newInputStream(path)) {
-      Result result = RangeResults.ofStream(stream, path.toFile().length());
+      Result result = RangeResults.ofStream(stream, Files.size(path));
       assertEquals(result.status(), PARTIAL_CONTENT);
-      assertEquals(result.header(CONTENT_RANGE).get(), "bytes 0-1/" + path.toFile().length());
+      assertEquals(result.header(CONTENT_RANGE).get(), "bytes 0-1/" + Files.size(path));
     }
   }
 
@@ -121,7 +121,7 @@ public class RangeResultsTest {
       throws IOException {
     this.mockRangeRequest();
     try (InputStream stream = Files.newInputStream(path)) {
-      Result result = RangeResults.ofStream(stream, path.toFile().length(), "file.txt", TEXT);
+      Result result = RangeResults.ofStream(stream, Files.size(path), "file.txt", TEXT);
       assertEquals(result.status(), PARTIAL_CONTENT);
       assertEquals(TEXT, result.body().contentType().orElse(""));
       assertEquals(
@@ -268,35 +268,35 @@ public class RangeResultsTest {
   // -- Sources
 
   @Test
-  public void shouldNotReturnRangeResultForSourceWhenHeaderIsNotPresent() {
+  public void shouldNotReturnRangeResultForSourceWhenHeaderIsNotPresent() throws IOException {
     this.mockRegularRequest();
 
     Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromPath(path);
     Result result =
-        RangeResults.ofSource(path.toFile().length(), source, path.toFile().getName(), BINARY);
+        RangeResults.ofSource(Files.size(path), source, path.toFile().getName(), BINARY);
 
     assertEquals(result.status(), OK);
     assertEquals(BINARY, result.body().contentType().orElse(""));
   }
 
   @Test
-  public void shouldReturnRangeResultForSourceWhenHeaderIsPresentAndContentTypeWasSpecified() {
+  public void shouldReturnRangeResultForSourceWhenHeaderIsPresentAndContentTypeWasSpecified() throws IOException {
     this.mockRangeRequest();
 
     Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromPath(path);
     Result result =
-        RangeResults.ofSource(path.toFile().length(), source, path.toFile().getName(), TEXT);
+        RangeResults.ofSource(Files.size(path), source, path.toFile().getName(), TEXT);
 
     assertEquals(result.status(), PARTIAL_CONTENT);
     assertEquals(TEXT, result.body().contentType().orElse(""));
   }
 
   @Test
-  public void shouldReturnRangeResultForSourceWithCustomFilename() {
+  public void shouldReturnRangeResultForSourceWithCustomFilename() throws IOException {
     this.mockRangeRequest();
 
     Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromPath(path);
-    Result result = RangeResults.ofSource(path.toFile().length(), source, "file.txt", BINARY);
+    Result result = RangeResults.ofSource(Files.size(path), source, "file.txt", BINARY);
 
     assertEquals(result.status(), PARTIAL_CONTENT);
     assertEquals(BINARY, result.body().contentType().orElse(""));
@@ -305,11 +305,11 @@ public class RangeResultsTest {
   }
 
   @Test
-  public void shouldNotReturnRangeResultForSourceWhenHeaderIsNotPresentWithCustomFilename() {
+  public void shouldNotReturnRangeResultForSourceWhenHeaderIsNotPresentWithCustomFilename() throws IOException {
     this.mockRegularRequest();
 
     Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromPath(path);
-    Result result = RangeResults.ofSource(path.toFile().length(), source, "file.txt", BINARY);
+    Result result = RangeResults.ofSource(Files.size(path), source, "file.txt", BINARY);
 
     assertEquals(result.status(), OK);
     assertEquals(BINARY, result.body().contentType().orElse(""));
@@ -318,10 +318,10 @@ public class RangeResultsTest {
   }
 
   @Test
-  public void shouldReturnPartialContentForSourceWithGivenEntityLength() {
+  public void shouldReturnPartialContentForSourceWithGivenEntityLength() throws IOException {
     this.mockRangeRequest();
 
-    long entityLength = path.toFile().length();
+    long entityLength = Files.size(path);
     Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromPath(path);
     Result result = RangeResults.ofSource(entityLength, source, "file.txt", TEXT);
 
@@ -332,11 +332,11 @@ public class RangeResultsTest {
   }
 
   @Test
-  public void shouldNotReturnRangeResultForStreamWhenFilenameHasSpecialChars() {
+  public void shouldNotReturnRangeResultForStreamWhenFilenameHasSpecialChars() throws IOException {
     this.mockRegularRequest();
 
     Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromPath(path);
-    Result result = RangeResults.ofSource(path.toFile().length(), source, "测 试.tmp", BINARY);
+    Result result = RangeResults.ofSource(Files.size(path), source, "测 试.tmp", BINARY);
 
     assertEquals(result.status(), OK);
     assertEquals(BINARY, result.body().contentType().orElse(""));
@@ -346,10 +346,10 @@ public class RangeResultsTest {
   }
 
   @Test
-  public void shouldReturnRangeResultForStreamWhenFilenameHasSpecialChars() {
+  public void shouldReturnRangeResultForStreamWhenFilenameHasSpecialChars() throws IOException {
     this.mockRangeRequest();
 
-    long entityLength = path.toFile().length();
+    long entityLength = Files.size(path);
     Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromPath(path);
     Result result = RangeResults.ofSource(entityLength, source, "测 试.tmp", TEXT);
 

--- a/core/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -6,6 +6,7 @@ package play.api.mvc
 
 import java.io.File
 import java.io.InputStream
+import java.nio.file.Files
 import java.nio.file.Path
 
 import akka.actor.ActorSystem
@@ -447,7 +448,7 @@ class RangeResultSpec extends Specification {
       val inputStream = java.nio.file.Files.newInputStream(file.toPath)
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType), _, _, _) =
-          RangeResult.ofStream(file.length(), inputStream, None, "file.mp4", Some("video/mp4"))
+          RangeResult.ofStream(Files.size(file.toPath), inputStream, None, "file.mp4", Some("video/mp4"))
         headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"")
         contentType must beSome("video/mp4")
       } finally {

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
@@ -20,6 +20,7 @@ import play.mvc.Result;
 import play.test.WithApplication;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -116,7 +117,12 @@ public class JavaStream extends WithApplication {
       java.nio.file.Path path = file.toPath();
       Source<ByteString, ?> source = FileIO.fromPath(path);
 
-      Optional<Long> contentLength = Optional.of(file.length());
+      Optional<Long> contentLength = null;
+      try {
+          contentLength = Optional.of(Files.size(path));
+      } catch (IOException ioe) {
+          throw new RuntimeException(ioe);
+      }
 
       return new Result(
           new ResponseHeader(200, Collections.emptyMap()),

--- a/documentation/manual/working/scalaGuide/main/async/code/scalaguide/async/scalastream/ScalaStream.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/scalaguide/async/scalastream/ScalaStream.scala
@@ -6,6 +6,7 @@ package scalaguide.async.scalastream
 
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.nio.file.Files
 import javax.inject.Inject
 
 import akka.stream.scaladsl.FileIO
@@ -68,7 +69,7 @@ class ScalaStreamController @Inject()(val controllerComponents: ControllerCompon
     val path: java.nio.file.Path      = file.toPath
     val source: Source[ByteString, _] = FileIO.fromPath(path)
 
-    val contentLength = Some(file.length())
+    val contentLength = Some(Files.size(file.toPath))
 
     Result(
       header = ResponseHeader(200, Map.empty),


### PR DESCRIPTION
Have a look at the answers here: https://stackoverflow.com/q/7226588/810109
I think it's better and safer to rely on `Files.size(...)`.