### PR TITLE
Leave Play for play.api.Play

### DIFF
--- a/core/play/src/main/scala/play/api/Mode.scala
+++ b/core/play/src/main/scala/play/api/Mode.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api
+
+/**
+ * Application mode, either `Dev`, `Test`, or `Prod`.
+ *
+ * @see [[play.Mode]]
+ */
+sealed abstract class Mode(val asJava: play.Mode)
+
+object Mode {
+  case object Dev  extends Mode(play.Mode.DEV)
+  case object Test extends Mode(play.Mode.TEST)
+  case object Prod extends Mode(play.Mode.PROD)
+
+  lazy val values: Set[play.api.Mode] = Set(Dev, Test, Prod)
+}

--- a/core/play/src/main/scala/play/api/Play.scala
+++ b/core/play/src/main/scala/play/api/Play.scala
@@ -25,21 +25,6 @@ import scala.util.Success
 import scala.util.Try
 
 /**
- * Application mode, either `Dev`, `Test`, or `Prod`.
- *
- * @see [[play.Mode]]
- */
-sealed abstract class Mode(val asJava: play.Mode)
-
-object Mode {
-  case object Dev  extends Mode(play.Mode.DEV)
-  case object Test extends Mode(play.Mode.TEST)
-  case object Prod extends Mode(play.Mode.PROD)
-
-  lazy val values: Set[play.api.Mode] = Set(Dev, Test, Prod)
-}
-
-/**
  * High-level API to access Play global features.
  */
 object Play {


### PR DESCRIPTION
Move play.api.Mode to its own file.  While its an important part of the
API, it shouldn't live above the actual Play object.