### PR TITLE
Fix master nightlies by looking for latest 2.13.0-RC2 releases

### DIFF
--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -19,8 +19,8 @@ AKKA_HTTP_VERSION=""
 # Check if it is a scheduled build
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     # `sort` is not necessary, but it is good to make it predictable.
-    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '2\.6-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
-    AKKA_HTTP_VERSION=$(curl -s https://dl.bintray.com/akka/snapshots/com/typesafe/akka/akka-http-core_2.12/maven-metadata.xml | xmllint --xpath '//latest/text()' -)
+    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.13.0-RC2/ | grep -oEi '2\.6-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+    AKKA_HTTP_VERSION=$(curl -s https://dl.bintray.com/akka/snapshots/com/typesafe/akka/akka-http-core_2.13.0-RC2/maven-metadata.xml | xmllint --xpath '//latest/text()' -)
 
     echo "Using Akka SNAPSHOT ${AKKA_VERSION} and Akka HTTP SNAPSHOT ${AKKA_HTTP_VERSION}"
 


### PR DESCRIPTION
There're a few different issues with scala cross-versioning right now,
with Akka HTTP upgrading to 2.13.0-RC3 and Akka being on slightly
different versions for 2.5.x and 2.6.x.  Right now Play master is using
Scala 2.13.0-RC2 (and Akka 2.6), so we'll use that as the key to lookup
"latest".

NO backport (fixed separately, and differently, on 2.7.x).

Fixes https://github.com/playframework/play-meta/issues/79