### PR TITLE
Run format and headerCheck on all scala/sbt versions

### DIFF
--- a/core/play-java/src/main/scala-2.11/play/core/j/JavaImplicitConversions.scala
+++ b/core/play-java/src/main/scala-2.11/play/core/j/JavaImplicitConversions.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.core.j
 
 import scala.collection.convert._

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala-sbt-0.13/com/typesafe/play/docs/sbtplugin/PlayDocsPluginCompat.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala-sbt-0.13/com/typesafe/play/docs/sbtplugin/PlayDocsPluginCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package com.typesafe.play.docs.sbtplugin
 
 import sbt._

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala-sbt-0.13/com/typesafe/play/docs/sbtplugin/PlayDocsValidationCompat.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala-sbt-0.13/com/typesafe/play/docs/sbtplugin/PlayDocsValidationCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package com.typesafe.play.docs.sbtplugin
 
 import sbt._

--- a/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlayExceptions.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlayExceptions.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.sbt
 
 import play.api._

--- a/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlayImportCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlayImportCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.sbt
 
 import sbt.Keys.logManager

--- a/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlayInternalKeysCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlayInternalKeysCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.sbt
 
 import sbt.TaskKey

--- a/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlaySettingsCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/PlaySettingsCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.sbt
 
 import java.util.concurrent.TimeUnit

--- a/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/routes/RoutesCompilerCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/routes/RoutesCompilerCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.sbt.routes
 
 import play.routes.compiler.RoutesCompiler.GeneratedSource

--- a/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/run/PlayReload.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.sbt.run
 
 import sbt._

--- a/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/run/PlayRunCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/run/PlayRunCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.sbt.run
 
 import sbt._

--- a/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/test/MediatorWorkaroundPluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-sbt-0.13/play/sbt/test/MediatorWorkaroundPluginCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package play.sbt.test
 
 import sbt.Keys.ivyScala

--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -40,7 +40,7 @@ runSbtNoisy() {
 # Runs code formating validation in the current directory
 scalafmtValidation() {
   printMessage "VALIDATE SCALA CODE FORMATTING"
-  runSbtNoisy scalafmtAll scalafmtSbt
+  runSbtNoisy +scalafmtAll scalafmtSbt
   git diff --exit-code || (
     echo "[error] ERROR: Scalafmt test failed for $1 source."
     echo "[error] To fix, format your sources using 'sbt scalafmtAll scalafmtAll' before submitting a pull request."

--- a/scripts/validate-code
+++ b/scripts/validate-code
@@ -14,7 +14,7 @@ scalafmtValidation "framework"
 javafmtValidation "framework"
 
 printMessage "VALIDATE FILE LICENSE HEADERS"
-runSbtNoisy headerCheck test:headerCheck
+runSbtNoisy +headerCheck +test:headerCheck
 
 
 printMessage "RUNNING WHITESOURCE REPORT"


### PR DESCRIPTION
Fixes #9719 on `2.6.x`.

We may have to manually forward port this to `2.7.x` and `master` but I don't recall seeing this issue on those branches.

I noticed this because of a failure in nightly jobs (vegemite).