### PR TITLE
Removed deprecated BodyParsers.urlFormEncoded

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -859,12 +859,6 @@ trait PlayBodyParsers extends BodyParserUtils {
   def tolerantFormUrlEncoded: BodyParser[Map[String, Seq[String]]] =
     tolerantFormUrlEncoded(DefaultMaxTextLength)
 
-  @deprecated("Use formUrlEncoded", "2.6.0")
-  def urlFormEncoded(maxLength: Long): BodyParser[Map[String, Seq[String]]] = formUrlEncoded(maxLength)
-
-  @deprecated("Use formUrlEncoded", "2.6.0")
-  def urlFormEncoded: BodyParser[Map[String, Seq[String]]] = formUrlEncoded
-
   /**
    * Parse the body as form url encoded if the Content-Type is application/x-www-form-urlencoded.
    *

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -221,7 +221,10 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.core.j.JavaImplicitConversions"),
       ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
+      // Removed deprecated BodyParsers.urlFormEncoded method
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.DefaultPlayBodyParsers.urlFormEncoded"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.PlayBodyParsers.urlFormEncoded")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Background Context

These methods was deprecated in 2.6.0