### PR TITLE
Eliminated inconsistency between class name and constructor in docs (#9667)

### DIFF
--- a/documentation/manual/working/commonGuide/build/code/javaguide/common/build/controllers/Assets.java
+++ b/documentation/manual/working/commonGuide/build/code/javaguide/common/build/controllers/Assets.java
@@ -12,8 +12,7 @@ import play.api.http.HttpErrorHandler;
 
 import javax.inject.Inject;
 
-// ###replace: public class Assets extends controllers.Assets {
-class Assets extends controllers.Assets {
+public class Assets extends controllers.Assets {
 
   @Inject
   public Assets(HttpErrorHandler errorHandler, AssetsMetadata meta) {

--- a/documentation/manual/working/commonGuide/build/code/javaguide/common/build/controllers/AssetsBuilder.java
+++ b/documentation/manual/working/commonGuide/build/code/javaguide/common/build/controllers/AssetsBuilder.java
@@ -12,7 +12,7 @@ import play.api.http.HttpErrorHandler;
 
 import javax.inject.Inject;
 
-// ###replace: public class AssetsBuilder extends controllers.Assets {
+// ###replace: public class Assets extends controllers.Assets {
 class Assets extends controllers.Assets {
 
   @Inject

--- a/documentation/manual/working/commonGuide/build/sbtSubProjects.md
+++ b/documentation/manual/working/commonGuide/build/sbtSubProjects.md
@@ -194,7 +194,7 @@ GET     /assets/*file       controllers.Assets.at(path="/public", file)
 ### Assets and controller classes should be all defined in the `controllers.admin` package
 
 Java
-: @[assets-builder](code/javaguide/common/build/controllers/AssetsBuilder.java)
+: @[assets-builder](code/javaguide/common/build/controllers/Assets.java)
 
 Scala
 : @[assets-builder](code/scalaguide/common/build/controllers/SubProjectsAssetsBuilder.scala)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?

# Helpful things

## Fixes

Fixes #9667

## Purpose

The code mentioned in [this file](https://github.com/playframework/playframework/blob/master/documentation/manual/working/commonGuide/build/code/javaguide/common/build/controllers/AssetsBuilder.java) is displayed in a section named **"Working with subprojects"** of the documentation, which may be found [**here.**](https://www.playframework.com/documentation/2.7.x/sbtSubProjects#Assets-and-controller-classes-should-be-all-defined-in-the-controllers.admin-package) 

The code can't be compiled because there is an inconsistency between the class' name and the constructor. In order to fix this, I changed the name of the class to Assets within the text of the replace annotation.