### PR TITLE
Don't require filename when sending resource

### DIFF
--- a/core/play/src/main/java/play/mvc/StatusHeader.java
+++ b/core/play/src/main/java/play/mvc/StatusHeader.java
@@ -251,7 +251,7 @@ public class StatusHeader extends Result {
     return doSendResource(
         StreamConverters.fromInputStream(() -> classLoader.getResourceAsStream(resourceName)),
         Optional.empty(),
-        Optional.of(resourceName),
+        Optional.ofNullable(resourceName),
         inline,
         fileMimeTypes);
   }
@@ -320,7 +320,7 @@ public class StatusHeader extends Result {
     return doSendResource(
         StreamConverters.fromInputStream(() -> classLoader.getResourceAsStream(resourceName)),
         Optional.empty(),
-        Optional.of(filename),
+        Optional.ofNullable(filename),
         inline,
         fileMimeTypes);
   }
@@ -423,7 +423,7 @@ public class StatusHeader extends Result {
       return doSendResource(
           FileIO.fromPath(path),
           Optional.of(Files.size(path)),
-          Optional.of(filename),
+          Optional.ofNullable(filename),
           inline,
           fileMimeTypes);
     } catch (IOException e) {
@@ -481,7 +481,7 @@ public class StatusHeader extends Result {
       return doSendResource(
           FileIO.fromPath(file.toPath()),
           Optional.of(Files.size(file.toPath())),
-          Optional.of(file.getName()),
+          Optional.ofNullable(file.getName()),
           inline,
           fileMimeTypes);
     } catch (final IOException ioe) {
@@ -543,7 +543,7 @@ public class StatusHeader extends Result {
       return doSendResource(
           FileIO.fromPath(file.toPath()),
           Optional.of(Files.size(file.toPath())),
-          Optional.of(fileName),
+          Optional.ofNullable(fileName),
           inline,
           fileMimeTypes);
     } catch (final IOException ioe) {
@@ -561,10 +561,11 @@ public class StatusHeader extends Result {
     // Create a Content-Disposition header
     StringBuilder cdBuilder = new StringBuilder();
     cdBuilder.append(inline ? "inline" : "attachment");
-    if (resourceName.isPresent()) {
-      cdBuilder.append("; ");
-      HttpHeaderParameterEncoding.encodeToBuilder("filename", resourceName.get(), cdBuilder);
-    }
+    resourceName.ifPresent(
+        rn -> {
+          cdBuilder.append("; ");
+          HttpHeaderParameterEncoding.encodeToBuilder("filename", rn, cdBuilder);
+        });
     Map<String, String> headers =
         Collections.singletonMap(Http.HeaderNames.CONTENT_DISPOSITION, cdBuilder.toString());
 

--- a/core/play/src/test/java/play/mvc/ResultsTest.java
+++ b/core/play/src/test/java/play/mvc/ResultsTest.java
@@ -131,6 +131,20 @@ public class ResultsTest {
   }
 
   @Test
+  public void sendPathInlineWithoutFileName() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, (String) null);
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline");
+  }
+
+  @Test
+  public void sendPathAsAttachmentWithoutFileName() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, false, (String) null);
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment");
+  }
+
+  @Test
   public void sendPathWithFileNameHasSpecialChars() throws IOException {
     Result result = Results.ok().sendPath(file, true, "测 试.tmp");
     assertEquals(result.status(), Http.Status.OK);
@@ -192,6 +206,20 @@ public class ResultsTest {
     assertEquals(result.status(), Http.Status.OK);
     assertEquals(
         result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+  }
+
+  @Test
+  public void sendFileInlineWithoutFileName() throws IOException {
+    Result result = Results.ok().sendFile(file.toFile(), (String) null);
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline");
+  }
+
+  @Test
+  public void sendFileAsAttachmentWithoutFileName() throws IOException {
+    Result result = Results.ok().sendFile(file.toFile(), false, (String) null);
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment");
   }
 
   @Test

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -239,6 +239,20 @@ class ResultsSpec extends Specification {
       )
     }
 
+    "support sending a file without filename" in withFile { (file, fileName) =>
+      val rh = Ok.sendFile(file, fileName = _ => null).header
+
+      (rh.status.aka("status") must_== OK)
+        .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome("inline"))
+    }
+
+    "support sending a file attached without filename" in withFile { (file, fileName) =>
+      val rh = Ok.sendFile(file, inline = false, fileName = _ => null).header
+
+      (rh.status.aka("status") must_== OK)
+        .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome("attachment"))
+    }
+
     "support sending a path with Ok status" in withPath { (file, fileName) =>
       val rh = Ok.sendPath(file).header
 
@@ -269,6 +283,20 @@ class ResultsSpec extends Specification {
           s"""inline; filename="? ?.tmp"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp"""
         )
       )
+    }
+
+    "support sending a path without filename" in withPath { (file, fileName) =>
+      val rh = Ok.sendPath(file, fileName = _ => null).header
+
+      (rh.status.aka("status") must_== OK)
+        .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome("inline"))
+    }
+
+    "support sending a path attached without filename" in withPath { (file, fileName) =>
+      val rh = Ok.sendPath(file, inline = false, fileName = _ => null).header
+
+      (rh.status.aka("status") must_== OK)
+        .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome("attachment"))
     }
 
     "allow checking content length" in withPath { (file, fileName) =>


### PR DESCRIPTION
In Play Java it's possible to skip the `; filename=...` part in the `Content-Disposition` header:

https://github.com/playframework/playframework/blob/625514b218d5f63c27cab0d8f21e8da5d77ab44d/core/play/src/main/java/play/mvc/StatusHeader.java#L564-L567

However right now the `resourceName` `Optional` is always non-empty because it's created with `of(...)` instead with `ofNullable`. So explictly passing `null` as filename will fail with an exception instead of just skipping that header part.

Along the way I also changed the Scala version to also use `Option` params and made it possible to skip the filename header part as well.

This pull request is a prerequisite for upcoming pull requests which fix stuff related to sending resources.