### PR TITLE
avoid deprecated unicode arrow chars

### DIFF
--- a/web/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -231,7 +231,7 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
     "action-specific headers" should {
       "use provided header instead of config value if allowActionSpecificHeaders=true in config" in withApplication(
         Ok("hello")
-          .withHeaders(REFERRER_POLICY → "my action-specific header"),
+          .withHeaders(REFERRER_POLICY -> "my action-specific header"),
         """
           |play.filters.headers.referrerPolicy="some policy"
           |play.filters.headers.allowActionSpecificHeaders=true
@@ -245,7 +245,7 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
       "use provided header instead of default if allowActionSpecificHeaders=true in config" in withApplication(
         Ok("hello")
-          .withHeaders(REFERRER_POLICY → "my action-specific header"),
+          .withHeaders(REFERRER_POLICY -> "my action-specific header"),
         """
           |play.filters.headers.allowActionSpecificHeaders=true
         """.stripMargin
@@ -258,7 +258,7 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
       "reject action-specific override if allowActionSpecificHeaders=false in config" in withApplication(
         Ok("hello")
-          .withHeaders(REFERRER_POLICY → "my action-specific header"),
+          .withHeaders(REFERRER_POLICY -> "my action-specific header"),
         """
           |play.filters.headers.referrerPolicy="some policy"
           |play.filters.headers.allowActionSpecificHeaders=false
@@ -274,7 +274,7 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
       "reject action-specific override if allowActionSpecificHeaders is not mentioned in config" in withApplication(
         Ok("hello")
-          .withHeaders(REFERRER_POLICY → "my action-specific header"),
+          .withHeaders(REFERRER_POLICY -> "my action-specific header"),
         """
           |play.filters.headers.referrerPolicy="some policy"
         """.stripMargin


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes unicode arrow char warnings

## Purpose

Fixes unicode arrow char warnings

## Background Context

deprecated since Scala 2.13

## References

https://github.com/scala/scala/commit/9e264483d04f48513f3a82e91365667f01a2f5f3

