### PR TITLE
Add 127.0.0.1 to allowed hosts filter

### DIFF
--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -215,7 +215,7 @@ play.filters {
     # A list of valid hosts (e.g. "example.com") or suffixes of valid hosts (e.g. ".example.com")
     # Note that ".example.com" will match example.com and any subdomain of example.com, with or without a trailing dot.
     # "." matches all domains, and "" matches an empty or nonexistent host.
-    allowed = ["localhost", ".local"]
+    allowed = ["localhost", ".local", "127.0.0.1"]
 
     routeModifiers {
       # If non empty, then requests will be checked if the route does not have this modifier. This is how we enable the


### PR DESCRIPTION
Is there something that speaks against adding `127.0.0.1` to allowed hosts? `localhost` is already there, so I think it's safe.
Every time I start up a Play app usually I navigate to '127.0.0.1:9000', hitting the allowed hosts filter which denies my request, so usually I always set this config in my `application.conf`.