### PR TITLE
Add a "status:needs-backport-2.6" label

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -66,6 +66,8 @@ labels:
     name: "status:merge-when-green"
     oldname: merge-when-green
   - color: fbca04
+    name: "status:needs-backport-2.6"
+  - color: fbca04
     name: "status:needs-backport"
   - color: fbca04
     name: "status:needs-forwardport"


### PR DESCRIPTION
To indicate on PRs that should backport also to the 2.6.x branch.