### PR TITLE
No need to send "Content-Disposition: inline" header

### DIFF
--- a/core/play/src/main/java/play/mvc/StatusHeader.java
+++ b/core/play/src/main/java/play/mvc/StatusHeader.java
@@ -558,16 +558,21 @@ public class StatusHeader extends Result {
       boolean inline,
       FileMimeTypes fileMimeTypes) {
 
-    // Create a Content-Disposition header
-    StringBuilder cdBuilder = new StringBuilder();
-    cdBuilder.append(inline ? "inline" : "attachment");
-    resourceName.ifPresent(
-        rn -> {
-          cdBuilder.append("; ");
-          HttpHeaderParameterEncoding.encodeToBuilder("filename", rn, cdBuilder);
-        });
-    Map<String, String> headers =
-        Collections.singletonMap(Http.HeaderNames.CONTENT_DISPOSITION, cdBuilder.toString());
+    Map<String, String> headers = Collections.emptyMap();
+    if (!inline || resourceName.filter(rn -> !rn.isEmpty()).isPresent()) {
+      // Create a Content-Disposition header
+      // According to RFC 6266 (Section 4.2) there is no need to send "Content-Disposition: inline"
+      // https://tools.ietf.org/html/rfc6266#section-4.2
+      StringBuilder cdBuilder = new StringBuilder();
+      cdBuilder.append(inline ? "inline" : "attachment");
+      resourceName.ifPresent(
+          rn -> {
+            cdBuilder.append("; ");
+            HttpHeaderParameterEncoding.encodeToBuilder("filename", rn, cdBuilder);
+          });
+      headers =
+          Collections.singletonMap(Http.HeaderNames.CONTENT_DISPOSITION, cdBuilder.toString());
+    }
 
     return new Result(
         status(),

--- a/core/play/src/test/java/play/mvc/ResultsTest.java
+++ b/core/play/src/test/java/play/mvc/ResultsTest.java
@@ -133,7 +133,7 @@ public class ResultsTest {
   public void sendPathInlineWithoutFileName() throws IOException {
     Result result = Results.unauthorized().sendPath(file, (String) null);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION), Optional.empty());
   }
 
   @Test
@@ -211,7 +211,7 @@ public class ResultsTest {
   public void sendFileInlineWithoutFileName() throws IOException {
     Result result = Results.ok().sendFile(file.toFile(), (String) null);
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION), Optional.empty());
   }
 
   @Test

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -243,7 +243,7 @@ class ResultsSpec extends Specification {
       val rh = Ok.sendFile(file, fileName = _ => null).header
 
       (rh.status.aka("status") must_== OK)
-        .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome("inline"))
+        .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beNone)
     }
 
     "support sending a file attached without filename" in withFile { (file, fileName) =>
@@ -289,7 +289,7 @@ class ResultsSpec extends Specification {
       val rh = Ok.sendPath(file, fileName = _ => null).header
 
       (rh.status.aka("status") must_== OK)
-        .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome("inline"))
+        .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beNone)
     }
 
     "support sending a path attached without filename" in withPath { (file, fileName) =>

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -155,6 +155,15 @@ This debug system has been removed, the debug flags that do not have a direct co
 
 Some of the default values used by Play had changed and that can have an impact on your application. This section details the default changes.
 
+### `Content-Disposition: inline` header not send anymore when serving files
+
+When serving files via the [[Scala API|ScalaStream#Serving-files]] or the [[Java API|JavaStream#Serving-files]] Play by default generates the `Content-Disposition` header automatically and sends it to the client.
+
+Starting with Play 2.8 however, when the computed header ends up being _exactly_ `Content-Disposition: inline` (when passing `inline = true`, which is the default, and `null` as file name),  it wont be send by Play automatically anymore. Because, according to [RFC 6266 Section 4.2](https://tools.ietf.org/html/rfc6266#section-4.2), rendering content inline is the default anyway.
+Therefore this change should not effect you at all, since all browsers adhere to the specs and do not treat this header in any special way but to render content inline, like no header was send.
+
+If you still want to send this exact header however, you can still do that by using the `withHeader(s)` methods from [`Scala's`](api/scala/play/api/mvc/Result.html#withHeaders\(headers:\(String,String\)*\):play.api.mvc.Result) or [`Java's`](api/java/play/mvc/Result.html#withHeader-java.lang.String-java.lang.String-) `Result` class.
+
 ## Updated libraries
 
 This section lists significant updates made to our dependencies.

--- a/documentation/manual/working/javaGuide/main/async/JavaStream.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaStream.md
@@ -51,6 +51,8 @@ You can also provide your own file name:
 
 @[serve-file-with-name](code/javaguide/async/JavaStream.java)
 
+> **Note**: If the computed header ends up being _exactly_ `Content-Disposition: inline` (when passing `null` as file name),  it wont be send by Play, because, according to [RFC 6266 Section 4.2](https://tools.ietf.org/html/rfc6266#section-4.2), rendering content inline is the default anyway.
+
 If you want to serve this file `attachment`:
 
 @[serve-file-attachment](code/javaguide/async/JavaStream.java)

--- a/documentation/manual/working/scalaGuide/main/async/ScalaStream.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaStream.md
@@ -51,6 +51,8 @@ You can also provide your own file name:
 
 @[serve-file-with-name](code/scalaguide/async/scalastream/ScalaStream.scala)
 
+> **Note**: If the computed header ends up being _exactly_ `Content-Disposition: inline` (when returning `null` as file name: `fileName = _ => null`),  it wont be send by Play, because, according to [RFC 6266 Section 4.2](https://tools.ietf.org/html/rfc6266#section-4.2), rendering content inline is the default anyway.
+
 If you want to serve this file `attachment`:
 
 @[serve-file-attachment](code/scalaguide/async/scalastream/ScalaStream.scala)


### PR DESCRIPTION
According to [RFC 6266 Section 4.2](https://tools.ietf.org/html/rfc6266#section-4.2) there is absolutely no need to send the header `Content-Disposition: inline`:

> On the other hand, if it matches "inline" (case-insensitively), this **implies default processing**. Therefore, **the disposition type "inline" is only useful when it is augmented with additional parameters**, such as the filename...

That should already be enough proof to skip this header, but here is a reference to the MDN web docs as well, [which also clearly state](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#As_a_response_header_for_the_main_body) that `inline` is the default:

> The first parameter in the HTTP context is either inline (**default value**, indicating it can be displayed inside the Web page, or as the Web page) or attachment...

Also Drupal stopped sending this exact header a couple of years ago already: 
https://www.drupal.org/project/private_download/issues/2010092

However, because I wanted to be 100% sure that nothing changes if not sending that specific header anymore I checked if any given browser engine would act differently when sending/not sending this header: Fortunately it turned out that all browsers adhere to the RFC meaning it just does not matter if you send this header or not, every browser just cares about `Content-Disposition: attachment...` and some about `Content-Disposition: inline; filename=...`, but no browser cares solely about `Content-Disposition: inline`. So IMHO it's safe to just avoid sending this _exact_ header.

Here are the relevant lines in the browsers' source codes:

#### Gecko (Firefox)

Just cares about `attachment`:  [Lines 401-411](https://hg.mozilla.org/mozilla-central/file/d55401632cea92b6b2775ba278274b5490275876/uriloader/base/nsURILoader.cpp#l409), same [here](https://hg.mozilla.org/mozilla-central/file/73c98da145a7c0ef518404493b23a979f328768e/uriloader/exthandler/nsExternalHelperAppService.cpp#l215).

#### Chromium (Chrome and upcoming MS Edge)

If you scroll through [this file](https://chromium.googlesource.com/chromium.git/+/53fad3a9e293951ef1e54dccbe8a9cdea0d5fc8d/net/http/http_content_disposition.cc#65) you will see the default is set to `inline` and only explicitly sets "attachment" (defined [here](https://chromium.googlesource.com/chromium.git/+/801f316d276b9bdab0f8109aa1055cc2d2153e1e/net/http/http_content_disposition.h#17)). Also [here](https://chromium.googlesource.com/chromium.git/+/f2cf4e9b5ee7d1270fa9410da9a7a795a533292b/content/browser/renderer_host/buffered_resource_handler.cc#404) Chromium just cares about attachment.

#### Webkit (Safari)

Just cares about [isAttachment](https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/platform/network/ResourceResponseBase.cpp?rev=239749#L746) and [isAttachmentWithFilename](https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/platform/network/ResourceResponseBase.cpp?rev=239749#L754). "inline" just doesn't matter.