### PR TITLE
fix markdown syntax issues in the 2.7 migration guide

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -123,57 +123,45 @@ To make the API more clear around this, there are now `moveTo` and `copyTo` meth
 Java
 : ```java
 package controllers;
-
 import play.libs.Files;
 import play.mvc.*;
-
 import java.nio.file.Paths;
-
 public class UploadController extends Controller {
-
-    public Result upload(Http.Request request) {
+  public Result upload(Http.Request request) {
         Http.MultipartFormData<Files.TemporaryFile> body = request.body().asMultipartFormData();
         Http.MultipartFormData.FilePart<Files.TemporaryFile> picture = body.getFile("picture");
         if (picture != null) {
-            String fileName = picture.getFilename();
-            String contentType = picture.getContentType();
-            Files.TemporaryFile file = picture.getRef();
-
-            // Use copyTo if you want to retain the file for sure when using the temporary file
-            // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
-            file.copyTo(Paths.get("/tmp/picture/destination.jpg"), true);
-            return ok("File uploaded");
+          String fileName = picture.getFilename();
+          String contentType = picture.getContentType();
+          Files.TemporaryFile file = picture.getRef();
+          // Use copyTo if you want to retain the file for sure when using the temporary file
+          // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
+          file.copyTo(Paths.get("/tmp/picture/destination.jpg"), true);
+          return ok("File uploaded");
         } else {
-            return badRequest().flashing("error", "Missing file");
+          return badRequest().flashing("error", "Missing file");
         }
-    }
-
+  }
 }
 ```
 
 Scala
 : ```scala
 package controllers
-
 import java.nio.file.Paths
-
 import javax.inject.Inject
 import play.api.mvc._
-
 class UploadController @Inject()(val controllerComponents: ControllerComponents) extends BaseController {
-
   def upload = Action(parse.multipartFormData) { request =>
-    request.body.file("picture").map { picture =>
-
-      val filename = Paths.get(picture.filename).getFileName
-
-      // Use copyTo if you want to retain the file for sure when using the temporary file
-      // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
-      picture.ref.copyTo(Paths.get(s"/tmp/picture/$filename"), replace = true)
-      Ok("File uploaded")
-    }.getOrElse {
-      Redirect(routes.HomeController.index).flashing("error" -> "Missing file")
-    }
+        request.body.file("picture").map { picture =>
+          val filename = Paths.get(picture.filename).getFileName
+          // Use copyTo if you want to retain the file for sure when using the temporary file
+          // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
+          picture.ref.copyTo(Paths.get(s"/tmp/picture/$filename"), replace = true)
+          Ok("File uploaded")
+        }.getOrElse {
+          Redirect(routes.HomeController.index).flashing("error" -> "Missing file")
+        }
   }
 }
 ```


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Fix markdown formatting issues in the 2.7 migration guide 

## Background Context

Why did you take this approach?

The documentation page is not displayed correctly due to markdown formatting issues