### PR TITLE
Upgrade twirl (in docs project) and sbt-native-packager

### DIFF
--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -18,4 +18,4 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.0.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.3")
 
 // Required for Tutorial
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.0-M2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ enablePlugins(BuildInfoPlugin)
 val Versions = new {
   // when updating sbtNativePackager version, be sure to also update the documentation links in
   // documentation/manual/working/commonGuide/production/Deploying.md
-  val sbtNativePackager  = "1.3.18"
+  val sbtNativePackager  = "1.3.19"
   val mima               = "0.3.0"
   val sbtJavaAgent       = "0.1.4"
   val sbtJavaFormatter   = "0.4.3"


### PR DESCRIPTION
Fixes #9024

The docs project still used M2.

Plus:
https://github.com/sbt/sbt-native-packager/blob/master/CHANGELOG.md#v1319-2019-03-02