### PR TITLE
Reuse the compiler bridges in the user's boot dir

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -580,6 +580,7 @@ object BuildSettings {
   def playScriptedSettings: Seq[Setting[_]] = Seq(
     ScriptedImport.scripted := ScriptedImport.scripted.tag(Tags.Test).evaluated,
     ScriptedImport.scriptedLaunchOpts ++= Seq(
+      s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
       "-Xmx512m",
       "-XX:MaxMetaspaceSize=512m",
       "-Dscala.version=" + sys.props


### PR DESCRIPTION
This should speed-up the scripted tests, by ~9s each.  So at 31 scripted
tests that's ~4m39s saved each time.

For context: by default scripted will give each scripted test an
isolated sbt "global directory", which by default is ~/.sbt.  This is
(sometimes) great for sbt's own tests, to avoid existing file state from
hiding the introduction of bugs, when developing sbt.

But when developing a plugin it's entirely wasteful.
Let's reuse the user's ("global") boot directory.

I tried using something more indirect, re-using sbt's own settings
and/or API.  But that turned out to be hard (e.g. can't access
state.value in scriptedLaunchOpts, because its a task in a setting) and
mostly unnecessary (turns out that sbt doesn't use the
scalaProvider.launcher.bootDirectory, like it should... -.-), so just
re-build the default.