### PR TITLE
[2.7.x]: Avoid using Akka and Akka HTTP snapshots for all build tasks

### DIFF
--- a/scripts/it-test-scala-212
+++ b/scripts/it-test-scala-212
@@ -9,6 +9,6 @@ cd "$BASEDIR"
 
 printMessage "RUNNING IT TESTS FOR SCALA 2.12"
 
-runSbt "Play-Integration-Test/it:test"
+runSbtWithSnapshots "Play-Integration-Test/it:test"
 
 printMessage "ALL IT TESTS PASSED"

--- a/scripts/it-test-scala-213
+++ b/scripts/it-test-scala-213
@@ -5,10 +5,13 @@
 # shellcheck source=scripts/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-cd "$BASEDIR"
-
-printMessage "RUNNING IT TESTS FOR SCALA 2.13"
-
-runSbt "++2.13.0-M5 Play-Integration-Test/it:test"
-
-printMessage "ALL IT TESTS PASSED"
+# We are not running Scala 2.13 job for scheduled builds because they use
+# Akka snapshots which aren't being published for Scala 2.13 yet.
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    printMessage "SKIPPING TESTS FOR SCALA 2.13"
+else
+    cd "$BASEDIR"
+    printMessage "RUNNING IT TESTS FOR SCALA 2.13"
+    runSbt "++2.13.0-M5 Play-Integration-Test/it:test"
+    printMessage "ALL IT TESTS PASSED"
+fi

--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -34,6 +34,11 @@ printMessage() {
   echo "[info]"
 }
 
-runSbt() {
+# Runs sbt commands using Akka and Akka HTTP snapshots
+runSbtWithSnapshots() {
   sbt "$AKKA_VERSION_OPTS" "$AKKA_HTTP_VERSION_OPTS" -jvm-opts "$BASEDIR/.travis-jvmopts" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
+}
+
+runSbt() {
+  sbt -jvm-opts "$BASEDIR/.travis-jvmopts" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
 }

--- a/scripts/test-docs
+++ b/scripts/test-docs
@@ -8,5 +8,5 @@
 cd "$DOCUMENTATION"
 
 printMessage "RUNNING DOCUMENTATION TESTS"
-runSbt test
+runSbtWithSnapshots test
 printMessage "ALL DOCUMENTATION TESTS PASSED"

--- a/scripts/test-sbt-plugins-0_13
+++ b/scripts/test-sbt-plugins-0_13
@@ -11,9 +11,9 @@ SBT_VERSION="0.13"
 cd "$BASEDIR"
 
 printMessage "PUBLISHING PLAY LOCALLY FOR SBT ${SBT_VERSION}"
-runSbt ++${SCALA_VERSION} quickPublish publishLocal
+runSbtWithSnapshots ++${SCALA_VERSION} quickPublish publishLocal
 
 printMessage "RUNNING SCRIPTED TESTS FOR SBT ${SBT_VERSION}"
-runSbt "++${SCALA_VERSION} scripted"
+runSbtWithSnapshots "++${SCALA_VERSION} scripted"
 
 printMessage "ALL SCRIPTED TESTS PASSED"

--- a/scripts/test-sbt-plugins-1_0
+++ b/scripts/test-sbt-plugins-1_0
@@ -11,9 +11,9 @@ SBT_VERSION="1.2.8"
 cd "$BASEDIR"
 
 printMessage "PUBLISHING PLAY LOCALLY FOR SBT ${SBT_VERSION}"
-runSbt ++${SCALA_VERSION} quickPublish publishLocal
+runSbtWithSnapshots ++${SCALA_VERSION} quickPublish publishLocal
 
 printMessage "RUNNING SCRIPTED TESTS FOR SBT ${SBT_VERSION}"
-runSbt scripted
+runSbtWithSnapshots scripted
 
 printMessage "ALL SCRIPTED TESTS PASSED"

--- a/scripts/test-scala-211
+++ b/scripts/test-scala-211
@@ -17,6 +17,6 @@ cd "$BASEDIR"
 printMessage "RUNNING TESTS FOR SCALA 2.11"
 
 # Use sbt-doge for building code https://github.com/sbt/sbt-doge#strict-aggregation
-runSbt "+++2.11.12 test"
+runSbt "++2.11.12 test"
 
 printMessage "ALL TESTS PASSED"

--- a/scripts/test-scala-212
+++ b/scripts/test-scala-212
@@ -9,6 +9,6 @@ cd "$BASEDIR"
 
 printMessage "RUNNING TESTS FOR SCALA 2.12"
 
-runSbt "test"
+runSbtWithSnapshots "test"
 
 printMessage "ALL TESTS PASSED"

--- a/scripts/validate-docs
+++ b/scripts/validate-docs
@@ -8,8 +8,8 @@
 cd "$DOCUMENTATION"
 
 printMessage "RUNNING DOCUMENTATION VALIDATION"
-runSbt evaluateSbtFiles
-runSbt validateDocs
+runSbtWithSnapshots evaluateSbtFiles
+runSbtWithSnapshots validateDocs
 runSbt headerCheck test:headerCheck
 
 printMessage "ALL DOCUMENTATION VALIDATION PASSED"

--- a/scripts/validate-microbenchmarks
+++ b/scripts/validate-microbenchmarks
@@ -21,6 +21,6 @@ printMessage "VALIDATING MICROBENCHMARKS"
 # is passed to runSbt as a single command and internally be
 # passed to sbt as a single command too.
 # foe = FailOnError http://mail.openjdk.java.net/pipermail/jmh-dev/2015-February/001685.html
-runSbt "Play-Microbenchmark/jmh:run -i 1 -wi 0 -f 1 -t 1 -foe=true"
+runSbtWithSnapshots "Play-Microbenchmark/jmh:run -i 1 -wi 0 -f 1 -t 1 -foe=true"
 
 printMessage "BENCHMARKS VALIDATED"


### PR DESCRIPTION
## Purpose

The main reasons are:

1. Akka does not have snapshot artifacts for Scala 2.11 and 2.13, so tasks
   that are cross running will fail.
2. Using the snapshots for some tasks is pointless, for example, mima binary
   compatibility check

# Background Context

I'm starting with 2.7.x branch because it also includes Scala 2.11, so it will be easier to forward port.

## References

Better to merge and backport #9124 first.