### PR TITLE
[2.7.x] Use error.invalid when form binding fails and messages are empty

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -82,6 +82,8 @@ public class Form<T> {
     /** Statically compiled Pattern for replacing "typeMismatch" in Form errors. */
     private static final Pattern REPLACE_TYPEMISMATCH = Pattern.compile("typeMismatch", Pattern.LITERAL);
 
+    private static final String INVALID_MSG_KEY = "error.invalid";
+
     /**
      * Defines a form element's display name.
      */
@@ -672,12 +674,13 @@ public class Form<T> {
                 ImmutableList.Builder<String> builder = ImmutableList.builder();
                 final Messages msgs = lang != null ? new MessagesImpl(lang, this.messagesApi) : null;
                 for (String code: error.getCodes()) {
-                    code = REPLACE_TYPEMISMATCH.matcher(code).replaceAll(Matcher.quoteReplacement("error.invalid"));
+                    code = REPLACE_TYPEMISMATCH.matcher(code).replaceAll(Matcher.quoteReplacement(INVALID_MSG_KEY));
                     if (msgs == null || msgs.isDefinedAt(code)) {
                         builder.add(code);
                     }
                 }
-                return new ValidationError(key, builder.build().reverse(),
+                final ImmutableList<String> messages = builder.build();
+                return new ValidationError(key, messages.isEmpty() ? Arrays.asList(INVALID_MSG_KEY) : messages.reverse(),
                         convertErrorArguments(error.getArguments()));
             } else {
                 return new ValidationError(key, error.getDefaultMessage(),


### PR DESCRIPTION
Fixes #8318 for the 2.7.x and master branch.

See https://github.com/playframework/playframework/issues/8318#issuecomment-455814157 for explanation.