### PR TITLE
Update Play-WS to version 2.0.3

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
@@ -4,13 +4,13 @@
 
 package play.it.server
 
+import akka.stream.ActorMaterializer
 import javax.inject.Inject
 import javax.inject.Provider
-
-import akka.stream.ActorMaterializer
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.concurrent.ActorSystemProvider
+import play.api.libs.ws.WSClient
 import play.api.mvc.DefaultActionBuilder
 import play.api.mvc.Request
 import play.api.mvc.Results
@@ -76,34 +76,37 @@ trait ServerReloadingSpec extends PlaySpecification with WsTestClient with Serve
 
       val testAppProvider = new TestApplicationProvider
       withApplicationProvider(testAppProvider) { implicit port: Port => // First we make a request to the server. This tries to load the application
-      // but fails because we set our TestApplicationProvider to contain to a Failure
-      // instead of an Application. The server can't load the Application configuration
-      // yet, so it loads some default flash configuration.
+        // but fails because we set our TestApplicationProvider to contain to a Failure
+        // instead of an Application. The server can't load the Application configuration
+        // yet, so it loads some default flash configuration.
 
-      {
         testAppProvider.provide(Failure(new Exception))
-        val response = await(wsUrl("/").get())
-        response.status must_== 500
-      }
+        val res1 = await(wsUrl("/").get())
+        res1.status must_== 500
 
-      // Now we update the TestApplicationProvider with a working Application.
-      // Then we make a request to the application to check that the Server has
-      // reloaded the flash configuration properly. The FlashTestRouterProvider
-      // has the logic for setting and reading the flash value.
+        // Now we update the TestApplicationProvider with a working Application.
+        // Then we make a request to the application to check that the Server has
+        // reloaded the flash configuration properly. The FlashTestRouterProvider
+        // has the logic for setting and reading the flash value.
 
-      {
-        testAppProvider.provide(
-          Success(
-            GuiceApplicationBuilder()
-              .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
-              .build()
-          )
+        val application = GuiceApplicationBuilder()
+          .configure("play.ws.ahc.useCookieStore" -> "true") // to preserve cookies between requests
+          .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
+          .build()
+
+        // This client producer is created based on the application above, which configures
+        // the use of cookie store to "true".N
+        val persistentCookiesClientProducer: (Port, String) => WSClient = { (port, scheme) =>
+          application.injector.instanceOf[WSClient]
+        }
+
+        testAppProvider.provide(Success(application))
+
+        val res2 = await(
+          wsUrl("/setflash")(client = persistentCookiesClientProducer, port = port).withFollowRedirects(true).get()
         )
-
-        val response = await(wsUrl("/setflash").withFollowRedirects(true).get())
-        response.status must_== 200
-        response.body must_== "Some(bar)"
-      }
+        res2.status must_== 200
+        res2.body must_== "Some(bar)"
       }
     }
 

--- a/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
@@ -76,7 +76,7 @@ trait ServerReloadingSpec extends PlaySpecification with WsTestClient with Serve
 
       val testAppProvider = new TestApplicationProvider
       withApplicationProvider(testAppProvider) { implicit port: Port => // First we make a request to the server. This tries to load the application
-        // but fails because we set our TestApplicationProvider to contain to a Failure
+        // but fails because we set our TestApplicationProvider to contain a Failure
         // instead of an Application. The server can't load the Application configuration
         // yet, so it loads some default flash configuration.
 

--- a/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
@@ -95,7 +95,7 @@ trait ServerReloadingSpec extends PlaySpecification with WsTestClient with Serve
           .build()
 
         // This client producer is created based on the application above, which configures
-        // the use of cookie store to "true".N
+        // the use of cookie store to "true".
         val persistentCookiesClientProducer: (Port, String) => WSClient = { (port, scheme) =>
           application.injector.instanceOf[WSClient]
         }

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -48,9 +48,20 @@ routesGenerator := StaticRoutesGenerator
 
 See changes made in `play.mvc.Http.Context` APIs. This is only relevant for Java users: [[Java `Http.Context` changes|JavaHttpContextMigration27]].
 
-### Play WS API Changes
+### Play WS Changes
 
 In Play 2.6, we extracted most of Play-WS into a [standalone project](https://github.com/playframework/play-ws) that has an independent release cycle. Play-WS now has a significant release that requires some changes in Play itself.
+
+#### Cookie store handling 
+
+Play-WS 2.0 brings an updated version of [Async-Http-Client](https://github.com/AsyncHttpClient/async-http-client) which has an internal cookie store that is global and can affect your application if you are sending user sensitive cookies in requests to third-party services. For example, since the cookie store is global, the application can mix cookies for a user with cookies for another one when making requests to the same host. There is now a new configuration that you can use to enable or disable the cache:
+
+```HOCON
+# Enables global cache cookie store
+play.ws.ahc.useCookieStore = true
+```
+
+By default, the cache is disabled. This affects other places such as following redirects automatically. Previously, the cookies for the first request were sent in the subsequent request, which is not the case when the cache is disabled. There is currently no way to configure the cache per request.
 
 #### Scala API
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -275,7 +275,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.0.1"
+  val playWsStandaloneVersion = "2.0.3"
   val playWsDeps = Seq(
     "com.typesafe.play"                        %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play"                        %% "play-ws-standalone-xml" % playWsStandaloneVersion,


### PR DESCRIPTION
## Purpose

This version has a new configuration that enables/disables an internal cookie store that is persistent across multiple requests to the same hosts. By default, it is disabled.

## References

- https://github.com/playframework/play-ws/pull/307
- https://github.com/playframework/play-ws/pull/313
