### PR TITLE
Fix "memory leak" in DelegatingMultipartFormDataBodyParser

### DIFF
--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -60,8 +60,8 @@ public class JavaFileUpload extends WithApplication {
         HttpErrorHandler errorHandler) {
       super(
           materializer,
-          config.parser().maxMemoryBuffer(), // (Small) buffer used for parsing the body
-          config.parser().maxDiskBuffer(), // Maximum allowed length of the requeest body
+          config.parser().maxMemoryBuffer(), // Small buffer used for parsing the body
+          config.parser().maxDiskBuffer(), // Maximum allowed length of the request body
           errorHandler);
     }
 

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -9,7 +9,7 @@ import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import org.junit.Test;
-import play.api.http.HttpErrorHandler;
+import play.http.HttpErrorHandler;
 import play.core.j.JavaHandlerComponents;
 import play.core.parsers.Multipart;
 import play.libs.Files.TemporaryFile;
@@ -58,7 +58,11 @@ public class JavaFileUpload extends WithApplication {
         Materializer materializer,
         play.api.http.HttpConfiguration config,
         HttpErrorHandler errorHandler) {
-      super(materializer, config.parser().maxDiskBuffer(), errorHandler);
+      super(
+          materializer,
+          config.parser().maxMemoryBuffer(), // (Small) buffer used for parsing the body
+          config.parser().maxDiskBuffer(), // Maximum allowed length of the requeest body
+          errorHandler);
     }
 
     /** Creates a file part handler that uses a custom accumulator. */

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -530,6 +530,9 @@ object BuildSettings {
       // Removing NoMaterializer
       ProblemFilters.exclude[MissingClassProblem]("play.api.test.NoMaterializer$"),
       ProblemFilters.exclude[MissingClassProblem]("play.api.test.NoMaterializer"),
+      // Fix "memory leak" in DelegatingMultipartFormDataBodyParser
+      ProblemFilters
+        .exclude[IncompatibleSignatureProblem]("play.mvc.BodyParser#DelegatingMultipartFormDataBodyParser.apply"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Following line in `DelegatingMultipartFormDataBodyParser` is very very nasty:
https://github.com/playframework/playframework/blob/f71d9e1da0a441952c451e27848a35edaebf05d6/core/play/src/main/java/play/mvc/BodyParser.java#L627

Here we pass `maxLength` to create a `multipartParser`... The `maxLength` param, _how we treat it_, is the maximum size of the whole request body that should be allowed for the upload, that's even how we show it [in the example in the docs](https://www.playframework.com/documentation/2.7.x/JavaFileUpload#Writing-a-custom-multipart-file-part-body-parser):
```java
  super(materializer, config.parser().maxDiskBuffer(), errorHandler);
```

The docs use `config.parser().maxDiskBuffer()`, which by default is 100M:
https://github.com/playframework/playframework/blob/f71d9e1da0a441952c451e27848a35edaebf05d6/core/play/src/main/resources/reference.conf#L108-L109


So... This is wrong.

What we _should_ actually pass to the `multipartParser` is just small memory buffer which will be used when parsing the request body:
https://github.com/playframework/playframework/blob/614cc959ffc22ee22427362d310f9922ef73b083/core/play/src/main/scala/play/core/parsers/Multipart.scala#L88
The Scala `MultipartFormData` parser handles this correctly:
https://github.com/playframework/playframework/blob/d67c5c652a6e08993668c6b2a701a12602caa0bf/core/play/src/main/scala/play/api/mvc/BodyParsers.scala#L951-L952
It passes `DefaultMaxTextLength` _hardcoded_, which boils down to [the `maxMemoryBuffer` config](https://github.com/playframework/playframework/blob/f71d9e1da0a441952c451e27848a35edaebf05d6/core/play/src/main/resources/reference.conf#L105-L106), which is just 100k. One line later, it then correctly makes use of the `maxLength` param by passing it to the `enforceMaxLength` parser, which actually makes sure the body size  does not exceed: https://github.com/playframework/playframework/blob/d67c5c652a6e08993668c6b2a701a12602caa0bf/core/play/src/main/scala/play/api/mvc/BodyParsers.scala#L953

Now, as a consequence of this bug, if someone is using the `DelegatingMultipartFormDataBodyParser` with a `maxLength` of let's say 2GB because one wants to allow 2GB file uploads, a 2 GB file would be loaded into memory... Instead of just 100kb pieces... Not so nice.