### PR TITLE
Update ScalaWebSockets.scala

### DIFF
--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -311,6 +311,8 @@ object Samples {
     //#streams1
     import play.api.mvc._
     import akka.stream.scaladsl._
+    import scala.util.Success
+    import scala.util.Failure
 
     def socket = WebSocket.accept[String, String] { request =>
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -313,6 +313,7 @@ object Samples {
     import akka.stream.scaladsl._
     import scala.util.Success
     import scala.util.Failure
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     def socket = WebSocket.accept[String, String] { request =>
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -321,6 +321,16 @@ object Samples {
       val out = Source.single("Hello!").concat(Source.maybe)
 
       Flow.fromSinkAndSource(in, out)
+      .watchTermination(){ (_, fut) =>
+      fut onComplete {
+        case Success(_) =>
+        //detects when client disconnected
+          println("Client disconnected")
+        case Failure(t) =>
+        //detects a disconnection failure
+          println(s"Disconnection failure: ${t.getMessage}")
+      }
+    }
     }
     //#streams1
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -324,8 +324,8 @@ object Samples {
       val out = Source.single("Hello!").concat(Source.maybe)
 
       Flow.fromSinkAndSource(in, out)
-      .watchTermination(){ (_, fut) =>
-      fut onComplete {
+      .watchTermination(){ (_, future) =>
+      future.onComplete {
         case Success(_) =>
         //detects when client disconnected
           println("Client disconnected")


### PR DESCRIPTION
Added example on how to detect client disconnection when using akka-stream to handle Websockets

# Pull Request Checklist

* [ x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ x] Have you added copyright headers to new files?
* [x ] Have you checked that both Scala and Java APIs are updated?
* [x ] Have you updated the documentation for both Scala and Java sections?
* [x ] Have you added tests for any changed functionality?

# Helpful things

## Fixes
Added example on how to detect client disconnection when using akka-stream to handle Websockets


## Purpose
The play-scala documentation whats missing an example on how to detect client diconnection when handling websocket using akka-stream.
What does this PR do?
Added example on how to detect client disconnection when using akka-stream to handle Websockets




## References

Are there any relevant issues / PRs / mailing lists discussions?
