### PR TITLE
[2.7.x] Log warning for @Singleton java actions

### DIFF
--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -44,6 +44,9 @@ class JavaActionAnnotations(
     val method: java.lang.reflect.Method,
     config: ActionCompositionConfiguration
 ) {
+
+  private val logger = Logger(classOf[JavaActionAnnotations])
+
   val parser: Class[_ <: JBodyParser[_]] =
     Seq(
       method.getAnnotation(classOf[play.mvc.BodyParser.Of]),
@@ -79,7 +82,18 @@ class JavaActionAnnotations(
             .filter(_.annotationType.isAnnotationPresent(classOf[play.mvc.With]))
             .flatMap(ia => ia.annotationType.getAnnotation(classOf[play.mvc.With]).value.map(c => (ia, c, ae)))
       }
-      .flatten
+      .flatten.map(v => {
+        if (v._2.isAnnotationPresent(classOf[javax.inject.Singleton])) {
+          // If action singletons would be allowed, it would be very, very likely that concurrent requests interfere with each other
+          // when setting the delegate property on that one-and-only singleton instance (see code further below where delegate gets set).
+          // If timing is right, it would be possible that, just before calling action.delegate, that the to-be-called delegate was just modified by a concurrent request
+          // and points to the next (=delegate) action of that other request (instead of it's own delegate action)
+          // As a result (at least) the path/query params of the request would be leaked to the others' request delegate (which eventually will be the action method in the controller).
+          // See https://github.com/playframework/playframework/issues/8985#issuecomment-457009162
+          logger.warn(s"Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class ${v._2.getName}")
+        }
+        v
+      })
       .reverse
   }
 

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -82,7 +82,8 @@ class JavaActionAnnotations(
             .filter(_.annotationType.isAnnotationPresent(classOf[play.mvc.With]))
             .flatMap(ia => ia.annotationType.getAnnotation(classOf[play.mvc.With]).value.map(c => (ia, c, ae)))
       }
-      .flatten.map(v => {
+      .flatten
+      .map(v => {
         if (v._2.isAnnotationPresent(classOf[javax.inject.Singleton])) {
           // If action singletons would be allowed, it would be very, very likely that concurrent requests interfere with each other
           // when setting the delegate property on that one-and-only singleton instance (see code further below where delegate gets set).
@@ -90,7 +91,9 @@ class JavaActionAnnotations(
           // and points to the next (=delegate) action of that other request (instead of it's own delegate action)
           // As a result (at least) the path/query params of the request would be leaked to the others' request delegate (which eventually will be the action method in the controller).
           // See https://github.com/playframework/playframework/issues/8985#issuecomment-457009162
-          logger.warn(s"Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class ${v._2.getName}")
+          logger.warn(
+            s"Singleton action instances are not allowed! Remove the @javax.inject.Singleton annotation from the action class ${v._2.getName}"
+          )
         }
         v
       })


### PR DESCRIPTION
Same like #8989 for 2.7.x but just logs a warning instead of aborting the request.