### PR TITLE
Fix fork-join-executor config in docs

### DIFF
--- a/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
+++ b/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
@@ -105,7 +105,7 @@ play.akka.config = "my-akka"
 Now settings will be read from the `my-akka` prefix instead of the `akka` prefix.
 
 ```
-my-akka.actor.default-dispatcher.fork-join-executor.pool-size-max = 64
+my-akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 64
 my-akka.actor.debug.receive = on
 ```
 

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/akka.conf
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/akka.conf
@@ -1,4 +1,4 @@
 #conf
-akka.actor.default-dispatcher.fork-join-executor.pool-size-max = 64
+akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 64
 akka.actor.debug.receive = on
 #conf

--- a/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
@@ -108,7 +108,7 @@ play.akka.config = "my-akka"
 Now settings will be read from the `my-akka` prefix instead of the `akka` prefix.
 
 ```
-my-akka.actor.default-dispatcher.fork-join-executor.pool-size-max = 64
+my-akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 64
 my-akka.actor.debug.receive = on
 ```
 


### PR DESCRIPTION
A `fork-join-executor` [does not have](https://github.com/akka/akka/blob/v2.5.21/akka-actor/src/main/resources/reference.conf#L445-L462) a `pool-size-max` config.

Fixes two occurrence in [`JavaAkka`](https://www.playframework.com/documentation/2.7.x/JavaAkka#Configuration) and one occurrence in [`ScalaAkka`](https://www.playframework.com/documentation/2.7.x/ScalaAkka#Configuration).
Interestingly, the first occurrence in `ScalaAkka` was fixed long time ago in #3905 already...