### PR TITLE
Remove incorrect documentation on SAXParserFactory construction

### DIFF
--- a/core/play/src/main/scala/play/api/Play.scala
+++ b/core/play/src/main/scala/play/api/Play.scala
@@ -55,12 +55,6 @@ object Play {
 
   private[play] val GlobalAppConfigKey = "play.allowGlobalApplication"
 
-  /*
-   * We want control over the sax parser used so we specify the factory required explicitly. We know that
-   * SAXParserFactoryImpl will yield a SAXParser having looked at its source code, despite there being
-   * no explicit doco stating this is the case. That said, there does not appear to be any other way than
-   * declaring a factory in order to yield a parser of a specific type.
-   */
   private[play] val xercesSaxParserFactory = SAXParserFactory.newInstance()
   xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
   xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE, false)


### PR DESCRIPTION
Fixes some leftover comment.  This was changed in https://github.com/wsargent/playframework/commit/ccda63815939b51fc2f24b5b1144b0c31e40cf6f#diff-8c92eba25113fadb7c0c63d00ee6a572L42 but the explicit factory comment was not removed.