### PR TITLE
Make Scala's file/temporaryFile parser respect max length

### DIFF
--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -391,6 +391,10 @@ public interface BodyParser<A> {
     public Raw(PlayBodyParsers parsers) {
       super(parsers.raw(), JavaParsers::toJavaRaw);
     }
+
+    public Raw(PlayBodyParsers parsers, long memoryThreshold, long maxLength) {
+      super(parsers.raw(memoryThreshold, maxLength), JavaParsers::toJavaRaw);
+    }
   }
 
   /**
@@ -438,6 +442,10 @@ public interface BodyParser<A> {
     @Inject
     public MultipartFormData(PlayBodyParsers parsers) {
       super(parsers.multipartFormData(), JavaParsers::toJavaMultipartFormData);
+    }
+
+    public MultipartFormData(PlayBodyParsers parsers, long maxLength) {
+      super(parsers.multipartFormData(maxLength), JavaParsers::toJavaMultipartFormData);
     }
   }
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -94,8 +94,10 @@ package scalaguide.http.scalabodyparsers {
         testAction(save, helloRequest.withSession("username" -> "player"))
       }
 
-      "body parser combining" in {
-        val save = new scalaguide.http.scalabodyparsers.full.Application(Helpers.stubControllerComponents()).save
+      "body parser combining" in new WithController() {
+        val save = new scalaguide.http.scalabodyparsers.full.Application(
+          Helpers.stubControllerComponents(playBodyParsers = stubPlayBodyParsers(app.materializer))
+        ).save
         testAction(save, helloRequest.withSession("username" -> "player"))
       }
 


### PR DESCRIPTION
Until now, Scala's file and temporaryFile bodyparser _never_ cared about how much data they parse. Meaning when using these parsers, bad guy can upload as much data as desired, filling up the disk like there is no tomorrow. Because all other parser by default respect the [`maxDiskBuffer`](https://github.com/playframework/playframework/blob/3843d256c8b5635da3eb386152b17218e5fe01b9/core/play/src/main/resources/reference.conf#L108-L109) config, this should apply to these two parser as well. Turns out this behaviour occurs since before even releasing Play 2.0 ([commit](https://github.com/playframework/playframework/commit/2a067fd4d443f707c3f56f0c074b111d742a596d#diff-9138e25f65ebbd50a32f077940baa128R73)) and never was fixed.