### PR TITLE
FilePart backporting

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -89,6 +89,39 @@ Other methods that were added to improve Java API:
 
 The API for body parser was mixing `Integer` and `Long` to define buffer lengths which could lead to overflow of values. The configuration is now uniformed to use `Long`. It means that if you are depending on `play.api.mvc.PlayBodyParsers.DefaultMaxTextLength` for example, you then need to use a `Long`. As such, `play.api.http.ParserConfiguration.maxMemoryBuffer` is now a `Long` too.
 
+### New fields and methods added to `FilePart` and `FileInfo`
+
+[`Scala's`](api/scala/play/api/mvc/MultipartFormData$$FilePart.html) and [`Java's`](api/java/play/mvc/Http.MultipartFormData.FilePart.html) `FilePart` classes have two new fields/methods which provide you the file size and the disposition type of a file that was uploaded via the `multipart/form-data` encoding:
+
+* [`fileSize`](api/scala/play/api/mvc/MultipartFormData$$FilePart.html#fileSize:Long) in the Scala API and [`getFileSize()`](api/java/play/mvc/Http.MultipartFormData.FilePart.html#getFileSize--) in the Java API
+* [`dispositionType`](api/scala/play/api/mvc/MultipartFormData$$FilePart.html#dispositionType:String) in the Scala API and [`getDispositionType()`](api/java/play/mvc/Http.MultipartFormData.FilePart.html#getDispositionType--) in the Java API
+
+Scala's [`FileInfo`](api/scala/play/core/parsers/Multipart$.html#FileInfoextendsProductwithSerializable) class does have the `dispositionType` field now as well.
+
+If you have Scala `case` statements containing `FilePart` or `FileInfo` you need to update those statements to also include these new fields, otherwise you get compiler errors:
+
+FilePart
+: ```scala
+case FilePart(key, filename, contentType, file, fileSize, dispositionType) => ...
+// Or if you don't use these new fields:
+case FilePart(key, filename, contentType, file, _, _) => ...
+```
+
+FileInfo
+: ```scala
+case FileInfo(partName, filename, contentType, dispositionType) => ...
+// Or if you don't use these new fields:
+case FileInfo(partName, filename, contentType, _) => ...
+```
+
+### Pass size of uploaded file to `FilePart` when using a custom body parser
+
+When uploading a file via the `multipart/form-data` encoding in [[Play Scala|ScalaFileUpload#Uploading-files-in-a-form-using-multipart/form-data]] or [[Play Java|JavaFileUpload#Uploading-files-in-a-form-using-multipart/form-data]] the `FilePart` now exposes the size of the uploaded file via [`fileSize`](api/scala/play/api/mvc/MultipartFormData$$FilePart.html#fileSize:Long) in the Scala API and [`getFileSize()`](api/java/play/mvc/Http.MultipartFormData.FilePart.html#getFileSize--) in the Java API.
+If you use a custom body parser for a file upload you need to pass the file size to the generated `FilePart` instance yourself. Otherwise the file size will not be set and default to `-1`. Have a look at the updated examples for a custom multipart file part body parser - in these example the `count` of the processed bytes (of the uploaded file) is passed to the created `FilePart` now:
+
+* [[Scala API example|ScalaFileUpload#Writing-your-own-body-parser]]
+* [[Java API example|JavaFileUpload#Writing-a-custom-multipart-file-part-body-parser]]
+
 ### Java's `FilePart` exposes the `TemporaryFile` for uploaded files
 
 By default, [[uploading files|JavaFileUpload]] via the `multipart/form-data` encoding uses a [`TemporaryFile`](api/java/play/libs/Files.TemporaryFile.html) API which relies on storing files in a temporary filesystem.

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -77,6 +77,7 @@ public class JavaFileUpload extends WithApplication {
                                                 filename,
                                                 contentType,
                                                 file,
+                                                results.getCount(),
                                                 dispositionType))
                         ));
             };
@@ -103,14 +104,14 @@ public class JavaFileUpload extends WithApplication {
         Path tmpFile = Files.createTempFile("temp", "txt");
         Files.write(tmpFile, "foo".getBytes());
         Source<ByteString, ?> source = FileIO.fromPath(tmpFile);
-        Http.MultipartFormData.FilePart<Source<ByteString, ?>> dp = new Http.MultipartFormData.FilePart<>("name", "filename", "text/plain", source);
+        Http.MultipartFormData.FilePart<Source<ByteString, ?>> dp = new Http.MultipartFormData.FilePart<>("name", "filename", "text/plain", source, Files.size(tmpFile));
         assertThat(contentAsString(call(new javaguide.testhelpers.MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     @BodyParser.Of(MultipartFormDataWithFileBodyParser.class)
                     public Result uploadCustomMultiPart(Http.Request request) throws Exception {
                         final Http.MultipartFormData<File> formData = request.body().asMultipartFormData();
                         final Http.MultipartFormData.FilePart<File> filePart = formData.getFile("name");
                         final File file = filePart.getRef();
-                        final long size = Files.size(file.toPath());
+                        final long size = filePart.getFileSize();
                         Files.deleteIfExists(file.toPath());
                         return ok("Got: file size = " + size + "");
                     }

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUploadTest.java
@@ -35,7 +35,7 @@ public class JavaFileUploadTest extends WithApplication {
     @Test
     public void testFileUpload() throws IOException {
         File file = getFile();
-        Http.MultipartFormData.Part<Source<ByteString, ?>> part = new Http.MultipartFormData.FilePart<>("picture", "file.pdf", "application/pdf", FileIO.fromPath(file.toPath()));
+        Http.MultipartFormData.Part<Source<ByteString, ?>> part = new Http.MultipartFormData.FilePart<>("picture", "file.pdf", "application/pdf", FileIO.fromPath(file.toPath()), Files.size(file.toPath()));
 
         //###replace:     Http.RequestBuilder request = Helpers.fakeRequest().uri(routes.MyController.upload().url())
         Http.RequestBuilder request = Helpers.fakeRequest().uri("/upload")

--- a/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/controllers/HomeController.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/javaguide/fileupload/controllers/HomeController.java
@@ -19,6 +19,7 @@ public class HomeController extends Controller {
         Http.MultipartFormData.FilePart<TemporaryFile> picture = body.getFile("picture");
         if (picture != null) {
             String fileName = picture.getFilename();
+            long fileSize = picture.getFileSize();
             String contentType = picture.getContentType();
             TemporaryFile file = picture.getRef();
             file.copyTo(Paths.get("/tmp/picture/destination.jpg"), true);

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -50,8 +50,10 @@ package scalaguide.upload.fileupload {
             // only get the last part of the filename
             // otherwise someone can send a path like ../../home/foo/bar.txt to write to other files on the system
             val filename = Paths.get(picture.filename).getFileName
+            val fileSize = picture.fileSize
+            val contentType = picture.contentType
 
-            picture.ref.moveTo(Paths.get(s"/tmp/picture/$filename"), replace = true)
+            picture.ref.copyTo(Paths.get(s"/tmp/picture/$filename"), replace = true)
             Ok("File uploaded")
           }.getOrElse {
             Redirect(routes.HomeController.index).flashing("error" -> "Missing file")
@@ -62,7 +64,7 @@ package scalaguide.upload.fileupload {
         val temporaryFileCreator = SingletonTemporaryFileCreator
         val tf = temporaryFileCreator.create(tmpFile)
         val request = FakeRequest().withBody(
-          MultipartFormData(Map.empty, Seq(FilePart("picture", "formuploaded", None, tf)), Nil)
+          MultipartFormData(Map.empty, Seq(FilePart("picture", "formuploaded", None, tf, JFiles.size(tf.path))), Nil)
         )
         testAction(upload, request)
 
@@ -132,13 +134,13 @@ package scalaguide.upload.fileupload {
           val fileSink = FileIO.toPath(path)
           val accumulator = Accumulator(fileSink)
           accumulator.map { case IOResult(count, status) =>
-            FilePart(partName, filename, contentType, file, dispositionType)
+            FilePart(partName, filename, contentType, file, count, dispositionType)
           }(ec)
       }
 
       def uploadCustom = Action(parse.multipartFormData(handleFilePartAsFile)) { request =>
         val fileOption = request.body.file("name").map {
-          case FilePart(key, filename, contentType, file, dispositionType) =>
+          case FilePart(key, filename, contentType, file, fileSize, dispositionType) =>
             file.toPath
         }
 

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -5,7 +5,8 @@ import BuildSettings._
 import Dependencies._
 import Generators._
 import com.lightbend.sbt.javaagent.JavaAgent.JavaAgentKeys.{javaAgents, resolvedJavaAgents}
-import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaReportBinaryIssues}
+import com.typesafe.tools.mima.core.{DirectMissingMethodProblem, IncompatibleMethTypeProblem, IncompatibleResultTypeProblem, ProblemFilters}
+import com.typesafe.tools.mima.plugin.MimaKeys.{mimaBinaryIssueFilters, mimaPreviousArtifacts, mimaReportBinaryIssues}
 import interplay.PlayBuildBase.autoImport._
 import interplay.ScalaVersions._
 import pl.project13.scala.sbt.JmhPlugin.generateJmhSourcesAndResources
@@ -87,7 +88,22 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "play")
         twirlSources ++ twirlCompiledSources
       },
       Docs.apiDocsIncludeManaged := true
-    ).settings(Docs.playdocSettings: _*)
+    )
+    .settings(Docs.playdocSettings: _*)
+    .settings(
+      mimaBinaryIssueFilters := Seq(
+        // temporary exclusion for RC9
+        // RC9 contains an incomplete PR #8878 that was completed on #8913
+        // once we release 2.7.0 GA, MiMa must be configured to 2.7.0 and those exclusions can be removed
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.mvc.Http#MultipartFormData#FilePart.this"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MultipartFormData#FilePart.apply"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MultipartFormData#FilePart.copy"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MultipartFormData#FilePart.this"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.mvc.MultipartFormData#FilePart.copy$default$5"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.mvc.MultipartFormData#FilePart.apply$default$5"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.mvc.MultipartFormData#FilePart.<init>$default$5")
+      )
+    )
     .dependsOn(
       BuildLinkProject,
       StreamsProject

--- a/framework/src/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -106,13 +106,22 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
         parts.dataParts.get("noQuotesText1:colon") must beSome(Seq("text field with unquoted name and colon"))
         parts.files must haveLength(5)
         parts.file("file1") must beSome.like {
-          case filePart => PlayIO.readFileAsString(filePart.ref) must_== "the first file\r\n"
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== "the first file\r\n"
+            filePart.fileSize must_== 16
+          }
         }
         parts.file("file2") must beSome.like {
-          case filePart => PlayIO.readFileAsString(filePart.ref) must_== "the second file\r\n"
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== "the second file\r\n"
+            filePart.fileSize must_== 17
+          }
         }
         parts.file("file3") must beSome.like {
-          case filePart => PlayIO.readFileAsString(filePart.ref) must_== "the third file (with 'Content-Disposition: file' instead of 'form-data' as used in webhook callbacks of some scanners, see issue #8527)\r\n"
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== "the third file (with 'Content-Disposition: file' instead of 'form-data' as used in webhook callbacks of some scanners, see issue #8527)\r\n"
+            filePart.fileSize must_== 137
+          }
         }
         parts.file("file_with_space_only") must beSome.like {
           case filePart => PlayIO.readFileAsString(filePart.ref) must_== " "
@@ -211,7 +220,7 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
     "return server internal error when file upload fails because temporary file creator fails" in withClientAndServer(1 /* super small total space */ ) { ws =>
       val fileBody: ByteString = ByteString.fromString("the file body")
       val sourceFileBody: Source[ByteString, NotUsed] = Source.single(fileBody)
-      val filePart: FilePart[Source[ByteString, NotUsed]] = FilePart(key = "file", filename = "file.txt", contentType = Option("text/plain"), ref = sourceFileBody)
+      val filePart: FilePart[Source[ByteString, NotUsed]] = FilePart(key = "file", filename = "file.txt", contentType = Option("text/plain"), ref = sourceFileBody, fileSize = fileBody.size)
 
       val response = ws
         .url("/")

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -941,12 +941,8 @@ object FormSpec {
       .build()
   }
 
-  def dummyMultipartRequest(dataParts: Map[String, Array[String]] = Map.empty, fileParts: List[FilePart[TemporaryFile]] = List.empty): Request = {
-    new RequestBuilder().method("POST").uri("http://localhost/test").build().withBody(
-      new RequestBody(new Http.MultipartFormData[TemporaryFile] {
-        override def asFormUrlEncoded(): util.Map[String, Array[String]] = dataParts.asJava
-        override def getFiles: util.List[FilePart[TemporaryFile]] = fileParts.asJava
-      }))
+  def dummyMultipartRequest(dataParts: Map[String, Array[String]] = Map.empty, fileParts: List[FilePart[_]] = List.empty): Request = {
+    new RequestBuilder().method("POST").uri("http://localhost/test").bodyMultipart(dataParts.asJava, fileParts.asJava).build()
   }
 
   def validatorFactory(): ValidatorFactory = {

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -673,6 +673,7 @@ public interface BodyParser<A> {
                     filePart.filename(),
                     OptionConverters.toJava(filePart.contentType()).orElse(null),
                     filePart.ref(),
+                    filePart.fileSize(),
                     filePart.dispositionType()
             );
         }
@@ -683,6 +684,7 @@ public interface BodyParser<A> {
                     filePart.getFilename(),
                     Option.apply(filePart.getContentType()),
                     filePart.getFile(),
+                    filePart.getFileSize(),
                     filePart.getDispositionType()
             );
         }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -41,6 +41,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.*;
@@ -1213,7 +1214,7 @@ public class Http {
          * @return the modified builder
          */
         protected RequestBuilder body(RequestBody body, String contentType) {
-            header("Content-Type", contentType);
+            header(HeaderNames.CONTENT_TYPE, contentType);
             body(body);
             return this;
         }
@@ -1230,12 +1231,56 @@ public class Http {
                 headers(getHeaders().remove(HeaderNames.CONTENT_LENGTH).remove(HeaderNames.TRANSFER_ENCODING));
             } else {
                 if (!getHeaders().get(HeaderNames.TRANSFER_ENCODING).isPresent()) {
-                    int length = body.asBytes().length();
-                    header(HeaderNames.CONTENT_LENGTH, Integer.toString(length));
+                    final MultipartFormData<?> multipartFormData = body.asMultipartFormData();
+                    if (multipartFormData != null) {
+                        header(HeaderNames.CONTENT_LENGTH, Long.toString(calcMultipartFormDataBodyLength(multipartFormData)));
+                    } else {
+                        int length = body.asBytes().length();
+                        header(HeaderNames.CONTENT_LENGTH, Integer.toString(length));
+                    }
                 }
             }
             req = req.withBody(body);
             return this;
+        }
+
+        private long calcMultipartFormDataBodyLength(final MultipartFormData<?> multipartFormData) {
+            final String boundaryToContentTypeStart = MultipartFormatter.boundaryToContentType("");
+            final String boundary = getHeaders().get(HeaderNames.CONTENT_TYPE)
+                    .filter(ct -> ct.startsWith(boundaryToContentTypeStart))
+                    .map(ct -> "\r\n--" + ct.substring(boundaryToContentTypeStart.length()))
+                    .orElseThrow(() -> new RuntimeException(("Content-Type header starting with \"" + boundaryToContentTypeStart + "\" needs to be present")));
+
+            long dataSizeSum = multipartFormData.asFormUrlEncoded().entrySet().stream().mapToLong(dataPart -> Arrays.stream(dataPart.getValue()).mapToLong(value ->
+                    partLength(boundary, "form-data", dataPart.getKey() + (dataPart.getValue().length > 1 ? "[]" : ""), null, null, value)
+            ).sum()).sum();
+
+            long fileHeadersSizeSum = multipartFormData.getFiles().stream()
+                    .mapToLong(filePart ->
+                        // Pass empty body because we add the file size sum later instead anyway (see next assignment below)
+                        partLength(boundary, filePart.getDispositionType(), filePart.getKey(), filePart.getFilename(), filePart.getContentType(), "")
+                    ).sum();
+            long fileSizeSum = multipartFormData.getFiles().stream().mapToLong(filePart -> filePart.getFileSize()).sum();
+
+            long length = dataSizeSum + fileHeadersSizeSum + fileSizeSum;
+
+            if(length > 0) {
+                // Remove trailing "\r\n" from first boundary
+                length -= 2;
+                // Add last boundary with double dash (--) at the end
+                length += (boundary + "--").getBytes(StandardCharsets.UTF_8).length;
+            }
+            return length;
+        }
+
+        private int partLength(final String boundary, final String dispositionType, final String name, final String filename, final String contentType, final String body) {
+            final String part =
+                    boundary + "\r\n" +
+                    "Content-Disposition: " + dispositionType + "; name=\"" + name  + "\"" + (filename != null ? "; filename=\"" + filename + "\"" : "") + "\r\n" +
+                    (contentType != null ? "Content-Type: " + contentType + "\r\n" : "") +
+                    "\r\n" +
+                    body;
+            return part.getBytes(StandardCharsets.UTF_8).length;
         }
 
         /**
@@ -1334,6 +1379,28 @@ public class Http {
             } catch (InterruptedException | ExecutionException e) {
                 throw new RuntimeException("Failure while materializing Multipart/Form Data", e);
             }
+        }
+
+        /**
+         * Set a Multipart Form url encoded body to this request.
+         *
+         * @param formData the URL form-encoded data part
+         * @param files the files part
+         * @return the modified builder
+         */
+        public RequestBuilder bodyMultipart(Map<String, String[]> formData, List<MultipartFormData.FilePart> files) {
+            MultipartFormData multipartFormData = new MultipartFormData() {
+                @Override
+                public Map<String, String[]> asFormUrlEncoded() {
+                    return Collections.unmodifiableMap(formData);
+                }
+
+                @Override
+                public List<FilePart> getFiles() {
+                    return Collections.unmodifiableList(files);
+                }
+            };
+            return body(new RequestBody(multipartFormData), MultipartFormatter.boundaryToContentType(MultipartFormatter.randomBoundary()));
         }
 
         /**
@@ -1882,17 +1949,23 @@ public class Http {
             final String contentType;
             final A ref;
             final String dispositionType;
+            final long fileSize;
 
             public FilePart(String key, String filename, String contentType, A ref) {
-                this(key, filename, contentType, ref, "form-data");
+                this(key, filename, contentType, ref, -1);
             }
 
-            public FilePart(String key, String filename, String contentType, A ref, String dispositionType) {
+            public FilePart(String key, String filename, String contentType, A ref, long fileSize) {
+                this(key, filename, contentType, ref, fileSize, "form-data");
+            }
+
+            public FilePart(String key, String filename, String contentType, A ref, long fileSize, String dispositionType) {
                 this.key = key;
                 this.filename = filename;
                 this.contentType = contentType;
                 this.ref = ref;
                 this.dispositionType = dispositionType;
+                this.fileSize = fileSize;
             }
 
             /**
@@ -1956,6 +2029,15 @@ public class Http {
              */
             public String getDispositionType() {
                 return dispositionType;
+            }
+
+            /**
+             * The size of the file in bytes.
+             *
+             * @return the size of the file in bytes
+             */
+            public long getFileSize() {
+                return fileSize;
             }
 
         }

--- a/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
+++ b/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
@@ -34,7 +34,7 @@ public class MultipartFormatter {
                 if (fp.ref instanceof Source) {
                     Source ref = (Source) fp.ref;
                     Option<String> ct = Option.apply(fp.getContentType());
-                    return (MultipartFormData.Part)new MultipartFormData.FilePart<akka.stream.scaladsl.Source<ByteString, ?>>(fp.getKey(), fp.getFilename(), ct, ref.asScala(), fp.getDispositionType());
+                    return (MultipartFormData.Part)new MultipartFormData.FilePart<akka.stream.scaladsl.Source<ByteString, ?>>(fp.getKey(), fp.getFilename(), ct, ref.asScala(), fp.getFileSize(), fp.getDispositionType());
                 }
             }
             throw new UnsupportedOperationException("Unsupported Part Class");

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -192,7 +192,7 @@ object MultipartFormData {
   /**
    * A file part.
    */
-  case class FilePart[A](key: String, filename: String, contentType: Option[String], ref: A, dispositionType: String = "form-data") extends Part[A]
+  case class FilePart[A](key: String, filename: String, contentType: Option[String], ref: A, fileSize: Long = -1, dispositionType: String = "form-data") extends Part[A]
 
   /**
    * A part that has not been properly parsed.

--- a/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -146,7 +146,7 @@ object Multipart {
 
             def completePartFormatting(): Source[ByteString, Any] = bodyPart match {
               case MultipartFormData.DataPart(_, data) => Source.single((f ~~ ByteString(data)).get)
-              case MultipartFormData.FilePart(_, _, _, ref, _) => bodyPartChunks(ref)
+              case MultipartFormData.FilePart(_, _, _, ref, _, _) => bodyPartChunks(ref)
               case _ => throw new UnsupportedOperationException()
             }
 
@@ -155,7 +155,7 @@ object Multipart {
 
             val (key, filename, contentType, dispositionType) = bodyPart match {
               case MultipartFormData.DataPart(innerKey, _) => (innerKey, None, Option("text/plain"), "form-data")
-              case MultipartFormData.FilePart(innerKey, innerFilename, innerContentType, _, innerDispositionType) => (innerKey, Option(innerFilename), innerContentType, innerDispositionType)
+              case MultipartFormData.FilePart(innerKey, innerFilename, innerContentType, _, _, innerDispositionType) => (innerKey, Option(innerFilename), innerContentType, innerDispositionType)
               case _ => throw new UnsupportedOperationException()
             }
             renderDisposition(f, dispositionType, key, filename)

--- a/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -32,7 +32,7 @@ object JavaParsers {
       lazy val getFiles = {
         multipart.files.map { file =>
           new play.mvc.Http.MultipartFormData.FilePart(
-            file.key, file.filename, file.contentType.orNull, new DelegateTemporaryFile(file.ref).asInstanceOf[JTemporaryFile], file.dispositionType)
+            file.key, file.filename, file.contentType.orNull, new DelegateTemporaryFile(file.ref).asInstanceOf[JTemporaryFile], file.fileSize, file.dispositionType)
         }.asJava
       }
     }

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -126,7 +126,7 @@ object Multipart {
       val tempFile = temporaryFileCreator.create("multipartBody", "asTemporaryFile")
       Accumulator(FileIO.toPath(tempFile.path)).mapFuture {
         case IOResult(_, Failure(error)) => Future.failed(error)
-        case _ => Future.successful(FilePart(partName, filename, contentType, tempFile, dispositionType))
+        case IOResult(count, _) => Future.successful(FilePart(partName, filename, contentType, tempFile, count, dispositionType))
       }
   }
 
@@ -405,7 +405,7 @@ object Multipart {
           if (memoryBufferSize > maxMemoryBufferSize) {
             bufferExceeded(s"Memory buffer full ($maxMemoryBufferSize) on part $partName")
           } else {
-            emit(FilePart(partName, fileName, contentType, (), dispositionType))
+            emit(FilePart(partName, fileName, contentType, (), -1, dispositionType))
             handleFileData(input, partStart, memoryBufferSize)
           }
         }


### PR DESCRIPTION
Manual backport of #8913.

Includes MiMa exclusions that we should remove as soon as we cut 2.7.0.

Resolves #8934