### PR TITLE
error can't find javaguide

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide.binder.routes
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide.binder.routes
@@ -1,9 +1,9 @@
 # #user
-GET     /user/:user            controllers.BinderApplication.user(user: javaguide.binder.models.User)
+GET     /user/:user            controllers.BinderApplication.user(user: models.User)
 # #user
 
 # #ageRange
-GET     /ageRange              controllers.BinderApplication.age(age: javaguide.binder.models.AgeRange)
+GET     /ageRange              controllers.BinderApplication.age(age: models.AgeRange)
 # #ageRange
 
 GET     /users/list            controllers.Users.list


### PR DESCRIPTION
if you use it with `javaguide.binder.models.User` then you get an error that it can't be found. Instead use `models.User`.

# Helpful things

## Purpose

it fixes an error that occures when you try this example

## Background Context

because I had to deal with this bug for half a day before I found the solution by accident.

