### PR TITLE
Request.contentType discard the boundary of the form-data

### DIFF
--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -378,6 +378,9 @@ public class Http {
     /** @return The request content type excluding the charset, if it exists. */
     Optional<String> contentType();
 
+    /** @return The request content type (with params) excluding the charset, if it exists. */
+    Optional<String> contentTypeWithParams();
+
     /** @return The request charset, which comes from the content type header, if it exists. */
     Optional<String> charset();
 

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -257,6 +257,11 @@ trait RequestHeader {
   lazy val contentType: Option[String] = mediaType.map(mt => mt.mediaType + "/" + mt.mediaSubType)
 
   /**
+   * Returns the value of the Content-Type header with the parameters
+   */
+  lazy val contentTypeWithParams: Option[String] = mediaType.map(_.toString)
+
+  /**
    * Returns the charset of the request for text-based body
    */
   lazy val charset: Option[String] = for {

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -244,6 +244,8 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def contentType(): Optional[String] = OptionConverters.toJava(header.contentType)
 
+  override def contentTypeWithParams(): Optional[String] = OptionConverters.toJava(header.contentTypeWithParams)
+
   override def charset(): Optional[String] = OptionConverters.toJava(header.charset)
 
   override def withTransientLang(lang: play.i18n.Lang): JRequestHeader = addAttr(i18n.Messages.Attrs.CurrentLang, lang)

--- a/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 import akka.stream.Materializer
 import akka.util.ByteString
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -64,6 +65,15 @@ class FakesSpec extends PlaySpecification {
       route(app, req).aka("response") must beSome.which { resp =>
         contentAsString(resp).aka("content") must_== "text/xml;charset=utf-16le"
       }
+    }
+
+    "content-type with params should return full content-type with its params" in {
+      val contentTypeWithBoundary = "multipart/form-data; boundary=----WebKitFormBoundary76R0zZdvXnlHAQqg"
+      val headers =
+        Seq(("Content-Type", contentTypeWithBoundary))
+      val request = FakeRequest(GET, "/testCall")
+        .withHeaders(headers: _*)
+      request.contentTypeWithParams must beSome.which(ct => ct must_== contentTypeWithBoundary)
     }
 
     "set a Content-Type header when one is unspecified and required" in new WithApplication() {


### PR DESCRIPTION
Fixes #9820