### PR TITLE
Fix doc compilation using GraalVM

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -6,9 +6,8 @@ import com.typesafe.play.docs.sbtplugin.Imports._
 import com.typesafe.play.docs.sbtplugin._
 import com.typesafe.play.sbt.enhancer.PlayEnhancer
 import play.core.PlayVersion
-import sbt._
-import akka.JavaVersion
-import akka.CrossJava
+import playbuild.JavaVersion
+import playbuild.CrossJava
 
 val DocsApplication = config("docs").hide
 
@@ -24,7 +23,10 @@ lazy val main = Project("Play-Documentation", file("."))
       "-parameters",
       "-Xlint:unchecked",
       "-Xlint:deprecation",
-    ) ++ JavaVersion.sourceAndTarget(CrossJava.Keys.fullJavaHomes.value("8")),
+    ) ++ {
+      val javaHomes = fullJavaHomes.value
+      JavaVersion.sourceAndTarget(javaHomes.get("8").orElse(javaHomes.get("system@8")))
+    },
     ivyConfigurations += DocsApplication,
     // We need to publishLocal playDocs since its jar file is
     // a dependency of `docsJarFile` setting.


### PR DESCRIPTION
With the previous setup I was getting an exception because my
`fullJavaHomes` doesn't have an entry for "8".  This is because the
discovery that sbt does to set `fullJavaHomes` is very flaky, so I added
a fallback of using "system@8" as the key for the Java 8 home (a naming
convention in Jabba that sbt "discovers").

But then I also changed `sourceAndTarget` so it just ignores the
possibly-missing Java home if on JDK 8 already.

I also cleaned up a bit: deleted the unused crossJavaSettings, deleted
the duplicate keys that are in sbt proper, and I changed the package to
`playbuild` as this isn't Akka (and this code isn't part of Play, it's
part of Play's build).