### PR TITLE
Disallow @Singleton java actions to avoid data leaks between requests

### DIFF
--- a/core/play-integration-test/src/it/java/play/it/http/ActionCompositionOrderTest.java
+++ b/core/play-integration-test/src/it/java/play/it/http/ActionCompositionOrderTest.java
@@ -156,4 +156,17 @@ public class ActionCompositionOrderTest {
             return delegate.call(req);
         }
     }
+
+    @With(SingletonActionAnnotationAction.class)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SingletonActionAnnotation {}
+
+    @javax.inject.Singleton
+    static class SingletonActionAnnotationAction extends Action<SingletonActionAnnotation> {
+        @Override
+        public CompletionStage<Result> call(Http.Request req) {
+            return delegate.call(req);
+        }
+    }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -16,6 +16,7 @@ import play.http.ActionCreator
 import play.http.DefaultActionCreator
 import play.it.http.ActionCompositionOrderTest.ActionAnnotation
 import play.it.http.ActionCompositionOrderTest.ControllerAnnotation
+import play.it.http.ActionCompositionOrderTest.SingletonActionAnnotation
 import play.it.http.ActionCompositionOrderTest.WithUsername
 import play.mvc.EssentialFilter
 import play.mvc.Result
@@ -359,6 +360,14 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       allowHttpContext = false
     ) { response =>
       response.body must beEqualTo("ctx.args were set")
+    }
+
+    "abort the request when action class is annotated with @javax.inject.Singleton" in makeRequest(new MockController {
+      @SingletonActionAnnotation
+      override def action: Result = Results.ok()
+    }) { response =>
+      response.status must_== 500
+      response.body must contain("RuntimeException: Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class play.it.http.ActionCompositionOrderTest$SingletonActionAnnotationAction")
     }
   }
 

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -367,7 +367,9 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       override def action: Result = Results.ok()
     }) { response =>
       response.status must_== 500
-      response.body must contain("RuntimeException: Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class play.it.http.ActionCompositionOrderTest$SingletonActionAnnotationAction")
+      response.body must contain(
+        "RuntimeException: Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class play.it.http.ActionCompositionOrderTest$SingletonActionAnnotationAction"
+      )
     }
   }
 

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -79,7 +79,8 @@ class JavaActionAnnotations(
             .filter(_.annotationType.isAnnotationPresent(classOf[play.mvc.With]))
             .flatMap(ia => ia.annotationType.getAnnotation(classOf[play.mvc.With]).value.map(c => (ia, c, ae)))
       }
-      .flatten.map(v => {
+      .flatten
+      .map(v => {
         if (v._2.isAnnotationPresent(classOf[javax.inject.Singleton])) {
           // If action singletons would be allowed, it would be very, very likely that concurrent requests interfere with each other
           // when setting the delegate property on that one-and-only singleton instance (see code further below where delegate gets set).
@@ -87,7 +88,9 @@ class JavaActionAnnotations(
           // and points to the next (=delegate) action of that other request (instead of it's own delegate action)
           // As a result (at least) the path/query params of the request would be leaked to the others' request delegate (which eventually will be the action method in the controller).
           // See https://github.com/playframework/playframework/issues/8985#issuecomment-457009162
-          throw new RuntimeException(s"Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class ${v._2.getName}")
+          throw new RuntimeException(
+            s"Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class ${v._2.getName}"
+          )
         }
         v
       })

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -79,7 +79,18 @@ class JavaActionAnnotations(
             .filter(_.annotationType.isAnnotationPresent(classOf[play.mvc.With]))
             .flatMap(ia => ia.annotationType.getAnnotation(classOf[play.mvc.With]).value.map(c => (ia, c, ae)))
       }
-      .flatten
+      .flatten.map(v => {
+        if (v._2.isAnnotationPresent(classOf[javax.inject.Singleton])) {
+          // If action singletons would be allowed, it would be very, very likely that concurrent requests interfere with each other
+          // when setting the delegate property on that one-and-only singleton instance (see code further below where delegate gets set).
+          // If timing is right, it would be possible that, just before calling action.delegate, that the to-be-called delegate was just modified by a concurrent request
+          // and points to the next (=delegate) action of that other request (instead of it's own delegate action)
+          // As a result (at least) the path/query params of the request would be leaked to the others' request delegate (which eventually will be the action method in the controller).
+          // See https://github.com/playframework/playframework/issues/8985#issuecomment-457009162
+          throw new RuntimeException(s"Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class ${v._2.getName}")
+        }
+        v
+      })
       .reverse
   }
 


### PR DESCRIPTION
Fixes #8985
See https://github.com/playframework/playframework/issues/8985#issuecomment-457009162 for further explanation how data could be leaked between distinct requests.

We already have [a warning note in the docs](https://www.playframework.com/documentation/2.6.x/JavaActionsComposition#Composing-actions):
> _**Note**: Every request **must** be served by a distinct instance of your play.mvc.Action. If a singleton pattern is used, requests will be routed incorrectly during multiple request scenarios._

However because it's quite easy to check if an action is marked as singleton, I think it's safer to just abort the whole request to completely avoid scenarios where data could be leaked. Like the note in the docs says it already, each action **has to be**  a distinct instance and this pull requests makes sure that's the case.