### PR TITLE
Fix typo "PahBindable" -> "PathBindable"

### DIFF
--- a/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
+++ b/documentation/manual/releases/release27/migration27/JavaHttpContextMigration27.md
@@ -40,7 +40,7 @@ public class HomeController extends Controller {
 
 Play will automatically detect a route param of type `Request` (which is an import for `play.mvc.Http.Request`) and will pass the actual request into the corresponding action method's param.
 
-> **Note**: It is unlikely but possible that you have a custom `QueryStringBindable` or `PahBindable` with the name `Request`. If so, that one would now collide with Play detection of request params.
+> **Note**: It is unlikely but possible that you have a custom `QueryStringBindable` or `PathBindable` with the name `Request`. If so, that one would now collide with Play detection of request params.
 > Therefore you should use the fully qualified name of your `Request` type, for example.
 >
 >     GET    /        controllers.HomeController.index(myRequest: com.mycompany.Request)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

This fixes a typo when referencing hypothetical PathBindables named "Request". This typo only exists in the Java documentation.
