### PR TITLE
Hibernate Validator upgrade (critical bugfix)

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -108,7 +108,7 @@ object Dependencies {
 
   val javaFormsDeps = Seq(
 
-    "org.hibernate.validator" % "hibernate-validator" % "6.0.13.Final",
+    "org.hibernate.validator" % "hibernate-validator" % "6.0.14.Final",
 
     ("org.springframework" % "spring-context" % springFrameworkVersion)
       .exclude("org.springframework", "spring-aop")


### PR DESCRIPTION
See http://in.relation.to/2019/01/07/hibernate-validator-6014-final-out/

Needs to be backported to 2.7.x.