### PR TITLE
PlayNonCrossBuiltProject were inheriting multiple scala versions.

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -234,7 +234,8 @@ object BuildSettings {
       .settings(omnidocSettings: _*)
       .settings(
         autoScalaLibrary := false,
-        crossPaths := false
+        crossPaths := false,
+        crossScalaVersions := Seq(ScalaVersions.scala212)
       )
   }
 


### PR DESCRIPTION
The inherited settings for `PlayNonCrossBuiltProject` include multiple values on `crossScalaVersions`. I don't think this makes sense considering these are settings for non-cross built projects.

I've made the override here and not `play/interplay` because the making the change there required creating a new `AutoPlugin` for `NonCrossBuild` and override this setting and ... 

The idea of `NonCrossBuild` seems to only exist in play itself so this hack seems fine.