### PR TITLE
BodyParsers check Content-Length header if it exceeds maxLength

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -384,22 +384,26 @@ trait BodyParserUtils {
       implicit mat: Materializer
   ): BodyParser[Either[MaxSizeExceeded, A]] =
     BodyParser(s"maxLength=$maxLength, wrapping=$parser") { request =>
-      val takeUpToFlow = Flow.fromGraph(new BodyParsers.TakeUpTo(maxLength))
+      if (BodyParserUtils.contentLengthHeaderExceedsMaxLength(request, maxLength)) {
+        Accumulator.done(Future.successful(Right(Left(MaxSizeExceeded(maxLength)))))
+      } else {
+        val takeUpToFlow = Flow.fromGraph(new BodyParsers.TakeUpTo(maxLength))
 
-      // Apply the request
-      val parserSink = parser.apply(request).toSink
+        // Apply the request
+        val parserSink = parser.apply(request).toSink
 
-      Accumulator(takeUpToFlow.toMat(parserSink) { (statusFuture, resultFuture) =>
-        import Execution.Implicits.trampoline
-        statusFuture.flatMap {
-          case exceeded: MaxSizeExceeded => Future.successful(Right(Left(exceeded)))
-          case _ =>
-            resultFuture.map {
-              case Left(result) => Left(result)
-              case Right(a)     => Right(Right(a))
-            }
-        }
-      })
+        Accumulator(takeUpToFlow.toMat(parserSink) { (statusFuture, resultFuture) =>
+          import Execution.Implicits.trampoline
+          statusFuture.flatMap {
+            case exceeded: MaxSizeExceeded => Future.successful(Right(Left(exceeded)))
+            case _ =>
+              resultFuture.map {
+                case Left(result) => Left(result)
+                case Right(a)     => Right(Right(a))
+              }
+          }
+        })
+      }
     }
 }
 
@@ -833,14 +837,22 @@ trait PlayBodyParsers extends BodyParserUtils {
    */
   def file(to: File): BodyParser[File] = file(to, DefaultMaxDiskLength)
 
+  private def requestEntityTooLarge(request: RequestHeader) =
+    createBadResult("Request Entity Too Large", REQUEST_ENTITY_TOO_LARGE)(request).map(Left(_))(Execution.trampoline)
+
   /**
    * Store the body content into a temporary file.
    *
    * @param maxLength Max length (in bytes) allowed or returns EntityTooLarge HTTP response.
    */
   def temporaryFile(maxLength: Long): BodyParser[TemporaryFile] = BodyParser("temporaryFile") { request =>
-    val tempFile = temporaryFileCreator.create("requestBody", "asTemporaryFile")
-    file(tempFile, maxLength)(request).map(_.fold(result => Left(result), _ => Right(tempFile)))(Execution.trampoline)
+    if (BodyParserUtils.contentLengthHeaderExceedsMaxLength(request, maxLength)) {
+      // We check early here already to not even create a temporary file
+      Accumulator.done(requestEntityTooLarge(request))
+    } else {
+      val tempFile = temporaryFileCreator.create("requestBody", "asTemporaryFile")
+      file(tempFile, maxLength)(request).map(_.fold(result => Left(result), _ => Right(tempFile)))(Execution.trampoline)
+    }
   }
 
   /**
@@ -1000,19 +1012,17 @@ trait PlayBodyParsers extends BodyParserUtils {
       maxLength: Long,
       accumulator: Accumulator[ByteString, Either[Result, A]]
   ): Accumulator[ByteString, Either[Result, A]] = {
-    val takeUpToFlow = Flow.fromGraph(new BodyParsers.TakeUpTo(maxLength))
-    Accumulator(takeUpToFlow.toMat(accumulator.toSink) { (statusFuture, resultFuture) =>
-      import Execution.Implicits.trampoline
-      val defaultCtx = materializer.executionContext
-      statusFuture.flatMap {
-        case MaxSizeExceeded(_) =>
-          val badResult = Future
-            .successful(())
-            .flatMap(_ => createBadResult("Request Entity Too Large", REQUEST_ENTITY_TOO_LARGE)(request))(defaultCtx)
-          badResult.map(Left(_))
-        case MaxSizeNotExceeded => resultFuture
-      }
-    })
+    if (BodyParserUtils.contentLengthHeaderExceedsMaxLength(request, maxLength)) {
+      Accumulator.done(requestEntityTooLarge(request))
+    } else {
+      val takeUpToFlow = Flow.fromGraph(new BodyParsers.TakeUpTo(maxLength))
+      Accumulator(takeUpToFlow.toMat(accumulator.toSink) { (statusFuture, resultFuture) =>
+        statusFuture.flatMap {
+          case MaxSizeExceeded(_) => requestEntityTooLarge(request)
+          case MaxSizeNotExceeded => resultFuture
+        }(Execution.trampoline)
+      })
+    }
   }
 
   /**
@@ -1039,25 +1049,28 @@ trait PlayBodyParsers extends BodyParserUtils {
         }
       }
 
-      Accumulator.strict[ByteString, Either[Result, A]](
-        // If the body was strict
-        {
-          case Some(bytes) if bytes.size <= maxLength =>
-            parseBody(bytes)
-          case None =>
-            parseBody(ByteString.empty)
-          case _ =>
-            createBadResult("Request Entity Too Large", REQUEST_ENTITY_TOO_LARGE)(request).map(Left.apply)
-        },
-        // Otherwise, use an enforce max length accumulator on a folding sink
-        enforceMaxLength(
-          request,
-          maxLength,
-          Accumulator(
-            Sink.fold[ByteString, ByteString](ByteString.empty)((state, bs) => state ++ bs)
-          ).mapFuture(parseBody)
-        ).toSink
-      )
+      if (BodyParserUtils.contentLengthHeaderExceedsMaxLength(request, maxLength)) {
+        Accumulator.done(requestEntityTooLarge(request))
+      } else {
+        Accumulator.strict[ByteString, Either[Result, A]](
+          // If the body was strict
+          {
+            case Some(bytes) if bytes.size <= maxLength =>
+              parseBody(bytes)
+            case None =>
+              parseBody(ByteString.empty)
+            case _ => requestEntityTooLarge(request)
+          },
+          // Otherwise, use an enforce max length accumulator on a folding sink
+          enforceMaxLength(
+            request,
+            maxLength,
+            Accumulator(
+              Sink.fold[ByteString, ByteString](ByteString.empty)((state, bs) => state ++ bs)
+            ).mapFuture(parseBody)
+          ).toSink
+        )
+      }
     }
 }
 

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -38,6 +38,7 @@ import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+import scala.util.control.Exception.catching
 import scala.util.control.NonFatal
 import scala.xml._
 
@@ -400,6 +401,21 @@ trait BodyParserUtils {
         }
       })
     }
+}
+
+object BodyParserUtils {
+
+  /**
+   * @param request The request whose Content-Length header will be checked (if it exists).
+   * @param maxLength Maximum allowed bytes.
+   * @return true if the request's Content-Length header value is greater than maxLength.
+   *         false otherwise or if the request does not have a Content-Length header (or if it can't be parsed).
+   */
+  def contentLengthHeaderExceedsMaxLength(request: RequestHeader, maxLength: Long) =
+    request.headers
+      .get(HeaderNames.CONTENT_LENGTH)
+      .flatMap(clh => catching(classOf[NumberFormatException]).opt(clh.toLong))
+      .exists(_ > maxLength)
 }
 
 class DefaultPlayBodyParsers @Inject()(

--- a/core/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
@@ -4,6 +4,8 @@
 
 package play.api.mvc
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
@@ -11,6 +13,11 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
+import org.specs2.specification.core.Fragment
+import play.api.data.Form
+import play.api.data.Forms.of
+import play.api.data.format.Formats.stringFormat
+import play.api.http.HeaderNames
 import play.api.http.Status
 import play.api.libs.streams.Accumulator
 import play.core.test.FakeRequest
@@ -28,9 +35,12 @@ import scala.util.Try
 class MaxLengthBodyParserSpec extends Specification with AfterAll {
 
   val MaxLength10 = 10
+  val MaxLength15 = 15
   val MaxLength20 = 20
   val Body15      = ByteString("hello" * 3)
   val req         = FakeRequest("GET", "/x")
+  val reqCLH15    = req.withHeaders((HeaderNames.CONTENT_LENGTH, "15"))
+  val reqCLH16    = req.withHeaders((HeaderNames.CONTENT_LENGTH, "16"))
 
   implicit val system = ActorSystem()
   implicit val mat    = Materializer.matFromSystem
@@ -61,8 +71,15 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
     (parser, bodyParsed.future)
   }
 
-  def feed[A](accumulator: Accumulator[ByteString, A]): A = {
-    Await.result(accumulator.run(Source.fromIterator(() => Body15.grouped(3))), 5.seconds)
+  def feed[A](
+      accumulator: Accumulator[ByteString, A],
+      food: ByteString = Body15,
+      ai: AtomicInteger = new AtomicInteger
+  ): A = {
+    Await.result(accumulator.run(Source.fromIterator(() => {
+      ai.incrementAndGet()
+      food.grouped(3)
+    })), 5.seconds)
   }
 
   def assertDidNotParse(parsed: Future[Unit]) = {
@@ -78,9 +95,12 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
     }
   }
 
-  def maxLengthParserEnforced(result: Either[Result, Either[MaxSizeExceeded, ByteString]]) = {
+  def maxLengthParserEnforced(
+      result: Either[Result, Either[MaxSizeExceeded, ByteString]],
+      maxLength: Int = MaxLength10
+  ) = {
     result must beRight[Either[MaxSizeExceeded, ByteString]].which { inner =>
-      inner must beLeft(MaxSizeExceeded(MaxLength10))
+      inner must beLeft(MaxSizeExceeded(maxLength))
     }
   }
 
@@ -138,6 +158,142 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
       Await.result(parsed, 5.seconds) must_== (())
     }
 
+    val bodyParsers = Seq(
+      // Tuple3: (bodyParser with maxLength of 15, Content-Type header, 15 bytes to feed the parser)
+      (parse.text(maxLength = MaxLength15), Some("text/plain"), Body15),
+      (parse.tolerantText(maxLength = MaxLength15), None, Body15),
+      (parse.byteString(maxLength = MaxLength15), None, Body15),
+      (parse.xml(maxLength = MaxLength15), Some("application/xml"), ByteString("<foo>15 b</foo>")),       // 15 bytes
+      (parse.tolerantXml(maxLength = MaxLength15), None, ByteString("<foo>15 b</foo>")),                  // 15 bytes
+      (parse.json(maxLength = MaxLength15), Some("application/json"), ByteString("""{ "x": "15 b" }""")), // 15 bytes
+      (parse.tolerantJson(maxLength = MaxLength15), None, ByteString("""{ "x": "15 b" }""")),             // 15 bytes
+      (
+        parse.form(Form("myfield" -> of[String](stringFormat)), maxLength = Some(MaxLength15)),
+        Some("application/x-www-form-urlencoded"),
+        ByteString("myfield=15bytes") // 15 bytes
+      ),
+      (parse.formUrlEncoded(maxLength = MaxLength15), Some("application/x-www-form-urlencoded"), Body15),
+      (parse.tolerantFormUrlEncoded(maxLength = MaxLength15), None, Body15),
+      (
+        parse.multipartFormData(maxLength = MaxLength15),
+        Some("multipart/form-data; boundary=aabbccddeee"),
+        ByteString("--aabbccddeee--") // 15 bytes
+      ),
+      (parse.raw(maxLength = MaxLength15), None, Body15),
+      (
+        parse.file(parse.temporaryFileCreator.create("requestBody", "asTemporaryFile"), maxLength = MaxLength15),
+        None,
+        Body15
+      ),
+      (parse.temporaryFile(maxLength = MaxLength15), None, Body15),
+    )
+    // maxLength body parser needs special treatment because it uses Either[MaxSizeExceeded,...] instead of Either[Result,...]
+    val maxLengthParser = parse.maxLength(MaxLength15, BodyParser(req => bodyParser._1)) // bodyParser._1 does not matter really
+
+    "not run body parser when existing Content-Length header exceeds maxLength " in {
+      Fragment.foreach(bodyParsers) { bodyParser =>
+        bodyParser._1.toString >> {
+          // Let's feed a request, that, via its Content-Length header, pretends to have a body size of 16 bytes,
+          // to a body parser that only allows maximum 15 bytes. The actual body we want to parse
+          // (with an actual content length of 15 bytes, which would be ok) will never be parsed.
+          val ai = new AtomicInteger()
+          val result = feed(
+            bodyParser._1
+              .apply(bodyParser._2.map(ct => reqCLH16.withHeaders((HeaderNames.CONTENT_TYPE, ct))).getOrElse(reqCLH16)),
+            food = bodyParser._3,
+            ai = ai
+          )
+          enforceMaxLengthEnforced(result)
+          ai.get must_== 0 // makes sure no parsing took place at all
+        }
+      }
+
+      // special treatment for maxLength
+      maxLengthParser.toString() in {
+        val ai     = new AtomicInteger()
+        val result = feed(maxLengthParser.apply(reqCLH16), food = Body15, ai = ai)
+        maxLengthParserEnforced(result, MaxLength15)
+        ai.get must_== 0 // makes sure no parsing took place at all
+      }
+    }
+
+    "run body parser when existing Content-Length header does not exceed maxLength " in {
+      Fragment.foreach(bodyParsers) { bodyParser =>
+        bodyParser._1.toString >> {
+          // Same like above test, but now the Content-Length header does not exceed maxLength (actually matched the
+          // actual body size)
+          val ai = new AtomicInteger()
+          val result = feed(
+            bodyParser._1
+              .apply(bodyParser._2.map(ct => reqCLH15.withHeaders((HeaderNames.CONTENT_TYPE, ct))).getOrElse(reqCLH15)),
+            food = bodyParser._3,
+            ai = ai
+          )
+          result must beRight // successfully parsed
+          ai.get must_== 1    // also makes sure parsing took place
+        }
+      }
+
+      // special treatment for maxLength
+      maxLengthParser.toString() in {
+        val ai     = new AtomicInteger()
+        val result = feed(maxLengthParser.apply(reqCLH15), food = Body15, ai = ai)
+        result must beRight.which { inner =>
+          inner must beRight(Body15)
+        }
+        ai.get must_== 1 // makes sure parsing took place
+      }
+    }
+
+    "run body parser when no Content-Length header exists and actual body size does not exceed maxLength" in {
+      Fragment.foreach(bodyParsers) { bodyParser =>
+        bodyParser._1.toString >> {
+          val ai = new AtomicInteger()
+          val result = feed(
+            bodyParser._1
+              .apply(bodyParser._2.map(ct => req.withHeaders((HeaderNames.CONTENT_TYPE, ct))).getOrElse(req)),
+            food = bodyParser._3,
+            ai = ai
+          )
+          result must beRight // successfully parsed
+          ai.get must_== 1    // also makes sure parsing took place
+        }
+      }
+
+      // special treatment for maxLength
+      maxLengthParser.toString() in {
+        val ai     = new AtomicInteger()
+        val result = feed(maxLengthParser.apply(req), food = Body15, ai = ai)
+        result must beRight.which { inner =>
+          inner must beRight(Body15)
+        }
+        ai.get must_== 1 // makes sure parsing took place
+      }
+    }
+
+    "run body parser when no Content-Length header exists and actual body size exceeds maxLength" in {
+      Fragment.foreach(bodyParsers) { bodyParser =>
+        bodyParser._1.toString >> {
+          val ai = new AtomicInteger()
+          val result = feed(
+            bodyParser._1
+              .apply(bodyParser._2.map(ct => req.withHeaders((HeaderNames.CONTENT_TYPE, ct))).getOrElse(req)),
+            food = ByteString(" ") ++ bodyParser._3, // prepend space to exceed maxLength by one byte
+            ai = ai
+          )
+          enforceMaxLengthEnforced(result) // parser realised body is too large
+          ai.get must_== 1                 // also makes sure parsing took place
+        }
+      }
+
+      // special treatment for maxLength
+      maxLengthParser.toString() in {
+        val ai     = new AtomicInteger()
+        val result = feed(maxLengthParser.apply(req), food = ByteString(" ") ++ Body15, ai = ai) // prepend space to exceed maxLength by one byte
+        maxLengthParserEnforced(result, MaxLength15) // parser realised body is too large
+        ai.get must_== 1                             // makes sure parsing took place
+      }
+    }
   }
 
 }

--- a/core/play/src/test/scala/play/mvc/DummyDelegatingMultipartFormDataBodyParser.java
+++ b/core/play/src/test/scala/play/mvc/DummyDelegatingMultipartFormDataBodyParser.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.mvc;
+
+import akka.stream.IOResult;
+import akka.stream.Materializer;
+import akka.stream.javadsl.FileIO;
+import akka.stream.javadsl.Sink;
+import akka.util.ByteString;
+import play.api.http.HttpConfiguration;
+import play.core.parsers.Multipart;
+import play.http.HttpErrorHandler;
+import play.libs.streams.Accumulator;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public class DummyDelegatingMultipartFormDataBodyParser
+        extends BodyParser.DelegatingMultipartFormDataBodyParser<File> {
+
+  @Inject
+  public DummyDelegatingMultipartFormDataBodyParser(
+          Materializer materializer,
+          long maxMemoryBufferSize,
+          long maxLength,
+          HttpErrorHandler errorHandler) {
+    super(materializer, maxMemoryBufferSize, maxLength, errorHandler);
+  }
+
+  @Override
+  public Function<Multipart.FileInfo, Accumulator<ByteString, Http.MultipartFormData.FilePart<File>>>
+    createFilePartHandler() {
+      return (Multipart.FileInfo fileInfo) -> {
+        final String filename = fileInfo.fileName();
+        final String partname = fileInfo.partName();
+        final String contentType = fileInfo.contentType().getOrElse(null);
+        final File file = generateTempFile();
+        final String dispositionType = fileInfo.dispositionType();
+
+        final Sink<ByteString, CompletionStage<IOResult>> sink = FileIO.toPath(file.toPath());
+        return Accumulator.fromSink(
+                sink.mapMaterializedValue(
+                        completionStage ->
+                                completionStage.thenApplyAsync(
+                                        results ->
+                                                new Http.MultipartFormData.FilePart<>(
+                                                        partname,
+                                                        filename,
+                                                        contentType,
+                                                        file,
+                                                        results.getCount(),
+                                                        dispositionType))));
+      };
+  }
+
+  private File generateTempFile() {
+    try {
+      final Path path = Files.createTempFile("multipartBody", "tempFile");
+      return path.toFile();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.mvc
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.javadsl.Source
+import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
+import org.specs2.matcher.MustMatchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+import org.specs2.specification.core.Fragment
+import play.api.Environment
+import play.api.Mode
+import play.api.http.HeaderNames
+import play.api.http.Status
+import play.api.mvc.PlayBodyParsers
+import play.libs.streams.Accumulator
+import play.http.DefaultHttpErrorHandler
+import play.libs.F
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
+
+class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatchers {
+  "Java MaxLengthBodyParserSpec" title
+
+  val Body15   = ByteString("hello" * 3)
+  def req      = new Http.RequestBuilder().method("GET").path("/x")
+  def reqCLH15 = req.header(HeaderNames.CONTENT_LENGTH, "15")
+  def reqCLH16 = req.header(HeaderNames.CONTENT_LENGTH, "16")
+
+  implicit val system       = ActorSystem("java-max-length-body-parser-spec")
+  implicit val materializer = Materializer.matFromSystem
+
+  def afterAll(): Unit = {
+    materializer.shutdown()
+    system.terminate()
+  }
+
+  val underlyingParsers = PlayBodyParsers()
+  val defaultHttpErrorHandler =
+    new DefaultHttpErrorHandler(ConfigFactory.empty(), Environment(null, null, Mode.Prod).asJava, null, null)
+
+  def feed[A](
+      accumulator: Accumulator[ByteString, A],
+      food: ByteString = Body15,
+      ai: AtomicInteger = new AtomicInteger
+  ): A = {
+    accumulator
+      .run(Source.fromIterator[ByteString](() => {
+        ai.incrementAndGet()
+        food.grouped(3).asJava
+      }), materializer)
+      .toCompletableFuture
+      .get(5, TimeUnit.SECONDS)
+  }
+
+  def maxLengthEnforced(result: F.Either[Result, _]) = {
+    result.left.asScala.map(_.status) must beSome(Status.REQUEST_ENTITY_TOO_LARGE)
+    result.right.asScala must beNone
+  }
+
+  val bodyParsers: Seq[(BodyParser[_], Option[String], ByteString)] = Seq(
+    // Tuple3: (bodyParser with maxLength of 15, Content-Type header, 15 bytes to feed the parser)
+    (new BodyParser.Text(15, defaultHttpErrorHandler), Some("text/plain"), Body15),
+    (new BodyParser.TolerantText(15, defaultHttpErrorHandler), None, Body15),
+    (new BodyParser.Bytes(15, defaultHttpErrorHandler), None, Body15),
+    (
+      new BodyParser.Xml(15, defaultHttpErrorHandler, underlyingParsers),
+      Some("application/xml"),
+      ByteString("<foo>15 b</foo>") // 15 bytes
+    ),
+    (new BodyParser.TolerantXml(15, defaultHttpErrorHandler), None, ByteString("<foo>15 b</foo>")),                  // 15 bytes
+    (new BodyParser.Json(15, defaultHttpErrorHandler), Some("application/json"), ByteString("""{ "x": "15 b" }""")), // 15 bytes
+    (new BodyParser.TolerantJson(15, defaultHttpErrorHandler), None, ByteString("""{ "x": "15 b" }""")),             // 15 bytes
+    (new BodyParser.FormUrlEncoded(15, defaultHttpErrorHandler), Some("application/x-www-form-urlencoded"), Body15),
+    (
+      new BodyParser.MultipartFormData(underlyingParsers, 15),
+      Some("multipart/form-data; boundary=aabbccddeee"),
+      ByteString("--aabbccddeee--") // 15 bytes
+    ),
+    (
+      new DummyDelegatingMultipartFormDataBodyParser(materializer, 102400, 15, defaultHttpErrorHandler),
+      Some("multipart/form-data; boundary=aabbccddeee"),
+      ByteString("--aabbccddeee--") // 15 bytes
+    ),
+    (new BodyParser.Raw(underlyingParsers, 102400, 15), None, Body15),
+  )
+
+  "Max length body handling" should {
+    "not run body parser when existing Content-Length header exceeds maxLength " in {
+      Fragment.foreach(bodyParsers) { bodyParser =>
+        bodyParser._1.toString >> {
+          // Let's feed a request, that, via its Content-Length header, pretends to have a body size of 16 bytes,
+          // to a body parser that only allows maximum 15 bytes. The actual body we want to parse
+          // (with an actual content length of 15 bytes, which would be ok) will never be parsed.
+          val ai = new AtomicInteger()
+          val result = feed(
+            bodyParser._1
+              .apply(
+                bodyParser._2.map(ct => reqCLH16.header(HeaderNames.CONTENT_TYPE, ct)).getOrElse(reqCLH16).build()
+              ),
+            food = bodyParser._3,
+            ai = ai
+          )
+          maxLengthEnforced(result)
+          ai.get must_== 0 // makes sure no parsing took place at all
+        }
+      }
+    }
+
+    "run body parser when existing Content-Length header does not exceed maxLength " in {
+      Fragment.foreach(bodyParsers) { bodyParser =>
+        bodyParser._1.toString >> {
+          // Same like above test, but now the Content-Length header does not exceed maxLength (actually matched the
+          // actual body size)
+          val ai = new AtomicInteger()
+          val result = feed(
+            bodyParser._1
+              .apply(
+                bodyParser._2.map(ct => reqCLH15.header(HeaderNames.CONTENT_TYPE, ct)).getOrElse(reqCLH15).build()
+              ),
+            food = bodyParser._3,
+            ai = ai
+          )
+          result.left.asScala must beNone
+          result.right.asScala must beSome // successfully parsed
+          ai.get must_== 1                 // also makes sure parsing took place
+        }
+      }
+    }
+
+    "run body parser when no Content-Length header exists and actual body size does not exceed maxLength" in {
+      Fragment.foreach(bodyParsers) { bodyParser =>
+        bodyParser._1.toString >> {
+          val ai = new AtomicInteger()
+          val result = feed(
+            bodyParser._1
+              .apply(
+                bodyParser._2.map(ct => req.header(HeaderNames.CONTENT_TYPE, ct)).getOrElse(req).build()
+              ),
+            food = bodyParser._3,
+            ai = ai
+          )
+          result.left.asScala must beNone
+          result.right.asScala must beSome // successfully parsed
+          ai.get must_== 1                 // also makes sure parsing took place
+        }
+      }
+    }
+
+    "run body parser when no Content-Length header exists and actual body size exceeds maxLength" in {
+      Fragment.foreach(bodyParsers) { bodyParser =>
+        bodyParser._1.toString >> {
+          val ai = new AtomicInteger()
+          val result = feed(
+            bodyParser._1
+              .apply(
+                bodyParser._2.map(ct => req.header(HeaderNames.CONTENT_TYPE, ct)).getOrElse(req).build()
+              ),
+            food = ByteString(" ") ++ bodyParser._3, // prepend space to exceed maxLength by one byte
+            ai = ai
+          )
+          maxLengthEnforced(result) // parser realised body is too large
+          ai.get must_== 1          // also makes sure parsing took place
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #8336

This pull request makes sure all the built-in body parsers, no matter if Scala or Java API, check the `Content-Length` header before even trying to parse the body in case its value is exceeded.
This continues the work done in #9625 (which did the same checks, but higher up in the server backends already).
I added exhaustive tests for _all_ built-in body parser, Scala and Java.

(Depends on #9647).