### PR TITLE
[2.7] Configure travis to build only stable branches and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
 language: scala
 
+branches:
+  only:
+    - master
+    # Explicitly listing the maintained versions since we don't care
+    # anymore about builds in unmaintained branches.
+    - 2.7.x
+    - 2.6.x
+    # Builds for tags. See Travis docs for more details:
+    # https://docs.travis-ci.com/user/customizing-the-build/#using-regular-expressions
+    - /^\d+\.\d+\.\d+(\-\w{2,})?$/
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Backports #9132
Replaces faulty #9136