### PR TITLE
Use a consistent version of Scala

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -89,6 +89,7 @@ object BuildSettings {
 
   /** These settings are used by all projects. */
   def playCommonSettings: Seq[Setting[_]] = Def.settings(
+    scalaVersion := ScalaVersions.scala212,
     fileHeaderSettings,
     homepage := Some(url("https://playframework.com")),
     ivyLoggingLevel := UpdateLogging.DownloadOnly,


### PR DESCRIPTION
## Purpose

Before the build was using Scala 2.12.7 for scalaVersion but 2.12.8 in crossScalaVersions. This is a follow up of #9189 to fix problems in our release process.