### PR TITLE
Use single abstract methods where it improves code readability

### DIFF
--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -6,14 +6,11 @@ package play.api.cache
 
 import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
 import java.util.Optional
 
 import akka.util.Timeout
-
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.execute.AsResult
-
 import play.api.test.PlaySpecification
 import play.api.test.WithApplication
 import play.cache.{ AsyncCacheApi => JavaAsyncCacheApi }
@@ -55,9 +52,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         val future = cacheApi
-          .getOrElseUpdate[String]("foo", new Callable[CompletionStage[String]] {
-            override def call() = CompletableFuture.completedFuture[String]("bar")
-          })
+          .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"))
           .toScala
 
         future must beEqualTo("bar").await
@@ -66,9 +61,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         val future = cacheApi
-          .getOrElseUpdate[String]("foo", new Callable[CompletionStage[String]] {
-            override def call() = CompletableFuture.completedFuture[String]("bar")
-          }, 1 /* second */ )
+          .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"), 1 /* second */ )
           .toScala
 
         future must beEqualTo("bar").await
@@ -121,18 +114,14 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-        val value = cacheApi.getOrElseUpdate[String]("foo", new Callable[String] {
-          override def call() = "bar"
-        })
+        val value    = cacheApi.getOrElseUpdate[String]("foo", () => "bar")
 
         value must beEqualTo("bar")
         cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-        val future = cacheApi.getOrElseUpdate[String]("foo", new Callable[String] {
-          override def call() = "bar"
-        }, 1 /* second */ )
+        val future   = cacheApi.getOrElseUpdate[String]("foo", () => "bar", 1 /* second */ )
 
         future must beEqualTo("bar")
 

--- a/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -4,16 +4,12 @@
 
 package play.api.cache
 
-import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
 import java.util.Optional
 
 import akka.util.Timeout
-
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.execute.AsResult
-
 import play.api.test.PlaySpecification
 import play.api.test.WithApplication
 import play.cache.{ AsyncCacheApi => JavaAsyncCacheApi }
@@ -55,9 +51,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         val future = cacheApi
-          .getOrElseUpdate[String]("foo", new Callable[CompletionStage[String]] {
-            override def call() = CompletableFuture.completedFuture[String]("bar")
-          })
+          .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"))
           .toScala
 
         future must beEqualTo("bar").await
@@ -66,9 +60,7 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         val future = cacheApi
-          .getOrElseUpdate[String]("foo", new Callable[CompletionStage[String]] {
-            override def call() = CompletableFuture.completedFuture[String]("bar")
-          }, 1 /* second */ )
+          .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"), 1 /* second */ )
           .toScala
 
         future must beEqualTo("bar").await
@@ -121,18 +113,14 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-        val value = cacheApi.getOrElseUpdate[String]("foo", new Callable[String] {
-          override def call() = "bar"
-        })
+        val value    = cacheApi.getOrElseUpdate[String]("foo", () => "bar")
 
         value must beEqualTo("bar")
         cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-        val future = cacheApi.getOrElseUpdate[String]("foo", new Callable[String] {
-          override def call() = "bar"
-        }, 1 /* second */ )
+        val future   = cacheApi.getOrElseUpdate[String]("foo", () => "bar", 1 /* second */ )
 
         future must beEqualTo("bar")
 

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaCachedActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaCachedActionSpec.scala
@@ -4,13 +4,11 @@
 
 package play.it.http
 
-import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
 import java.util.concurrent.TimeUnit
+
 import javax.inject.Inject
 import javax.inject.Provider
-
 import akka.Done
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
@@ -190,12 +188,10 @@ class TestAsyncCacheApiProvider @Inject()(lifeCycle: ApplicationLifecycle)(impli
       .expireAfterWrite(1, TimeUnit.SECONDS) // consistent with the value used in @Cached annotations above
       .build[String, Object]()
 
-    lifeCycle.addStopHook(new Callable[CompletionStage[_]] {
-      override def call(): CompletionStage[_] = {
-        cache.cleanUp()
-        cache.invalidateAll()
-        CompletableFuture.completedFuture(true)
-      }
+    lifeCycle.addStopHook(() => {
+      cache.cleanUp()
+      cache.invalidateAll()
+      CompletableFuture.completedFuture(true)
     })
 
     new TestAsyncCacheApi(cache)

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -5,7 +5,7 @@
 package play.it.http
 
 import java.io.ByteArrayInputStream
-import java.util.Arrays
+import java.util
 import java.util.Locale
 import java.util.Optional
 
@@ -581,7 +581,7 @@ trait JavaResultsHandlingSpec
       def action(request: Http.Request) = {
         val objectNode = Json.newObject
         objectNode.put("foo", "bar")
-        val dataSource: Source[JsonNode, NotUsed] = akka.stream.javadsl.Source.from(Arrays.asList(objectNode))
+        val dataSource: Source[JsonNode, NotUsed] = akka.stream.javadsl.Source.from(util.Arrays.asList(objectNode))
         val cometSource                           = dataSource.via(Comet.json("callback"))
         Results.ok().chunked(cometSource)
       }
@@ -593,10 +593,8 @@ trait JavaResultsHandlingSpec
 
     "chunk event source results" in makeRequest(new MockController {
       def action(request: Http.Request) = {
-        val dataSource = akka.stream.javadsl.Source.from(List("a", "b").asJava).map {
-          new akka.japi.function.Function[String, EventSource.Event] {
-            def apply(t: String) = EventSource.Event.event(t)
-          }
+        val dataSource = akka.stream.javadsl.Source.from(List("a", "b").asJava).map { t =>
+          EventSource.Event.event(t)
         }
         val eventSource = dataSource.via(EventSource.flow())
         Results.ok().chunked(eventSource).as("text/event-stream")

--- a/core/play-streams/src/test/scala/play/api/libs/streams/ExecutionSpec.scala
+++ b/core/play-streams/src/test/scala/play/api/libs/streams/ExecutionSpec.scala
@@ -29,9 +29,7 @@ class ExecutionSpec extends Specification {
     "not overflow the stack" in {
       def executeRecursively(ec: ExecutionContext, times: Int): Unit = {
         if (times > 0) {
-          ec.execute(new Runnable {
-            def run() = executeRecursively(ec, times - 1)
-          })
+          ec.execute(() => executeRecursively(ec, times - 1))
         }
       }
 
@@ -61,7 +59,7 @@ class ExecutionSpec extends Specification {
     "execute code in the order it was submitted" in {
       val runRecord = scala.collection.mutable.Buffer.empty[Int]
       case class TestRunnable(id: Int, children: Runnable*) extends Runnable {
-        def run() = {
+        def run(): Unit = {
           runRecord += id
           for (c <- children) trampoline.execute(c)
         }

--- a/core/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -9,31 +9,26 @@ import java.util.concurrent.CompletionStage
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
+import akka.NotUsed
+
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-
 import scala.compat.java8.FutureConverters
-
 import akka.actor.ActorSystem
 import akka.stream.javadsl.Source
 import akka.stream.javadsl.Sink
 import akka.stream.ActorMaterializer
 import akka.stream.Materializer
 import akka.japi.function.{ Function => JFn }
-import akka.japi.function.{ Function2 => JFn2 }
-
 import org.reactivestreams.Subscription
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Publisher
 
 class AccumulatorSpec extends org.specs2.mutable.Specification {
   // JavaConversions is required because JavaConverters.asJavaIterable only exists in 2.12
   // and we cross compile for 2.11
   import scala.collection.JavaConverters._
 
-  def withMaterializer[T](block: Materializer => T) = {
+  def withMaterializer[T](block: Materializer => T): T = {
     val system = ActorSystem("test")
     try {
       block(ActorMaterializer()(system))
@@ -43,22 +38,19 @@ class AccumulatorSpec extends org.specs2.mutable.Specification {
     }
   }
 
-  def sum: Accumulator[Int, Int] =
-    Accumulator.fromSink(Sink.fold[Int, Int](0, new JFn2[Int, Int, Int] { def apply(a: Int, b: Int) = a + b }))
+  def sum: Accumulator[Int, Int] = Accumulator.fromSink(Sink.fold[Int, Int](0, (a, b) => a + b))
 
-  def source                  = Source.from((1 to 3).asJava)
-  def sawait[T](f: Future[T]) = Await.result(f, 10.seconds)
-  def await[T](f: CompletionStage[T]) =
+  def source: Source[Int, NotUsed] = Source.from((1 to 3).asJava)
+  def await[T](f: Future[T]): T    = Await.result(f, 10.seconds)
+  def await[T](f: CompletionStage[T]): T =
     f.toCompletableFuture.get(10, TimeUnit.SECONDS)
 
-  def errorSource[T] =
-    Source.fromPublisher(new Publisher[T] {
-      def subscribe(s: Subscriber[_ >: T]) = {
-        s.onSubscribe(new Subscription {
-          def cancel()         = s.onComplete()
-          def request(n: Long) = s.onError(new RuntimeException("error"))
-        })
-      }
+  def errorSource[T]: Source[T, NotUsed] =
+    Source.fromPublisher(s => {
+      s.onSubscribe(new Subscription {
+        def cancel(): Unit         = s.onComplete()
+        def request(n: Long): Unit = s.onError(new RuntimeException("error"))
+      })
     })
 
   "an accumulator" should {
@@ -106,7 +98,7 @@ class AccumulatorSpec extends org.specs2.mutable.Specification {
             FutureConverters.toScala(f)
         })
 
-        sawait(play.api.libs.streams.Accumulator(sink.asScala).run(source.asScala)) must_== 6
+        await(play.api.libs.streams.Accumulator(sink.asScala).run(source.asScala)) must_== 6
       }
     }
   }

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -412,7 +412,8 @@ object Files {
             s"Reaper enabled but no temp folder has been created yet, starting in $initialDelay with $interval intervals"
           )
       }
-      cancellable = Some(actorSystem.scheduler.schedule(initialDelay, interval) {
+
+      cancellable = Some(actorSystem.scheduler.scheduleAtFixedRate(initialDelay, interval) { () =>
         reap()
       }(actorSystem.dispatcher))
     }

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -8,14 +8,15 @@ import java.io.File
 import java.io.IOException
 import java.lang.ref.Reference
 import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{ Files => JFiles, _ }
+import java.nio.file.{ Files => JFiles }
+import java.nio.file._
 import java.time.Clock
 import java.time.Instant
-import java.util.function.Predicate
+import java.util.stream
+
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
-
 import akka.actor.ActorSystem
 import akka.actor.Cancellable
 import com.google.common.base.FinalizablePhantomReference
@@ -318,7 +319,7 @@ object Files {
             playTempFolder,
             new SimpleFileVisitor[Path] {
               override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
-                logger.debug(s"stopHook: Removing leftover temporary file $path from ${playTempFolder}")
+                logger.debug(s"stopHook: Removing leftover temporary file $path from $playTempFolder")
                 deletePath(path)
                 FileVisitResult.CONTINUE
               }
@@ -367,15 +368,13 @@ object Files {
           .map { f =>
             import scala.compat.java8.StreamConverters._
 
-            val directoryStream = JFiles.list(f)
+            val directoryStream: stream.Stream[Path] = JFiles.list(f)
 
             try {
               val reaped = directoryStream
-                .filter(new Predicate[Path]() {
-                  override def test(p: Path): Boolean = {
-                    val lastModifiedTime = JFiles.getLastModifiedTime(p).toInstant
-                    lastModifiedTime.isBefore(secondsAgo)
-                  }
+                .filter(p => {
+                  val lastModifiedTime = JFiles.getLastModifiedTime(p).toInstant
+                  lastModifiedTime.isBefore(secondsAgo)
                 })
                 .toScala[List]
 
@@ -465,14 +464,14 @@ object Files {
     )
     class TemporaryFileReaperConfigurationProvider @Inject()(configuration: Configuration)
         extends Provider[TemporaryFileReaperConfiguration] {
-      lazy val get = fromConfiguration(configuration)
+      lazy val get: TemporaryFileReaperConfiguration = fromConfiguration(configuration)
     }
   }
 
   @Singleton
   class TemporaryFileReaperConfigurationProvider @Inject()(configuration: Configuration)
       extends Provider[TemporaryFileReaperConfiguration] {
-    lazy val get = TemporaryFileReaperConfiguration.fromConfiguration(configuration)
+    lazy val get: TemporaryFileReaperConfiguration = TemporaryFileReaperConfiguration.fromConfiguration(configuration)
   }
 
   /**

--- a/core/play/src/main/scala/play/api/mvc/Action.scala
+++ b/core/play/src/main/scala/play/api/mvc/Action.scala
@@ -26,7 +26,7 @@ import scala.language.higherKinds
 trait EssentialAction extends (RequestHeader => Accumulator[ByteString, Result]) with Handler { self =>
 
   /** @return itself, for better support in the routes file. */
-  def apply() = this
+  def apply(): EssentialAction = this
 
   def asJava: play.mvc.EssentialAction = new play.mvc.EssentialAction() {
     def apply(rh: play.mvc.Http.RequestHeader) = self(rh.asScala).map(_.asJava)(Execution.trampoline).asJava

--- a/core/play/src/main/scala/play/core/utils/HttpHeaderEncoding.scala
+++ b/core/play/src/main/scala/play/core/utils/HttpHeaderEncoding.scala
@@ -5,7 +5,6 @@
 package play.core.utils
 
 import java.lang.{ StringBuilder => JStringBuilder }
-import java.util.function.IntConsumer
 import java.util.{ BitSet => JBitSet }
 
 /**
@@ -110,8 +109,8 @@ private[play] object HttpHeaderParameterEncoding {
     // end up with multiple placeholders per logical character.
     value
       .codePoints()
-      .forEach(new IntConsumer {
-        override def accept(codePoint: Int): Unit = {
+      .forEach(
+        codePoint =>
           // We could support a wider range of characters here by using
           // the 'token' or 'quoted printable' encoding, however it's
           // simpler to use the subset of characters that is also valid
@@ -124,8 +123,7 @@ private[play] object HttpHeaderParameterEncoding {
             // Render a placeholder instead of the unsupported character.
             builder.append(PlaceholderChar)
           }
-        }
-      })
+      )
 
     builder.append('"')
 

--- a/dev-mode/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
+++ b/dev-mode/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
@@ -23,7 +23,7 @@ class DocumentationHandler(repo: FileRepository, apiRepo: FileRepository, toClos
     with Closeable {
 
   def this(repo: FileRepository, toClose: Closeable) = this(repo, repo, toClose)
-  def this(repo: FileRepository, apiRepo: FileRepository) = this(repo, apiRepo, new Closeable() { def close() = () })
+  def this(repo: FileRepository, apiRepo: FileRepository) = this(repo, apiRepo, () => ())
   def this(repo: FileRepository) = this(repo, repo)
 
   private val fileMimeTypes: FileMimeTypes = {

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -318,9 +318,7 @@ private[server] trait ServerFromRouter {
 
 private[play] object JavaServerHelper {
   def forRouter(router: JRouter, mode: Mode, httpPort: Option[Integer], sslPort: Option[Integer]): Server = {
-    forRouter(mode, httpPort, sslPort)(new JFunction[JBuiltInComponents, JRouter] {
-      override def apply(components: JBuiltInComponents): JRouter = router
-    })
+    forRouter(mode, httpPort, sslPort)(_ => router)
   }
 
   def forRouter(mode: Mode, httpPort: Option[Integer], sslPort: Option[Integer])(


### PR DESCRIPTION
It can be done now since we drop Scala 2.11. :-)