### PR TITLE
Play.privateMaybeApplication should return Failure instead of sys.error

### DIFF
--- a/core/play/src/main/scala/play/api/Play.scala
+++ b/core/play/src/main/scala/play/api/Play.scala
@@ -52,7 +52,7 @@ object Play {
       Success(_currentApp.get)
     } else {
       Failure(
-        sys.error(
+        new RuntimeException(
           s"""
              |The global application reference is disabled. Play's global state is deprecated and will
              |be removed in a future release. You should use dependency injection instead. To enable

--- a/core/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
+++ b/core/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
@@ -32,7 +32,7 @@ class PlayGlobalAppSpec extends Specification {
     "start apps with global state disabled" in {
       val app = testApp(false)
       Play.start(app)
-      Play.privateMaybeApplication must throwA[RuntimeException]
+      Play.privateMaybeApplication must beFailedTry
       Play.stop(app)
       success
     }
@@ -79,7 +79,7 @@ class PlayGlobalAppSpec extends Specification {
       Play.start(app2)
       app1.isTerminated must beFalse
       app2.isTerminated must beFalse
-      Play.privateMaybeApplication must throwA[RuntimeException]
+      Play.privateMaybeApplication must beFailedTry
       Play.stop(app1)
       Play.stop(app2)
       success
@@ -87,7 +87,7 @@ class PlayGlobalAppSpec extends Specification {
     "should stop an app with global state disabled" in {
       val app = testApp(false)
       Play.start(app)
-      Play.privateMaybeApplication must throwA[RuntimeException]
+      Play.privateMaybeApplication must beFailedTry
 
       Play.stop(app)
       app.isTerminated must beTrue
@@ -99,7 +99,7 @@ class PlayGlobalAppSpec extends Specification {
 
       Play.stop(app)
       app.isTerminated must beTrue
-      Play.privateMaybeApplication must throwA[RuntimeException]
+      Play.privateMaybeApplication must beFailedTry
     }
   }
 }


### PR DESCRIPTION
Play.privateMaybeApplication should return Failure instead of sys.error which throws an exception

# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

No related issue, but I can open one if necessary.
This fix is more important for Play 2.7.x since Play.current/maybeApplication/unsafeApplication were already removed in master, but still is more correct to respect the signature and return a Failure than throw an exception.

## Purpose

With this fix `Play.maybeApplication` returns a None instead of throwing an exception

## References 

Introduced in https://github.com/playframework/playframework/pull/8462
