### PR TITLE
Only run Netty integration tests in Travis for cron builds

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecification.scala
@@ -29,8 +29,8 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
   parent =>
   implicit def integrationServerProvider: ServerProvider
 
-  val isTravis: Boolean     = sys.env.get("TRAVIS").exists(_.toBoolean)
-  val isTravisCron: Boolean = sys.env.get("TRAVIS_EVENT_TYPE").exists(_.equalsIgnoreCase("cron"))
+  val isTravis: Boolean                = sys.env.get("TRAVIS").exists(_.toBoolean)
+  val isTravisCron: Boolean            = sys.env.get("TRAVIS_EVENT_TYPE").exists(_.equalsIgnoreCase("cron"))
   val isContinuousIntegration: Boolean = isTravis
   val isCronBuild: Boolean             = isTravisCron // TODO We don't have cron builds for CircleCI yet
 
@@ -52,31 +52,6 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
       case _: NettyIntegrationSpecification    => ResultExecution.execute(AsResult(t))
       case _: AkkaHttpIntegrationSpecification => Skipped()
     }
-  }
-
-  implicit class UntilNettyHttpFixed[T: AsResult](t: => T) {
-
-    /**
-     * We may want to skip some tests if they're slow due to timeouts. This tag
-     * won't remind us if the tests start passing.
-     */
-    def skipUntilNettyHttpFixed: Result = parent match {
-      case _: NettyIntegrationSpecification    => Skipped()
-      case _: AkkaHttpIntegrationSpecification => ResultExecution.execute(AsResult(t))
-    }
-  }
-
-  implicit class UntilFastCIServer[T: AsResult](t: => T) {
-    def skipOnSlowCIServer: Result = parent match {
-      case _ if isContinuousIntegrationEnvironment => Skipped()
-      case _                                       => ResultExecution.execute(AsResult(t))
-    }
-  }
-
-  // There are some tests that we still want to run, but Travis CI will fail
-  // because the server is underpowered...
-  def isContinuousIntegrationEnvironment: Boolean = {
-    System.getenv("CONTINUOUS_INTEGRATION") == "true"
   }
 
   /**

--- a/core/play-integration-test/src/it/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/HttpPipeliningSpec.scala
@@ -49,7 +49,7 @@ trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecifi
       responses(0).body must beLeft("long")
       responses(1).status must_== 200
       responses(1).body must beLeft("short")
-    }.skipOnSlowCIServer
+    }
 
     "wait for the first response body to return before returning the second" in withServer(EssentialAction { req =>
       req.path match {
@@ -73,7 +73,7 @@ trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecifi
       responses(0).body.right.get._1 must containAllOf(Seq("chunk", "chunk", "chunk")).inOrder
       responses(1).status must_== 200
       responses(1).body must beLeft("short")
-    }.skipOnSlowCIServer
+    }
 
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
@@ -101,7 +101,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       responses.length must_== 2
       responses(0).status must_== 200
       responses(1).status must_== 200
-    }.skipOnSlowCIServer
+    }
 
     "support 'infinite' as an infinite timeout" in withServerAndConfig(
       Map(
@@ -117,7 +117,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       responses.length must_== 2
       responses(0).status must_== 200
       responses(1).status must_== 200
-    }.skipOnSlowCIServer
+    }
 
     "support sub-second timeouts" in withServer(httpTimeout = 300.millis, httpsTimeout = 300.millis)(EssentialAction {
       req =>
@@ -126,7 +126,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       doRequests(port, trickle = 400L) must throwA[IOException].like {
         case e => (e must beAnInstanceOf[SocketException]).or(e.getCause must beAnInstanceOf[SocketException])
       }
-    }.skipOnSlowCIServer
+    }
 
     "support a separate timeout for https" in withServer(
       1.second,
@@ -143,7 +143,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       doRequests(httpsPort, trickle = 600L, secure = true) must throwA[IOException].like {
         case e => (e must beAnInstanceOf[SocketException]).or(e.getCause must beAnInstanceOf[SocketException])
       }
-    }.skipOnSlowCIServer
+    }
 
     "support multi-second timeouts" in withServer(httpTimeout = 1500.millis, httpsTimeout = 1500.millis)(
       EssentialAction { req =>
@@ -153,7 +153,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       doRequests(port, trickle = 1600L) must throwA[IOException].like {
         case e => (e must beAnInstanceOf[SocketException]).or(e.getCause must beAnInstanceOf[SocketException])
       }
-    }.skipOnSlowCIServer
+    }
 
     "not timeout for slow requests with a sub-second timeout" in withServer(
       httpTimeout = 700.millis,
@@ -165,7 +165,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       responses.length must_== 2
       responses(0).status must_== 200
       responses(1).status must_== 200
-    }.skipOnSlowCIServer
+    }
 
     "not timeout for slow requests with a multi-second timeout" in withServer(
       httpTimeout = 1500.millis,
@@ -177,7 +177,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       responses.length must_== 2
       responses(0).status must_== 200
       responses(1).status must_== 200
-    }.skipOnSlowCIServer
+    }
   }
 
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
@@ -150,7 +150,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
         Accumulator(Sink.ignore).map(_ => Results.Ok)
       }
     ) { port =>
-      doRequests(port, trickle = 1600L) must throwA[IOException].like {
+      doRequests(port, trickle = 2600L) must throwA[IOException].like {
         case e => (e must beAnInstanceOf[SocketException]).or(e.getCause must beAnInstanceOf[SocketException])
       }
     }


### PR DESCRIPTION
## Purpose

While the build builds... :-)

This helps to reduce the amount of time our tests take to run for each pull request. The accumulated gain for each pull request (and push) is larger than the upset of delaying the discover that a change broke Netty server backend (something we will only see in nightly builds).

Also, removes some test skippers that aren't used anymore.