### PR TITLE
413 instead of 500 when max-content-length exceeds + Netty config

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -21,12 +21,18 @@ import play.it._
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.util.Random
 
-class NettyRequestBodyHandlingSpec    extends RequestBodyHandlingSpec with NettyIntegrationSpecification
-class AkkaHttpRequestBodyHandlingSpec extends RequestBodyHandlingSpec with AkkaHttpIntegrationSpecification
+class NettyRequestBodyHandlingSpec    extends RequestBodyHandlingSpec with NettyIntegrationSpecification {
+  override def maxContentLengthConfigurationKey: String = "play.server.netty.maxContentLength"
+}
+class AkkaHttpRequestBodyHandlingSpec extends RequestBodyHandlingSpec with AkkaHttpIntegrationSpecification {
+  override def maxContentLengthConfigurationKey: String = "play.server.akka.max-content-length"
+}
 
 trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   sequential
+
+  def maxContentLengthConfigurationKey: String
 
   "Play request body handling" should {
 
@@ -138,18 +144,32 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       responses(0).status must_== 200
     }
 
-    "handle a big http request and fail" in withServerAndConfig("play.server.akka.max-content-length" -> "1b")(
+    "handle a big http request and fail with HTTP Error '413 request entity too large'" in withServerAndConfig(maxContentLengthConfigurationKey -> "21b")(
       (Action, parse) =>
         Action(parse.default(Some(Long.MaxValue))) { rh =>
           Results.Ok(rh.body.asText.getOrElse(""))
         }
     ) { port =>
-      val body = "Hello World" * 2
+      val body = "Hello World" * 2 // => 22 bytes, but we allow only 21 bytes
       val responses = BasicHttpClient.makeRequests(port, trickleFeed = Some(100L))(
         BasicRequest("POST", "/", "HTTP/1.1", Map("Content-Length" -> body.length.toString), body)
       )
       responses.length must_== 1
-      responses(0).status must_== 500
-    }.skipUntilNettyHttpFixed // netty does not need that test, since it does not provide a built-in max-content-length
+      responses(0).status must_== 413
+    }
+
+    "handle a big http request with exact amount of allowed Content-Length" in withServerAndConfig(maxContentLengthConfigurationKey -> "22b")(
+      (Action, parse) =>
+        Action(parse.default(Some(Long.MaxValue))) { rh =>
+          Results.Ok(rh.body.asText.getOrElse(""))
+        }
+    ) { port =>
+      val body = "Hello World" * 2 // => 22 bytes, same what we allow
+      val responses = BasicHttpClient.makeRequests(port, trickleFeed = Some(100L))(
+        BasicRequest("POST", "/", "HTTP/1.1", Map("Content-Length" -> body.length.toString), body)
+      )
+      responses.length must_== 1
+      responses(0).status must_== 200
+    }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -21,18 +21,12 @@ import play.it._
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.util.Random
 
-class NettyRequestBodyHandlingSpec    extends RequestBodyHandlingSpec with NettyIntegrationSpecification {
-  override def maxContentLengthConfigurationKey: String = "play.server.netty.maxContentLength"
-}
-class AkkaHttpRequestBodyHandlingSpec extends RequestBodyHandlingSpec with AkkaHttpIntegrationSpecification {
-  override def maxContentLengthConfigurationKey: String = "play.server.akka.max-content-length"
-}
+class NettyRequestBodyHandlingSpec    extends RequestBodyHandlingSpec with NettyIntegrationSpecification
+class AkkaHttpRequestBodyHandlingSpec extends RequestBodyHandlingSpec with AkkaHttpIntegrationSpecification
 
 trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   sequential
-
-  def maxContentLengthConfigurationKey: String
 
   "Play request body handling" should {
 
@@ -144,7 +138,9 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       responses(0).status must_== 200
     }
 
-    "handle a big http request and fail with HTTP Error '413 request entity too large'" in withServerAndConfig(maxContentLengthConfigurationKey -> "21b")(
+    "handle a big http request and fail with HTTP Error '413 request entity too large'" in withServerAndConfig(
+      "play.server.max-content-length" -> "21b"
+    )(
       (Action, parse) =>
         Action(parse.default(Some(Long.MaxValue))) { rh =>
           Results.Ok(rh.body.asText.getOrElse(""))
@@ -158,7 +154,9 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       responses(0).status must_== 413
     }
 
-    "handle a big http request with exact amount of allowed Content-Length" in withServerAndConfig(maxContentLengthConfigurationKey -> "22b")(
+    "handle a big http request with exact amount of allowed Content-Length" in withServerAndConfig(
+      "play.server.max-content-length" -> "22b"
+    )(
       (Action, parse) =>
         Action(parse.default(Some(Long.MaxValue))) { rh =>
           Results.Ok(rh.body.asText.getOrElse(""))

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -181,6 +181,18 @@ User's accept-language `en-GB` does not match any of the conf. The play app resp
 
 User's accept-language `en-GB` matches `en`. The play app responds English page.
 
+### Generalized server backend configurations
+
+Play comes with two [[server backends|Server]]:
+
+- [[Akka HTTP|AkkaHttpServer]] (the default), which [[can be configured|SettingsAkkaHttp]] via `play.server.akka.*`
+- [[Netty|NettyServer]], which [[can be configured|SettingsNetty]] via `play.server.netty.*`.
+
+Until now, we kept these configurations separate, even if there were settings that applied to both backends and therefore were conclusively duplicates.
+With Play 2.8 we start to generalize such duplicate server backend configurations and move them directly below `play.server.*`:
+
+* `play.server.akka.max-content-length` is now deprecated. It moved to `play.server.max-content-length`. Starting with Play 2.8 the Netty server backend will now also respect that config.
+
 ## Defaults changes
 
 Some of the default values used by Play had changed and that can have an impact on your application. This section details the default changes.

--- a/documentation/manual/working/commonGuide/server/Server.md
+++ b/documentation/manual/working/commonGuide/server/Server.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com> -->
 # Server Backends
 
-Play comes two configurable server backends, which handle the low level work of processing HTTP requests and responses to and from TCP/IP packets.
+Play comes with two configurable server backends, which handle the low level work of processing HTTP requests and responses to and from TCP/IP packets.
 
 Starting in 2.6.x, the default server backend is the Akka HTTP server backend, based on the [Akka-HTTP](https://doc.akka.io/docs/akka-http/current/) server.  Prior to 2.6.x, the server backend is Netty.
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -527,6 +527,8 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleSignatureProblem]("play.api.mvc.Results#Status.sendPath$default$3"),
       // Add contentType param (which defaults to None) to Results.chunked(...) like Results.streamed(...) already has
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Results#Status.chunked"),
+      // Netty's request handler needs maxContentLength to check if request size exceeds allowed configured value
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler.this"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/transport/server/play-akka-http-server/src/main/resources/reference.conf
+++ b/transport/server/play-akka-http-server/src/main/resources/reference.conf
@@ -50,10 +50,6 @@ play {
       # `ignore` : just ignore the illegal characters in response header value
       illegal-response-header-value-processing-mode = warn
 
-      # This setting is set in `akka.http.server.parsing.max-content-length`
-      # Play uses the concept of a `BodyParser` to enforce this limit, so we override it to infinite.
-      max-content-length = infinite
-
       # This setting is set in `akka.http.server.parsing.max-header-value-length`
       # and it limits the length of HTTP header values.
       max-header-value-length = 8k

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -88,7 +88,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
   private val serverConfig = context.config.configuration.get[Configuration]("play.server")
 
   /** Helper to access server configuration under the `play.server.akka` prefix. */
-  private val akkaServerConfig = context.config.configuration.get[Configuration]("play.server.akka")
+  private val akkaServerConfig = serverConfig.get[Configuration]("akka")
 
   private val akkaServerConfigReader = new AkkaServerConfigReader(akkaServerConfig)
 
@@ -128,7 +128,9 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
   /** Called by Play when creating its Akka HTTP parser settings. Result stored in [[parserSettings]]. */
   protected def createParserSettings(): ParserSettings =
     ParserSettings(akkaHttpConfig)
-      .withMaxContentLength(Server.getPossiblyInfiniteBytes(akkaServerConfig.underlying, "max-content-length"))
+      .withMaxContentLength(
+        Server.getPossiblyInfiniteBytes(serverConfig.underlying, "max-content-length", "akka.max-content-length")
+      )
       .withMaxHeaderValueLength(akkaServerConfig.get[ConfigMemorySize]("max-header-value-length").toBytes.toInt)
       .withIncludeTlsSessionInfoHeader(akkaServerConfig.get[Boolean]("tls-session-info-header"))
       .withModeledHeaderParsing(false) // Disable most of Akka HTTP's header parsing; use RawHeaders instead

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -31,13 +31,6 @@ play.server {
     # specified. This only controls the maximum length of the Netty chunk byte buffers.
     maxChunkSize = 8192
 
-    # If a request contains a Content-Length header it will be checked against this maximum value.
-    # If the value of a given Content-Length header exceeds this configured value, the request will not be processed
-    # further but instead the error handler will be called with Http status code 413 "Entity too large".
-    # If set to infinite or if no Content-Length header exists then no check will take place at all
-    # and the request will continue to be processed.
-    maxContentLength = infinite
-
     # Whether the Netty wire should be logged
     log.wire = false
 

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -31,8 +31,6 @@ play.server {
     # specified. This only controls the maximum length of the Netty chunk byte buffers.
     maxChunkSize = 8192
 
-    # Equivalent of the Akka HTTP server backend "play.server.akka.max-content-length" config.
-    # However because Netty doesn't have this feature built-in, Play provides its own implementation:
     # If a request contains a Content-Length header it will be checked against this maximum value.
     # If the value of a given Content-Length header exceeds this configured value, the request will not be processed
     # further but instead the error handler will be called with Http status code 413 "Entity too large".

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -31,6 +31,15 @@ play.server {
     # specified. This only controls the maximum length of the Netty chunk byte buffers.
     maxChunkSize = 8192
 
+    # Equivalent of the Akka HTTP server backend "play.server.akka.max-content-length" config.
+    # However because Netty doesn't have this feature built-in, Play provides its own implementation:
+    # If a request contains a Content-Length header it will be checked against this maximum value.
+    # If the value of a given Content-Length header exceeds this configured value, the request will not be processed
+    # further but instead the error handler will be called with Http status code 413 "Entity too large".
+    # If set to infinite or if no Content-Length header exists then no check will take place at all
+    # and the request will continue to be processed.
+    maxContentLength = infinite
+
     # Whether the Netty wire should be logged
     log.wire = false
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -68,6 +68,7 @@ class NettyServer(
   private val serverHeader         = nettyConfig.get[Option[String]]("server-header").collect { case s if s.nonEmpty => s }
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize        = nettyConfig.get[Int]("maxHeaderSize")
+  private val maxContentLength     = Server.getPossiblyInfiniteBytes(nettyConfig.underlying, "maxContentLength")
   private val maxChunkSize         = nettyConfig.get[Int]("maxChunkSize")
   private val logWire              = nettyConfig.get[Boolean]("log.wire")
 
@@ -176,7 +177,8 @@ class NettyServer(
   /**
    * Create a new PlayRequestHandler.
    */
-  protected[this] def newRequestHandler(): ChannelInboundHandler = new PlayRequestHandler(this, serverHeader)
+  protected[this] def newRequestHandler(): ChannelInboundHandler =
+    new PlayRequestHandler(this, serverHeader, maxContentLength)
 
   /**
    * Create a sink for the incoming connection channels.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -68,7 +68,7 @@ class NettyServer(
   private val serverHeader         = nettyConfig.get[Option[String]]("server-header").collect { case s if s.nonEmpty => s }
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize        = nettyConfig.get[Int]("maxHeaderSize")
-  private val maxContentLength     = Server.getPossiblyInfiniteBytes(nettyConfig.underlying, "maxContentLength")
+  private val maxContentLength     = Server.getPossiblyInfiniteBytes(serverConfig.underlying, "max-content-length")
   private val maxChunkSize         = nettyConfig.get[Int]("maxChunkSize")
   private val logWire              = nettyConfig.get[Boolean]("log.wire")
 

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -104,6 +104,14 @@ play {
       # deprecation cycle.
       addDebugInfoToRequests = false
     }
+
+    # If a request contains a Content-Length header it will be checked against this maximum value.
+    # If the value of a given Content-Length header exceeds this configured value, the request will not be processed
+    # further but instead the error handler will be called with Http status code 413 "Entity too large".
+    # If set to infinite or if no Content-Length header exists then no check will take place at all
+    # and the request will continue to be processed.
+    # Play uses the concept of a `BodyParser` to enforce this limit, so we set it to infinite.
+    max-content-length = infinite
   }
 
   editor = ${?PLAY_EDITOR}

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -7,6 +7,7 @@ package play.core.server
 import java.util.function.{ Function => JFunction }
 
 import akka.actor.CoordinatedShutdown
+import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import play.api.ApplicationLoader.Context
 import play.api._
@@ -133,6 +134,17 @@ object Server {
    */
   private[server] def actionForResult(errorResult: Future[Result]): Handler = {
     EssentialAction(_ => Accumulator.done(errorResult))
+  }
+
+  /**
+   * Parses the config setting `infinite` as `Long.MaxValue` otherwise uses Config's built-in
+   * parsing of byte values.
+   */
+  private[server] def getPossiblyInfiniteBytes(config: Config, path: String): Long = {
+    config.getString(path) match {
+      case "infinite" => Long.MaxValue
+      case _          => config.getBytes(path)
+    }
   }
 
   /**

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -140,10 +140,14 @@ object Server {
    * Parses the config setting `infinite` as `Long.MaxValue` otherwise uses Config's built-in
    * parsing of byte values.
    */
-  private[server] def getPossiblyInfiniteBytes(config: Config, path: String): Long = {
-    config.getString(path) match {
+  private[server] def getPossiblyInfiniteBytes(
+      config: Config,
+      path: String,
+      deprecatedPath: String = """"""""
+  ): Long = {
+    Configuration(config).getDeprecated[String](path, deprecatedPath) match {
       case "infinite" => Long.MaxValue
-      case _          => config.getBytes(path)
+      case _          => config.getBytes(if (config.hasPath(deprecatedPath)) deprecatedPath else path)
     }
   }
 


### PR DESCRIPTION
When using Akka HTTP as server backend and making use of `play.server.akka.max-content-length` (by setting it to some byte value instead of [the default](https://github.com/playframework/playframework/blob/2.7.3/transport/server/play-akka-http-server/src/main/resources/reference.conf#L53-L55) `infinite`) and a request comes with a `Content-Length` header whose value exceeds that configured `max-content-length` value, Play will return a HTTP 500 status code right now. Which is wrong, it should be a 413 "request entity too large". Marcos agrees with me: https://github.com/playframework/playframework/issues/8336#issuecomment-440457326 (Also akka-http [did change this recently](https://github.com/akka/akka-http/pull/2395) after [users reported the wrong behaviour](https://github.com/akka/akka-http/issues/358)).

Already working on it, I also added the equivalent config for Netty, `play.server.netty.maxContentLength`, which does the same check on the `Content-Length` header. Because netty does not have this feature built-in, I added it to the according request handler. Advantage of this setting (like in akka-http) is that a framework user can specify a maximum content length that should never be exceeded and that such a request (body) won't even be processed further and safes CPU cycles.

Luckily there was a test in place already which I just had to change to check for 413 :wink: