### PR TITLE
Eliminated the type parameter associated with WebSocket in docs (fixe…

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -51,7 +51,7 @@ Sometimes you may wish to reject a WebSocket request, for example, if the user m
 
 ### Accepting a WebSocket asynchronously
 
-You may need to do some asynchronous processing before you are ready to create an actor or reject the WebSocket, if that's the case, you can simply return `CompletionStage<WebSocket<A>>` instead of `WebSocket<A>`.
+You may need to do some asynchronous processing before you are ready to create an actor or reject the WebSocket, if that's the case, you can simply return `CompletionStage<WebSocket>` instead of `WebSocket`.
 
 ### Handling different types of messages
 


### PR DESCRIPTION
…s #8940)

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?

* [ ] Have you added copyright headers to new files?
**I've not added any new files.**
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
**This PR pertains only to the Java section of the documentation.**

* [ ] Have you added tests for any changed functionality?
**I've not changed any existing functionality,**

# Helpful things

## Fixes

Fixes #8940 

## Purpose

This PR eliminates a mistake regarding the `WebSocket` class in the documentation