### PR TITLE
Add more tests to HelpersSpec

### DIFF
--- a/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -13,6 +13,8 @@ import play.api.http.HttpConfiguration
 import play.api.i18n._
 import play.twirl.api.Html
 
+import java.util.Optional
+
 class HelpersSpec extends Specification {
   import FieldConstructor.defaultField
 
@@ -329,6 +331,22 @@ class HelpersSpec extends Specification {
     "correctly lookup error in messages when _error is supplied as Option[String] but keep raw html" in {
       inputText
         .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Option(Html("error.generalcustomerror")))
+        .body must contain(
+        """<dd class="error">Some <b>general custom</b> error message</dd>"""
+      )
+    }
+
+    "correctly lookup error in messages when _error is supplied as Optional[String]" in {
+      inputText
+        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Optional.of("error.generalcustomerror"))
+        .body must contain(
+        """<dd class="error">Some &lt;b&gt;general custom&lt;/b&gt; error message</dd>"""
+      )
+    }
+
+    "correctly lookup error in messages when _error is supplied as Optional[String] but keep raw html" in {
+      inputText
+        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Optional.of(Html("error.generalcustomerror")))
         .body must contain(
         """<dd class="error">Some <b>general custom</b> error message</dd>"""
       )


### PR DESCRIPTION
Now that #9397 bumps twirl to 1.5.0-M2 - which includes https://github.com/playframework/twirl/pull/226 - I can finally add those test which should have been in #9385 already.