### PR TITLE
Added instance for QueryStringBindable[Short]

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -361,6 +361,17 @@ object QueryStringBindable {
     bindableLong.transform(Long.box, Long.unbox)
 
   /**
+   * QueryString binder for Short.
+   */
+  implicit object bindableShort
+      extends Parsing[Short](_.toShort, _.toString, (s, e) => s"Cannot parse parameter $s as Short: ${e.getMessage}")
+
+  /**
+   * QueryString binder for Java Short.
+   */
+  implicit def bindableJavaShort: QueryStringBindable[java.lang.Short] = bindableShort.transform(Short.box, Short.unbox)
+
+  /**
    * QueryString binder for Double.
    */
   implicit object bindableDouble

--- a/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -148,6 +148,37 @@ class BindersSpec extends Specification {
     }
   }
 
+  "URL QueryStringBindable Short" should {
+    val subject = implicitly[QueryStringBindable[Short]]
+    val short   = 7.toShort
+    val string  = "7"
+
+    "Unbind query string short as string" in {
+      subject.unbind("key", short) must equalTo("key=" + short.toString)
+    }
+    "Bind query string as short" in {
+      subject.bind("key", Map("key" -> Seq(string))) must equalTo(Some(Right(short)))
+    }
+    "Fail on value must contain only digits" in {
+      subject.bind("key", Map("key" -> Seq("foo"))) must be_==(
+        Some(Left("Cannot parse parameter key as Short: For input string: \"foo\""))
+      )
+    }
+    "Fail on value < -32768" in {
+      subject.bind("key", Map("key" -> Seq("-32769"))) must be_==(
+        Some(Left("Cannot parse parameter key as Short: Value out of range. Value:\"-32769\" Radix:10"))
+      )
+    }
+    "Fail on value > 32767" in {
+      subject.bind("key", Map("key" -> Seq("32768"))) must be_==(
+        Some(Left("Cannot parse parameter key as Short: Value out of range. Value:\"32768\" Radix:10"))
+      )
+    }
+    "Be None on empty" in {
+      subject.bind("key", Map("key" -> Seq(""))) must equalTo(None)
+    }
+  }
+
   "URL PathBindable Char" should {
     val subject = implicitly[PathBindable[Char]]
     val char    = 'X'


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Adds an instance of QueryStringBindable[Short] which allows to use queryString params with Short type


