### PR TITLE
Use Scala 2.13.0 as main version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ jobs:
     - script: scripts/test-docs
       name: "Run documentation tests"
     - script: scripts/it-test-scala-212
-      name: "Run it tests for Scala 2.12"
+      name: "Run integration tests for Scala 2.12"
     - script: scripts/it-test-scala-213
-      name: "Run it tests for Scala 2.13"
+      name: "Run integration tests for Scala 2.13"
 
     - stage: test-sbt
       script: scripts/test-sbt-plugins-0_13
@@ -55,17 +55,17 @@ jobs:
     - script: scripts/test-sbt-plugins-1_0
       name: "Scripted tests for sbt 1"
 
-    # Test against Java 11, but only for Scala 2.12
+    # Test against Java 11, but only for Scala 2.13
     - stage: java11
-      script: scripts/test-scala-212
+      script: scripts/test-scala-213
       env: TRAVIS_JDK=adopt@1.11.0-2
-      name: "Run tests for Scala 2.12 and Java 11"
-    - script: scripts/it-test-scala-212
+      name: "Run tests for Scala 2.13 and Java 11"
+    - script: scripts/it-test-scala-213
       env: TRAVIS_JDK=adopt@1.11.0-2
-      name: "Run it tests for Scala 2.12 and Java 11"
+      name: "Run it tests for Scala 2.13 and Java 11"
     - script: scripts/test-docs
       env: TRAVIS_JDK=adopt@1.11.0-2
-      name: "Run documentation tests for Scala 2.12 and Java 11"
+      name: "Run documentation tests for Scala 2.13 and Java 11"
     - script: scripts/test-sbt-plugins-1_0
       env: TRAVIS_JDK=adopt@1.11.0-2
       name: "Scripted tests for sbt 1 and Java 11"

--- a/build.sbt
+++ b/build.sbt
@@ -209,7 +209,7 @@ lazy val SbtPluginProject = PlaySbtPluginProject("Sbt-Plugin", "dev-mode/sbt-plu
       .task(
         PlayVersion(
           version.value,
-          (scalaVersion in PlayProject).value,
+          scala212,
           sbtVersion.value,
           jettyAlpnAgent.revision,
           (sourceManaged in Compile).value

--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -19,4 +19,4 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.0.0")
 
 // Required for Tutorial
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.0-M2")

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -550,6 +550,10 @@ object BuildSettings {
       .settings(
         scalacOptions += "-target:jvm-1.8"
       )
+      .settings(
+        scalaVersion := ScalaVersions.scala213,
+        crossScalaVersions := Seq(ScalaVersions.scala213, ScalaVersions.scala212)
+      )
   }
 
   def omnidocSettings: Seq[Setting[_]] = Omnidoc.projectSettings ++ Seq(

--- a/scripts/test-docs
+++ b/scripts/test-docs
@@ -8,5 +8,5 @@
 cd "$DOCUMENTATION"
 
 printMessage "RUNNING DOCUMENTATION TESTS"
-runSbt test
+runSbt "++2.13.0 test"
 printMessage "ALL DOCUMENTATION TESTS PASSED"


### PR DESCRIPTION
This PR adds 2.13.0 cross build and make it the default one as well.
