### PR TITLE
Update dependencies javax.* to jakarta

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
   // currently jjwt needs the JAXB Api package in JDK 9+
   // since it actually uses javax/xml/bind/DatatypeConverter
   // See: https://github.com/jwtk/jjwt/issues/317
-  val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1"
+  val jaxbApi = "jakarta.xml.bind" % "jakarta.xml.bind-api" % "2.3.2"
 
   val jdbcDeps = Seq(
     "com.zaxxer"         % "HikariCP" % "3.3.1",
@@ -153,8 +153,8 @@ object Dependencies {
         guava,
         jjwt,
         jaxbApi,
-        "javax.transaction" % "jta"          % "1.1",
-        "javax.inject"      % "javax.inject" % "1",
+        "jakarta.transaction" % "jakarta.transaction-api" % "1.3.2",
+        "javax.inject"        % "javax.inject"            % "1",
         scalaReflect(scalaVersion),
         scalaJava8Compat,
         sslConfig


### PR DESCRIPTION
Oracle has given JEE to the Eclipse Foundation roughly 1 year ago, and
the project has been renamed Jakarta.

The dependencies were renamed following the guideline of the Eclipse
foundation that can be found here:
https://wiki.eclipse.org/New_Maven_Coordinates.

The new dependencies version are drop-in replacement, but:
  - they have a license more business friendly (Eclipse Public License
instead of CDDL + GPL)
  - it will be easier to follow the version update with scala steward
