### PR TITLE
Avoid gzip buffer overflow when dealing with big file.

### DIFF
--- a/core/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
@@ -40,7 +40,7 @@ object GzipFlow {
 
       setHandler(out, new OutHandler {
         override def onPull(): Unit = {
-          if (isClosed(in)) emitChunk()
+          if (buffer.length >= chunkSize || isClosed(in)) emitChunk()
           else pull(in)
         }
       })


### PR DESCRIPTION
Polling more data than `chunkSize` on each `onPush` fill the `buffer` faster than it gets emptied. This situation gets worse when `chunkSize` is small.
If the buffer contains more than `Int.Max` element a `ByteString` with negative size is produced leading to obvious error downflow. 


The error produces downflow :
```
a.a.RepointableActorRef - Error in stage [akka.stream.impl.io.compression.CompressionUtils$$anon$1@685b613b]: null
java.lang.NegativeArraySizeException: null
	at scala.reflect.ManifestFactory$ByteManifest.newArray(Manifest.scala:93)
	at scala.reflect.ManifestFactory$ByteManifest.newArray(Manifest.scala:91)
	at akka.util.ByteIterator.toArray(ByteIterator.scala:464)
	at akka.util.ByteString.toArray(ByteString.scala:729)
	at akka.stream.impl.io.compression.GzipCompressor.updateCrc(GzipCompressor.scala:27)
	at akka.stream.impl.io.compression.GzipCompressor.compressWithBuffer(GzipCompressor.scala:20)
	at akka.stream.impl.io.compression.DeflateCompressor.compressAndFlush(DeflateCompressor.scala:23)
	at akka.stream.impl.io.compression.CompressionUtils$$anon$1$$anon$2.onPush(CompressionUtils.scala:27)
	at akka.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter.scala:519)
	at akka.stream.impl.fusing.GraphInterpreter.execute(GraphInterpreter.scala:411)
	at akka.stream.impl.fusing.GraphInterpreterShell.runBatch(ActorGraphInterpreter.scala:588)
	at akka.stream.impl.fusing.ActorGraphInterpreter$SimpleBoundaryEvent.execute(ActorGraphInterpreter.scala:45)
	at akka.stream.impl.fusing.ActorGraphInterpreter$SimpleBoundaryEvent.execute$(ActorGraphInterpreter.scala:41)
	at akka.stream.impl.fusing.ActorGraphInterpreter$BatchingActorInputBoundary$OnNext.execute(ActorGraphInterpreter.scala:78)
	at akka.stream.impl.fusing.GraphInterpreterShell.processEvent(ActorGraphInterpreter.scala:563)
	at akka.stream.impl.fusing.ActorGraphInterpreter.akka$stream$impl$fusing$ActorGraphInterpreter$$processEvent(ActorGraphInterpreter.scala:745)
	at akka.stream.impl.fusing.ActorGraphInterpreter$$anonfun$receive$1.applyOrElse(ActorGraphInterpreter.scala:760)
	at akka.actor.Actor.aroundReceive(Actor.scala:517)
	at akka.actor.Actor.aroundReceive$(Actor.scala:515)
	at akka.stream.impl.fusing.ActorGraphInterpreter.aroundReceive(ActorGraphInterpreter.scala:670)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:588)
	at akka.actor.ActorCell.invoke(ActorCell.scala:557)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:258)
	at akka.dispatch.Mailbox.run(Mailbox.scala:225)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:235)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

To avoid this situation a pull is made only if there is not enough data for the next chunk. It also keeps `buffer` memory consumption low. ( < chunkSize vs >2GB )

Another obvious solution to avoid this error is to have a `chunkSize` superior to input data, which can be hard to determine and could affect gzip chunk efficiency.
