### PR TITLE
BodyParser to parse json content given a json.Reads

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -682,7 +682,7 @@ trait PlayBodyParsers extends BodyParserUtils {
    * Parse the body as Json given a BodyParser,
    * validating the result with the Json reader.
    */
-  def jsonReads[A](parser: BodyParser[JsValue])(implicit reader: Reads[A]): BodyParser[A] =
+  private def jsonReads[A](parser: BodyParser[JsValue])(implicit reader: Reads[A]): BodyParser[A] =
     BodyParser("json reader") { request =>
       import Execution.Implicits.trampoline
       parser(request).mapFuture {

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -645,6 +645,15 @@ trait PlayBodyParsers extends BodyParserUtils {
   def tolerantJson: BodyParser[JsValue] = tolerantJson(DefaultMaxTextLength)
 
   /**
+   * Parse the body as Json without checking the Content-Type,
+   * validating the result with the Json reader.
+   *
+   * @tparam A the type to read and validate from the body.
+   * @param reader a Json reader for type A.
+   */
+  def tolerantJson[A](implicit reader: Reads[A]): BodyParser[A] = jsonReads(tolerantJson)
+
+  /**
    * Parse the body as Json if the Content-Type is text/json or application/json.
    *
    * @param maxLength Max length (in bytes) allowed or returns EntityTooLarge HTTP response.
@@ -667,10 +676,16 @@ trait PlayBodyParsers extends BodyParserUtils {
    * @tparam A the type to read and validate from the body.
    * @param reader a Json reader for type A.
    */
-  def json[A](implicit reader: Reads[A]): BodyParser[A] =
+  def json[A](implicit reader: Reads[A]): BodyParser[A] = jsonReads(json)
+
+  /**
+   * Parse the body as Json given a BodyParser,
+   * validating the result with the Json reader.
+   */
+  def jsonReads[A](parser: BodyParser[JsValue])(implicit reader: Reads[A]): BodyParser[A] =
     BodyParser("json reader") { request =>
       import Execution.Implicits.trampoline
-      json(request).mapFuture {
+      parser(request).mapFuture {
         case Left(simpleResult) =>
           Future.successful(Left(simpleResult))
         case Right(jsValue) =>


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [X] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes the need to use the `tolerantJson` `BodyParser`, and then validate the `JsValue`

## Purpose

What does this PR do?
`BodyParser`s are great to parse request bodies. The `tolerantJson` is currently lacking the option of passing a `json.Reads` similarly to the `json` `BodyParser`. This PR remediates this issue. 

## Background Context

Why did you take this approach?
I extracted most of the logic from the `json` `BodyReader`. This removes the need to duplicate logic. 

## References

Are there any relevant issues / PRs / mailing lists discussions?
Not that I am aware.
