### PR TITLE
Remove deprecated internal API

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -591,6 +591,8 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleSignatureProblem]("play.filters.gzip.GzipFilterConfig.unapply"),
       // Remove deprecated Messages implicits
       ProblemFilters.exclude[MissingClassProblem]("play.api.i18n.Messages$Implicits$"),
+      // Remove deprecated internal API
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.executeAction"),
       // Remove deprecated security methods
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Security.Authenticated"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Security.username"),

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -402,19 +402,6 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     }
   }
 
-  @deprecated("This method is an internal API and should not be public", "2.6.10")
-  def executeAction(
-      request: HttpRequest,
-      taggedRequestHeader: RequestHeader,
-      requestBodySource: Either[ByteString, Source[ByteString, _]],
-      action: EssentialAction,
-      errorHandler: HttpErrorHandler
-  ): Future[HttpResponse] = {
-    runAction(applicationProvider.get, request, taggedRequestHeader, requestBodySource, action, errorHandler)(
-      system.dispatcher
-    )
-  }
-
   private[play] def runAction(
       tryApp: Try[Application],
       request: HttpRequest,


### PR DESCRIPTION
I want this removed, because I _may_ add a param to `runAction` after RC1.