### PR TITLE
Allow to set inline content-disposition AND filename together

### DIFF
--- a/core/play/src/main/java/play/mvc/Results.java
+++ b/core/play/src/main/java/play/mvc/Results.java
@@ -456,6 +456,31 @@ public class Results {
   }
 
   /**
+   * Generates a 200 OK result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result ok(File content, boolean inline, String filename) {
+    return status(OK, content, inline, filename);
+  }
+
+  /**
+   * Generates a 200 OK result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result ok(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(OK, content, inline, filename, fileMimeTypes);
+  }
+
+  /**
    * Generates a 201 Created result.
    *
    * @return the result
@@ -624,6 +649,31 @@ public class Results {
    */
   public static Result created(File content, String filename, FileMimeTypes fileMimeTypes) {
     return status(CREATED, content, filename, fileMimeTypes);
+  }
+
+  /**
+   * Generates a 201 Created result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result created(File content, boolean inline, String filename) {
+    return status(CREATED, content, inline, filename);
+  }
+
+  /**
+   * Generates a 201 Created result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result created(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(CREATED, content, inline, filename, fileMimeTypes);
   }
 
   /**
@@ -798,6 +848,32 @@ public class Results {
   }
 
   /**
+   * Generates a 400 Bad Request result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result badRequest(File content, boolean inline, String filename) {
+    return status(BAD_REQUEST, content, inline, filename);
+  }
+
+  /**
+   * Generates a 400 Bad Request result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result badRequest(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(BAD_REQUEST, content, inline, filename, fileMimeTypes);
+  }
+
+
+  /**
    * Generates a 401 Unauthorized result.
    *
    * @return the result
@@ -966,6 +1042,31 @@ public class Results {
    */
   public static Result unauthorized(File content, String filename, FileMimeTypes fileMimeTypes) {
     return status(UNAUTHORIZED, content, filename, fileMimeTypes);
+  }
+
+  /**
+   * Generates a 401 Unauthorized result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result unauthorized(File content, boolean inline, String filename) {
+    return status(UNAUTHORIZED, content, inline, filename);
+  }
+
+  /**
+   * Generates a 401 Unauthorized result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result unauthorized(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(UNAUTHORIZED, content, inline, filename, fileMimeTypes);
   }
 
   /**
@@ -1140,6 +1241,31 @@ public class Results {
   }
 
   /**
+   * Generates a 402 Payment Required result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result paymentRequired(File content, boolean inline, String filename) {
+    return status(PAYMENT_REQUIRED, content, inline, filename);
+  }
+
+  /**
+   * Generates a 402 Payment Required result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result paymentRequired(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(PAYMENT_REQUIRED, content, inline, filename, fileMimeTypes);
+  }
+
+  /**
    * Generates a 403 Forbidden result.
    *
    * @return the result
@@ -1308,6 +1434,31 @@ public class Results {
    */
   public static Result forbidden(File content, String filename, FileMimeTypes fileMimeTypes) {
     return status(FORBIDDEN, content, filename, fileMimeTypes);
+  }
+
+  /**
+   * Generates a 403 Forbidden result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result forbidden(File content, boolean inline, String filename) {
+    return status(FORBIDDEN, content, inline, filename);
+  }
+
+  /**
+   * Generates a 403 Forbidden result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result forbidden(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(FORBIDDEN, content, inline, filename, fileMimeTypes);
   }
 
   /**
@@ -1482,6 +1633,31 @@ public class Results {
   }
 
   /**
+   * Generates a 404 Not Found result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result notFound(File content, boolean inline, String filename) {
+    return status(NOT_FOUND, content, inline, filename);
+  }
+
+  /**
+   * Generates a 404 Not Found result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result notFound(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(NOT_FOUND, content, inline, filename, fileMimeTypes);
+  }
+
+  /**
    * Generates a 406 Not Acceptable result.
    *
    * @return the result
@@ -1650,6 +1826,31 @@ public class Results {
    */
   public static Result notAcceptable(File content, String filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_ACCEPTABLE, content, filename, fileMimeTypes);
+  }
+
+  /**
+   * Generates a 406 Not Acceptable result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result notAcceptable(File content, boolean inline, String filename) {
+    return status(NOT_ACCEPTABLE, content, inline, filename);
+  }
+
+  /**
+   * Generates a 406 Not Acceptable result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result notAcceptable(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(NOT_ACCEPTABLE, content, inline, filename, fileMimeTypes);
   }
 
   /**
@@ -1826,6 +2027,33 @@ public class Results {
   }
 
   /**
+   * Generates a 415 Unsupported Media Type result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result unsupportedMediaType(
+      File content, boolean inline, String filename) {
+    return status(UNSUPPORTED_MEDIA_TYPE, content, inline, filename);
+  }
+
+  /**
+   * Generates a 415 Unsupported Media Type result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result unsupportedMediaType(
+      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(UNSUPPORTED_MEDIA_TYPE, content, inline, filename, fileMimeTypes);
+  }
+
+  /**
    * Generates a 428 Precondition Required result.
    *
    * @return the result
@@ -1999,6 +2227,31 @@ public class Results {
   }
 
   /**
+   * Generates a 428 Precondition Required result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result preconditionRequired(File content, boolean inline, String filename) {
+    return status(PRECONDITION_REQUIRED, content, inline, filename);
+  }
+
+  /**
+   * Generates a 428 Precondition Required result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result preconditionRequired(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(PRECONDITION_REQUIRED, content, inline, filename, fileMimeTypes);
+  }
+
+  /**
    * Generates a 429 Too Many Requests result.
    *
    * @return the result
@@ -2167,6 +2420,31 @@ public class Results {
    */
   public static Result tooManyRequests(File content, String filename, FileMimeTypes fileMimeTypes) {
     return status(TOO_MANY_REQUESTS, content, filename, fileMimeTypes);
+  }
+
+  /**
+   * Generates a 429 Too Many Requests result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result tooManyRequests(File content, boolean inline, String filename) {
+    return status(TOO_MANY_REQUESTS, content, inline, filename);
+  }
+
+  /**
+   * Generates a 429 Too Many Requests result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result tooManyRequests(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(TOO_MANY_REQUESTS, content, inline, filename, fileMimeTypes);
   }
 
   /**
@@ -2343,6 +2621,31 @@ public class Results {
   }
 
   /**
+   * Generates a 431 Request Header Fields Too Large result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result requestHeaderFieldsTooLarge(File content, boolean inline, String filename) {
+    return status(REQUEST_HEADER_FIELDS_TOO_LARGE, content, inline, filename);
+  }
+
+  /**
+   * Generates a 431 Request Header Fields Too Large result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result requestHeaderFieldsTooLarge(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(REQUEST_HEADER_FIELDS_TOO_LARGE, content, inline, filename, fileMimeTypes);
+  }
+
+  /**
    * Generates a 500 Internal Server Error result.
    *
    * @return the result
@@ -2516,6 +2819,31 @@ public class Results {
   }
 
   /**
+   * Generates a 500 Internal Server Error result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result internalServerError(File content, boolean inline, String filename) {
+    return status(INTERNAL_SERVER_ERROR, content, inline, filename);
+  }
+
+  /**
+   * Generates a 500 Internal Server Error result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result internalServerError(File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(INTERNAL_SERVER_ERROR, content, inline, filename, fileMimeTypes);
+  }
+
+  /**
    * Generates a 511 Network Authentication Required result.
    *
    * @return the result
@@ -2686,6 +3014,33 @@ public class Results {
   public static Result networkAuthenticationRequired(
       File content, String filename, FileMimeTypes fileMimeTypes) {
     return status(NETWORK_AUTHENTICATION_REQUIRED, content, filename, fileMimeTypes);
+  }
+
+  /**
+   * Generates a 511 Network Authentication Required result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result networkAuthenticationRequired(
+      File content, boolean inline, String filename) {
+    return status(NETWORK_AUTHENTICATION_REQUIRED, content, inline, filename);
+  }
+
+  /**
+   * Generates a 511 Network Authentication Required result.
+   *
+   * @param content The file to send.
+   * @param inline Whether the file should be sent inline, or as an attachment.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result networkAuthenticationRequired(
+      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return status(NETWORK_AUTHENTICATION_REQUIRED, content, inline, filename, fileMimeTypes);
   }
 
   /**

--- a/core/play/src/main/java/play/mvc/Results.java
+++ b/core/play/src/main/java/play/mvc/Results.java
@@ -185,7 +185,7 @@ public class Results {
    * @return the result
    */
   public static Result status(int status, File content, FileMimeTypes fileMimeTypes) {
-    return status(status, content, true, fileMimeTypes);
+    return status(status).sendFile(content, fileMimeTypes);
   }
 
   /**

--- a/core/play/src/main/java/play/mvc/Results.java
+++ b/core/play/src/main/java/play/mvc/Results.java
@@ -241,6 +241,35 @@ public class Results {
   }
 
   /**
+   * Generates a result.
+   *
+   * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+   * @param content the file to send
+   * @param inline <code>true</code> to have it sent with inline Content-Disposition.
+   * @param fileName the name that the client should receive this file as
+   * @return the result
+   */
+  public static Result status(
+          int status, File content, boolean inline, String fileName) {
+    return status(status).sendFile(content, inline, fileName);
+  }
+
+  /**
+   * Generates a result.
+   *
+   * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+   * @param content the file to send
+   * @param inline <code>true</code> to have it sent with inline Content-Disposition.
+   * @param fileName the name that the client should receive this file as
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result status(
+          int status, File content, boolean inline, String fileName, FileMimeTypes fileMimeTypes) {
+    return status(status).sendFile(content, inline, fileName, fileMimeTypes);
+  }
+
+  /**
    * Generates a 204 No Content result.
    *
    * @return the result

--- a/core/play/src/main/java/play/mvc/StatusHeader.java
+++ b/core/play/src/main/java/play/mvc/StatusHeader.java
@@ -116,12 +116,66 @@ public class StatusHeader extends Result {
    *
    * @param resourceName The path of the resource to load.
    * @param classLoader The classloader to load it from.
+   * @param fileName The file name of the resource.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+          String resourceName, ClassLoader classLoader, String fileName) {
+    return sendResource(resourceName, classLoader, fileName, StaticFileMimeTypes.fileMimeTypes());
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param fileName The file name of the resource.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+          String resourceName, ClassLoader classLoader, String fileName, FileMimeTypes fileMimeTypes) {
+    return sendResource(resourceName, classLoader, DEFAULT_INLINE_MODE, fileName, fileMimeTypes);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
    * @param fileMimeTypes Used for file type mapping.
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(
       String resourceName, ClassLoader classLoader, FileMimeTypes fileMimeTypes) {
     return sendResource(resourceName, classLoader, DEFAULT_INLINE_MODE, fileMimeTypes);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param fileName The file name of the resource.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(String resourceName, String fileName) {
+    return sendResource(resourceName, fileName, StaticFileMimeTypes.fileMimeTypes());
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param fileName The file name of the resource.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(String resourceName, String fileName, FileMimeTypes fileMimeTypes) {
+    return sendResource(resourceName, DEFAULT_INLINE_MODE, fileName, fileMimeTypes);
   }
 
   /**

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -539,15 +539,16 @@ trait Results {
      * @param resource The path of the resource to load.
      * @param classLoader The classloader to load it from, defaults to the classloader for this class.
      * @param inline Whether it should be served as an inline file, or as an attachment.
+     * @param fileName Function to retrieve the file name. By default the name of the resource is used.
      */
     def sendResource(
         resource: String,
         classLoader: ClassLoader = Results.getClass.getClassLoader,
-        inline: Boolean = true
+        inline: Boolean = true,
+        fileName: String => String = _.split('/').last
     )(implicit fileMimeTypes: FileMimeTypes): Result = {
       val stream   = classLoader.getResourceAsStream(resource)
-      val fileName = resource.split('/').last
-      streamFile(StreamConverters.fromInputStream(() => stream), fileName, stream.available(), inline)
+      streamFile(StreamConverters.fromInputStream(() => stream), fileName(resource), stream.available(), inline)
     }
 
     /**

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -547,7 +547,7 @@ trait Results {
         inline: Boolean = true,
         fileName: String => String = _.split('/').last
     )(implicit fileMimeTypes: FileMimeTypes): Result = {
-      val stream   = classLoader.getResourceAsStream(resource)
+      val stream = classLoader.getResourceAsStream(resource)
       streamFile(StreamConverters.fromInputStream(() => stream), fileName(resource), stream.available(), inline)
     }
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -216,7 +216,10 @@ object BuildSettings {
         // Scala 2.11 removed
         ProblemFilters.exclude[MissingClassProblem]("play.core.j.AbstractFilter"),
         ProblemFilters.exclude[MissingClassProblem]("play.core.j.JavaImplicitConversions"),
-        ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$")
+        ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$"),
+
+        // Add fileName param (with default value) to Scala's sendResource(...) method
+        ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource")
       ),
       unmanagedSourceDirectories in Compile += {
         (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -217,7 +217,6 @@ object BuildSettings {
         ProblemFilters.exclude[MissingClassProblem]("play.core.j.AbstractFilter"),
         ProblemFilters.exclude[MissingClassProblem]("play.core.j.JavaImplicitConversions"),
         ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$"),
-
         // Add fileName param (with default value) to Scala's sendResource(...) method
         ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource")
       ),


### PR DESCRIPTION
This just bit me:
When sending a file (or resource) there are no `ok(...)`,... methods that take **both** the inline **and** the filename param.
(The current workaround is to directly call `return status(OK).sendFile(file, true, "somefilename.txt")` because the `sendXXX` methods do provide those params already...)

Plus:
I also added `sendResource` methods which solely take a filename param (right now you always have to also pass an inline param or a other param as well). Actually the `sendResource` just wasn't on par with all the other `sendXXX` method, which do have such methods already.

Now all those methods should be up-to-date.