### PR TITLE
Fix typo `openid` -> `openId`

### DIFF
--- a/documentation/manual/working/scalaGuide/main/ws/ScalaOpenID.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaOpenID.md
@@ -14,7 +14,7 @@ Step 1 may be omitted if all your users are using the same OpenID provider (for 
 
 ## Usage
 
-To use OpenID, first add `openid`  to your `build.sbt` file:
+To use OpenID, first add `openId`  to your `build.sbt` file:
 
 ```scala
 libraryDependencies ++= Seq(


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

This pull request fixes a typo. This typo only exists in the Scala documentation.