### PR TITLE
[2.7.x] Add RequestBuilder.lang(...) and Result.withLang(locale,...)

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -6,6 +6,7 @@ package play.it.http
 
 import java.io.ByteArrayInputStream
 import java.util.Arrays
+import java.util.Locale
 import java.util.Optional
 
 import akka.NotUsed
@@ -364,6 +365,19 @@ trait JavaResultsHandlingSpec
           override def action: Result = {
             val javaMessagesApi = app.injector.instanceOf[MessagesApi]
             Results.ok("Hello world").withLang(Lang.forCode("pt-Br"), javaMessagesApi)
+          }
+        }
+      } { response =>
+        response.headers("Set-Cookie") must contain(
+          (s: String) => s.equalsIgnoreCase("PLAY_LANG=pt-BR; SameSite=Lax; Path=/")
+        )
+      }
+
+      "works with Result.withLang(locale)" in makeRequestWithApp() { app =>
+        new MockController() {
+          override def action: Result = {
+            val javaMessagesApi = app.injector.instanceOf[MessagesApi]
+            Results.ok("Hello world").withLang(new Locale("pt", "BR"), javaMessagesApi)
           }
         }
       } { response =>

--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -18,8 +18,8 @@ import play.libs.typedmap.TypedKey;
 import play.mvc.Http.Context;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
+import play.test.Helpers;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -223,6 +223,41 @@ public class RequestBuilderTest {
 
     // Language attr should be removed
     assertFalse(builder.withoutTransientLang().build().transientLang().isPresent());
+  }
+
+  @Test
+  public void testNewRequestsShouldNotHaveALangCookie() {
+    RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+    Request request = builder.build();
+    assertNull(request.cookie(Helpers.stubMessagesApi().langCookieName()));
+    assertFalse(request.transientLang().isPresent());
+    assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
+  }
+
+  @Test
+  public void testAddALangCookieToRequestBuilder() {
+    RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+    Lang lang = new Lang(Locale.GERMAN);
+    Request request = builder.langCookie(lang, Helpers.stubMessagesApi()).build();
+
+    assertEquals(lang.code(), request.cookie(Helpers.stubMessagesApi().langCookieName()).value());
+    assertFalse(request.transientLang().isPresent());
+    assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
+  }
+
+  @Test
+  public void testAddALangCookieByLocaleToRequestBuilder() {
+    RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
+
+    Locale locale = Locale.GERMAN;
+    Request request = builder.langCookie(locale, Helpers.stubMessagesApi()).build();
+
+    assertEquals(
+        locale.toLanguageTag(), request.cookie(Helpers.stubMessagesApi().langCookieName()).value());
+    assertFalse(request.transientLang().isPresent());
+    assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
   }
 
   @Test

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -1933,6 +1933,30 @@ public class Http {
     }
 
     /**
+     * Sets given lang in a cookie.
+     *
+     * @param lang The language to use.
+     * @return the builder instance
+     */
+    public RequestBuilder langCookie(Lang lang, MessagesApi messagesApi) {
+      return Results.ok()
+          .withLang(lang, messagesApi)
+          .getCookie(messagesApi.langCookieName())
+          .map(this::cookie)
+          .orElse(this);
+    }
+
+    /**
+     * Sets given lang in a cookie.
+     *
+     * @param locale The language to use.
+     * @return the builder instance
+     */
+    public RequestBuilder langCookie(Locale locale, MessagesApi messagesApi) {
+      return langCookie(new Lang(locale), messagesApi);
+    }
+
+    /**
      * Sets the transient language.
      *
      * @param lang The language to use.

--- a/core/play/src/main/java/play/mvc/Result.java
+++ b/core/play/src/main/java/play/mvc/Result.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -555,6 +556,26 @@ public class Result {
    */
   public Result withLang(Lang lang, MessagesApi messagesApi) {
     return messagesApi.setLang(this, lang);
+  }
+
+  /**
+   * Returns a new result with the given lang set in a cookie. For example:
+   *
+   * <pre>{@code
+   * public Result action() {
+   *     ok("Hello").withLang(new Locale("es"), messagesApi);
+   * }
+   * }</pre>
+   *
+   * Where {@code messagesApi} were injected.
+   *
+   * @param locale the new lang
+   * @param messagesApi the messages api implementation
+   * @return a new result with the given lang.
+   * @see MessagesApi#setLang(Result, Lang)
+   */
+  public Result withLang(Locale locale, MessagesApi messagesApi) {
+    return withLang(new Lang(locale), messagesApi);
   }
 
   /**


### PR DESCRIPTION
Backports #9304 and #9303 (without the deprecations)