### PR TITLE
Scripted test: Parallel streams use akka FJP threads, not commonPool

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/app/controllers/HomeController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/app/controllers/HomeController.java
@@ -1,0 +1,23 @@
+package controllers;
+
+import play.mvc.Controller;
+import play.mvc.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.stream.IntStream;
+
+public class HomeController extends Controller {
+
+    final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    public Result index() {
+        // Replace digits to not log the thread number
+        log.debug(Thread.currentThread().getName().replaceAll("\\d", ""));
+        int sum = IntStream.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).parallel().map(v -> {
+            log.debug(Thread.currentThread().getName().replaceAll("\\d", ""));
+            return v;
+        }).sum();
+        return ok("Sum: " + sum);
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/build.sbt
@@ -1,0 +1,31 @@
+//
+// Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+//
+name := """akka-fork-join-pool"""
+organization := "com.lightbend.play"
+
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayJava)
+  .settings(
+    scalaVersion := sys.props("scala.version"),
+    updateOptions := updateOptions.value.withLatestSnapshots(false),
+    evictionWarningOptions in update ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),
+    PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
+    libraryDependencies += guice,
+    InputKey[Unit]("callIndex") := {
+      try ScriptedTools.callIndex() catch { case e: java.net.ConnectException =>
+        play.sbt.run.PlayRun.stop(state.value)
+        throw e
+      }
+    },
+    InputKey[Unit]("checkLines") := {
+      val args                  = Def.spaceDelimited("<source> <target>").parsed
+      val source :: target :: _ = args
+        try ScriptedTools.checkLines(source, target) catch { case e: java.net.ConnectException =>
+          play.sbt.run.PlayRun.stop(state.value)
+          throw e
+        }
+    }
+  )

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/conf/logback.xml
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/conf/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder>
+      <pattern>[%level] %logger - %message%n%xException{10}</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="controllers.HomeController" level="DEBUG" />
+
+  <root level="ERROR">
+    <appender-ref ref="FILE" />
+  </root>
+
+</configuration>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/conf/routes
@@ -1,0 +1,1 @@
+GET        /                controllers.HomeController.index()

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/expected-application-log.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/expected-application-log.txt
@@ -1,0 +1,1 @@
+[DEBUG] controllers.HomeController - application-akka.actor.default-dispatcher-

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+//
+
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-scripted-tools" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/test
@@ -1,0 +1,8 @@
+> playUpdateSecret
+> runProd --no-exit-sbt
+$ sleep 8000
+> callIndex
+$ sleep 2000
+# Make sure we just run on akka threads, and never on "ForkJoinPool.commonPool-worker-x" threads
+> checkLines expected-application-log.txt target/universal/stage/logs/application.log
+> stopProd --no-exit-sbt


### PR DESCRIPTION
Fixes #8167
Fixes #7751
Real fix for #7615

This pull request itself is not the fix. The fix is that Play 2.8 upgrades to akka 2.6. Just read [this comment](https://github.com/playframework/playframework/issues/8167#issuecomment-490645264).

If you run this scripted tests with Play 2.7 you will see that also Java's default common pool will be used (and the test will fail):
```
[DEBUG] controllers.HomeController - ForkJoinPool.commonPool-worker-2
```
Starting with Play 2.8 however that will not be the case anymore. No common pool -> no SecurityExceptions anymore :wink: 

(This scripted test is basically a copy of the [`http-backend-netty-channel-options`](https://github.com/playframework/playframework/tree/c0fb84c769ec215cdf1af475e1e426f51d91ed90/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options) test, slightly modified of course)