### PR TITLE
Disable branch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,7 @@
 language: scala
 
-branches:
-  only:
-    - master
-    # Explicitly listing the maintained versions since we don't care
-    # anymore about builds in unmaintained branches.
-    - 2.7.x
-    - 2.6.x
-    # Builds for tags. See Travis docs for more details:
-    # https://docs.travis-ci.com/user/customizing-the-build/#using-regular-expressions
-    - /^\d+\.\d+\.\d+(\-\w{2,})?$/
+# Only build PRs and tags: https://docs.travis-ci.com/user/conditional-builds-stages-jobs/
+if: type = pull_request OR tag IS present
 
 addons:
   apt:


### PR DESCRIPTION
Disable building the master, 2.7.x and 2.6.x branches.  This avoids that
every merge into those branches kicks off a build.  This isn't necessary
because we use Mergify's ["strict merge workflow"][] which means the PR
is up-to-date with the target branch before it gets merged.  As an
additional safe-guard I've changed the branch protection in GitHub to
require PRs to be up-to-date before merging, also.

["strict merge workflow"]: https://doc.mergify.io/strict-workflow.html