### PR TITLE
Netty: Make sure to init static Epoll/UnixChannelOption members

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/app/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/app/controllers/HomeController.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+
+@Singleton
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def index() = Action { implicit request: Request[AnyContent] =>
+    Ok
+  }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/build.sbt
@@ -1,0 +1,22 @@
+//
+// Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+//
+name := """netty-channel-options"""
+organization := "com.lightbend.play"
+
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala)
+  .enablePlugins(PlayNettyServer)
+  .disablePlugins(PlayAkkaHttpServer)
+  .settings(
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.8"),
+    PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
+    libraryDependencies ++= Seq(
+      guice
+    ),
+    InputKey[Unit]("callIndex") := {
+      DevModeBuild.callIndex()
+    }
+  )

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/build.sbt
@@ -18,5 +18,10 @@ lazy val root = (project in file("."))
     ),
     InputKey[Unit]("callIndex") := {
       DevModeBuild.callIndex()
+    },
+    InputKey[Unit]("checkLines") := {
+      val args                  = Def.spaceDelimited("<source> <target>").parsed
+      val source :: target :: _ = args
+      DevModeBuild.checkLines(source, target)
     }
   )

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/conf/application.conf
@@ -1,0 +1,18 @@
+play.server {
+  netty {
+    option {
+      SO_BACKLOG = 256
+      "io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT" = true
+      "io.netty.channel.epoll.EpollChannelOption#TCP_CORK" = true
+      foo = "abc"
+      child {
+        SO_KEEPALIVE = true
+        TCP_NODELAY = true
+        "io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT" = false
+        "io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN_CONNECT" = true
+        "io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN" = 3
+        bar = "xyz"
+      }
+    }
+  }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/conf/logback.xml
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/conf/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder>
+      <pattern>[%level] %logger - %message%n%xException{10}</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="play.core.server" level="DEBUG" />
+
+  <root level="ERROR">
+    <appender-ref ref="FILE" />
+  </root>
+
+</configuration>

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/conf/routes
@@ -1,0 +1,1 @@
+GET        /                controllers.HomeController.index()

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/expected-application-log.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/expected-application-log.txt
@@ -1,0 +1,16 @@
+[DEBUG] play.core.server.NettyServer - Class io.netty.channel.ChannelOption will be initialized (if it hasn't been initialized already)
+[DEBUG] play.core.server.NettyServer - Class io.netty.channel.unix.UnixChannelOption will be initialized (if it hasn't been initialized already)
+[DEBUG] play.core.server.NettyServer - Class io.netty.channel.epoll.EpollChannelOption will be initialized (if it hasn't been initialized already)
+[WARN] play.core.server.NettyServer - Ignoring unknown Netty channel option: foo
+[WARN] play.core.server.NettyServer - Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to true at bootstrapping
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_BACKLOG to 256 at bootstrapping
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_CORK to true at bootstrapping
+[INFO] play.core.server.NettyServer - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN_CONNECT to true
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_NODELAY to true
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_KEEPALIVE to true
+[WARN] play.core.server.NettyServer - Ignoring unknown Netty channel option: bar
+[WARN] play.core.server.NettyServer - Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN to 3
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to false

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/expected-application-log.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/expected-application-log.txt
@@ -6,7 +6,6 @@
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to true at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_BACKLOG to 256 at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_CORK to true at bootstrapping
-[INFO] play.core.server.NettyServer - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN_CONNECT to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_NODELAY to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_KEEPALIVE to true

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/project/Build.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/project/Build.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+import sbt._
+
+object DevModeBuild {
+
+  val ConnectTimeout = 10000
+  val ReadTimeout    = 10000
+
+  def callIndex(): Unit = callUrl("/")
+
+  private def callUrl(path: String, headers: (String, String)*): (Int, String) = {
+    val url  = new java.net.URL("http://localhost:9000" + path)
+    val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]
+    conn.setConnectTimeout(ConnectTimeout)
+    conn.setReadTimeout(ReadTimeout)
+
+    headers.foreach(h => conn.setRequestProperty(h._1, h._2))
+
+    val status = conn.getResponseCode
+
+    val is = if (conn.getResponseCode >= 400) {
+      conn.getErrorStream
+    } else {
+      conn.getInputStream
+    }
+
+    // The input stream may be null if there's no body
+    val contents = if (is != null) {
+      val c = IO.readStream(is)
+      is.close()
+      c
+    } else ""
+    conn.disconnect()
+
+    (status, contents)
+  }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/project/Build.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/project/Build.scala
@@ -10,6 +10,24 @@ object DevModeBuild {
 
   def callIndex(): Unit = callUrl("/")
 
+  def checkLines(source: String, target: String): Unit = {
+    val sourceLines = IO.readLines(new File(source))
+    val targetLines = IO.readLines(new File(target))
+
+    println("Source:")
+    println("-------")
+    println(sourceLines.mkString("\n"))
+    println("Target:")
+    println("-------")
+    println(targetLines.mkString("\n"))
+
+    sourceLines.foreach(sl => {
+      if (!targetLines.contains(sl)) {
+        throw new RuntimeException(s"File $target didn't contain line:\n$sl")
+      }
+    })
+  }
+
   private def callUrl(path: String, headers: (String, String)*): (Int, String) = {
     val url  = new java.net.URL("http://localhost:9000" + path)
     val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/project/plugins.sbt
@@ -1,0 +1,4 @@
+//
+// Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+//
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/test
@@ -3,5 +3,5 @@
 $ sleep 5000
 > callIndex
 $ sleep 2000
-$ must-mirror target/universal/stage/logs/application.log expected-application-log.txt
+> checkLines expected-application-log.txt target/universal/stage/logs/application.log
 > stopProd --no-exit-sbt

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/test
@@ -1,0 +1,7 @@
+> playUpdateSecret
+> runProd --no-exit-sbt
+$ sleep 5000
+> callIndex
+$ sleep 2000
+$ must-mirror target/universal/stage/logs/application.log expected-application-log.txt
+> stopProd --no-exit-sbt

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "assets-sample",
     version := "1.0-SNAPSHOT",
-    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.3"),
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.8"),
     includeFilter in (Assets, LessKeys.less) := "*.less",
     excludeFilter in (Assets, LessKeys.less) := "_*.less",
     PlayKeys.generateAssetsJar := false


### PR DESCRIPTION
Follow-up to #9031

We allow [to pass various options](https://github.com/playframework/playframework/blob/9bf8e49deb60f0203d4140e98eb4437ba5351209/transport/server/play-netty-server/src/main/resources/reference.conf#L50-L68) to Netty:
```
play.server.netty {
  option {
    // options for bootstrapping go in here (_directly_ inside the "option" path)

    child {
      // options for channels go in here (inside the "child" path)
    }

  }
}
```

As you can see we have options for bootstrapping Netty and options for channels. All of these options are defined in [`ChannelOption`](https://netty.io/4.1/api/io/netty/channel/ChannelOption.html) and - when using native socket transport - it's subclasses [`UnixChannelOption`](https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html) and [`EpollChannelOption`](https://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html).
You can put some options in both of the above "scopes".

**However there is a problem in Play:**
Play sets the options of the above two "scopes" at different times. It turns out the when setting an option of the `EpollChannelOption` or `UnixChannelOption` *during bootstrapping* [here](https://github.com/playframework/playframework/blob/9bf8e49deb60f0203d4140e98eb4437ba5351209/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala#L156), these classes are not initialized yet and so are their static members... But it's necessary that these classes and their static members are initialized because they "register" themself via the static `valueOf` method by putting their names/values in a pool/map, e.g. [here](https://github.com/netty/netty/blob/netty-4.1.33.Final/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java#L25).
Play then checks if an option exists by checking that Netty pool/map of options:
https://github.com/playframework/playframework/blob/9bf8e49deb60f0203d4140e98eb4437ba5351209/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala#L117-L119
However if a class was not initialized yet, it did not register it options, meaning that `exists` returns `false` - and the option will never be set plus warning `Ignoring unknown Netty channel option: ...`.

For me this happened "only" when trying to set a `EpollChannelOption` or `UnixChannelOption` option during bootstrap (maybe because these classes live in different jars?) (Important: When staging, not in dev mode!).
When setting them in the channel "scope" (`child` path), there was no problem, but I guess that is because these channel options [are set much later](https://github.com/playframework/playframework/blob/9bf8e49deb60f0203d4140e98eb4437ba5351209/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala#L177), when Netty was bootstrapped already and the app is running and on-the-fly needs a to bind a channel (`bindChannel(...)` calling `channelSink(...)`) - and at this later time the classes have been loaded already probably.

If you come up with a better idea how to fix this, let me know.