### PR TITLE
[master] Fix GC bug and API for TemporaryFile move and copy methods

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -147,69 +147,20 @@ if (picture != null) {
 }
 ```
 
-### Differentiate `moveTo` and `copyTo` in `TemporaryFile`
+### Added `copyTo` and renamed the move methods in `TemporaryFile`
 
-Until Play 2.5, `moveTo` method was actually making a copy of the file to the destination and deleting the source. There was a subtle change in Play 2.6 where the file was instead being moved atomically depending on certain conditions. For such cases, both the source and destination end up using the same [`inode`](https://en.wikipedia.org/wiki/Inode) and then deleting the source implies that the destination will be deleted too.
+Until Play 2.5, the `moveTo` method was actually making a copy of the file to the destination and deleting the source. There was a subtle change in Play 2.6 where the file was instead being moved atomically depending on certain conditions. For such cases, both the source and destination end up using the same [`inode`](https://en.wikipedia.org/wiki/Inode).
+To make the API more clear around this, there is now a `copyTo` method which always creates a copy that does not share the `inode` of the source file.
 
-To make the API more clear around this, there are now `moveTo` and `copyTo` methods where `copyTo` always create a copy that does not share the same `inode`. So, if the application is configured to clean up temporary files (see documentation for [[Scala|ScalaFileUpload#Cleaning-up-temporary-files]] or [[Java|JavaFileUpload#Cleaning-up-temporary-files]]) and you want to retain the destination, then use `copyTo` instead of `moveTo`. For example:
+Another change in Play 2.7 is, that methods in `TemporaryFile`, which move a file, have been renamed:
 
-Java
-: ```java
-package controllers;
+| **deprecated method**          | **new method**
+|--------------------------------|-----------------------------------
+| `moveTo(...)`                  | `moveFileTo(...)`
+| `atomicMoveWithFallback(...)`  | `atomicMoveFileWithFallback(...)`
 
-import play.libs.Files;
-import play.mvc.*;
-
-import java.nio.file.Paths;
-
-public class UploadController extends Controller {
-
-    public Result upload(Http.Request request) {
-        Http.MultipartFormData<Files.TemporaryFile> body = request.body().asMultipartFormData();
-        Http.MultipartFormData.FilePart<Files.TemporaryFile> picture = body.getFile("picture");
-        if (picture != null) {
-            String fileName = picture.getFilename();
-            String contentType = picture.getContentType();
-            Files.TemporaryFile file = picture.getRef();
-
-            // Use copyTo if you want to retain the file for sure when using the temporary file
-            // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
-            file.copyTo(Paths.get("/tmp/picture/destination.jpg"), true);
-            return ok("File uploaded");
-        } else {
-            return badRequest().flashing("error", "Missing file");
-        }
-    }
-
-}
-```
-
-Scala
-: ```scala
-package controllers
-
-import java.nio.file.Paths
-
-import javax.inject.Inject
-import play.api.mvc._
-
-class UploadController @Inject()(val controllerComponents: ControllerComponents) extends BaseController {
-
-  def upload = Action(parse.multipartFormData) { request =>
-    request.body.file("picture").map { picture =>
-
-      val filename = Paths.get(picture.filename).getFileName
-
-      // Use copyTo if you want to retain the file for sure when using the temporary file
-      // reaper. Use moveTo if you are not using the reaper or don't care about keeping the files.
-      picture.ref.copyTo(Paths.get(s"/tmp/picture/$filename"), replace = true)
-      Ok("File uploaded")
-    }.getOrElse {
-      Redirect(routes.HomeController.index).flashing("error" -> "Missing file")
-    }
-  }
-}
-```
+These new methods return a `Path` instead of a `TemporaryFile` now. Returning a `TemporaryFile` from these methods was a mistake from the beginning, because someone could get the wrong impression that such returned files are actual temporary files, which automatically will be removed by Play's temporary file cleaning facilities eventually at some point - which however isn't true.
+Because these methods are intended to be used when moving files out of Play's internal temp folder (where uploaded files get stored initially), it makes sense that eventually it's a developer's responsibility what to do with a moved destination file (and if, how and when to delete it). Changing the return type now clarifies that.
 
 ### Guice compatibility changes
 

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -113,7 +113,7 @@ package scalaguide.upload.fileupload {
 
       //#upload-file-directly-action
         def upload = Action(parse.temporaryFile) { request =>
-          request.body.moveTo(Paths.get("/tmp/picture/uploaded"), replace = true)
+          request.body.moveFileTo(Paths.get("/tmp/picture/uploaded"), replace = true)
           Ok("File uploaded")
         }
         //#upload-file-directly-action

--- a/framework/src/play/src/main/java/play/libs/Files.java
+++ b/framework/src/play/src/main/java/play/libs/Files.java
@@ -47,7 +47,7 @@ public final class Files {
          *
          * @see #copyTo(Path, boolean)
          */
-        default TemporaryFile copyTo(File destination) {
+        default Path copyTo(File destination) {
             return copyTo(destination, false);
         }
 
@@ -60,7 +60,7 @@ public final class Files {
          *
          * @see #copyTo(Path, boolean)
          */
-        default TemporaryFile copyTo(File destination, boolean replace) {
+        default Path copyTo(File destination, boolean replace) {
             return copyTo(destination.toPath(), replace);
         }
 
@@ -71,7 +71,7 @@ public final class Files {
          *
          * @see #copyTo(Path, boolean)
          */
-        default TemporaryFile copyTo(Path destination) {
+        default Path copyTo(Path destination) {
             return copyTo(destination, false);
         }
 
@@ -82,7 +82,7 @@ public final class Files {
          * @param destination the path destination.
          * @param replace if it should replace an existing file.
          */
-        TemporaryFile copyTo(Path destination, boolean replace);
+        Path copyTo(Path destination, boolean replace);
 
         /**
          * Move the file using a {@link java.io.File}.
@@ -222,8 +222,8 @@ public final class Files {
         }
 
         @Override
-        public TemporaryFile copyTo(Path destination, boolean replace) {
-            return new DelegateTemporaryFile(temporaryFile.copyTo(destination, replace), this.temporaryFileCreator);
+        public Path copyTo(Path destination, boolean replace) {
+            return temporaryFile.copyTo(destination, replace);
         }
 
         @Override

--- a/framework/src/play/src/main/java/play/libs/Files.java
+++ b/framework/src/play/src/main/java/play/libs/Files.java
@@ -89,8 +89,58 @@ public final class Files {
          *
          * @param destination the path to the destination file
          *
-         * @see #moveTo(Path, boolean)
+         * @see #moveFileTo(Path, boolean)
          */
+        default Path moveFileTo(File destination) {
+            return moveFileTo(destination, false);
+        }
+
+        /**
+         * Move the file to the specified destination {@link java.io.File}. In some cases, the source and destination file
+         * may point to the same {@code inode} meaning that deleting the source will result in the destination being deleted
+         * too. See the documentation for {@link java.nio.file.Files#move(Path, Path, CopyOption...)} to see more details.
+         *
+         * This behavior is especially relevant if you are also using the {@link play.api.libs.Files.TemporaryFileReaper}
+         * which deletes temporary files.
+         *
+         * @param destination the path to the destination file
+         * @param replace true if an existing file should be replaced, false otherwise.
+         */
+        Path moveFileTo(File destination, boolean replace);
+
+        /**
+         * Move the file using a {@link java.nio.file.Path}.
+         *
+         * @param to the path to the destination file.
+         *
+         * @see #moveFileTo(Path, boolean)
+         */
+        default Path moveFileTo(Path to) {
+            return moveFileTo(to, false);
+        }
+
+        /**
+         * Move the file using a {@link java.nio.file.Path}.
+         *
+         * @param to the path to the destination file
+         * @param replace true if an existing file should be replaced, false otherwise.
+         *
+         * @see #moveFileTo(Path, boolean)
+         */
+        default Path moveFileTo(Path to, boolean replace) {
+            return moveFileTo(to.toFile(), replace);
+        }
+
+        /**
+         * Move the file using a {@link java.io.File}.
+         *
+         * @param destination the path to the destination file
+         *
+         * @see #moveTo(Path, boolean)
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #moveFileTo(File)} instead.
+         */
+        @Deprecated
         default TemporaryFile moveTo(File destination) {
             return moveTo(destination, false);
         }
@@ -105,7 +155,10 @@ public final class Files {
          *
          * @param destination the path to the destination file
          * @param replace true if an existing file should be replaced, false otherwise.
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #moveFileTo(File, boolean)} instead.
          */
+        @Deprecated
         TemporaryFile moveTo(File destination, boolean replace);
 
         /**
@@ -114,7 +167,10 @@ public final class Files {
          * @param to the path to the destination file.
          *
          * @see #moveTo(Path, boolean)
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #moveFileTo(Path)} instead.
          */
+        @Deprecated
         default TemporaryFile moveTo(Path to) {
             return moveTo(to, false);
         }
@@ -126,7 +182,10 @@ public final class Files {
          * @param replace true if an existing file should be replaced, false otherwise.
          *
          * @see #moveTo(Path, boolean)
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #moveFileTo(Path, boolean)} instead.
          */
+        @Deprecated
         default TemporaryFile moveTo(Path to, boolean replace) {
             return moveTo(to.toFile(), replace);
         }
@@ -139,7 +198,7 @@ public final class Files {
          *
          * @param to the path to the destination file
          */
-        TemporaryFile atomicMoveWithFallback(File to);
+        Path atomicMoveFileWithFallback(File to);
 
         /**
          * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
@@ -149,6 +208,34 @@ public final class Files {
          *
          * @param to the path to the destination file
          */
+        default Path atomicMoveFileWithFallback(Path to) {
+            return atomicMoveFileWithFallback(to.toFile());
+        }
+
+        /**
+         * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+         *
+         * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+         * existent files or not, considering that it will always replaces, makes the API more predictable.
+         *
+         * @param to the path to the destination file
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #atomicMoveFileWithFallback(File)} instead.
+         */
+        @Deprecated
+        TemporaryFile atomicMoveWithFallback(File to);
+
+        /**
+         * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+         *
+         * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+         * existent files or not, considering that it will always replaces, makes the API more predictable.
+         *
+         * @param to the path to the destination file
+         *
+         * @deprecated Deprecated as of 2.7.0. Use {@link #atomicMoveFileWithFallback(Path)} instead.
+         */
+        @Deprecated
         default TemporaryFile atomicMoveWithFallback(Path to) {
             return atomicMoveWithFallback(to.toFile());
         }
@@ -217,6 +304,12 @@ public final class Files {
         }
 
         @Override
+        public Path moveFileTo(File to, boolean replace) {
+            return temporaryFile.moveFileTo(to, replace);
+        }
+
+        @Override
+        @Deprecated
         public TemporaryFile moveTo(File to, boolean replace) {
             return new DelegateTemporaryFile(temporaryFile.moveTo(to, replace), this.temporaryFileCreator);
         }
@@ -227,6 +320,12 @@ public final class Files {
         }
 
         @Override
+        public Path atomicMoveFileWithFallback(File to) {
+            return temporaryFile.atomicMoveFileWithFallback(to.toPath());
+        }
+
+        @Override
+        @Deprecated
         public TemporaryFile atomicMoveWithFallback(File to) {
             return new DelegateTemporaryFile(temporaryFile.atomicMoveWithFallback(to.toPath()), this.temporaryFileCreator);
         }

--- a/framework/src/play/src/main/java/play/libs/Files.java
+++ b/framework/src/play/src/main/java/play/libs/Files.java
@@ -97,11 +97,7 @@ public final class Files {
 
         /**
          * Move the file to the specified destination {@link java.io.File}. In some cases, the source and destination file
-         * may point to the same {@code inode} meaning that deleting the source will result in the destination being deleted
-         * too. See the documentation for {@link java.nio.file.Files#move(Path, Path, CopyOption...)} to see more details.
-         *
-         * This behavior is especially relevant if you are also using the {@link play.api.libs.Files.TemporaryFileReaper}
-         * which deletes temporary files.
+         * may point to the same {@code inode}. See the documentation for {@link java.nio.file.Files#move(Path, Path, CopyOption...)} to see more details.
          *
          * @param destination the path to the destination file
          * @param replace true if an existing file should be replaced, false otherwise.
@@ -147,11 +143,7 @@ public final class Files {
 
         /**
          * Move the file to the specified destination {@link java.io.File}. In some cases, the source and destination file
-         * may point to the same {@code inode} meaning that deleting the source will result in the destination being deleted
-         * too. See the documentation for {@link java.nio.file.Files#move(Path, Path, CopyOption...)} to see more details.
-         *
-         * This behavior is especially relevant if you are also using the {@link play.api.libs.Files.TemporaryFileReaper}
-         * which deletes temporary files.
+         * may point to the same {@code inode}. See the documentation for {@link java.nio.file.Files#move(Path, Path, CopyOption...)} to see more details.
          *
          * @param destination the path to the destination file
          * @param replace true if an existing file should be replaced, false otherwise.

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -83,7 +83,7 @@ object Files {
      * @param to the destination file.
      * @param replace if it should replace an existing file.
      */
-    def copyTo(to: java.io.File, replace: Boolean = false): TemporaryFile = copyTo(to.toPath, replace)
+    def copyTo(to: java.io.File, replace: Boolean = false): Path = copyTo(to.toPath, replace)
 
     /**
      * Copy the file to the specified path destination and, if the destination exists, decide if replace it
@@ -92,7 +92,7 @@ object Files {
      * @param to the path destination.
      * @param replace if it should replace an existing file.
      */
-    def copyTo(to: Path, replace: Boolean): TemporaryFile = {
+    def copyTo(to: Path, replace: Boolean): Path = {
       val destination = try
         if (replace) JFiles.copy(path, to, StandardCopyOption.REPLACE_EXISTING)
         else if (!to.toFile.exists()) JFiles.copy(path, to)
@@ -101,7 +101,7 @@ object Files {
         case _: FileAlreadyExistsException => to
       }
 
-      temporaryFileCreator.create(destination)
+      destination
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -106,8 +106,7 @@ object Files {
 
     /**
      * Move the file to the specified destination [[java.io.File]]. In some cases, the source and destination file
-     * may point to the same `inode` meaning that deleting the source will result in the destination being deleted
-     * too. See the documentation for [[java.nio.file.Files.move()]] to see more details.
+     * may point to the same `inode`. See the documentation for [[java.nio.file.Files.move()]] to see more details.
      *
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
@@ -138,8 +137,7 @@ object Files {
 
     /**
      * Move the file to the specified destination [[java.io.File]]. In some cases, the source and destination file
-     * may point to the same `inode` meaning that deleting the source will result in the destination being deleted
-     * too. See the documentation for [[java.nio.file.Files.move()]] to see more details.
+     * may point to the same `inode`. See the documentation for [[java.nio.file.Files.move()]] to see more details.
      *
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -112,8 +112,8 @@ object Files {
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
      */
-    def moveTo(to: java.io.File, replace: Boolean = false): TemporaryFile = {
-      moveTo(to.toPath, replace)
+    def moveFileTo(to: java.io.File, replace: Boolean = false): Path = {
+      moveFileTo(to.toPath, replace)
     }
 
     /**
@@ -122,7 +122,7 @@ object Files {
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
      */
-    def moveTo(to: Path, replace: Boolean): TemporaryFile = {
+    def moveFileTo(to: Path, replace: Boolean): Path = {
       val destination = try {
         if (replace)
           JFiles.move(path, to, StandardCopyOption.REPLACE_EXISTING)
@@ -132,6 +132,36 @@ object Files {
       } catch {
         case ex: FileAlreadyExistsException => to
       }
+
+      destination
+    }
+
+    /**
+     * Move the file to the specified destination [[java.io.File]]. In some cases, the source and destination file
+     * may point to the same `inode` meaning that deleting the source will result in the destination being deleted
+     * too. See the documentation for [[java.nio.file.Files.move()]] to see more details.
+     *
+     * @param to the path to the destination file
+     * @param replace true if an existing file should be replaced, false otherwise.
+     *
+     * @deprecated Since 2.7.0. Use [[moveFileTo()]] instead.
+     */
+    @deprecated("Use moveFileTo instead", "2.7.0")
+    def moveTo(to: java.io.File, replace: Boolean = false): TemporaryFile = {
+      moveTo(to.toPath, replace)
+    }
+
+    /**
+     * Move the file using a [[java.nio.file.Path]].
+     *
+     * @param to the path to the destination file
+     * @param replace true if an existing file should be replaced, false otherwise.
+     *
+     * @deprecated Since 2.7.0. Use [[moveFileTo()]] instead.
+     */
+    @deprecated("Use moveFileTo instead", "2.7.0")
+    def moveTo(to: Path, replace: Boolean): TemporaryFile = {
+      val destination = moveFileTo(to, replace)
 
       new TemporaryFile {
         override def path = destination
@@ -148,7 +178,7 @@ object Files {
      *
      * @param to the path to the destination file
      */
-    def atomicMoveWithFallback(to: File): TemporaryFile = atomicMoveWithFallback(to.toPath)
+    def atomicMoveFileWithFallback(to: File): Path = atomicMoveFileWithFallback(to.toPath)
 
     /**
      * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
@@ -159,7 +189,7 @@ object Files {
      * @param to the path to the destination file
      */
     // see https://github.com/apache/kafka/blob/d345d53/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L608-L626
-    def atomicMoveWithFallback(to: Path): TemporaryFile = {
+    def atomicMoveFileWithFallback(to: Path): Path = {
       val destination = try {
         JFiles.move(path, to, StandardCopyOption.ATOMIC_MOVE)
       } catch {
@@ -174,6 +204,37 @@ object Files {
               throw inner
           }
       }
+
+      destination
+    }
+
+    /**
+     * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+     *
+     * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+     * existent files or not, considering that it will always replaces, makes the API more predictable.
+     *
+     * @param to the path to the destination file
+     *
+     * @deprecated Since 2.7.0. Use [[atomicMoveFileWithFallback()]] instead.
+     */
+    @deprecated("Use atomicMoveFileWithFallback instead", "2.7.0")
+    def atomicMoveWithFallback(to: File): TemporaryFile = atomicMoveWithFallback(to.toPath)
+
+    /**
+     * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+     *
+     * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+     * existent files or not, considering that it will always replaces, makes the API more predictable.
+     *
+     * @param to the path to the destination file
+     *
+     * @deprecated Since 2.7.0. Use [[atomicMoveFileWithFallback()]] instead.
+     */
+    // see https://github.com/apache/kafka/blob/d345d53/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L608-L626
+    @deprecated("Use atomicMoveFileWithFallback instead", "2.7.0")
+    def atomicMoveWithFallback(to: Path): TemporaryFile = {
+      val destination = atomicMoveFileWithFallback(to)
 
       new TemporaryFile {
         override def path = destination

--- a/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -189,7 +189,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(destination, "already exists")
 
         val to = creator.create(file).copyTo(destination, replace = false)
-        new String(java.nio.file.Files.readAllBytes(to.toPath)) must contain("already exists")
+        new String(java.nio.file.Files.readAllBytes(to)) must contain("already exists")
       }
 
       "delete source file has no impact on the destination file" in new WithScope() {


### PR DESCRIPTION
Forward port of #8958 except the MiMa rules in `build.sbt`. (Just did a simple rebase onto master)