### PR TITLE
[2.7.x]: Avoid error when web command fails and there is a Java error handler

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -107,12 +107,13 @@ object Server {
       // with all attributes necessary to translate it to Java.
       // TODO: `copyRequestHeader` may be a misleading name here since the method is doing more than that.
       val factoryMadeHeader: RequestHeader = application.requestFactory.copyRequestHeader(request)
+      val enrichedRequest: RequestHeader = application.requestFactory.copyRequestHeader(request)
       try {
         // We hen use the Application's logic to handle that request.
-        val (handlerHeader, handler) = application.requestHandler.handlerForRequest(factoryMadeHeader)
+        val (handlerHeader, handler) = application.requestHandler.handlerForRequest(enrichedRequest)
         (handlerHeader, handler)
       } catch {
-        handleErrors(application.errorHandler, factoryMadeHeader)
+        handleErrors(application.errorHandler, enrichedRequest)
       }
     } catch {
       handleErrors(DefaultHttpErrorHandler, request)

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -105,8 +105,8 @@ object Server {
       // The request created by the request factory needs to be at this scope so that it can be
       // used by application error handler. The reason for that is that this request is populated
       // with all attributes necessary to translate it to Java.
-      // TODO: `copyRequestHeader` may be a misleading name here since the method is doing more than that.
-      val factoryMadeHeader: RequestHeader = application.requestFactory.copyRequestHeader(request)
+      // TODO: `copyRequestHeader` is a misleading name here since it is also populating the request with attributes
+      //       such as id, session, flash, etc.
       val enrichedRequest: RequestHeader = application.requestFactory.copyRequestHeader(request)
       try {
         // We hen use the Application's logic to handle that request.

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -95,7 +95,7 @@ object Server {
       case e: Throwable =>
         val errorResult = errorHandler.onServerError(req, e)
         val errorAction = actionForResult(errorResult)
-        (request, errorAction)
+        (req, errorAction)
     }
 
     try {

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -89,11 +89,11 @@ object Server {
    */
   private[server] def getHandlerFor(request: RequestHeader, tryApp: Try[Application]): (RequestHeader, Handler) = {
 
-    @inline def handleErrors(errorHandler: HttpErrorHandler): PartialFunction[Throwable, (RequestHeader, Handler)] = {
+    @inline def handleErrors(errorHandler: HttpErrorHandler, req: RequestHeader): PartialFunction[Throwable, (RequestHeader, Handler)] = {
       case e: ThreadDeath => throw e
       case e: VirtualMachineError => throw e
       case e: Throwable =>
-        val errorResult = errorHandler.onServerError(request, e)
+        val errorResult = errorHandler.onServerError(req, e)
         val errorAction = actionForResult(errorResult)
         (request, errorAction)
     }
@@ -101,18 +101,21 @@ object Server {
     try {
       // Get the Application from the try.
       val application = tryApp.get
+      // We managed to get an Application, now make a fresh request using the Application's RequestFactory.
+      // The request created by the request factory needs to be at this scope so that it can be
+      // used by application error handler. The reason for that is that this request is populated
+      // with all attributes necessary to translate it to Java.
+      // TODO: `copyRequestHeader` may be a misleading name here since the method is doing more than that.
+      val factoryMadeHeader: RequestHeader = application.requestFactory.copyRequestHeader(request)
       try {
-        // We managed to get an Application, now make a fresh request
-        // using the Application's RequestFactory, then use the Application's
-        // logic to handle that request.
-        val factoryMadeHeader: RequestHeader = application.requestFactory.copyRequestHeader(request)
+        // We hen use the Application's logic to handle that request.
         val (handlerHeader, handler) = application.requestHandler.handlerForRequest(factoryMadeHeader)
         (handlerHeader, handler)
       } catch {
-        handleErrors(application.errorHandler)
+        handleErrors(application.errorHandler, factoryMadeHeader)
       }
     } catch {
-      handleErrors(DefaultHttpErrorHandler)
+      handleErrors(DefaultHttpErrorHandler, request)
     }
   }
 

--- a/framework/src/play/src/main/java/play/BuiltInComponentsFromContext.java
+++ b/framework/src/play/src/main/java/play/BuiltInComponentsFromContext.java
@@ -88,6 +88,8 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
 
     @Override
     public Optional<SourceMapper> sourceMapper() {
+        // Using `devContext()` method here instead of `context.sourceMapper()` because it will then
+        // respect any overrides a user might define.
         return devContext().map(play.api.ApplicationLoader.DevContext::sourceMapper);
     }
 
@@ -98,6 +100,9 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
 
     @Override
     public WebCommands webCommands() {
+        // We are maintaining state for webCommands because it is a mutable object
+        // where it is possible to add new handlers. Therefor the state needs to be
+        // consistent everywhere it is called.
         return this._webCommands.get();
     }
 

--- a/framework/src/play/src/main/java/play/BuiltInComponentsFromContext.java
+++ b/framework/src/play/src/main/java/play/BuiltInComponentsFromContext.java
@@ -20,7 +20,9 @@ import play.api.libs.concurrent.CoordinatedShutdownProvider;
 import play.api.mvc.request.DefaultRequestFactory;
 import play.api.mvc.request.RequestFactory;
 
+import play.core.DefaultWebCommands;
 import play.core.SourceMapper;
+import play.core.WebCommands;
 import play.core.j.*;
 
 import play.http.DefaultHttpErrorHandler;
@@ -68,6 +70,7 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
 
     private final Supplier<HttpErrorHandler> _httpErrorHandler = lazy(this::createHttpErrorHandler);
     private final Supplier<MappedJavaHandlerComponents> _javaHandlerComponents = lazy(this::createJavaHandlerComponents);
+    private final Supplier<WebCommands> _webCommands = lazy(this::createWebCommands);
 
     public BuiltInComponentsFromContext(ApplicationLoader.Context context) {
         this.context = context;
@@ -85,7 +88,21 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
 
     @Override
     public Optional<SourceMapper> sourceMapper() {
-        return context.sourceMapper();
+        return devContext().map(play.api.ApplicationLoader.DevContext::sourceMapper);
+    }
+
+    @Override
+    public Optional<play.api.ApplicationLoader.DevContext> devContext() {
+        return context.devContext();
+    }
+
+    @Override
+    public WebCommands webCommands() {
+        return this._webCommands.get();
+    }
+
+    private WebCommands createWebCommands() {
+        return new DefaultWebCommands();
     }
 
     @Override


### PR DESCRIPTION
## Fixes

Fixes #8947.

## Purpose

This fixes a problem with requests failing in an unexpected way when there is the need to translate the request to Java (for example if there is a Java error handler) and web commands fail. The problem can be seen in evolutions, but any web command would make the request fails.

## Background Context

See explanation at this comment: https://github.com/playframework/playframework/issues/8947#issuecomment-455196484