### PR TITLE
Fix comment about loading play.akka.dev-mode.*/akka.* configs

### DIFF
--- a/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -229,8 +229,9 @@ object DevServerStart {
           // between the actor system for dev mode and the application actor system
           // users can resolve it by add a specific configuration for dev mode.
             .getConfig("play.akka.dev-mode")
-            // We then fallback to the app configuration to avoid losing configurations
-            // made using devSettings, system properties and application.conf itself.
+            // We then fallback to the root configuration to avoid losing configurations
+            // from the "akka.*" config picked up from the reference*.conf's and
+            // made to the "akka.*" config using devSettings or system properties.
             .withFallback(serverConfig.configuration.underlying)
         }
         val actorSystem = ActorSystem("play-dev-mode", devModeAkkaConfig)


### PR DESCRIPTION
@marcospereira The comment you added in #8173 is not correct. `application.conf` is not included in `serverConfig` at all, it is completely ignored when starting the backend server.
We even have a note about this fact here:

> **Note:** In dev mode, when you use the `run` command, your `application.conf` settings will not be picked up by the server. This is because in dev mode the server starts before the application classpath is available. There are several [other options](https://www.playframework.com/documentation/2.7.x/ConfigFile#Using-with-the-run-command) you'll need to use instead.