### PR TITLE
Avoid an unchecked cast warning

### DIFF
--- a/core/play/src/main/java/play/libs/typedmap/TypedMap.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedMap.java
@@ -8,7 +8,6 @@ import play.api.libs.typedmap.TypedMap$;
 import play.libs.Scala;
 import scala.compat.java8.OptionConverters;
 
-import java.util.Arrays;
 import java.util.Optional;
 
 /**
@@ -90,6 +89,11 @@ public final class TypedMap {
     return new TypedMap(underlying.updated(key.asScala(), value));
   }
 
+  private static <A> play.api.libs.typedmap.TypedMap putEntry(
+      final play.api.libs.typedmap.TypedMap typedMap, final TypedEntry<A> entry) {
+    return typedMap.updated(entry.key().asScala(), entry.value());
+  }
+
   /**
    * Update the map with several entries, returning a new instance of the map.
    *
@@ -99,7 +103,7 @@ public final class TypedMap {
   public TypedMap putAll(TypedEntry<?>... entries) {
     play.api.libs.typedmap.TypedMap newUnderlying = underlying;
     for (TypedEntry<?> e : entries) {
-      newUnderlying = newUnderlying.updated(((TypedKey<Object>) e.key()).asScala(), e.value());
+      newUnderlying = putEntry(newUnderlying, e);
     }
     return new TypedMap(newUnderlying);
   }


### PR DESCRIPTION
    [warn] /d/play/core/play/src/main/java/play/libs/typedmap/TypedMap.java:102:1: unchecked cast
    [warn]   required: play.libs.typedmap.TypedKey<java.lang.Object>
    [warn]   found:    play.libs.typedmap.TypedKey<capture#1 of ?>
    [warn]       newUnderlying = newUnderlying.updated(((TypedKey<Object>) e.key()).asScala(), e.value());