### PR TITLE
Resolve 10 deprecation warnings about EC#prepare

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ import Dependencies._
 import Generators._
 import com.lightbend.sbt.javaagent.JavaAgent.JavaAgentKeys.javaAgents
 import com.lightbend.sbt.javaagent.JavaAgent.JavaAgentKeys.resolvedJavaAgents
-import com.typesafe.tools.mima.core._
 import interplay.PlayBuildBase.autoImport._
 import interplay.ScalaVersions._
 import pl.project13.scala.sbt.JmhPlugin.generateJmhSourcesAndResources
@@ -77,10 +76,6 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
       .taskValue,
     sourceDirectories in (Compile, TwirlKeys.compileTemplates) := (unmanagedSourceDirectories in Compile).value,
     TwirlKeys.templateImports += "play.api.templates.PlayMagic._",
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.j.JavaParsers.parse"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.mvc.Http#MultipartFormData#FilePart.getFile"),
-    ),
     mappings in (Compile, packageSrc) ++= {
       // Add both the templates, useful for end users to read, and the Scala sources that they get compiled to,
       // so omnidoc can compile and produce scaladocs for them.

--- a/core/play/src/main/java/play/libs/F.java
+++ b/core/play/src/main/java/play/libs/F.java
@@ -341,21 +341,6 @@ public class F {
     return new Tuple5<A, B, C, D, E>(a, b, c, d, e);
   }
 
-  /**
-   * Converts the execution context to an executor, preparing it first.
-   *
-   * @param ec the execution context.
-   * @return the Java Executor.
-   */
-  private static Executor toExecutor(ExecutionContext ec) {
-    ExecutionContext prepared = ec.prepare();
-    if (prepared instanceof Executor) {
-      return (Executor) prepared;
-    } else {
-      return prepared::execute;
-    }
-  }
-
   public static class LazySupplier<T> implements Supplier<T> {
 
     private T value;

--- a/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
+++ b/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
@@ -37,11 +37,6 @@ public abstract class CustomExecutionContext implements ExecutionContextExecutor
   }
 
   @Override
-  public ExecutionContext prepare() {
-    return executionContext.prepare();
-  }
-
-  @Override
   public void execute(Runnable command) {
     executionContext.execute(command);
   }

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -142,7 +142,7 @@ private class SelfPopulatingMap[K, V] {
     store.putIfAbsent(k, p.future) match {
       case Some(f) => f
       case None =>
-        val f = Future(pf(k))(ec.prepare())
+        val f = Future(pf(k))(ec)
         f.onComplete {
           case Failure(_) | Success(None) => store.remove(k)
           case _                          => // Do nothing, the asset was successfully found and is now cached

--- a/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala
+++ b/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala
@@ -44,12 +44,8 @@ object HttpExecutionContext {
   /**
    * Create an ExecutionContext that will, when prepared, be created with values from that thread.
    */
-  def unprepared(delegate: ExecutionContext) = new ExecutionContext {
-    def execute(runnable: Runnable) =
-      delegate.execute(runnable) // FIXME: Make calling this an error once SI-7383 is fixed
-    def reportFailure(t: Throwable)          = delegate.reportFailure(t)
-    override def prepare(): ExecutionContext = fromThread(delegate)
-  }
+  @deprecated("This is a no-op, now that ExecutionContext#prepare is deprecated.", "2.8.0")
+  def unprepared(delegate: ExecutionContext) = delegate
 }
 
 /**
@@ -85,13 +81,4 @@ class HttpExecutionContext(contextClassLoader: ClassLoader, delegate: ExecutionC
     })
 
   override def reportFailure(t: Throwable) = delegate.reportFailure(t)
-
-  override def prepare(): ExecutionContext = {
-    val delegatePrepared = delegate.prepare()
-    if (delegatePrepared eq delegate) {
-      this
-    } else {
-      new HttpExecutionContext(contextClassLoader, httpContext, delegatePrepared)
-    }
-  }
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -244,7 +244,11 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.Default.TOO_MANY_REQUEST"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.Default.TooManyRequest"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.ExternalAssets.TOO_MANY_REQUEST"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.ExternalAssets.TooManyRequest")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("controllers.ExternalAssets.TooManyRequest"),
+      // Remove deprecated
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.j.JavaParsers.parse"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.mvc.Http#MultipartFormData#FilePart.getFile"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.concurrent.CustomExecutionContext.prepare"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
    [warn] /d/play/core/play/src/main/scala/play/api/controllers/Assets.scala:145:34: method prepare in trait ExecutionContext is deprecated (since 2.12.0): preparation of ExecutionContexts will be removed
    [warn]         val f = Future(pf(k))(ec.prepare())
    [warn]                                  ^
    [warn] /d/play/core/play/src/main/scala/play/api/mvc/Action.scala:99:24: method prepare in trait ExecutionContext is deprecated (since 2.12.0): preparation of ExecutionContexts will be removed
    [warn]     }(executionContext.prepare)
    [warn]                        ^
    [warn] /d/play/core/play/src/main/scala/play/api/mvc/Action.scala:142:27: method prepare in trait ExecutionContext is deprecated (since 2.12.0): preparation of ExecutionContexts will be removed
    [warn]     implicit val pec = ec.prepare()
    [warn]                           ^
    [warn] /d/play/core/play/src/main/scala/play/api/mvc/Action.scala:162:27: method prepare in trait ExecutionContext is deprecated (since 2.12.0): preparation of ExecutionContexts will be removed
    [warn]     implicit val pec = ec.prepare()
    [warn]                           ^
    [warn] /d/play/core/play/src/main/scala/play/api/mvc/Action.scala:197:27: method prepare in trait ExecutionContext is deprecated (since 2.12.0): preparation of ExecutionContexts will be removed
    [warn]     implicit val pec = ec.prepare()
    [warn]                           ^
    [warn] /d/play/core/play/src/main/scala/play/api/mvc/Action.scala:219:27: method prepare in trait ExecutionContext is deprecated (since 2.12.0): preparation of ExecutionContexts will be removed
    [warn]     implicit val pec = ec.prepare()
    [warn]                           ^
    [warn] /d/play/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala:89:37: method prepare in trait ExecutionContext is deprecated (since 2.12.0): preparation of ExecutionContexts will be removed
    [warn]     val delegatePrepared = delegate.prepare()
    [warn]                                     ^
    [warn] 7 warnings found
    [warn] /d/play/core/play/src/main/java/play/libs/F.java:351:1: prepare() in scala.concurrent.ExecutionContext has been deprecated
    [warn]     ExecutionContext prepared = ec.prepare();
    [warn] /d/play/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java:40:1: prepare() in scala.concurrent.ExecutionContext has been deprecated
    [warn]   public ExecutionContext prepare() {
    [warn] /d/play/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java:41:1: prepare() in scala.concurrent.ExecutionContext has been deprecated
    [warn]     return executionContext.prepare();