### PR TITLE
[2.7.x] Fix i18n handling for forms

### DIFF
--- a/core/play/src/main/scala/play/api/data/Form.scala
+++ b/core/play/src/main/scala/play/api/data/Form.scala
@@ -9,6 +9,7 @@ import scala.language.existentials
 import format._
 import play.api.data.validation._
 import play.api.http.HttpVerbs
+import play.api.templates.PlayMagic.translate
 
 /**
  * Helper to manage HTML form description, submission and validation.
@@ -257,19 +258,11 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
       errors
         .groupBy(_.key)
         .mapValues { errors =>
-          errors.map(e => messages(e.message, e.args.map(a => translateMsgArg(a)): _*))
+          errors.map(e => messages(e.message, e.args.map(a => translate(a)): _*))
         }
         .toMap
     )
 
-  }
-
-  private def translateMsgArg(msgArg: Any)(implicit provider: play.api.i18n.MessagesProvider) = msgArg match {
-    case key: String => provider.messages(key)
-    case keys: Seq[_] =>
-      val k = keys.asInstanceOf[Seq[String]]
-      k.map(key => provider.messages(key))
-    case _ => msgArg
   }
 
   /**

--- a/core/play/src/main/scala/play/api/templates/Templates.scala
+++ b/core/play/src/main/scala/play/api/templates/Templates.scala
@@ -4,6 +4,13 @@
 
 package play.api.templates
 
+import java.util.Optional
+
+import play.twirl.api.Html
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
+
 /** Defines a magic helper for Play templates. */
 object PlayMagic {
 
@@ -16,7 +23,7 @@ object PlayMagic {
    * }}}
    */
   def toHtmlArgs(args: Map[Symbol, Any]) =
-    play.twirl.api.Html(
+    Html(
       args
         .map({
           case (s, None) => s.name
@@ -24,5 +31,27 @@ object PlayMagic {
         })
         .mkString(" ")
     )
+
+  /**
+   * Uses the passed MessagesProvider to translates the given argument.
+   * If the argument is a raw html, it will translate its string representation and will then again return raw html.
+   * The argument to translate can also be a sequence that wraps a string or raw html. In this case every element
+   * of the sequence will be translated.
+   */
+  def translate(arg: Any)(implicit p: play.api.i18n.MessagesProvider): Any = arg match {
+    case key: String       => p.messages(key)
+    case key: Html         => Html(p.messages(key.toString))
+    case Some(key: String) => Some(p.messages(key))
+    case Some(key: Html)   => Some(Html(p.messages(key.toString)))
+    case key: Optional[_] =>
+      key.asScala match {
+        case Some(key: String) => Some(p.messages(key)).asJava
+        case Some(key: Html)   => Some(Html(p.messages(key.toString))).asJava
+        case _                 => arg
+      }
+    case keys: Seq[_]            => keys.map(key => translate(key))
+    case keys: java.util.List[_] => keys.asScala.map(key => translate(key)).asJava
+    case _                       => arg
+  }
 
 }

--- a/core/play/src/main/scala/views/helper/checkbox.scala.html
+++ b/core/play/src/main/scala/views/helper/checkbox.scala.html
@@ -16,5 +16,5 @@
 @boxValue = @{ args.toMap.get('value).getOrElse("true") }
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="checkbox" id="@id" name="@name" value="@boxValue" @if(value == Some(boxValue)){checked="checked"} @toHtmlArgs(htmlArgs.filterKeys(_ != 'value).toMap)/>
-    <span>@args.toMap.get('_text)</span>
+    <span>@translate(args.toMap.get('_text))</span>
 }

--- a/core/play/src/main/scala/views/helper/select.scala.html
+++ b/core/play/src/main/scala/views/helper/select.scala.html
@@ -30,7 +30,7 @@
     }){ selectedValues =>
         <select id="@id" name="@selectName" @toHtmlArgs(htmlArgs)>
             @args.toMap.get('_default).map { defaultValue =>
-                <option class="blank" value="">@defaultValue</option>
+                <option class="blank" value="">@translate(defaultValue)</option>
             }
             @options.map { case (k, v) =>
                 @defining( selectedValues.contains(k) ) { selected =>

--- a/core/play/src/test/resources/messages
+++ b/core/play/src/test/resources/messages
@@ -1,13 +1,13 @@
-error.custom=This is a {0}
-error.customarg=custom error
+error.custom=This <b>is</b> a {0}
+error.customarg=custom <b>error</b>
 
-error.generalcustomerror=Some general custom error message
+error.generalcustomerror=Some <b>general custom</b> error message
 
-constraint.custom=I am a {0}
-constraint.customarg=custom constraint
+constraint.custom=I <b>am</b> a {0}
+constraint.customarg=custom <b>constraint</b>
 
-format.custom=Look at me! I am a {0}
-format.customarg=custom format pattern
+format.custom=Look <b>at</b> me! I am a {0}
+format.customarg=custom <b>format</b> pattern
 
-myfieldlabel=I am the label of the field
-myfieldname=I am the name of the field
+myfieldlabel=I am the <b>label</b> of the field
+myfieldname=I am the <b>name</b> of the field

--- a/core/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormSpec.scala
@@ -445,7 +445,7 @@ class FormSpec extends Specification {
 
     val form =
       Form(single("foo" -> Forms.text), Map.empty, Seq(FormError("foo", "error.custom", Seq("error.customarg"))), None)
-    (form.errorsAsJson \ "foo")(0).asOpt[String] must beSome("This is a custom error")
+    (form.errorsAsJson \ "foo")(0).asOpt[String] must beSome("This <b>is</b> a custom <b>error</b>")
   }
 
   "correctly format error messages with arguments" in {

--- a/core/play/src/test/scala/play/api/templates/TemplatesSpec.scala
+++ b/core/play/src/test/scala/play/api/templates/TemplatesSpec.scala
@@ -4,17 +4,121 @@
 
 package play.api.templates
 
+import java.util.Optional
+
 import akka.util.ByteString
 import org.specs2.mutable._
+import play.api.Configuration
+import play.api.Environment
+import play.api.http.HttpConfiguration
 import play.api.http.HttpEntity
 import play.api.http.Writeable
+import play.api.i18n.DefaultLangsProvider
+import play.api.i18n.DefaultMessagesApiProvider
+import play.api.i18n.Messages
 import play.api.mvc.Results
 import play.mvc.{ Results => JResults }
+import play.twirl.api.Html
+
+import scala.collection.JavaConverters._
 
 class TemplatesSpec extends Specification {
   "toHtmlArgs" should {
     "escape attribute values" in {
       PlayMagic.toHtmlArgs(Map('foo -> """bar <>&"'""")).body must_== """foo="bar &lt;&gt;&amp;&quot;&#x27;""""
+    }
+  }
+
+  "translate" should {
+
+    val conf                        = Configuration.reference
+    val langs                       = new DefaultLangsProvider(conf).get
+    val httpConfiguration           = HttpConfiguration.fromConfiguration(conf, Environment.simple())
+    val messagesApi                 = new DefaultMessagesApiProvider(Environment.simple(), conf, langs, httpConfiguration).get
+    implicit val messages: Messages = messagesApi.preferred(Seq.empty)
+
+    "handle String" in {
+      PlayMagic.translate("myfieldlabel") must_== """I am the <b>label</b> of the field"""
+    }
+
+    "handle Html" in {
+      PlayMagic.translate(Html("myfieldlabel")) must_== Html("""I am the <b>label</b> of the field""")
+    }
+
+    "handle Option[String]" in {
+      PlayMagic.translate(Some("myfieldlabel")) must_== Some("""I am the <b>label</b> of the field""")
+    }
+
+    "handle Option[Html]" in {
+      PlayMagic.translate(Some(Html("myfieldlabel"))) must_== Some(Html("""I am the <b>label</b> of the field"""))
+    }
+
+    "handle Optional[String]" in {
+      PlayMagic.translate(Optional.of("myfieldlabel")) must_== Optional.of("""I am the <b>label</b> of the field""")
+    }
+
+    "handle Optional[Html]" in {
+      PlayMagic.translate(Optional.of(Html("myfieldlabel"))) must_== Optional.of(
+        Html("""I am the <b>label</b> of the field""")
+      )
+    }
+
+    "handle Seq[String, Html, Option[String], Option[Html]]" in {
+      PlayMagic.translate(
+        Seq("myfieldlabel", Html("myfieldname"), Some("myfieldlabel"), Some(Html("myfieldname")))
+      ) must_== Seq(
+        """I am the <b>label</b> of the field""",
+        Html("""I am the <b>name</b> of the field"""),
+        Some("""I am the <b>label</b> of the field"""),
+        Some(Html("""I am the <b>name</b> of the field"""))
+      )
+    }
+
+    "handle Java List[String, Html, Optional[String], Optional[Html]]" in {
+      PlayMagic.translate(
+        Seq("myfieldlabel", Html("myfieldname"), Optional.of("myfieldlabel"), Optional.of(Html("myfieldname"))).asJava
+      ) must_== Seq(
+        """I am the <b>label</b> of the field""",
+        Html("""I am the <b>name</b> of the field"""),
+        Optional.of("""I am the <b>label</b> of the field"""),
+        Optional.of(Html("""I am the <b>name</b> of the field"""))
+      ).asJava
+    }
+
+    "handle String that can't be found in messages" in {
+      PlayMagic.translate("foo.me") must_== "foo.me"
+    }
+
+    "handle Html that can't be found in messages" in {
+      PlayMagic.translate(Html("foo.me")) must_== Html("foo.me")
+    }
+
+    "handle String that can't be found in messages wrapped in Option" in {
+      PlayMagic.translate(Some("foo.me")) must_== Some("foo.me")
+    }
+
+    "handle Html that can't be found in messages wrapped in Option" in {
+      PlayMagic.translate(Some(Html("foo.me"))) must_== Some(Html("foo.me"))
+    }
+
+    "handle String that can't be found in messages wrapped in Optional" in {
+      PlayMagic.translate(Optional.of("foo.me")) must_== Optional.of("foo.me")
+    }
+
+    "handle Html that can't be found in messages wrapped in Optional" in {
+      PlayMagic.translate(Optional.of(Html("foo.me"))) must_== Optional.of(Html("foo.me"))
+    }
+
+    "handle non String / non Html" in {
+      PlayMagic.translate(4) must_== 4
+    }
+
+    "handle non String / non Html wrapped in Option" in {
+      PlayMagic.translate(Some(4)) must_== Some(4)
+    }
+
+    "handle non String / non Html wrapped in Optional" in {
+      PlayMagic.translate(Optional.of(4)) must_== Optional.of(4)
     }
   }
 

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -64,6 +64,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static play.api.templates.PlayMagic.translate;
 import static play.libs.F.Tuple;
 
 /** Helper to manage HTML form description, submission and validation. */
@@ -1329,7 +1330,7 @@ public class Form<T> {
                   messagesApi.get(
                       lang,
                       reversedMessages,
-                      translateMsgArg(error.arguments(), messagesApi, lang)));
+                      translate(error.arguments(), new MessagesImpl(lang, this.messagesApi))));
             } else {
               messages.add(error.message());
             }
@@ -1337,32 +1338,6 @@ public class Form<T> {
           }
         });
     return play.libs.Json.toJson(allMessages);
-  }
-
-  private Object translateMsgArg(List<Object> arguments, MessagesApi messagesApi, Lang lang) {
-    if (arguments != null) {
-      return arguments.stream()
-          .map(
-              arg -> {
-                if (arg instanceof String) {
-                  return messagesApi != null ? messagesApi.get(lang, (String) arg) : (String) arg;
-                }
-                if (arg instanceof List) {
-                  return ((List<?>) arg)
-                      .stream()
-                          .map(
-                              key ->
-                                  messagesApi != null
-                                      ? messagesApi.get(lang, (String) key)
-                                      : (String) key)
-                          .collect(Collectors.toList());
-                }
-                return arg;
-              })
-          .collect(Collectors.toList());
-    } else {
-      return null;
-    }
   }
 
   /**


### PR DESCRIPTION
Manually backporting #9385 because `Form.scala` had conflicts (other files no problem).