### PR TITLE
Remove deprecated cache key

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -58,7 +58,7 @@ object PlayImport extends PlayImportCompat {
   val javaJpa = component("play-java-jpa")
 
   val filters = component("filters-helpers")
-  
+
   // Integration with JSR 107
   val jcache = component("play-jcache")
 

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -58,10 +58,7 @@ object PlayImport extends PlayImportCompat {
   val javaJpa = component("play-java-jpa")
 
   val filters = component("filters-helpers")
-
-  @deprecated("Use ehcache for ehcache implementation, or cacheApi for just the API", since = "2.6.0")
-  val cache = component("play-ehcache")
-
+  
   // Integration with JSR 107
   val jcache = component("play-jcache")
 


### PR DESCRIPTION
## Purpose

Removes the `cache` key from PlayImports, deprecated since 2.6.0