### PR TITLE
Added "None" to Same-site Cookie

### DIFF
--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -1834,7 +1834,8 @@ public class Http {
     /** The cookie SameSite attribute */
     public enum SameSite {
       STRICT("Strict"),
-      LAX("Lax");
+      LAX("Lax"),
+      NONE("None");
 
       private final String value;
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Added the item None to Samesite.

## Background Context

Chrome will make samesite default to Lax.
And the old default was defined as None.
https://www.chromestatus.com/feature/5088147346030592

## References

