### PR TITLE
Remove strict behavior from Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,6 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: smart
 
   - name: backport patches to 2.7.x branch
     conditions:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: scala
 
-# Only build non-pushes (so PRs, API requests & cron jobs) OR tags OR forks
-# https://docs.travis-ci.com/user/conditional-builds-stages-jobs/
-if: type != push OR tag IS present OR repo != playframework/playframework
-
 addons:
   apt:
     packages:


### PR DESCRIPTION
To avoid having merge commits made by `mergify[bot]` which conflicts with CLA bot.