### PR TITLE
Remove unnecessary import

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/HttpFiltersComponents.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/HttpFiltersComponents.scala
@@ -5,7 +5,6 @@
 package play.filters
 
 import play.api.mvc.EssentialFilter
-import play.filters.csp.CSPComponents
 import play.filters.csrf.CSRFComponents
 import play.filters.headers.SecurityHeadersComponents
 import play.filters.hosts.AllowedHostsComponents


### PR DESCRIPTION
or was an oversight not to extend `CSPComponents` and include `cspFilter` in `httpFilters` by default ?
