### PR TITLE
Add Akka version to play.core.PlayVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
           scalaVersion.value,
           sbtVersion.value,
           jettyAlpnAgent.revision,
+          Dependencies.akkaVersion,
           (sourceManaged in Compile).value
         )
       )
@@ -207,6 +208,7 @@ lazy val SbtPluginProject = PlaySbtPluginProject("Sbt-Plugin", "dev-mode/sbt-plu
           (scalaVersion in PlayProject).value,
           sbtVersion.value,
           jettyAlpnAgent.revision,
+          Dependencies.akkaVersion,
           (sourceManaged in Compile).value
         )
       )

--- a/documentation/manual/releases/release28/Highlights28.md
+++ b/documentation/manual/releases/release28/Highlights28.md
@@ -9,11 +9,21 @@ Play 2.8 brings the latest minor version of Akka. Although Akka 2.6 is binary co
 
 ## Other additions
 
+### Build additions
+
+When adding Akka moodules to your application, it is important that you use a consistent version of Akka for all the modules since [mixed versioning is not allowed](https://doc.akka.io/docs/akka/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed). To make it easier, `play.core.PlayVersion` object now adds `akkaVersion` so that you can use it in your builds like:
+
+```scala
+import play.core.PlayVersion.akkaVersion
+
+libraryDependencies += "com.typesafe.akka" %% "akka-cluster" % akkaVersion
+```
+
 ### Lang cookie max age configuration
 
 It is now possible to configure a max age for language cookie. To do that, add the following to your `application.conf`:
 
-```
+```HOCON
 play.i18n.langCookieMaxAge = 15 seconds
 ```
 

--- a/project/Tasks.scala
+++ b/project/Tasks.scala
@@ -12,19 +12,21 @@ object Generators {
       scalaVersion: String,
       sbtVersion: String,
       jettyAlpnAgentVersion: String,
+      akkaVersion: String,
       dir: File
   ): Seq[File] = {
     val file = dir / "PlayVersion.scala"
     val scalaSource =
-      """|package play.core
-         |
-         |object PlayVersion {
-         |  val current = "%s"
-         |  val scalaVersion = "%s"
-         |  val sbtVersion = "%s"
-         |  private[play] val jettyAlpnAgentVersion = "%s"
-         |}
-         |""".stripMargin.format(version, scalaVersion, sbtVersion, jettyAlpnAgentVersion)
+      s"""|package play.core
+          |
+          |object PlayVersion {
+          |  val current = "$version"
+          |  val scalaVersion = "$scalaVersion"
+          |  val sbtVersion = "$sbtVersion"
+          |  val akkaVersion = "$akkaVersion"
+          |  private[play] val jettyAlpnAgentVersion = "$jettyAlpnAgentVersion"
+          |}
+          |""".stripMargin
 
     if (!file.exists() || IO.read(file) != scalaSource) {
       IO.write(file, scalaSource)


### PR DESCRIPTION
## Purpose

Make it simple to keep other Akka modules added by users in sync with modules used out-of-box by Play.

## References

https://github.com/playframework/play-samples/pull/38#discussion_r300434361
