### PR TITLE
Scalafmt 2.0.0-RC5

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,4 +9,4 @@ rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifi
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
-version = 2.0.0-RC4
+version = 2.0.0-RC5

--- a/scripts/scalafmt
+++ b/scripts/scalafmt
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-declare -r scalafmt_version="2.0.0-RC4"
+declare -r scalafmt_version="2.0.0-RC5"
 
 die() { echo "Aborting: $*"; exit 1; }
 


### PR DESCRIPTION
This one is important because as of 2.0.0-RC5 scalafmt-dynamic actually
uses the Scalafmt "version" key in .scalafmt.conf to dispatch to that
Scalafmt version.

- [ ] Backport to 2.7.x
- [ ] Backport to 2.6.x