### PR TITLE
Fixed an issue where RequestHeader.path was decoded when using AkkaHt…

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -291,5 +291,23 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
       }
     }
 
+    "maintain uri and path consistency" in {
+      def uriInRequest(uri: String): MatchResult[Either[String, _]] = {
+        withServer(
+          (Action, _) =>
+            Action { rh =>
+              Results.Ok((rh.uri.contains(rh.path) && rh.uri.contains(rh.rawQueryString)).toString)
+            }
+        ) { port =>
+          val Seq(response) = BasicHttpClient.makeRequests(port)(
+            BasicRequest("GET", uri, "HTTP/1.1", Map(), "")
+          )
+          response.body must beLeft(s"true")
+        }
+      }
+      "encoded uri" in uriInRequest("/foo%3Abar?bar%3Abaz=foo")
+      "decoded uri" in uriInRequest("/foo:bar?bar:baz=foo")
+    }
+
   }
 }

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -94,7 +94,6 @@ private[server] class AkkaModelConversion(
       request.method.name,
       new RequestTarget {
 
-        val (parsedPath, _) = PathAndQueryParser.parse(headers.uri)
 
         override lazy val uri: URI = new URI(headers.uri)
 
@@ -102,7 +101,7 @@ private[server] class AkkaModelConversion(
 
         override lazy val path: String = {
           try {
-            parsedPath
+            PathAndQueryParser.parsePath(headers.uri)
           } catch {
             case NonFatal(e) =>
               logger.warn("Failed to parse path; returning empty string.", e)

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -94,7 +94,6 @@ private[server] class AkkaModelConversion(
       request.method.name,
       new RequestTarget {
 
-
         override lazy val uri: URI = new URI(headers.uri)
 
         override def uriString: String = headers.uri

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -27,6 +27,7 @@ import play.api.mvc._
 import play.api.mvc.request.RemoteConnection
 import play.api.mvc.request.RequestTarget
 import play.core.server.common.ForwardedHeaderHandler
+import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
 import play.mvc.Http.HeaderNames
 
@@ -92,13 +93,16 @@ private[server] class AkkaModelConversion(
       ),
       request.method.name,
       new RequestTarget {
+
+        val (parsedPath, _) = PathAndQueryParser.parse(headers.uri)
+
         override lazy val uri: URI = new URI(headers.uri)
 
         override def uriString: String = headers.uri
 
         override lazy val path: String = {
           try {
-            uri.getRawPath
+            parsedPath
           } catch {
             case NonFatal(e) =>
               logger.warn("Failed to parse path; returning empty string.", e)

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -98,7 +98,7 @@ private[server] class AkkaModelConversion(
 
         override lazy val path: String = {
           try {
-            request.uri.path.toString
+            uri.getRawPath
           } catch {
             case NonFatal(e) =>
               logger.warn("Failed to parse path; returning empty string.", e)

--- a/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
@@ -9,7 +9,7 @@ private[server] object PathAndQueryParser {
 
   /**
    * Parse URI String into path and query string parts.
-   * The path part is validate using [[java.net.URI]].
+   * The path part is validated using [[java.net.URI]].
    *
    * See https://tools.ietf.org/html/rfc3986
    *
@@ -41,7 +41,7 @@ private[server] object PathAndQueryParser {
 
   /**
    * Parse URI String and extract the path part only.
-   * The path part is validate using [[java.net.URI]].
+   * The path part is validated using [[java.net.URI]].
    *
    * See https://tools.ietf.org/html/rfc3986
    *

--- a/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.common
+
+import java.net.URI
+
+private[server] object PathAndQueryParser {
+
+  /**
+   * Parse URI String into path and query string parts.
+   * The path part is validate using [[java.net.URI]].
+   *
+   * See https://tools.ietf.org/html/rfc3986
+   *
+   * @throws IllegalArgumentException if path is invalid.
+   * @return
+   */
+  @throws[IllegalArgumentException]
+  def parse(uri: String): (String, String) = {
+    // https://tools.ietf.org/html/rfc3986#section-3.3
+    val withoutHost = uri.dropWhile(_ != '/')
+    // The path is terminated by the first question mark ("?")
+    // or number sign ("#") character, or by the end of the URI.
+    val queryEndPos = Some(withoutHost.indexOf('#')).filter(_ != -1).getOrElse(withoutHost.length)
+    val pathEndPos  = Some(withoutHost.indexOf('?')).filter(_ != -1).getOrElse(queryEndPos)
+    val unsafePath  = withoutHost.substring(0, pathEndPos)
+    // https://tools.ietf.org/html/rfc3986#section-3.4
+    // The query component is indicated by the first question
+    // mark ("?") character and terminated by a number sign ("#") character
+    // or by the end of the URI.
+    val queryString = withoutHost.substring(pathEndPos, queryEndPos)
+
+    // wrapping into URI to handle absoluteURI and path validation
+    val parsedPath = Option(new URI(unsafePath).getRawPath).getOrElse {
+      // if the URI has a invalid path, this will trigger a 400 error
+      throw new IllegalStateException(s"Cannot parse path from URI: $unsafePath")
+    }
+    (parsedPath, queryString)
+  }
+
+}

--- a/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
@@ -39,4 +39,16 @@ private[server] object PathAndQueryParser {
     (parsedPath, queryString)
   }
 
+  /**
+   * Parse URI String and extract the path part only.
+   * The path part is validate using [[java.net.URI]].
+   *
+   * See https://tools.ietf.org/html/rfc3986
+   *
+   * @throws IllegalArgumentException if path is invalid.
+   * @return
+   */
+  @throws[IllegalArgumentException]
+  def parsePath(uri: String): String = parse(uri)._1
+
 }


### PR DESCRIPTION
…tpServer but not NettyServer

## Fixes

Fixes #9190 

Also added test cases, without the change, `AkkaHttpRequestHeadersSpec` would fail but not `NettyRequestHeadersSpec`.

```
[info] AkkaHttpRequestHeadersSpec
[info] Play request header handling should
[info]   + get request headers properly
[info]   + remove request headers properly
[info]   + replace request headers properly
[info]   + not expose a content-type when there's no body
[info]   + pass common tests for headers
[info]   + get request headers properly when Content-Encoding is set
[info]   preserve the value of headers
[info]     + for UTF-8 Content-Disposition headers
[info]     + for Authorization headers
[info]   preserve the case of header names
[info]     + 'Foo' header
[info]     + 'foo' header
[info]     + 'Authorization' header
[info]     + 'authorization' header
[info]     + 'User-Agent' header with valid value
[info]     + 'User-Agent' header with invalid value
[info]   + respect max header value setting
[info]   maintain uri and path consistency
[error]     x encoded uri
[error]      Left(false) is Left but 'false' != 'true' (RequestHeadersSpec.scala:305)
[info]     + decoded uri
```