### PR TITLE
The wrong dependency was specified for Java

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/code/javaws.sbt
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaws.sbt
@@ -4,6 +4,6 @@
 
 //#javaws-sbt-dependencies
 libraryDependencies ++= Seq(
-  ws
+  javaWs
 )
 //#javaws-sbt-dependencies


### PR DESCRIPTION
javaWs is the ws dependency required to use ws with Java.

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
