### PR TITLE
Add RequestBuilder.lang(...) helper to set language cookie

### DIFF
--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -16,6 +16,7 @@ import play.libs.Files.TemporaryFileCreator;
 import play.libs.typedmap.TypedKey;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
+import play.test.Helpers;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -220,6 +221,44 @@ public class RequestBuilderTest {
 
     // Language attr should be removed
     assertFalse(builder.withoutTransientLang().build().transientLang().isPresent());
+  }
+
+  @Test
+  public void testNewRequestsShouldNotHaveALangCookie() {
+    RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+    Request request = builder.build();
+    assertFalse(request.getCookie(Helpers.stubMessagesApi().langCookieName()).isPresent());
+    assertFalse(request.transientLang().isPresent());
+    assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
+  }
+
+  @Test
+  public void testAddALangCookieToRequestBuilder() {
+    RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+    Lang lang = new Lang(Locale.GERMAN);
+    Request request = builder.langCookie(lang, Helpers.stubMessagesApi()).build();
+
+    assertEquals(
+        Optional.of(lang.code()),
+        request.getCookie(Helpers.stubMessagesApi().langCookieName()).map(c -> c.value()));
+    assertFalse(request.transientLang().isPresent());
+    assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
+  }
+
+  @Test
+  public void testAddALangCookieByLocaleToRequestBuilder() {
+    RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+    Locale locale = Locale.GERMAN;
+    Request request = builder.langCookie(locale, Helpers.stubMessagesApi()).build();
+
+    assertEquals(
+        Optional.of(locale.toLanguageTag()),
+        request.getCookie(Helpers.stubMessagesApi().langCookieName()).map(c -> c.value()));
+    assertFalse(request.transientLang().isPresent());
+    assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
   }
 
   @Test

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -1954,6 +1954,30 @@ public class Http {
     }
 
     /**
+     * Sets given lang in a cookie.
+     *
+     * @param lang The language to use.
+     * @return the builder instance
+     */
+    public RequestBuilder langCookie(Lang lang, MessagesApi messagesApi) {
+      return Results.ok()
+          .withLang(lang, messagesApi)
+          .cookie(messagesApi.langCookieName())
+          .map(this::cookie)
+          .orElse(this);
+    }
+
+    /**
+     * Sets given lang in a cookie.
+     *
+     * @param locale The language to use.
+     * @return the builder instance
+     */
+    public RequestBuilder langCookie(Locale locale, MessagesApi messagesApi) {
+      return langCookie(new Lang(locale), messagesApi);
+    }
+
+    /**
      * Sets the transient language.
      *
      * @param lang The language to use.

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -26,6 +26,7 @@ import play.api.test.WithApplication
 import play.api.Application
 import play.components.TemporaryFileComponents
 import play.data.validation.ValidationError
+import play.i18n.Lang
 import play.libs.Files.TemporaryFile
 import play.libs.Files.TemporaryFileCreator
 import play.mvc.EssentialFilter
@@ -455,7 +456,7 @@ trait FormSpec extends CommonFormSpec {
         .bodyFormArrayValues(
           Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")).asJava
         )
-        .cookie(Http.Cookie.builder(Helpers.stubMessagesApi().langCookieName(), "fr").build())
+        .langCookie(Lang.forCode("fr"), Helpers.stubMessagesApi())
         .build()
 
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)


### PR DESCRIPTION
I was missing such a method a couple of times already, specially for [`play.mvc.HttpTest`](https://github.com/playframework/playframework/blob/master/core/play-java/src/test/java/play/mvc/HttpTest.java), where you always have to create and set the cookie yourself. 
I will refactor `HttpTest` and get rid of `Http.Context` in one of my next PRs.