### PR TITLE
apiDocs: Drop "-subpackages play"

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -170,12 +170,6 @@ object Docs {
       // (sources, classpath, outputDirectory, options, maxErrors, log)
       scaladoc(apiDocsScalaSources, classpath, apiTarget / "scala", options, 10, streams.log)
 
-      val subpackagesOpt =
-        if (scala.util.Properties.isJavaAtLeast("11")) Nil // TODO: fix Javadoc 11 run
-        else {
-          List("-subpackages", "play")
-        }
-
       val javadocOptions = List(
         "-windowtitle",
         label,
@@ -190,7 +184,6 @@ object Docs {
         "-link",
         "https://doc.akka.io/japi/akka-http/current/",
         "-notimestamp",
-      ) ::: subpackagesOpt ::: List(
         "-Xmaxwarns",
         "1000",
         "-exclude",


### PR DESCRIPTION
From my testing (running Play-Docs/apiDocs and inspecting the content in
dev-mode/play-docs/target/scala-2.12/apidocs/ and viewing it in the
browser) it appears that before and after nothing changes from no having
this.

I think the intent of "-subpackages x" is that you invoke it like
`javadoc src/liba -subpackages com.acme.liba.foo:com.acme.liba.bar`.
But the way we invoke it is by passing the source files directly, so
javadoc will document all the packages we care about already (which is
the "play" package and every subpackage of it too.)