### PR TITLE
Fix path in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-core/play-integration-test/src/test/resources/testassets/* binary
+core/play-integration-test/src/it/resources/testassets/* binary


### PR DESCRIPTION
Original commit:
https://github.com/playframework/playframework/commit/66e80342e4198cd0baff167c19f64098823232a9#diff-fc723d30b02a4cca7a534518111c1a66
Path pointed to this folder back then:
https://github.com/playframework/playframework/tree/2.7.0-M1/framework/src/play-integration-test/src/test/resources/testassets/

This folder does not exist anymore, it was renamed to:
https://github.com/playframework/playframework/tree/master/core/play-integration-test/src/it/resources/testassets/