### PR TITLE
Overloaded ActorSystemProvider.start to accept a List[Setup]

### DIFF
--- a/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -135,12 +135,35 @@ object ActorSystemProvider {
   case object ApplicationShutdownReason extends CoordinatedShutdown.Reason
 
   /**
+   * Start an ActorSystem, using the given configuration and ClassLoader.
+   *
+   * @return The ActorSystem and a function that can be used to stop it.
+   */
+  @deprecated("Use setup(ClassLoader, Configuration, Setup*) instead", "2.8.0")
+  protected[ActorSystemProvider] def start(classLoader: ClassLoader, config: Configuration): ActorSystem = {
+    start(classLoader, config, Seq.empty: _*)
+  }
+
+  /**
+   * Start an ActorSystem, using the given configuration, ClassLoader, and additional ActorSystem Setup.
+   *
+   * @return The ActorSystem and a function that can be used to stop it.
+   */
+  @deprecated("Use setup(ClassLoader, Configuration, Setup*) instead", "2.8.0")
+  protected[ActorSystemProvider] def start(
+      classLoader: ClassLoader,
+      config: Configuration,
+      additionalSetup: Setup
+  ): ActorSystem = {
+    start(classLoader, config, Seq(additionalSetup): _*)
+  }
+
+  /**
    * Start an ActorSystem, using the given configuration, ClassLoader, and optional additional ActorSystem Setups.
    *
    * @return The ActorSystem and a function that can be used to stop it.
    */
-
-   def start(classLoader: ClassLoader, config: Configuration, additionalSetups:Setup*): ActorSystem = {
+  def start(classLoader: ClassLoader, config: Configuration, additionalSetups: Setup*): ActorSystem = {
     val exitJvmPath = "akka.coordinated-shutdown.exit-jvm"
     if (config.get[Boolean](exitJvmPath)) {
       // When this setting is enabled, there'll be a deadlock at shutdown. Therefore, we
@@ -183,9 +206,8 @@ object ActorSystemProvider {
 
     val name = config.get[String]("play.akka.actor-system")
 
-    val bootstrapSetup = BootstrapSetup(Some(classLoader), Some(akkaConfig), None)
-    val actorSystemSetup = ActorSystemSetup(bootstrapSetup +: additionalSetups:_*)
-
+    val bootstrapSetup   = BootstrapSetup(Some(classLoader), Some(akkaConfig), None)
+    val actorSystemSetup = ActorSystemSetup(bootstrapSetup +: additionalSetups: _*)
 
     val system = ActorSystem(name, actorSystemSetup)
     logger.debug(s"Starting application default Akka system: $name")

--- a/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -148,11 +148,11 @@ object ActorSystemProvider {
    *
    * @return The ActorSystem and a function that can be used to stop it.
    */
-  def start(classLoader: ClassLoader, config: Configuration, additionalSetup: Setup): ActorSystem = {
+  def start(classLoader: ClassLoader, config: Configuration, additionalSetup: List[Setup]): ActorSystem = {
     start(classLoader, config, Some(additionalSetup))
   }
 
-  private def start(classLoader: ClassLoader, config: Configuration, additionalSetup: Option[Setup]): ActorSystem = {
+  private def start(classLoader: ClassLoader, config: Configuration, additionalSetup: Option[List[Setup]]): ActorSystem = {
     val exitJvmPath = "akka.coordinated-shutdown.exit-jvm"
     if (config.get[Boolean](exitJvmPath)) {
       // When this setting is enabled, there'll be a deadlock at shutdown. Therefore, we
@@ -197,7 +197,7 @@ object ActorSystemProvider {
 
     val bootstrapSetup = BootstrapSetup(Some(classLoader), Some(akkaConfig), None)
     val actorSystemSetup = additionalSetup match {
-      case Some(setup) => ActorSystemSetup(bootstrapSetup, setup)
+      case Some(setup:List[Setup]) => ActorSystemSetup(bootstrapSetup +: setup:_*)
       case None        => ActorSystemSetup(bootstrapSetup)
     }
 

--- a/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -144,7 +144,7 @@ object ActorSystemProvider {
   }
 
   /**
-   * Start an ActorSystem, using the given configuration, ClassLoader, and additional ActorSystem Setup.
+   * Start an ActorSystem, using the given configuration, ClassLoader, and a list of additional ActorSystem Setups.
    *
    * @return The ActorSystem and a function that can be used to stop it.
    */


### PR DESCRIPTION
The changes are for the issue ActorSystemProvider should accept a List of Setup #9106.

Changes are needed to add health check setups

Fixes #9106