### PR TITLE
File serving methods changed the type of their filename parameters

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -428,7 +428,7 @@ trait ScalaResultsHandlingSpec
           implicit val mimeTypes: FileMimeTypes = new DefaultFileMimeTypes(FileMimeTypesConfiguration())
           Results.Ok.sendFile(
             tempFile.toFile,
-            fileName = _ => "测 试.tmp"
+            fileName = _ => Some("测 试.tmp")
           )
         } { port =>
           val response = BasicHttpClient

--- a/core/play/src/main/java/play/mvc/Results.java
+++ b/core/play/src/main/java/play/mvc/Results.java
@@ -248,9 +248,39 @@ public class Results {
    * @param content the file to send
    * @param fileName the name that the client should receive this file as
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #status(int, File, Optional)}.
    */
+  @Deprecated
   public static Result status(int status, File content, String fileName) {
+    return status(status, content, Optional.ofNullable(fileName));
+  }
+
+  /**
+   * Generates a result.
+   *
+   * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+   * @param content the file to send
+   * @param fileName the name that the client should receive this file as
+   * @return the result
+   */
+  public static Result status(int status, File content, Optional<String> fileName) {
     return status(status, content, fileName, StaticFileMimeTypes.fileMimeTypes());
+  }
+
+  /**
+   * Generates a result.
+   *
+   * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+   * @param content the file to send
+   * @param fileName the name that the client should receive this file as
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #status(int, File, Optional, FileMimeTypes)}.
+   */
+  @Deprecated
+  public static Result status(
+      int status, File content, String fileName, FileMimeTypes fileMimeTypes) {
+    return status(status, content, Optional.ofNullable(fileName), fileMimeTypes);
   }
 
   /**
@@ -263,7 +293,7 @@ public class Results {
    * @return the result
    */
   public static Result status(
-      int status, File content, String fileName, FileMimeTypes fileMimeTypes) {
+      int status, File content, Optional<String> fileName, FileMimeTypes fileMimeTypes) {
     return status(status).sendFile(content, fileName, fileMimeTypes);
   }
 
@@ -276,7 +306,7 @@ public class Results {
    * @param fileName the name that the client should receive this file as
    * @return the result
    */
-  public static Result status(int status, File content, boolean inline, String fileName) {
+  public static Result status(int status, File content, boolean inline, Optional<String> fileName) {
     return status(status).sendFile(content, inline, fileName);
   }
 
@@ -291,7 +321,11 @@ public class Results {
    * @return the result
    */
   public static Result status(
-      int status, File content, boolean inline, String fileName, FileMimeTypes fileMimeTypes) {
+      int status,
+      File content,
+      boolean inline,
+      Optional<String> fileName,
+      FileMimeTypes fileMimeTypes) {
     return status(status).sendFile(content, inline, fileName, fileMimeTypes);
   }
 
@@ -352,7 +386,7 @@ public class Results {
    * @param fileName the name that the client should receive this path as
    * @return the result
    */
-  public static Result status(int status, Path content, String fileName) {
+  public static Result status(int status, Path content, Optional<String> fileName) {
     return status(status, content, fileName, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -366,7 +400,7 @@ public class Results {
    * @return the result
    */
   public static Result status(
-      int status, Path content, String fileName, FileMimeTypes fileMimeTypes) {
+      int status, Path content, Optional<String> fileName, FileMimeTypes fileMimeTypes) {
     return status(status).sendPath(content, fileName, fileMimeTypes);
   }
 
@@ -379,7 +413,7 @@ public class Results {
    * @param fileName the name that the client should receive this path as
    * @return the result
    */
-  public static Result status(int status, Path content, boolean inline, String fileName) {
+  public static Result status(int status, Path content, boolean inline, Optional<String> fileName) {
     return status(status).sendPath(content, inline, fileName);
   }
 
@@ -394,7 +428,11 @@ public class Results {
    * @return the result
    */
   public static Result status(
-      int status, Path content, boolean inline, String fileName, FileMimeTypes fileMimeTypes) {
+      int status,
+      Path content,
+      boolean inline,
+      Optional<String> fileName,
+      FileMimeTypes fileMimeTypes) {
     return status(status).sendPath(content, inline, fileName, fileMimeTypes);
   }
 
@@ -567,8 +605,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #ok(File, Optional)}.
    */
+  @Deprecated
   public static Result ok(File content, String filename) {
+    return ok(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 200 OK result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result ok(File content, Optional<String> filename) {
     return ok(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -579,8 +630,22 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #ok(File, Optional, FileMimeTypes)}.
    */
+  @Deprecated
   public static Result ok(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return ok(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 200 OK result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result ok(File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(OK, content, filename, fileMimeTypes);
   }
 
@@ -592,7 +657,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result ok(File content, boolean inline, String filename) {
+  public static Result ok(File content, boolean inline, Optional<String> filename) {
     return status(OK, content, inline, filename);
   }
 
@@ -606,7 +671,7 @@ public class Results {
    * @return the result
    */
   public static Result ok(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(OK, content, inline, filename, fileMimeTypes);
   }
 
@@ -661,7 +726,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result ok(Path content, String filename) {
+  public static Result ok(Path content, Optional<String> filename) {
     return ok(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -673,7 +738,7 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result ok(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result ok(Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(OK, content, filename, fileMimeTypes);
   }
 
@@ -685,7 +750,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result ok(Path content, boolean inline, String filename) {
+  public static Result ok(Path content, boolean inline, Optional<String> filename) {
     return status(OK, content, inline, filename);
   }
 
@@ -699,7 +764,7 @@ public class Results {
    * @return the result
    */
   public static Result ok(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(OK, content, inline, filename, fileMimeTypes);
   }
 
@@ -857,8 +922,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #created(File, Optional)}.
    */
+  @Deprecated
   public static Result created(File content, String filename) {
+    return created(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 201 Created result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result created(File content, Optional<String> filename) {
     return created(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -869,8 +947,23 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #created(File, Optional, FileMimeTypes)}.
    */
+  @Deprecated
   public static Result created(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return created(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 201 Created result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result created(
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(CREATED, content, filename, fileMimeTypes);
   }
 
@@ -882,7 +975,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result created(File content, boolean inline, String filename) {
+  public static Result created(File content, boolean inline, Optional<String> filename) {
     return status(CREATED, content, inline, filename);
   }
 
@@ -896,7 +989,7 @@ public class Results {
    * @return the result
    */
   public static Result created(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(CREATED, content, inline, filename, fileMimeTypes);
   }
 
@@ -951,7 +1044,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result created(Path content, String filename) {
+  public static Result created(Path content, Optional<String> filename) {
     return created(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -963,7 +1056,8 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result created(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result created(
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(CREATED, content, filename, fileMimeTypes);
   }
 
@@ -975,7 +1069,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result created(Path content, boolean inline, String filename) {
+  public static Result created(Path content, boolean inline, Optional<String> filename) {
     return status(CREATED, content, inline, filename);
   }
 
@@ -989,7 +1083,7 @@ public class Results {
    * @return the result
    */
   public static Result created(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(CREATED, content, inline, filename, fileMimeTypes);
   }
 
@@ -1147,8 +1241,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #badRequest(File, Optional)}.
    */
+  @Deprecated
   public static Result badRequest(File content, String filename) {
+    return badRequest(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 400 Bad Request result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result badRequest(File content, Optional<String> filename) {
     return badRequest(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -1159,8 +1266,23 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #badRequest(File, Optional, FileMimeTypes)}.
    */
+  @Deprecated
   public static Result badRequest(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return badRequest(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 400 Bad Request result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result badRequest(
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(BAD_REQUEST, content, filename, fileMimeTypes);
   }
 
@@ -1172,7 +1294,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result badRequest(File content, boolean inline, String filename) {
+  public static Result badRequest(File content, boolean inline, Optional<String> filename) {
     return status(BAD_REQUEST, content, inline, filename);
   }
 
@@ -1186,7 +1308,7 @@ public class Results {
    * @return the result
    */
   public static Result badRequest(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(BAD_REQUEST, content, inline, filename, fileMimeTypes);
   }
 
@@ -1241,7 +1363,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result badRequest(Path content, String filename) {
+  public static Result badRequest(Path content, Optional<String> filename) {
     return badRequest(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -1253,7 +1375,8 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result badRequest(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result badRequest(
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(BAD_REQUEST, content, filename, fileMimeTypes);
   }
 
@@ -1265,7 +1388,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result badRequest(Path content, boolean inline, String filename) {
+  public static Result badRequest(Path content, boolean inline, Optional<String> filename) {
     return status(BAD_REQUEST, content, inline, filename);
   }
 
@@ -1279,7 +1402,7 @@ public class Results {
    * @return the result
    */
   public static Result badRequest(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(BAD_REQUEST, content, inline, filename, fileMimeTypes);
   }
 
@@ -1437,8 +1560,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #unauthorized(File, Optional)}.
    */
+  @Deprecated
   public static Result unauthorized(File content, String filename) {
+    return unauthorized(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 401 Unauthorized result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result unauthorized(File content, Optional<String> filename) {
     return unauthorized(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -1449,8 +1585,24 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #unauthorized(File, Optional,
+   *     FileMimeTypes)}.
    */
+  @Deprecated
   public static Result unauthorized(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return unauthorized(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 401 Unauthorized result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result unauthorized(
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(UNAUTHORIZED, content, filename, fileMimeTypes);
   }
 
@@ -1462,7 +1614,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result unauthorized(File content, boolean inline, String filename) {
+  public static Result unauthorized(File content, boolean inline, Optional<String> filename) {
     return status(UNAUTHORIZED, content, inline, filename);
   }
 
@@ -1476,7 +1628,7 @@ public class Results {
    * @return the result
    */
   public static Result unauthorized(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(UNAUTHORIZED, content, inline, filename, fileMimeTypes);
   }
 
@@ -1531,7 +1683,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result unauthorized(Path content, String filename) {
+  public static Result unauthorized(Path content, Optional<String> filename) {
     return unauthorized(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -1543,7 +1695,8 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result unauthorized(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result unauthorized(
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(UNAUTHORIZED, content, filename, fileMimeTypes);
   }
 
@@ -1555,7 +1708,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result unauthorized(Path content, boolean inline, String filename) {
+  public static Result unauthorized(Path content, boolean inline, Optional<String> filename) {
     return status(UNAUTHORIZED, content, inline, filename);
   }
 
@@ -1569,7 +1722,7 @@ public class Results {
    * @return the result
    */
   public static Result unauthorized(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(UNAUTHORIZED, content, inline, filename, fileMimeTypes);
   }
 
@@ -1727,8 +1880,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #paymentRequired(File, Optional)}.
    */
+  @Deprecated
   public static Result paymentRequired(File content, String filename) {
+    return paymentRequired(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 402 Payment Required result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result paymentRequired(File content, Optional<String> filename) {
     return paymentRequired(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -1739,8 +1905,24 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #paymentRequired(File, Optional,
+   *     FileMimeTypes)}.
    */
+  @Deprecated
   public static Result paymentRequired(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return paymentRequired(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 402 Payment Required result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result paymentRequired(
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(PAYMENT_REQUIRED, content, filename, fileMimeTypes);
   }
 
@@ -1752,7 +1934,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result paymentRequired(File content, boolean inline, String filename) {
+  public static Result paymentRequired(File content, boolean inline, Optional<String> filename) {
     return status(PAYMENT_REQUIRED, content, inline, filename);
   }
 
@@ -1766,7 +1948,7 @@ public class Results {
    * @return the result
    */
   public static Result paymentRequired(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(PAYMENT_REQUIRED, content, inline, filename, fileMimeTypes);
   }
 
@@ -1821,7 +2003,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result paymentRequired(Path content, String filename) {
+  public static Result paymentRequired(Path content, Optional<String> filename) {
     return paymentRequired(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -1833,7 +2015,8 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result paymentRequired(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result paymentRequired(
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(PAYMENT_REQUIRED, content, filename, fileMimeTypes);
   }
 
@@ -1845,7 +2028,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result paymentRequired(Path content, boolean inline, String filename) {
+  public static Result paymentRequired(Path content, boolean inline, Optional<String> filename) {
     return status(PAYMENT_REQUIRED, content, inline, filename);
   }
 
@@ -1859,7 +2042,7 @@ public class Results {
    * @return the result
    */
   public static Result paymentRequired(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(PAYMENT_REQUIRED, content, inline, filename, fileMimeTypes);
   }
 
@@ -2017,8 +2200,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #forbidden(File, Optional)}.
    */
+  @Deprecated
   public static Result forbidden(File content, String filename) {
+    return forbidden(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 403 Forbidden result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result forbidden(File content, Optional<String> filename) {
     return forbidden(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -2029,8 +2225,23 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #forbidden(File, Optional, FileMimeTypes)}.
    */
+  @Deprecated
   public static Result forbidden(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return forbidden(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 403 Forbidden result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result forbidden(
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(FORBIDDEN, content, filename, fileMimeTypes);
   }
 
@@ -2042,7 +2253,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result forbidden(File content, boolean inline, String filename) {
+  public static Result forbidden(File content, boolean inline, Optional<String> filename) {
     return status(FORBIDDEN, content, inline, filename);
   }
 
@@ -2056,7 +2267,7 @@ public class Results {
    * @return the result
    */
   public static Result forbidden(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(FORBIDDEN, content, inline, filename, fileMimeTypes);
   }
 
@@ -2111,7 +2322,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result forbidden(Path content, String filename) {
+  public static Result forbidden(Path content, Optional<String> filename) {
     return forbidden(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -2123,7 +2334,8 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result forbidden(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result forbidden(
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(FORBIDDEN, content, filename, fileMimeTypes);
   }
 
@@ -2135,7 +2347,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result forbidden(Path content, boolean inline, String filename) {
+  public static Result forbidden(Path content, boolean inline, Optional<String> filename) {
     return status(FORBIDDEN, content, inline, filename);
   }
 
@@ -2149,7 +2361,7 @@ public class Results {
    * @return the result
    */
   public static Result forbidden(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(FORBIDDEN, content, inline, filename, fileMimeTypes);
   }
 
@@ -2307,8 +2519,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #notFound(File, Optional)}.
    */
+  @Deprecated
   public static Result notFound(File content, String filename) {
+    return notFound(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 404 Not Found result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result notFound(File content, Optional<String> filename) {
     return notFound(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -2319,8 +2544,23 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #notFound(File, Optional, FileMimeTypes)}.
    */
+  @Deprecated
   public static Result notFound(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return notFound(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 404 Not Found result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result notFound(
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_FOUND, content, filename, fileMimeTypes);
   }
 
@@ -2332,7 +2572,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result notFound(File content, boolean inline, String filename) {
+  public static Result notFound(File content, boolean inline, Optional<String> filename) {
     return status(NOT_FOUND, content, inline, filename);
   }
 
@@ -2346,7 +2586,7 @@ public class Results {
    * @return the result
    */
   public static Result notFound(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_FOUND, content, inline, filename, fileMimeTypes);
   }
 
@@ -2401,7 +2641,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result notFound(Path content, String filename) {
+  public static Result notFound(Path content, Optional<String> filename) {
     return notFound(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -2413,7 +2653,8 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result notFound(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result notFound(
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_FOUND, content, filename, fileMimeTypes);
   }
 
@@ -2425,7 +2666,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result notFound(Path content, boolean inline, String filename) {
+  public static Result notFound(Path content, boolean inline, Optional<String> filename) {
     return status(NOT_FOUND, content, inline, filename);
   }
 
@@ -2439,7 +2680,7 @@ public class Results {
    * @return the result
    */
   public static Result notFound(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_FOUND, content, inline, filename, fileMimeTypes);
   }
 
@@ -2597,8 +2838,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #notAcceptable(File, Optional)}.
    */
+  @Deprecated
   public static Result notAcceptable(File content, String filename) {
+    return notAcceptable(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 406 Not Acceptable result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result notAcceptable(File content, Optional<String> filename) {
     return notAcceptable(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -2609,8 +2863,24 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #notAcceptable(File, Optional,
+   *     FileMimeTypes)}.
    */
+  @Deprecated
   public static Result notAcceptable(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return notAcceptable(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 406 Not Acceptable result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result notAcceptable(
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_ACCEPTABLE, content, filename, fileMimeTypes);
   }
 
@@ -2622,7 +2892,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result notAcceptable(File content, boolean inline, String filename) {
+  public static Result notAcceptable(File content, boolean inline, Optional<String> filename) {
     return status(NOT_ACCEPTABLE, content, inline, filename);
   }
 
@@ -2636,7 +2906,7 @@ public class Results {
    * @return the result
    */
   public static Result notAcceptable(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_ACCEPTABLE, content, inline, filename, fileMimeTypes);
   }
 
@@ -2691,7 +2961,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result notAcceptable(Path content, String filename) {
+  public static Result notAcceptable(Path content, Optional<String> filename) {
     return notAcceptable(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -2703,7 +2973,8 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result notAcceptable(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result notAcceptable(
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_ACCEPTABLE, content, filename, fileMimeTypes);
   }
 
@@ -2715,7 +2986,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result notAcceptable(Path content, boolean inline, String filename) {
+  public static Result notAcceptable(Path content, boolean inline, Optional<String> filename) {
     return status(NOT_ACCEPTABLE, content, inline, filename);
   }
 
@@ -2729,7 +3000,7 @@ public class Results {
    * @return the result
    */
   public static Result notAcceptable(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NOT_ACCEPTABLE, content, inline, filename, fileMimeTypes);
   }
 
@@ -2888,9 +3159,38 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #unsupportedMediaType(File, Optional)}.
    */
+  @Deprecated
   public static Result unsupportedMediaType(File content, String filename) {
+    return unsupportedMediaType(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 415 Unsupported Media Type result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result unsupportedMediaType(File content, Optional<String> filename) {
     return unsupportedMediaType(content, filename, StaticFileMimeTypes.fileMimeTypes());
+  }
+
+  /**
+   * Generates a 415 Unsupported Media Type result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #unsupportedMediaType(File, Optional,
+   *     FileMimeTypes)}.
+   */
+  @Deprecated
+  public static Result unsupportedMediaType(
+      File content, String filename, FileMimeTypes fileMimeTypes) {
+    return unsupportedMediaType(content, Optional.ofNullable(filename), fileMimeTypes);
   }
 
   /**
@@ -2902,7 +3202,7 @@ public class Results {
    * @return the result
    */
   public static Result unsupportedMediaType(
-      File content, String filename, FileMimeTypes fileMimeTypes) {
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(UNSUPPORTED_MEDIA_TYPE, content, filename, fileMimeTypes);
   }
 
@@ -2914,7 +3214,8 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result unsupportedMediaType(File content, boolean inline, String filename) {
+  public static Result unsupportedMediaType(
+      File content, boolean inline, Optional<String> filename) {
     return status(UNSUPPORTED_MEDIA_TYPE, content, inline, filename);
   }
 
@@ -2928,7 +3229,7 @@ public class Results {
    * @return the result
    */
   public static Result unsupportedMediaType(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(UNSUPPORTED_MEDIA_TYPE, content, inline, filename, fileMimeTypes);
   }
 
@@ -2984,7 +3285,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result unsupportedMediaType(Path content, String filename) {
+  public static Result unsupportedMediaType(Path content, Optional<String> filename) {
     return unsupportedMediaType(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -2997,7 +3298,7 @@ public class Results {
    * @return the result
    */
   public static Result unsupportedMediaType(
-      Path content, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(UNSUPPORTED_MEDIA_TYPE, content, filename, fileMimeTypes);
   }
 
@@ -3009,7 +3310,8 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result unsupportedMediaType(Path content, boolean inline, String filename) {
+  public static Result unsupportedMediaType(
+      Path content, boolean inline, Optional<String> filename) {
     return status(UNSUPPORTED_MEDIA_TYPE, content, inline, filename);
   }
 
@@ -3023,7 +3325,7 @@ public class Results {
    * @return the result
    */
   public static Result unsupportedMediaType(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(UNSUPPORTED_MEDIA_TYPE, content, inline, filename, fileMimeTypes);
   }
 
@@ -3182,9 +3484,38 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #preconditionRequired(File, Optional)}.
    */
+  @Deprecated
   public static Result preconditionRequired(File content, String filename) {
+    return preconditionRequired(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 428 Precondition Required result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result preconditionRequired(File content, Optional<String> filename) {
     return preconditionRequired(content, filename, StaticFileMimeTypes.fileMimeTypes());
+  }
+
+  /**
+   * Generates a 428 Precondition Required result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #preconditionRequired(File, Optional,
+   *     FileMimeTypes)}.
+   */
+  @Deprecated
+  public static Result preconditionRequired(
+      File content, String filename, FileMimeTypes fileMimeTypes) {
+    return preconditionRequired(content, Optional.ofNullable(filename), fileMimeTypes);
   }
 
   /**
@@ -3196,7 +3527,7 @@ public class Results {
    * @return the result
    */
   public static Result preconditionRequired(
-      File content, String filename, FileMimeTypes fileMimeTypes) {
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(PRECONDITION_REQUIRED, content, filename, fileMimeTypes);
   }
 
@@ -3208,7 +3539,8 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result preconditionRequired(File content, boolean inline, String filename) {
+  public static Result preconditionRequired(
+      File content, boolean inline, Optional<String> filename) {
     return status(PRECONDITION_REQUIRED, content, inline, filename);
   }
 
@@ -3222,7 +3554,7 @@ public class Results {
    * @return the result
    */
   public static Result preconditionRequired(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(PRECONDITION_REQUIRED, content, inline, filename, fileMimeTypes);
   }
 
@@ -3278,7 +3610,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result preconditionRequired(Path content, String filename) {
+  public static Result preconditionRequired(Path content, Optional<String> filename) {
     return preconditionRequired(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -3291,7 +3623,7 @@ public class Results {
    * @return the result
    */
   public static Result preconditionRequired(
-      Path content, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(PRECONDITION_REQUIRED, content, filename, fileMimeTypes);
   }
 
@@ -3303,7 +3635,8 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result preconditionRequired(Path content, boolean inline, String filename) {
+  public static Result preconditionRequired(
+      Path content, boolean inline, Optional<String> filename) {
     return status(PRECONDITION_REQUIRED, content, inline, filename);
   }
 
@@ -3317,7 +3650,7 @@ public class Results {
    * @return the result
    */
   public static Result preconditionRequired(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(PRECONDITION_REQUIRED, content, inline, filename, fileMimeTypes);
   }
 
@@ -3475,8 +3808,21 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #tooManyRequests(File, Optional)}.
    */
+  @Deprecated
   public static Result tooManyRequests(File content, String filename) {
+    return tooManyRequests(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 429 Too Many Requests result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result tooManyRequests(File content, Optional<String> filename) {
     return tooManyRequests(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -3487,8 +3833,24 @@ public class Results {
    * @param filename The name to send the file as.
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #tooManyRequests(File, Optional,
+   *     FileMimeTypes)}.
    */
+  @Deprecated
   public static Result tooManyRequests(File content, String filename, FileMimeTypes fileMimeTypes) {
+    return tooManyRequests(content, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Generates a 429 Too Many Requests result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   */
+  public static Result tooManyRequests(
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(TOO_MANY_REQUESTS, content, filename, fileMimeTypes);
   }
 
@@ -3500,7 +3862,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result tooManyRequests(File content, boolean inline, String filename) {
+  public static Result tooManyRequests(File content, boolean inline, Optional<String> filename) {
     return status(TOO_MANY_REQUESTS, content, inline, filename);
   }
 
@@ -3514,7 +3876,7 @@ public class Results {
    * @return the result
    */
   public static Result tooManyRequests(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(TOO_MANY_REQUESTS, content, inline, filename, fileMimeTypes);
   }
 
@@ -3569,7 +3931,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result tooManyRequests(Path content, String filename) {
+  public static Result tooManyRequests(Path content, Optional<String> filename) {
     return tooManyRequests(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -3581,7 +3943,8 @@ public class Results {
    * @param fileMimeTypes Used for file type mapping.
    * @return the result
    */
-  public static Result tooManyRequests(Path content, String filename, FileMimeTypes fileMimeTypes) {
+  public static Result tooManyRequests(
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(TOO_MANY_REQUESTS, content, filename, fileMimeTypes);
   }
 
@@ -3593,7 +3956,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result tooManyRequests(Path content, boolean inline, String filename) {
+  public static Result tooManyRequests(Path content, boolean inline, Optional<String> filename) {
     return status(TOO_MANY_REQUESTS, content, inline, filename);
   }
 
@@ -3607,7 +3970,7 @@ public class Results {
    * @return the result
    */
   public static Result tooManyRequests(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(TOO_MANY_REQUESTS, content, inline, filename, fileMimeTypes);
   }
 
@@ -3766,9 +4129,39 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #requestHeaderFieldsTooLarge(File,
+   *     Optional)}.
    */
+  @Deprecated
   public static Result requestHeaderFieldsTooLarge(File content, String filename) {
+    return requestHeaderFieldsTooLarge(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 431 Request Header Fields Too Large result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result requestHeaderFieldsTooLarge(File content, Optional<String> filename) {
     return requestHeaderFieldsTooLarge(content, filename, StaticFileMimeTypes.fileMimeTypes());
+  }
+
+  /**
+   * Generates a 431 Request Header Fields Too Large result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #requestHeaderFieldsTooLarge(File, Optional,
+   *     FileMimeTypes)}.
+   */
+  @Deprecated
+  public static Result requestHeaderFieldsTooLarge(
+      File content, String filename, FileMimeTypes fileMimeTypes) {
+    return requestHeaderFieldsTooLarge(content, Optional.ofNullable(filename), fileMimeTypes);
   }
 
   /**
@@ -3780,7 +4173,7 @@ public class Results {
    * @return the result
    */
   public static Result requestHeaderFieldsTooLarge(
-      File content, String filename, FileMimeTypes fileMimeTypes) {
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(REQUEST_HEADER_FIELDS_TOO_LARGE, content, filename, fileMimeTypes);
   }
 
@@ -3792,7 +4185,8 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result requestHeaderFieldsTooLarge(File content, boolean inline, String filename) {
+  public static Result requestHeaderFieldsTooLarge(
+      File content, boolean inline, Optional<String> filename) {
     return status(REQUEST_HEADER_FIELDS_TOO_LARGE, content, inline, filename);
   }
 
@@ -3806,7 +4200,7 @@ public class Results {
    * @return the result
    */
   public static Result requestHeaderFieldsTooLarge(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(REQUEST_HEADER_FIELDS_TOO_LARGE, content, inline, filename, fileMimeTypes);
   }
 
@@ -3862,7 +4256,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result requestHeaderFieldsTooLarge(Path content, String filename) {
+  public static Result requestHeaderFieldsTooLarge(Path content, Optional<String> filename) {
     return requestHeaderFieldsTooLarge(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -3875,7 +4269,7 @@ public class Results {
    * @return the result
    */
   public static Result requestHeaderFieldsTooLarge(
-      Path content, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(REQUEST_HEADER_FIELDS_TOO_LARGE, content, filename, fileMimeTypes);
   }
 
@@ -3887,7 +4281,8 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result requestHeaderFieldsTooLarge(Path content, boolean inline, String filename) {
+  public static Result requestHeaderFieldsTooLarge(
+      Path content, boolean inline, Optional<String> filename) {
     return status(REQUEST_HEADER_FIELDS_TOO_LARGE, content, inline, filename);
   }
 
@@ -3901,7 +4296,7 @@ public class Results {
    * @return the result
    */
   public static Result requestHeaderFieldsTooLarge(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(REQUEST_HEADER_FIELDS_TOO_LARGE, content, inline, filename, fileMimeTypes);
   }
 
@@ -4060,9 +4455,38 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #internalServerError(File, Optional)}.
    */
+  @Deprecated
   public static Result internalServerError(File content, String filename) {
+    return internalServerError(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 500 Internal Server Error result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result internalServerError(File content, Optional<String> filename) {
     return internalServerError(content, filename, StaticFileMimeTypes.fileMimeTypes());
+  }
+
+  /**
+   * Generates a 500 Internal Server Error result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #internalServerError(File, Optional,
+   *     FileMimeTypes)}.
+   */
+  @Deprecated
+  public static Result internalServerError(
+      File content, String filename, FileMimeTypes fileMimeTypes) {
+    return internalServerError(content, Optional.ofNullable(filename), fileMimeTypes);
   }
 
   /**
@@ -4074,7 +4498,7 @@ public class Results {
    * @return the result
    */
   public static Result internalServerError(
-      File content, String filename, FileMimeTypes fileMimeTypes) {
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(INTERNAL_SERVER_ERROR, content, filename, fileMimeTypes);
   }
 
@@ -4086,7 +4510,8 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result internalServerError(File content, boolean inline, String filename) {
+  public static Result internalServerError(
+      File content, boolean inline, Optional<String> filename) {
     return status(INTERNAL_SERVER_ERROR, content, inline, filename);
   }
 
@@ -4100,7 +4525,7 @@ public class Results {
    * @return the result
    */
   public static Result internalServerError(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(INTERNAL_SERVER_ERROR, content, inline, filename, fileMimeTypes);
   }
 
@@ -4156,7 +4581,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result internalServerError(Path content, String filename) {
+  public static Result internalServerError(Path content, Optional<String> filename) {
     return internalServerError(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -4169,7 +4594,7 @@ public class Results {
    * @return the result
    */
   public static Result internalServerError(
-      Path content, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(INTERNAL_SERVER_ERROR, content, filename, fileMimeTypes);
   }
 
@@ -4181,7 +4606,8 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result internalServerError(Path content, boolean inline, String filename) {
+  public static Result internalServerError(
+      Path content, boolean inline, Optional<String> filename) {
     return status(INTERNAL_SERVER_ERROR, content, inline, filename);
   }
 
@@ -4195,7 +4621,7 @@ public class Results {
    * @return the result
    */
   public static Result internalServerError(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(INTERNAL_SERVER_ERROR, content, inline, filename, fileMimeTypes);
   }
 
@@ -4354,9 +4780,39 @@ public class Results {
    * @param content The file to send.
    * @param filename The name to send the file as.
    * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #networkAuthenticationRequired(File,
+   *     Optional)}.
    */
+  @Deprecated
   public static Result networkAuthenticationRequired(File content, String filename) {
+    return networkAuthenticationRequired(content, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Generates a 511 Network Authentication Required result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @return the result
+   */
+  public static Result networkAuthenticationRequired(File content, Optional<String> filename) {
     return networkAuthenticationRequired(content, filename, StaticFileMimeTypes.fileMimeTypes());
+  }
+
+  /**
+   * Generates a 511 Network Authentication Required result.
+   *
+   * @param content The file to send.
+   * @param filename The name to send the file as.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return the result
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #networkAuthenticationRequired(File,
+   *     Optional, FileMimeTypes)}.
+   */
+  @Deprecated
+  public static Result networkAuthenticationRequired(
+      File content, String filename, FileMimeTypes fileMimeTypes) {
+    return networkAuthenticationRequired(content, Optional.ofNullable(filename), fileMimeTypes);
   }
 
   /**
@@ -4368,7 +4824,7 @@ public class Results {
    * @return the result
    */
   public static Result networkAuthenticationRequired(
-      File content, String filename, FileMimeTypes fileMimeTypes) {
+      File content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NETWORK_AUTHENTICATION_REQUIRED, content, filename, fileMimeTypes);
   }
 
@@ -4381,7 +4837,7 @@ public class Results {
    * @return the result
    */
   public static Result networkAuthenticationRequired(
-      File content, boolean inline, String filename) {
+      File content, boolean inline, Optional<String> filename) {
     return status(NETWORK_AUTHENTICATION_REQUIRED, content, inline, filename);
   }
 
@@ -4395,7 +4851,7 @@ public class Results {
    * @return the result
    */
   public static Result networkAuthenticationRequired(
-      File content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      File content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NETWORK_AUTHENTICATION_REQUIRED, content, inline, filename, fileMimeTypes);
   }
 
@@ -4451,7 +4907,7 @@ public class Results {
    * @param filename The name to send the file as.
    * @return the result
    */
-  public static Result networkAuthenticationRequired(Path content, String filename) {
+  public static Result networkAuthenticationRequired(Path content, Optional<String> filename) {
     return networkAuthenticationRequired(content, filename, StaticFileMimeTypes.fileMimeTypes());
   }
 
@@ -4464,7 +4920,7 @@ public class Results {
    * @return the result
    */
   public static Result networkAuthenticationRequired(
-      Path content, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NETWORK_AUTHENTICATION_REQUIRED, content, filename, fileMimeTypes);
   }
 
@@ -4477,7 +4933,7 @@ public class Results {
    * @return the result
    */
   public static Result networkAuthenticationRequired(
-      Path content, boolean inline, String filename) {
+      Path content, boolean inline, Optional<String> filename) {
     return status(NETWORK_AUTHENTICATION_REQUIRED, content, inline, filename);
   }
 
@@ -4491,7 +4947,7 @@ public class Results {
    * @return the result
    */
   public static Result networkAuthenticationRequired(
-      Path content, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+      Path content, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return status(NETWORK_AUTHENTICATION_REQUIRED, content, inline, filename, fileMimeTypes);
   }
 

--- a/core/play/src/main/java/play/mvc/StatusHeader.java
+++ b/core/play/src/main/java/play/mvc/StatusHeader.java
@@ -309,7 +309,8 @@ public class StatusHeader extends Result {
    * @param fileName The file name of the resource.
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
-  public Result sendResource(String resourceName, ClassLoader classLoader, String fileName) {
+  public Result sendResource(
+      String resourceName, ClassLoader classLoader, Optional<String> fileName) {
     return sendResource(resourceName, classLoader, fileName, () -> {}, null);
   }
 
@@ -327,7 +328,7 @@ public class StatusHeader extends Result {
   public Result sendResource(
       String resourceName,
       ClassLoader classLoader,
-      String fileName,
+      Optional<String> fileName,
       Runnable onClose,
       Executor executor) {
     return sendResource(
@@ -349,7 +350,10 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(
-      String resourceName, ClassLoader classLoader, String fileName, FileMimeTypes fileMimeTypes) {
+      String resourceName,
+      ClassLoader classLoader,
+      Optional<String> fileName,
+      FileMimeTypes fileMimeTypes) {
     return sendResource(resourceName, classLoader, fileName, fileMimeTypes, () -> {}, null);
   }
 
@@ -368,7 +372,7 @@ public class StatusHeader extends Result {
   public Result sendResource(
       String resourceName,
       ClassLoader classLoader,
-      String fileName,
+      Optional<String> fileName,
       FileMimeTypes fileMimeTypes,
       Runnable onClose,
       Executor executor) {
@@ -419,7 +423,7 @@ public class StatusHeader extends Result {
    * @param fileName The file name of the resource.
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
-  public Result sendResource(String resourceName, String fileName) {
+  public Result sendResource(String resourceName, Optional<String> fileName) {
     return sendResource(resourceName, fileName, () -> {}, null);
   }
 
@@ -436,7 +440,7 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
   public Result sendResource(
-      String resourceName, String fileName, Runnable onClose, Executor executor) {
+      String resourceName, Optional<String> fileName, Runnable onClose, Executor executor) {
     return sendResource(
         resourceName, fileName, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
@@ -451,7 +455,8 @@ public class StatusHeader extends Result {
    * @param fileMimeTypes Used for file type mapping.
    * @return a '200 OK' result containing the resource in the body with in-line content disposition.
    */
-  public Result sendResource(String resourceName, String fileName, FileMimeTypes fileMimeTypes) {
+  public Result sendResource(
+      String resourceName, Optional<String> fileName, FileMimeTypes fileMimeTypes) {
     return sendResource(resourceName, fileName, fileMimeTypes, () -> {}, null);
   }
 
@@ -470,7 +475,7 @@ public class StatusHeader extends Result {
    */
   public Result sendResource(
       String resourceName,
-      String fileName,
+      Optional<String> fileName,
       FileMimeTypes fileMimeTypes,
       Runnable onClose,
       Executor executor) {
@@ -613,7 +618,30 @@ public class StatusHeader extends Result {
       Runnable onClose,
       Executor executor) {
     return sendResource(
-        resourceName, classLoader, inline, resourceName, fileMimeTypes, onClose, executor);
+        resourceName,
+        classLoader,
+        inline,
+        Optional.ofNullable(resourceName),
+        fileMimeTypes,
+        onClose,
+        executor);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the resource.
+   * @return a '200 OK' result containing the resource in the body.
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendResource(String, boolean,
+   *     Optional<String>)}.
+   */
+  @Deprecated
+  public Result sendResource(String resourceName, boolean inline, String filename) {
+    return sendResource(resourceName, inline, Optional.ofNullable(filename));
   }
 
   /**
@@ -626,7 +654,7 @@ public class StatusHeader extends Result {
    * @param filename The file name of the resource.
    * @return a '200 OK' result containing the resource in the body.
    */
-  public Result sendResource(String resourceName, boolean inline, String filename) {
+  public Result sendResource(String resourceName, boolean inline, Optional<String> filename) {
     return sendResource(resourceName, inline, filename, () -> {}, null);
   }
 
@@ -644,7 +672,11 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the resource in the body.
    */
   public Result sendResource(
-      String resourceName, boolean inline, String filename, Runnable onClose, Executor executor) {
+      String resourceName,
+      boolean inline,
+      Optional<String> filename,
+      Runnable onClose,
+      Executor executor) {
     return sendResource(
         resourceName, inline, filename, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
@@ -659,9 +691,28 @@ public class StatusHeader extends Result {
    * @param filename The file name of the resource.
    * @param fileMimeTypes Used for file type mapping.
    * @return a '200 OK' result containing the resource in the body.
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendResource(String, boolean, Optional,
+   *     FileMimeTypes)}.
    */
+  @Deprecated
   public Result sendResource(
       String resourceName, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return sendResource(resourceName, inline, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Send the given resource.
+   *
+   * <p>The resource will be loaded from the same classloader that this class comes from.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the resource.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return sendResource(resourceName, inline, filename, fileMimeTypes, () -> {}, null);
   }
 
@@ -682,7 +733,7 @@ public class StatusHeader extends Result {
   public Result sendResource(
       String resourceName,
       boolean inline,
-      String filename,
+      Optional<String> filename,
       FileMimeTypes fileMimeTypes,
       Runnable onClose,
       Executor executor) {
@@ -704,9 +755,26 @@ public class StatusHeader extends Result {
    * @param inline Whether it should be served as an inline file, or as an attachment.
    * @param filename The file name of the resource.
    * @return a '200 OK' result containing the resource in the body.
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendResource(String, ClassLoader, boolean,
+   *     Optional)}.
    */
+  @Deprecated
   public Result sendResource(
       String resourceName, ClassLoader classLoader, boolean inline, String filename) {
+    return sendResource(resourceName, classLoader, inline, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the resource.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName, ClassLoader classLoader, boolean inline, Optional<String> filename) {
     return sendResource(resourceName, classLoader, inline, filename, () -> {}, null);
   }
 
@@ -726,7 +794,7 @@ public class StatusHeader extends Result {
       String resourceName,
       ClassLoader classLoader,
       boolean inline,
-      String filename,
+      Optional<String> filename,
       Runnable onClose,
       Executor executor) {
     return sendResource(
@@ -748,12 +816,35 @@ public class StatusHeader extends Result {
    * @param filename The file name of the resource.
    * @param fileMimeTypes Used for file type mapping.
    * @return a '200 OK' result containing the resource in the body.
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendResource(String, ClassLoader, boolean,
+   *     Optional, FileMimeTypes)}.
    */
+  @Deprecated
   public Result sendResource(
       String resourceName,
       ClassLoader classLoader,
       boolean inline,
       String filename,
+      FileMimeTypes fileMimeTypes) {
+    return sendResource(
+        resourceName, classLoader, inline, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Send the given resource from the given classloader.
+   *
+   * @param resourceName The path of the resource to load.
+   * @param classLoader The classloader to load it from.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the resource.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return a '200 OK' result containing the resource in the body.
+   */
+  public Result sendResource(
+      String resourceName,
+      ClassLoader classLoader,
+      boolean inline,
+      Optional<String> filename,
       FileMimeTypes fileMimeTypes) {
     return sendResource(resourceName, classLoader, inline, filename, fileMimeTypes, () -> {}, null);
   }
@@ -775,14 +866,14 @@ public class StatusHeader extends Result {
       String resourceName,
       ClassLoader classLoader,
       boolean inline,
-      String filename,
+      Optional<String> filename,
       FileMimeTypes fileMimeTypes,
       Runnable onClose,
       Executor executor) {
     return doSendResource(
         StreamConverters.fromInputStream(() -> classLoader.getResourceAsStream(resourceName)),
         Optional.empty(),
-        Optional.ofNullable(filename),
+        filename,
         inline,
         fileMimeTypes,
         onClose,
@@ -892,7 +983,26 @@ public class StatusHeader extends Result {
    */
   public Result sendPath(
       Path path, boolean inline, FileMimeTypes fileMimeTypes, Runnable onClose, Executor executor) {
-    return sendPath(path, inline, path.getFileName().toString(), fileMimeTypes, onClose, executor);
+    return sendPath(
+        path,
+        inline,
+        Optional.ofNullable(path).map(p -> p.getFileName().toString()),
+        fileMimeTypes,
+        onClose,
+        executor);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+   *
+   * @param path The path to send.
+   * @param filename The file name of the path.
+   * @return a '200 OK' result containing the file at the provided path
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendPath(Path, Optional)}.
+   */
+  @Deprecated
+  public Result sendPath(Path path, String filename) {
+    return sendPath(path, Optional.ofNullable(filename));
   }
 
   /**
@@ -902,7 +1012,7 @@ public class StatusHeader extends Result {
    * @param filename The file name of the path.
    * @return a '200 OK' result containing the file at the provided path
    */
-  public Result sendPath(Path path, String filename) {
+  public Result sendPath(Path path, Optional<String> filename) {
     return sendPath(path, filename, () -> {}, null);
   }
 
@@ -916,7 +1026,8 @@ public class StatusHeader extends Result {
    * @param executor The executor to use for asynchronous execution of {@code onClose}.
    * @return a '200 OK' result containing the file at the provided path
    */
-  public Result sendPath(Path path, String filename, Runnable onClose, Executor executor) {
+  public Result sendPath(
+      Path path, Optional<String> filename, Runnable onClose, Executor executor) {
     return sendPath(path, filename, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
@@ -927,8 +1038,22 @@ public class StatusHeader extends Result {
    * @param filename The file name of the path.
    * @param fileMimeTypes Used for file type mapping.
    * @return a '200 OK' result containing the file at the provided path
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendPath(Path, Optional, FileMimeTypes)}.
    */
+  @Deprecated
   public Result sendPath(Path path, String filename, FileMimeTypes fileMimeTypes) {
+    return sendPath(path, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+   *
+   * @param path The path to send.
+   * @param filename The file name of the path.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(Path path, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return sendPath(path, filename, fileMimeTypes, () -> {}, null);
   }
 
@@ -945,7 +1070,7 @@ public class StatusHeader extends Result {
    */
   public Result sendPath(
       Path path,
-      String filename,
+      Optional<String> filename,
       FileMimeTypes fileMimeTypes,
       Runnable onClose,
       Executor executor) {
@@ -959,8 +1084,22 @@ public class StatusHeader extends Result {
    * @param inline Whether it should be served as an inline file, or as an attachment.
    * @param filename The file name of the path.
    * @return a '200 OK' result containing the file at the provided path
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendPath(Path, boolean, Optional)}.
    */
+  @Deprecated
   public Result sendPath(Path path, boolean inline, String filename) {
+    return sendPath(path, inline, Optional.ofNullable(filename));
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions
+   *
+   * @param path The path to send.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the path.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(Path path, boolean inline, Optional<String> filename) {
     return sendPath(path, inline, filename, () -> {}, null);
   }
 
@@ -976,7 +1115,7 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file at the provided path
    */
   public Result sendPath(
-      Path path, boolean inline, String filename, Runnable onClose, Executor executor) {
+      Path path, boolean inline, Optional<String> filename, Runnable onClose, Executor executor) {
     return sendPath(path, inline, filename, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
@@ -988,8 +1127,25 @@ public class StatusHeader extends Result {
    * @param filename The file name of the path.
    * @param fileMimeTypes Used for file type mapping.
    * @return a '200 OK' result containing the file at the provided path
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendPath(Path, boolean, Optional,
+   *     FileMimeTypes)}.
    */
+  @Deprecated
   public Result sendPath(Path path, boolean inline, String filename, FileMimeTypes fileMimeTypes) {
+    return sendPath(path, inline, Optional.ofNullable(filename), fileMimeTypes);
+  }
+
+  /**
+   * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions
+   *
+   * @param path The path to send.
+   * @param inline Whether it should be served as an inline file, or as an attachment.
+   * @param filename The file name of the path.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return a '200 OK' result containing the file at the provided path
+   */
+  public Result sendPath(
+      Path path, boolean inline, Optional<String> filename, FileMimeTypes fileMimeTypes) {
     return sendPath(path, inline, filename, fileMimeTypes, () -> {}, null);
   }
 
@@ -1008,7 +1164,7 @@ public class StatusHeader extends Result {
   public Result sendPath(
       Path path,
       boolean inline,
-      String filename,
+      Optional<String> filename,
       FileMimeTypes fileMimeTypes,
       Runnable onClose,
       Executor executor) {
@@ -1019,7 +1175,7 @@ public class StatusHeader extends Result {
       return doSendResource(
           FileIO.fromPath(path),
           Optional.of(Files.size(path)),
-          Optional.ofNullable(filename),
+          filename,
           inline,
           fileMimeTypes,
           onClose,
@@ -1135,7 +1291,26 @@ public class StatusHeader extends Result {
     if (file == null) {
       throw new NullPointerException("null file");
     }
-    return sendFile(file, inline, file.getName(), fileMimeTypes, onClose, executor);
+    return sendFile(
+        file,
+        inline,
+        Optional.ofNullable(file).map(f -> f.getName()),
+        fileMimeTypes,
+        onClose,
+        executor);
+  }
+
+  /**
+   * Send the given file.
+   *
+   * @param file The file to send.
+   * @param fileName The name of the attachment
+   * @return a '200 OK' result containing the file
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendFile(File, Optional)}.
+   */
+  @Deprecated
+  public Result sendFile(File file, String fileName) {
+    return sendFile(file, Optional.ofNullable(fileName));
   }
 
   /**
@@ -1145,7 +1320,7 @@ public class StatusHeader extends Result {
    * @param fileName The name of the attachment
    * @return a '200 OK' result containing the file
    */
-  public Result sendFile(File file, String fileName) {
+  public Result sendFile(File file, Optional<String> fileName) {
     return sendFile(file, fileName, () -> {}, null);
   }
 
@@ -1159,7 +1334,8 @@ public class StatusHeader extends Result {
    * @param executor The executor to use for asynchronous execution of {@code onClose}.
    * @return a '200 OK' result containing the file
    */
-  public Result sendFile(File file, String fileName, Runnable onClose, Executor executor) {
+  public Result sendFile(
+      File file, Optional<String> fileName, Runnable onClose, Executor executor) {
     return sendFile(file, fileName, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
@@ -1170,8 +1346,22 @@ public class StatusHeader extends Result {
    * @param fileName The name of the attachment
    * @param fileMimeTypes Used for file type mapping.
    * @return a '200 OK' result containing the file
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendFile(File, Optional, FileMimeTypes)}.
    */
+  @Deprecated
   public Result sendFile(File file, String fileName, FileMimeTypes fileMimeTypes) {
+    return sendFile(file, Optional.ofNullable(fileName), fileMimeTypes);
+  }
+
+  /**
+   * Send the given file.
+   *
+   * @param file The file to send.
+   * @param fileName The name of the attachment
+   * @param fileMimeTypes Used for file type mapping.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(File file, Optional<String> fileName, FileMimeTypes fileMimeTypes) {
     return sendFile(file, fileName, fileMimeTypes, () -> {}, null);
   }
 
@@ -1188,7 +1378,7 @@ public class StatusHeader extends Result {
    */
   public Result sendFile(
       File file,
-      String fileName,
+      Optional<String> fileName,
       FileMimeTypes fileMimeTypes,
       Runnable onClose,
       Executor executor) {
@@ -1203,8 +1393,23 @@ public class StatusHeader extends Result {
    * @param inline True if the file should be sent inline, false if it should be sent as an
    *     attachment.
    * @return a '200 OK' result containing the file
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendFile(File, boolean, Optional)}.
    */
+  @Deprecated
   public Result sendFile(File file, boolean inline, String fileName) {
+    return sendFile(file, inline, Optional.ofNullable(fileName));
+  }
+
+  /**
+   * Send the given file.
+   *
+   * @param file The file to send.
+   * @param fileName The name of the attachment
+   * @param inline True if the file should be sent inline, false if it should be sent as an
+   *     attachment.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(File file, boolean inline, Optional<String> fileName) {
     return sendFile(file, inline, fileName, () -> {}, null);
   }
 
@@ -1221,7 +1426,7 @@ public class StatusHeader extends Result {
    * @return a '200 OK' result containing the file
    */
   public Result sendFile(
-      File file, boolean inline, String fileName, Runnable onClose, Executor executor) {
+      File file, boolean inline, Optional<String> fileName, Runnable onClose, Executor executor) {
     return sendFile(file, inline, fileName, StaticFileMimeTypes.fileMimeTypes(), onClose, executor);
   }
 
@@ -1234,8 +1439,26 @@ public class StatusHeader extends Result {
    *     attachment.
    * @param fileMimeTypes Used for file type mapping.
    * @return a '200 OK' result containing the file
+   * @deprecated Deprecated as of 2.8.0. Use to {@link #sendFile(File, boolean, Optional,
+   *     FileMimeTypes)}.
    */
+  @Deprecated
   public Result sendFile(File file, boolean inline, String fileName, FileMimeTypes fileMimeTypes) {
+    return sendFile(file, inline, Optional.ofNullable(fileName), fileMimeTypes);
+  }
+
+  /**
+   * Send the given file.
+   *
+   * @param file The file to send.
+   * @param fileName The name of the attachment
+   * @param inline True if the file should be sent inline, false if it should be sent as an
+   *     attachment.
+   * @param fileMimeTypes Used for file type mapping.
+   * @return a '200 OK' result containing the file
+   */
+  public Result sendFile(
+      File file, boolean inline, Optional<String> fileName, FileMimeTypes fileMimeTypes) {
     return sendFile(file, inline, fileName, fileMimeTypes, () -> {}, null);
   }
 
@@ -1255,7 +1478,7 @@ public class StatusHeader extends Result {
   public Result sendFile(
       File file,
       boolean inline,
-      String fileName,
+      Optional<String> fileName,
       FileMimeTypes fileMimeTypes,
       Runnable onClose,
       Executor executor) {
@@ -1266,7 +1489,7 @@ public class StatusHeader extends Result {
       return doSendResource(
           FileIO.fromPath(file.toPath()),
           Optional.of(Files.size(file.toPath())),
-          Optional.ofNullable(fileName),
+          fileName,
           inline,
           fileMimeTypes,
           onClose,

--- a/core/play/src/test/java/play/mvc/ResultsTest.java
+++ b/core/play/src/test/java/play/mvc/ResultsTest.java
@@ -125,7 +125,7 @@ public class ResultsTest {
 
   @Test
   public void sendPathWithFileName() throws IOException {
-    Result result = Results.unauthorized().sendPath(file, "foo.bar");
+    Result result = Results.unauthorized().sendPath(file, Optional.of("foo.bar"));
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
     assertEquals(
         result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
@@ -133,7 +133,7 @@ public class ResultsTest {
 
   @Test
   public void sendPathInlineWithFileName() throws IOException {
-    Result result = Results.unauthorized().sendPath(file, true, "foo.bar");
+    Result result = Results.unauthorized().sendPath(file, true, Optional.of("foo.bar"));
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
     assertEquals(
         result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
@@ -141,21 +141,21 @@ public class ResultsTest {
 
   @Test
   public void sendPathInlineWithoutFileName() throws IOException {
-    Result result = Results.unauthorized().sendPath(file, (String) null);
+    Result result = Results.unauthorized().sendPath(file, Optional.empty());
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
     assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION), Optional.empty());
   }
 
   @Test
   public void sendPathAsAttachmentWithoutFileName() throws IOException {
-    Result result = Results.unauthorized().sendPath(file, false, (String) null);
+    Result result = Results.unauthorized().sendPath(file, false, Optional.empty());
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
     assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment");
   }
 
   @Test
   public void sendPathWithFileNameHasSpecialChars() throws IOException {
-    Result result = Results.ok().sendPath(file, true, "测 试.tmp");
+    Result result = Results.ok().sendPath(file, true, Optional.of("测 试.tmp"));
     assertEquals(result.status(), Http.Status.OK);
     assertEquals(
         result.header(HeaderNames.CONTENT_DISPOSITION).get(),
@@ -203,7 +203,7 @@ public class ResultsTest {
 
   @Test
   public void sendFileWithFileName() throws IOException {
-    Result result = Results.unauthorized().sendFile(file.toFile(), "foo.bar");
+    Result result = Results.unauthorized().sendFile(file.toFile(), Optional.of("foo.bar"));
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
     assertEquals(
         result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
@@ -211,7 +211,7 @@ public class ResultsTest {
 
   @Test
   public void sendFileInlineWithFileName() throws IOException {
-    Result result = Results.ok().sendFile(file.toFile(), true, "foo.bar");
+    Result result = Results.ok().sendFile(file.toFile(), true, Optional.of("foo.bar"));
     assertEquals(result.status(), Http.Status.OK);
     assertEquals(
         result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
@@ -219,21 +219,21 @@ public class ResultsTest {
 
   @Test
   public void sendFileInlineWithoutFileName() throws IOException {
-    Result result = Results.ok().sendFile(file.toFile(), (String) null);
+    Result result = Results.ok().sendFile(file.toFile(), Optional.empty());
     assertEquals(result.status(), Http.Status.OK);
     assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION), Optional.empty());
   }
 
   @Test
   public void sendFileAsAttachmentWithoutFileName() throws IOException {
-    Result result = Results.ok().sendFile(file.toFile(), false, (String) null);
+    Result result = Results.ok().sendFile(file.toFile(), false, Optional.empty());
     assertEquals(result.status(), Http.Status.OK);
     assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment");
   }
 
   @Test
   public void sendFileWithFileNameHasSpecialChars() throws IOException {
-    Result result = Results.ok().sendFile(file.toFile(), true, "测 试.tmp");
+    Result result = Results.ok().sendFile(file.toFile(), true, Optional.of("测 试.tmp"));
     assertEquals(result.status(), Http.Status.OK);
     assertEquals(
         result.header(HeaderNames.CONTENT_DISPOSITION).get(),

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -230,7 +230,7 @@ class ResultsSpec extends Specification {
     }
 
     "support sending a file with filename" in withFile { (file, fileName) =>
-      val rh = Ok.sendFile(file, fileName = _ => "测 试.tmp").header
+      val rh = Ok.sendFile(file, fileName = _ => Some("测 试.tmp")).header
 
       (rh.status.aka("status") must_== OK).and(
         rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome(
@@ -240,14 +240,14 @@ class ResultsSpec extends Specification {
     }
 
     "support sending a file without filename" in withFile { (file, fileName) =>
-      val rh = Ok.sendFile(file, fileName = _ => null).header
+      val rh = Ok.sendFile(file, fileName = _ => None).header
 
       (rh.status.aka("status") must_== OK)
         .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beNone)
     }
 
     "support sending a file attached without filename" in withFile { (file, fileName) =>
-      val rh = Ok.sendFile(file, inline = false, fileName = _ => null).header
+      val rh = Ok.sendFile(file, inline = false, fileName = _ => None).header
 
       (rh.status.aka("status") must_== OK)
         .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome("attachment"))
@@ -276,7 +276,7 @@ class ResultsSpec extends Specification {
     }
 
     "support sending a path with filename" in withPath { (file, fileName) =>
-      val rh = Ok.sendPath(file, fileName = _ => "测 试.tmp").header
+      val rh = Ok.sendPath(file, fileName = _ => Some("测 试.tmp")).header
 
       (rh.status.aka("status") must_== OK).and(
         rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome(
@@ -286,14 +286,14 @@ class ResultsSpec extends Specification {
     }
 
     "support sending a path without filename" in withPath { (file, fileName) =>
-      val rh = Ok.sendPath(file, fileName = _ => null).header
+      val rh = Ok.sendPath(file, fileName = _ => None).header
 
       (rh.status.aka("status") must_== OK)
         .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beNone)
     }
 
     "support sending a path attached without filename" in withPath { (file, fileName) =>
-      val rh = Ok.sendPath(file, inline = false, fileName = _ => null).header
+      val rh = Ok.sendPath(file, inline = false, fileName = _ => None).header
 
       (rh.status.aka("status") must_== OK)
         .and(rh.headers.get(CONTENT_DISPOSITION).aka("disposition") must beSome("attachment"))

--- a/dev-mode/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/dev-mode/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -44,7 +44,7 @@ class DocServerStart {
                 forceTranslationReport.call()
                 Results.Redirect("/@report")
               } else {
-                Results.Ok.sendFile(translationReport.call(), inline = true, fileName = _ => "report.html")(
+                Results.Ok.sendFile(translationReport.call(), inline = true, fileName = _ => Some("report.html"))(
                   executionContext,
                   fileMimeTypes
                 )

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -62,6 +62,11 @@ val projectB = (project in file("projectB"))
   .settings(commonSettings)
 ```
 
+### File serving methods changed the type of their `filename` parameters
+
+Methods for serving files, like `ok(File content, ...)` (and similar) in the [Java API](api/java/play/mvc/Results.html#ok-java.io.File-) or `sendFile`, `sendPath` and `sendResource` in both Java's  [`StatusHeader`](api/java/play/mvc/StatusHeader.html) and Scala's [`Status`](api/scala/play/api/mvc/Results$Status.html) class changed the type of their `filename` parameters: Instead of using a plain `String`, the Scala API now uses an `Option[String]` as return type for its `filename` parameter function. The Java API changed the parameter type to be an `Optional<String>`.
+This API change better reflects the fact that you can pass `None` / `Optional.empty()` if you don't want the `Content-Disposition` header to include a filename.
+
 ### Deprecated APIs were removed
 
 Many APIs that were deprecated in earlier versions were removed in Play 2.8. If you are still using them we recommend migrating to the new APIs before upgrading to Play 2.8. Check the Javadocs and Scaladocs for migration notes. See also the [[migration guide for Play 2.7|Migration27]] for more information.

--- a/documentation/manual/working/scalaGuide/main/async/code/scalaguide/async/scalastream/ScalaStream.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/scalaguide/async/scalastream/ScalaStream.scala
@@ -88,7 +88,7 @@ class ScalaStreamController @Inject()(val controllerComponents: ControllerCompon
   def fileWithName = Action {
     Ok.sendFile(
       content = new java.io.File("/tmp/fileToServe.pdf"),
-      fileName = _ => "termsOfService.pdf"
+      fileName = _ => Some("termsOfService.pdf")
     )
   }
   //#serve-file-with-name

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -521,6 +521,11 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.ObjectMapperProvider.this"),
       // Add configuration for temporary file directory
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.Files#DefaultTemporaryFileCreator.this"),
+      // Return type of filename function parameter changed from String to Option[String]
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.api.mvc.Results#Status.sendFile"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.api.mvc.Results#Status.sendFile$default$3"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.api.mvc.Results#Status.sendPath"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.api.mvc.Results#Status.sendPath$default$3"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
From the migration notes I added:

> _Methods for serving files, like `ok(File content, ...)` (and similar) in the [Java API](https://www.playframework.com/documentation/2.7.x/api/java/play/mvc/Results.html#ok-java.io.File-) or `sendFile`, `sendPath` and `sendResource` in both Java's  [`StatusHeader`](https://www.playframework.com/documentation/2.7.x/api/java/play/mvc/StatusHeader.html) and Scala's [`Status`](https://www.playframework.com/documentation/2.7.x/api/scala/play/api/mvc/Results$Status.html) class changed the type of their `filename` parameters: Instead of using a plain `String`, the Scala API now uses an `Option[String]` as return type for its `filename` parameter function. The Java API changed the parameter type to be an `Optional<String>`.            
This API change better reflects the fact that you can pass `None` / `Optional.empty()` if you don't want the `Content-Disposition` header to include a filename._

As you can see in the updated tests, specially the Java API was very ugly, because you had to pass `(String) null` (yes, casting). Passing `empty()` / `None` is much nicer.

In the Java API I could easily deprecate the old methods for smoother migration, for Scala that was not possible because the parameter itself is of type `Function1`, which does not change when "overloading" its type parameters (I think you get what I mean).

One more pull request after that one in the line...