### PR TITLE
Add configuration for temporary file directory

### DIFF
--- a/core/play/src/main/java/play/BuiltInComponentsFromContext.java
+++ b/core/play/src/main/java/play/BuiltInComponentsFromContext.java
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
 import com.typesafe.config.Config;
 
+import play.api.Configuration;
 import play.api.OptionalDevContext;
 import play.api.OptionalSourceMapper;
 import play.api.http.DefaultFileMimeTypesProvider;
@@ -268,14 +269,15 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
   }
 
   private Files.TemporaryFileCreator createTempFileCreator() {
+
+    Configuration conf = configuration();
     play.api.libs.Files.DefaultTemporaryFileReaper temporaryFileReaper =
         new play.api.libs.Files.DefaultTemporaryFileReaper(
             actorSystem(),
-            play.api.libs.Files.TemporaryFileReaperConfiguration$.MODULE$.fromConfiguration(
-                configuration()));
+            play.api.libs.Files.TemporaryFileReaperConfiguration$.MODULE$.fromConfiguration(conf));
 
     return new play.api.libs.Files.DefaultTemporaryFileCreator(
-            applicationLifecycle().asScala(), temporaryFileReaper)
+            applicationLifecycle().asScala(), temporaryFileReaper, conf)
         .asJava();
   }
 }

--- a/core/play/src/main/java/play/BuiltInComponentsFromContext.java
+++ b/core/play/src/main/java/play/BuiltInComponentsFromContext.java
@@ -269,7 +269,6 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
   }
 
   private Files.TemporaryFileCreator createTempFileCreator() {
-
     Configuration conf = configuration();
     play.api.libs.Files.DefaultTemporaryFileReaper temporaryFileReaper =
         new play.api.libs.Files.DefaultTemporaryFileReaper(

--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -802,6 +802,7 @@ play {
     # Removes stale temporary files from the filesystem.  This is a backup
     # to the "remove-on-gc" functionality in the default temporary file creator,
     # for when GC is not happening fast enough.  Uses play.http.blockingIoDispatcher.
+    dir = ${?java.io.tmpdir}
     reaper {
       enabled = false
       initialDelay = "5 minutes"

--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -799,10 +799,12 @@ play {
   }
 
   temporaryFile {
+    # Path to directory where temporary files will be stored
+    dir = ${?java.io.tmpdir}
+
     # Removes stale temporary files from the filesystem.  This is a backup
     # to the "remove-on-gc" functionality in the default temporary file creator,
     # for when GC is not happening fast enough.  Uses play.http.blockingIoDispatcher.
-    dir = ${?java.io.tmpdir}
     reaper {
       enabled = false
       initialDelay = "5 minutes"

--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -408,7 +408,8 @@ trait BuiltInComponents extends I18nComponents {
 
   lazy val tempFileReaper: TemporaryFileReaper =
     new DefaultTemporaryFileReaper(actorSystem, TemporaryFileReaperConfiguration.fromConfiguration(configuration))
-  lazy val tempFileCreator: TemporaryFileCreator = new DefaultTemporaryFileCreator(applicationLifecycle, tempFileReaper, configuration)
+  lazy val tempFileCreator: TemporaryFileCreator =
+    new DefaultTemporaryFileCreator(applicationLifecycle, tempFileReaper, configuration)
 
   lazy val fileMimeTypes: FileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes).get
 

--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -408,7 +408,7 @@ trait BuiltInComponents extends I18nComponents {
 
   lazy val tempFileReaper: TemporaryFileReaper =
     new DefaultTemporaryFileReaper(actorSystem, TemporaryFileReaperConfiguration.fromConfiguration(configuration))
-  lazy val tempFileCreator: TemporaryFileCreator = new DefaultTemporaryFileCreator(applicationLifecycle, tempFileReaper)
+  lazy val tempFileCreator: TemporaryFileCreator = new DefaultTemporaryFileCreator(applicationLifecycle, tempFileReaper, configuration)
 
   lazy val fileMimeTypes: FileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes).get
 

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -256,7 +256,7 @@ object Files {
     private val TempDirectoryPrefix = "playtemp"
     private val playTempFolder: Path = {
       val dir       = conf.get[String]("play.temporaryFile.dir")
-      val tmpFolder = JFiles.createDirectories(Paths.get(s"$dir/$TempDirectoryPrefix"))
+      val tmpFolder = Paths.get(s"$dir/$TempDirectoryPrefix/")
       temporaryFileReaper.updateTempFolder(tmpFolder)
       tmpFolder
     }

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -253,9 +253,9 @@ object Files {
     // Keeping references ensures that the FinalizablePhantomReference itself is not garbage-collected.
     private val references = Sets.newConcurrentHashSet[Reference[TemporaryFile]]()
 
-    private val TempDirectoryPrefix  = "playtemp"
+    private val TempDirectoryPrefix = "playtemp"
     private val playTempFolder: Path = {
-      val dir = conf.get[String]("play.temporaryFile.dir")
+      val dir       = conf.get[String]("play.temporaryFile.dir")
       val tmpFolder = JFiles.createDirectories(Paths.get(s"$dir/$TempDirectoryPrefix"))
       temporaryFileReaper.updateTempFolder(tmpFolder)
       tmpFolder
@@ -273,12 +273,13 @@ object Files {
 
     private def createReference(tempFile: TemporaryFile) = {
       val path = tempFile.path
-      val reference = new FinalizablePhantomReference[TemporaryFile](tempFile, frq) {
-        override def finalizeReferent(): Unit = {
-          references.remove(this)
-          deletePath(path)
+      val reference =
+        new FinalizablePhantomReference[TemporaryFile](tempFile, frq) {
+          override def finalizeReferent(): Unit = {
+            references.remove(this)
+            deletePath(path)
+          }
         }
-      }
       references.add(reference)
       tempFile
     }

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -253,20 +253,10 @@ object Files {
     // Keeping references ensures that the FinalizablePhantomReference itself is not garbage-collected.
     private val references = Sets.newConcurrentHashSet[Reference[TemporaryFile]]()
 
-    private val TempDirectoryPrefix = "playtemp"
-    private val playTempFolder: Path = buildPlayTempFolderFromConfiguration(conf)
-
-    private def buildPlayTempFolderFromConfiguration(conf: Configuration) : Path = {
-
-      val tmpFolder =
-        if (conf.has("play.temporaryFile.dir")) {
-          val dir = conf.get[String]("play.temporaryFile.dir")
-          Paths.get( s"$dir/$TempDirectoryPrefix")
-        }
-        else {
-          JFiles.createTempDirectory(TempDirectoryPrefix)
-        }
-
+    private val TempDirectoryPrefix  = "playtemp"
+    private val playTempFolder: Path = {
+      val dir = conf.get[String]("play.temporaryFile.dir")
+      val tmpFolder = JFiles.createDirectories(Paths.get(s"$dir/$TempDirectoryPrefix"))
       temporaryFileReaper.updateTempFolder(tmpFolder)
       tmpFolder
     }

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -313,21 +313,23 @@ object Files {
      */
     applicationLifecycle.addStopHook { () =>
       Future.successful(
-        JFiles.walkFileTree(
-          playTempFolder,
-          new SimpleFileVisitor[Path] {
-            override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
-              logger.debug(s"stopHook: Removing leftover temporary file $path from ${playTempFolder}")
-              deletePath(path)
-              FileVisitResult.CONTINUE
-            }
+        if (JFiles.isDirectory(playTempFolder)) {
+          JFiles.walkFileTree(
+            playTempFolder,
+            new SimpleFileVisitor[Path] {
+              override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+                logger.debug(s"stopHook: Removing leftover temporary file $path from ${playTempFolder}")
+                deletePath(path)
+                FileVisitResult.CONTINUE
+              }
 
-            override def postVisitDirectory(path: Path, exc: IOException): FileVisitResult = {
-              deletePath(path)
-              FileVisitResult.CONTINUE
+              override def postVisitDirectory(path: Path, exc: IOException): FileVisitResult = {
+                deletePath(path)
+                FileVisitResult.CONTINUE
+              }
             }
-          }
-        )
+          )
+        }
       )
     }
   }

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -6,7 +6,7 @@ package play.api.libs
 
 import java.io.File
 import java.nio.charset.Charset
-import java.nio.file.Path
+import java.nio.file.{ Path, Paths }
 import java.nio.file.{ Files => JFiles }
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
@@ -64,7 +64,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       val lifecycle = new DefaultApplicationLifecycle
       val reaper    = mock[TemporaryFileReaper]
-      val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+      val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
       try {
         val executionContext = ExecutionContext.fromExecutorService(threadPool)
@@ -99,7 +99,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
     "recreate directory if it is deleted" in new WithScope() {
       val lifecycle     = new DefaultApplicationLifecycle
       val reaper        = mock[TemporaryFileReaper]
-      val creator       = new DefaultTemporaryFileCreator(lifecycle, reaper)
+      val creator       = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
       val temporaryFile = creator.create("foo", "bar")
       JFiles.delete(temporaryFile.toPath)
       creator.create("foo", "baz")
@@ -112,7 +112,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "copy when destination does not exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("copy.txt")
         val destination = parentDirectory.resolve("does-not-exists.txt")
@@ -137,7 +137,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "copy when destination does not exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("copy.txt")
         val destination = parentDirectory.resolve("destination.txt")
@@ -161,7 +161,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "copy when destination exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("copy.txt")
         val destination = parentDirectory.resolve("destination.txt")
@@ -186,7 +186,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "do not copy when destination exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("do-not-replace.txt")
         val destination = parentDirectory.resolve("already-exists.txt")
@@ -201,7 +201,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "delete source file has no impact on the destination file" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file = parentDirectory.resolve("move.txt")
         writeFile(file, "file to be moved")
@@ -228,7 +228,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "move when destination does not exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
         val destination = parentDirectory.resolve("does-not-exists.txt")
@@ -249,7 +249,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "move when destination does not exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
         val destination = parentDirectory.resolve("destination.txt")
@@ -269,7 +269,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "move when destination exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
         val destination = parentDirectory.resolve("destination.txt")
@@ -290,7 +290,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "do not move when destination exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("do-not-replace.txt")
         val destination = parentDirectory.resolve("already-exists.txt")
@@ -305,7 +305,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "move a file atomically with replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file = parentDirectory.resolve("move.txt")
         writeFile(file, "file to be moved")
@@ -323,7 +323,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "move when destination does not exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
         val destination = parentDirectory.resolve("does-not-exists.txt")
@@ -344,7 +344,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "move when destination does not exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
         val destination = parentDirectory.resolve("destination.txt")
@@ -364,7 +364,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "move when destination exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
         val destination = parentDirectory.resolve("destination.txt")
@@ -385,7 +385,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "do not move when destination exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper,Configuration.reference)
 
         val file        = parentDirectory.resolve("do-not-replace.txt")
         val destination = parentDirectory.resolve("already-exists.txt")
@@ -400,7 +400,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "move a file atomically with replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file = parentDirectory.resolve("move.txt")
         writeFile(file, "file to be moved")
@@ -436,6 +436,21 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       }
       tempFile.exists must beFalse
     }
+
+
+    "works when using custom temporary file directory" in new WithScope() {
+        val lifecycle   = new DefaultApplicationLifecycle
+        val reaper      = mock[TemporaryFileReaper]
+        val path        = parentDirectory.toAbsolutePath().toString()
+        val customPath  = s"$path/custom/"
+        val conf        = Configuration.from(Map("play.temporaryFile.dir" -> customPath))
+        val creator     = new DefaultTemporaryFileCreator(lifecycle, reaper, conf)
+
+        creator.create("foo", "bar")
+
+        JFiles.exists(Paths.get(s"$customPath/playtemp")) must beTrue
+      }
+
   }
 
   private def writeFile(file: Path, content: String) = {

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -437,7 +437,6 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       tempFile.exists must beFalse
     }
 
-
     "works when using custom temporary file directory" in new WithScope() {
         val lifecycle   = new DefaultApplicationLifecycle
         val reaper      = mock[TemporaryFileReaper]

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -6,7 +6,8 @@ package play.api.libs
 
 import java.io.File
 import java.nio.charset.Charset
-import java.nio.file.{ Path, Paths }
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.{ Files => JFiles }
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
@@ -385,7 +386,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       "do not move when destination exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
         val reaper    = mock[TemporaryFileReaper]
-        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper,Configuration.reference)
+        val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("do-not-replace.txt")
         val destination = parentDirectory.resolve("already-exists.txt")
@@ -438,18 +439,17 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
     }
 
     "works when using custom temporary file directory" in new WithScope() {
-        val lifecycle   = new DefaultApplicationLifecycle
-        val reaper      = mock[TemporaryFileReaper]
-        val path        = parentDirectory.toAbsolutePath().toString()
-        val customPath  = s"$path/custom/"
-        val conf        = Configuration.from(Map("play.temporaryFile.dir" -> customPath))
-        val creator     = new DefaultTemporaryFileCreator(lifecycle, reaper, conf)
+      val lifecycle  = new DefaultApplicationLifecycle
+      val reaper     = mock[TemporaryFileReaper]
+      val path       = parentDirectory.toAbsolutePath().toString()
+      val customPath = s"$path/custom/"
+      val conf       = Configuration.from(Map("play.temporaryFile.dir" -> customPath))
+      val creator    = new DefaultTemporaryFileCreator(lifecycle, reaper, conf)
 
-        creator.create("foo", "bar")
+      creator.create("foo", "bar")
 
-        JFiles.exists(Paths.get(s"$customPath/playtemp")) must beTrue
-      }
-
+      JFiles.exists(Paths.get(s"$customPath/playtemp")) must beTrue
+    }
   }
 
   private def writeFile(file: Path, content: String) = {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -506,7 +506,9 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.i18n.DefaultMessagesApi.this"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.i18n.MessagesApi.langCookieMaxAge"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.stubMessagesApi"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.StubMessagesFactory.stubMessagesApi")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.StubMessagesFactory.stubMessagesApi"),
+      // Add configuration for temporary file directory
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.Files#DefaultTemporaryFileCreator.this")
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Resolves #9066

The optional configuration key `play.temporaryFile.dir` can now be used to define the temporary file directory. When absent, the temporary file directory will default to `java.io.tmpdir` as per existing behaviour.

Unit test has been added to ensure correct behaviour, and existing tests have been updated.

