### PR TITLE
Show generic configurations in Production Configuration docs

### DIFF
--- a/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
+++ b/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
@@ -116,7 +116,11 @@ You can also use Netty as the HTTP server, which also provides its own configura
 
 @[](/confs/play-netty-server/reference.conf)
 
-> **Note**: The Netty server backend is not the default in 2.6.x, and so must be specifically enabled.
+> **Note**: The Netty server backend is not the default in 2.6.x, and so must be [[specifically enabled|NettyServer]].
+
+The configurations above are specific to the Akka HTTP and Netty server backend, but other more generic configurations are also available:
+
+@[](/confs/play-server/reference.conf)
 
 ## Logging configuration
 


### PR DESCRIPTION
We do so [here](https://www.playframework.com/documentation/2.7.x/SettingsAkkaHttp) and [here](https://www.playframework.com/documentation/2.7.x/SettingsNetty), so I guess it makes sense to show the configs [here](https://www.playframework.com/documentation/2.7.x/ProductionConfiguration#Server-configuration-options) as well.