### PR TITLE
Renamed methods back to their original names

### DIFF
--- a/cache/play-cache/src/main/java/play/cache/AsyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/AsyncCacheApi.java
@@ -23,11 +23,9 @@ public interface AsyncCacheApi {
    *
    * @param <T> the type of the stored object
    * @param key the key to look up
-   * @return a CompletionStage containing the value
-   * @deprecated Deprecated as of 2.7.0. Use {@link #getOptional(String)} instead.
+   * @return a CompletionStage containing the value wrapped in an Optional
    */
-  @Deprecated
-  <T> CompletionStage<T> get(String key);
+  <T> CompletionStage<Optional<T>> get(String key);
 
   /**
    * Retrieves an object by key.
@@ -35,8 +33,12 @@ public interface AsyncCacheApi {
    * @param <T> the type of the stored object
    * @param key the key to look up
    * @return a CompletionStage containing the value wrapped in an Optional
+   * @deprecated Deprecated as of 2.8.0. Renamed to {@link #get(String)}.
    */
-  <T> CompletionStage<Optional<T>> getOptional(String key);
+  @Deprecated
+  default <T> CompletionStage<Optional<T>> getOptional(String key) {
+    return get(key);
+  }
 
   /**
    * Retrieve a value from the cache, or set it from a default Callable function.

--- a/cache/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
@@ -39,13 +39,7 @@ public class DefaultAsyncCacheApi implements AsyncCacheApi {
   }
 
   @Override
-  @Deprecated
-  public <T> CompletionStage<T> get(String key) {
-    return toJava(asyncCacheApi.get(key, Scala.<T>classTag())).thenApply(Scala::orNull);
-  }
-
-  @Override
-  public <T> CompletionStage<Optional<T>> getOptional(String key) {
+  public <T> CompletionStage<Optional<T>> get(String key) {
     return toJava(asyncCacheApi.get(key, Scala.<T>classTag())).thenApply(OptionConverters::toJava);
   }
 

--- a/cache/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
@@ -34,14 +34,8 @@ public class DefaultSyncCacheApi implements SyncCacheApi {
   }
 
   @Override
-  @Deprecated
-  public <T> T get(String key) {
+  public <T> Optional<T> get(String key) {
     return blocking(cacheApi.get(key));
-  }
-
-  @Override
-  public <T> Optional<T> getOptional(String key) {
-    return blocking(cacheApi.getOptional(key));
   }
 
   @Override

--- a/cache/play-cache/src/main/java/play/cache/SyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/SyncCacheApi.java
@@ -14,11 +14,9 @@ public interface SyncCacheApi {
    *
    * @param <T> the type of the stored object
    * @param key the key to look up
-   * @return the object or null
-   * @deprecated Deprecated as of 2.7.0. Use {@link #getOptional(String)} instead.
+   * @return the object wrapped in an Optional
    */
-  @Deprecated
-  <T> T get(String key);
+  <T> Optional<T> get(String key);
 
   /**
    * Retrieves an object by key.
@@ -26,8 +24,12 @@ public interface SyncCacheApi {
    * @param <T> the type of the stored object
    * @param key the key to look up
    * @return the object wrapped in an Optional
+   * @deprecated Deprecated as of 2.8.0. Renamed to {@link #get(String)}.
    */
-  <T> Optional<T> getOptional(String key);
+  @Deprecated
+  default <T> Optional<T> getOptional(String key) {
+    return get(key);
+  }
 
   /**
    * Retrieve a value from the cache, or set it from a default Callable function.

--- a/cache/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
+++ b/cache/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
@@ -24,18 +24,7 @@ public class SyncCacheApiAdapter implements SyncCacheApi {
   }
 
   @Override
-  @Deprecated
-  public <T> T get(String key) {
-    scala.Option<T> opt = scalaApi.get(key, Scala.classTag());
-    if (opt.isDefined()) {
-      return opt.get();
-    } else {
-      return null;
-    }
-  }
-
-  @Override
-  public <T> Optional<T> getOptional(String key) {
+  public <T> Optional<T> get(String key) {
     return toJava(scalaApi.get(key, Scala.classTag()));
   }
 

--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -32,25 +32,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar", 1 /* second */ ).toScala)
 
-      after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await }
+      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await }
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar", 10 /* seconds */ ).toScala)
 
-      after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await }
+      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         await(cacheApi.set("foo", "bar").toScala)
-        cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+        cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -61,7 +61,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
           .toScala
 
         future must beEqualTo("bar").await
-        cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+        cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -73,25 +73,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
         future must beEqualTo("bar").await
 
-        after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await }
+        after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
 
       await(cacheApi.remove("foo").toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await
     }
 
     "remove all values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
 
       await(cacheApi.removeAll().toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await
     }
   }
 
@@ -99,25 +99,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar")
-      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
+      cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar", 1 /* second */ )
 
-      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty()).eventually(3, 2.seconds)
+      cacheApi.get[String]("foo") must beEqualTo(Optional.empty()).eventually(3, 2.seconds)
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar", 10 /* seconds */ )
 
-      after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar")) }
+      after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar")) }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
         cacheApi.set("foo", "bar")
-        cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
+        cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
@@ -126,7 +126,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
         })
 
         value must beEqualTo("bar")
-        cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
+        cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
@@ -136,16 +136,16 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
         future must beEqualTo("bar")
 
-        after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty()) }
+        after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.empty()) }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar")
-      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
+      cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
 
       cacheApi.remove("foo")
-      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty())
+      cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
     }
   }
 }

--- a/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -32,25 +32,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar", 1 /* second */ ).toScala)
 
-      after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await }
+      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await }
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar", 10 /* seconds */ ).toScala)
 
-      after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await }
+      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         await(cacheApi.set("foo", "bar").toScala)
-        cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+        cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -61,7 +61,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
           .toScala
 
         future must beEqualTo("bar").await
-        cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+        cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
@@ -73,25 +73,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
         future must beEqualTo("bar").await
 
-        after2sec { cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await }
+        after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
 
       await(cacheApi.remove("foo").toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await
     }
 
     "remove all values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
       await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
 
       await(cacheApi.removeAll().toScala)
-      cacheApi.getOptional[String]("foo").toScala must beEqualTo(Optional.empty()).await
+      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await
     }
   }
 
@@ -99,25 +99,25 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar")
-      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
+      cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar", 1 /* second */ )
 
-      after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty()) }
+      after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.empty()) }
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar", 10 /* seconds */ )
 
-      after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar")) }
+      after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar")) }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
         cacheApi.set("foo", "bar")
-        cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
+        cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
@@ -126,7 +126,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
         })
 
         value must beEqualTo("bar")
-        cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
+        cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
@@ -136,16 +136,16 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
         future must beEqualTo("bar")
 
-        after2sec { cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty()) }
+        after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.empty()) }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
       cacheApi.set("foo", "bar")
-      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.of("bar"))
+      cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
 
       cacheApi.remove("foo")
-      cacheApi.getOptional[String]("foo") must beEqualTo(Optional.empty())
+      cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
     }
   }
 }

--- a/core/play/src/main/java/play/libs/Files.java
+++ b/core/play/src/main/java/play/libs/Files.java
@@ -80,7 +80,9 @@ public final class Files {
      *
      * @param destination the path to the destination file
      * @see #moveFileTo(Path, boolean)
+     * @deprecated Deprecated as of 2.8.0. Renamed to {@link #moveTo(File)}.
      */
+    @Deprecated
     default Path moveFileTo(File destination) {
       return moveFileTo(destination, false);
     }
@@ -92,7 +94,9 @@ public final class Files {
      *
      * @param destination the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
+     * @deprecated Deprecated as of 2.8.0. Renamed to {@link #moveTo(File, boolean)}.
      */
+    @Deprecated
     Path moveFileTo(File destination, boolean replace);
 
     /**
@@ -100,7 +104,9 @@ public final class Files {
      *
      * @param to the path to the destination file.
      * @see #moveFileTo(Path, boolean)
+     * @deprecated Deprecated as of 2.8.0. Renamed to {@link #moveTo(Path)}.
      */
+    @Deprecated
     default Path moveFileTo(Path to) {
       return moveFileTo(to, false);
     }
@@ -111,7 +117,9 @@ public final class Files {
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
      * @see #moveFileTo(Path, boolean)
+     * @deprecated Deprecated as of 2.8.0. Renamed to {@link #moveTo(Path, boolean)}.
      */
+    @Deprecated
     default Path moveFileTo(Path to, boolean replace) {
       return moveFileTo(to.toFile(), replace);
     }
@@ -121,10 +129,8 @@ public final class Files {
      *
      * @param destination the path to the destination file
      * @see #moveTo(Path, boolean)
-     * @deprecated Deprecated as of 2.7.0. Use {@link #moveFileTo(File)} instead.
      */
-    @Deprecated
-    default TemporaryFile moveTo(File destination) {
+    default Path moveTo(File destination) {
       return moveTo(destination, false);
     }
 
@@ -135,20 +141,16 @@ public final class Files {
      *
      * @param destination the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
-     * @deprecated Deprecated as of 2.7.0. Use {@link #moveFileTo(File, boolean)} instead.
      */
-    @Deprecated
-    TemporaryFile moveTo(File destination, boolean replace);
+    Path moveTo(File destination, boolean replace);
 
     /**
      * Move the file using a {@link java.nio.file.Path}.
      *
      * @param to the path to the destination file.
      * @see #moveTo(Path, boolean)
-     * @deprecated Deprecated as of 2.7.0. Use {@link #moveFileTo(Path)} instead.
      */
-    @Deprecated
-    default TemporaryFile moveTo(Path to) {
+    default Path moveTo(Path to) {
       return moveTo(to, false);
     }
 
@@ -158,10 +160,8 @@ public final class Files {
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
      * @see #moveTo(Path, boolean)
-     * @deprecated Deprecated as of 2.7.0. Use {@link #moveFileTo(Path, boolean)} instead.
      */
-    @Deprecated
-    default TemporaryFile moveTo(Path to, boolean replace) {
+    default Path moveTo(Path to, boolean replace) {
       return moveTo(to.toFile(), replace);
     }
 
@@ -173,7 +173,9 @@ public final class Files {
      * more predictable.
      *
      * @param to the path to the destination file
+     * @deprecated Deprecated as of 2.8.0. Renamed to {@link #atomicMoveWithFallback(File)}.
      */
+    @Deprecated
     Path atomicMoveFileWithFallback(File to);
 
     /**
@@ -184,7 +186,9 @@ public final class Files {
      * more predictable.
      *
      * @param to the path to the destination file
+     * @deprecated Deprecated as of 2.8.0. Renamed to {@link #atomicMoveWithFallback(Path)}.
      */
+    @Deprecated
     default Path atomicMoveFileWithFallback(Path to) {
       return atomicMoveFileWithFallback(to.toFile());
     }
@@ -197,10 +201,8 @@ public final class Files {
      * more predictable.
      *
      * @param to the path to the destination file
-     * @deprecated Deprecated as of 2.7.0. Use {@link #atomicMoveFileWithFallback(File)} instead.
      */
-    @Deprecated
-    TemporaryFile atomicMoveWithFallback(File to);
+    Path atomicMoveWithFallback(File to);
 
     /**
      * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
@@ -210,10 +212,8 @@ public final class Files {
      * more predictable.
      *
      * @param to the path to the destination file
-     * @deprecated Deprecated as of 2.7.0. Use {@link #atomicMoveFileWithFallback(Path)} instead.
      */
-    @Deprecated
-    default TemporaryFile atomicMoveWithFallback(Path to) {
+    default Path atomicMoveWithFallback(Path to) {
       return atomicMoveWithFallback(to.toFile());
     }
   }
@@ -281,15 +281,14 @@ public final class Files {
     }
 
     @Override
+    @Deprecated
     public Path moveFileTo(File to, boolean replace) {
-      return temporaryFile.moveFileTo(to, replace);
+      return moveTo(to, replace);
     }
 
     @Override
-    @Deprecated
-    public TemporaryFile moveTo(File to, boolean replace) {
-      return new DelegateTemporaryFile(
-          temporaryFile.moveTo(to, replace), this.temporaryFileCreator);
+    public Path moveTo(File to, boolean replace) {
+      return temporaryFile.moveTo(to, replace);
     }
 
     @Override
@@ -298,15 +297,14 @@ public final class Files {
     }
 
     @Override
+    @Deprecated
     public Path atomicMoveFileWithFallback(File to) {
-      return temporaryFile.atomicMoveFileWithFallback(to.toPath());
+      return atomicMoveWithFallback(to);
     }
 
     @Override
-    @Deprecated
-    public TemporaryFile atomicMoveWithFallback(File to) {
-      return new DelegateTemporaryFile(
-          temporaryFile.atomicMoveWithFallback(to.toPath()), this.temporaryFileCreator);
+    public Path atomicMoveWithFallback(File to) {
+      return temporaryFile.atomicMoveWithFallback(to.toPath());
     }
   }
 

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -3403,18 +3403,18 @@ public class Http {
     /**
      * @param name Name of the cookie to retrieve
      * @return the cookie that is associated with the given name
-     * @deprecated Deprecated as of 2.7.0. Use {@link #getCookie(String)}
      */
-    @Deprecated
-    default Cookie get(String name) {
-      return getCookie(name).get();
-    }
+    Optional<Cookie> get(String name);
 
     /**
      * @param name Name of the cookie to retrieve
      * @return the optional cookie that is associated with the given name
+     * @deprecated Deprecated as of 2.8.0. Renamed to {@link #get(String)}
      */
-    Optional<Cookie> getCookie(String name);
+    @Deprecated
+    default Optional<Cookie> getCookie(String name) {
+      return get(name);
+    }
   }
 
   /** Defines all standard HTTP headers. */

--- a/core/play/src/main/java/play/mvc/Result.java
+++ b/core/play/src/main/java/play/mvc/Result.java
@@ -390,11 +390,9 @@ public class Result {
    * Extracts a Cookie value from this Result value
    *
    * @param name the cookie's name.
-   * @return the cookie (if it was set)
-   * @deprecated Deprecated as of 2.7.0. Use {@link #getCookie(String)}
+   * @return the optional cookie
    */
-  @Deprecated
-  public Cookie cookie(String name) {
+  public Optional<Cookie> cookie(String name) {
     return cookies().get(name);
   }
 
@@ -403,9 +401,11 @@ public class Result {
    *
    * @param name the cookie's name.
    * @return the optional cookie
+   * @deprecated Deprecated as of 2.8.0. Renamed to {@link #cookie(String)}
    */
+  @Deprecated
   public Optional<Cookie> getCookie(String name) {
-    return cookies().getCookie(name);
+    return cookie(name);
   }
 
   /**
@@ -416,7 +416,7 @@ public class Result {
   public Cookies cookies() {
     return new Cookies() {
       @Override
-      public Optional<Cookie> getCookie(String name) {
+      public Optional<Cookie> get(String name) {
         return cookies.stream().filter(c -> c.name().equals(name)).findFirst();
       }
 

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -117,7 +117,9 @@ object Files {
      *
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
+     * @deprecated Since 2.8.0. Renamed to [[moveTo()]].
      */
+    @deprecated("Renamed to moveTo", "2.8.0")
     def moveFileTo(to: java.io.File, replace: Boolean = false): Path = {
       moveFileTo(to.toPath, replace)
     }
@@ -127,8 +129,29 @@ object Files {
      *
      * @param to the path to the destination file
      * @param replace true if an existing file should be replaced, false otherwise.
+     * @deprecated Since 2.8.0. Renamed to [[moveTo()]].
      */
-    def moveFileTo(to: Path, replace: Boolean): Path = {
+    @deprecated("Renamed to moveTo", "2.8.0")
+    def moveFileTo(to: Path, replace: Boolean): Path = moveTo(to, replace)
+
+    /**
+     * Move the file to the specified destination [[java.io.File]]. In some cases, the source and destination file
+     * may point to the same `inode`. See the documentation for [[java.nio.file.Files.move()]] to see more details.
+     *
+     * @param to the path to the destination file
+     * @param replace true if an existing file should be replaced, false otherwise.
+     */
+    def moveTo(to: java.io.File, replace: Boolean = false): Path = {
+      moveTo(to.toPath, replace)
+    }
+
+    /**
+     * Move the file using a [[java.nio.file.Path]].
+     *
+     * @param to the path to the destination file
+     * @param replace true if an existing file should be replaced, false otherwise.
+     */
+    def moveTo(to: Path, replace: Boolean): Path = {
       val destination = try {
         if (replace)
           JFiles.move(path, to, StandardCopyOption.REPLACE_EXISTING)
@@ -143,37 +166,29 @@ object Files {
     }
 
     /**
-     * Move the file to the specified destination [[java.io.File]]. In some cases, the source and destination file
-     * may point to the same `inode`. See the documentation for [[java.nio.file.Files.move()]] to see more details.
+     * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+     *
+     * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+     * existent files or not, considering that it will always replaces, makes the API more predictable.
      *
      * @param to the path to the destination file
-     * @param replace true if an existing file should be replaced, false otherwise.
-     *
-     * @deprecated Since 2.7.0. Use [[moveFileTo()]] instead.
+     * @deprecated Since 2.8.0. Renamed to [[atomicMoveWithFallback()]].
      */
-    @deprecated("Use moveFileTo instead", "2.7.0")
-    def moveTo(to: java.io.File, replace: Boolean = false): TemporaryFile = {
-      moveTo(to.toPath, replace)
-    }
+    @deprecated("Renamed to atomicMoveWithFallback", "2.8.0")
+    def atomicMoveFileWithFallback(to: File): Path = atomicMoveFileWithFallback(to.toPath)
 
     /**
-     * Move the file using a [[java.nio.file.Path]].
+     * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
+     *
+     * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+     * existent files or not, considering that it will always replaces, makes the API more predictable.
      *
      * @param to the path to the destination file
-     * @param replace true if an existing file should be replaced, false otherwise.
-     *
-     * @deprecated Since 2.7.0. Use [[moveFileTo()]] instead.
+     * @deprecated Since 2.8.0. Renamed to [[atomicMoveWithFallback()]].
      */
-    @deprecated("Use moveFileTo instead", "2.7.0")
-    def moveTo(to: Path, replace: Boolean): TemporaryFile = {
-      val destination = moveFileTo(to, replace)
-
-      new TemporaryFile {
-        override def path                 = destination
-        override def file                 = destination.toFile
-        override def temporaryFileCreator = TemporaryFile.this.temporaryFileCreator
-      }
-    }
+    // see https://github.com/apache/kafka/blob/d345d53/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L608-L626
+    @deprecated("Renamed to atomicMoveWithFallback", "2.8.0")
+    def atomicMoveFileWithFallback(to: Path): Path = atomicMoveWithFallback(to)
 
     /**
      * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
@@ -183,7 +198,7 @@ object Files {
      *
      * @param to the path to the destination file
      */
-    def atomicMoveFileWithFallback(to: File): Path = atomicMoveFileWithFallback(to.toPath)
+    def atomicMoveWithFallback(to: File): Path = atomicMoveWithFallback(to.toPath)
 
     /**
      * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
@@ -194,7 +209,7 @@ object Files {
      * @param to the path to the destination file
      */
     // see https://github.com/apache/kafka/blob/d345d53/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L608-L626
-    def atomicMoveFileWithFallback(to: Path): Path = {
+    def atomicMoveWithFallback(to: Path): Path = {
       val destination = try {
         JFiles.move(path, to, StandardCopyOption.ATOMIC_MOVE)
       } catch {
@@ -213,41 +228,6 @@ object Files {
       }
 
       destination
-    }
-
-    /**
-     * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
-     *
-     * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
-     * existent files or not, considering that it will always replaces, makes the API more predictable.
-     *
-     * @param to the path to the destination file
-     *
-     * @deprecated Since 2.7.0. Use [[atomicMoveFileWithFallback()]] instead.
-     */
-    @deprecated("Use atomicMoveFileWithFallback instead", "2.7.0")
-    def atomicMoveWithFallback(to: File): TemporaryFile = atomicMoveWithFallback(to.toPath)
-
-    /**
-     * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
-     *
-     * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
-     * existent files or not, considering that it will always replaces, makes the API more predictable.
-     *
-     * @param to the path to the destination file
-     *
-     * @deprecated Since 2.7.0. Use [[atomicMoveFileWithFallback()]] instead.
-     */
-    // see https://github.com/apache/kafka/blob/d345d53/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L608-L626
-    @deprecated("Use atomicMoveFileWithFallback instead", "2.7.0")
-    def atomicMoveWithFallback(to: Path): TemporaryFile = {
-      val destination = atomicMoveFileWithFallback(to)
-
-      new TemporaryFile {
-        override def path                 = destination
-        override def file                 = destination.toFile
-        override def temporaryFileCreator = TemporaryFile.this.temporaryFileCreator
-      }
     }
   }
 

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -57,11 +57,7 @@ trait JavaHelpers {
   def cookiesToJavaCookies(cookies: Cookies) = {
     new JCookies {
 
-      override def get(name: String): JCookie = {
-        cookies.get(name).map(_.asJava).orNull
-      }
-
-      override def getCookie(name: String): Optional[JCookie] = {
+      override def get(name: String): Optional[JCookie] = {
         Optional.ofNullable(cookies.get(name).map(_.asJava).orNull)
       }
 
@@ -358,11 +354,11 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   @deprecated
   override def cookie(name: String): JCookie = {
-    cookies().get(name)
+    cookies().get(name).orElse(null)
   }
 
   override def getCookie(name: String): Optional[JCookie] = {
-    cookies().getCookie(name)
+    cookies().get(name)
   }
 
   override def hasBody: Boolean = header.hasBody

--- a/core/play/src/test/java/play/mvc/ResultsTest.java
+++ b/core/play/src/test/java/play/mvc/ResultsTest.java
@@ -72,7 +72,7 @@ public class ResultsTest {
             .withCookies(Http.Cookie.builder("cookie-name", "cookie value").build())
             .as(Http.MimeTypes.HTML);
 
-    assertEquals("cookie value", result.getCookie("cookie-name").get().value());
+    assertEquals("cookie value", result.cookie("cookie-name").get().value());
   }
 
   // -- Path tests
@@ -208,8 +208,8 @@ public class ResultsTest {
     Result result =
         Results.ok()
             .withCookies(new Http.Cookie("foo", "1", 1000, "/", "example.com", false, true, null));
-    assertTrue(result.getCookie("foo").isPresent());
-    assertEquals(result.getCookie("foo").get().name(), "foo");
-    assertFalse(result.getCookie("bar").isPresent());
+    assertTrue(result.cookie("foo").isPresent());
+    assertEquals(result.cookie("foo").get().name(), "foo");
+    assertFalse(result.cookie("bar").isPresent());
   }
 }

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -237,7 +237,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(file, "file to be moved")
 
         // move the file
-        creator.create(file).moveFileTo(destination, replace = false)
+        creator.create(file).moveTo(destination, replace = false)
 
         JFiles.exists(file) must beFalse
         JFiles.exists(destination) must beTrue
@@ -257,7 +257,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         // Create source file only
         writeFile(file, "file to be moved")
 
-        creator.create(file).moveFileTo(destination, replace = true)
+        creator.create(file).moveTo(destination, replace = true)
 
         JFiles.exists(file) must beFalse
         JFiles.exists(destination) must beTrue
@@ -278,7 +278,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(file, "file to be moved")
         writeFile(destination, "the destination file")
 
-        creator.create(file).moveFileTo(destination, replace = true)
+        creator.create(file).moveTo(destination, replace = true)
 
         JFiles.exists(file) must beFalse
         JFiles.exists(destination) must beTrue
@@ -298,7 +298,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(file, "file that won't be replaced")
         writeFile(destination, "already exists")
 
-        val to = creator.create(file).moveFileTo(destination, replace = false)
+        val to = creator.create(file).moveTo(destination, replace = false)
         new String(java.nio.file.Files.readAllBytes(to)) must contain("already exists")
       }
 
@@ -311,7 +311,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(file, "file to be moved")
 
         val destination = parentDirectory.resolve("destination.txt")
-        creator.create(file).atomicMoveFileWithFallback(destination)
+        creator.create(file).atomicMoveWithFallback(destination)
 
         JFiles.exists(file) must beFalse
         JFiles.exists(destination) must beTrue
@@ -332,7 +332,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(file, "file to be moved")
 
         // move the file
-        creator.create(file).moveFileTo(destination, replace = false)
+        creator.create(file).moveTo(destination, replace = false)
 
         JFiles.exists(file) must beFalse
         JFiles.exists(destination) must beTrue
@@ -352,7 +352,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         // Create source file only
         writeFile(file, "file to be moved")
 
-        creator.create(file).moveFileTo(destination, replace = true)
+        creator.create(file).moveTo(destination, replace = true)
 
         JFiles.exists(file) must beFalse
         JFiles.exists(destination) must beTrue
@@ -373,7 +373,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(file, "file to be moved")
         writeFile(destination, "the destination file")
 
-        creator.create(file).moveFileTo(destination, replace = true)
+        creator.create(file).moveTo(destination, replace = true)
 
         JFiles.exists(file) must beFalse
         JFiles.exists(destination) must beTrue
@@ -393,7 +393,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(file, "file that won't be replaced")
         writeFile(destination, "already exists")
 
-        val to = creator.create(file).moveFileTo(destination, replace = false)
+        val to = creator.create(file).moveTo(destination, replace = false)
         new String(java.nio.file.Files.readAllBytes(to)) must contain("already exists")
       }
 
@@ -406,7 +406,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
         writeFile(file, "file to be moved")
 
         val destination = parentDirectory.resolve("destination.txt")
-        creator.create(file).atomicMoveFileWithFallback(destination)
+        creator.create(file).atomicMoveWithFallback(destination)
 
         JFiles.exists(file) must beFalse
         JFiles.exists(destination) must beTrue

--- a/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/JavaCache.java
+++ b/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/JavaCache.java
@@ -64,7 +64,7 @@ public class JavaCache extends WithApplication {
       block(result);
     }
     // #get
-    CompletionStage<Optional<News>> news = cache.getOptional("item.key");
+    CompletionStage<Optional<News>> news = cache.get("item.key");
     // #get
     assertThat(block(news).get(), equalTo(frontPageNews));
     // #get-or-else
@@ -82,7 +82,7 @@ public class JavaCache extends WithApplication {
       // #removeAll
       block(result);
     }
-    assertThat(cache.sync().getOptional("item.key"), equalTo(Optional.empty()));
+    assertThat(cache.sync().get("item.key"), equalTo(Optional.empty()));
   }
 
   private CompletionStage<News> lookUpFrontPageNews() {
@@ -111,7 +111,7 @@ public class JavaCache extends WithApplication {
         contentAsString(
             call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)),
         equalTo("Hello world"));
-    assertThat(cache.sync().getOptional("homePage").get(), notNullValue());
+    assertThat(cache.sync().get("homePage").get(), notNullValue());
     cache.sync().set("homePage", Results.ok("something else"));
     assertThat(
         contentAsString(

--- a/documentation/manual/working/javaGuide/main/cache/code/javaguide/ehcache/JavaEhCache.java
+++ b/documentation/manual/working/javaGuide/main/cache/code/javaguide/ehcache/JavaEhCache.java
@@ -64,7 +64,7 @@ public class JavaEhCache extends WithApplication {
       block(result);
     }
     // #get
-    CompletionStage<Optional<News>> news = cache.getOptional("item.key");
+    CompletionStage<Optional<News>> news = cache.get("item.key");
     // #get
     assertThat(block(news).get(), equalTo(frontPageNews));
     // #get-or-else
@@ -82,7 +82,7 @@ public class JavaEhCache extends WithApplication {
       // #removeAll
       block(result);
     }
-    assertThat(cache.sync().getOptional("item.key"), equalTo(Optional.empty()));
+    assertThat(cache.sync().get("item.key"), equalTo(Optional.empty()));
   }
 
   private CompletionStage<News> lookUpFrontPageNews() {
@@ -111,7 +111,7 @@ public class JavaEhCache extends WithApplication {
         contentAsString(
             call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)),
         equalTo("Hello world"));
-    assertThat(cache.sync().getOptional("homePage").get(), notNullValue());
+    assertThat(cache.sync().get("homePage").get(), notNullValue());
     cache.set("homePage", Results.ok("something else"));
     assertThat(
         contentAsString(

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -100,7 +100,7 @@ public class JavaResponse extends WithApplication {
                 mat)
             .cookies();
 
-    Optional<Cookie> cookie = cookies.getCookie("theme");
+    Optional<Cookie> cookie = cookies.get("theme");
     assertTrue(cookie.isPresent());
     assertThat(cookie.get().value(), equalTo("blue"));
   }
@@ -129,7 +129,7 @@ public class JavaResponse extends WithApplication {
                 fakeRequest(),
                 mat)
             .cookies();
-    Optional<Cookie> cookieOpt = cookies.getCookie("theme");
+    Optional<Cookie> cookieOpt = cookies.get("theme");
 
     assertTrue(cookieOpt.isPresent());
 
@@ -158,7 +158,7 @@ public class JavaResponse extends WithApplication {
                 fakeRequest(),
                 mat)
             .cookies();
-    Optional<Cookie> cookie = cookies.getCookie("theme");
+    Optional<Cookie> cookie = cookies.get("theme");
     assertTrue(cookie.isPresent());
     assertThat(cookie.get().name(), equalTo("theme"));
     assertThat(cookie.get().value(), equalTo(""));

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -120,7 +120,7 @@ package scalaguide.upload.fileupload {
 
       //#upload-file-directly-action
       def upload = Action(parse.temporaryFile) { request =>
-        request.body.moveFileTo(Paths.get("/tmp/picture/uploaded"), replace = true)
+        request.body.moveTo(Paths.get("/tmp/picture/uploaded"), replace = true)
         Ok("File uploaded")
       }
       //#upload-file-directly-action

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -234,6 +234,10 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.Play.unsafeApplication"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.evolutions.Evolutions.applyFor"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.evolutions.Evolutions.applyFor$default$*"),
+      // Renamed methods back to original name
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.mvc.Http#Cookies.get"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.mvc.Result.cookie"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Cookies.get"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
       // play.api.Logger$ no longer extends play.api.Logger

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -238,6 +238,13 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.mvc.Http#Cookies.get"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.mvc.Result.cookie"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Cookies.get"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.cache.DefaultAsyncCacheApi.getOptional"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.cache.DefaultSyncCacheApi.getOptional"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.cache.SyncCacheApiAdapter.getOptional"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.cache.DefaultSyncCacheApi.get"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.cache.SyncCacheApiAdapter.get"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.cache.SyncCacheApi.get"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.SyncCacheApi.get"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
       // play.api.Logger$ no longer extends play.api.Logger

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -245,6 +245,27 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.cache.SyncCacheApiAdapter.get"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.cache.SyncCacheApi.get"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.SyncCacheApi.get"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.api.libs.Files#DefaultTemporaryFileCreator#DefaultTemporaryFile.atomicMoveWithFallback"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.api.libs.Files#DefaultTemporaryFileCreator#DefaultTemporaryFile.moveTo"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.api.libs.Files#SingletonTemporaryFileCreator#SingletonTemporaryFile.atomicMoveWithFallback"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.api.libs.Files#SingletonTemporaryFileCreator#SingletonTemporaryFile.moveTo"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.Files#TemporaryFile.atomicMoveWithFallback"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.Files#TemporaryFile.moveTo"),
+      ProblemFilters
+        .exclude[IncompatibleResultTypeProblem]("play.libs.Files#DelegateTemporaryFile.atomicMoveWithFallback"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.Files#DelegateTemporaryFile.moveTo"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.Files#TemporaryFile.atomicMoveWithFallback"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.libs.Files#TemporaryFile.moveTo"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.Files#TemporaryFile.atomicMoveWithFallback"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.Files#TemporaryFile.moveTo"),
       // Add fileName param (with default value) to Scala's sendResource(...) method
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.sendResource"),
       // play.api.Logger$ no longer extends play.api.Logger


### PR DESCRIPTION
Fixes #8344
For Play 2.7 we had to rename some methods because their return types changed.