### PR TITLE
Avoid deprecated ScalaInstance#libraryJar

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -127,9 +127,14 @@ object BuildSettings {
       }
     },
     autoAPIMappings := true,
-    apiMappings += scalaInstance.value.libraryJar -> url(
-      raw"""http://scala-lang.org/files/archive/api/${scalaInstance.value.actualVersion}/index.html"""
-    ),
+    apiMappings ++= {
+      val scalaInstance = Keys.scalaInstance.value
+      scalaInstance.libraryJars.map { libraryJar =>
+        libraryJar -> url(
+          raw"""http://scala-lang.org/files/archive/api/${scalaInstance.actualVersion}/index.html"""
+        )
+      }.toMap
+    },
     apiMappings ++= {
       // Maps JDK 1.8 jar into apidoc.
       val rtJar = sys.props


### PR DESCRIPTION
Switch to mapping all library jars.