### PR TITLE
Fix sbt version parsing for RC and M versions

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/run/PlayRunCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-1.0/play/sbt/run/PlayRunCompat.scala
@@ -60,7 +60,7 @@ private[run] trait PlayRunCompat {
       } yield watched
     }
 
-    val _ :: minor :: patch :: Nil = sbtVersion.split("\\.").map(_.toInt).toList
+    val _ :: minor :: patch :: Nil = sbtVersion.split("\\.").map(_.takeWhile(_.isDigit).toInt).toList
 
     if (minor >= 2) { // sbt 1.2.x and later
       watchUsingEvenMonitor


### PR DESCRIPTION
## Fixes

Fixes #9368.

## Purpose

Fix sbt parsing version in PlayRun to also handle RC and Milestone versions.