### PR TITLE
Fix i18n locale lookup behavior

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/i18n/LangSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/i18n/LangSpec.scala
@@ -13,13 +13,15 @@ class LangSpec extends PlaySpecification {
   "lang spec" should {
     "allow selecting preferred language" in {
       val esEs = Lang("es-ES")
-      val es   = Lang("es")
+      val es = Lang("es")
       val deDe = Lang("de-DE")
-      val de   = Lang("de")
+      val de = Lang("de")
       val enUs = Lang("en-US")
 
       implicit val app =
-        GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq(enUs, esEs, de).map(_.code)).build()
+        GuiceApplicationBuilder()
+          .configure("play.i18n.langs" -> Seq(enUs, esEs, de).map(_.code))
+          .build()
       val langs = app.injector.instanceOf[Langs]
 
       "with exact match" in {
@@ -30,12 +32,12 @@ class LangSpec extends PlaySpecification {
         langs.preferred(Seq(de)) must_== de
       }
 
-      "with just language match country specific" in {
-        langs.preferred(Seq(es)) must_== esEs
+      "with just language not match country specific" in {
+        langs.preferred(Seq(es)) must_== enUs
       }
 
-      "with language and country not match just language" in {
-        langs.preferred(Seq(deDe)) must_== enUs
+      "with language and country match just language" in {
+        langs.preferred(Seq(deDe)) must_== de
       }
 
       "with case insensitive match" in {
@@ -84,14 +86,16 @@ class LangSpec extends PlaySpecification {
 
       "preferred language" in {
         val crhUA = Lang("crh-UA")
-        val crh   = Lang("crh")
-        val ber   = Lang("ber")
+        val crh = Lang("crh")
+        val ber = Lang("ber")
         val berDZ = Lang("ber-DZ")
         val astES = Lang("ast-ES")
-        val ast   = Lang("ast")
+        val ast = Lang("ast")
 
         implicit val app =
-          GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq(crhUA, ber, astES).map(_.code)).build()
+          GuiceApplicationBuilder()
+            .configure("play.i18n.langs" -> Seq(crhUA, ber, astES).map(_.code))
+            .build()
         val langs = app.injector.instanceOf[Langs]
 
         "with exact match" in {
@@ -102,12 +106,12 @@ class LangSpec extends PlaySpecification {
           langs.preferred(Seq(ber)) must_== ber
         }
 
-        "with just language match country specific" in {
-          langs.preferred(Seq(ast)) must_== astES
+        "with just language not match country specific" in {
+          langs.preferred(Seq(ast)) must_== crhUA
         }
 
-        "with language and country not match just language" in {
-          langs.preferred(Seq(berDZ)) must_== crhUA
+        "with language and country match just language" in {
+          langs.preferred(Seq(berDZ)) must_== ber
         }
 
         "with case insensitive match" in {
@@ -128,24 +132,27 @@ class LangSpec extends PlaySpecification {
       }
 
       "preferred language" in {
-        val enUS   = Lang("en-US")
-        val az     = Lang("az")
+        val enUS = Lang("en-US")
+        val az = Lang("az")
         val azCyrl = Lang("az-Cyrl")
         val azLatn = Lang("az-Latn")
-        val zh     = Lang("zh")
+        val zh = Lang("zh")
         val zhHans = Lang("zh-Hans")
         val zhHant = Lang("zh-Hant")
 
         implicit val app =
-          GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq(zhHans, zh, azCyrl, enUS).map(_.code)).build()
+          GuiceApplicationBuilder()
+            .configure(
+              "play.i18n.langs" -> Seq(zhHans, zh, azCyrl, enUS).map(_.code))
+            .build()
         val langs = app.injector.instanceOf[Langs]
 
         "with exact match" in {
           langs.preferred(Seq(zhHans)) must_== zhHans
         }
 
-        "with just language match script specific" in {
-          langs.preferred(Seq(az)) must_== azCyrl
+        "with just language not match script specific" in {
+          langs.preferred(Seq(az)) must_== zhHans
         }
 
         "with case insensitive match" in {

--- a/core/play/src/main/scala/play/api/i18n/Langs.scala
+++ b/core/play/src/main/scala/play/api/i18n/Langs.scala
@@ -57,7 +57,7 @@ case class Lang(locale: Locale) {
    *
    * @param accept The accepted language
    */
-  @deprecated("For the Locale Lookup, use Langs#preferred instead", "2.7.0")
+  @deprecated("For the Locale Lookup, use Langs#preferred instead", "2.8.0")
   def satisfies(accept: Lang): Boolean =
     Locale.lookup(Seq(new Locale.LanguageRange(code)).asJava, Seq(accept.locale).asJava) != null
 

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -98,6 +98,31 @@ Until Play 2.7, both Play and Play-WS were using a version of [ssl-config](https
 
 This debug system has been removed, the debug flags that do not have a direct correlation in the new system are deprecated, and the new configuration is documented in [ssl-config docs](https://lightbend.github.io/ssl-config/DebuggingSSL.html).
 
+### I18n behavior changes
+
+Matching of languages behavior now satisfies [RFC 4647](https://www.ietf.org/rfc/rfc4647.txt).
+
+#### Example
+
+`conf/application.conf` file:
+
+```
+play.i18n.langs = [ "fr", "fr-FR", "en", "en-US" ]
+```
+
+User's accept-language:
+```
+en-GB
+```
+
+##### Before
+
+User's accept-language `en-GB` does not match any of the conf. The play app responds French page against user's will.
+
+##### After
+
+User's accept-language `en-GB` matches `en`. The play app responds English page.
+
 ## Defaults changes
 
 Some of the default values used by Play had changed and that can have an impact on your application. This section details the default changes.


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #8953

## Purpose

This fixes i18n locale lookup behavior  for satisfying RFC 4647.

## Background Context

I am developing Japanese language defaulted system which also supports English.
Although i18n setting is below, `Accept-Language: en-GB` does not much `en` and defaults to `ja`.

```
play.i18n.langs = [ "ja", "ja-JP", "en", "en-US" ]
```

I think that following the Language Lookup behavior described in RFC 4647 section 3.4. is preferable for the better i18n support.

## References

* #8953
* [RFC 4647](https://www.ietf.org/rfc/rfc4647.txt)
* https://discuss.lightbend.com/t/play-2-6-i18n-locale-lookup-behavior/3239

Thank you for your taking time 😄 