### PR TITLE
Netty's PlayRequestHandler can now access server config

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/main/resources/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/main/resources/application.conf
@@ -2,4 +2,4 @@
 
 ## This is an AkkaHTTP-specific setting so only the tests for AkkaHTTP-backed projects
 # should be able to read it.
-play.server.akka.server-header="AkkaHTTP Server"
+play.server.akka.server-header="AkkaHTTP Server Http2"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/test/scala/controllers/IntegrationTest.scala
@@ -29,10 +29,8 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     "use the user-configured HTTP backend during test" >> { implicit rs: RunningServer =>
       val result = await(wsUrl("/").get)
       // This assertion indirectly checks the HTTP backend used during tests is that configured
-      // by the user on `build.sbt`. The `play.server.akka.server-header` exists in all three
-      // tests in the `http-backend` suite, but only those tests using `AkkaHTTP` as a backend
-      // can read the header value because it's an Akka HTTP specific feature.
-      result.header("Server") must ===(Some("AkkaHTTP Server"))
+      // by the user on `build.sbt`.
+      result.header("Server") must ===(Some("AkkaHTTP Server Http2"))
     }
 
     "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
@@ -29,9 +29,7 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     "use the user-configured HTTP backend during test" >> { implicit rs: RunningServer =>
       val result = await(wsUrl("/").get)
       // This assertion indirectly checks the HTTP backend used during tests is that configured
-      // by the user on `build.sbt`. The `play.server.akka.server-header` exists in all three
-      // tests in the `http-backend` suite, but only those tests using `AkkaHTTP` as a backend
-      // can read the header value because it's an Akka HTTP specific feature.
+      // by the user on `build.sbt`.
       result.header("Server") must ===(Some("AkkaHTTP Server"))
     }
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/resources/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
-## This is an AkkaHTTP-specific setting so only the tests for AkkaHTTP-backed projects
+## This is an Netty-specific setting so only the tests for Netty-backed projects
 # should be able to read it.
-play.server.akka.server-header="AkkaHTTP Server"
+play.server.netty.server-header="Netty Server"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
@@ -29,10 +29,8 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     "use the user-configured HTTP backend during test" >> { implicit rs: RunningServer =>
       val result = await(wsUrl("/").get)
       // This assertion indirectly checks the HTTP backend used during tests is that configured
-      // by the user on `build.sbt`. The `play.server.akka.server-header` exists in all three
-      // tests in the `http-backend` suite, but only those tests using `AkkaHTTP` as a backend
-      // can read the header value because it's an Akka HTTP specific feature.
-      result.header("Server") must ===(None)
+      // by the user on `build.sbt`.
+      result.header("Server") must ===(Some("Netty Server"))
     }
 
     "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -589,6 +589,8 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilter.<init>$default$3"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.filters.gzip.GzipFilter.<init>$default$4"),
       ProblemFilters.exclude[IncompatibleSignatureProblem]("play.filters.gzip.GzipFilterConfig.unapply"),
+      // Netty's PlayRequestHandler can now access the server's config and therefore can read the serverHeader directly from it
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.netty.PlayRequestHandler.serverHeader")
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -54,7 +54,7 @@ case object Native extends NettyTransport
  * creates a Server implementation based Netty
  */
 class NettyServer(
-    val config: ServerConfig,
+    private[server] val config: ServerConfig,
     val applicationProvider: ApplicationProvider,
     stopHook: () => Future[_],
     val actorSystem: ActorSystem

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -54,7 +54,7 @@ case object Native extends NettyTransport
  * creates a Server implementation based Netty
  */
 class NettyServer(
-    config: ServerConfig,
+    val config: ServerConfig,
     val applicationProvider: ApplicationProvider,
     stopHook: () => Future[_],
     val actorSystem: ActorSystem
@@ -66,13 +66,11 @@ class NettyServer(
 
   private val serverConfig         = config.configuration.get[Configuration]("play.server")
   private val nettyConfig          = serverConfig.get[Configuration]("netty")
-  private val serverHeader         = nettyConfig.get[Option[String]]("server-header").collect { case s if s.nonEmpty => s }
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize =
     serverConfig.getDeprecated[ConfigMemorySize]("max-header-size", "netty.maxHeaderSize").toBytes.toInt
-  private val maxContentLength = Server.getPossiblyInfiniteBytes(serverConfig.underlying, "max-content-length")
-  private val maxChunkSize     = nettyConfig.get[Int]("maxChunkSize")
-  private val logWire          = nettyConfig.get[Boolean]("log.wire")
+  private val maxChunkSize = nettyConfig.get[Int]("maxChunkSize")
+  private val logWire      = nettyConfig.get[Boolean]("log.wire")
 
   private lazy val transport = nettyConfig.get[String]("transport") match {
     case "native" => Native
@@ -180,7 +178,7 @@ class NettyServer(
    * Create a new PlayRequestHandler.
    */
   protected[this] def newRequestHandler(): ChannelInboundHandler =
-    new PlayRequestHandler(this, serverHeader, maxContentLength)
+    new PlayRequestHandler(this)
 
   /**
    * Create a sink for the incoming connection channels.


### PR DESCRIPTION
Just little refactoring, nothing big.

Instead of reading values from the config and then just passing them  on to `PlayRequestHandler(...)`, I think its nicer if `PlayRequestHandler` itself can just access the config and read the values it needs.
Right now this is just the case for `serverHeader` and `maxContentLength`, however in an upcoming pull request I need to again access a config from within `PlayRequestHandler` and would have to do the same dance again.
Actually it was me who was not-so-clever (?) to pass variables instead of accessing the config itself when [introducing the server header](https://github.com/playframework/playframework/pull/8028/files#diff-646b4b205d4f5bb77cefd4aca60d534cR31) for netty and when [adding the max-content-length check](https://github.com/playframework/playframework/pull/9625/files#diff-e43b7c79ab267e19204588d0ce6f690dR39-R43) to netty.


Along the way I updated the scripted tests to reflect the fact that now, because of #8028 we can also set a server-header for the netty backend. Which also tests the `server-header` config.
A test for the max-content-length check is also in place already [since it was introduced](https://github.com/playframework/playframework/pull/9625/files#diff-6abd931f285977785b2ca49c67bff361R141-R143), so nothing to add here as well.