### PR TITLE
Explicitly depend on netty-transport-native-unix-common

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -156,7 +156,8 @@ object Dependencies {
   val nettyVersion = "4.1.34.Final"
 
   val netty = Seq(
-    "com.typesafe.netty" % "netty-reactive-streams-http" % "2.0.3",
+    "com.typesafe.netty" % "netty-reactive-streams-http"        % "2.0.3",
+    "io.netty"           % "netty-transport-native-unix-common" % nettyVersion,
     ("io.netty" % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
   ) ++ specs2Deps.map(_ % Test)
 


### PR DESCRIPTION
## Fixes

Fixes https://github.com/sbt/sbt/issues/4823
Ref https://github.com/playframework/playframework/pull/9049

## Purpose

The purpose is so play and play applications compile using sbt 1.3.0-RC2, and eventually sbt 1.3.0.

## Background Context

http://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.34.Final/netty-transport-native-epoll-4.1.34.Final.pom. Under Linux profile it says:

> The unix-common with classifier dependency is optional because it is not a runtime dependency, but a build time
> dependency to get the static library which is built directly into the shared library generated by this project.

and it makes netty-transport-native-unix-common an optional dependency, but Play directly uses `io.netty.channel.unix.UnixChannelOption`.
When using sbt 1.3.0-RC2 that uses Coursier, netty-transport-native-unix-common no longer becomes part of the resolution and it causes NoClassDefFoundError.

This PR adds explicit dependency to netty-transport-native-unix-common to make sure it is included into the dependency graph.