### PR TITLE
Add threshold to GzipFilter

### DIFF
--- a/documentation/manual/releases/release28/Highlights28.md
+++ b/documentation/manual/releases/release28/Highlights28.md
@@ -74,3 +74,16 @@ play.i18n.langCookieMaxAge = 15 seconds
 ```
 
 By the default, the configuration is `null` meaning no max age will be set for Lang cookie.
+
+### Threshold for the gzip filter
+
+If you have the gzip filter enabled you can now also set a byte threshold via `application.conf` to control which responses are and aren't gzipped based on their body size:
+
+```HOCON
+play.filters.gzip.threshold = 1k
+```
+Responses whose body size are equal or lower than the given byte threshold won't be compressed, because it's assumed, when gzipped, they end up being bigger than the original body.
+If the body size cannot be determined (e.g. chunked responses), then it is assumed the response is over the threshold.
+By default the threshold is set to 0 to compress all responses, no matter how large the response body size is.
+
+Please see [[the gzip filter page|GzipEncoding]] for more details.

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -553,6 +553,20 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.jpa.DefaultJPAApi.withTransaction"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.jpa.DefaultJPAApi.withTransaction"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.db.jpa.DefaultJPAApi.withTransaction"),
+      // Add treshold to GzipFilter
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilterConfig.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.gzip.GzipFilter.this"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilterConfig.apply$default$3"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilterConfig.apply$default$4"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilterConfig.copy$default$3"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilterConfig.copy$default$4"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilterConfig.<init>$default$3"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilterConfig.<init>$default$4"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilter.<init>$default$3"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilter.<init>$default$4"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.filters.gzip.GzipFilterConfig.unapply"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -279,6 +279,11 @@ play.filters {
 
     # The compression level to use, integer, -1 to 9, inclusive. See java.util.zip.Deflater.
     compressionLevel = -1
+
+    # The byte threshold for the response body size which controls if a response should be gzipped (e.g. 1k).
+    # If the body size cannot be determined, then it is assumed the response is over the threshold.
+    # Set to 0 if you want to compress all responses, no matter how large the response body size is.
+    threshold = 0
   }
 
   # Configuration for redirection to HTTPS and Strict-Transport-Security

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -261,6 +261,13 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       checkGzippedBody(makeGzipRequest(app), "these are 1_9 bytes")(app.materializer)
     }
 
+    "gzip responses if a byte threshold is set but the body size cannot be determined" in withApplication(
+      Ok.chunked(Source(List("these are 18 bytes"))),
+      threshold = 18
+    ) { implicit app =>
+      checkGzippedBody(makeGzipRequest(app), "these are 18 bytes")(app.materializer)
+    }
+
     val body = Random.nextString(1000)
 
     "a streamed body" should {

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -247,6 +247,20 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       await(result).body must beAnInstanceOf[HttpEntity.Chunked]
     }
 
+    "not gzip responses whose bodies are equals or smaller than the byte threshold" in withApplication(
+      Ok("these are 18 bytes"),
+      threshold = 18
+    ) { implicit app =>
+      checkNotGzipped(makeGzipRequest(app), "these are 18 bytes")(app.materializer)
+    }
+
+    "gzip responses whose bodies are larger than the byte threshold" in withApplication(
+      Ok("these are 1_9 bytes"),
+      threshold = 18
+    ) { implicit app =>
+      checkGzippedBody(makeGzipRequest(app), "these are 1_9 bytes")(app.materializer)
+    }
+
     val body = Random.nextString(1000)
 
     "a streamed body" should {
@@ -432,7 +446,8 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       chunkedThreshold: Int = 1024,
       whiteList: List[String] = List.empty,
       blackList: List[String] = List.empty,
-      compressionLevel: Int = Deflater.DEFAULT_COMPRESSION
+      compressionLevel: Int = Deflater.DEFAULT_COMPRESSION,
+      threshold: Int = 0
   )(block: Application => T): T = {
     val application = new GuiceApplicationBuilder()
       .configure(
@@ -440,7 +455,8 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
         "play.filters.gzip.bufferSize"            -> 512,
         "play.filters.gzip.contentType.whiteList" -> whiteList,
         "play.filters.gzip.contentType.blackList" -> blackList,
-        "play.filters.gzip.compressionLevel"      -> compressionLevel
+        "play.filters.gzip.compressionLevel"      -> compressionLevel,
+        "play.filters.gzip.threshold"             -> threshold
       )
       .overrides(
         bind[Result].to(result),


### PR DESCRIPTION
Fixes #9606

You can now set a treshold via config:
```
play.filters.gzip.threshold = 1k
```

**The question is should we set the threshold to something larger than 0 bytes out-of-the-box?**
E.g. Express.js [uses 1kb by default](https://github.com/expressjs/compression#threshold).
If we do so, we need to add migration notes.
If not, we can backport this pr to 2.7.x straight away without changes.