### PR TITLE
Updated the URL to the MongoDB ReactiveMongo Plugin page

### DIFF
--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -90,7 +90,7 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 * **Short description:** Provides managed MongoDB access and object mapping using [Morphia](http://morphiaorg.github.io/morphia/)
 
 ### MongoDB ReactiveMongo Plugin (Scala)
-* **Website (docs, sample):** <http://reactivemongo.org/releases/0.11/documentation/tutorial/play2.html>
+* **Website (docs, sample):** <http://reactivemongo.org/releases/0.1x/documentation/tutorial/play.html>
 * **Short description:** Provides a Play 2.x module for ReactiveMongo, asynchronous and reactive driver for MongoDB.
 
 ### Play-Hippo


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose
Updated the URL to the Reactive Mongo plugin page.

What does this PR do?
Replaces the current link to the Reactive Mongo documentation page with the latest one.

## Background Context
The [existing URL](http://reactivemongo.org/releases/0.11/documentation/tutorial/play2.html) to the Reactive Mongo plugin points to a page with information for Play 2.4 but not the latest versions. The [updated URL](http://reactivemongo.org/releases/0.1x/documentation/tutorial/play.html) includes guides for Play 2.5, 2.6 and 2.7.
