### PR TITLE
Adopt ConfigFactory.defaultReferenceUnresolved

### DIFF
--- a/core/play/src/main/scala/play/api/Configuration.scala
+++ b/core/play/src/main/scala/play/api/Configuration.scala
@@ -4,7 +4,6 @@
 
 package play.api
 
-import java.io._
 import java.net.URI
 import java.net.URL
 import java.util.Properties
@@ -59,27 +58,12 @@ object Configuration {
       // Inject our direct settings into the config.
       val directConfig: Config = ConfigFactory.parseMap(directSettings.asJava)
 
-      // Resolve application.conf ourselves because:
-      // - we may want to load configuration when application.conf is missing.
-      // - We also want to delay binding and resolving reference.conf, which
-      //   is usually part of the default application.conf loading behavior.
-      // - We want to read config.file and config.resource settings from our
-      //   own properties and directConfig rather than system properties.
+      // Resolve application.conf
       val applicationConfig: Config = {
-        def setting(key: String): Option[AnyRef] =
-          directSettings.get(key).orElse(Option(properties.getProperty(key)))
-
-        {
-          setting("config.resource").map(resource => ConfigFactory.parseResources(classLoader, resource.toString))
-        }.orElse {
-            setting("config.file").map(fileName => ConfigFactory.parseFileAnySyntax(new File(fileName.toString)))
-          }
-          .getOrElse {
-            val parseOptions = ConfigParseOptions.defaults
-              .setClassLoader(classLoader)
-              .setAllowMissing(allowMissingApplicationConf)
-            ConfigFactory.defaultApplication(parseOptions)
-          }
+        val parseOptions = ConfigParseOptions.defaults
+          .setClassLoader(classLoader)
+          .setAllowMissing(allowMissingApplicationConf)
+        ConfigFactory.defaultApplication(parseOptions)
       }
 
       // Resolve another .conf file so that we can override values in Akka's

--- a/core/play/src/main/scala/play/api/Configuration.scala
+++ b/core/play/src/main/scala/play/api/Configuration.scala
@@ -88,9 +88,9 @@ object Configuration {
       // Play's values in their application.conf.
       val playOverridesConfig: Config = ConfigFactory.parseResources(classLoader, "play/reference-overrides.conf")
 
-      // Resolve reference.conf ourselves because ConfigFactory.defaultReference resolves
-      // values, and we won't have a value for `play.server.dir` until all our config is combined.
-      val referenceConfig: Config = ConfigFactory.parseResources(classLoader, "reference.conf")
+      // Use defaultReferenceUnresolved to validate reference.conf is self-contained,
+      // but also allow values like `play.server.dir` to be redefined.
+      val referenceConfig: Config = ConfigFactory.defaultReferenceUnresolved(classLoader)
 
       // Combine all the config together into one big config
       val combinedConfig: Config = Seq(

--- a/core/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -337,7 +337,7 @@ class ConfigurationSpec extends Specification {
       configJavaVersion must beEqualTo(javaVersion)
     }
 
-    "user defined properties should have precedence over system properties" in {
+    "system properties override user-defined properties" in {
       val userProperties = new Properties()
       userProperties.setProperty("java.specification.version", "my java version")
 
@@ -348,7 +348,7 @@ class ConfigurationSpec extends Specification {
         allowMissingApplicationConf = true
       )
 
-      val javaVersion       = userProperties.getProperty("java.specification.version")
+      val javaVersion       = System.getProperty("java.specification.version")
       val configJavaVersion = configuration.get[String]("test.system.property.java.spec.version")
 
       configJavaVersion must beEqualTo(javaVersion)

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -148,7 +148,7 @@ class MyApp {
 }
 ```
 
-Keep in mind that user-defined properties have precedence over default System Properties.
+Keep in mind that system properties override user-defined properties.
 
 ### Debugging SSL Connections
 


### PR DESCRIPTION
This method is in the new 1.3.5-RC1 version of the config library
(should be released as 1.4.0).

The value added here is that we verify that the reference configuration
is self-containing (i.e. can be resolved) that is: it doesn't make
references to keys that are undefined.