### PR TITLE
[2.5.x] Fix application secret property name

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/ApplicationSecret.md
+++ b/documentation/manual/working/commonGuide/configuration/ApplicationSecret.md
@@ -6,7 +6,7 @@ Play uses a secret key for a number of things, including:
 * Signing session cookies and CSRF tokens
 * Built in encryption utilities
 
-It is configured in `application.conf`, with the property name `play.crypto.secret`, and defaults to `changeme`.  As the default suggests, it should be changed for production.
+It is configured in `application.conf`, with the property name `play.secret`, and defaults to `changeme`.  As the default suggests, it should be changed for production.
 
 > When started in prod mode, if Play finds that the secret is not set, or if it is set to `changeme`, Play will throw an error.
 


### PR DESCRIPTION
This should be `play.secret`. Confirmed on my Play 2.5 app.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?