### PR TITLE
[2.7.x] Fix nightlies by looking for latest 2.13.0-M5 releases

### DIFF
--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -19,8 +19,8 @@ AKKA_HTTP_VERSION=""
 # Check if it is a scheduled build
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     # `sort` is not necessary, but it is good to make it predictable.
-    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '2\.5-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
-    AKKA_HTTP_VERSION=$(curl -s https://dl.bintray.com/akka/snapshots/com/typesafe/akka/akka-http-core_2.12/maven-metadata.xml | xmllint --xpath '//latest/text()' -)
+    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.13.0-M5/ | grep -oEi '2\.5-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+    AKKA_HTTP_VERSION=$(curl -s https://dl.bintray.com/akka/snapshots/com/typesafe/akka/akka-http-core_2.13.0-M5/maven-metadata.xml | xmllint --xpath '//latest/text()' -)
 
     echo "Using Akka SNAPSHOT ${AKKA_VERSION} and Akka HTTP SNAPSHOT ${AKKA_HTTP_VERSION}"
 


### PR DESCRIPTION
Latest Akka HTTP (10.1.x) is cross-built for Scala 2.13.0-RC2, for which
there are no Akka 2.5 builds.  So we'll fix how we determine which is
the latest version of Akka HTTP by looking specifically in the 2.13.0-M5
metadata.  And, in a similar vein, do that for Akka too.