### PR TITLE
Split cron build extra opts

### DIFF
--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -20,7 +20,7 @@ AKKA_HTTP_VERSION=""
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     # `sort` is not necessary, but it is good to make it predictable.
     AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '2\.5-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
-    AKKA_HTTP_VERSION=$(curl -s https://dl.bintray.com/akka/maven/com/typesafe/akka/akka-http-core_2.12/maven-metadata.xml | xmllint --xpath '//latest/text()' -)
+    AKKA_HTTP_VERSION=$(curl -s https://dl.bintray.com/akka/snapshots/com/typesafe/akka/akka-http-core_2.12/maven-metadata.xml | xmllint --xpath '//latest/text()' -)
 
     echo "Using Akka SNAPSHOT ${AKKA_VERSION} and Akka HTTP SNAPSHOT ${AKKA_HTTP_VERSION}"
 

--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -13,7 +13,8 @@ export DOCUMENTATION=$BASEDIR/documentation
 
 export CURRENT_BRANCH=${TRAVIS_BRANCH}
 
-EXTRA_OPTS=""
+AKKA_VERSION=""
+AKKA_HTTP_VERSION=""
 
 # Check if it is a scheduled build
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
@@ -23,7 +24,8 @@ if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
 
     echo "Using Akka SNAPSHOT ${AKKA_VERSION} and Akka HTTP SNAPSHOT ${AKKA_HTTP_VERSION}"
 
-    EXTRA_OPTS="-Dakka.version=${AKKA_VERSION} -Dakka.http.version=${AKKA_HTTP_VERSION}"
+    AKKA_VERSION_OPTS="-Dakka.version=${AKKA_VERSION}"
+    AKKA_HTTP_VERSION_OPTS="-Dakka.http.version=${AKKA_HTTP_VERSION}"
 fi
 
 printMessage() {
@@ -33,5 +35,5 @@ printMessage() {
 }
 
 runSbt() {
-  sbt "$EXTRA_OPTS" -jvm-opts "$BASEDIR/.travis-jvmopts" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
+  sbt "$AKKA_VERSION_OPTS" "$AKKA_HTTP_VERSION_OPTS" -jvm-opts "$BASEDIR/.travis-jvmopts" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
 }


### PR DESCRIPTION
Strange enough, sbt wasn't reading the second -D option, but it was using the whole string "2.5-20190325-231121 -Dakka.http.version=10.1.7" as the akka version.
I guess this was broken since day one.