### PR TITLE
[2.6.x]: Update to Akka 2.5.21

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
@@ -8,11 +8,9 @@ import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util
-import java.util.Optional
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.TimeUnit
 
-import akka.NotUsed
 import akka.stream.javadsl
 import akka.stream.scaladsl.FileIO
 import akka.stream.scaladsl.Sink
@@ -40,9 +38,7 @@ import play.libs.ws.WSRequest
 import play.libs.ws.WSResponse
 import play.mvc.Http
 
-import scala.compat.java8.FutureConverters
 import scala.compat.java8.OptionConverters
-import scala.concurrent.Await
 import scala.concurrent.Future
 
 class NettyJavaWSSpec(val ee: ExecutionEnv) extends JavaWSSpec with NettyIntegrationSpecification
@@ -157,9 +153,12 @@ trait JavaWSSpec
     }
 
     "sending a simple multipart form body" in withServer { ws =>
-      val source = Source
-        .single(new Http.MultipartFormData.DataPart("hello", "world"))
-        .asJava[Http.MultipartFormData.Part[javadsl.Source[ByteString, _]], NotUsed]
+      val part: Http.MultipartFormData.Part[javadsl.Source[ByteString, _]] =
+        new Http.MultipartFormData.DataPart("hello", "world")
+      val source: javadsl.Source[Http.MultipartFormData.Part[javadsl.Source[ByteString, _]], _] = Source
+        .single(part)
+        .asJava
+
       val res  = ws.url("/post").post(source)
       val body = res.toCompletableFuture.get().asJson()
 

--- a/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -3,24 +3,22 @@
  */
 package play.api.libs.streams
 
-import java.util.concurrent.CompletionStage
-
 import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
-import akka.stream.ActorMaterializer
-import akka.stream.Materializer
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import org.specs2.mutable.Specification
 
 import scala.compat.java8.FutureConverters
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class AccumulatorSpec extends Specification {
 
@@ -134,7 +132,7 @@ class AccumulatorSpec extends Specification {
       "Java asScala" in withMaterializer { implicit m =>
         await(
           play.libs.streams.Accumulator
-            .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int, CompletionStage[Int]])
+            .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int])
             .asScala()
             .run(source)
         ) must_== 6
@@ -236,7 +234,7 @@ class AccumulatorSpec extends Specification {
         "Java asScala" in withMaterializer { implicit m =>
           await(
             play.libs.streams.Accumulator
-              .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int, CompletionStage[Int]])
+              .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int])
               .asScala()
               .run(source)
           ) must_== 6
@@ -299,7 +297,7 @@ class AccumulatorSpec extends Specification {
         "Java asScala" in withMaterializer { implicit m =>
           await(
             play.libs.streams.Accumulator
-              .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int, CompletionStage[Int]])
+              .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int])
               .asScala()
               .run(6)
           ) must_== 6

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.19")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.5.21")
   val akkaHttpVersion     = "10.0.15"
   val playJsonVersion     = "2.6.12"
 


### PR DESCRIPTION
## Purpose

Update Akka to version 2.5.21. This version changes the signature of `scaladsl.Source.asJava`, so some adjustment was necessary for our tests. This pull request also fixes the cron build for 2.6.x branch since it uses snapshots versions of Akka that contains such change.

## References

https://github.com/akka/akka/pull/26246
