### PR TITLE
Fix integration tests on Java 11 & enforce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,11 +66,6 @@ jobs:
       env: TRAVIS_JDK=adopt@1.11.0-2
       name: "Scripted tests for sbt 1 and Java 11"
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: TRAVIS_JDK=adopt@1.11.0-2 # not fully supported but allows problem discovery
-
 cache:
   directories:
     - "$HOME/.ivy2/cache"

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -4,6 +4,7 @@
 
 package play.it.test
 
+import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -72,6 +73,8 @@ trait OkHttpEndpointSupport {
           // See https://tools.ietf.org/html/rfc2818#section-3.1
           b.hostnameVerifier((_, _) => true)
         }
+        // https://github.com/square/okhttp/issues/3146#issuecomment-407933860
+        b.pingInterval(500, TimeUnit.MILLISECONDS)
         b
       }
     }

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -4,9 +4,6 @@
 
 package play.it.test
 
-import javax.net.ssl.HostnameVerifier
-import javax.net.ssl.SSLSession
-
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -68,19 +65,14 @@ trait OkHttpEndpointSupport {
       override val endpoint = e
       override val clientBuilder: OkHttpClient.Builder = {
         val b = new OkHttpClient.Builder()
-        endpoint.ssl match {
-          case Some(ssl) =>
-            // We are only using this for tests, so we are accepting all host names
-            // when OkHttp client verifies the identity of the server with the hostname.
-            // See https://tools.ietf.org/html/rfc2818#section-3.1
-            val allowAllHostnameVerifier = new HostnameVerifier {
-              override def verify(s: String, sslSession: SSLSession): Boolean = true
-            }
-
-            b.sslSocketFactory(ssl.sslContext.getSocketFactory, ssl.trustManager)
-              .hostnameVerifier(allowAllHostnameVerifier)
-          case _ => b
+        endpoint.ssl.foreach { ssl =>
+          b.sslSocketFactory(ssl.sslContext.getSocketFactory, ssl.trustManager)
+          // We are only using this for tests, so we are accepting all host names
+          // when OkHttp client verifies the identity of the server with the hostname.
+          // See https://tools.ietf.org/html/rfc2818#section-3.1
+          b.hostnameVerifier((_, _) => true)
         }
+        b
       }
     }
     block(serverClient)


### PR DESCRIPTION
The job "Run it tests for Scala 2.12 and Java 11" is failing: https://travis-ci.com/playframework/playframework/jobs/192016513

This tasks tracks fixing those issues and enforcing that it doesn't regress by removing the `allow_failures` for Java 11.

Fixes #8829