### PR TITLE
avoid deprecated Symbol literal

### DIFF
--- a/core/play/src/main/scala/play/api/templates/Templates.scala
+++ b/core/play/src/main/scala/play/api/templates/Templates.scala
@@ -19,7 +19,7 @@ object PlayMagic {
    *
    * For example:
    * {{{
-   * toHtmlArgs(Seq('id -> "item", 'style -> "color:red"))
+   * toHtmlArgs(Seq('id -> "item", Symbol("style") -> "color:red"))
    * }}}
    */
   def toHtmlArgs(args: Map[Symbol, Any]) =

--- a/core/play/src/main/scala/views/helper/form.scala.html
+++ b/core/play/src/main/scala/views/helper/form.scala.html
@@ -3,7 +3,7 @@
  *
  * Example:
  * {{{
- * @form(action = routes.Users.submit, args = 'class -> "myForm") {
+ * @form(action = routes.Users.submit, args = Symbol("class") -> "myForm") {
  *   ...
  * }
  * }}}

--- a/core/play/src/main/scala/views/helper/inputDate.scala.html
+++ b/core/play/src/main/scala/views/helper/inputDate.scala.html
@@ -3,7 +3,7 @@
  *
  * Example:
  * {{{
- * @inputDate(field = myForm("releaseDate"), args = 'size -> 10)
+ * @inputDate(field = myForm("releaseDate"), args = Symbol("size") -> 10)
  * }}}
  *
  * @param field The form field.

--- a/core/play/src/main/scala/views/helper/inputFile.scala.html
+++ b/core/play/src/main/scala/views/helper/inputFile.scala.html
@@ -3,7 +3,7 @@
  *
  * Example:
  * {{{
- * @inputFile(field = myForm("name"), args = 'size -> 10)
+ * @inputFile(field = myForm("name"), args = Symbol("size") -> 10)
  * }}}
  *
  * @param field The form field.

--- a/core/play/src/main/scala/views/helper/inputPassword.scala.html
+++ b/core/play/src/main/scala/views/helper/inputPassword.scala.html
@@ -3,7 +3,7 @@
  *
  * Example:
  * {{{
- * @inputPassword(field = myForm("password"), args = 'size -> 10)
+ * @inputPassword(field = myForm("password"), args = Symbol("size") -> 10)
  * }}}
  *
  * @param field The form field.

--- a/core/play/src/main/scala/views/helper/inputText.scala.html
+++ b/core/play/src/main/scala/views/helper/inputText.scala.html
@@ -3,7 +3,7 @@
  *
  * Example:
  * {{{
- * @inputText(field = myForm("name"), args = 'size -> 10, 'placeholder -> "Your name")
+ * @inputText(field = myForm("name"), args = Symbol("size") -> 10, Symbol("placeholder") -> "Your name")
  * }}}
  *
  * @param field The form field.

--- a/core/play/src/main/scala/views/helper/script.scala.html
+++ b/core/play/src/main/scala/views/helper/script.scala.html
@@ -3,7 +3,7 @@
 *
 * Example:
 * {{{
-* @script(args = 'type -> "text/javascript") {
+* @script(args = Symbol("type") -> "text/javascript") {
 *   ...
 * }
 * }}}

--- a/core/play/src/main/scala/views/helper/style.scala.html
+++ b/core/play/src/main/scala/views/helper/style.scala.html
@@ -3,7 +3,7 @@
 *
 * Example:
 * {{{
-* @style(args = 'type -> "text/css") {
+* @style(args = Symbol("type") -> "text/css") {
 *   ...
 * }
 * }}}

--- a/core/play/src/main/scala/views/helper/textarea.scala.html
+++ b/core/play/src/main/scala/views/helper/textarea.scala.html
@@ -3,7 +3,7 @@
  *
  * Example:
  * {{{
- * @textarea(field = myForm("address"), args = 'rows -> 3, 'cols -> 50)
+ * @textarea(field = myForm("address"), args = Symbol("rows") -> 3, Symbol("cols") -> 50)
  * }}}
  *
  * @param field The form field.

--- a/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -28,7 +28,7 @@ class HelpersSpec extends Specification {
 
     "allow setting a custom id" in {
 
-      val body = inputText.apply(Form(single("foo" -> Forms.text))("foo"), 'id -> "someid").body
+      val body = inputText.apply(Form(single("foo" -> Forms.text))("foo"), Symbol("id") -> "someid").body
 
       val idAttr = "id=\"someid\""
       body must contain(idAttr)
@@ -42,7 +42,7 @@ class HelpersSpec extends Specification {
     }
 
     "allow setting a custom type" in {
-      val body = inputText.apply(Form(single("foo" -> Forms.text))("foo"), 'type -> "email").body
+      val body = inputText.apply(Form(single("foo" -> Forms.text))("foo"), Symbol("type") -> "email").body
 
       val typeAttr = "type=\"email\""
       body must contain(typeAttr)
@@ -54,15 +54,15 @@ class HelpersSpec extends Specification {
 
   "@checkbox" should {
     "translate the _text argument" in {
-      val form = Form(single("foo"                  -> Forms.list(Forms.text)))
-      val body = checkbox.apply(form("foo"), '_text -> "myfieldlabel").body
+      val form = Form(single("foo"                           -> Forms.list(Forms.text)))
+      val body = checkbox.apply(form("foo"), Symbol("_text") -> "myfieldlabel").body
 
       body must contain("""<span>I am the &lt;b&gt;label&lt;/b&gt; of the field</span>""")
     }
 
     "translate the _text argument but keep raw html" in {
-      val form = Form(single("foo"                  -> Forms.list(Forms.text)))
-      val body = checkbox.apply(form("foo"), '_text -> Html("myfieldlabel")).body
+      val form = Form(single("foo"                           -> Forms.list(Forms.text)))
+      val body = checkbox.apply(form("foo"), Symbol("_text") -> Html("myfieldlabel")).body
 
       body must contain("""<span>I am the <b>label</b> of the field</span>""")
     }
@@ -85,7 +85,8 @@ class HelpersSpec extends Specification {
 
     "allow setting a custom id" in {
 
-      val body = select.apply(Form(single("foo" -> Forms.text))("foo"), Seq(("0", "test")), 'id -> "someid").body
+      val body =
+        select.apply(Form(single("foo" -> Forms.text))("foo"), Seq(("0", "test")), Symbol("id") -> "someid").body
 
       val idAttr = "id=\"someid\""
       body must contain(idAttr)
@@ -118,7 +119,7 @@ class HelpersSpec extends Specification {
 
     "Work as a multiple select" in {
       val form = Form(single("foo" -> Forms.list(Forms.text))).fill(List("0", "1"))
-      val body = select.apply(form("foo"), Seq(("0", "test"), ("1", "test")), 'multiple -> None).body
+      val body = select.apply(form("foo"), Seq(("0", "test"), ("1", "test")), Symbol("multiple") -> None).body
 
       // Append [] to the name for the form binding
       body must contain("name=\"foo[]\"")
@@ -131,7 +132,9 @@ class HelpersSpec extends Specification {
     "allow disabled options" in {
       val form = Form(single("foo" -> Forms.list(Forms.text))).fill(List("0", "1"))
       val body =
-        select.apply(form("foo"), Seq("0" -> "test0", "1" -> "test1", "2" -> "test2"), '_disabled -> Seq("0", "2")).body
+        select
+          .apply(form("foo"), Seq("0" -> "test0", "1" -> "test1", "2" -> "test2"), Symbol("_disabled") -> Seq("0", "2"))
+          .body
 
       body must contain("""<option value="0" disabled>test0</option>""")
       body must contain("""<option value="1">test1</option>""")
@@ -141,7 +144,9 @@ class HelpersSpec extends Specification {
     "translate default option" in {
       val form = Form(single("foo" -> Forms.list(Forms.text))).fill(List("0", "1"))
       val body =
-        select.apply(form("foo"), Seq("0" -> "test0", "1" -> "test1", "2" -> "test2"), '_default -> "myfieldlabel").body
+        select
+          .apply(form("foo"), Seq("0" -> "test0", "1" -> "test1", "2" -> "test2"), Symbol("_default") -> "myfieldlabel")
+          .body
 
       body must contain("""<option class="blank" value="">I am the &lt;b&gt;label&lt;/b&gt; of the field</option>""")
     }
@@ -150,7 +155,11 @@ class HelpersSpec extends Specification {
       val form = Form(single("foo" -> Forms.list(Forms.text))).fill(List("0", "1"))
       val body =
         select
-          .apply(form("foo"), Seq("0" -> "test0", "1" -> "test1", "2" -> "test2"), '_default -> Html("myfieldlabel"))
+          .apply(
+            form("foo"),
+            Seq("0" -> "test0", "1" -> "test1", "2" -> "test2"),
+            Symbol("_default") -> Html("myfieldlabel")
+          )
           .body
 
       body must contain("""<option class="blank" value="">I am the <b>label</b> of the field</option>""")
@@ -227,7 +236,7 @@ class HelpersSpec extends Specification {
       val roleForm = Form(single("role" -> Forms.text)).fill("foo")
       val body = repeat
         .apply(roleForm("bar"), min = 1) { roleField =>
-          select.apply(roleField, Seq("baz" -> "qux"), '_default -> "Role")
+          select.apply(roleField, Seq("baz" -> "qux"), Symbol("_default") -> "Role")
         }
         .mkString("")
 
@@ -257,50 +266,56 @@ class HelpersSpec extends Specification {
     }
 
     "correctly lookup _label in messages" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_label -> "myfieldlabel").body must contain(
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_label") -> "myfieldlabel").body must contain(
         "I am the &lt;b&gt;label&lt;/b&gt; of the field"
       )
     }
 
     "correctly lookup _label in messages but keep raw html" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_label -> Html("myfieldlabel")).body must contain(
+      inputText
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_label") -> Html("myfieldlabel"))
+        .body must contain(
         "I am the <b>label</b> of the field"
       )
     }
 
     "correctly lookup _name in messages" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_name -> "myfieldname").body must contain(
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_name") -> "myfieldname").body must contain(
         "I am the &lt;b&gt;name&lt;/b&gt; of the field"
       )
     }
 
     "correctly lookup _name in messages but keep raw html" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_name -> Html("myfieldname")).body must contain(
+      inputText
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_name") -> Html("myfieldname"))
+        .body must contain(
         "I am the <b>name</b> of the field"
       )
     }
 
     "correctly lookup _help in messages" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_help -> "myfieldname").body must contain(
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_help") -> "myfieldname").body must contain(
         """<dd class="info">I am the &lt;b&gt;name&lt;/b&gt; of the field</dd>"""
       )
     }
 
     "correctly lookup _help in messages but keep raw html" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_help -> Html("myfieldname")).body must contain(
+      inputText
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_help") -> Html("myfieldname"))
+        .body must contain(
         """<dd class="info">I am the <b>name</b> of the field</dd>"""
       )
     }
 
     "correctly display an error when _error is supplied as String" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_error -> "Force an error").body must contain(
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> "Force an error").body must contain(
         """<dd class="error">Force an error</dd>"""
       )
     }
 
     "correctly lookup error in messages when _error is supplied as String" in {
       inputText
-        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> "error.generalcustomerror")
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> "error.generalcustomerror")
         .body must contain(
         """<dd class="error">Some &lt;b&gt;general custom&lt;/b&gt; error message</dd>"""
       )
@@ -308,21 +323,23 @@ class HelpersSpec extends Specification {
 
     "correctly lookup error in messages when _error is supplied as String but keep raw html" in {
       inputText
-        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Html("error.generalcustomerror"))
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> Html("error.generalcustomerror"))
         .body must contain(
         """<dd class="error">Some <b>general custom</b> error message</dd>"""
       )
     }
 
     "correctly display an error when _error is supplied as Option[String]" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Option("Force an error")).body must contain(
+      inputText
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> Option("Force an error"))
+        .body must contain(
         """<dd class="error">Force an error</dd>"""
       )
     }
 
     "correctly lookup error in messages when _error is supplied as Option[String]" in {
       inputText
-        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Option("error.generalcustomerror"))
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> Option("error.generalcustomerror"))
         .body must contain(
         """<dd class="error">Some &lt;b&gt;general custom&lt;/b&gt; error message</dd>"""
       )
@@ -330,7 +347,7 @@ class HelpersSpec extends Specification {
 
     "correctly lookup error in messages when _error is supplied as Option[String] but keep raw html" in {
       inputText
-        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Option(Html("error.generalcustomerror")))
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> Option(Html("error.generalcustomerror")))
         .body must contain(
         """<dd class="error">Some <b>general custom</b> error message</dd>"""
       )
@@ -338,7 +355,7 @@ class HelpersSpec extends Specification {
 
     "correctly lookup error in messages when _error is supplied as Optional[String]" in {
       inputText
-        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Optional.of("error.generalcustomerror"))
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> Optional.of("error.generalcustomerror"))
         .body must contain(
         """<dd class="error">Some &lt;b&gt;general custom&lt;/b&gt; error message</dd>"""
       )
@@ -346,7 +363,10 @@ class HelpersSpec extends Specification {
 
     "correctly lookup error in messages when _error is supplied as Optional[String] but keep raw html" in {
       inputText
-        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Optional.of(Html("error.generalcustomerror")))
+        .apply(
+          Form(single("foo" -> Forms.text))("foo"),
+          Symbol("_error") -> Optional.of(Html("error.generalcustomerror"))
+        )
         .body must contain(
         """<dd class="error">Some <b>general custom</b> error message</dd>"""
       )
@@ -354,7 +374,7 @@ class HelpersSpec extends Specification {
 
     "correctly display an error when _error is supplied as Option[FormError]" in {
       inputText
-        .apply(Form(single("foo" -> Forms.text))("foo"), '_error -> Option(FormError("foo", "Force an error")))
+        .apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> Option(FormError("foo", "Force an error")))
         .body must contain(
         """<dd class="error">Force an error</dd>"""
       )
@@ -364,7 +384,7 @@ class HelpersSpec extends Specification {
       inputText
         .apply(
           Form(single("foo" -> Forms.text))("foo"),
-          '_error -> FormError("foo", "error.generalcustomerror")
+          Symbol("_error") -> FormError("foo", "error.generalcustomerror")
         )
         .body must contain(
         """<dd class="error">Some &lt;b&gt;general custom&lt;/b&gt; error message</dd>"""
@@ -375,7 +395,7 @@ class HelpersSpec extends Specification {
       inputText
         .apply(
           Form(single("foo" -> Forms.text))("foo"),
-          '_error -> Option(FormError("foo", "error.generalcustomerror"))
+          Symbol("_error") -> Option(FormError("foo", "error.generalcustomerror"))
         )
         .body must contain(
         """<dd class="error">Some &lt;b&gt;general custom&lt;/b&gt; error message</dd>"""
@@ -383,7 +403,7 @@ class HelpersSpec extends Specification {
     }
 
     "don't display an error when _error is supplied but is None" in {
-      inputText.apply(Form(single("foo" -> Forms.text))("foo"), '_error -> None).body must not contain (
+      inputText.apply(Form(single("foo" -> Forms.text))("foo"), Symbol("_error") -> None).body must not contain (
         """class="error""""
       )
     }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes Symbol literal warnings

## Purpose

Fixes Symbol literal warnings


## Background Context

Symbol literal deprecated since Scala 2.13

## References

- https://github.com/scala/scala/releases/tag/v2.13.0
- https://github.com/scala/scala/commit/f46fc7e49058352ff2ac5e843c343e24d0ee6e3c