### PR TITLE
No need to make method package private

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -670,6 +670,8 @@ object BuildSettings {
       // More deprecated removals
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.typedmap.TypedKey.underlying"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.TestServer.port"),
+      // Remove package private
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.runAction"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -392,7 +392,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     }
   }
 
-  private[play] def runAction(
+  private def runAction(
       tryApp: Try[Application],
       request: HttpRequest,
       taggedRequestHeader: RequestHeader,


### PR DESCRIPTION
Please merge this before RC1, I need it for an upcoming pull request. Thank you so much!

`runAction` is not used anywhere outside.
Also the netty equivalent method is just `private`:
https://github.com/playframework/playframework/blob/1851d5d83f388f0510ff642710d609e3e263ab7d/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala#L288-L293