### PR TITLE
WIP: Please comment on idea: Allow the sbt run exit key to be configurable

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
@@ -57,11 +57,24 @@ object PlayConsoleInteractionMode extends PlayInteractionMode {
     val consoleReader = new ConsoleReader
     try f(consoleReader) finally consoleReader.close()
   }
+
+  /***
+    * See if a new stop key character has been set
+    */
+  private val stopKeys = {
+    val stopCharacterCode = Option(System.getProperty("play.run.stopKeyCharacterCode")).map(_.toInt) match {
+      case Some(characterCode) => characterCode
+      case _ => 13
+    }
+
+    4 | -1 | stopCharacterCode
+  }
+
   private def waitForKey(): Unit = {
     withConsoleReader { consoleReader =>
       def waitEOF(): Unit = {
         consoleReader.readCharacter() match {
-          case 4 | 13 | -1 =>
+          case stopKeys =>
           // Note: we have to listen to -1 for jline2, for some reason...
           // STOP on Ctrl-D, Enter or EOF.
           case 11 =>


### PR DESCRIPTION
This is not yet a complete PR, before I invest any more time finalising it it'd be great to have some feedback on the idea - if I go ahead and complete it do you think it'll be merged?

I regularly accidentally press enter and end a run session, which is a frustration, i'd also like to be able to put enter newlines in the console for debugging. I understand stop-on-enter was a big discussion at the time, so i've kept it as a default but added a config key that overrides it (if specified)

TODO on this PR if I go ahead:
 - Change the text 'press enter to stop' to 'press <characterCode> to stop' if overriden
 - Update reference.conf with default value + docs (?)

An alternative approach i contemplated was binding something like backtick(`) to put a newline into the console but it felt like adding weird proprietary behaviour.