### PR TITLE
Fixed early response warning on chunked requests

### DIFF
--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -189,7 +189,7 @@ private[server] class AkkaModelConversion(
 
       case HttpEntity.Chunked(contentType, chunks) =>
         // FIXME: do something with trailing headers?
-        Right(chunks.takeWhile(!_.isLastChunk).map(_.data()))
+        Right(chunks.filter(!_.isLastChunk).map(_.data()))
     }
   }
 


### PR DESCRIPTION
The `takeWhile(_.isLastChunk)` causes the downstream sink to immediately receive a completion, while terminating upstream so that from Akka HTTPs perspective, the full request body hasn't been consumed yet. Due to one or the other of these, when the response does get sent, Akka HTTP outputs a warning saying the response is being sent before the request has been consumed.

This replaces it with a `filter(_.isLastChunk)`, so that no termination signals get introduced other than the one coming from Akka HTTP itself, and so consequently avoids the early termination error, meanwhile it has the same effect as `takeWhile` since the last chunk is always the last element in the stream.