### PR TITLE
[master] Remove incorrect comment on SAXParserFactory

### DIFF
--- a/core/play/src/main/scala/play/api/Play.scala
+++ b/core/play/src/main/scala/play/api/Play.scala
@@ -55,12 +55,6 @@ object Play {
 
   private[play] val GlobalAppConfigKey = "play.allowGlobalApplication"
 
-  /*
-   * We want control over the sax parser used so we specify the factory required explicitly. We know that
-   * SAXParserFactoryImpl will yield a SAXParser having looked at its source code, despite there being
-   * no explicit doco stating this is the case. That said, there does not appear to be any other way than
-   * declaring a factory in order to yield a parser of a specific type.
-   */
   private[play] val xercesSaxParserFactory = SAXParserFactory.newInstance()
   xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
   xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE, false)


### PR DESCRIPTION
Fixes an out of date comment for master branch.  This was changed in https://github.com/wsargent/playframework/commit/ccda638#diff-8c92eba25113fadb7c0c63d00ee6a572L42 but the explicit factory comment was not removed.

Backported to 2.7.x branch as https://github.com/playframework/playframework/pull/9103