### PR TITLE
Removed deprecated TOO_MANY_REQUEST field

### DIFF
--- a/core/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/core/play/src/main/scala/play/api/http/StandardValues.scala
@@ -222,8 +222,6 @@ trait Status {
   val PRECONDITION_REQUIRED           = 428
   val TOO_MANY_REQUESTS               = 429
   val REQUEST_HEADER_FIELDS_TOO_LARGE = 431
-  @deprecated("Use TOO_MANY_REQUESTS instead", "2.6.0")
-  val TOO_MANY_REQUEST = TOO_MANY_REQUESTS
 
   val INTERNAL_SERVER_ERROR           = 500
   val NOT_IMPLEMENTED                 = 501

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -734,10 +734,6 @@ trait Results {
   /** Generates a ‘431 REQUEST_HEADER_FIELDS_TOO_LARGE’ result. */
   val RequestHeaderFieldsTooLarge = new Status(REQUEST_HEADER_FIELDS_TOO_LARGE)
 
-  /** Generates a ‘429 TOO_MANY_REQUEST’ result. */
-  @deprecated("Use TooManyRequests instead", "2.6.0")
-  val TooManyRequest = TooManyRequests
-
   /** Generates a ‘500 INTERNAL_SERVER_ERROR’ result. */
   val InternalServerError = new Status(INTERNAL_SERVER_ERROR)
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -221,7 +221,8 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.core.j.JavaImplicitConversions"),
       ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.TOO_MANY_REQUEST")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -225,6 +225,7 @@ object BuildSettings {
       // Removed deprecated TOO_MANY_REQUEST field
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.Status.TOO_MANY_REQUEST"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.AbstractController.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MessagesAbstractController.TOO_MANY_REQUEST"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.ControllerHelpers.TOO_MANY_REQUEST"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.TOO_MANY_REQUEST"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.Default.TOO_MANY_REQUEST"),

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -222,7 +222,14 @@ object BuildSettings {
       ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.Status.TOO_MANY_REQUEST")
+      // Removed deprecated TOO_MANY_REQUEST field
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.Status.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.AbstractController.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.ControllerHelpers.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.Default.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.ExternalAssets.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.AssetsBuilder.TOO_MANY_REQUEST")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -222,7 +222,7 @@ object BuildSettings {
       ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.TOO_MANY_REQUEST")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.Status.TOO_MANY_REQUEST")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -225,12 +225,19 @@ object BuildSettings {
       // Removed deprecated TOO_MANY_REQUEST field
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.Status.TOO_MANY_REQUEST"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.AbstractController.TOO_MANY_REQUEST"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MessagesAbstractController.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.AbstractController.TooManyRequest"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.ControllerHelpers.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.ControllerHelpers.TooManyRequest"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MessagesAbstractController.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MessagesAbstractController.TooManyRequest"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results.TooManyRequest"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.AssetsBuilder.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.AssetsBuilder.TooManyRequest"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.Default.TOO_MANY_REQUEST"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.Default.TooManyRequest"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.ExternalAssets.TOO_MANY_REQUEST"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.AssetsBuilder.TOO_MANY_REQUEST")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.ExternalAssets.TooManyRequest")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Background context

This fileld was deprecated in 2.6.0
