### PR TITLE
Let mergify takes care of backports

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -9,8 +9,8 @@ repository:
   has_wiki: false
   has_downloads: true
   default_branch: master
-  allow_squash_merge: true
-  allow_merge_commit: false
+  allow_squash_merge: false
+  allow_merge_commit: true
   allow_rebase_merge: false
 
 teams:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,9 +9,42 @@ pull_request_rules:
       - label!=status:block-merge
     actions:
       merge:
-        method: squash
+        method: merge
         strict: smart
-        
+
+  - name: backport patches to 2.7.x branch
+    conditions:
+      - merged
+      - label=status:needs-backport
+    actions:
+      backport:
+        branches:
+          - 2.7.x  
+      label:
+        remove: [status:needs-backport]
+
+  - name: backport patches to 2.6.x branch
+    conditions:
+      - merged
+      - label=status:needs-backport-2.6
+    actions:
+      backport:
+        branches:
+          - 2.6.x  
+      label:
+        remove: [status:needs-backport-2.6]
+
+  - name: forward patches to master branch
+    conditions:
+      - merged
+      - label=status:needs-forwardport
+    actions:
+      backport:
+        branches:
+          - master  
+      label:
+        remove: [status:needs-forwardport]
+
   - name: Delete the PR branch after merge
     conditions:
       - merged


### PR DESCRIPTION
We have learned that Mergify backports doesn't work well with squash merges, therefore, in order to benefit of backports and forward porst, we need to modify our strategy and move to merge commits.