### PR TITLE
Add headers for .conf and .xml files

### DIFF
--- a/cache/play-cache/src/test/resources/logback-test.xml
+++ b/cache/play-cache/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/cache/play-caffeine-cache/src/main/resources/reference.conf
+++ b/cache/play-caffeine-cache/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
 
   modules {

--- a/cache/play-caffeine-cache/src/test/resources/logback-test.xml
+++ b/cache/play-caffeine-cache/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/cache/play-ehcache/src/main/resources/ehcache-default.xml
+++ b/cache/play-ehcache/src/main/resources/ehcache-default.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../config/ehcache.xsd" updateCheck="false">
 
     <defaultCache

--- a/cache/play-ehcache/src/main/resources/reference.conf
+++ b/cache/play-ehcache/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
 
   modules {

--- a/cache/play-ehcache/src/test/resources/ehcache-alternate.xml
+++ b/cache/play-ehcache/src/test/resources/ehcache-alternate.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../config/ehcache.xsd" updateCheck="false">
 
   <defaultCache

--- a/cache/play-ehcache/src/test/resources/logback-test.xml
+++ b/cache/play-ehcache/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/cache/play-jcache/src/main/resources/reference.conf
+++ b/cache/play-jcache/src/main/resources/reference.conf
@@ -1,1 +1,3 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play.modules.enabled+=play.api.libs.jcache.JCacheModule

--- a/cluster/play-cluster-sharding/src/main/resources/play/reference-overrides.conf
+++ b/cluster/play-cluster-sharding/src/main/resources/play/reference-overrides.conf
@@ -1,2 +1,4 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 # we need provider to be 'cluster' when using this module
 akka.actor.provider = cluster

--- a/cluster/play-cluster-sharding/src/main/resources/reference.conf
+++ b/cluster/play-cluster-sharding/src/main/resources/reference.conf
@@ -1,1 +1,3 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play.modules.enabled += "play.api.cluster.sharding.typed.ClusterShardingModule"

--- a/cluster/play-java-cluster-sharding/src/main/resources/play/reference-overrides.conf
+++ b/cluster/play-java-cluster-sharding/src/main/resources/play/reference-overrides.conf
@@ -1,2 +1,4 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 # we need provider to be 'cluster' when using this module
 akka.actor.provider = cluster

--- a/cluster/play-java-cluster-sharding/src/main/resources/reference.conf
+++ b/cluster/play-java-cluster-sharding/src/main/resources/reference.conf
@@ -1,1 +1,3 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play.modules.enabled += "play.cluster.sharding.typed.ClusterShardingModule"

--- a/core/play-guice/src/main/resources/reference.conf
+++ b/core/play-guice/src/main/resources/reference.conf
@@ -1,2 +1,3 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
 play.application.loader = "play.api.inject.guice.GuiceApplicationLoader"

--- a/core/play-guice/src/test/resources/logback-test.xml
+++ b/core/play-guice/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/core/play-java/src/main/resources/reference.conf
+++ b/core/play-java/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
   modules {
     enabled += "play.inject.BuiltInModule"

--- a/core/play-java/src/test/resources/logback-test.xml
+++ b/core/play-java/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/core/play-logback/src/main/resources/logback-play-default.xml
+++ b/core/play-logback/src/main/resources/logback-play-default.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <!-- The default logback configuration that Play uses if no other configuration is provided -->
 <configuration>
 

--- a/core/play-logback/src/main/resources/logback-play-dev.xml
+++ b/core/play-logback/src/main/resources/logback-play-dev.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <!-- The default logback configuration that Play uses in dev mode if no other configuration is provided -->
 <configuration>
 

--- a/core/play-logback/src/main/resources/logback-play-logSql.xml
+++ b/core/play-logback/src/main/resources/logback-play-logSql.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <!-- The default logback configuration that Play uses if no other configuration is provided -->
 <configuration>
 

--- a/core/play-streams/src/test/resources/logback-test.xml
+++ b/core/play-streams/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/core/play/src/main/resources/play/reference-overrides.conf
+++ b/core/play/src/main/resources/play/reference-overrides.conf
@@ -1,6 +1,4 @@
-#
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-#
 
 # Hack to override some of Akka's defaults in Play
 

--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -1,6 +1,4 @@
-#
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-#
 
 # Reference configuration for Play
 

--- a/core/play/src/test/resources/logback-test.xml
+++ b/core/play/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/core/play/src/test/resources/reference.conf
+++ b/core/play/src/test/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
   http {
     secret {

--- a/dev-mode/routes-compiler/src/test/resources/logback-test.xml
+++ b/dev-mode/routes-compiler/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/dev-mode/run-support/src/test/resources/logback-test.xml
+++ b/dev-mode/run-support/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/dev-mode/sbt-plugin/src/test/resources/logback-test.xml
+++ b/dev-mode/sbt-plugin/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -9,6 +9,9 @@ import play.core.PlayVersion
 import playbuild.JavaVersion
 import playbuild.CrossJava
 
+import de.heikoseeberger.sbtheader.FileType
+import de.heikoseeberger.sbtheader.CommentStyle
+
 val DocsApplication = config("docs").hide
 
 lazy val main = Project("Play-Documentation", file("."))
@@ -79,6 +82,7 @@ lazy val main = Project("Play-Documentation", file("."))
     fork in Test := true,
     javaOptions in Test ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>")),
+    headerMappings += (FileType.xml -> CommentStyle.xmlStyleBlockComment),
     sourceDirectories in javafmt in Test ++= (unmanagedSourceDirectories in Test).value,
     sourceDirectories in javafmt in Test ++= (unmanagedResourceDirectories in Test).value,
     // No need to show eviction warnings for Play documentation.

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -82,7 +82,10 @@ lazy val main = Project("Play-Documentation", file("."))
     fork in Test := true,
     javaOptions in Test ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>")),
-    headerMappings += (FileType.xml -> CommentStyle.xmlStyleBlockComment),
+    headerMappings ++= Map(
+      FileType.xml -> CommentStyle.xmlStyleBlockComment,
+      FileType.conf -> CommentStyle.hashLineComment
+    ),
     sourceDirectories in javafmt in Test ++= (unmanagedSourceDirectories in Test).value,
     sourceDirectories in javafmt in Test ++= (unmanagedResourceDirectories in Test).value,
     // No need to show eviction warnings for Play documentation.

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -83,7 +83,7 @@ lazy val main = Project("Play-Documentation", file("."))
     javaOptions in Test ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>")),
     headerMappings ++= Map(
-      FileType.xml -> CommentStyle.xmlStyleBlockComment,
+      FileType.xml  -> CommentStyle.xmlStyleBlockComment,
       FileType.conf -> CommentStyle.hashLineComment
     ),
     sourceDirectories in javafmt in Test ++= (unmanagedSourceDirectories in Test).value,

--- a/documentation/manual/working/commonGuide/configuration/code/application.conf
+++ b/documentation/manual/working/commonGuide/configuration/code/application.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 //#custom-akka-http-server-provider
 //###replace: play.server.provider = server.CustomAkkaHttpServerProvider
 #play.server.provider = server.CustomAkkaHttpServerProvider

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/akka.conf
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/akka.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 #conf
 akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 64
 akka.actor.debug.receive = on

--- a/documentation/src/main/resources/application.conf
+++ b/documentation/src/main/resources/application.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play.http.secret.key = "i am very secret"
 
 # To avoid port conflicts when running documentation tests

--- a/documentation/src/test/resources/logback.xml
+++ b/documentation/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
 
 <configuration>
 

--- a/persistence/play-java-jdbc/src/main/resources/reference.conf
+++ b/persistence/play-java-jdbc/src/main/resources/reference.conf
@@ -1,1 +1,3 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play.modules.enabled += "play.db.DBModule"

--- a/persistence/play-java-jdbc/src/test/resources/logback-test.xml
+++ b/persistence/play-java-jdbc/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/persistence/play-java-jpa/src/main/resources/reference.conf
+++ b/persistence/play-java-jpa/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
   modules {
     enabled += "play.db.jpa.JPAModule"

--- a/persistence/play-java-jpa/src/test/resources/META-INF/persistence.xml
+++ b/persistence/play-java-jpa/src/test/resources/META-INF/persistence.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"

--- a/persistence/play-java-jpa/src/test/resources/logback-test.xml
+++ b/persistence/play-java-jpa/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/persistence/play-jdbc-evolutions/src/main/resources/reference.conf
+++ b/persistence/play-jdbc-evolutions/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
 
   modules {

--- a/persistence/play-jdbc-evolutions/src/test/resources/logback-test.xml
+++ b/persistence/play-jdbc-evolutions/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/persistence/play-jdbc/src/main/resources/reference.conf
+++ b/persistence/play-jdbc/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
 
   modules {

--- a/persistence/play-jdbc/src/test/resources/application.conf
+++ b/persistence/play-jdbc/src/test/resources/application.conf
@@ -1,2 +1,4 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 # Necessary when running tests using DEV or PROD mode.
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b

--- a/persistence/play-jdbc/src/test/resources/logback-test.xml
+++ b/persistence/play-jdbc/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -53,7 +53,10 @@ object BuildSettings {
       fileUriRegexFilter(".*/cookie/encoding/.*") || fileUriRegexFilter(".*/inject/SourceProvider.java$") ||
       fileUriRegexFilter(".*/libs/reflect/.*"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>")),
-    headerMappings += (FileType.xml -> CommentStyle.xmlStyleBlockComment)
+    headerMappings ++= Map(
+      FileType.xml -> CommentStyle.xmlStyleBlockComment,
+      FileType.conf -> CommentStyle.hashLineComment
+    )
   )
 
   private val VersionPattern = """^(\d+).(\d+).(\d+)(-.*)?""".r

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -54,7 +54,7 @@ object BuildSettings {
       fileUriRegexFilter(".*/libs/reflect/.*"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>")),
     headerMappings ++= Map(
-      FileType.xml -> CommentStyle.xmlStyleBlockComment,
+      FileType.xml  -> CommentStyle.xmlStyleBlockComment,
       FileType.conf -> CommentStyle.hashLineComment
     )
   )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -10,6 +10,8 @@ import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import com.typesafe.tools.mima.plugin.MimaPlugin._
 import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
+import de.heikoseeberger.sbtheader.FileType
+import de.heikoseeberger.sbtheader.CommentStyle
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import interplay._
 import interplay.Omnidoc.autoImport._
@@ -50,7 +52,8 @@ object BuildSettings {
     excludeFilter in (Compile, headerSources) := HiddenFileFilter ||
       fileUriRegexFilter(".*/cookie/encoding/.*") || fileUriRegexFilter(".*/inject/SourceProvider.java$") ||
       fileUriRegexFilter(".*/libs/reflect/.*"),
-    headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>"))
+    headerLicense := Some(HeaderLicense.Custom("Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>")),
+    headerMappings += (FileType.xml -> CommentStyle.xmlStyleBlockComment)
   )
 
   private val VersionPattern = """^(\d+).(\d+).(\d+)(-.*)?""".r

--- a/testkit/play-specs2/src/test/resources/logback-test.xml
+++ b/testkit/play-specs2/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/testkit/play-test/src/test/resources/logback-test.xml
+++ b/testkit/play-test/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/transport/client/play-ahc-ws/src/main/resources/reference.conf
+++ b/transport/client/play-ahc-ws/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
   modules {
     enabled += "play.api.libs.ws.ahc.AhcWSModule"

--- a/transport/client/play-ahc-ws/src/test/resources/caffeine.conf
+++ b/transport/client/play-ahc-ws/src/test/resources/caffeine.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 caffeine.jcache {
   play-ws-cache {
     listeners = ["caffeine.jcache.listeners.test-listener"]

--- a/transport/client/play-ahc-ws/src/test/resources/ehcache-play-ws-cache.xml
+++ b/transport/client/play-ahc-ws/src/test/resources/ehcache-play-ws-cache.xml
@@ -1,3 +1,7 @@
+<!--
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <ehcache
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://ehcache.org/ehcache.xsd"

--- a/transport/client/play-ahc-ws/src/test/resources/logback-test.xml
+++ b/transport/client/play-ahc-ws/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
   <!-- Suppress logback complaining about multiple logback-test.xml files -->
   <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>

--- a/transport/server/play-akka-http-server/src/main/resources/play/reference-overrides.conf
+++ b/transport/server/play-akka-http-server/src/main/resources/play/reference-overrides.conf
@@ -1,6 +1,4 @@
-#
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-#
 
 # Hack to override some of Akka's defaults in Play
 

--- a/transport/server/play-akka-http-server/src/main/resources/reference.conf
+++ b/transport/server/play-akka-http-server/src/main/resources/reference.conf
@@ -1,6 +1,4 @@
-#
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-#
 
 # Configuration for Play's AkkaHttpServer
 play {

--- a/transport/server/play-akka-http-server/src/test/resources/application.conf
+++ b/transport/server/play-akka-http-server/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
   http.secret.key = rosebud
   

--- a/transport/server/play-akka-http2-support/src/main/resources/reference.conf
+++ b/transport/server/play-akka-http2-support/src/main/resources/reference.conf
@@ -1,6 +1,4 @@
-#
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-#
 
 # Determines whether HTTP2 is enabled.
 play.server.akka.http2 {

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play.server {
 
   # The server provider class name

--- a/transport/server/play-netty-server/src/test/resources/application.conf
+++ b/transport/server/play-netty-server/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
   http.secret.key = rosebud
   

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
 
   server {

--- a/transport/server/play-server/src/test/resources/application.conf
+++ b/transport/server/play-server/src/test/resources/application.conf
@@ -1,2 +1,4 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 # Needed so play-server tests run
 play.http.secret.key = "MwWGiFxb0bkpy=TU`ON=O23;3TqKgHAJWqSE3XsSfE`ByOqZcLuwmvc;^/;wCxqR"

--- a/transport/server/play-server/src/test/resources/logback-test.xml
+++ b/transport/server/play-server/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play.modules {
   enabled += "play.filters.csrf.CSRFModule"
   enabled += "play.filters.cors.CORSModule"

--- a/web/play-filters-helpers/src/test/resources/application.conf
+++ b/web/play-filters-helpers/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b
 
 play.http.filters=play.api.http.NoHttpFilters

--- a/web/play-filters-helpers/src/test/resources/logback-test.xml
+++ b/web/play-filters-helpers/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/web/play-java-forms/src/main/resources/reference.conf
+++ b/web/play-java-forms/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
   modules {
     enabled += "play.data.FormFactoryModule"

--- a/web/play-openid/src/main/resources/reference.conf
+++ b/web/play-openid/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
 play {
   modules {
     enabled += "play.libs.ws.ahc.AhcWSModule"

--- a/web/play-openid/src/test/resources/logback-test.xml
+++ b/web/play-openid/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <configuration>
     <!-- Suppress logback complaining about multiple logback-test.xml files -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/google-account-response.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/google-account-response.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">
 <XRD>
 <Service priority="0">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/invalid-op-identifier.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/invalid-op-identifier.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">
     <XRD>
         <Service>

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/multi-service-with-op-and-claimed-id-service.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/multi-service-with-op-and-claimed-id-service.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">
     <XRD>
 

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/multi-service.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/multi-service.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)"
            xmlns:openid="http://openid.net/xmlns/1.0">
     <XRD ref="xri://=example">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-op-non-unique.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-op-non-unique.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">
     <XRD>
         <Service>

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-op.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-op.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">
     <XRD>
         <Service>

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-openid-1-op.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-openid-1-op.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">
     <XRD>
         <Service>

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-openid-1.1-op.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-openid-1.1-op.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
-  -->
+   Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+-->
+
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">
     <XRD>
         <Service>


### PR DESCRIPTION
## Purpose

Manage headers for `.xml` and `.conf` files.

## References

See this comment from @renatocaval: https://github.com/playframework/playframework/pull/9695#discussion_r330466192 in @mkurz PR. The build was green even if the headers aren't there.
