### PR TITLE
Configure travis to build only stable branches and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
     - 2.6.x
     # Builds for tags. See Travis docs for more details:
     # https://docs.travis-ci.com/user/customizing-the-build/#using-regular-expressions
-    - /^\d+\.\d+\.\d+$/
+    - /^\d+\.\d+\.\d+(\-\w{2,})?$/
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
 language: scala
 
+branches:
+  only:
+    - master
+    # Explicitly listing the maintaned versions since we don't care
+    # anymore about builds in unmaintained branches.
+    - 2.7.x
+    - 2.6.x
+    # Builds for tags. See Travis docs for more details:
+    # https://docs.travis-ci.com/user/customizing-the-build/#using-regular-expressions
+    - /^\d+\.\d+\.\d+$/
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 branches:
   only:
     - master
-    # Explicitly listing the maintaned versions since we don't care
+    # Explicitly listing the maintained versions since we don't care
     # anymore about builds in unmaintained branches.
     - 2.7.x
     - 2.6.x


### PR DESCRIPTION
Mergify create branches directly on the /playframework/playframework/ repository when doing backports, meaning Travis runs builds for the pull request and the new branch. The same problem happens when someone does a small change using Github UI since it also creates a branch here.

This avoids the double build by limiting which branches are built. Only stable-maintained branches and release tags have builds.
