### PR TITLE
For privacy reasons bind to 127.0.0.1 by default

### DIFF
--- a/dev-mode/run-support/src/test/scala/play/runsupport/FilterArgsSpec.scala
+++ b/dev-mode/run-support/src/test/scala/play/runsupport/FilterArgsSpec.scala
@@ -10,7 +10,7 @@ import org.specs2.execute.Result
 class FilterArgsSpec extends Specification {
 
   val defaultHttpPort    = 9000
-  val defaultHttpAddress = "0.0.0.0"
+  val defaultHttpAddress = "127.0.0.1"
 
   def check(args: String*)(
       properties: Seq[(String, String)] = Seq.empty,

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -117,7 +117,7 @@ object PlaySettings extends PlaySettingsCompat {
     fileWatchService := FileWatchService
       .defaultWatchService(target.value, getPoolInterval(pollInterval.value).toMillis.toInt, sLog.value),
     playDefaultPort := 9000,
-    playDefaultAddress := "0.0.0.0",
+    playDefaultAddress := "127.0.0.1",
     // Default hooks
     playRunHooks := Nil,
     playInteractionMode := PlayConsoleInteractionMode,

--- a/documentation/manual/gettingStarted/PlayConsole.md
+++ b/documentation/manual/gettingStarted/PlayConsole.md
@@ -20,7 +20,7 @@ You will see something like:
 
 --- (Running the application from sbt, auto-reloading is enabled) ---
 
-[info] play - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
+[info] play - Listening for HTTP on /127.0.0.1:9000
 
 (Server started, use Enter to stop and go back to the console...)
 The application starts directly. When you quit the server using Ctrl+D or Enter, the command prompt returns.
@@ -68,7 +68,7 @@ $ sbt
 
 --- (Running the application, auto-reloading is enabled) ---
 
-[info] p.c.s.AkkaHttpServer - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
+[info] p.c.s.AkkaHttpServer - Listening for HTTP on /127.0.0.1:9000
 
 (Server started, use Ctrl+D to stop and go back to the console...)
 ```
@@ -193,7 +193,7 @@ $ sbt run
 
 --- (Running the application from sbt, auto-reloading is enabled) ---
 
-[info] play - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
+[info] play - Listening for HTTP on /127.0.0.1:9000
 
 (Server started, use Enter to stop and go back to the console...)
 ```

--- a/documentation/manual/hacking/Translations.md
+++ b/documentation/manual/hacking/Translations.md
@@ -64,9 +64,9 @@ First off, start the documentation server.  The documentation server will serve 
 $ sbt run
 [info] Set current project to root (in build file:/Users/jroper/tmp/foo-translation/)
 [info] play - Application started (Dev)
-[info] play - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
+[info] play - Listening for HTTP on /127.0.0.1:9000
 
-Documentation server started, you can now view the docs by going to http://0:0:0:0:0:0:0:0:9000
+Documentation server started, you can now view the docs by going to http://127.0.0.1:9000
 ```
 
 Now open <http://localhost:9000/> in your browser.  You should be able to see the default Play documentation.  It's time to translate your first page.

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -94,6 +94,17 @@ Many changes have been made to Play's internal APIs. These APIs are used interna
 
 Some of the default values used by Play had changed and that can have an impact on your application. This section details the default changes.
 
+### Server binds to `127.0.0.1` by default now
+
+Until Play 2.7 the backend server by default bound to the `0.0.0.0` address (all addresses).
+If you didn't change that default and are connected to an untrusted network while developing a Play application anyone on that network could just access your Play app by navigating to your IP address (and the port your app is running on, by default `9000`).
+
+For obvious privacy reasons that default binding address changed to `127.0.0.1` in `DEV` as well as in `PROD` mode. You can still open up your application to be accessible from outside:
+
+* In `DEV` mode you can pass `-Dhttp.address=...` to the `run` command or set `PlayKeys.devSettings += "play.server.http.address" -> "..."` in your `build.sbt`. See the [[detailed docs|ConfigFile#Using-with-the-run-command]].
+
+* In `PROD` mode you can start you application with the `-Dhttp.address=...` argument or set `play.server.http.address=...` in `application.conf`. See the [[detailed docs|ProductionConfiguration#Overriding-configuration-with-system-properties]].
+
 ## Updated libraries
 
 This section lists significant updates made to our dependencies.

--- a/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
+++ b/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
@@ -65,10 +65,10 @@ $ /path/to/bin/<project-name> -Dplay.http.secret.key=ad31779d4ee49d5ad5162bf1429
 
 #### Specifying the HTTP server address and port using system properties
 
-You can provide both HTTP port and address easily using system properties. The default is to listen on port `9000` at the `0.0.0.0` address (all addresses).
+You can provide both HTTP port and address easily using system properties. The default is to listen on port `9000` at the `127.0.0.1` address (localhost only).
 
 ```
-$ /path/to/bin/<project-name> -Dhttp.port=1234 -Dhttp.address=127.0.0.1
+$ /path/to/bin/<project-name> -Dhttp.port=1234 -Dhttp.address=0.0.0.0
 ```
 
 #### Changing the path of RUNNING_PID

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -98,7 +98,7 @@ $ heroku logs
 2015-07-13T20:44:54.960105+00:00 app[web.1]: [info] p.a.l.c.ActorSystemProvider - Starting application default Akka system: application
 2015-07-13T20:44:55.066582+00:00 app[web.1]: [info] play.api.Play$ - Application started (Prod)
 2015-07-13T20:44:55.445021+00:00 heroku[web.1]: State changed from starting to up
-2015-07-13T20:44:55.330940+00:00 app[web.1]: [info] p.c.s.AkkaHttpServer - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
+2015-07-13T20:44:55.330940+00:00 app[web.1]: [info] p.c.s.AkkaHttpServer - Listening for HTTP on /127.0.0.1:9000
 ...
 ```
 
@@ -112,7 +112,7 @@ $ heroku logs -t --app warm-frost-1289
 2015-07-13T20:44:54.960105+00:00 app[web.1]: [info] p.a.l.c.ActorSystemProvider - Starting application default Akka system: application
 2015-07-13T20:44:55.066582+00:00 app[web.1]: [info] play.api.Play$ - Application started (Prod)
 2015-07-13T20:44:55.445021+00:00 heroku[web.1]: State changed from starting to up
-2015-07-13T20:44:55.330940+00:00 app[web.1]: [info] p.c.s.AkkaHttpServer - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
+2015-07-13T20:44:55.330940+00:00 app[web.1]: [info] p.c.s.AkkaHttpServer - Listening for HTTP on /127.0.0.1:9000
 ...
 ```
 

--- a/testkit/play-test/src/main/java/play/test/TestServer.java
+++ b/testkit/play-test/src/main/java/play/test/TestServer.java
@@ -53,7 +53,7 @@ public class TestServer extends play.api.test.TestServer {
         new File("."),
         (Option) OptionConverters.toScala(port),
         (Option) OptionConverters.toScala(sslPort),
-        "0.0.0.0",
+        "127.0.0.1",
         Mode.TEST.asScala(),
         System.getProperties());
   }

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -15,7 +15,7 @@ play {
       port = ${?http.port}
 
       # The interface address to bind to.
-      address = "0.0.0.0"
+      address = "127.0.0.1"
       address = ${?http.address}
 
       # The idle timeout for an open connection after which it will be closed
@@ -32,7 +32,7 @@ play {
       port = ${?https.port}
 
       # The interface address to bind to
-      address = "0.0.0.0"
+      address = "127.0.0.1"
       address = ${?https.address}
 
       # The idle timeout for an open connection after which it will be closed

--- a/transport/server/play-server/src/main/scala/play/core/server/ProdServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ProdServerStart.scala
@@ -138,7 +138,7 @@ object ProdServerStart {
     val httpsPort = parsePort("https")
     if (httpPort.orElse(httpsPort).isEmpty) throw ServerStartException("Must provide either an HTTP or HTTPS port")
 
-    val address = configuration.getOptional[String]("play.server.http.address").getOrElse("0.0.0.0")
+    val address = configuration.getOptional[String]("play.server.http.address").getOrElse("127.0.0.1")
 
     ServerConfig(
       rootDir = rootDir,

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerConfig.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerConfig.scala
@@ -44,7 +44,7 @@ object ServerConfig {
       rootDir: File = new File("."),
       port: Option[Int] = Some(9000),
       sslPort: Option[Int] = None,
-      address: String = "0.0.0.0",
+      address: String = "127.0.0.1",
       mode: Mode = Mode.Prod,
       properties: Properties = System.getProperties
   ): ServerConfig = {


### PR DESCRIPTION
Lots of people work in coworking spaces, cafes, libraries, etc. and connect to networks which are somewhat not trustworthy. Anyone hitting your IP could see what you are working on. Not good in regards to privacy (GDPR, sensitive client data, etc.)

I also think it's not a good idea to default to `0.0.0.0` in production: You deploy your app on a server, that server has various network interfaces, suddenly your app will be available where it shouldn't be, or should be seen only by a load balancer instead of when hitting the IP of the server etc.

(Yes I know there is the allowed hosts filter which by default blocks external traffic, however it gets disabled for debugging or whatever reason).