### PR TITLE
Dependency injection support for Akka Typed Scheduler

### DIFF
--- a/core/play/src/main/java/play/BuiltInComponents.java
+++ b/core/play/src/main/java/play/BuiltInComponents.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 /** Helper to provide the Play built in components. */
 public interface BuiltInComponents
     extends AkkaComponents,
+        AkkaTypedComponents,
         ApplicationComponents,
         BaseComponents,
         BodyParserComponents,

--- a/core/play/src/main/java/play/components/AkkaTypedComponents.java
+++ b/core/play/src/main/java/play/components/AkkaTypedComponents.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.components;
+
+import akka.actor.ActorSystem;
+import akka.actor.typed.Scheduler;
+import play.api.libs.concurrent.AkkaSchedulerProvider;
+
+/** Akka Typed components. */
+public interface AkkaTypedComponents {
+  ActorSystem actorSystem();
+
+  default Scheduler scheduler() {
+    return new AkkaSchedulerProvider(actorSystem()).get();
+  }
+}

--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -18,7 +18,7 @@ import play.api.inject.ApplicationLifecycle
 import play.api.inject._
 import play.api.internal.libs.concurrent.CoordinatedShutdownSupport
 import play.api.libs.Files._
-import play.api.libs.concurrent.ActorSystemProvider
+import play.api.libs.concurrent.AkkaComponents
 import play.api.libs.concurrent.AkkaTypedComponents
 import play.api.libs.concurrent.CoordinatedShutdownProvider
 import play.api.libs.crypto._
@@ -34,7 +34,6 @@ import play.core.WebCommands
 import play.utils._
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
@@ -297,7 +296,7 @@ private[play] final case object ApplicationStoppedReason extends CoordinatedShut
 /**
  * Helper to provide the Play built in components.
  */
-trait BuiltInComponents extends I18nComponents with AkkaTypedComponents {
+trait BuiltInComponents extends I18nComponents with AkkaComponents with AkkaTypedComponents {
 
   /** The application's environment, e.g. it's [[ClassLoader]] and root path. */
   def environment: Environment
@@ -395,12 +394,6 @@ trait BuiltInComponents extends I18nComponents with AkkaTypedComponents {
     materializer,
     coordinatedShutdown
   )
-
-  lazy val actorSystem: ActorSystem            = new ActorSystemProvider(environment, configuration).get
-  implicit lazy val materializer: Materializer = Materializer.matFromSystem(actorSystem)
-  lazy val coordinatedShutdown: CoordinatedShutdown =
-    new CoordinatedShutdownProvider(actorSystem, applicationLifecycle).get
-  implicit lazy val executionContext: ExecutionContext = actorSystem.dispatcher
 
   lazy val cookieSigner: CookieSigner = new CookieSignerProvider(httpConfiguration.secret).get
 

--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -19,6 +19,7 @@ import play.api.inject._
 import play.api.internal.libs.concurrent.CoordinatedShutdownSupport
 import play.api.libs.Files._
 import play.api.libs.concurrent.ActorSystemProvider
+import play.api.libs.concurrent.AkkaTypedComponents
 import play.api.libs.concurrent.CoordinatedShutdownProvider
 import play.api.libs.crypto._
 import play.api.mvc._
@@ -296,7 +297,7 @@ private[play] final case object ApplicationStoppedReason extends CoordinatedShut
 /**
  * Helper to provide the Play built in components.
  */
-trait BuiltInComponents extends I18nComponents {
+trait BuiltInComponents extends I18nComponents with AkkaTypedComponents {
 
   /** The application's environment, e.g. it's [[ClassLoader]] and root path. */
   def environment: Environment

--- a/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -11,6 +11,7 @@ import javax.inject.Provider
 import javax.inject.Singleton
 import akka.actor.ActorSystem
 import akka.actor.CoordinatedShutdown
+import akka.actor.typed.Scheduler
 import akka.stream.Materializer
 import com.typesafe.config.Config
 import play.api._
@@ -77,6 +78,8 @@ class BuiltinModule
         bind[ActorSystem].toProvider[ActorSystemProvider],
         bind[Materializer].toProvider[MaterializerProvider],
         bind[CoordinatedShutdown].toProvider[CoordinatedShutdownProvider],
+        // Typed Akka Scheduler bind
+        bind[Scheduler].toProvider[AkkaSchedulerProvider],
         bind[ExecutionContextExecutor].toProvider[ExecutionContextProvider],
         bind[ExecutionContext].to(bind[ExecutionContextExecutor]),
         bind[Executor].to(bind[ExecutionContextExecutor]),

--- a/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -7,8 +7,14 @@ package play.api.libs.concurrent
 import akka.Done
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.setup.Setup
+import akka.actor.typed.Scheduler
+import akka.actor.Actor
+import akka.actor.ActorContext
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.BootstrapSetup
 import akka.actor.CoordinatedShutdown
-import akka.actor._
+import akka.actor.Props
 import akka.stream.Materializer
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigValueFactory
@@ -99,6 +105,14 @@ trait AkkaComponents {
 }
 
 /**
+ * Akka Typed components.
+ */
+trait AkkaTypedComponents {
+  def actorSystem: ActorSystem
+  implicit lazy val scheduler: Scheduler = new AkkaSchedulerProvider(actorSystem).get
+}
+
+/**
  * Provider for the actor system
  */
 @Singleton
@@ -123,6 +137,15 @@ class MaterializerProvider @Inject()(actorSystem: ActorSystem) extends Provider[
 @Singleton
 class ExecutionContextProvider @Inject()(actorSystem: ActorSystem) extends Provider[ExecutionContextExecutor] {
   def get: ExecutionContextExecutor = actorSystem.dispatcher
+}
+
+/**
+ * Provider for an [[akka.actor.typed.Scheduler Akka Typed Scheduler]].
+ */
+@Singleton
+class AkkaSchedulerProvider @Inject()(actorSystem: ActorSystem) extends Provider[Scheduler] {
+  import akka.actor.typed.scaladsl.adapter._
+  override lazy val get: Scheduler = actorSystem.scheduler.toTyped
 }
 
 object ActorSystemProvider {

--- a/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -102,6 +102,13 @@ trait AkkaComponents {
   def applicationLifecycle: ApplicationLifecycle
 
   lazy val actorSystem: ActorSystem = new ActorSystemProvider(environment, configuration).get
+
+  lazy val coordinatedShutdown: CoordinatedShutdown =
+    new CoordinatedShutdownProvider(actorSystem, applicationLifecycle).get
+
+  implicit lazy val materializer: Materializer = Materializer.matFromSystem(actorSystem)
+
+  implicit lazy val executionContext: ExecutionContext = actorSystem.dispatcher
 }
 
 /**
@@ -262,7 +269,7 @@ class ActorRefProvider[T <: Actor: ClassTag](name: String, props: Props => Props
   @Inject private var actorSystem: ActorSystem = _
   @Inject private var injector: Injector       = _
 
-  lazy val get = {
+  lazy val get: ActorRef = {
     val creation = Props(injector.instanceOf[T])
     actorSystem.actorOf(props(creation), name)
   }

--- a/documentation/manual/working/commonGuide/akka/AkkaTyped.md
+++ b/documentation/manual/working/commonGuide/akka/AkkaTyped.md
@@ -1,6 +1,8 @@
 <!--- Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com> -->
 # Integrating with Akka Typed
 
+Akka 2.6 marked the new typed Actor API ("Akka Typed") as stable. The typed API is now officially the main API for Akka. In the typed API, each actor needs to declares which message type it is able to handle and the type system enforces that only messages of this type can be sent to the actor. Although Play does not fully adopt Akka Typed, we already provide some APIs to better integrate it in Play applications. It's important to note that the Akka classic APIs are still fully supported and existing applications can continue to use them. There are no plans to deprecate or remove Akka classic API. 
+
 ## Akka Actor Typed styles
 
 Akka's [Actor Typed API][] has two styles:
@@ -84,3 +86,22 @@ Java FP
 
 Java OO
 : @[oo-app-module](code/javaguide/akka/typed/oo/AppModule.java)
+
+
+## Using the `AskPattern` & Typed Scheduler
+
+When [interacting with actors from outside of another Actor](https://doc.akka.io/docs/akka/2.6/typed/interaction-patterns.html#request-response-with-ask-from-outside-an-actor), for example from a `Controller`, you need to use `AskPattern.ask` to send a message to the actor and get a response. The `AskPattern.ask` method requires a `akka.actor.typed.Scheduler` that you can obtain via Dependency Injection.
+
+### Runtime dependency injection
+
+Runtime dependency injection works as any other runtime DI module in Play. The `Scheduler` is part of the default bindings, so the module is enabled automatically and an instance is available for injection.
+
+### Compile-time dependency injection
+
+If you're using compile-time DI, you can get have access to the `Scheduler` by using the components like below:
+
+Java
+: @[scheduler-compile-time-injection](code/javaguide/akka/components/ComponentsWithTypedScheduler.java)
+
+Scala
+: @[scheduler-compile-time-injection](code/scalaguide/akka/components/ComponentsWithTypedScheduler.scala)

--- a/documentation/manual/working/commonGuide/akka/code/javaguide/akka/components/ComponentsWithTypedScheduler.java
+++ b/documentation/manual/working/commonGuide/akka/code/javaguide/akka/components/ComponentsWithTypedScheduler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package javaguide.akka.components;
+
+// #scheduler-compile-time-injection
+import play.ApplicationLoader;
+import play.BuiltInComponentsFromContext;
+import play.components.AkkaTypedComponents;
+import play.controllers.AssetsComponents;
+import play.routing.Router;
+import play.filters.components.HttpFiltersComponents;
+
+public class ComponentsWithTypedScheduler extends BuiltInComponentsFromContext
+    implements AkkaTypedComponents, AssetsComponents, HttpFiltersComponents {
+
+  public ComponentsWithTypedScheduler(ApplicationLoader.Context context) {
+    super(context);
+  }
+
+  @Override
+  public Router router() {
+    return Router.empty();
+  }
+}
+// #scheduler-compile-time-injection

--- a/documentation/manual/working/commonGuide/akka/code/scalaguide/akka/components/ComponentsWithTypedScheduler.scala
+++ b/documentation/manual/working/commonGuide/akka/code/scalaguide/akka/components/ComponentsWithTypedScheduler.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package scalaguide.akka.components
+
+//#scheduler-compile-time-injection
+import play.api.Application
+import play.api.ApplicationLoader
+import play.api.ApplicationLoader.Context
+import play.api.BuiltInComponentsFromContext
+
+import play.api.routing.Router
+import play.filters.HttpFiltersComponents
+
+import play.api.libs.concurrent.AkkaTypedComponents
+
+class MyApplicationLoaderUsingTypedScheduler extends ApplicationLoader {
+  override def load(context: Context): Application = {
+    new ComponentsWithTypedScheduler(context).application
+  }
+}
+
+class ComponentsWithTypedScheduler(context: Context)
+    extends BuiltInComponentsFromContext(context)
+    with HttpFiltersComponents
+    with AkkaTypedComponents {
+
+  override lazy val router: Router = Router.empty
+}
+//#scheduler-compile-time-injection


### PR DESCRIPTION
## Purpose

In Akka 2.6.0, when using Akka Typed and [`ask` pattern](https://github.com/akka/akka/blob/b8636462588ec2f73e264ac6dc3ece5825120e60/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala#L107-L117), it is necessary to provide a `Scheduler`. To make it easier for users, this adds a new binding for runtime dependency injection and new components for compile-time injection.

## Status & Tasks

- [x] Documentation