### PR TITLE
Remove deprecated Default object

### DIFF
--- a/core/play/src/main/scala/play/api/controllers/Default.scala
+++ b/core/play/src/main/scala/play/api/controllers/Default.scala
@@ -8,9 +8,6 @@ import javax.inject.Inject
 
 import play.api.mvc._
 
-@deprecated("Use Default class instead", "2.6.0")
-object Default extends Default
-
 /**
  * Default actions ready to use as is from your routes file.
  *

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -598,6 +598,8 @@ object BuildSettings {
       // Remove unneeded implicit materializer
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("play.core.server.netty.NettyModelConversion.convertRequestBody"),
+      // Remove deprecated Default singleton object
+      ProblemFilters.exclude[MissingClassProblem]("controllers.Default$"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
## Purpose

Removes deprecated `controllers.Default` singleton object, deprecated since 2.6.x.