### PR TITLE
Make sure play.server.http(s).port/address always gets set in DEV mode

### DIFF
--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -186,9 +186,16 @@ object Reloader {
 
     require(httpPort.isDefined || httpsPort.isDefined, "You have to specify https.port when http.port is disabled")
 
+    // If the port(s) or the address were set via their shortcuts (http.address, http(s).port or first non-property argument,
+    // but who knows how they will be set in a future change) also set the actual configs they are shortcuts for.
+    // So when reading the actual (long) keys from the config (play.server.http...) the values match and are correct.
+    val systemPropertiesAddressPorts = Seq("play.server.http.address" -> httpAddress) ++
+      httpPort.map(port => Seq("play.server.http.port"   -> port.toString)).getOrElse(Nil) ++
+      httpsPort.map(port => Seq("play.server.https.port" -> port.toString)).getOrElse(Nil)
+
     // Properties are combined in this specific order so that command line
     // properties win over the configured one, making them more useful.
-    val systemPropertiesCombined = systemPropertiesJavaOptions ++ systemPropertiesArgs
+    val systemPropertiesCombined = systemPropertiesJavaOptions ++ systemPropertiesArgs ++ systemPropertiesAddressPorts
     // Set Java properties
     systemPropertiesCombined.foreach {
       case (key, value) => System.setProperty(key, value)


### PR DESCRIPTION
I want to be sure that inside an app whenever I read the server port(s) or the address from the config via 
```java
config.getInt("play.server.http.port")
config.getInt("play.server.https.port")
config.getString("play.server.http.address")
```
I get the actual values the backend server is running with. Usually that is the case of course.

There are exceptions however: E.g. when defining the http port as the first non-property argument in dev mode via
```
run 9003
```
the `play.server.http.port` setting stays the default (9000) while the server is running with 9003.

Or when setting the port/address in `build.sbt` via
```sbt
PlayKeys.playDefaultPort := 9004
PlayKeys.playDefaultAddress := "..."
```
the same behaviour occurs.

This can make problems during development if you have components that rely on the correct `play.server.http(s).port/address` config.

When using the shortcuts `-Dhttp.port`, `-Dhttps.port` or `-Dhttp.address` with `run` we luckily already set the configs via substitutions in the according `reference.conf` (which gets loaded and passed to the backend server when it starts up, even in dev mode):
https://github.com/playframework/playframework/blob/e1f2f387b9bdf87dd67508187ba4c681e5eb06e2/transport/server/play-server/src/main/resources/reference.conf#L15
https://github.com/playframework/playframework/blob/e1f2f387b9bdf87dd67508187ba4c681e5eb06e2/transport/server/play-server/src/main/resources/reference.conf#L32
https://github.com/playframework/playframework/blob/e1f2f387b9bdf87dd67508187ba4c681e5eb06e2/transport/server/play-server/src/main/resources/reference.conf#L19

However, that substitutions will not kick in of course in the cases described above (and maybe even other cases...?)

To fix this let's just always set the configs when applicable.