### PR TITLE
Remove application.secret and play.crypto.secret support

### DIFF
--- a/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -285,7 +285,7 @@ object HttpConfiguration {
     val Blank = """\s*""".r
 
     val secret =
-      config.getDeprecated[Option[String]]("play.http.secret.key", "play.crypto.secret", "application.secret") match {
+      config.getDeprecated[Option[String]]("play.http.secret.key") match {
         case (Some("changeme") | Some(Blank()) | None) if environment.mode == Mode.Prod =>
           val message =
             """

--- a/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -285,7 +285,7 @@ object HttpConfiguration {
     val Blank = """\s*""".r
 
     val secret =
-      config.getDeprecated[Option[String]]("play.http.secret.key") match {
+      config.get[Option[String]]("play.http.secret.key") match {
         case (Some("changeme") | Some(Blank()) | None) if environment.mode == Mode.Prod =>
           val message =
             """

--- a/core/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
+++ b/core/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
@@ -14,25 +14,6 @@ class ActualKeySecretConfigurationParserSpec extends SecretConfigurationParserSp
   override def secretKey: String = "play.http.secret.key"
 }
 
-class DeprecatedKeySecretConfigurationParserSpec extends SecretConfigurationParserSpec {
-  override def secretKey: String = "play.crypto.secret"
-
-  override def parseSecret(mode: Mode, secret: Option[String] = None) = {
-    HttpConfiguration
-      .fromConfiguration(
-        Configuration.reference ++ Configuration.from(
-          secret.map(secretKey -> _).toMap ++ Map(
-            "play.http.secret.key" -> null
-          )
-        ),
-        Environment.simple(mode = mode)
-      )
-      .secret
-      .secret
-  }
-
-}
-
 trait SecretConfigurationParserSpec extends Specification {
 
   def secretKey: String

--- a/core/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
+++ b/core/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
@@ -10,13 +10,9 @@ import play.api.Environment
 import play.api.Mode
 import play.api.PlayException
 
-class ActualKeySecretConfigurationParserSpec extends SecretConfigurationParserSpec {
-  override def secretKey: String = "play.http.secret.key"
-}
+class SecretConfigurationParserSpec extends Specification {
 
-trait SecretConfigurationParserSpec extends Specification {
-
-  def secretKey: String
+  def secretKey: String = "play.http.secret.key"
 
   val Secret = "abcdefghijklmnopqrs"
 


### PR DESCRIPTION

## Fixes

Fixes #8981

## Purpose

Removed `play.crypto.secret` & `application.secret` leaving `play.http.secret.key` as the only way to set secret key

