### PR TITLE
Assert testkit uses the correct ServerProvider

### DIFF
--- a/framework/src/sbt-plugin/src/sbt-test/README.md
+++ b/framework/src/sbt-plugin/src/sbt-test/README.md
@@ -103,5 +103,5 @@ Provides a few test for custom behaviors depending on the HTTP backend used.
 In Test mode, Play provides tools to handle the Server and Application lifecycles. These tools must create a server
 using the configured backend and the specified protocols:
 
-* test the backend is Akka HTTP of Netty
+* test the backend is Akka HTTP or Netty
 * test HTTP/2 is dis/enabled 

--- a/framework/src/sbt-plugin/src/sbt-test/README.md
+++ b/framework/src/sbt-plugin/src/sbt-test/README.md
@@ -93,3 +93,15 @@ b- Using `akka.coordinated-shutdown.reason-overrides....exit-jvm` for a custom r
 c- (TODO) Using a custom `exit-code` is honored
 
 d- (TODO) Using a custom `exit-code` for a custom reason is honored
+
+## HTTP backend test suite
+
+Provides a few test for custom behaviors depending on the HTTP backend used.
+
+### Test mode must use user settings
+
+In Test mode, Play provides tools to handle the Server and Application lifecycles. These tools must create a server
+using the configured backend and the specified protocols:
+
+* test the backend is Akka HTTP of Netty
+* test HTTP/2 is dis/enabled 

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/build.sbt
@@ -1,0 +1,19 @@
+name := """play-scala-seed"""
+organization := "com.example"
+
+version := "1.0-SNAPSHOT"
+
+//
+// Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+//
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala, PlayAkkaHttp2Support)
+  // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
+  .disablePlugins(PlayLayoutPlugin)
+
+scalaVersion := "2.12.8"
+
+libraryDependencies += guice
+libraryDependencies += specs2
+libraryDependencies += ws

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+
+unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "project" / s"scala-sbt-${sbtBinaryVersion.value}"

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/src/main/resources/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+# https://www.playframework.com/documentation/latest/Configuration
+
+## This is an AkkaHTTP-specific setting so only the tests for AkkaHTTP-backed projects
+# should be able to read it.
+play.server.akka.server-header="AkkaHTTP Server"

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/src/main/resources/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/src/main/resources/routes
@@ -1,0 +1,1 @@
+GET     /                           controllers.HomeController.index

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/src/main/scala/controllers/HomeController.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/src/main/scala/controllers/HomeController.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+
+
+@Singleton
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def index() = Action { implicit request: Request[AnyContent] =>
+    Ok("Successful response.")
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/src/test/scala/controllers/IntegrationTest.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/src/test/scala/controllers/IntegrationTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package controllers
+
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.{ WSClient, WSRequest }
+import play.api.test.{ PlaySpecification, _ }
+
+class IntegrationTest extends
+  ForServer
+  with   PlaySpecification
+  with ApplicationFactories
+{
+
+  protected def applicationFactory: ApplicationFactory = withGuiceApp(GuiceApplicationBuilder())
+
+  def wsUrl(path: String)(implicit running: RunningServer): WSRequest = {
+    val ws = running.app.injector.instanceOf[WSClient]
+    val url = running.endpoints.httpEndpoint.get.pathUrl(path)
+    ws.url(url)
+  }
+
+  "Integration test" should {
+
+    "use the controller successfully" >> { implicit rs: RunningServer =>
+        val result = await(wsUrl("/").get)
+        result.status must ===(200)
+    }
+
+    "use the user-configured HTTP backend during test" >> { implicit rs: RunningServer =>
+      val result = await(wsUrl("/").get)
+      // This assertion indirectly checks the HTTP backend used during tests is that configured
+      // by the user on `build.sbt`. The `play.server.akka.server-header` exists in all three
+      // tests in the `http-backend` suite, but only those tests using `AkkaHTTP` as a backend
+      // can read the header value because it's an Akka HTTP specific feature.
+      result.header("Server") must ===(Some("AkkaHTTP Server"))
+    }
+
+    "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>
+      rs.endpoints.endpoints.filter(_.expectedHttpVersions.contains("2")) must not be Nil
+    }
+
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/test
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/test
@@ -1,0 +1,4 @@
+# Asserts the backend is Akka HTTP via checking a particular header is added on the response
+# Asserts tests start an HTTP/2 endpoint
+
+> test

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/build.sbt
@@ -1,0 +1,19 @@
+name := """play-scala-seed"""
+organization := "com.example"
+
+version := "1.0-SNAPSHOT"
+
+//
+// Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+//
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala)
+  // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
+  .disablePlugins(PlayLayoutPlugin)
+
+scalaVersion := "2.12.8"
+
+libraryDependencies += guice
+libraryDependencies += specs2
+libraryDependencies += ws

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+
+unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "project" / s"scala-sbt-${sbtBinaryVersion.value}"

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/src/main/resources/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+# https://www.playframework.com/documentation/latest/Configuration
+
+## This is an AkkaHTTP-specific setting so only the tests for AkkaHTTP-backed projects
+# should be able to read it.
+play.server.akka.server-header="AkkaHTTP Server"

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/src/main/resources/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/src/main/resources/routes
@@ -1,0 +1,1 @@
+GET     /                           controllers.HomeController.index

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/src/main/scala/controllers/HomeController.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/src/main/scala/controllers/HomeController.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+
+
+@Singleton
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def index() = Action { implicit request: Request[AnyContent] =>
+    Ok("Successful response.")
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/src/test/scala/controllers/IntegrationTest.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/src/test/scala/controllers/IntegrationTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package controllers
+
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.{ WSClient, WSRequest }
+import play.api.test.{ PlaySpecification, _ }
+
+class IntegrationTest extends
+  ForServer
+  with   PlaySpecification
+  with ApplicationFactories
+{
+
+  protected def applicationFactory: ApplicationFactory = withGuiceApp(GuiceApplicationBuilder())
+
+  def wsUrl(path: String)(implicit running: RunningServer): WSRequest = {
+    val ws = running.app.injector.instanceOf[WSClient]
+    val url = running.endpoints.httpEndpoint.get.pathUrl(path)
+    ws.url(url)
+  }
+
+  "Integration test" should {
+
+    "use the controller successfully" >> { implicit rs: RunningServer =>
+        val result = await(wsUrl("/").get)
+        result.status must ===(200)
+    }
+
+    "use the user-configured HTTP backend during test" >> { implicit rs: RunningServer =>
+      val result = await(wsUrl("/").get)
+      // This assertion indirectly checks the HTTP backend used during tests is that configured
+      // by the user on `build.sbt`. The `play.server.akka.server-header` exists in all three
+      // tests in the `http-backend` suite, but only those tests using `AkkaHTTP` as a backend
+      // can read the header value because it's an Akka HTTP specific feature.
+      result.header("Server") must ===(Some("AkkaHTTP Server"))
+    }
+
+    "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>
+      rs.endpoints.endpoints.filter(_.expectedHttpVersions.contains("2")) must be(Nil)
+    }
+
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/test
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/akka-http/test
@@ -1,0 +1,4 @@
+# Asserts the backend is Akka HTTP via checking a particular header is added on the response
+# Asserts tests don't start an HTTP/2 endpoint
+
+> test

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/build.sbt
@@ -1,0 +1,20 @@
+name := """play-scala-seed"""
+organization := "com.example"
+
+version := "1.0-SNAPSHOT"
+
+//
+// Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+//
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala, PlayNettyServer)
+  .disablePlugins(PlayAkkaHttpServer)
+  // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
+  .disablePlugins(PlayLayoutPlugin)
+
+scalaVersion := "2.12.8"
+
+libraryDependencies += guice
+libraryDependencies += specs2
+libraryDependencies += ws

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+
+unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "project" / s"scala-sbt-${sbtBinaryVersion.value}"

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/src/main/resources/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+# https://www.playframework.com/documentation/latest/Configuration
+
+## This is an AkkaHTTP-specific setting so only the tests for AkkaHTTP-backed projects
+# should be able to read it.
+play.server.akka.server-header="AkkaHTTP Server"

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/src/main/resources/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/src/main/resources/routes
@@ -1,0 +1,1 @@
+GET     /                           controllers.HomeController.index

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/src/main/scala/controllers/HomeController.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/src/main/scala/controllers/HomeController.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+
+
+@Singleton
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def index() = Action { implicit request: Request[AnyContent] =>
+    Ok("Successful response.")
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/src/test/scala/controllers/IntegrationTest.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/src/test/scala/controllers/IntegrationTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package controllers
+
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.{ WSClient, WSRequest }
+import play.api.test.{ PlaySpecification, _ }
+
+class IntegrationTest extends
+  ForServer
+  with   PlaySpecification
+  with ApplicationFactories
+{
+
+  protected def applicationFactory: ApplicationFactory = withGuiceApp(GuiceApplicationBuilder())
+
+  def wsUrl(path: String)(implicit running: RunningServer): WSRequest = {
+    val ws = running.app.injector.instanceOf[WSClient]
+    val url = running.endpoints.httpEndpoint.get.pathUrl(path)
+    ws.url(url)
+  }
+
+  "Integration test" should {
+
+    "use the controller successfully" >> { implicit rs: RunningServer =>
+        val result = await(wsUrl("/").get)
+        result.status must ===(200)
+    }
+
+    "use the user-configured HTTP backend during test" >> { implicit rs: RunningServer =>
+      val result = await(wsUrl("/").get)
+      // This assertion indirectly checks the HTTP backend used during tests is that configured
+      // by the user on `build.sbt`. The `play.server.akka.server-header` exists in all three
+      // tests in the `http-backend` suite, but only those tests using `AkkaHTTP` as a backend
+      // can read the header value because it's an Akka HTTP specific feature.
+      result.header("Server") must ===(None)
+    }
+
+    "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>
+      rs.endpoints.endpoints.filter(_.expectedHttpVersions.contains("2")) must be(Nil)
+    }
+
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/test
+++ b/framework/src/sbt-plugin/src/sbt-test/http-backend/netty/test
@@ -1,0 +1,4 @@
+# Asserts the backend is Netty via checking a particular header is missing on the response
+# Asserts tests don't start an HTTP/2 endpoint
+
+> test


### PR DESCRIPTION
This is a complement to #8963 

Adds a `scripted` test suite to assert in test code a user always gets a `Server` implemented with the desired backend and protocols.