### PR TITLE
Correctly read netty channel options

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
@@ -29,4 +29,4 @@ play.server {
 
 ## Configuring channel options
 
-The available options are defined in [Netty channel option documentation](https://netty.io/4.1/api/io/netty/channel/ChannelOption.html). If you are using native socket transport you can set [additional options](https://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html).
+The available options are defined in [Netty channel option documentation](https://netty.io/4.1/api/io/netty/channel/ChannelOption.html). If you are using native socket transport you can set [these](https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html) and [these](https://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html) additional options.

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -40,7 +40,10 @@ play.server {
 
     # Netty options. Possible keys here are defined by:
     #
-    # http://netty.io/4.0/api/io/netty/channel/ChannelOption.html
+    # http://netty.io/4.1/api/io/netty/channel/ChannelOption.html
+    # For native socket transport:
+    # https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html
+    # https://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html
     #
     # Options that pertain to the listening server socket are defined at the top level, options for the sockets associated
     # with received client connections are prefixed with child.*
@@ -55,6 +58,11 @@ play.server {
 
         # Set whether the TCP no delay flag is set
         # TCP_NODELAY = false
+
+        # Example how to set native socket transport options
+        # (Full qualified class name + "#" + option)
+        # "io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT" = true
+        # "io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN" = 1
       }
 
     }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -113,10 +113,11 @@ class NettyServer(
       case other          => other
     }
     config.entrySet().asScala.filterNot(_.getKey.startsWith("child.")).foreach { option =>
-      if (ChannelOption.exists(option.getKey)) {
-        setOption(ChannelOption.valueOf(option.getKey), unwrap(option.getValue))
+      val cleanKey = option.getKey.stripPrefix("\"").stripSuffix("\"")
+      if (ChannelOption.exists(cleanKey)) {
+        setOption(ChannelOption.valueOf(cleanKey), unwrap(option.getValue))
       } else {
-        logger.warn("Ignoring unknown Netty channel option: " + option.getKey)
+        logger.warn("Ignoring unknown Netty channel option: " + cleanKey)
         transport match {
           case Native =>
             logger.warn(

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -122,8 +122,8 @@ class NettyServer(
           case Native =>
             logger.warn(
               "Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html, " +
-              "https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html and " +
-              "http://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html"
+                "https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html and " +
+                "http://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html"
             )
           case Jdk =>
             logger.warn("Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html")

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -121,10 +121,12 @@ class NettyServer(
         transport match {
           case Native =>
             logger.warn(
-              "Valid values can be found at http://netty.io/4.0/api/io/netty/channel/ChannelOption.html and http://netty.io/4.0/api/io/netty/channel/epoll/EpollChannelOption.html"
+              "Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html, " +
+              "https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html and " +
+              "http://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html"
             )
           case Jdk =>
-            logger.warn("Valid values can be found at http://netty.io/4.0/api/io/netty/channel/ChannelOption.html")
+            logger.warn("Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html")
         }
       }
     }


### PR DESCRIPTION
Fixes #9030

This pull request strips any `"` prefixes and suffixes when setting netty channel options from the key so an config key containing `#` that needs to be quoted (like `"io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN" = 1`) can be passed to netty correctly (without the quotes).

I also updated the docs and reference conf with valid examples.

Needs to be backported to `2.7.x`