### PR TITLE
Get rid of some extra Akka "performance" tweaks, refs #7242

### DIFF
--- a/core/play/src/main/resources/play/reference-overrides.conf
+++ b/core/play/src/main/resources/play/reference-overrides.conf
@@ -22,16 +22,6 @@ akka {
       fork-join-executor {
         # Settings this to 1 instead of 3 seems to improve performance.
         parallelism-factor = 1.0
-
-        # @richdougherty: Not sure why this is set below the Akka
-        # default.
-        parallelism-max = 24
-
-        # Setting this to LIFO changes the fork-join-executor
-        # to use a stack discipline for task scheduling. This usually
-        # improves throughput at the cost of possibly increasing
-        # latency and risking task starvation (which should be rare).
-        task-peeking-mode = LIFO
       }
     }
   }


### PR DESCRIPTION
Fixes #7242.

General Akka performance tweaks shouldn't be the scope of reference overrides so
let's remove them.

No one remembers the original reason why maximum number of threads was limited, so
let's go of that.

Setting LIFO mode is just a speculation that this might be better and that users actually
care more about throughput than about latency and fairness. It's not Play's job to make
that call.

`parallelism-factor = 1.0` is indeed a very useful default for now but Akka hasn't dared to
change it yet (but will for 2.6). So, let's keep that for now.