### PR TITLE
Removes Akka snaphost resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -456,7 +456,6 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
     playCommonSettings,
     scalaVersion := (scalaVersion in PlayProject).value,
     playBuildRepoName in ThisBuild := "playframework",
-    resolvers in ThisBuild += Resolver.bintrayRepo("akka", "snapshots"),
     concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
     libraryDependencies ++= (runtime(scalaVersion.value) ++ jdbcDeps),
     Docs.apiDocsInclude := false,


### PR DESCRIPTION
When adopting Scala 2.13, in order to use latest builds from akka we added this resolver unconditionally.
