### PR TITLE
Refactoring Java's Results and StatusHeader class

### DIFF
--- a/core/play/src/main/java/play/mvc/Results.java
+++ b/core/play/src/main/java/play/mvc/Results.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Optional;
 
 import akka.util.ByteString;
 import com.fasterxml.jackson.core.JsonEncoding;
@@ -59,7 +58,7 @@ public class Results {
     if (content == null) {
       throw new NullPointerException("Null content");
     }
-    return new Result(status, HttpEntity.fromContent(content, charset));
+    return status(status).sendEntity(HttpEntity.fromContent(content, charset));
   }
 
   /**
@@ -85,7 +84,7 @@ public class Results {
     if (content == null) {
       throw new NullPointerException("Null content");
     }
-    return new Result(status, HttpEntity.fromString(content, charset));
+    return status(status).sendEntity(HttpEntity.fromString(content, charset));
   }
 
   /**
@@ -125,8 +124,7 @@ public class Results {
     if (content == null) {
       throw new NullPointerException("Null content");
     }
-    return new Result(
-        status, new HttpEntity.Strict(ByteString.fromArray(content), Optional.empty()));
+    return status(status).sendBytes(content);
   }
 
   /**
@@ -140,7 +138,7 @@ public class Results {
     if (content == null) {
       throw new NullPointerException("Null content");
     }
-    return new Result(status, new HttpEntity.Strict(content, Optional.empty()));
+    return status(status).sendByteString(content);
   }
 
   /**

--- a/core/play/src/main/java/play/mvc/StatusHeader.java
+++ b/core/play/src/main/java/play/mvc/StatusHeader.java
@@ -76,6 +76,27 @@ public class StatusHeader extends Result {
   }
 
   /**
+   * Send the given bytes.
+   *
+   * @param content The bytes to send.
+   * @return The result.
+   */
+  public Result sendBytes(byte[] content) {
+    return new Result(
+        status(), new HttpEntity.Strict(ByteString.fromArray(content), Optional.empty()));
+  }
+
+  /**
+   * Send the given ByteString.
+   *
+   * @param content The ByteString to send.
+   * @return The result.
+   */
+  public Result sendByteString(ByteString content) {
+    return new Result(status(), new HttpEntity.Strict(content, Optional.empty()));
+  }
+
+  /**
    * Send the given resource.
    *
    * <p>The resource will be loaded from the same classloader that this class comes from.


### PR DESCRIPTION
Just small refactoring, no behaviour changes.
In `Results` we reuse the methods from `StatusHeader` everywhere except in the methods I changed in the pull request. Therefore I also added `sendBytes` and `sendByteString`.

This pull request is a prerequisite for my next pull request(s) where I will add/overload more method(s) in these classes.