### PR TITLE
Move example logback conf to docs

### DIFF
--- a/documentation/manual/working/commonGuide/database/AccessingAnSQLDatabase.md
+++ b/documentation/manual/working/commonGuide/database/AccessingAnSQLDatabase.md
@@ -136,7 +136,7 @@ db.default.logSql=true
 
 After that, you can configure the jdbcdslog-exp [log level as explained in their manual](https://code.google.com/p/jdbcdslog/wiki/UserGuide#Setup_logging_engine). Basically, you need to configure your root logger to `INFO` and then decide what jdbcdslog-exp will log (connections, statements and result sets). Here is an example using `logback.xml` to configure the logs:
 
-@[](/confs/play-logback/logback-play-logSql.xml)
+@[](code/logback-play-logSql.xml)
 
 > **Warning**: Keep in mind that this is intended to be used just in development environments and you should not configure it in production, since there is a performance degradation and it will pollute your logs.
 

--- a/documentation/manual/working/commonGuide/database/code/logback-play-logSql.xml
+++ b/documentation/manual/working/commonGuide/database/code/logback-play-logSql.xml
@@ -1,3 +1,7 @@
+<!--
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
 
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />

--- a/documentation/manual/working/commonGuide/database/code/logback-play-logSql.xml
+++ b/documentation/manual/working/commonGuide/database/code/logback-play-logSql.xml
@@ -1,8 +1,3 @@
-<!--
-   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
--->
-
-<!-- The default logback configuration that Play uses if no other configuration is provided -->
 <configuration>
 
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />


### PR DESCRIPTION
Having the `logback-play-logSql.xml` where it is now is a bit confusing. It's just used as an example in the documentation, not for Play itself (at least I can not find where it would be used).

@marcospereira You added this file in #4713, that's why I want your thumbs up for this pull request (was it on purpose that you didn't put it in the docs folder?)