### PR TITLE
Fix typo "ScalatTest + Play"

### DIFF
--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -59,7 +59,7 @@ If your project is using Play Ebean, you need to upgrade it:
 addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "3.0.0")
 ```
 
-### ScalaTest + Plus upgrade
+### ScalaTest + Play upgrade
 
 If your project is using [[ScalaTest + Play|ScalaTestingWithScalaTest]], you need to upgrade it:
 


### PR DESCRIPTION
"ScalaTest + Plus" in Migration25 page may be typo of "ScalaTest + Play".