### PR TITLE
Add onClose callback to Java's sendFile/Path/Resource methods

### DIFF
--- a/core/play/src/main/java/play/mvc/StatusHeader.java
+++ b/core/play/src/main/java/play/mvc/StatusHeader.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 
 import akka.stream.javadsl.FileIO;
 import akka.stream.javadsl.Source;
@@ -105,7 +106,22 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(String resourceName) {
-    return sendResource(resourceName, StaticFileMimeTypes.fileMimeTypes());
+    return sendResource(resourceName, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(String resourceName, Runnable onClose, Executor executor) {
+    return sendResource(resourceName, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -118,7 +134,24 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(String resourceName, FileMimeTypes fileMimeTypes) {
-    return sendResource(resourceName, DEFAULT_INLINE_MODE, fileMimeTypes);
+    return sendResource(resourceName, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName, FileMimeTypes fileMimeTypes, Runnable onClose, Executor executor) {
+    return sendResource(resourceName, DEFAULT_INLINE_MODE, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -129,7 +162,23 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(String resourceName, ClassLoader classLoader) {
-    return sendResource(resourceName, classLoader, StaticFileMimeTypes.fileMimeTypes());
+    return sendResource(resourceName, classLoader, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName, ClassLoader classLoader, Runnable onClose, Executor executor) {
+    return sendResource(
+        resourceName, classLoader, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -141,7 +190,33 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(String resourceName, ClassLoader classLoader, String fileName) {
-    return sendResource(resourceName, classLoader, fileName, StaticFileMimeTypes.fileMimeTypes());
+    return sendResource(resourceName, classLoader, fileName, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param fileName The file name of the resource.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName,
+      ClassLoader classLoader,
+      String fileName,
+      Runnable onClose,
+      Executor executor) {
+    return sendResource(
+        resourceName,
+        classLoader,
+        fileName,
+        StaticFileMimeTypes.fileMimeTypes(),
+        onClose,
+        executor);
   }
 
   /**
@@ -155,7 +230,30 @@ public class StatusHeader extends Result {
    */
   public Result sendResource(
       String resourceName, ClassLoader classLoader, String fileName, FileMimeTypes fileMimeTypes) {
-    return sendResource(resourceName, classLoader, DEFAULT_INLINE_MODE, fileName, fileMimeTypes);
+    return sendResource(resourceName, classLoader, fileName, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param fileName The file name of the resource.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName,
+      ClassLoader classLoader,
+      String fileName,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
+    return sendResource(
+        resourceName, classLoader, DEFAULT_INLINE_MODE, fileName, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -168,7 +266,28 @@ public class StatusHeader extends Result {
    */
   public Result sendResource(
       String resourceName, ClassLoader classLoader, FileMimeTypes fileMimeTypes) {
-    return sendResource(resourceName, classLoader, DEFAULT_INLINE_MODE, fileMimeTypes);
+    return sendResource(resourceName, classLoader, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName,
+      ClassLoader classLoader,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
+    return sendResource(
+        resourceName, classLoader, DEFAULT_INLINE_MODE, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -181,7 +300,25 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(String resourceName, String fileName) {
-    return sendResource(resourceName, fileName, StaticFileMimeTypes.fileMimeTypes());
+    return sendResource(resourceName, fileName, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param fileName The file name of the resource.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName, String fileName, Runnable onClose, Executor executor) {
+    return sendResource(
+        resourceName, fileName, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -195,7 +332,30 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(String resourceName, String fileName, FileMimeTypes fileMimeTypes) {
-    return sendResource(resourceName, DEFAULT_INLINE_MODE, fileName, fileMimeTypes);
+    return sendResource(resourceName, fileName, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param fileName The file name of the resource.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName,
+      String fileName,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
+    return sendResource(
+        resourceName, DEFAULT_INLINE_MODE, fileName, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -208,7 +368,25 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(String resourceName, boolean inline) {
-    return sendResource(resourceName, inline, StaticFileMimeTypes.fileMimeTypes());
+    return sendResource(resourceName, inline, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName, boolean inline, Runnable onClose, Executor executor) {
+    return sendResource(
+        resourceName, inline, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -222,7 +400,30 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(String resourceName, boolean inline, FileMimeTypes fileMimeTypes) {
-    return sendResource(resourceName, this.getClass().getClassLoader(), inline, fileMimeTypes);
+    return sendResource(resourceName, inline, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body with in-line content disposition.
+   */
+  public Result sendResource(
+      String resourceName,
+      boolean inline,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
+    return sendResource(
+        resourceName, this.getClass().getClassLoader(), inline, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -234,7 +435,28 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body.
    */
   public Result sendResource(String resourceName, ClassLoader classLoader, boolean inline) {
-    return sendResource(resourceName, classLoader, inline, StaticFileMimeTypes.fileMimeTypes());
+    return sendResource(resourceName, classLoader, inline, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName,
+      ClassLoader classLoader,
+      boolean inline,
+      Runnable onClose,
+      Executor executor) {
+    return sendResource(
+        resourceName, classLoader, inline, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -248,7 +470,30 @@ public class StatusHeader extends Result {
    */
   public Result sendResource(
       String resourceName, ClassLoader classLoader, boolean inline, FileMimeTypes fileMimeTypes) {
-    return sendResource(resourceName, classLoader, inline, resourceName, fileMimeTypes);
+    return sendResource(resourceName, classLoader, inline, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName,
+      ClassLoader classLoader,
+      boolean inline,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
+    return sendResource(
+        resourceName, classLoader, inline, resourceName, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -262,7 +507,26 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body.
    */
   public Result sendResource(String resourceName, boolean inline, String filename) {
-    return sendResource(resourceName, inline, filename, StaticFileMimeTypes.fileMimeTypes());
+    return sendResource(resourceName, inline, filename, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the resource.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName, boolean inline, String filename, Runnable onClose, Executor executor) {
+    return sendResource(
+        resourceName, inline, filename, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -278,8 +542,38 @@ public class StatusHeader extends Result {
    */
   public Result sendResource(
       String resourceName, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return sendResource(resourceName, inline, filename, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the resource.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName,
+      boolean inline,
+      String filename,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
     return sendResource(
-        resourceName, this.getClass().getClassLoader(), inline, filename, fileMimeTypes);
+        resourceName,
+        this.getClass().getClassLoader(),
+        inline,
+        filename,
+        fileMimeTypes,
+        onClose,
+        executor);
   }
 
   /**
@@ -293,9 +587,38 @@ public class StatusHeader extends Result {
    */
   public Result sendResource(
       String resourceName, ClassLoader classLoader, boolean inline, String filename) {
-    return sendResource(
-        resourceName, classLoader, inline, filename, StaticFileMimeTypes.fileMimeTypes());
+    return sendResource(resourceName, classLoader, inline, filename, () -> {}, null);
   }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the resource.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName,
+      ClassLoader classLoader,
+      boolean inline,
+      String filename,
+      Runnable onClose,
+      Executor executor) {
+    return sendResource(
+        resourceName,
+        classLoader,
+        inline,
+        filename,
+        StaticFileMimeTypes.fileMimeTypes(),
+        onClose,
+        executor);
+  }
+
   /**
    * Send the given resource from the given classloader.
    *
@@ -312,8 +635,37 @@ public class StatusHeader extends Result {
       boolean inline,
       String filename,
       FileMimeTypes fileMimeTypes) {
+    return sendResource(resourceName, classLoader, inline, filename, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the resource.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName,
+      ClassLoader classLoader,
+      boolean inline,
+      String filename,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
     return doSendResource(
-        StreamConverters.fromInputStream(() -> classLoader.getResourceAsStream(resourceName)),
+        StreamConverters.fromInputStream(() -> classLoader.getResourceAsStream(resourceName))
+            .mapMaterializedValue(
+                cs ->
+                    executor != null
+                        ? cs.whenCompleteAsync((ioResult, exception) -> onClose.run(), executor)
+                        : cs.whenCompleteAsync((ioResult, exception) -> onClose.run())),
         Optional.empty(),
         Optional.ofNullable(filename),
         inline,
@@ -328,7 +680,21 @@ public class StatusHeader extends Result {
    *     disposition.
    */
   public Result sendPath(Path path) {
-    return sendPath(path, StaticFileMimeTypes.fileMimeTypes());
+    return sendPath(path, () -> {}, null);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+   *
+   * @param path The path to send.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file at the provided path with inline content
+   *     disposition.
+   */
+  public Result sendPath(Path path, Runnable onClose, Executor executor) {
+    return sendPath(path, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -340,7 +706,23 @@ public class StatusHeader extends Result {
    *     disposition.
    */
   public Result sendPath(Path path, FileMimeTypes fileMimeTypes) {
-    return sendPath(path, DEFAULT_INLINE_MODE, fileMimeTypes);
+    return sendPath(path, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+   *
+   * @param path The path to send.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file at the provided path with inline content
+   *     disposition.
+   */
+  public Result sendPath(
+      Path path, FileMimeTypes fileMimeTypes, Runnable onClose, Executor executor) {
+    return sendPath(path, DEFAULT_INLINE_MODE, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -351,7 +733,21 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file at the provided path
    */
   public Result sendPath(Path path, boolean inline) {
-    return sendPath(path, inline, StaticFileMimeTypes.fileMimeTypes());
+    return sendPath(path, inline, () -> {}, null);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+   *
+   * @param path The path to send.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(Path path, boolean inline, Runnable onClose, Executor executor) {
+    return sendPath(path, inline, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -363,7 +759,23 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file at the provided path
    */
   public Result sendPath(Path path, boolean inline, FileMimeTypes fileMimeTypes) {
-    return sendPath(path, inline, path.getFileName().toString(), fileMimeTypes);
+    return sendPath(path, inline, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+   *
+   * @param path The path to send.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(
+      Path path, boolean inline, FileMimeTypes fileMimeTypes, Runnable onClose, Executor executor) {
+    return sendPath(path, inline, path.getFileName().toString(), fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -374,7 +786,21 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file at the provided path
    */
   public Result sendPath(Path path, String filename) {
-    return sendPath(path, filename, StaticFileMimeTypes.fileMimeTypes());
+    return sendPath(path, filename, () -> {}, null);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+   *
+   * @param path The path to send.
+   * @param filename The file name of the path.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(Path path, String filename, Runnable onClose, Executor executor) {
+    return sendPath(path, filename, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -386,7 +812,27 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file at the provided path
    */
   public Result sendPath(Path path, String filename, FileMimeTypes fileMimeTypes) {
-    return sendPath(path, DEFAULT_INLINE_MODE, filename, fileMimeTypes);
+    return sendPath(path, filename, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+   *
+   * @param path The path to send.
+   * @param filename The file name of the path.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(
+      Path path,
+      String filename,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
+    return sendPath(path, DEFAULT_INLINE_MODE, filename, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -398,7 +844,23 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file at the provided path
    */
   public Result sendPath(Path path, boolean inline, String filename) {
-    return sendPath(path, inline, filename, StaticFileMimeTypes.fileMimeTypes());
+    return sendPath(path, inline, filename, () -> {}, null);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions
+   *
+   * @param path The path to send.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the path.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(
+      Path path, boolean inline, String filename, Runnable onClose, Executor executor) {
+    return sendPath(path, inline, filename, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -411,12 +873,39 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file at the provided path
    */
   public Result sendPath(Path path, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return sendPath(path, inline, filename, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions
+   *
+   * @param path The path to send.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the path.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(
+      Path path,
+      boolean inline,
+      String filename,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
     if (path == null) {
       throw new NullPointerException("null content");
     }
     try {
       return doSendResource(
-          FileIO.fromPath(path),
+          FileIO.fromPath(path)
+              .mapMaterializedValue(
+                  cs ->
+                      executor != null
+                          ? cs.whenCompleteAsync((ioResult, exception) -> onClose.run(), executor)
+                          : cs.whenCompleteAsync((ioResult, exception) -> onClose.run())),
           Optional.of(Files.size(path)),
           Optional.ofNullable(filename),
           inline,
@@ -433,7 +922,20 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file.
    */
   public Result sendFile(File file) {
-    return sendFile(file, StaticFileMimeTypes.fileMimeTypes());
+    return sendFile(file, () -> {}, null);
+  }
+
+  /**
+   * Sends the given file using the default inline mode.
+   *
+   * @param file The file to send.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file.
+   */
+  public Result sendFile(File file, Runnable onClose, Executor executor) {
+    return sendFile(file, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -444,7 +946,22 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file.
    */
   public Result sendFile(File file, FileMimeTypes fileMimeTypes) {
-    return sendFile(file, DEFAULT_INLINE_MODE, fileMimeTypes);
+    return sendFile(file, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Sends the given file using the default inline mode.
+   *
+   * @param file The file to send.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file.
+   */
+  public Result sendFile(
+      File file, FileMimeTypes fileMimeTypes, Runnable onClose, Executor executor) {
+    return sendFile(file, DEFAULT_INLINE_MODE, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -456,7 +973,22 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file
    */
   public Result sendFile(File file, boolean inline) {
-    return sendFile(file, inline, StaticFileMimeTypes.fileMimeTypes());
+    return sendFile(file, inline, () -> {}, null);
+  }
+
+  /**
+   * Sends the given file.
+   *
+   * @param file The file to send.
+   * @param inline True if the file should be sent inline, false if it should be sent as an
+   *     attachment.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(File file, boolean inline, Runnable onClose, Executor executor) {
+    return sendFile(file, inline, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -469,10 +1001,27 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file
    */
   public Result sendFile(File file, boolean inline, FileMimeTypes fileMimeTypes) {
+    return sendFile(file, inline, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Sends the given file.
+   *
+   * @param file The file to send.
+   * @param inline True if the file should be sent inline, false if it should be sent as an
+   *     attachment.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(
+      File file, boolean inline, FileMimeTypes fileMimeTypes, Runnable onClose, Executor executor) {
     if (file == null) {
       throw new NullPointerException("null file");
     }
-    return sendFile(file, inline, file.getName(), fileMimeTypes);
+    return sendFile(file, inline, file.getName(), fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -483,7 +1032,21 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file
    */
   public Result sendFile(File file, String fileName) {
-    return sendFile(file, fileName, StaticFileMimeTypes.fileMimeTypes());
+    return sendFile(file, fileName, () -> {}, null);
+  }
+
+  /**
+   * Send the given file.
+   *
+   * @param file The file to send.
+   * @param fileName The name of the attachment
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(File file, String fileName, Runnable onClose, Executor executor) {
+    return sendFile(file, fileName, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -495,7 +1058,27 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file
    */
   public Result sendFile(File file, String fileName, FileMimeTypes fileMimeTypes) {
-    return sendFile(file, DEFAULT_INLINE_MODE, fileName, fileMimeTypes);
+    return sendFile(file, fileName, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given file.
+   *
+   * @param file The file to send.
+   * @param fileName The name of the attachment
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(
+      File file,
+      String fileName,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
+    return sendFile(file, DEFAULT_INLINE_MODE, fileName, fileMimeTypes, onClose, executor);
   }
 
   /**
@@ -508,7 +1091,24 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file
    */
   public Result sendFile(File file, boolean inline, String fileName) {
-    return sendFile(file, inline, fileName, StaticFileMimeTypes.fileMimeTypes());
+    return sendFile(file, inline, fileName, () -> {}, null);
+  }
+
+  /**
+   * Send the given file.
+   *
+   * @param file The file to send.
+   * @param fileName The name of the attachment
+   * @param inline True if the file should be sent inline, false if it should be sent as an
+   *     attachment.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(
+      File file, boolean inline, String fileName, Runnable onClose, Executor executor) {
+    return sendFile(file, inline, fileName, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
   /**
@@ -522,12 +1122,40 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file
    */
   public Result sendFile(File file, boolean inline, String fileName, FileMimeTypes fileMimeTypes) {
+    return sendFile(file, inline, fileName, fileMimeTypes, () -> {}, null);
+  }
+
+  /**
+   * Send the given file.
+   *
+   * @param file The file to send.
+   * @param fileName The name of the attachment
+   * @param inline True if the file should be sent inline, false if it should be sent as an
+   *     attachment.
+   * @param fileMimeTypes Used for file type mapping.
+   * @param onClose Useful in order to perform cleanup operations (e.g. deleting a temporary file
+   *     generated for a download).
+   * @param executor The executor to use for asynchronous execution of {@code onClose}.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(
+      File file,
+      boolean inline,
+      String fileName,
+      FileMimeTypes fileMimeTypes,
+      Runnable onClose,
+      Executor executor) {
     if (file == null) {
       throw new NullPointerException("null file");
     }
     try {
       return doSendResource(
-          FileIO.fromPath(file.toPath()),
+          FileIO.fromPath(file.toPath())
+              .mapMaterializedValue(
+                  cs ->
+                      executor != null
+                          ? cs.whenCompleteAsync((ioResult, exception) -> onClose.run(), executor)
+                          : cs.whenCompleteAsync((ioResult, exception) -> onClose.run())),
           Optional.of(Files.size(file.toPath())),
           Optional.ofNullable(fileName),
           inline,

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -117,7 +117,7 @@ class ScalaTestingWebServiceClients extends Specification {
           override def router: Router = Router.from {
             case GET(p"/repositories") =>
               Action { req =>
-                Results.Ok.sendResource("github/repositories.json")(fileMimeTypes)
+                Results.Ok.sendResource("github/repositories.json")(executionContext, fileMimeTypes)
               }
           }
         }.application
@@ -142,7 +142,7 @@ class ScalaTestingWebServiceClients extends Specification {
             override def router: Router = Router.from {
               case GET(p"/repositories") =>
                 Action { req =>
-                  Results.Ok.sendResource("github/repositories.json")(fileMimeTypes)
+                  Results.Ok.sendResource("github/repositories.json")(executionContext, fileMimeTypes)
                 }
             }
           }.application


### PR DESCRIPTION
The Scala API has the same since a very long time already: #203, even though [it was broken](https://github.com/playframework/playframework/issues/6351) for a while, but eventually got fixed again: #6362

Besides of overloading all the `sendFile`, `sendPath` and `sendResouce` methods in the Java API, so every existing method has a variant that takes `..., Runnable onClose, Executor executor`, I also added two more tests to the Scala API ones (also the `sendResource` method in Scala was lacking the feature, so I just added it).