### PR TITLE
Added the support of max-header-count for AkkaHttpServer

### DIFF
--- a/transport/server/play-akka-http-server/src/main/resources/reference.conf
+++ b/transport/server/play-akka-http-server/src/main/resources/reference.conf
@@ -58,6 +58,10 @@ play {
       # and it limits the length of HTTP header values.
       max-header-value-length = 8k
 
+      # This setting is set in `akka.http.server.parsing.max-header-count`
+      # and it limits the number of HTTP headers.
+      max-header-count = 64
+
 
       # Enables/disables inclusion of an Tls-Session-Info header in parsed
       # messages over Tls transports (i.e., HttpRequest on server side and


### PR DESCRIPTION
## Purpose

Something that is nice to have. Previously, there is no mapping for `max-header-count` configuration.