### PR TITLE
Support RangeResult where the Source provider can pre-seek to the start

### DIFF
--- a/core/play/src/main/java/play/mvc/RangeResults.java
+++ b/core/play/src/main/java/play/mvc/RangeResults.java
@@ -4,6 +4,7 @@
 
 package play.mvc;
 
+import akka.annotation.ApiMayChange;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import play.core.j.JavaRangeResult;
@@ -24,6 +25,7 @@ public class RangeResults {
     return request.header(Http.HeaderNames.RANGE);
   }
 
+  @ApiMayChange
   public static class SourceAndOffset {
     private final long offset;
     private final Source<ByteString, ?> source;
@@ -42,6 +44,7 @@ public class RangeResults {
     }
   }
 
+  @ApiMayChange
   public interface SourceFunction extends java.util.function.LongFunction<SourceAndOffset> {}
 
   /**
@@ -255,6 +258,7 @@ public class RangeResults {
         Optional.ofNullable(contentType));
   }
 
+  @ApiMayChange
   public static Result ofSource(
       Http.Request request,
       Long entityLength,

--- a/core/play/src/main/java/play/mvc/RangeResults.java
+++ b/core/play/src/main/java/play/mvc/RangeResults.java
@@ -24,6 +24,26 @@ public class RangeResults {
     return request.header(Http.HeaderNames.RANGE);
   }
 
+  public static class SourceAndOffset {
+    private final long offset;
+    private final Source<ByteString, ?> source;
+
+    public SourceAndOffset(long offset, Source<ByteString, ?> source) {
+      this.offset = offset;
+      this.source = source;
+    }
+
+    public long getOffset() {
+      return offset;
+    }
+
+    public Source<ByteString, ?> getSource() {
+      return source;
+    }
+  }
+
+  public interface SourceFunction extends java.util.function.LongFunction<SourceAndOffset> {}
+
   /**
    * Returns the stream as a result considering "Range" header. If the header is present and it is
    * satisfiable, then a Result containing just the requested part will be returned. If the header
@@ -230,6 +250,20 @@ public class RangeResults {
     return JavaRangeResult.ofSource(
         entityLength,
         source,
+        rangeHeader(request),
+        Optional.ofNullable(fileName),
+        Optional.ofNullable(contentType));
+  }
+
+  public static Result ofSource(
+      Http.Request request,
+      Long entityLength,
+      SourceFunction getSource,
+      String fileName,
+      String contentType) {
+    return JavaRangeResult.ofSource(
+        Optional.of(entityLength),
+        getSource,
         rangeHeader(request),
         Optional.ofNullable(fileName),
         Optional.ofNullable(contentType));

--- a/core/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/core/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -7,6 +7,7 @@ package play.api.mvc
 import java.nio.file.Files
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
@@ -408,6 +409,7 @@ object RangeResult {
     contentType
   )
 
+  @ApiMayChange
   def ofSource(
       entityLength: Option[Long],
       getSource: Long => (Long, Source[ByteString, _]),

--- a/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
@@ -8,7 +8,6 @@ import java.io.InputStream
 import java.io.File
 import java.nio.file.Path
 import java.util.Optional
-import java.util.function.Function
 
 import akka.annotation.ApiMayChange
 import play.mvc.RangeResults
@@ -18,7 +17,6 @@ import scala.compat.java8.OptionConverters._
 import akka.stream.javadsl.Source
 import akka.util.ByteString
 import play.api.mvc.RangeResult
-import play.mvc.RangeResults.SourceAndOffset
 
 /**
  * Java compatible RangeResult

--- a/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
@@ -7,22 +7,25 @@ package play.core.j
 import java.io.InputStream
 import java.io.File
 import java.nio.file.Path
-
 import java.util.Optional
+import java.util.function.Function
+
+import play.mvc.RangeResults
 import play.mvc.Result
 
 import scala.compat.java8.OptionConverters._
-
 import akka.stream.javadsl.Source
 import akka.util.ByteString
 import play.api.mvc.RangeResult
+import play.mvc.RangeResults.SourceAndOffset
 
 /**
  * Java compatible RangeResult
  */
 object JavaRangeResult {
 
-  private type OptString = Optional[String]
+  private type OptString   = Optional[String]
+  private type ScalaSource = akka.stream.scaladsl.Source[ByteString, _]
 
   def ofStream(stream: InputStream, rangeHeader: OptString, fileName: String, contentType: OptString): Result = {
     RangeResult.ofStream(stream, rangeHeader.asScala, fileName, contentType.asScala).asJava
@@ -75,6 +78,22 @@ object JavaRangeResult {
   ): Result = {
     RangeResult
       .ofSource(entityLength.asScala, source.asScala, rangeHeader.asScala, fileName.asScala, contentType.asScala)
+      .asJava
+  }
+
+  def ofSource(
+      entityLength: Optional[Long],
+      getSource: RangeResults.SourceFunction,
+      rangeHeader: OptString,
+      fileName: OptString,
+      contentType: OptString
+  ): Result = {
+    val getSourceAsScala: Long => (Long, ScalaSource) = { offset =>
+      val result = getSource(offset)
+      (result.getOffset, result.getSource.asScala)
+    }
+    RangeResult
+      .ofSource(entityLength.asScala, getSourceAsScala, rangeHeader.asScala, fileName.asScala, contentType.asScala)
       .asJava
   }
 }

--- a/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
@@ -10,6 +10,7 @@ import java.nio.file.Path
 import java.util.Optional
 import java.util.function.Function
 
+import akka.annotation.ApiMayChange
 import play.mvc.RangeResults
 import play.mvc.Result
 
@@ -81,6 +82,7 @@ object JavaRangeResult {
       .asJava
   }
 
+  @ApiMayChange
   def ofSource(
       entityLength: Optional[Long],
       getSource: RangeResults.SourceFunction,

--- a/documentation/manual/releases/release28/Highlights28.md
+++ b/documentation/manual/releases/release28/Highlights28.md
@@ -63,6 +63,10 @@ See [[Integrating with Akka Typed|AkkaTyped]] for more details.
 
 ## Other additions
 
+### Support pre-seek Sources for Range Results
+
+In some cases, it is possible to pre-seek the `Source` when returning results for requests containing a `Range` header. For example, if the application is using [Alpakka S3 connector](https://doc.akka.io/docs/alpakka/current/s3.html), it will efficiently download only the section specified by the `Range` header. See more details in [[Java|JavaResponse]] and [[Scala|ScalaResults]] documentation.
+
 ### Build additions
 
 Because [Akka does not allow mixing versions](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed), when adding Akka modules to your application, it is important to use a consistent version for all them. To make that easier, `play.core.PlayVersion` object now has an `akkaVersion` variable that you can use it in your builds like:

--- a/documentation/manual/working/javaGuide/main/http/JavaResponse.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaResponse.md
@@ -1,9 +1,9 @@
 <!--- Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com> -->
-# Manipulating the response
+# Manipulating Results
 
-## Changing the default Content-Type
+## Changing the default `Content-Type`
 
-The result content type is automatically inferred from the Java value you specify as body.
+The result content type is automatically inferred from the Java value you specify as response body.
 
 For example:
 
@@ -19,17 +19,23 @@ This is pretty useful, but sometimes you want to change it. Just use the `as(new
 
 @[custom-content-type](code/javaguide/http/JavaResponse.java)
 
-## Setting HTTP response headers
+or even better, using:
+
+@[content-type_defined_html](code/javaguide/http/JavaResponse.java)
+
+## Manipulating HTTP headers
+
+You can also add (or update) any HTTP header to the result:
 
 @[response-headers](code/javaguide/http/JavaResponse.java)
 
-Note that setting an HTTP header will automatically discard any previous value.
+Note that setting an HTTP header will automatically discard the previous value if it was existing in the original result.
 
 ## Setting and discarding cookies
 
 Cookies are just a special form of HTTP headers, but Play provides a set of helpers to make it easier.
 
-You can easily add a Cookie to the HTTP response:
+You can easily add a Cookie to the HTTP response using:
 
 @[set-cookie](code/javaguide/http/JavaResponse.java)
 
@@ -43,12 +49,32 @@ To discard a Cookie previously stored on the web browser:
 
 If you set a path or domain when setting the cookie, make sure that you set the same path or domain when discarding the cookie, as the browser will only discard it if the name, path and domain match.
 
-## Specifying the character encoding for text results
+## Changing the charset for text based HTTP responses
 
-For a text-based HTTP response it is very important to handle the character encoding correctly. Play handles that for you and uses `utf-8` by default.
+For a text based HTTP response it is very important to handle the charset correctly. Play handles that for you and uses `utf-8` by default (see [why to use utf-8](http://www.w3.org/International/questions/qa-choosing-encodings#useunicode)).
 
-The encoding is used to both convert the text response to the corresponding bytes to send over the network socket, and to add the proper `;charset=xxx` extension to the `Content-Type` header.
+The charset is used to both convert the text response to the corresponding bytes to send over the network socket, and to update the `Content-Type` header with the proper `;charset=xxx` extension.
 
 The encoding can be specified when you are generating the `Result` value:
 
 @[charset](code/javaguide/http/JavaResponse.java)
+
+## Range Results
+
+Play supports part of [RFC 7233](https://tools.ietf.org/html/rfc7233) which defines how range requests and partial responses works. It enables you to delivery a `206 Partial Content` if a satisfiable `Range` header is present in the request. It will also returns a `Accept-Ranges: bytes` for the delivered `Result`.
+
+> **Note:** Besides the fact that some parsing is done to better handle multiple ranges, `multipart/byteranges` is not fully supported yet.
+
+Range results can be generated for a `Source`, `InputStream`, File, and `Path`. See [`RangeResult`](api/java/play/mvc/RangeResults.html) API documentation for see all the methods available. For example:
+
+@[range-result-input-stream](code/javaguide/http/JavaResponse.java)
+
+Or for an `Source`:
+
+@[range-result-source](code/javaguide/http/JavaResponse.java)
+
+When the request `Range` is not satisfiable, for example, if the range in the request's `Range` header field do not overlap the current extent of the selected resource, then a HTTP status `416` (Range Not Satisfiable) is returned.
+
+It is also possible to pre-seek for a specific position of the `Source` to more efficiently deliver range results. To do that, you can provide a function where the pre-seek happens:
+
+@[range-result-source-with-offset](code/javaguide/http/JavaResponse.java)

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -4,6 +4,9 @@
 
 package javaguide.http;
 
+import akka.NotUsed;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
 import javaguide.testhelpers.MockJavaAction;
 import org.junit.Test;
@@ -11,12 +14,19 @@ import play.core.j.JavaHandlerComponents;
 import play.libs.Json;
 import play.mvc.Http;
 import play.mvc.Http.Cookie;
+import play.mvc.Http.MimeTypes;
+import play.mvc.RangeResults;
 import play.mvc.Result;
+import play.test.Helpers;
 import play.test.WithApplication;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static javaguide.testhelpers.MockJavaActionHelper.*;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -58,6 +68,15 @@ public class JavaResponse extends WithApplication {
   }
 
   @Test
+  public void customDefiningContentType() {
+    // #content-type_defined_html
+    Result htmlResult = ok("<h1>Hello World!</h1>").as(MimeTypes.HTML);
+    // #content-type_defined_html
+
+    assertThat(htmlResult.contentType().get(), containsString("text/html"));
+  }
+
+  @Test
   public void responseHeaders() {
     Map<String, String> headers =
         call(
@@ -65,7 +84,7 @@ public class JavaResponse extends WithApplication {
                   // #response-headers
                   public Result index() {
                     return ok("<h1>Hello World!</h1>")
-                        .as("text/html")
+                        .as(MimeTypes.HTML)
                         .withHeader(CACHE_CONTROL, "max-age=3600")
                         .withHeader(ETAG, "some-etag-calculated-value");
                   }
@@ -86,7 +105,7 @@ public class JavaResponse extends WithApplication {
                   // #set-cookie
                   public Result index() {
                     return ok("<h1>Hello World!</h1>")
-                        .as("text/html")
+                        .as(MimeTypes.HTML)
                         .withCookies(Cookie.builder("theme", "blue").build());
                   }
                   // #set-cookie
@@ -108,7 +127,7 @@ public class JavaResponse extends WithApplication {
                   // #detailed-set-cookie
                   public Result index() {
                     return ok("<h1>Hello World!</h1>")
-                        .as("text/html")
+                        .as(MimeTypes.HTML)
                         .withCookies(
                             Cookie.builder("theme", "blue")
                                 .withMaxAge(Duration.ofSeconds(3600))
@@ -146,7 +165,7 @@ public class JavaResponse extends WithApplication {
                 new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                   // #discard-cookie
                   public Result index() {
-                    return ok("<h1>Hello World!</h1>").as("text/html").discardingCookie("theme");
+                    return ok("<h1>Hello World!</h1>").as(MimeTypes.HTML).discardingCookie("theme");
                   }
                   // #discard-cookie
                 },
@@ -176,5 +195,95 @@ public class JavaResponse extends WithApplication {
             .charset()
             .get(),
         equalTo("iso-8859-1"));
+  }
+
+  @Test
+  public void rangeResultInputStream() {
+    Result result =
+        call(
+            new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
+              // #range-result-input-stream
+              public Result index(Http.Request request) {
+                String content = "This is the full content!";
+                InputStream input = getInputStream(content);
+                return RangeResults.ofStream(request, input, content.length());
+              }
+              // #range-result-input-stream
+
+              private InputStream getInputStream(String content) {
+                return new ByteArrayInputStream(content.getBytes());
+              }
+            },
+            fakeRequest().header(RANGE, "bytes=0-3"),
+            mat);
+
+    assertThat(result.status(), equalTo(PARTIAL_CONTENT));
+    assertThat(Helpers.contentAsString(result, mat), equalTo("This"));
+  }
+
+  @Test
+  public void rangeResultSource() {
+    Result result =
+        call(
+            new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
+              // #range-result-source
+              public Result index(Http.Request request) {
+                String content = "This is the full content!";
+                Source<ByteString, NotUsed> source = sourceFrom(content);
+                return RangeResults.ofSource(
+                    request, (long) content.length(), source, "file.txt", MimeTypes.TEXT);
+              }
+              // #range-result-source
+
+              private Source<ByteString, NotUsed> sourceFrom(String content) {
+                List<ByteString> byteStrings =
+                    content
+                        .chars()
+                        .boxed()
+                        .map(c -> ByteString.fromArray(new byte[] {c.byteValue()}))
+                        .collect(Collectors.toList());
+                return akka.stream.javadsl.Source.from(byteStrings);
+              }
+            },
+            fakeRequest().header(RANGE, "bytes=0-3"),
+            mat);
+
+    assertThat(result.status(), equalTo(PARTIAL_CONTENT));
+    assertThat(Helpers.contentAsString(result, mat), equalTo("This"));
+  }
+
+  @Test
+  public void rangeResultSourceOffset() {
+    Result result =
+        call(
+            new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
+              // #range-result-source-with-offset
+              public Result index(Http.Request request) {
+                String content = "This is the full content!";
+                return RangeResults.ofSource(
+                    request,
+                    (long) content.length(),
+                    offset ->
+                        new RangeResults.SourceAndOffset(offset, sourceFrom(content).drop(offset)),
+                    "file.txt",
+                    MimeTypes.TEXT);
+              }
+              // #range-result-source-with-offset
+
+              private Source<ByteString, NotUsed> sourceFrom(String content) {
+                List<ByteString> byteStrings =
+                    content
+                        .chars()
+                        .boxed()
+                        .map(c -> ByteString.fromArray(new byte[] {c.byteValue()}))
+                        .collect(Collectors.toList());
+                return akka.stream.javadsl.Source.from(byteStrings);
+              }
+            },
+            fakeRequest().header(RANGE, "bytes=8-10"),
+            mat);
+
+    assertThat(result.status(), equalTo(PARTIAL_CONTENT));
+    assertThat(Helpers.contentAsString(result, mat), equalTo("the"));
   }
 }

--- a/documentation/manual/working/scalaGuide/main/http/ScalaResults.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaResults.md
@@ -53,7 +53,7 @@ You can also set and remove cookies as part of the same response:
 
 ## Changing the charset for text based HTTP responses
 
-For text based HTTP response it is very important to handle the charset correctly. Play handles that for you and uses `utf-8` by default (see [why to use utf-8](http://www.w3.org/International/questions/qa-choosing-encodings#useunicode)).
+For a text based HTTP response it is very important to handle the charset correctly. Play handles that for you and uses `utf-8` by default (see [why to use utf-8](http://www.w3.org/International/questions/qa-choosing-encodings#useunicode)).
 
 The charset is used to both convert the text response to the corresponding bytes to send over the network socket, and to update the `Content-Type` header with the proper `;charset=xxx` extension.
 
@@ -68,3 +68,23 @@ Now if you are wondering how the `HTML` method works, here it is how it is defin
 @[Source-Code-HTML](code/ScalaResults.scala)
 
 You can do the same in your API if you need to handle the charset in a generic way.
+
+## Range Results
+
+Play supports part of [RFC 7233](https://tools.ietf.org/html/rfc7233) which defines how range requests and partial responses works. It enables you to delivery a `206 Partial Content` if a satisfiable `Range` header is present in the request. It will also returns a `Accept-Ranges: bytes` for the delivered `Result`.
+
+> **Note:** Besides the fact that some parsing is done to better handle multiple ranges, `multipart/byteranges` is not fully supported yet.
+
+Range results can be generated for a `Source`, `InputStream`, File, and `Path`. See [`RangeResult`](api/scala/play/api/mvc/RangeResult$.html) API documentation for see all the methods available. For example:
+
+@[range-result-input-stream](code/ScalaResults.scala)
+
+Or for an `Source`:
+
+@[range-result-source](code/ScalaResults.scala)
+
+When the request `Range` is not satisfiable, for example, if the range in the request's `Range` header field do not overlap the current extent of the selected resource, then a HTTP status `416` (Range Not Satisfiable) is returned.
+
+It is also possible to pre-seek for a specific position of the `Source` to more efficiently deliver range results. To do that, you can provide a function where the pre-seek happens:
+
+@[range-result-source-with-offset](code/ScalaResults.scala)


### PR DESCRIPTION
Apologies that this does not yet include a Java API change or documentation - I will squash that in once someone's had a look to make sure this approach looks sane.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

When requesting the very end of a very large file, it can be inefficient to open a file at the start and drop N bytes. This is even more true for data backed by an HTTP API such as S3, where having to download the entire file to serve the last few bytes is extremely inefficient. This allows Source providers to seek directly to the start of the requested range.

## Background Context

Our application stores files in a Swift deployment, and needs to efficiently serve range requests.

By the time ByteStrings are being processed an HTTP response will have already begun, making it too late to implement preseeking at this stage. I've only added a new overload - existing method overloads remain the same.

I don't know what people's opinions are on having the function return a (Long, Source) tuple - would it be worth a case class for clarity? I went with passing just the Long offset around rather than a range object as those are all currently package private and I think exposing those would constitute a larger API change.
