### PR TITLE
2.7: Give scripted tests a resolver for Akka snapshots

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/evolutions/auto-apply-false/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/evolutions/auto-apply-false/build.sbt
@@ -29,3 +29,16 @@ lazy val root = (project in file("."))
       DevModeBuild.verifyResourceContains(path, status.toInt, assertions, 0)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/evolutions/auto-apply-true/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/evolutions/auto-apply-true/build.sbt
@@ -29,3 +29,16 @@ lazy val root = (project in file("."))
       DevModeBuild.verifyResourceContains(path, status.toInt, assertions, 0)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/evolutions/multiple-databases/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/evolutions/multiple-databases/build.sbt
@@ -29,3 +29,16 @@ lazy val root = (project in file("."))
       DevModeBuild.verifyResourceContains(path, status.toInt, assertions, 0)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/akka-http-http2/build.sbt
@@ -17,3 +17,16 @@ scalaVersion := "2.12.9"
 libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/akka-http/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/akka-http/build.sbt
@@ -17,3 +17,16 @@ scalaVersion := "2.12.9"
 libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty-channel-options/build.sbt
@@ -25,3 +25,16 @@ lazy val root = (project in file("."))
       DevModeBuild.checkLines(source, target)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/netty/build.sbt
@@ -18,3 +18,16 @@ scalaVersion := "2.12.9"
 libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/http-backend/system-property/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/http-backend/system-property/build.sbt
@@ -32,3 +32,16 @@ InputKey[Unit]("verifyResourceContains") := {
   val assertions = args.tail.tail
   DevModeBuild.verifyResourceContains(path, status, assertions, 0)
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/maven-layout/twirl-reload/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/maven-layout/twirl-reload/build.sbt
@@ -19,3 +19,16 @@ lazy val root = (project in file("."))
       DevModeBuild.verifyResourceContains(path, status.toInt, assertions, 0)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/build.sbt
@@ -18,3 +18,16 @@ lazy val root = (project in file("."))
       DevModeBuild.verifyResourceContains(path, status, assertions, 0)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/build.sbt
@@ -17,3 +17,16 @@ lazy val root = (project in file("."))
       DevModeBuild.verifyResourceContains(path, status, assertions, 0)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -34,3 +34,16 @@ lazy val root = (project in file("."))
       DevModeBuild.verifyResourceContains(path, status.toInt, assertions, 0)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
@@ -16,3 +16,16 @@ lazy val root = (project in file("."))
     excludeFilter in (Assets, LessKeys.less) := "_*.less",
     PlayKeys.generateAssetsJar := false
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
@@ -15,3 +15,16 @@ lazy val root = (project in file("."))
     play.sbt.PlayImport.PlayKeys.includeDocumentationInBinary := false,
     packageDoc in Compile := { new File(".") }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -78,3 +78,16 @@ InputKey[Unit]("countApplicationConf") := {
     sys.error(s"Expected application.conf to be $expected times on classpath, but it was there $count times")
   }
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
@@ -15,3 +15,16 @@ lazy val root = (project in file("."))
       DevModeBuild.verifyResourceContains(path, status.toInt, Seq.empty, 0)
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
@@ -64,3 +64,16 @@ TaskKey[Unit]("check-assets-jar-on-classpath") := {
     throw new RuntimeException("Could not find " + assetsJar + " in start script")
   }
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
@@ -75,3 +75,16 @@ TaskKey[Unit]("checkPlayCompileEverything") := {
     throw new RuntimeException("Expected " + expectedSourceFiles + " but got " + allSources)
   }
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/build.sbt
@@ -25,3 +25,16 @@ lazy val root = (project in file("."))
       }
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/build.sbt
@@ -23,3 +23,16 @@ lazy val root = (project in file("."))
       Project.runTask(compile in Compile, state)
     }.value
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/build.sbt
@@ -20,3 +20,16 @@ lazy val root = (project in file("."))
       }
     }
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes-with-request-passed/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes-with-request-passed/build.sbt
@@ -45,3 +45,16 @@ lazy val c: Project = (project in file("c"))
   .enablePlugins(MediatorWorkaroundPlugin)
   .settings(commonSettings: _*)
   .dependsOn(b)
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/build.sbt
@@ -45,3 +45,16 @@ lazy val c: Project = (project in file("c"))
   .enablePlugins(MediatorWorkaroundPlugin)
   .settings(commonSettings: _*)
   .dependsOn(b)
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/build.sbt
@@ -10,3 +10,16 @@ lazy val root = (project in file("."))
     // turn off cross paths so that expressions don't need to include the scala version
     crossPaths := false
   )
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation-with-request-passed/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation-with-request-passed/build.sbt
@@ -79,3 +79,16 @@ scalacOptions ++= {
     "-Xfuture"
   )
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
@@ -79,3 +79,16 @@ scalacOptions ++= {
     "-Xfuture"
   )
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/no-package-declaration-in-routes-file/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/no-package-declaration-in-routes-file/build.sbt
@@ -79,3 +79,16 @@ scalacOptions ++= {
     "-Xfuture"
   )
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
@@ -68,3 +68,16 @@ scalacOptions ++= {
     "-Xfuture"
   )
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
@@ -46,3 +46,16 @@ def assertSome[T: ClassTag](o: Option[T]): T = {
 def assertLeft[T: ClassTag](e: Either[T, _]) = {
   e.left.getOrElse(throw new Exception("Expected Left[" + implicitly[ClassTag[T]] + "]"))
 }
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/shutdown/downing/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/shutdown/downing/build.sbt
@@ -45,3 +45,16 @@ lazy val root = (project in file("."))
   )
 
 //sigtermApplication
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})

--- a/dev-mode/sbt-plugin/src/sbt-test/shutdown/happy-path/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/shutdown/happy-path/build.sbt
@@ -45,3 +45,16 @@ lazy val root = (project in file("."))
   )
 
 //sigtermApplication
+
+// This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
+// the snapshot resolvers in `cron` builds.
+// If this is a cron job in Travis:
+// https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+resolvers in ThisBuild ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+  case Some(_) =>
+    Seq(
+      "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+      "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+    )
+  case None => Seq.empty
+})


### PR DESCRIPTION
Manual backport of #9717

This should fix the 2.7.x cron build failures.