### PR TITLE
Make Request.hasBody return false for empty buffers

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionSpec.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.it.http
+
+import akka.util.ByteString
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.EmptyBody
+import play.api.libs.ws.InMemoryBody
+import play.api.libs.ws.WSBody
+import play.api.libs.ws.WSResponse
+import play.api.routing.Router
+import play.api.test.PlaySpecification
+import play.api.test.TestServer
+import play.api.test.WsTestClient
+import play.core.j.MappedJavaHandlerComponents
+import play.http.ActionCreator
+import play.http.DefaultActionCreator
+import play.mvc.EssentialFilter
+import play.mvc.Result
+import play.mvc.Results
+import play.mvc.Http._
+import play.routing.{ Router => JRouter }
+
+class GuiceJavaActionSpec extends JavaActionSpec {
+
+  override def makeRequest[T](
+      method: String,
+      controller: MockController,
+      configuration: Map[String, AnyRef] = Map.empty,
+      body: WSBody = EmptyBody
+  )(block: WSResponse => T): T = {
+    implicit val port = testServerPort
+    lazy val app: Application = GuiceApplicationBuilder()
+      .configure(configuration)
+      .routes {
+        case _ => JAction(app, controller)
+      }
+      .build()
+
+    running(TestServer(port, app)) {
+      val response = await(wsUrl("/").withBody(body).execute(method))
+      block(response)
+    }
+  }
+}
+
+class BuiltInComponentsJavaActionSpec extends JavaActionSpec {
+
+  def context(initialSettings: Map[String, AnyRef]): play.ApplicationLoader.Context = {
+    import scala.collection.JavaConverters._
+    play.ApplicationLoader.create(play.Environment.simple(), initialSettings.asJava)
+  }
+
+  override def makeRequest[T](
+      method: String,
+      controller: MockController,
+      configuration: Map[String, AnyRef] = Map.empty,
+      body: WSBody = EmptyBody
+  )(block: (WSResponse) => T): T = {
+    implicit val port = testServerPort
+    val components = new play.BuiltInComponentsFromContext(context(configuration)) {
+
+      override def javaHandlerComponents(): MappedJavaHandlerComponents = {
+        super
+          .javaHandlerComponents()
+      }
+
+      override def router(): JRouter = {
+        Router.from {
+          case _ => JAction(application().asScala(), controller, javaHandlerComponents())
+        }.asJava
+      }
+
+      override def httpFilters(): java.util.List[EssentialFilter] = java.util.Collections.emptyList()
+
+      override def actionCreator(): ActionCreator = {
+        configuration
+          .get[Option[String]]("play.http.actionCreator")
+          .map(Class.forName)
+          .map(c => c.getDeclaredConstructor().newInstance().asInstanceOf[ActionCreator])
+          .getOrElse(new DefaultActionCreator)
+      }
+    }
+
+    running(TestServer(port, components.application().asScala())) {
+      val response = await(wsUrl("/").withBody(body).execute(method))
+      block(response)
+    }
+  }
+}
+
+trait JavaActionSpec extends PlaySpecification with WsTestClient {
+
+  def makeRequest[T](
+      method: String,
+      controller: MockController,
+      configuration: Map[String, AnyRef] = Map.empty,
+      body: WSBody = EmptyBody
+  )(block: WSResponse => T): T
+
+  "POST request" should {
+    "with no body should result in hasBody = false" in makeRequest(
+      "POST",
+      new MockController {
+        override def action(request: Request): Result =
+          Results.ok(
+            s"hasBody: ${request.hasBody}, Content-Length: ${request.header(HeaderNames.CONTENT_LENGTH).orElse("")}"
+          )
+      }
+    ) { response =>
+      response.body must beEqualTo("hasBody: false, Content-Length: 0")
+    }
+    "with body should result in hasBody = true" in makeRequest(
+      "POST",
+      new MockController {
+        override def action(request: Request): Result =
+          Results.ok(
+            s"hasBody: ${request.hasBody}, Content-Length: ${request.header(HeaderNames.CONTENT_LENGTH).orElse("")}"
+          )
+      },
+      body = InMemoryBody(ByteString("a"))
+    ) { response =>
+      response.body must beEqualTo("hasBody: true, Content-Length: 1")
+    }
+  }
+}

--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -95,8 +95,7 @@ public interface BodyParser<A> {
 
     @Override
     public Accumulator<ByteString, F.Either<Result, Object>> apply(Http.RequestHeader request) {
-      if (request.hasHeader(Http.HeaderNames.CONTENT_LENGTH)
-          || request.hasHeader(Http.HeaderNames.TRANSFER_ENCODING)) {
+      if (request.hasBody()) {
         return super.apply(request);
       } else {
         return BodyParser.<Optional<Void>, Object>widen(new Empty()).apply(request);

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -5,6 +5,7 @@
 package play.api.mvc
 
 import java.util.Locale
+import java.util.Optional
 
 import play.api.i18n.Lang
 import play.api.i18n.Messages
@@ -27,17 +28,41 @@ trait Request[+A] extends RequestHeader {
   self =>
 
   /**
-   * True if this request has a body. This is either done by inspecting the body itself to see if it is an entity
-   * representing an "empty" body.
+   * True if this request has a body. This is either done by inspecting the request headers or the body itself to see if
+   * it is an entity representing an "empty" body.
    */
   override def hasBody: Boolean = {
-    @tailrec @inline def isEmptyBody(body: Any): Boolean = body match {
-      case rb: play.mvc.Http.RequestBody                      => isEmptyBody(rb.as(classOf[AnyRef]))
-      case AnyContentAsEmpty | null | ()                      => true
-      case unit if unit.isInstanceOf[scala.runtime.BoxedUnit] => true
-      case _                                                  => false
+    import play.api.http.HeaderNames._
+    if (headers.get(CONTENT_LENGTH).isDefined || headers.get(TRANSFER_ENCODING).isDefined) {
+      // A relevant header is set, which means this is a real request or a fake request used for testing where the user
+      // cared about setting the headers. We can just use them to see if a body exists. In a real life production application,
+      // where clients basically always send these headers when applicable (for requests that send bodies like POST, etc.)
+      // we are very likely to enter this if branch.
+      super.hasBody
+    } else {
+      // No relevant header present, very likely this is a real life GET request (or alike) without a body or a fake request
+      // used for testing where the user did not care about setting the headers (but maybe did set an entity though).
+      // Let's do our best to find out if there is an entity that represents an "empty" body.
+      @tailrec @inline def isEmptyBody(body: Any): Boolean = body match {
+        case rb: play.mvc.Http.RequestBody =>
+          rb match {
+            // In PlayJava, Optional.empty() is used to represent an empty body
+            case _ if rb.as(classOf[Optional[_]]) != null => !rb.as(classOf[Optional[_]]).isPresent
+            case _                                        => isEmptyBody(rb.as(classOf[AnyRef]))
+          }
+        case AnyContentAsEmpty | null | ()                      => true
+        case unit if unit.isInstanceOf[scala.runtime.BoxedUnit] => true
+        // All values which are known to represent an empty body have been checked, therefore, if we end up here, technically
+        // it is sure something is set (at least it's not null), even though this something might represent "empty"/"no body"
+        // (like an empty string or an empty ByteString) - but how should we know? This something could be a custom type
+        // coming from a custom body parser defined entirely by the user... Sure, we could check for the most common types
+        // if they represent an empty body (empty Strings, empty ByteString, etc.) but that would not be consistent
+        // (custom types defined by the user that represent "empty" would still return false)
+        case _ => false
+      }
+
+      !isEmptyBody(body)
     }
-    !isEmptyBody(body) || super.hasBody
   }
 
   /**

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -33,6 +33,7 @@ trait Request[+A] extends RequestHeader {
   override def hasBody: Boolean = {
     @tailrec @inline def isEmptyBody(body: Any): Boolean = body match {
       case rb: play.mvc.Http.RequestBody                      => isEmptyBody(rb.as(classOf[AnyRef]))
+      case raw: play.mvc.Http.RawBuffer                       => raw.size == 0
       case AnyContentAsEmpty | null | ()                      => true
       case unit if unit.isInstanceOf[scala.runtime.BoxedUnit] => true
       case _                                                  => false

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -33,7 +33,6 @@ trait Request[+A] extends RequestHeader {
   override def hasBody: Boolean = {
     @tailrec @inline def isEmptyBody(body: Any): Boolean = body match {
       case rb: play.mvc.Http.RequestBody                      => isEmptyBody(rb.as(classOf[AnyRef]))
-      case raw: play.mvc.Http.RawBuffer                       => raw.size == 0
       case AnyContentAsEmpty | null | ()                      => true
       case unit if unit.isInstanceOf[scala.runtime.BoxedUnit] => true
       case _                                                  => false

--- a/core/play/src/test/scala/play/api/mvc/DefaultBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/DefaultBodyParserSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+import play.core.test.FakeRequest
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class DefaultBodyParserSpec extends Specification with AfterAll {
+
+  implicit val system = ActorSystem()
+  implicit val mat    = Materializer.matFromSystem
+  val parsers         = PlayBodyParsers()
+
+  override def afterAll: Unit = {
+    system.terminate()
+  }
+
+  def parse(request: RequestHeader, byteString: ByteString) = {
+    val parser: BodyParser[AnyContent] = parsers.default
+    Await.result(parser(request).run(Source.single(byteString)), Duration.Inf)
+  }
+
+  "Default Body Parser" should {
+    "handle 'Content-Length: 0' header as empty body (containing AnyContentAsEmpty)" in {
+      val body = ByteString.empty
+      val postRequest =
+        FakeRequest("POST", "/")
+          .withBody(body)
+          .withHeaders("Content-Type" -> "text/plain; charset=utf-8", "Content-Length" -> "0")
+      postRequest.hasBody must beFalse
+      parse(postRequest, body) must beRight[AnyContent].like {
+        case empty: AnyContent => empty must beEqualTo(AnyContentAsEmpty)
+      }
+    }
+    "handle 'Content-Length: 1' header as non-empty body" in {
+      val body = ByteString("a")
+      val postRequest =
+        FakeRequest("POST", "/")
+          .withBody(body)
+          .withHeaders("Content-Type" -> "text/plain; charset=utf-8", "Content-Length" -> "1")
+      postRequest.hasBody must beTrue
+      parse(postRequest, body) must beRight[AnyContent].like {
+        case text: AnyContentAsText => text must beEqualTo(AnyContentAsText("a"))
+      }
+    }
+    "handle null body without Content-Length and Transfer-Encoding headers as empty body (containing AnyContentAsEmpty)" in {
+      val body = ByteString.empty
+      val postRequest =
+        FakeRequest("POST", "/")
+          .withBody(null)
+          .withHeaders("Content-Type" -> "text/plain; charset=utf-8")
+      (postRequest.body == null) must beTrue
+      postRequest.hasBody must beFalse
+      parse(postRequest, body) must beRight[AnyContent].like {
+        case empty: AnyContent => empty must beEqualTo(AnyContentAsEmpty)
+      }
+    }
+    "handle missing Content-Length and Transfer-Encoding headers as empty body (containing AnyContentAsEmpty)" in {
+      val body = ByteString.empty
+      val postRequest =
+        FakeRequest("POST", "/")
+          .withHeaders("Content-Type" -> "text/plain; charset=utf-8")
+      postRequest.body must beEqualTo(AnyContentAsEmpty)
+      postRequest.hasBody must beFalse
+      parse(postRequest, body) must beRight[AnyContent].like {
+        case empty: AnyContent => empty must beEqualTo(AnyContentAsEmpty)
+      }
+    }
+  }
+
+}

--- a/core/play/src/test/scala/play/mvc/DefaultBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/DefaultBodyParserSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.mvc
+
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.javadsl.Source
+import akka.util.ByteString
+import org.specs2.matcher.MustMatchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+import play.api.http.HttpConfiguration
+import play.api.http.ParserConfiguration
+import play.api.mvc.PlayBodyParsers
+import play.http.HttpErrorHandler
+import play.libs.F
+import play.mvc.Http.RequestBody
+
+import scala.compat.java8.OptionConverters._
+
+class DefaultBodyParserSpec extends Specification with AfterAll with MustMatchers {
+  "Java DefaultBodyParserSpec" title
+
+  implicit val system       = ActorSystem("default-body-parser-spec")
+  implicit val materializer = Materializer.matFromSystem
+
+  def afterAll(): Unit = {
+    materializer.shutdown()
+    system.terminate()
+  }
+
+  val config                                                 = ParserConfiguration()
+  @inline def req(r: play.api.mvc.Request[Http.RequestBody]) = new Http.RequestImpl(r)
+
+  val httpConfiguration = HttpConfiguration()
+  val bodyParser        = PlayBodyParsers()
+
+  val httpErrorHandler: HttpErrorHandler = new HttpErrorHandler {
+    override def onClientError(request: Http.RequestHeader, statusCode: Int, message: String): CompletionStage[Result] =
+      ???
+    override def onServerError(request: Http.RequestHeader, exception: Throwable): CompletionStage[Result] = ???
+  }
+
+  def parse(request: Http.Request, byteString: ByteString): Either[Result, Object] = {
+    val parser: BodyParser[Object] = new BodyParser.Default(httpErrorHandler, httpConfiguration, bodyParser)
+    val disj: F.Either[Result, Object] =
+      parser(request).run(Source.single(byteString), materializer).toCompletableFuture.get
+    if (disj.left.isPresent) {
+      Left(disj.left.get)
+    } else Right(disj.right.get)
+  }
+
+  "Default Body Parser" should {
+    "handle 'Content-Length: 0' header as empty body (containing Optional.empty)" in {
+      val body = ByteString.empty
+      val postRequest =
+        new Http.RequestBuilder().method("POST").body(new RequestBody(body.utf8String), "text/plain").req
+      postRequest.hasBody must beFalse
+      parse(req(postRequest), body) must beRight[Object].like {
+        case empty: Optional[_] => empty.asScala must beNone
+      }
+    }
+    "handle 'Content-Length: 1' header as non-empty body" in {
+      val body = ByteString("a")
+      val postRequest =
+        new Http.RequestBuilder().method("POST").body(new RequestBody(body.utf8String), "text/plain").req
+      postRequest.hasBody must beTrue
+      parse(req(postRequest), body) must beRight[Object].like {
+        case text: String => text must beEqualTo("a")
+      }
+    }
+    "handle RequestBody containing null as empty body (containing Optional.empty)" in {
+      val body = ByteString.empty
+      val postRequest =
+        new Http.RequestBuilder().method("POST").body(new RequestBody(null), "text/plain").req
+      postRequest.hasBody must beFalse
+      parse(req(postRequest), body) must beRight[Object].like {
+        case empty: Optional[_] => empty.asScala must beNone
+      }
+    }
+    "handle missing Content-Length and Transfer-Encoding headers as empty body (containing Optional.empty)" in {
+      val body = ByteString.empty
+      val postRequest =
+        new Http.RequestBuilder().method("POST").req
+      postRequest.hasBody must beFalse
+      parse(req(postRequest), body) must beRight[Object].like {
+        case empty: Optional[_] => empty.asScala must beNone
+      }
+    }
+  }
+}

--- a/testkit/play-test/src/test/java/play/test/HelpersTest.java
+++ b/testkit/play-test/src/test/java/play/test/HelpersTest.java
@@ -144,4 +144,17 @@ public class HelpersTest {
     Result result = Helpers.route(app, request);
     assertThat(result.status(), equalTo(404));
   }
+
+  @Test
+  public void shouldReturnProperHasBodyValueForFakeRequest() {
+    Http.Request request = Helpers.fakeRequest("POST", "/uri").build();
+    assertThat(request.hasBody(), equalTo(false));
+  }
+
+  @Test
+  public void shouldReturnProperHasBodyValueForEmptyRawBuffer() {
+    Http.Request request =
+        Helpers.fakeRequest("POST", "/uri").bodyRaw(ByteString.emptyByteString()).build();
+    assertThat(request.hasBody(), equalTo(false));
+  }
 }

--- a/testkit/play-test/src/test/java/play/test/HelpersTest.java
+++ b/testkit/play-test/src/test/java/play/test/HelpersTest.java
@@ -147,14 +147,24 @@ public class HelpersTest {
 
   @Test
   public void shouldReturnProperHasBodyValueForFakeRequest() {
+    // Does not set a Content-Length and also not a Transfer-Encoding header, sets null as body
     Http.Request request = Helpers.fakeRequest("POST", "/uri").build();
     assertThat(request.hasBody(), equalTo(false));
   }
 
   @Test
   public void shouldReturnProperHasBodyValueForEmptyRawBuffer() {
+    // Does set a Content-Length header
     Http.Request request =
         Helpers.fakeRequest("POST", "/uri").bodyRaw(ByteString.emptyByteString()).build();
     assertThat(request.hasBody(), equalTo(false));
+  }
+
+  @Test
+  public void shouldReturnProperHasBodyValueForNonEmptyRawBuffer() {
+    // Does set a Content-Length header
+    Http.Request request =
+        Helpers.fakeRequest("POST", "/uri").bodyRaw(ByteString.fromString("a")).build();
+    assertThat(request.hasBody(), equalTo(true));
   }
 }


### PR DESCRIPTION
`hasBody()` must return false for all empty requests, including ones
with a buffer assigned, but not holding any data (buffer size = 0).

This should fix #9757