### PR TITLE
Prefer incubating over experimental

### DIFF
--- a/documentation/manual/working/commonGuide/akka/AkkaClusterSharding.md
+++ b/documentation/manual/working/commonGuide/akka/AkkaClusterSharding.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com> -->
-# Cluster Sharding for Akka Typed (experimental)
+# Cluster Sharding for Akka Typed (incubating)
 
-Play provides an experimental module for integration with [Akka Cluster Sharding Typed](https://doc.akka.io/docs/akka/2.6/typed/cluster-sharding.html). To enable this module, add the following dependency to your build:
+Play provides an [incubating](https://developer.lightbend.com/docs/lightbend-platform/introduction/getting-help/support-terminology.html) module for integration with [Akka Cluster Sharding Typed](https://doc.akka.io/docs/akka/2.6/typed/cluster-sharding.html). To enable this module, add the following dependency to your build:
 
 Java
 : @[java-cluster-deps](code/javaguide/javaguide.clusterdeps.sbt)

--- a/documentation/manual/working/commonGuide/akka/AkkaIntegrations.md
+++ b/documentation/manual/working/commonGuide/akka/AkkaIntegrations.md
@@ -4,4 +4,4 @@
 This section covers some topics related to working with advanced features in Akka.
 
 - [[Integrating with Akka Typed|AkkaTyped]]
-- [[Akka Cluster Sharding for Akka Typed (experimental)|AkkaClusterSharding]]
+- [[Akka Cluster Sharding for Akka Typed (incubating)|AkkaClusterSharding]]

--- a/documentation/manual/working/commonGuide/akka/index.toc
+++ b/documentation/manual/working/commonGuide/akka/index.toc
@@ -1,3 +1,3 @@
 AkkaIntegrations: Akka Advanced Integrations
 AkkaTyped:Integrating with Akka Typed
-AkkaClusterSharding:Akka Cluster Sharding for Akka Typed (experimental)
+AkkaClusterSharding:Akka Cluster Sharding for Akka Typed (incubating)

--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -22,7 +22,7 @@ You can read more about the configuration settings in the [Akka HTTP documentati
 >
 > They will be automatically recognized. Keep in mind that Play configurations listed above will override the Akka ones.
 
-There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have [[enabled the `AkkaHttp2Support` plugin|AkkaHttpServer#HTTP/2-support-(experimental)]]:
+There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have [[enabled the `AkkaHttp2Support` plugin|AkkaHttpServer#HTTP/2-support-(incubating)]]:
 
 @[](/confs/play-akka-http2-support/reference.conf)
 

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -239,11 +239,8 @@ Also, be aware the `DATABASE_URL` is in the platform independent format:
 vendor://username:password@host:port/db
 ```
 
-Play will automatically convert this into a JDBC URL for you if you are using one
-of the built in database connection pools. But other database libraries and
-frameworks, such as Slick or Hibernate, may not support this format natively.
-If that's the case, you may try using the experimental `JDBC_DATABASE_URL` in
-place of `DATABASE_URL` in the configuration like this:
+Play will automatically convert this into a JDBC URL for you if you are using one of the built in database connection pools. But other database libraries and frameworks, such as Slick or Hibernate, may not support this format natively.
+If that's the case, you may try using the [dynamic](https://devcenter.heroku.com/articles/connecting-to-relational-databases-on-heroku-with-java#using-the-jdbc_database_url) `JDBC_DATABASE_URL` in place of `DATABASE_URL` in the configuration like this:
 
 ```text
 db.default.url=${?JDBC_DATABASE_URL}

--- a/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
+++ b/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
@@ -23,9 +23,9 @@ Please configure any work with blocking APIs off the main rendering thread, usin
 
 There are a variety of options that can be configured for the Akka HTTP server. These are given in the [[documentation on configuring Akka HTTP|SettingsAkkaHttp]].
 
-## HTTP/2 support (experimental)
+## HTTP/2 support (incubating)
 
-Play's Akka HTTP server also supports HTTP/2. This feature is labeled "experimental" because the API may change in the future, and it has not been thoroughly tested in the wild. However, if you'd like to help Play improve please do test out HTTP/2 support and give us feedback about your experience.
+Play's Akka HTTP server also supports HTTP/2. This feature is labeled "incubating" because the API may change in the future, and it has not been thoroughly tested in the wild. However, if you'd like to help Play improve please do test out HTTP/2 support and give us feedback about your experience.
 
 You also should [[Configure HTTPS|ConfiguringHttps]] on your server before enabling HTTP/2. In general, browsers require TLS to work with HTTP/2, and Play's Akka HTTP server uses ALPN (a TLS extension) to negotiate the protocol with clients that support it.
 


### PR DESCRIPTION
#9503 introduced more usages of `experimental`.  Instead, prefer using [`incubating`](https://developer.lightbend.com/docs/lightbend-platform/introduction/getting-help/support-terminology.html).

Since the issue affected other existing pages I'm sending a separate PR.

I'm not editing any reference to `experimental` on release notes, highlights or migration guides on purpose.