### PR TITLE
Upgrade guava

### DIFF
--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -536,9 +536,9 @@ If your application is using a version that is newer than the one used by Play, 
 
 HikariCP was updated to the latest version which finally removed the configuration `initializationFailFast`, replaced by `initializationFailTimeout`. See [HikariCP changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) and [documentation for `initializationFailTimeout`](https://github.com/brettwooldridge/HikariCP#infrequently-used) to better understand how to use this configuration.
 
-### `Guava` version updated to 27.0.1-jre
+### `Guava` version updated to 27.1-jre
 
-Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 27.0.1-jre. Lots of changes were made in the library, and you can see the full changelog [here](https://github.com/google/guava/releases).
+Play 2.6.x provided 23.0 version of Guava library. Now it is updated to last actual version, 27.1-jre. Lots of changes were made in the library, and you can see the full changelog [here](https://github.com/google/guava/releases).
 
 ### specs2 updated to 4.3.5
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
   val slf4j        = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % slf4jVersion)
   val slf4jSimple  = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
-  val guava      = "com.google.guava"         % "guava"        % "27.0.1-jre"
+  val guava      = "com.google.guava"         % "guava"        % "27.1-jre"
   val findBugs   = "com.google.code.findbugs" % "jsr305"       % "3.0.2" // Needed by guava
   val mockitoAll = "org.mockito"              % "mockito-core" % "2.23.4"
 


### PR DESCRIPTION
https://github.com/google/guava/releases/tag/v27.1

We may want to backport.