### PR TITLE
Refactor SSLEngineProvider to also expose SSLContext

### DIFF
--- a/core/play/src/main/java/play/server/SSLEngineProvider.java
+++ b/core/play/src/main/java/play/server/SSLEngineProvider.java
@@ -4,10 +4,30 @@
 
 package play.server;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
+/**
+ * To configure the SSLEngine used by Play as a server, extend this class. In particular, if you
+ * want to call sslEngine.setNeedClientAuth(true), this is the place to do it.
+ *
+ * <p>If you want to specify your own SSL engine, define a class implementing this interface. If the
+ * implementing class takes ApplicationProvider in the constructor, then the applicationProvider is
+ * passed into it, if available.
+ *
+ * <p>The path to this class should be configured with the system property
+ *
+ * <pre>play.server.https.engineProvider</pre>
+ */
 public interface SSLEngineProvider {
 
   /** @return the SSL engine to be used for HTTPS connection. */
   SSLEngine createSSLEngine();
+
+  /**
+   * The {@link SSLContext} used to create the SSLEngine.
+   *
+   * @see #createSSLEngine()
+   */
+  SSLContext sslContext();
 }

--- a/core/play/src/main/scala/play/server/api/SSLEngineProvider.scala
+++ b/core/play/src/main/scala/play/server/api/SSLEngineProvider.scala
@@ -7,19 +7,13 @@ package play.server.api
 import javax.net.ssl.SSLEngine
 
 /**
- * To configure the SSLEngine used by Play as a server, extend this class.  In particular, if you want to call
- * sslEngine.setNeedClientAuth(true), this is the place to do it.
- *
- * If you want to specify your own SSL engine, define a class implementing this interface.  If the implementing class
- * takes ApplicationProvider in the constructor, then the applicationProvider is passed into it, if available.
- *
- * The path to this class should be configured with the system property <pre>play.server.https.engineProvider</pre>
+ * To configure the SSLEngine used by Play as a server, extend this class. See more details in [[play.server.SSLEngineProvider]].
  */
 trait SSLEngineProvider extends play.server.SSLEngineProvider {
 
   /**
    * @return the SSL engine to be used for HTTPS connection.
    */
-  def createSSLEngine: SSLEngine
+  override def createSSLEngine: SSLEngine
 
 }

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -30,7 +30,11 @@ At the time of this writing `1.2.8` is the latest version in the sbt 1.x family,
 
 ## API Changes
 
-Multiple API changes were made following our policy of deprecating the existing APIs before removing them. This section details these changes.
+Play 2.8 contains multiple API changes. As usual, we follow our policy of deprecating existing APIs before removing them. This section details these changes.
+
+### SSLEngineProvider makes SSLContext visible
+
+When [[configuring HTTPS|ConfiguringHttps]], it is possible to override the [`play.server.SSLEngineProvider`](api/java/play/server/SSLEngineProvider.html) if you need to fully configure the SSL certificates. Before Play 2.8.0, the provider only made the [SSLEngine](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLEngine.html) visible. Now, to better integrate with third-party libraries, the [SSLContext](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) must be visible as well. See more details at [[ConfiguringHttps]] page.
 
 ### Scala 2.11 support discontinued
 

--- a/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
+++ b/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
@@ -33,7 +33,7 @@ Another alternative to configure the SSL certificates is to provide a custom [SS
 Scala
 : @[scalaexample](code/scalaguide/CustomSSLEngineProvider.scala)
 
-Java:
+Java
 : @[javaexample](code/javaguide/CustomSSLEngineProvider.java)
 
 Having created an implementation for `play.server.SSLEngineProvider` or `play.server.api.SSLEngineProvider`, the following system property configures Play to use it:

--- a/documentation/manual/working/commonGuide/production/code/javaguide/CustomSSLEngineProvider.java
+++ b/documentation/manual/working/commonGuide/production/code/javaguide/CustomSSLEngineProvider.java
@@ -8,21 +8,29 @@ package javaguide;
 import play.server.ApplicationProvider;
 import play.server.SSLEngineProvider;
 
+import javax.inject.Inject;
 import javax.net.ssl.*;
 import java.security.NoSuchAlgorithmException;
 
 public class CustomSSLEngineProvider implements SSLEngineProvider {
-  private ApplicationProvider applicationProvider;
 
+  private final ApplicationProvider applicationProvider;
+
+  @Inject
   public CustomSSLEngineProvider(ApplicationProvider applicationProvider) {
     this.applicationProvider = applicationProvider;
   }
 
   @Override
   public SSLEngine createSSLEngine() {
+    return sslContext().createSSLEngine();
+  }
+
+  @Override
+  public SSLContext sslContext() {
     try {
-      // change it to your custom implementation
-      return SSLContext.getDefault().createSSLEngine();
+      // Change it to your custom implementation, possibly using ApplicationProvider.
+      return SSLContext.getDefault();
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }

--- a/documentation/manual/working/commonGuide/production/code/scalaguide/CustomSSLEngineProvider.scala
+++ b/documentation/manual/working/commonGuide/production/code/scalaguide/CustomSSLEngineProvider.scala
@@ -5,15 +5,21 @@
 package scalaguide
 
 // #scalaexample
+import javax.inject.Inject
 import javax.net.ssl._
 import play.core.ApplicationProvider
 import play.server.api._
 
-class CustomSSLEngineProvider(appProvider: ApplicationProvider) extends SSLEngineProvider {
+class CustomSSLEngineProvider @Inject()(appProvider: ApplicationProvider) extends SSLEngineProvider {
 
   override def createSSLEngine(): SSLEngine = {
     // change it to your custom implementation
-    SSLContext.getDefault.createSSLEngine
+    sslContext().createSSLEngine
+  }
+
+  override def sslContext(): SSLContext = {
+    // change it to your custom implementation
+    SSLContext.getDefault
   }
 
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -673,6 +673,11 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.TestServer.port"),
       // Remove package private
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.AkkaHttpServer.runAction"),
+      // Add SSLContext to SSLEngineProvider
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.server.SSLEngineProvider.sslContext"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("play.core.server.ssl.DefaultSSLEngineProvider.createSSLContext"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ssl.noCATrustManager.nullArray"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
@@ -33,6 +33,6 @@ import play.server.api.SSLEngineProvider
     appProvider: ApplicationProvider
 ) extends SSLEngineProvider {
 
-  def createSSLEngine: SSLEngine = SelfSigned.sslContext.createSSLEngine()
-
+  override def createSSLEngine: SSLEngine = sslContext.createSSLEngine()
+  override def sslContext: SSLContext     = SelfSigned.sslContext
 }


### PR DESCRIPTION
This is targeting 2.8.x now, but we can later re-target it to master if we decide too many things are changing.