### PR TITLE
Break play+omnidoc's circular dependency

### DIFF
--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -28,7 +28,7 @@ object Imports {
     val manualPath = SettingKey[File]("playDocsManualPath", "The location of the manual", KeyRanks.CSetting)
     val docsVersion =
       SettingKey[String]("playDocsVersion", "The version of the documentation to fallback to.", KeyRanks.ASetting)
-    val docsName    = SettingKey[String]("playDocsName", "The name of the documentation artifact", KeyRanks.BSetting)
+    val docsName    = play.sbt.PlayImport.PlayKeys.playDocsName
     val docsJarFile = TaskKey[Option[File]]("playDocsJarFile", "Optional play docs jar file", KeyRanks.CTask)
     val resources = TaskKey[Seq[PlayDocsResource]](
       "playDocsResources",

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -23,6 +23,7 @@ object PlayService extends AutoPlugin {
 
   val autoImport = PlayImport
 
+  override def globalSettings  = PlaySettings.serviceGlobalSettings
   override def projectSettings = PlaySettings.serviceSettings
 }
 

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -47,6 +47,10 @@ object PlaySettings extends PlaySettingsCompat {
     Classpaths.managedJars(config, (classpathTypes in config).value, update.value)
   }
 
+  lazy val serviceGlobalSettings: Seq[Setting[_]] = Seq(
+    playOmnidoc := false
+  )
+
   // Settings for a Play service (not a web project)
   lazy val serviceSettings = Seq[Setting[_]](
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-encoding", "utf8"),
@@ -66,7 +70,6 @@ object PlaySettings extends PlaySettingsCompat {
     },
     libraryDependencies += "com.typesafe.play" %% "play-test" % play.core.PlayVersion.current % "test",
     ivyConfigurations += DocsApplication,
-    playOmnidoc := !play.core.PlayVersion.current.endsWith("-SNAPSHOT"),
     playDocsName := { if (playOmnidoc.value) "play-omnidoc" else "play-docs" },
     playDocsModule := Some(
       "com.typesafe.play" %% playDocsName.value % play.core.PlayVersion.current % DocsApplication.name

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -164,6 +164,14 @@ Therefore this change should not effect you at all, since all browsers adhere to
 
 If you still want to send this exact header however, you can still do that by using the `withHeader(s)` methods from [`Scala's`](api/scala/play/api/mvc/Result.html#withHeaders\(headers:\(String,String\)*\):play.api.mvc.Result) or [`Java's`](api/java/play/mvc/Result.html#withHeader-java.lang.String-java.lang.String-) `Result` class.
 
+### sbt: The `playOmnidoc` key now defaults to `false`
+
+The Play's sbt plugin key `playOmnidoc`, which used to default to `true` (for non-snapshot version of Play) now
+defaults to `false` (and does so in sbt's `Global` scope).  The impact is that any Play app that previously
+enabled the `PlayDocsPlugin` won't get all the documentation they used when running the app and going to
+`http://localhost:9000/@documentation`.  You can reverse this change by setting `ThisBuild / playOmnidoc :=
+true` in your sbt build.
+
 ## Updated libraries
 
 This section lists significant updates made to our dependencies.


### PR DESCRIPTION
Now non-snapshot Play applications won't depend on play-omnidoc by
default, which means, for example, that our seeds and sample apps won't
break in the interim between a playframework/playframework release and a
playframework/omnidoc release (which has additional dependencies - e.g.
scalatestplus-play).

Fixes #9438