### PR TITLE
[2.6.x]: Fix version after release

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.6.22"
+version in ThisBuild := "2.6.23-SNAPSHOT"


### PR DESCRIPTION
The latest release was finished manually, so there was no
step to update the version to add `-SNAPSHOT`.
