### PR TITLE
Providing a test to show POST request is fired with an empty body

### DIFF
--- a/testkit/play-test/src/test/java/play/test/HelpersTest.java
+++ b/testkit/play-test/src/test/java/play/test/HelpersTest.java
@@ -135,4 +135,13 @@ public class HelpersTest {
       Await.result(future, Duration.create("5s"));
     }
   }
+
+  @Test
+  public void shouldSuccessfullyExecutePostRequestWithEmptyBody() {
+    Http.RequestBuilder request = Helpers.fakeRequest("POST", "/uri");
+    Application app = Helpers.fakeApplication();
+
+    Result result = Helpers.route(app, request);
+    assertThat(result.status(), equalTo(404));
+  }
 }

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -15,6 +15,7 @@ import play.api.test.Helpers._
 import play.twirl.api.Content
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.reflectiveCalls
 
 class HelpersSpec extends Specification {
@@ -141,14 +142,24 @@ class HelpersSpec extends Specification {
 
   "Fakes" in {
     "FakeRequest" should {
+
       "parse query strings" in {
         val request = FakeRequest("GET", "/uri?q1=1&q2=2", FakeHeaders(), AnyContentAsEmpty)
         request.queryString.get("q1") must beSome.which(_.contains("1"))
         request.queryString.get("q2") must beSome.which(_.contains("2"))
       }
+
       "return an empty map when there is no query string parameters" in {
         val request = FakeRequest("GET", "/uri", FakeHeaders(), AnyContentAsEmpty)
         request.queryString must beEmpty
+      }
+
+      "successfully execute a POST request with an empty body" in {
+        val request = FakeRequest(POST, "/uri").withHeaders("<myheader>" -> "headervalue")
+        val fakeApplication = Helpers.baseApplicationBuilder.build()
+        val result = Helpers.route(fakeApplication, request)
+
+        result.get.map(result => result.header.status mustEqual 404)
       }
     }
   }

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -155,9 +155,9 @@ class HelpersSpec extends Specification {
       }
 
       "successfully execute a POST request with an empty body" in {
-        val request = FakeRequest(POST, "/uri").withHeaders("<myheader>" -> "headervalue")
+        val request         = FakeRequest(POST, "/uri").withHeaders("<myheader>" -> "headervalue")
         val fakeApplication = Helpers.baseApplicationBuilder.build()
-        val result = Helpers.route(fakeApplication, request)
+        val result          = Helpers.route(fakeApplication, request)
 
         result.get.map(result => result.header.status mustEqual 404)
       }


### PR DESCRIPTION
Issue #8632

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

The issue that was reported in the issue is actually fixed already. It just seems that there was a test missing, which is now included in this PR.

## References

#8632
