### PR TITLE
Form input helper argument "_error" should handle String

### DIFF
--- a/core/play/src/main/scala/views/helper/Helpers.scala
+++ b/core/play/src/main/scala/views/helper/Helpers.scala
@@ -34,7 +34,9 @@ package views.html.helper {
       (args.get('_error) match {
         case Some(Some(play.api.data.FormError(_, message, args))) =>
           Some(Seq(p.messages(message, args.map(a => translateMsgArg(a)): _*)))
-        case _ => None
+        case Some(Some(message: String)) => Some(Seq(p.messages(message)))
+        case Some(message: String)       => Some(Seq(p.messages(message)))
+        case _                           => None
       }).getOrElse {
         (if (args.get('_showErrors) match {
                case Some(false) => false

--- a/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -229,5 +229,31 @@ class HelpersSpec extends Specification {
         "I am the name of the field"
       )
     }
+
+    "correctly display an error when _error is supplied as String" in {
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_error -> "Force an error").body must contain(
+        """<dd class="error">Force an error</dd>"""
+      )
+    }
+
+    "correctly display an error when _error is supplied as Option[String]" in {
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Option("Force an error")).body must contain(
+        """<dd class="error">Force an error</dd>"""
+      )
+    }
+
+    "correctly display an error when _error is supplied as Option[FormError]" in {
+      inputText
+        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Option(FormError("foo", "Force an error")))
+        .body must contain(
+        """<dd class="error">Force an error</dd>"""
+      )
+    }
+
+    "don't display an error when _error is supplied but is None" in {
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_error -> None).body must not contain (
+        """class="error""""
+      )
+    }
   }
 }


### PR DESCRIPTION
Fixes https://discuss.lightbend.com/t/form-template-helpers-error-force-an-error/3471

According to [the docs](https://www.playframework.com/documentation/2.7.x/JavaFormHelpers#Field-constructors) you can force an error by passing a *String* param to a form helper:
```
'_error -> "Force an error"
```
However with a string this just doesn't work right now. You have to pass a `FormError` object wrapped in an `Option` instead to make it work:
```
'_error -> Some(FormError("foo", "Force an error"))
```

This pull request finally makes `String` (and `Option(String)`) work so it behaves like the documentation says. You can now write:
```
'_error -> Some("Force an error")
'_error -> "Force an error"
```