### PR TITLE
Remove Netty & Akka HTTP server as dependencies on Play-Test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,8 +166,10 @@ lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "testkit/play-test
   )
   .dependsOn(
     PlayGuiceProject,
-    PlayAkkaHttpServerProject,
-    PlayNettyServerProject
+    PlayServerProject,
+    // We still need a server provider when running Play-Test tests.
+    // Since Akka HTTP is the default, we should use it here.
+    PlayAkkaHttpServerProject % "test"
   )
 
 lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "testkit/play-specs2")
@@ -259,6 +261,7 @@ lazy val PlayAhcWsProject = PlayCrossBuiltProject("Play-AHC-WS", "transport/clie
   .dependsOn(PlayWsProject, PlayCaffeineCacheProject % "test")
   .dependsOn(PlaySpecs2Project % "test")
   .dependsOn(PlayTestProject % "test->test")
+  .dependsOn(PlayAkkaHttpServerProject % "test") // Because we need a server provider when running the tests
 
 lazy val PlayOpenIdProject = PlayCrossBuiltProject("Play-OpenID", "web/play-openid")
   .settings(
@@ -276,10 +279,11 @@ lazy val PlayFiltersHelpersProject = PlayCrossBuiltProject("Filters-Helpers", "w
   )
   .dependsOn(
     PlayProject,
-    PlayTestProject   % "test",
-    PlayJavaProject   % "test",
-    PlaySpecs2Project % "test",
-    PlayAhcWsProject  % "test"
+    PlayTestProject           % "test",
+    PlayJavaProject           % "test",
+    PlaySpecs2Project         % "test",
+    PlayAhcWsProject          % "test",
+    PlayAkkaHttpServerProject % "test" // Because we need a server provider when running the tests
   )
 
 lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Test", "core/play-integration-test")
@@ -354,8 +358,9 @@ lazy val PlayMicrobenchmarkProject = PlayCrossBuiltProject("Play-Microbenchmark"
     mimaPreviousArtifacts := Set.empty
   )
   .dependsOn(
-    PlayProject % "test->test",
-    PlayLogback % "test->test",
+    PlayProject                % "test->test",
+    PlayLogback                % "test->test",
+    PlayIntegrationTestProject % "test->it",
     PlayAhcWsProject,
     PlaySpecs2Project,
     PlayFiltersHelpersProject,

--- a/core/play-integration-test/src/it/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
@@ -50,7 +50,7 @@ class AkkaHttpCustomServerProviderSpec
       f(param)
     }
 
-  import ServerEndpointRecipe.AkkaHttp11Plaintext
+  import AkkaHttpServerEndpointRecipes.AkkaHttp11Plaintext
 
   "an AkkaHttpServer with standard settings" should {
     "serve a routed GET request" in requestWithMethod(AkkaHttp11Plaintext, "GET", null)(_ must beRight("get"))

--- a/core/play-integration-test/src/it/scala/play/it/test/AkkaHttpServerEndpointRecipes.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/AkkaHttpServerEndpointRecipes.scala
@@ -1,0 +1,56 @@
+package play.it.test
+
+import play.api.Configuration
+import play.api.http.HttpProtocol
+import play.api.test.HttpServerEndpointRecipe
+import play.api.test.HttpsServerEndpointRecipe
+import play.api.test.ServerEndpointRecipe
+import play.core.server.AkkaHttpServer
+
+object AkkaHttpServerEndpointRecipes {
+
+  private def http2Conf(enabled: Boolean, alwaysForInsecure: Boolean = false): Configuration = Configuration(
+    "play.server.akka.http2.enabled"           -> enabled,
+    "play.server.akka.http2.alwaysForInsecure" -> alwaysForInsecure
+  )
+
+  val AkkaHttp11Plaintext = new HttpServerEndpointRecipe(
+    "Akka HTTP HTTP/1.1 (plaintext)",
+    AkkaHttpServer.provider,
+    http2Conf(enabled = false),
+    Set(HttpProtocol.HTTP_1_1, HttpProtocol.HTTP_1_1),
+    None
+  )
+
+  val AkkaHttp11Encrypted = new HttpsServerEndpointRecipe(
+    "Akka HTTP HTTP/1.1 (encrypted)",
+    AkkaHttpServer.provider,
+    http2Conf(enabled = false),
+    Set(HttpProtocol.HTTP_1_1, HttpProtocol.HTTP_1_1),
+    None
+  )
+
+  val AkkaHttp20Plaintext = new HttpServerEndpointRecipe(
+    "Akka HTTP HTTP/2 (plaintext)",
+    AkkaHttpServer.provider,
+    http2Conf(enabled = true, alwaysForInsecure = true),
+    Set(HttpProtocol.HTTP_2_0),
+    None
+  )
+
+  val AkkaHttp20Encrypted = new HttpsServerEndpointRecipe(
+    "Akka HTTP HTTP/2 (encrypted)",
+    AkkaHttpServer.provider,
+    http2Conf(enabled = true),
+    Set(HttpProtocol.HTTP_1_1, HttpProtocol.HTTP_1_1, HttpProtocol.HTTP_2_0),
+    None
+  )
+
+  val AllRecipes: Seq[ServerEndpointRecipe] = Seq(
+    AkkaHttp11Plaintext,
+    AkkaHttp11Encrypted,
+    AkkaHttp20Encrypted
+  )
+
+  val AllRecipesIncludingExperimental: Seq[ServerEndpointRecipe] = AllRecipes :+ AkkaHttp20Plaintext
+}

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -10,7 +10,7 @@ import org.specs2.execute.Result
 import org.specs2.execute.ResultExecution
 import org.specs2.mutable.SpecLike
 import org.specs2.specification.core.Fragment
-
+import play.api.http.HttpProtocol
 import play.api.test.ApplicationFactories
 import play.api.test.ApplicationFactory
 import play.api.test.ServerEndpointRecipe
@@ -88,7 +88,7 @@ trait EndpointIntegrationSpecification extends SpecLike with PendingUntilFixed w
      * indicate that the test is no longer pending a fix.
      */
     def pendingUntilHttp2Fixed(endpoint: ServerEndpoint): Result = {
-      conditionalPendingUntilFixed(endpoint.expectedHttpVersions.contains("2"))
+      conditionalPendingUntilFixed(endpoint.protocols.contains(HttpProtocol.HTTP_2_0))
     }
   }
 

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -62,7 +62,7 @@ trait EndpointIntegrationSpecification extends SpecLike with PendingUntilFixed w
      * }}}
      */
     def withAllEndpoints[A: AsResult](block: ServerEndpoint => A): Fragment =
-      withEndpoints(ServerEndpointRecipe.AllRecipes)(block)
+      withEndpoints(NettyServerEndpointRecipes.AllRecipes ++ AkkaHttpServerEndpointRecipes.AllRecipes)(block)
   }
 
   /**

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
@@ -23,9 +23,9 @@ class EndpointIntegrationSpecificationSpec
       withResult(Results.Ok("Hello")).withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
         val response: Response = okEndpoint.call("/")
         val protocol           = response.protocol
-        if (okEndpoint.endpoint.expectedHttpVersions.contains("2")) {
+        if (okEndpoint.endpoint.protocols.contains(HTTP_2_0)) {
           protocol must_== Protocol.HTTP_2
-        } else if (okEndpoint.endpoint.expectedHttpVersions.contains("1.1")) {
+        } else if (okEndpoint.endpoint.protocols.contains(HTTP_1_1)) {
           protocol must_== Protocol.HTTP_1_1
         } else {
           ko("All endpoints should support at least HTTP/1.1")
@@ -39,7 +39,7 @@ class EndpointIntegrationSpecificationSpec
       }
     }.withAllOkHttpEndpoints { okHttpEndpoint: OkHttpEndpoint =>
       val response: Response = okHttpEndpoint.call("/")
-      response.body.string must_== okHttpEndpoint.endpoint.expectedServerAttr.toString
+      response.body.string must_== okHttpEndpoint.endpoint.serverAttribute.toString
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/test/NettyServerEndpointRecipes.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/NettyServerEndpointRecipes.scala
@@ -1,0 +1,32 @@
+package play.it.test
+
+import play.api.Configuration
+import play.api.http.HttpProtocol
+import play.api.test.HttpServerEndpointRecipe
+import play.api.test.HttpsServerEndpointRecipe
+import play.api.test.ServerEndpointRecipe
+import play.core.server.NettyServer
+
+object NettyServerEndpointRecipes {
+
+  val Netty11Plaintext = new HttpServerEndpointRecipe(
+    "Netty HTTP/1.1 (plaintext)",
+    NettyServer.provider,
+    Configuration.empty,
+    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
+    Option("netty")
+  )
+
+  val Netty11Encrypted = new HttpsServerEndpointRecipe(
+    "Netty HTTP/1.1 (encrypted)",
+    NettyServer.provider,
+    Configuration.empty,
+    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
+    Option("netty")
+  )
+
+  val AllRecipes: Seq[ServerEndpointRecipe] = Seq(
+    Netty11Plaintext,
+    Netty11Encrypted
+  )
+}

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -66,8 +66,8 @@ trait OkHttpEndpointSupport {
       override val endpoint = e
       override val clientBuilder: OkHttpClient.Builder = {
         val b = new OkHttpClient.Builder()
-        endpoint.ssl.foreach { ssl =>
-          b.sslSocketFactory(ssl.sslContext.getSocketFactory, ssl.trustManager)
+        endpoint.ssl.foreach { sslContext =>
+          b.sslSocketFactory(sslContext.getSocketFactory)
           // We are only using this for tests, so we are accepting all host names
           // when OkHttp client verifies the identity of the server with the hostname.
           // See https://tools.ietf.org/html/rfc2818#section-3.1

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -5,6 +5,7 @@
 package play.it.test
 
 import java.util.concurrent.TimeUnit
+
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -12,6 +13,7 @@ import org.specs2.execute.AsResult
 import org.specs2.specification.core.Fragment
 import play.api.test.ApplicationFactory
 import play.api.test.ServerEndpointRecipe
+import play.core.server.LoggingTrustManager
 import play.core.server.ServerEndpoint
 
 /**
@@ -67,7 +69,7 @@ trait OkHttpEndpointSupport {
       override val clientBuilder: OkHttpClient.Builder = {
         val b = new OkHttpClient.Builder()
         endpoint.ssl.foreach { sslContext =>
-          b.sslSocketFactory(sslContext.getSocketFactory)
+          b.sslSocketFactory(sslContext.getSocketFactory, LoggingTrustManager)
           // We are only using this for tests, so we are accepting all host names
           // when OkHttp client verifies the identity of the server with the hostname.
           // See https://tools.ietf.org/html/rfc2818#section-3.1

--- a/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -117,8 +117,8 @@ object HelloWorldBenchmark {
           .writeTimeout(Timeout, TimeUnit.SECONDS)
         // Add SSL options if we need to
         val b2 = bench.serverEndpoint.ssl match {
-          case Some(ssl) =>
-            b1.sslSocketFactory(ssl.sslContext.getSocketFactory, ssl.trustManager)
+          case Some(sslContext) =>
+            b1.sslSocketFactory(sslContext.getSocketFactory)
               .hostnameVerifier((s: String, sslSession: SSLSession) => true)
           case _ => b1
         }

--- a/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -12,6 +12,7 @@ import okhttp3.Request
 import okhttp3.Response
 import javax.net.ssl.SSLSession
 import org.openjdk.jmh.annotations._
+import play.api.http.HttpProtocol
 import play.api.mvc.Results
 import play.api.test.ApplicationFactory
 import play.api.test.ServerEndpointRecipe
@@ -126,9 +127,9 @@ object HelloWorldBenchmark {
       // Pre-build the request
       request = new Request.Builder().url(bench.serverEndpoint.pathUrl("/")).build()
       // Store the expected protocol so we can verify we're testing the correct HTTP version
-      expectedProtocol = if (bench.serverEndpoint.expectedHttpVersions.contains("2")) {
+      expectedProtocol = if (bench.serverEndpoint.protocols.contains(HttpProtocol.HTTP_2_0)) {
         Protocol.HTTP_2
-      } else if (bench.serverEndpoint.expectedHttpVersions.contains("1.1")) {
+      } else if (bench.serverEndpoint.protocols.contains(HttpProtocol.HTTP_1_1)) {
         Protocol.HTTP_1_1
       } else {
         throw new IllegalArgumentException("Server endpoint must support either HTTP version 1.1 or 2")

--- a/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -10,12 +10,12 @@ import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
-import javax.net.ssl.SSLSession
 import org.openjdk.jmh.annotations._
 import play.api.http.HttpProtocol
 import play.api.mvc.Results
 import play.api.test.ApplicationFactory
 import play.api.test.ServerEndpointRecipe
+import play.core.server.LoggingTrustManager
 import play.core.server.ServerEndpoint
 import play.microbenchmark.it.HelloWorldBenchmark.ThreadState
 
@@ -118,8 +118,8 @@ object HelloWorldBenchmark {
         // Add SSL options if we need to
         val b2 = bench.serverEndpoint.ssl match {
           case Some(sslContext) =>
-            b1.sslSocketFactory(sslContext.getSocketFactory)
-              .hostnameVerifier((s: String, sslSession: SSLSession) => true)
+            b1.sslSocketFactory(sslContext.getSocketFactory, LoggingTrustManager)
+              .hostnameVerifier((_, _) => true)
           case _ => b1
         }
         b2.build()

--- a/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -49,11 +49,11 @@ class HelloWorldBenchmark {
   def setup(): Unit = {
     val appFactory = ApplicationFactory.withResult(Results.Ok("Hello world"))
     val endpointRecipe = endpoint match {
-      case "nt-11-pln" => ServerEndpointRecipe.Netty11Plaintext
-      case "nt-11-enc" => ServerEndpointRecipe.Netty11Plaintext
-      case "ak-11-pln" => ServerEndpointRecipe.AkkaHttp11Plaintext
-      case "ak-11-enc" => ServerEndpointRecipe.AkkaHttp11Encrypted
-      case "ak-20-enc" => ServerEndpointRecipe.AkkaHttp20Encrypted
+      case "nt-11-pln" => play.it.test.NettyServerEndpointRecipes.Netty11Plaintext
+      case "nt-11-enc" => play.it.test.NettyServerEndpointRecipes.Netty11Plaintext
+      case "ak-11-pln" => play.it.test.AkkaHttpServerEndpointRecipes.AkkaHttp11Plaintext
+      case "ak-11-enc" => play.it.test.AkkaHttpServerEndpointRecipes.AkkaHttp11Encrypted
+      case "ak-20-enc" => play.it.test.AkkaHttpServerEndpointRecipes.AkkaHttp20Encrypted
 
     }
     val startResult = ServerEndpointRecipe.startEndpoint(endpointRecipe, appFactory)

--- a/core/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/core/play/src/main/scala/play/api/http/StandardValues.scala
@@ -353,6 +353,7 @@ trait HttpProtocol {
   // Versions
   val HTTP_1_0 = "HTTP/1.0"
   val HTTP_1_1 = "HTTP/1.1"
+  val HTTP_2_0 = "HTTP/2.0"
 
   // Other HTTP protocol values
   val CHUNKED = "chunked"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/test/scala/controllers/IntegrationTest.scala
@@ -9,6 +9,8 @@ import play.api.libs.ws.WSRequest
 import play.api.test.PlaySpecification
 import play.api.test._
 
+import play.api.http.HttpProtocol
+
 class IntegrationTest extends ForServer with PlaySpecification with ApplicationFactories {
 
   protected def applicationFactory: ApplicationFactory = withGuiceApp(GuiceApplicationBuilder())
@@ -34,7 +36,7 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     }
 
     "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>
-      rs.endpoints.endpoints.filter(_.expectedHttpVersions.contains("2")) must not be Nil
+      rs.endpoints.endpoints.filter(_.protocols.contains(HttpProtocol.HTTP_2_0)) must not be Nil
     }
 
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
@@ -9,6 +9,8 @@ import play.api.libs.ws.WSRequest
 import play.api.test.PlaySpecification
 import play.api.test._
 
+import play.api.http.HttpProtocol
+
 class IntegrationTest extends ForServer with PlaySpecification with ApplicationFactories {
 
   protected def applicationFactory: ApplicationFactory = withGuiceApp(GuiceApplicationBuilder())
@@ -34,7 +36,7 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     }
 
     "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>
-      rs.endpoints.endpoints.filter(_.expectedHttpVersions.contains("2")) must be(Nil)
+      rs.endpoints.endpoints.filter(_.protocols.contains(HttpProtocol.HTTP_2_0)) must be(Nil)
     }
 
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
@@ -9,6 +9,8 @@ import play.api.libs.ws.WSRequest
 import play.api.test.PlaySpecification
 import play.api.test._
 
+import play.api.http.HttpProtocol
+
 class IntegrationTest extends ForServer with PlaySpecification with ApplicationFactories {
 
   protected def applicationFactory: ApplicationFactory = withGuiceApp(GuiceApplicationBuilder())
@@ -34,7 +36,7 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     }
 
     "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>
-      rs.endpoints.endpoints.filter(_.expectedHttpVersions.contains("2")) must be(Nil)
+      rs.endpoints.endpoints.filter(_.protocols.contains(HttpProtocol.HTTP_2_0)) must be(Nil)
     }
 
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/build.sbt
@@ -4,7 +4,7 @@
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala).enablePlugins(MediatorWorkaroundPlugin)
 
-name := "system-property"
+name := "http-backend-system-property"
 
 scalaVersion := sys.props("scala.version")
 updateOptions := updateOptions.value.withLatestSnapshots(false)
@@ -13,10 +13,7 @@ evictionWarningOptions in update ~= (_.withWarnTransitiveEvictions(false).withWa
 // because the "test" directory clashes with the scripted test file
 scalaSource in Test := (baseDirectory.value / "tests")
 
-val playAkkaHttpServer = "com.typesafe.play" %% "play-akka-http-server" % sys.props("project.version")
-val playNettyServer    = "com.typesafe.play" %% "play-netty-server"     % sys.props("project.version")
-
-libraryDependencies ++= Seq(playAkkaHttpServer, playNettyServer, guice, ws, specs2 % Test)
+libraryDependencies ++= Seq(akkaHttpServer, nettyServer, guice, ws, specs2 % Test)
 
 fork in Test := true
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/test
@@ -1,8 +1,3 @@
-# Start dev mode with the default server - AkkaHttpServer
-> run
-> verifyResourceContains / 200 unknown
-> playStop
-
 # Start dev mode with an overridden server - AkkaHttpServer
 > run -Dplay.server.provider=play.core.server.AkkaHttpServerProvider
 > verifyResourceContains / 200 unknown

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -107,7 +107,7 @@ object ScriptedTools extends AutoPlugin with ScriptedTools0 {
       messages.foreach(println)
     } catch {
       case e: Exception =>
-        println(s"Got exception: $e")
+        println(s"Got exception: $e. Cause was ${e.getCause}")
         // Using 30 max attempts so that we can give more chances to
         // the file watcher service. This is relevant when using the
         // default JDK watch service which does uses polling.

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -224,6 +224,14 @@ If you still want to send this exact header however, you can still do that by us
 
 The Play's sbt plugin key `playOmnidoc`, which used to default to `true` (for non-snapshot version of Play) now defaults to `false` (and does so in sbt's `Global` scope).  The impact is that any Play app that previously enabled the `PlayDocsPlugin` won't get all the documentation they used when running the app and going to `http://localhost:9000/@documentation`.  You can reverse this change by setting `ThisBuild / playOmnidoc := true` in your sbt build.
 
+## Dependency graph changes
+
+Until Play 2.7.0, [`"com.typesafe.play" %% "play-test"` artifact](https://mvnrepository.com/artifact/com.typesafe.play/play-test_2.13/2.7.3) was including both Akka HTTP and Netty server backends. This creates unstable behavior for your tests and, also, made them possibly use a different server than the production code, depending on how the classpath is sorted. In Play 2.8, `play-test` depends on `play-server` instead, and then the tests will use the same server provider that the application uses. If, for some reason, you need add a provider to our tests, you can do that by adding either Akka HTTP or Netty server dependencies as a `"test"` dependency. For example:
+
+```scala
+libraryDependencies += akkaHttpServer % "test" // Use nettyServer if you want the Netty Server backend
+```
+
 ## Updated libraries
 
 This section lists significant updates made to our dependencies.

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ServerFunctionalTest.java
@@ -11,7 +11,6 @@ import org.junit.*;
 
 import play.test.*;
 import play.libs.ws.*;
-import scala.Option;
 
 import static org.junit.Assert.*;
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -678,6 +678,33 @@ object BuildSettings {
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("play.core.server.ssl.DefaultSSLEngineProvider.createSSLContext"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ssl.noCATrustManager.nullArray"),
+      // Move ServerEndpoints definition to Server implementation
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.AkkaHttp11Encrypted"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.AkkaHttp11Plaintext"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.AkkaHttp20Encrypted"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.AkkaHttp20Plaintext"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.AllRecipes"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.AllRecipesIncludingExperimental"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.Netty11Encrypted"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.ServerEndpointRecipe.Netty11Plaintext"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ServerEndpoint.expectedHttpVersions"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ServerEndpoint.expectedServerAttr"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ServerEndpoints.andThen"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ServerEndpoints.compose"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.core.server.ServerEndpoint.apply"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.core.server.ServerEndpoint.copy"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.core.server.ServerEndpoint.copy$default$7"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.core.server.ServerEndpoint.ssl"),
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("play.core.server.ServerEndpoint.unapply"),
+      ProblemFilters.exclude[MissingClassProblem]("play.core.server.ServerEndpoint$ClientSsl"),
+      ProblemFilters.exclude[MissingClassProblem]("play.core.server.ServerEndpoint$ClientSsl$"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.core.server.ServerEndpoints$"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HttpProtocol.HTTP_2_0"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "play.api.http.HttpProtocol.play$api$http$HttpProtocol$_setter_$HTTP_2_0_="
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.core.server.Server.serverEndpoints"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ val webjarsLocatorCore = "0.37"
 val sbtHeader          = "5.2.0"
 val scalafmt           = "2.0.1"
 val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.5.0-M5") // sync with documentation/project/plugins.sbt
-val interplay: String  = sys.props.getOrElse("interplay.version", "2.1.1")
+val interplay: String  = sys.props.getOrElse("interplay.version", "2.1.2")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackager,

--- a/testkit/play-test/src/main/java/play/test/TestServer.java
+++ b/testkit/play-test/src/main/java/play/test/TestServer.java
@@ -7,7 +7,6 @@ package play.test;
 import play.Application;
 import play.Mode;
 import play.core.server.ServerConfig;
-import play.core.server.ServerProvider;
 import scala.Option;
 import scala.compat.java8.OptionConverters;
 

--- a/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -5,9 +5,9 @@
 package play.api.test
 
 import akka.annotation.ApiMayChange
-
 import play.api.Application
 import play.api.Configuration
+import play.api.http.HttpProtocol
 import play.core.server.ServerEndpoint.ClientSsl
 import play.core.server.AkkaHttpServer
 import play.core.server.NettyServer
@@ -77,8 +77,8 @@ import play.core.server.ServerProvider
       scheme = "http",
       host = "localhost",
       port = runningServer.runningHttpPort.get,
-      expectedHttpVersions = recipe.expectedHttpVersions,
-      expectedServerAttr = recipe.expectedServerAttr,
+      protocols = recipe.expectedHttpVersions,
+      serverAttribute = recipe.expectedServerAttr,
       ssl = None
     )
   }
@@ -113,10 +113,11 @@ import play.core.server.ServerProvider
 
   override val configuredHttpPort: Option[Int]  = None
   override val configuredHttpsPort: Option[Int] = Some(0)
-  override def serverConfiguration: Configuration =
+  override def serverConfiguration: Configuration = extraServerConfiguration.withFallback(
     Configuration(
       "play.server.https.engineProvider" -> classOf[SelfSignedSSLEngineProvider].getName
-    ) ++ extraServerConfiguration
+    )
+  )
 
   override def createEndpointFromServer(runningServer: TestServer): ServerEndpoint = {
     ServerEndpoint(
@@ -124,8 +125,8 @@ import play.core.server.ServerProvider
       scheme = "https",
       host = "localhost",
       port = runningServer.runningHttpsPort.get,
-      expectedHttpVersions = recipe.expectedHttpVersions,
-      expectedServerAttr = recipe.expectedServerAttr,
+      protocols = recipe.expectedHttpVersions,
+      serverAttribute = recipe.expectedServerAttr,
       ssl = Some(
         ClientSsl(
           SelfSigned.sslContext,
@@ -165,28 +166,28 @@ import play.core.server.ServerProvider
     "Netty HTTP/1.1 (plaintext)",
     NettyServer.provider,
     Configuration.empty,
-    Set("1.0", "1.1"),
+    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
     Option("netty")
   )
   val Netty11Encrypted = new HttpsServerEndpointRecipe(
     "Netty HTTP/1.1 (encrypted)",
     NettyServer.provider,
     Configuration.empty,
-    Set("1.0", "1.1"),
+    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
     Option("netty")
   )
   val AkkaHttp11Plaintext = new HttpServerEndpointRecipe(
     "Akka HTTP HTTP/1.1 (plaintext)",
     AkkaHttpServer.provider,
     http2Conf(false),
-    Set("1.0", "1.1"),
+    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
     None
   )
   val AkkaHttp11Encrypted = new HttpsServerEndpointRecipe(
     "Akka HTTP HTTP/1.1 (encrypted)",
     AkkaHttpServer.provider,
     http2Conf(false),
-    Set("1.0", "1.1"),
+    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
     None
   )
   @ApiMayChange
@@ -194,14 +195,14 @@ import play.core.server.ServerProvider
     "Akka HTTP HTTP/2 (plaintext)",
     AkkaHttpServer.provider,
     http2Conf(enabled = true, alwaysForInsecure = true),
-    Set("2"),
+    Set(HttpProtocol.HTTP_2_0),
     None
   )
   val AkkaHttp20Encrypted = new HttpsServerEndpointRecipe(
     "Akka HTTP HTTP/2 (encrypted)",
     AkkaHttpServer.provider,
     http2Conf(enabled = true),
-    Set("1.0", "1.1", "2"),
+    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1, HttpProtocol.HTTP_2_0),
     None
   )
 

--- a/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -7,9 +7,6 @@ package play.api.test
 import akka.annotation.ApiMayChange
 import play.api.Application
 import play.api.Configuration
-import play.api.http.HttpProtocol
-import play.core.server.AkkaHttpServer
-import play.core.server.NettyServer
 import play.core.server.SelfSigned
 import play.core.server.SelfSignedSSLEngineProvider
 import play.core.server.ServerConfig
@@ -154,76 +151,6 @@ import play.core.server.ServerProvider
 }
 
 @ApiMayChange object ServerEndpointRecipe {
-
-  private def http2Conf(enabled: Boolean, alwaysForInsecure: Boolean = false): Configuration = Configuration(
-    "play.server.akka.http2.enabled"           -> enabled,
-    "play.server.akka.http2.alwaysForInsecure" -> alwaysForInsecure
-  )
-
-  val Netty11Plaintext = new HttpServerEndpointRecipe(
-    "Netty HTTP/1.1 (plaintext)",
-    NettyServer.provider,
-    Configuration.empty,
-    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
-    Option("netty")
-  )
-
-  val Netty11Encrypted = new HttpsServerEndpointRecipe(
-    "Netty HTTP/1.1 (encrypted)",
-    NettyServer.provider,
-    Configuration.empty,
-    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
-    Option("netty")
-  )
-
-  val AkkaHttp11Plaintext = new HttpServerEndpointRecipe(
-    "Akka HTTP HTTP/1.1 (plaintext)",
-    AkkaHttpServer.provider,
-    http2Conf(enabled = false),
-    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
-    None
-  )
-
-  val AkkaHttp11Encrypted = new HttpsServerEndpointRecipe(
-    "Akka HTTP HTTP/1.1 (encrypted)",
-    AkkaHttpServer.provider,
-    http2Conf(enabled = false),
-    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
-    None
-  )
-
-  val AkkaHttp20Plaintext = new HttpServerEndpointRecipe(
-    "Akka HTTP HTTP/2 (plaintext)",
-    AkkaHttpServer.provider,
-    http2Conf(enabled = true, alwaysForInsecure = true),
-    Set(HttpProtocol.HTTP_2_0),
-    None
-  )
-
-  val AkkaHttp20Encrypted = new HttpsServerEndpointRecipe(
-    "Akka HTTP HTTP/2 (encrypted)",
-    AkkaHttpServer.provider,
-    http2Conf(enabled = true),
-    Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1, HttpProtocol.HTTP_2_0),
-    None
-  )
-
-  /**
-   * All non-experimental server endpoint recipes.
-   */
-  val AllRecipes: Seq[ServerEndpointRecipe] = Seq(
-    Netty11Plaintext,
-    Netty11Encrypted,
-    AkkaHttp11Plaintext,
-    AkkaHttp11Encrypted,
-    AkkaHttp20Encrypted
-  )
-
-  /**
-   * All server endpoint recipes including experimental.
-   */
-  @ApiMayChange
-  val AllRecipesIncludingExperimental: Seq[ServerEndpointRecipe] = AllRecipes :+ AkkaHttp20Plaintext
 
   /**
    * Starts a server by following a [[ServerEndpointRecipe]] and using the

--- a/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -183,6 +183,7 @@ import play.core.server.ServerProvider
     Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
     None
   )
+
   val AkkaHttp11Encrypted = new HttpsServerEndpointRecipe(
     "Akka HTTP HTTP/1.1 (encrypted)",
     AkkaHttpServer.provider,
@@ -191,7 +192,6 @@ import play.core.server.ServerProvider
     None
   )
 
-  @ApiMayChange
   val AkkaHttp20Plaintext = new HttpServerEndpointRecipe(
     "Akka HTTP HTTP/2 (plaintext)",
     AkkaHttpServer.provider,

--- a/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -4,9 +4,11 @@
 
 package play.api.test
 
+import akka.annotation.ApiMayChange
 import play.api._
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.core.server._
+
 import scala.util.control.NonFatal
 
 /**
@@ -80,6 +82,7 @@ case class TestServer(config: ServerConfig, application: Application, serverProv
   /**
    * True if the port is running either on HTTP or HTTPS port.
    */
+  @ApiMayChange
   def isRunning: Boolean = runningHttpPort.nonEmpty || runningHttpsPort.nonEmpty
 }
 

--- a/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -19,10 +19,10 @@ import scala.util.control.NonFatal
 case class TestServer(config: ServerConfig, application: Application, serverProvider: Option[ServerProvider]) {
 
   private var testServerProcess: TestServerProcess = _
-  private var testServer: Server                   = _
+  private[test] var server: Server                 = _
 
   private def getTestServerIfRunning: Server = {
-    val s = testServer
+    val s = server
     if (s == null) {
       throw new IllegalStateException("Test server not running")
     }
@@ -43,10 +43,10 @@ case class TestServer(config: ServerConfig, application: Application, serverProv
         ServerProvider.fromConfiguration(testServerProcess.classLoader, config.configuration)
       }
       Play.start(application)
-      testServer = resolvedServerProvider.createServer(config, application)
+      server = resolvedServerProvider.createServer(config, application)
       testServerProcess.addShutdownHook {
-        val ts = testServer
-        testServer = null // Clear field before stopping, in case an error occurs
+        val ts = server
+        server = null // Clear field before stopping, in case an error occurs
         ts.stop()
       }
     } catch {
@@ -76,6 +76,11 @@ case class TestServer(config: ServerConfig, application: Application, serverProv
    * The HTTPS port that the server is running on.
    */
   def runningHttpsPort: Option[Int] = getTestServerIfRunning.httpsPort
+
+  /**
+   * True if the port is running either on HTTP or HTTPS port.
+   */
+  def isRunning: Boolean = runningHttpPort.nonEmpty || runningHttpsPort.nonEmpty
 }
 
 object TestServer {

--- a/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -80,7 +80,7 @@ case class TestServer(config: ServerConfig, application: Application, serverProv
   def runningHttpsPort: Option[Int] = getTestServerIfRunning.httpsPort
 
   /**
-   * True if the port is running either on HTTP or HTTPS port.
+   * True if the server is running either on HTTP or HTTPS port.
    */
   @ApiMayChange
   def isRunning: Boolean = runningHttpPort.nonEmpty || runningHttpsPort.nonEmpty

--- a/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
@@ -72,38 +72,6 @@ import scala.util.control.NonFatal
   protected def serverProvider(app: Application): ServerProvider =
     ServerProvider.fromConfiguration(getClass.getClassLoader, serverConfig(app).configuration)
 
-  protected def serverEndpoints(testServer: TestServer): ServerEndpoints = {
-    val useAkkaHttp = testServer.serverProvider.get.isInstanceOf[AkkaHttpServerProvider]
-    val useHttp2 = testServer.application.configuration
-      .getOptional[Boolean]("play.server.akka.http2.enabled")
-      .getOrElse(false)
-
-    val httpEndpoint: Option[ServerEndpoint] = testServer.runningHttpPort.map(_ => {
-      val recipe = if (useAkkaHttp) {
-        if (useHttp2) {
-          ServerEndpointRecipe.AkkaHttp20Plaintext
-        } else {
-          ServerEndpointRecipe.AkkaHttp11Plaintext
-        }
-      } else {
-        ServerEndpointRecipe.Netty11Plaintext
-      }
-      recipe.createEndpointFromServer(testServer)
-    })
-
-    val httpsEndpoint: Option[ServerEndpoint] = testServer.runningHttpsPort.map(_ => {
-      val recipe = if (useAkkaHttp) {
-        if (useHttp2) {
-          ServerEndpointRecipe.AkkaHttp20Encrypted
-        } else {
-          ServerEndpointRecipe.AkkaHttp11Encrypted
-        }
-      } else {
-        ServerEndpointRecipe.Netty11Encrypted
-      }
-      recipe.createEndpointFromServer(testServer)
-    })
-
-    ServerEndpoints(httpEndpoint.toSeq ++ httpsEndpoint.toSeq)
-  }
+  protected def serverEndpoints(testServer: TestServer): ServerEndpoints =
+    if (testServer.isRunning) testServer.server.serverEndpoints else ServerEndpoints.empty
 }

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -5,8 +5,6 @@
 package play.core.server
 
 import java.net.InetSocketAddress
-import java.security.Provider
-import java.security.SecureRandom
 
 import akka.Done
 import akka.actor.ActorSystem
@@ -35,6 +33,7 @@ import play.api._
 import play.api.http.DefaultHttpErrorHandler
 import play.api.http.HeaderNames
 import play.api.http.HttpErrorHandler
+import play.api.http.{ HttpProtocol => PlayHttpProcol }
 import play.api.http.Status
 import play.api.internal.libs.concurrent.CoordinatedShutdownSupport
 import play.api.libs.streams.Accumulator
@@ -100,7 +99,8 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
   private lazy val initialSettings        = ServerSettings(akkaHttpConfig)
   private val defaultHostHeader           = akkaServerConfigReader.getHostHeader.fold(throw _, identity)
   private val transparentHeadRequests     = akkaServerConfig.get[Boolean]("transparent-head-requests")
-  private val serverHeader = akkaServerConfig.get[Option[String]]("server-header").collect {
+  private val serverHeaderConfig          = akkaServerConfig.getOptional[String]("server-header")
+  private val serverHeader = serverHeaderConfig.collect {
     case s if s.nonEmpty => headers.Server(s)
   }
   private val bindTimeout         = akkaServerConfig.get[FiniteDuration]("bindTimeout")
@@ -203,6 +203,10 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     Await.result(bindingFuture, bindTimeout)
   }
 
+  // Lazy since it will only be required when HTTPS is bound.
+  private lazy val sslContext: SSLContext =
+    ServerSSLEngine.createSSLEngineProvider(context.config, applicationProvider).sslContext()
+
   private val httpServerBinding = context.config.port.map(
     port =>
       createServerBinding(
@@ -214,8 +218,6 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
 
   private val httpsServerBinding = context.config.sslPort.map { port =>
     val connectionContext = try {
-      val sslContext: SSLContext =
-        ServerSSLEngine.createSSLEngineProvider(context.config, applicationProvider).sslContext()
       val clientAuth: Option[TLSClientAuth] = createClientAuth()
       ConnectionContext.https(
         sslContext = sslContext,
@@ -492,10 +494,72 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     httpServerBinding.orElse(httpsServerBinding).map(_.localAddress).get
   }
 
-  override def httpPort: Option[Int] = httpServerBinding.map(_.localAddress.getPort)
+  private lazy val Http1Plain = httpServerBinding
+    .map(_.localAddress)
+    .map(
+      address =>
+        ServerEndpoint(
+          description = "Akka HTTP HTTP/1.1 (plaintext)",
+          scheme = "http",
+          host = address.getHostName,
+          port = address.getPort,
+          protocols = Set(PlayHttpProcol.HTTP_1_0, PlayHttpProcol.HTTP_1_1),
+          serverAttribute = serverHeaderConfig,
+          ssl = None
+        )
+    )
 
-  override def httpsPort: Option[Int] = httpsServerBinding.map(_.localAddress.getPort)
+  private lazy val Http1Encrypted = httpsServerBinding
+    .map(_.localAddress)
+    .map(
+      address =>
+        ServerEndpoint(
+          description = "Akka HTTP HTTP/1.1 (encrypted)",
+          scheme = "https",
+          host = address.getHostName,
+          port = address.getPort,
+          protocols = Set(PlayHttpProcol.HTTP_1_0, PlayHttpProcol.HTTP_1_1),
+          serverAttribute = serverHeaderConfig,
+          ssl = Option(sslContext)
+        )
+    )
 
+  private lazy val Http2Plain = httpServerBinding
+    .map(_.localAddress)
+    .map(
+      address =>
+        ServerEndpoint(
+          description = "Akka HTTP HTTP/2 (plaintext)",
+          scheme = "http",
+          host = address.getHostName,
+          port = address.getPort,
+          protocols = Set(PlayHttpProcol.HTTP_2_0),
+          serverAttribute = serverHeaderConfig,
+          ssl = None
+        )
+    )
+
+  private lazy val Http2Encrypted = httpsServerBinding
+    .map(_.localAddress)
+    .map(
+      address =>
+        ServerEndpoint(
+          description = "Akka HTTP HTTP/2 (encrypted)",
+          scheme = "https",
+          host = address.getHostName,
+          port = address.getPort,
+          protocols = Set(PlayHttpProcol.HTTP_1_0, PlayHttpProcol.HTTP_1_1, PlayHttpProcol.HTTP_2_0),
+          serverAttribute = serverHeaderConfig,
+          ssl = Option(sslContext)
+        )
+    )
+
+  override val serverEndpoints: ServerEndpoints = {
+    val httpEndpoint  = if (http2Enabled) Http2Plain else Http1Plain
+    val httpsEndpoint = if (http2Enabled) Http2Encrypted else Http1Encrypted
+
+    ServerEndpoints(httpEndpoint.toSeq ++ httpsEndpoint.toSeq)
+  }
 }
 
 /**

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -501,7 +501,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
         ServerEndpoint(
           description = "Akka HTTP HTTP/1.1 (plaintext)",
           scheme = "http",
-          host = address.getHostName,
+          host = context.config.address,
           port = address.getPort,
           protocols = Set(PlayHttpProcol.HTTP_1_0, PlayHttpProcol.HTTP_1_1),
           serverAttribute = serverHeaderConfig,
@@ -516,7 +516,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
         ServerEndpoint(
           description = "Akka HTTP HTTP/1.1 (encrypted)",
           scheme = "https",
-          host = address.getHostName,
+          host = context.config.address,
           port = address.getPort,
           protocols = Set(PlayHttpProcol.HTTP_1_0, PlayHttpProcol.HTTP_1_1),
           serverAttribute = serverHeaderConfig,
@@ -531,7 +531,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
         ServerEndpoint(
           description = "Akka HTTP HTTP/2 (plaintext)",
           scheme = "http",
-          host = address.getHostName,
+          host = context.config.address,
           port = address.getPort,
           protocols = Set(PlayHttpProcol.HTTP_2_0),
           serverAttribute = serverHeaderConfig,
@@ -546,7 +546,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
         ServerEndpoint(
           description = "Akka HTTP HTTP/2 (encrypted)",
           scheme = "https",
-          host = address.getHostName,
+          host = context.config.address,
           port = address.getPort,
           protocols = Set(PlayHttpProcol.HTTP_1_0, PlayHttpProcol.HTTP_1_1, PlayHttpProcol.HTTP_2_0),
           serverAttribute = serverHeaderConfig,

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -340,7 +340,7 @@ class NettyServer(
         ServerEndpoint(
           description = "Netty HTTP/1.1 (plaintext)",
           scheme = "http",
-          host = address.getHostName,
+          host = config.address,
           port = address.getPort,
           protocols = Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
           serverAttribute = serverHeader,
@@ -355,7 +355,7 @@ class NettyServer(
         ServerEndpoint(
           description = "Netty HTTP/1.1 (encrypted)",
           scheme = "https",
-          host = address.getHostName,
+          host = config.address,
           port = address.getPort,
           protocols = Set(HttpProtocol.HTTP_1_0, HttpProtocol.HTTP_1_1),
           serverAttribute = serverHeader,

--- a/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
@@ -5,13 +5,13 @@
 package play.core.server
 
 import java.security.KeyStore
-import javax.net.ssl._
+import java.security.cert.X509Certificate
 
+import javax.net.ssl._
 import com.typesafe.sslconfig.ssl.FakeKeyStore
 import com.typesafe.sslconfig.ssl.FakeSSLTools
-
 import akka.annotation.ApiMayChange
-
+import org.slf4j.LoggerFactory
 import play.core.ApplicationProvider
 import play.server.api.SSLEngineProvider
 
@@ -35,4 +35,21 @@ import play.server.api.SSLEngineProvider
 
   override def createSSLEngine: SSLEngine = sslContext.createSSLEngine()
   override def sslContext: SSLContext     = SelfSigned.sslContext
+}
+
+private[play] object LoggingTrustManager extends X509TrustManager {
+  private val logger = LoggerFactory.getLogger("LoggingTrustManager")
+
+  override def checkClientTrusted(chain: Array[X509Certificate], authType: String): Unit = {
+    logger.debug(s"checkClientTrusted for chain = $chain and authType = $authType")
+  }
+
+  override def checkServerTrusted(chain: Array[X509Certificate], authType: String): Unit = {
+    logger.debug(s"checkServerTrusted for chain = $chain and authType = $authType")
+  }
+
+  override def getAcceptedIssuers: Array[X509Certificate] = {
+    logger.debug(s"calling getAcceptedIssuers")
+    Array.empty
+  }
 }

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -65,7 +65,7 @@ trait Server extends ReloadableServer {
    *
    * @return The HTTP port the server is bound to, if the HTTP connector is enabled.
    */
-  def httpPort: Option[Int]
+  def httpPort: Option[Int] = serverEndpoints.httpEndpoint.map(_.port)
 
   /**
    * Returns the HTTPS port of the server.
@@ -74,8 +74,12 @@ trait Server extends ReloadableServer {
    *
    * @return The HTTPS port the server is bound to, if the HTTPS connector is enabled.
    */
-  def httpsPort: Option[Int]
+  def httpsPort: Option[Int] = serverEndpoints.httpsEndpoint.map(_.port)
 
+  /**
+   * Endpoints information for this server.
+   */
+  def serverEndpoints: ServerEndpoints
 }
 
 /**

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -7,6 +7,7 @@ package play.core.server
 import java.util.function.{ Function => JFunction }
 
 import akka.actor.CoordinatedShutdown
+import akka.annotation.ApiMayChange
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import play.api.ApplicationLoader.Context
@@ -79,6 +80,7 @@ trait Server extends ReloadableServer {
   /**
    * Endpoints information for this server.
    */
+  @ApiMayChange
   def serverEndpoints: ServerEndpoints
 }
 

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
@@ -21,8 +21,8 @@ import play.core.server.ServerEndpoint.ClientSsl
     scheme: String,
     host: String,
     port: Int,
-    expectedHttpVersions: Set[String],
-    expectedServerAttr: Option[String],
+    protocols: Set[String],
+    serverAttribute: Option[String],
     ssl: Option[ClientSsl]
 ) {
 

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
@@ -8,8 +8,6 @@ import javax.net.ssl._
 
 import akka.annotation.ApiMayChange
 
-import play.core.server.ServerEndpoint.ClientSsl
-
 /**
  * Contains information about which port and protocol can be used to connect to the server.
  * This class is used to abstract out the details of connecting to different backends
@@ -23,7 +21,7 @@ import play.core.server.ServerEndpoint.ClientSsl
     port: Int,
     protocols: Set[String],
     serverAttribute: Option[String],
-    ssl: Option[ClientSsl]
+    ssl: Option[SSLContext]
 ) {
 
   /**
@@ -31,10 +29,4 @@ import play.core.server.ServerEndpoint.ClientSsl
    */
   def pathUrl(path: String): String = s"$scheme://$host:$port$path"
 
-}
-
-@ApiMayChange object ServerEndpoint {
-
-  /** Contains SSL information for a client that wants to connect to a [[ServerEndpoint]]. */
-  final case class ClientSsl(sslContext: SSLContext, trustManager: X509TrustManager)
 }

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoints.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoints.scala
@@ -20,3 +20,8 @@ import akka.annotation.ApiMayChange
   /** Convenient way to get an HTTPS endpoint */
   val httpsEndpoint: Option[ServerEndpoint] = endpointForScheme("https")
 }
+
+@ApiMayChange
+object ServerEndpoints {
+  val empty: ServerEndpoints = ServerEndpoints(Seq.empty)
+}

--- a/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
@@ -5,23 +5,23 @@
 package play.core.server
 
 import java.io.File
+import java.net.InetSocketAddress
 import java.nio.charset.Charset
 import java.nio.file.Files
 import java.util.Properties
 import java.util.concurrent._
 
 import com.google.common.io.{ Files => GFiles }
-import org.specs2.matcher.EventuallyMatchers
 import org.specs2.mutable.Specification
 import play.api.Mode
 import play.api.Play
+import play.core.ApplicationProvider
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Failure
-import scala.util.Random
 import scala.util.Success
 import scala.util.Try
 
@@ -56,18 +56,23 @@ class FakeServerProcess(
 // A family of fake servers for us to test
 
 class FakeServer(context: ServerProvider.Context) extends Server with ReloadableServer {
-  def config                  = context.config
-  def applicationProvider     = context.appProvider
-  def mode                    = config.mode
-  def mainAddress             = ???
   @volatile var stopCallCount = 0
-  override def stop() = {
+  val config: ServerConfig    = context.config
+
+  override def applicationProvider: ApplicationProvider = context.appProvider
+  override def mode: Mode                               = config.mode
+  override def mainAddress: InetSocketAddress           = ???
+
+  override def stop(): Unit = {
     applicationProvider.get.map(Play.stop)
     stopCallCount += 1
     super.stop()
   }
-  def httpPort  = config.port
-  def httpsPort = config.sslPort
+
+  override def httpPort: Option[Int]  = config.port
+  override def httpsPort: Option[Int] = config.sslPort
+
+  override def serverEndpoints: ServerEndpoints = ServerEndpoints.empty
 }
 
 class FakeServerProvider extends ServerProvider {

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -217,7 +217,7 @@ play.filters {
     # A list of valid hosts (e.g. "example.com") or suffixes of valid hosts (e.g. ".example.com")
     # Note that ".example.com" will match example.com and any subdomain of example.com, with or without a trailing dot.
     # "." matches all domains, and "" matches an empty or nonexistent host.
-    allowed = ["localhost", ".local", "127.0.0.1"]
+    allowed = ["localhost", ".local", "127.0.0.1", "0.0.0.0"]
 
     routeModifiers {
       # If non empty, then requests will be checked if the route does not have this modifier. This is how we enable the

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -267,10 +267,14 @@ trait FormSpec extends CommonFormSpec {
       myForm.hasErrors() must beEqualTo(false)
     }
     "access fields when filled with a default value with direct field access" in {
+      def createDate(): Date = {
+        // Thu Jan 01 01:00:00 CET 1970
+        Date.from(LocalDate.of(1970, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant)
+      }
       val st: Subtask = new Subtask()
-      st.dueDate = new Date(0) // Thu Jan 01 01:00:00 CET 1970
+      st.dueDate = createDate()
       val myForm = formFactory.form(classOf[play.data.Subtask]).withDirectFieldAccess(true).fill(st)
-      myForm.get().dueDate must beEqualTo(new Date(0))
+      myForm.get().dueDate must beEqualTo(createDate())
       myForm("dueDate").value().asScala must beSome("01/01/1970")
       myForm("dueDate").format() must beEqualTo(F.Tuple("format.date", List("dd/MM/yyyy").asJava))
       myForm("dueDate").constraints() must beEqualTo(List(F.Tuple("constraint.required", List().asJava)).asJava)


### PR DESCRIPTION
This is a well-organized version of #9834 and depends on #9836. I'm proposing this again because I still think that fixing the dependency graph to not include multiple server providers out-of-the-box is the proper fix right now. Of course, we can later decide to re-target this to master.

Although the change looks extensive, there are only two breaking changes on stable APIs (on top of the changes made in #9836):

- Adding `play.api.http.HttpProtocol.HTTP_2_0`
- Adding `play.core.server.Server.serverEndpoints`

All the other changes are affecting `@ApiMayChange` APIs, which is okay.