### PR TITLE
Replaced UpdateLogging.FULL with UpdateLogging.Full

### DIFF
--- a/documentation/manual/working/commonGuide/build/SBTCookbook.md
+++ b/documentation/manual/working/commonGuide/build/SBTCookbook.md
@@ -59,7 +59,7 @@ The first line will disable documentation generation and the second one will avo
 By default `ivyLoggingLevel` is set on `UpdateLogging.DownloadOnly`. You can change this value with:
 
  * `UpdateLogging.Quiet` only displays errors
- * `UpdateLogging.FULL` logs the most
+ * `UpdateLogging.Full` logs the most
 
 For example if you want to only display errors:
 


### PR DESCRIPTION
If you enter UpdateLogging.FULL in sbt it creates errors.

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
