### PR TITLE
Correctly encode the key of URL params when redirecting

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -793,8 +793,10 @@ trait Results {
       .filterNot(_.isEmpty)
       .map { params =>
         (if (url.contains("?")) "&" else "?") + params.toSeq
-          .flatMap { pair =>
-            pair._2.map(value => (URLEncoder.encode(pair._1, "utf-8") + "=" + URLEncoder.encode(value, "utf-8")))
+          .flatMap {
+            case (key, values) =>
+              val encodedKey = URLEncoder.encode(key, "utf-8")
+              values.map(value => (encodedKey + "=" + URLEncoder.encode(value, "utf-8")))
           }
           .mkString("&")
       }

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -794,7 +794,7 @@ trait Results {
       .map { params =>
         (if (url.contains("?")) "&" else "?") + params.toSeq
           .flatMap { pair =>
-            pair._2.map(value => (pair._1 + "=" + URLEncoder.encode(value, "utf-8")))
+            pair._2.map(value => (URLEncoder.encode(pair._1, "utf-8") + "=" + URLEncoder.encode(value, "utf-8")))
           }
           .mkString("&")
       }

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -344,6 +344,17 @@ class ResultsSpec extends Specification {
       Results.Redirect(Call("GET", url, fragment)).header.headers.get(LOCATION) must_== Option(expectedLocation)
     }
 
+    "redirect with a query string" in {
+      val url                 = "http://host:port/path"
+      val queryString         = Map(
+        "*-._" -> Seq(""" """"),
+        """ """" -> Seq("*-._")
+      )
+      val expectedQueryString = "*-._=+%22&+%22=*-._"
+      val expectedLocation    = url + "?" + expectedQueryString
+      Results.Redirect(url, queryString).header.headers.get(LOCATION) must_== Option(expectedLocation)
+    }
+
     "redirect with a fragment and status" in {
       val url              = "http://host:port/path?k1=v1&k2=v2"
       val fragment         = "my-fragment"

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -345,9 +345,9 @@ class ResultsSpec extends Specification {
     }
 
     "redirect with a query string" in {
-      val url                 = "http://host:port/path"
-      val queryString         = Map(
-        "*-._" -> Seq(""" """"),
+      val url = "http://host:port/path"
+      val queryString = Map(
+        "*-._"   -> Seq(""" """"),
         """ """" -> Seq("*-._")
       )
       val expectedQueryString = "*-._=+%22&+%22=*-._"


### PR DESCRIPTION
# Pull Request Checklist

> Have you added tests for any changed functionality?

Yes, there was no test so I added one.


## before
```
[error]   x redirect with a query string (9 ms)
[error]    Some(http://host:port/path?*-._=+%22& "=*-._) != Some(http://host:port/path?*-._=+%22&+%22=*-._) (ResultsSpec.scala:354)
[error] Actual:   ...+%22&[ "]=*-._...
[error] Expected: ...+%22&[+%22]=*-._...
```
## after
```
[info]   + redirect with a query string (3 ms)
```

# Why am I doing this

When constructing a query string using HTML form encoding, this is the algorithm that should be followed: https://url.spec.whatwg.org/#concept-urlencoded-byte-serializer
This requires the same encoding of the key and the value, separated by `=` and then by `&`

At present the caller of `Redirect` has to encode the key before passing it in. We have hit this bug here: https://github.com/guardian/support-frontend/pull/1884 .  This requirement breaks the principle that the code that serialises the data (key names) into the serialised form (the query string) should do the relevant escaping.

If this process isn't done, then any unicode characters in the key would cause an error from the bottom of Akka Http complaining, in fact it correctly complains about a HTTP header being invalid, because non ascii isn't possible as a header value. ref https://www.ietf.org/rfc/rfc2616.txt

I have amended the code here to do the escaping as per the specification mentioned.

# Why perhaps shouldn't this be shipped as is

That spec mentioned is only how to encode, rather than an expression of what is valid.  This means as a conservative alternative, it may be possible to ignore the spec, and implement something to only escape `#`, `=` and `&` plus all characters outside the unreserved and reserved set defined in [rfc3986](https://tools.ietf.org/html/rfc3986).  I woudn't recommend this course as it's very custom and non stanadrd, but it might result in a lower chance of breaking existing uses.

As another idea, possibly more realistic, it may be necessary to deprecate the old way and introduce the fix as a new function, to avoid silently breaking existing code when people upgrade.

# summary

Any thoughts, suggestions would be nice, I am not sure what the model is for potentially breaking changes, but I'm happy to add as a new method and deprecate the old.  Just let me know in the comments.  Cheers!