### PR TITLE
Send HSTS header when X-Forwarded-Proto header is 'https'

### DIFF
--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -194,6 +194,12 @@ With Play 2.8 we start to generalize such duplicate server backend configuration
 * `play.server.akka.max-content-length` is now deprecated. It moved to `play.server.max-content-length`. Starting with Play 2.8 the Netty server backend will now also respect that config.
 * `play.server.akka.max-header-value-length` and `play.server.netty.maxHeaderSize` are both deprecated now. Those configs moved to `play.server.max-header-size`.
 
+### The `excludePaths` config of the Redirect HTTPS filter changed
+
+The `play.filters.https.excludePaths` config of the [[Redirect HTTPS filter|RedirectHttpsFilter]] now contains a list of paths instead of URIs.
+That means query params don't matter anymore. If the list contains `/foo` the request `/foo?abc=xyz` will now be excluded too.
+Before Play 2.8, because the URI of a request (path + query params) was checked against the list, you needed to add _exactly_ a request's URI to exclude it from redirecting.
+
 ## Defaults changes
 
 Some of the default values used by Play had changed and that can have an impact on your application. This section details the default changes.

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -289,7 +289,7 @@ play.filters {
     redirectEnabled = null
 
     # The Strict-Transport-Security header is used to signal to browsers to always use https.
-    # This header is added whenever the filter makes the redirect.
+    # This header is added whenever a request is secure and redirectEnabled is true.
     # Set to null to disable the header.
     strictTransportSecurity = "max-age=31536000; includeSubDomains"
 
@@ -304,13 +304,14 @@ play.filters {
     # [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto)
     xForwardedProtoEnabled = false
 
-    # Status code returns 200 and is not redirected if path is in this list.
+    # No redirect happens if path is in this list.
+    # Query params don't matter, meaning if the list contains "/foo" the request "/foo?abc=xyz" will be excluded too.
+    # Paths in this list are encoded, if you want to exclude "/foöbär" you have to add "/fo%C3%B6b%C3%A4r" to the list.
     excludePaths = []
 
     # The HTTPS port to use in the Redirect's Location URL.
     # e.g. port = 9443 results in https://playframework.com:9443/some/url
     port = null
     port = ${?play.server.https.port} # default to same HTTPS port as play server
-    port = ${?https.port} # read https.port system property if provided explicitly
   }
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -13,7 +13,6 @@ import play.api._
 import play.api.http.HttpFilters
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.inject.guice.GuiceableModule
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.mvc.request.RemoteConnection
@@ -83,6 +82,21 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
     "not redirect when on https but send HSTS header" in new WithApplication(buildApp(mode = Mode.Prod)) {
       val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
       val result = route(app, request().withConnection(secure)).get
+
+      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
+      status(result) must_== OK
+    }
+
+    "not redirect when X-Forwarded-Proto header is 'https' (and not on https) but send HSTS header" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.xForwardedProtoEnabled = true
+      """.stripMargin,
+        mode = Mode.Prod
+      )
+    ) {
+      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+      val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "https")).get
 
       header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
       status(result) must_== OK
@@ -167,6 +181,22 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       status(result) must_== PERMANENT_REDIRECT
     }
 
+    "send HSTS header when request itself is not secure but X-Forwarded-Proto header is 'https'" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.filters.https.xForwardedProtoEnabled = true
+      """.stripMargin,
+        mode = Mode.Test
+      )
+    ) {
+      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+      val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "https")).get
+
+      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
+      status(result) must_== OK
+    }
+
     "not redirect when path included in redirectExcludePath" in new WithApplication(
       buildApp(
         """
@@ -184,10 +214,30 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       status(result) must_== OK
     }
 
+    "not redirect when path included in redirectExcludePath and request has query params" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.filters.https.xForwardedProtoEnabled = true
+          |play.filters.https.excludePaths = ["/skip"]
+      """.stripMargin,
+        mode = Mode.Test
+      )
+    ) {
+      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+      val result = route(
+        app,
+        request("/skip", Some("foo=bar")).withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")
+      ).get
+
+      header(STRICT_TRANSPORT_SECURITY, result) must beNone
+      status(result) must_== OK
+    }
+
   }
 
-  private def request(uri: String = "/") = {
-    FakeRequest(method = "GET", path = uri)
+  private def request(path: String = "/", queryParams: Option[String] = None) = {
+    FakeRequest(method = "GET", path = path + queryParams.map("?" + _).getOrElse(""))
       .withHeaders(HOST -> "playframework.com")
   }
 


### PR DESCRIPTION
Fixes #9208

Along the way I corrected some comments and fixed other bugs as well :wink: 

EDIT: I guess we can backport this to 2.7.