### PR TITLE
Fixed an issue where RequestHeader.path

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/RequestHeadersSpec.scala
@@ -292,5 +292,23 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
       }
     }
 
+    "maintain uri and path consistency" in {
+      def uriInRequest(uri: String): MatchResult[Either[String, _]] = {
+        withServer(
+          (Action, _) =>
+            Action { rh =>
+              Results.Ok((rh.uri.contains(rh.path) && rh.uri.contains(rh.rawQueryString)).toString)
+            }
+        ) { port =>
+          val Seq(response) = BasicHttpClient.makeRequests(port)(
+            BasicRequest("GET", uri, "HTTP/1.1", Map(), "")
+          )
+          response.body must beLeft(s"true")
+        }
+      }
+      "encoded uri" in uriInRequest("/foo%3Abar?bar%3Abaz=foo")
+      "decoded uri" in uriInRequest("/foo:bar?bar:baz=foo")
+    }
+
   }
 }

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -28,6 +28,7 @@ import play.api.mvc._
 import play.api.mvc.request.RemoteConnection
 import play.api.mvc.request.RequestTarget
 import play.core.server.common.ForwardedHeaderHandler
+import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
 import play.mvc.Http.HeaderNames
 
@@ -93,13 +94,14 @@ private[server] class AkkaModelConversion(
       ),
       request.method.name,
       new RequestTarget {
+
         override lazy val uri: URI = new URI(headers.uri)
 
         override def uriString: String = headers.uri
 
         override lazy val path: String = {
           try {
-            request.uri.path.toString
+            PathAndQueryParser.parsePath(headers.uri)
           } catch {
             case NonFatal(e) =>
               logger.warn("Failed to parse path; returning empty string.", e)

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -9,8 +9,8 @@ import java.net.InetSocketAddress
 import java.net.URI
 import java.security.cert.X509Certificate
 import java.time.Instant
-import javax.net.ssl.SSLPeerUnverifiedException
 
+import javax.net.ssl.SSLPeerUnverifiedException
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
@@ -34,6 +34,7 @@ import play.api.mvc.request.RemoteConnection
 import play.api.mvc.request.RequestAttrKey
 import play.api.mvc.request.RequestTarget
 import play.core.server.common.ForwardedHeaderHandler
+import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
 
 import scala.collection.JavaConverters._
@@ -49,22 +50,6 @@ private[server] class NettyModelConversion(
 ) {
 
   private val logger = Logger(classOf[NettyModelConversion])
-
-  private def parsePathAndQuery(uri: String): (String, String) = {
-    // https://tools.ietf.org/html/rfc3986#section-3.3
-    val withoutHost = uri.dropWhile(_ != '/')
-    // The path is terminated by the first question mark ("?")
-    // or number sign ("#") character, or by the end of the URI.
-    val queryEndPos = Some(withoutHost.indexOf('#')).filter(_ != -1).getOrElse(withoutHost.length)
-    val pathEndPos  = Some(withoutHost.indexOf('?')).filter(_ != -1).getOrElse(queryEndPos)
-    val path        = withoutHost.substring(0, pathEndPos)
-    // https://tools.ietf.org/html/rfc3986#section-3.4
-    // The query component is indicated by the first question
-    // mark ("?") character and terminated by a number sign ("#") character
-    // or by the end of the URI.
-    val queryString = withoutHost.substring(pathEndPos, queryEndPos)
-    (path, queryString)
-  }
 
   /**
    * Convert a Netty request to a Play RequestHeader.
@@ -109,12 +94,8 @@ private[server] class NettyModelConversion(
 
   /** Create request target information from a Netty request. */
   private def createRequestTarget(request: HttpRequest): RequestTarget = {
-    val (unsafePath, parsedQueryString) = parsePathAndQuery(request.uri)
-    // wrapping into URI to handle absoluteURI and path validation
-    val parsedPath = Option(new URI(unsafePath).getRawPath).getOrElse {
-      // if the URI has a invalid path, this will trigger a 400 error
-      throw new IllegalStateException(s"Cannot parse path from URI: $unsafePath")
-    }
+    val (parsedPath, parsedQueryString) = PathAndQueryParser.parse(request.uri)
+
     new RequestTarget {
       override lazy val uri: URI       = new URI(uriString)
       override def uriString: String   = request.uri

--- a/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.common
+
+import java.net.URI
+
+private[server] object PathAndQueryParser {
+
+  /**
+   * Parse URI String into path and query string parts.
+   * The path part is validated using [[java.net.URI]].
+   *
+   * See https://tools.ietf.org/html/rfc3986
+   *
+   * @throws IllegalArgumentException if path is invalid.
+   * @return
+   */
+  @throws[IllegalArgumentException]
+  def parse(uri: String): (String, String) = {
+    // https://tools.ietf.org/html/rfc3986#section-3.3
+    val withoutHost = uri.dropWhile(_ != '/')
+    // The path is terminated by the first question mark ("?")
+    // or number sign ("#") character, or by the end of the URI.
+    val queryEndPos = Some(withoutHost.indexOf('#')).filter(_ != -1).getOrElse(withoutHost.length)
+    val pathEndPos  = Some(withoutHost.indexOf('?')).filter(_ != -1).getOrElse(queryEndPos)
+    val unsafePath  = withoutHost.substring(0, pathEndPos)
+    // https://tools.ietf.org/html/rfc3986#section-3.4
+    // The query component is indicated by the first question
+    // mark ("?") character and terminated by a number sign ("#") character
+    // or by the end of the URI.
+    val queryString = withoutHost.substring(pathEndPos, queryEndPos)
+
+    // wrapping into URI to handle absoluteURI and path validation
+    val parsedPath = Option(new URI(unsafePath).getRawPath).getOrElse {
+      // if the URI has a invalid path, this will trigger a 400 error
+      throw new IllegalStateException(s"Cannot parse path from URI: $unsafePath")
+    }
+    (parsedPath, queryString)
+  }
+
+  /**
+   * Parse URI String and extract the path part only.
+   * The path part is validated using [[java.net.URI]].
+   *
+   * See https://tools.ietf.org/html/rfc3986
+   *
+   * @throws IllegalArgumentException if path is invalid.
+   * @return
+   */
+  @throws[IllegalArgumentException]
+  def parsePath(uri: String): String = parse(uri)._1
+
+}


### PR DESCRIPTION
This is a forward port of #9191. 

For some reason, the auto backport PR is not building, so I'm trying it on a new PR that I can eventually modify and test. 

The original PR was sent to `2.6.x`. Once this get merged in `master` we should backport to `2.7.x`