### PR TITLE
Removed deprecated method Database.toScala()

### DIFF
--- a/persistence/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
@@ -125,11 +125,6 @@ public class DefaultDatabase implements Database {
     db.shutdown();
   }
 
-  @Override
-  public play.api.db.Database toScala() {
-    return db;
-  }
-
   /**
    * Create a Scala function wrapper for ConnectionRunnable.
    *

--- a/persistence/play-jdbc-api/src/main/java/play/db/Database.java
+++ b/persistence/play-jdbc-api/src/main/java/play/db/Database.java
@@ -129,17 +129,6 @@ public interface Database {
    * Converts the given database to a Scala database
    *
    * @return the database for scala API.
-   * @deprecated As of release 2.6.0. Use {@link #asScala()}
-   */
-  @Deprecated
-  public default play.api.db.Database toScala() {
-    return asScala();
-  }
-
-  /**
-   * Converts the given database to a Scala database
-   *
-   * @return the database for scala API.
    */
   public default play.api.db.Database asScala() {
     return new play.api.db.Database() {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -223,7 +223,7 @@ object BuildSettings {
       // Add fileName param (with default value) to Scala's sendResource(...) method
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
       // Removed deprecated method Database.toScala()
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.Database.toScala")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.Database.toScala"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.DefaultDatabase.toScala")
     ),
     unmanagedSourceDirectories in Compile += {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -221,7 +221,10 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.core.j.JavaImplicitConversions"),
       ProblemFilters.exclude[MissingTypesProblem]("play.core.j.PlayMagicForJava$"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
+      // Removed deprecated method Database.toScala()
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.Database.toScala")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.DefaultDatabase.toScala")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Background Context

This method was deprecated in 2.6.0
