### PR TITLE
specs2 upgrade

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
 
-  val specs2Version = "4.3.5"
+  val specs2Version = "4.3.6"
   val specs2Deps = Seq(
     "specs2-core",
     "specs2-junit",


### PR DESCRIPTION
Has been published now for Scala 2.13.0-M5:
https://github.com/etorreborre/specs2/issues/709#issuecomment-452867297