### PR TITLE
Remove deprecated AkkaHttpServer methods

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -598,6 +598,9 @@ object BuildSettings {
       // Remove unneeded implicit materializer
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.convertRequestBody"),
+      // Remove deprecated AkkaHttpServer methods
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.executeAction"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.this"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -67,16 +67,6 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
 
   registerShutdownTasks()
 
-  @deprecated("Use new AkkaHttpServer(Context) instead", "2.6.14")
-  def this(
-      config: ServerConfig,
-      applicationProvider: ApplicationProvider,
-      actorSystem: ActorSystem,
-      materializer: Materializer,
-      stopHook: () => Future[_]
-  ) =
-    this(AkkaHttpServer.Context(config, applicationProvider, actorSystem, materializer, stopHook))
-
   import AkkaHttpServer._
 
   assert(
@@ -400,19 +390,6 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
       case (unhandled, _) => sys.error(s"AkkaHttpServer doesn't handle Handlers of this type: $unhandled")
 
     }
-  }
-
-  @deprecated("This method is an internal API and should not be public", "2.6.10")
-  def executeAction(
-      request: HttpRequest,
-      taggedRequestHeader: RequestHeader,
-      requestBodySource: Either[ByteString, Source[ByteString, _]],
-      action: EssentialAction,
-      errorHandler: HttpErrorHandler
-  ): Future[HttpResponse] = {
-    runAction(applicationProvider.get, request, taggedRequestHeader, requestBodySource, action, errorHandler)(
-      system.dispatcher
-    )
   }
 
   private[play] def runAction(


### PR DESCRIPTION
## Purpose

Removes some `AkkaHttpServer` methods, deprecated since 2.6.14