### PR TITLE
Allow to set port(s) and address via env variables

### DIFF
--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -116,6 +116,7 @@ object Reloader {
         .orElse(prop("http.port"))
         .orElse(otherArgs.headOption)
         .orElse(devMap.get("play.server.http.port"))
+        .orElse(sys.env.get("PLAY_HTTP_PORT"))
     val httpPort: Option[Int] = parsePortValue(httpPortString, Option(defaultHttpPort))
 
     // https port can be defined as a -D(play.server.)https.port argument or system property
@@ -123,6 +124,7 @@ object Reloader {
       prop("play.server.https.port")
         .orElse(prop("https.port"))
         .orElse(devMap.get("play.server.https.port"))
+        .orElse(sys.env.get("PLAY_HTTPS_PORT"))
     val httpsPort = parsePortValue(httpsPortString)
 
     // http address can be defined as a -D(play.server.)http.address argument or system property
@@ -130,6 +132,7 @@ object Reloader {
       prop("play.server.http.address")
         .orElse(prop("http.address"))
         .orElse(devMap.get("play.server.http.address"))
+        .orElse(sys.env.get("PLAY_HTTP_ADDRESS"))
         .getOrElse(defaultHttpAddress)
 
     (properties, httpPort, httpsPort, httpAddress)

--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -49,10 +49,18 @@ PlayKeys.devSettings += "play.server.http.port" -> "8080"
 
 ### HTTP server settings in `application.conf`
 
-In `run` mode the HTTP server part of Play starts before the application has been compiled. This means that the HTTP server cannot access the `application.conf` file when it starts. If you want to override HTTP server settings while using the `run` command you cannot use the `application.conf` file. Instead, you need to either use system properties or the `devSettings` setting shown above. An example of a server setting is the HTTP port. Other server settings can be seen [[here|ProductionConfiguration#Server-configuration-options]].
+In `run` mode the HTTP server part of Play starts before the application has been compiled. This means that the HTTP server cannot access the `application.conf` file when it starts. If you want to override HTTP server settings while using the `run` command you cannot use the `application.conf` file. Instead, you need to either use system properties or the `devSettings` setting shown above. An example of a server setting is the HTTP port:
 
 ```
 > run -Dhttp.port=1234
+```
+
+Other server settings can be seen [[here|ProductionConfiguration#Server-configuration-options]]. As you can see in these server settings the http(s) port(s) and address will fallback to the config keys `PLAY_HTTP_PORT`, `PLAY_HTTPS_PORT` and `PLAY_HTTP_ADDRESS` if a port or address are not defined already e.g. via `PlayKeys.devSettings`. Because these config keys are substitutions you can define them also via environment variables, e.g. when using Bash in Linux:
+
+```
+export PLAY_HTTP_PORT=9001
+export PLAY_HTTPS_PORT=9002
+export PLAY_HTTP_ADDRESS=127.0.0.1
 ```
 
 There is also a specific *namespace* if you need to customize Akka configuration for development mode (the mode used with `run` command). You need to prefix your configuration in `PlayKeys.devSettings` with `play.akka.dev-mode`, for example:

--- a/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
+++ b/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
@@ -71,6 +71,18 @@ You can provide both HTTP port and address easily using system properties. The d
 $ /path/to/bin/<project-name> -Dhttp.port=1234 -Dhttp.address=127.0.0.1
 ```
 
+#### Specifying the HTTP server address and port using environment variables
+
+You can provide both HTTP port and address easily using environment variables, e.g. when using Bash in Linux:
+
+```
+export PLAY_HTTP_PORT=1234
+export PLAY_HTTPS_PORT=1235
+export PLAY_HTTP_ADDRESS=127.0.0.1
+```
+
+These variables are picked up last, meaning any already defined port or address in `application.conf` or via system properties will override these environment variables.
+
 #### Changing the path of RUNNING_PID
 
 It is possible to change the path to the file that contains the process id of the started application. Normally this file is placed in the root directory of your play project, however it is advised that you put it somewhere where it will be automatically cleared on restart, such as `/var/run`:

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -12,10 +12,12 @@ play {
       # The HTTP port of the server. Use a value of "disabled" if the server
       # shouldn't bind an HTTP port.
       port = 9000
+      port = ${?PLAY_HTTP_PORT}
       port = ${?http.port}
 
       # The interface address to bind to.
       address = "0.0.0.0"
+      address = ${?PLAY_HTTP_ADDRESS}
       address = ${?http.address}
 
       # The idle timeout for an open connection after which it will be closed
@@ -29,10 +31,12 @@ play {
     https {
 
       # The HTTPS port of the server.
+      port = ${?PLAY_HTTPS_PORT}
       port = ${?https.port}
 
       # The interface address to bind to
       address = "0.0.0.0"
+      address = ${?PLAY_HTTPS_ADDRESS}
       address = ${?https.address}
 
       # The idle timeout for an open connection after which it will be closed


### PR DESCRIPTION
We want to be able to control the server port(s) and address via environment variables. Unfortunately in Linux it's not possible set set environment variables that contain dots (`http.port`,...).
Therefore I added `PLAY_HTTP_PORT`, `PLAY_HTTPS_PORT` and `PLAY_HTTP_ADDRESS`, the same format that we use for PLAY_EDITOR already

https://github.com/playframework/playframework/blob/02d92bf5b2cd4eb46490b76571a11d8e24422d68/transport/server/play-server/src/main/resources/reference.conf#L105

This is backwards compatible because the env variable is the last fallback (before using the default value).