### PR TITLE
Overload Result#withLang

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -6,6 +6,7 @@ package play.it.http
 
 import java.io.ByteArrayInputStream
 import java.util.Arrays
+import java.util.Locale
 import java.util.Optional
 
 import akka.NotUsed
@@ -339,6 +340,19 @@ trait JavaResultsHandlingSpec
           override def action(request: Http.Request): Result = {
             val javaMessagesApi = app.injector.instanceOf[MessagesApi]
             Results.ok("Hello world").withLang(Lang.forCode("pt-Br"), javaMessagesApi)
+          }
+        }
+      } { response =>
+        response.headers("Set-Cookie") must contain(
+          (s: String) => s.equalsIgnoreCase("PLAY_LANG=pt-BR; SameSite=Lax; Path=/")
+        )
+      }
+
+      "works with Result.withLang(locale)" in makeRequestWithApp() { app =>
+        new MockController() {
+          override def action(request: Http.Request): Result = {
+            val javaMessagesApi = app.injector.instanceOf[MessagesApi]
+            Results.ok("Hello world").withLang(new Locale("pt", "BR"), javaMessagesApi)
           }
         }
       } { response =>

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -1114,7 +1114,9 @@ public class Http {
      *
      * @param code The language to use.
      * @return The new version of this object with the given transient language set.
+     * @deprecated Deprecated as of 2.8.0 Use {@link #withTransientLang(Lang)} instead.
      */
+    @Deprecated
     default RequestHeader withTransientLang(String code) {
       return addAttr(Messages.Attrs.CurrentLang, Lang.forCode(code));
     }
@@ -1186,6 +1188,7 @@ public class Http {
     }
 
     // Override return type and provide default implementation
+    @Deprecated
     default Request withTransientLang(String code) {
       return addAttr(Messages.Attrs.CurrentLang, Lang.forCode(code));
     }
@@ -1966,7 +1969,9 @@ public class Http {
      *
      * @param code The language to use.
      * @return the builder instance
+     * @deprecated Deprecated as of 2.8.0 Use {@link #transientLang(Lang)} instead.
      */
+    @Deprecated
     public RequestBuilder transientLang(String code) {
       req = req.withTransientLang(code);
       return this;

--- a/core/play/src/main/java/play/mvc/Result.java
+++ b/core/play/src/main/java/play/mvc/Result.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -555,6 +556,26 @@ public class Result {
    */
   public Result withLang(Lang lang, MessagesApi messagesApi) {
     return messagesApi.setLang(this, lang);
+  }
+
+  /**
+   * Returns a new result with the given lang set in a cookie. For example:
+   *
+   * <pre>{@code
+   * public Result action() {
+   *     ok("Hello").withLang(new Locale("es"), messagesApi);
+   * }
+   * }</pre>
+   *
+   * Where {@code messagesApi} were injected.
+   *
+   * @param locale the new lang
+   * @param messagesApi the messages api implementation
+   * @return a new result with the given lang.
+   * @see MessagesApi#setLang(Result, Lang)
+   */
+  public Result withLang(Locale locale, MessagesApi messagesApi) {
+    return withLang(new Lang(locale), messagesApi);
   }
 
   /**

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -369,6 +369,7 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def withTransientLang(lang: play.i18n.Lang): JRequestHeader = addAttr(i18n.Messages.Attrs.CurrentLang, lang)
 
+  @deprecated
   override def withTransientLang(code: String): JRequestHeader = withTransientLang(play.i18n.Lang.forCode(code))
 
   override def withTransientLang(locale: Locale): JRequestHeader = withTransientLang(new play.i18n.Lang(locale))
@@ -395,6 +396,7 @@ class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(reque
 
   override def withTransientLang(lang: play.i18n.Lang): JRequest =
     addAttr(i18n.Messages.Attrs.CurrentLang, lang)
+  @deprecated
   override def withTransientLang(code: String): JRequest =
     withTransientLang(play.i18n.Lang.forCode(code))
   override def withTransientLang(locale: Locale): JRequest =


### PR DESCRIPTION
`Result.withLang(...)` should also take a `String` and a `Locale`, which makes it more comfortable to work with (specially for writing tests).

We have the same already for `Request.withTransientLang`:

https://github.com/playframework/playframework/blob/69844601c616de09292d94d21cf525638f88034f/core/play/src/main/java/play/mvc/Http.java#L1106
https://github.com/playframework/playframework/blob/69844601c616de09292d94d21cf525638f88034f/core/play/src/main/java/play/mvc/Http.java#L1118
https://github.com/playframework/playframework/blob/69844601c616de09292d94d21cf525638f88034f/core/play/src/main/java/play/mvc/Http.java#L1130

And for `RequestBuilder.transientLang`:

https://github.com/playframework/playframework/blob/69844601c616de09292d94d21cf525638f88034f/core/play/src/main/java/play/mvc/Http.java#L1959
https://github.com/playframework/playframework/blob/69844601c616de09292d94d21cf525638f88034f/core/play/src/main/java/play/mvc/Http.java#L1970
https://github.com/playframework/playframework/blob/69844601c616de09292d94d21cf525638f88034f/core/play/src/main/java/play/mvc/Http.java#L1981