### PR TITLE
[2.7.x] Remove incorrect documentation 

### DIFF
--- a/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -10,6 +10,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
+import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSession
 import org.openjdk.jmh.annotations._
 import play.api.mvc.Results
@@ -118,7 +119,9 @@ object HelloWorldBenchmark {
         val b2 = bench.serverEndpoint.ssl match {
           case Some(ssl) =>
             b1.sslSocketFactory(ssl.sslContext.getSocketFactory, ssl.trustManager)
-              .hostnameVerifier((s: String, sslSession: SSLSession) => true)
+              .hostnameVerifier(new HostnameVerifier {
+                override def verify(s: String, sslSession: SSLSession): Boolean = true
+              })
           case _ => b1
         }
         b2.build()

--- a/core/play/src/main/scala/play/api/Play.scala
+++ b/core/play/src/main/scala/play/api/Play.scala
@@ -55,12 +55,6 @@ object Play {
 
   private[play] val GlobalAppConfigKey = "play.allowGlobalApplication"
 
-  /*
-   * We want control over the sax parser used so we specify the factory required explicitly. We know that
-   * SAXParserFactoryImpl will yield a SAXParser having looked at its source code, despite there being
-   * no explicit doco stating this is the case. That said, there does not appear to be any other way than
-   * declaring a factory in order to yield a parser of a specific type.
-   */
   private[play] val xercesSaxParserFactory = SAXParserFactory.newInstance()
   xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
   xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE, false)

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -894,8 +894,9 @@ public class Form<T> {
     if (this.directFieldAccess) {
       // FYI: initBeanPropertyAccess() is the default, let's switch to direct field access instead
       dataBinder
-          .initDirectFieldAccess(); // this should happen last, when everything else was set on the
-                                    // dataBinder already
+          // this should happen last, when everything else was set on the
+          // dataBinder already
+          .initDirectFieldAccess();
     }
     return dataBinder;
   }


### PR DESCRIPTION
Fixes an out of date comment for 2.7.x branch. This was changed in wsargent/playframework@ccda638#diff-8c92eba25113fadb7c0c63d00ee6a572L42 but the explicit factory comment was not removed.

This was originally https://github.com/playframework/playframework/pull/9085 but was incorrectly created from the playframework branch (and then couldn't be merged because of build breakage, and could not be force pushed).