### PR TITLE
Update interplay to version 2.0.9

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ val Versions = new {
   val sbtHeader          = "5.2.0"
   val scalafmt           = "2.0.1"
   val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.5.0-M4")
-  val interplay: String  = sys.props.getOrElse("interplay.version", "2.0.8")
+  val interplay: String  = sys.props.getOrElse("interplay.version", "2.0.9")
 }
 
 buildInfoKeys := Seq[BuildInfoKey](


### PR DESCRIPTION
This version brings Scala 2.12.10.
