### PR TITLE
Remove deprecated BodyParsers

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/core/play/src/main/scala/play/api/mvc/Controller.scala
@@ -261,7 +261,7 @@ case class DefaultControllerComponents @Inject()(
  * traits extending [[BaseController]] instead.
  */
 @deprecated("Your controller should extend AbstractController, BaseController, or InjectedController instead.", "2.6.0")
-trait Controller extends ControllerHelpers with BodyParsers {
+trait Controller extends ControllerHelpers {
 
   /**
    * Retrieve the language implicitly from the request.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -133,7 +133,7 @@ If you need the old behavior back, you can define a `Writeable` with an arbitrar
 
 ## Scala Controller changes
 
-The idiomatic Play controller has in the past required global state. The main places that was needed was in the global `play.api.mvc.Action` object and [`BodyParsers#parse`](api/scala/play/api/mvc/BodyParsers.html#parse:play.api.mvc.PlayBodyParsers) method.
+The idiomatic Play controller has in the past required global state. The main places that was needed was in the global `play.api.mvc.Action` object and `BodyParsers#parse` method.
 
 We have provided several new controller classes with new ways of injecting that state, providing the same syntax:
  - [`BaseController`](api/scala/play/api/mvc/BaseController.html): a trait with an abstract [`ControllerComponents`](api/scala/play/api/mvc/ControllerComponents.html) that can be provided by an implementing class.
@@ -201,7 +201,7 @@ class Controller @Inject() (
 
 The Scala [`ActionBuilder`](api/scala/play/api/mvc/ActionBuilder.html) trait has been modified to specify the type of the body as a type parameter, and add an abstract `parser` member as the default body parsers. You will need to modify your ActionBuilders and pass the body parser directly.
 
-The `play.api.mvc.Action` global object and [`BodyParsers#parse`](api/scala/play/api/mvc/BodyParsers.html#parse:play.api.mvc.PlayBodyParsers) are now deprecated. They are replaced by injectable traits, [`DefaultActionBuilder`](api/scala/play/api/mvc/DefaultActionBuilder.html) and [`PlayBodyParsers`](api/scala/play/api/mvc/PlayBodyParsers.html) respectively. If you are inside a controller, they are automatically provided by the new [`BaseController`](api/scala/play/api/mvc/BaseController.html) trait (see [the controller changes](#Scala-Controller-changes) above).
+The `play.api.mvc.Action` global object and `BodyParsers#parse` are now deprecated. They are replaced by injectable traits, [`DefaultActionBuilder`](api/scala/play/api/mvc/DefaultActionBuilder.html) and [`PlayBodyParsers`](api/scala/play/api/mvc/PlayBodyParsers.html) respectively. If you are inside a controller, they are automatically provided by the new [`BaseController`](api/scala/play/api/mvc/BaseController.html) trait (see [the controller changes](#Scala-Controller-changes) above).
 
 ## Cookies
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -598,6 +598,12 @@ object BuildSettings {
       // Remove unneeded implicit materializer
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.convertRequestBody"),
+      // Remove deprecated BodyParsers trait
+      ProblemFilters.exclude[MissingClassProblem]("play.api.mvc.BodyParsers"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.api.mvc.Controller"),
+      ProblemFilters.exclude[IncompatibleTemplateDefProblem]("play.api.mvc.BodyParsers"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.api.mvc.BodyParsers$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.BodyParsers.parse"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
## Purpose

Removes the BodyParsers trait, deprecated since 2.6.0

## Background Context

There's only one public val on the trait, which is deprecated, and the trait itself is useless without it.  Removing the entire thing is better than leaving it empty.