### PR TITLE
Remove unneeded implicit materializer

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -594,7 +594,10 @@ object BuildSettings {
       // Remove deprecated security methods
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Security.Authenticated"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Security.username"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Security#AuthenticatedBuilder.apply")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Security#AuthenticatedBuilder.apply"),
+      // Remove unneeded implicit materializer
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.convertRequestBody"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -173,7 +173,7 @@ private[server] class NettyModelConversion(
   }
 
   /** Create the source for the request body */
-  def convertRequestBody(request: HttpRequest)(implicit mat: Materializer): Option[Source[ByteString, Any]] = {
+  def convertRequestBody(request: HttpRequest): Option[Source[ByteString, Any]] = {
     request match {
       case full: FullHttpRequest =>
         val content = httpContentToByteString(full)


### PR DESCRIPTION
Was used long time ago for [`MaterializeOnDemandPublisher`](https://github.com/playframework/playframework/blob/2.5.0/framework/src/play-streams/src/main/scala/play/api/libs/streams/MaterializeOnDemandPublisher.scala#L47);
https://github.com/playframework/playframework/commit/12732318e4fdca08c9a1f175a9959e2c8a884c3c#diff-591d0c41805033f6b0a185df83b21b9aR137

Not needed anymore since this commit:
https://github.com/playframework/playframework/commit/26e33bc666bc1863ddc9d207428ab87b38e5c724#diff-591d0c41805033f6b0a185df83b21b9aR128