### PR TITLE
[2.7] Enable Akka 2.5 snapshots, including for Scala 2.13, in all CI tasks

### DIFF
--- a/project/Release.scala
+++ b/project/Release.scala
@@ -18,7 +18,7 @@ object Release {
     // these settings. They are required to make sbt 1 and sbt-release (at least < 1.0.10) work together.
     crossScalaVersions := Nil,
     publish / skip := true,
-    // Disable cross building because we're using sbt-doge cross building
+    // Disable cross building because we're using sbt's native "+" cross-building
     releaseCrossBuild := false,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
@@ -37,7 +37,7 @@ object Release {
   )
 
   /**
-   * sbt release's releaseStepCommand does not execute remaining commands, which sbt-doge relies on
+   * sbt release's releaseStepCommand does not execute remaining commands, which sbt's native "+" cross-building relies on (TBC)
    */
   private def releaseStepCommandAndRemaining(command: String): State => State = { originalState =>
     // Capture current remaining commands

--- a/scripts/it-test-scala-212
+++ b/scripts/it-test-scala-212
@@ -9,6 +9,6 @@ cd "$BASEDIR"
 
 printMessage "RUNNING IT TESTS FOR SCALA 2.12"
 
-runSbtWithSnapshots "Play-Integration-Test/it:test"
+runSbt "Play-Integration-Test/it:test"
 
 printMessage "ALL IT TESTS PASSED"

--- a/scripts/it-test-scala-213
+++ b/scripts/it-test-scala-213
@@ -5,13 +5,7 @@
 # shellcheck source=scripts/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-# We are not running Scala 2.13 job for scheduled builds because they use
-# Akka snapshots which aren't being published for Scala 2.13 yet.
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-    printMessage "SKIPPING TESTS FOR SCALA 2.13"
-else
-    cd "$BASEDIR"
-    printMessage "RUNNING IT TESTS FOR SCALA 2.13"
-    runSbt "++2.13.0-M5 Play-Integration-Test/it:test"
-    printMessage "ALL IT TESTS PASSED"
-fi
+cd "$BASEDIR"
+printMessage "RUNNING IT TESTS FOR SCALA 2.13"
+runSbt "++2.13.0-M5 Play-Integration-Test/it:test"
+printMessage "ALL IT TESTS PASSED"

--- a/scripts/publish-local
+++ b/scripts/publish-local
@@ -8,7 +8,6 @@
 cd "$BASEDIR"
 
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-
   printMessage "RUNNING PUBLISH LOCAL"
   runSbt "+publishLocal"
   printMessage "PUBLISH LOCAL PASSED"

--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -34,13 +34,8 @@ printMessage() {
   echo "[info]"
 }
 
-# Runs sbt commands using Akka and Akka HTTP snapshots
-runSbtWithSnapshots() {
-  sbt "$AKKA_VERSION_OPTS" "$AKKA_HTTP_VERSION_OPTS" -jvm-opts "$BASEDIR/.travis-jvmopts" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
-}
-
 runSbt() {
-  sbt -jvm-opts "$BASEDIR/.travis-jvmopts" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
+  sbt "$AKKA_VERSION_OPTS" "$AKKA_HTTP_VERSION_OPTS" -jvm-opts "$BASEDIR/.travis-jvmopts" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
 }
 
 # Runs code formating validation in the current directory

--- a/scripts/test-docs
+++ b/scripts/test-docs
@@ -8,5 +8,5 @@
 cd "$DOCUMENTATION"
 
 printMessage "RUNNING DOCUMENTATION TESTS"
-runSbtWithSnapshots test
+runSbt test
 printMessage "ALL DOCUMENTATION TESTS PASSED"

--- a/scripts/test-sbt-plugins-0_13
+++ b/scripts/test-sbt-plugins-0_13
@@ -11,9 +11,9 @@ SBT_VERSION="0.13"
 cd "$BASEDIR"
 
 printMessage "PUBLISHING PLAY LOCALLY FOR SBT ${SBT_VERSION}"
-runSbtWithSnapshots ++${SCALA_VERSION} quickPublish publishLocal
+runSbt ++${SCALA_VERSION} quickPublish publishLocal
 
 printMessage "RUNNING SCRIPTED TESTS FOR SBT ${SBT_VERSION}"
-runSbtWithSnapshots "++${SCALA_VERSION} scripted"
+runSbt "++${SCALA_VERSION} scripted"
 
 printMessage "ALL SCRIPTED TESTS PASSED"

--- a/scripts/test-sbt-plugins-1_0
+++ b/scripts/test-sbt-plugins-1_0
@@ -11,9 +11,9 @@ SBT_VERSION="1.2.8"
 cd "$BASEDIR"
 
 printMessage "PUBLISHING PLAY LOCALLY FOR SBT ${SBT_VERSION}"
-runSbtWithSnapshots ++${SCALA_VERSION} quickPublish publishLocal
+runSbt ++${SCALA_VERSION} quickPublish publishLocal
 
 printMessage "RUNNING SCRIPTED TESTS FOR SBT ${SBT_VERSION}"
-runSbtWithSnapshots scripted
+runSbt scripted
 
 printMessage "ALL SCRIPTED TESTS PASSED"

--- a/scripts/test-scala-212
+++ b/scripts/test-scala-212
@@ -9,6 +9,6 @@ cd "$BASEDIR"
 
 printMessage "RUNNING TESTS FOR SCALA 2.12"
 
-runSbtWithSnapshots "test"
+runSbt "test"
 
 printMessage "ALL TESTS PASSED"

--- a/scripts/test-scala-213
+++ b/scripts/test-scala-213
@@ -5,17 +5,10 @@
 # shellcheck source=scripts/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-# We are not running Scala 2.13 job for scheduled builds because they use
-# Akka snapshots which aren't being published for Scala 2.13 yet.
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-    printMessage "SKIPPING TESTS FOR SCALA 2.13"
-else
-    cd "$BASEDIR"
+cd "$BASEDIR"
 
-    printMessage "RUNNING TESTS FOR SCALA 2.13"
+printMessage "RUNNING TESTS FOR SCALA 2.13"
 
-    # Use sbt-doge for building code https://github.com/sbt/sbt-doge#strict-aggregation
-    runSbt "++2.13.0-M5 test"
+runSbt "++2.13.0-M5 test"
 
-    printMessage "ALL TESTS PASSED"
-fi
+printMessage "ALL TESTS PASSED"

--- a/scripts/validate-docs
+++ b/scripts/validate-docs
@@ -8,8 +8,8 @@
 cd "$DOCUMENTATION"
 
 printMessage "RUNNING DOCUMENTATION VALIDATION"
-runSbtWithSnapshots evaluateSbtFiles
-runSbtWithSnapshots validateDocs
+runSbt evaluateSbtFiles
+runSbt validateDocs
 runSbt headerCheck test:headerCheck
 
 scalafmtValidation "documentation"

--- a/scripts/validate-microbenchmarks
+++ b/scripts/validate-microbenchmarks
@@ -21,6 +21,6 @@ printMessage "VALIDATING MICROBENCHMARKS"
 # is passed to runSbt as a single command and internally be
 # passed to sbt as a single command too.
 # foe = FailOnError http://mail.openjdk.java.net/pipermail/jmh-dev/2015-February/001685.html
-runSbtWithSnapshots "Play-Microbenchmark/jmh:run -i 1 -wi 0 -f 1 -t 1 -foe=true"
+runSbt "Play-Microbenchmark/jmh:run -i 1 -wi 0 -f 1 -t 1 -foe=true"
 
 printMessage "BENCHMARKS VALIDATED"


### PR DESCRIPTION
Note how the akka and akka-http version overrides move from the removed
runSbtWithSnapshots function to the runSbt function.  This makes it so
all executions of runSbt use the snapshots (when set).

Play-half of https://github.com/playframework/play-meta/issues/79.