### PR TITLE
In DEV mode props from args should override props from javaOptions

### DIFF
--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -180,14 +180,15 @@ object Reloader {
       reloadLock: AnyRef
   ): DevServer = {
 
-    val (properties, httpPort, httpsPort, httpAddress) =
+    val (systemPropertiesArgs, httpPort, httpsPort, httpAddress) =
       filterArgs(args, defaultHttpPort, defaultHttpAddress, devSettings)
-    val systemProperties = extractSystemProperties(javaOptions)
+    val systemPropertiesJavaOptions = extractSystemProperties(javaOptions)
 
     require(httpPort.isDefined || httpsPort.isDefined, "You have to specify https.port when http.port is disabled")
 
     // Set Java properties
-    (properties ++ systemProperties).foreach {
+    val systemPropertiesCombined = systemPropertiesJavaOptions ++ systemPropertiesArgs
+    systemPropertiesCombined.foreach {
       case (key, value) => System.setProperty(key, value)
     }
 
@@ -296,7 +297,7 @@ object Reloader {
           runHooks.run(_.afterStopped())
 
           // Remove Java properties
-          properties.foreach {
+          systemPropertiesCombined.foreach {
             case (key, _) => System.clearProperty(key)
           }
         }

--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -186,8 +186,10 @@ object Reloader {
 
     require(httpPort.isDefined || httpsPort.isDefined, "You have to specify https.port when http.port is disabled")
 
-    // Set Java properties
+    // Properties are combined in this specific order so that command line
+    // properties win over the configured one, making them more useful.
     val systemPropertiesCombined = systemPropertiesJavaOptions ++ systemPropertiesArgs
+    // Set Java properties
     systemPropertiesCombined.foreach {
       case (key, value) => System.setProperty(key, value)
     }


### PR DESCRIPTION
Effects dev mode only.

If you have in your `build.sbt`:
```sbt
javaOptions in Runtime += "-Dmyconfkey=one"
```
then run your app in dev mode via
```sbt
run -Dmyconfkey=ten
```
and later in your running app read the key via
```java
config.getString("myconfkey")
```
the result should be`ten`, taken from the command line. Command line args/props should always win, otherwise they are useless. However right now it is `one`.
Fix is easy, we just need to change the order.

Along the way I also fixed a bug I guess: Turns out that we didn't clean all the system properties we set when closing the dev server...

(I also renamed the variables to make clear what they are about)