### PR TITLE
play-test should not depend on netty server backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -156,8 +156,7 @@ lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "testkit/play-test
   )
   .dependsOn(
     PlayGuiceProject,
-    PlayAkkaHttpServerProject,
-    PlayNettyServerProject
+    PlayAkkaHttpServerProject
   )
 
 lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "testkit/play-specs2")

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -62,7 +62,7 @@ trait EndpointIntegrationSpecification extends SpecLike with PendingUntilFixed w
      * }}}
      */
     def withAllEndpoints[A: AsResult](block: ServerEndpoint => A): Fragment =
-      withEndpoints(ServerEndpointRecipe.AllRecipes)(block)
+      withEndpoints(NettyServerEndpoints.NettyEndpoints ++ ServerEndpointRecipe.AllRecipes)(block)
   }
 
   /**

--- a/core/play-integration-test/src/it/scala/play/it/test/NettyServerEndpoints.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/NettyServerEndpoints.scala
@@ -1,5 +1,31 @@
 package play.it.test
 
-class NettyServerEndpoints {
+import play.api.Configuration
+import play.api.test.HttpServerEndpointRecipe
+import play.api.test.HttpsServerEndpointRecipe
+import play.core.server.NettyServer
+
+object NettyServerEndpoints {
+
+  val Netty11Plaintext = new HttpServerEndpointRecipe(
+    "Netty HTTP/1.1 (plaintext)",
+    NettyServer.provider,
+    Configuration.empty,
+    Set("1.0", "1.1"),
+    Option("netty")
+  )
+
+  val Netty11Encrypted = new HttpsServerEndpointRecipe(
+    "Netty HTTP/1.1 (encrypted)",
+    NettyServer.provider,
+    Configuration.empty,
+    Set("1.0", "1.1"),
+    Option("netty")
+  )
+
+  val NettyEndpoints = Seq(
+    Netty11Plaintext,
+    Netty11Encrypted
+  )
 
 }

--- a/core/play-integration-test/src/it/scala/play/it/test/NettyServerEndpoints.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/NettyServerEndpoints.scala
@@ -1,0 +1,5 @@
+package play.it.test
+
+class NettyServerEndpoints {
+
+}

--- a/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -47,8 +47,6 @@ class HelloWorldBenchmark {
   def setup(): Unit = {
     val appFactory = ApplicationFactory.withResult(Results.Ok("Hello world"))
     val endpointRecipe = endpoint match {
-      case "nt-11-pln" => ServerEndpointRecipe.Netty11Plaintext
-      case "nt-11-enc" => ServerEndpointRecipe.Netty11Plaintext
       case "ak-11-pln" => ServerEndpointRecipe.AkkaHttp11Plaintext
       case "ak-11-enc" => ServerEndpointRecipe.AkkaHttp11Encrypted
       case "ak-20-enc" => ServerEndpointRecipe.AkkaHttp20Encrypted

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -217,7 +217,10 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.core.j.JavaImplicitConversions"),
       ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
+      // Remove NettyServer dependency from Play-Test
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.Netty11Encrypted"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.Netty11Plaintext")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
@@ -73,34 +73,27 @@ import scala.util.control.NonFatal
     ServerProvider.fromConfiguration(getClass.getClassLoader, serverConfig(app).configuration)
 
   protected def serverEndpoints(testServer: TestServer): ServerEndpoints = {
-    val useAkkaHttp = testServer.serverProvider.get.isInstanceOf[AkkaHttpServerProvider]
     val useHttp2 = testServer.application.configuration
       .getOptional[Boolean]("play.server.akka.http2.enabled")
       .getOrElse(false)
 
     val httpEndpoint: Option[ServerEndpoint] = testServer.runningHttpPort.map(_ => {
-      val recipe = if (useAkkaHttp) {
-        if (useHttp2) {
-          ServerEndpointRecipe.AkkaHttp20Plaintext
-        } else {
-          ServerEndpointRecipe.AkkaHttp11Plaintext
-        }
+      val recipe = if (useHttp2) {
+        ServerEndpointRecipe.AkkaHttp20Plaintext
       } else {
-        ServerEndpointRecipe.Netty11Plaintext
+        ServerEndpointRecipe.AkkaHttp11Plaintext
       }
+
       recipe.createEndpointFromServer(testServer)
     })
 
     val httpsEndpoint: Option[ServerEndpoint] = testServer.runningHttpsPort.map(_ => {
-      val recipe = if (useAkkaHttp) {
-        if (useHttp2) {
-          ServerEndpointRecipe.AkkaHttp20Encrypted
-        } else {
-          ServerEndpointRecipe.AkkaHttp11Encrypted
-        }
+      val recipe = if (useHttp2) {
+        ServerEndpointRecipe.AkkaHttp20Encrypted
       } else {
-        ServerEndpointRecipe.Netty11Encrypted
+        ServerEndpointRecipe.AkkaHttp11Encrypted
       }
+
       recipe.createEndpointFromServer(testServer)
     })
 


### PR DESCRIPTION
## Purpose

https://github.com/playframework/playframework/pull/8681 introduced Netty server backend as a dependency for play-test, but having both server backends in the classpath can result in an arbitrary selection of which backend is used since both have `play.server.provider` in their `reference.conf` file.

## Backporting

Although changing the dependency chain is not ideal, this should be backported for 2.7.x since it can result in tests running on the wrong server backend, while in production the correct one will be used. 