### PR TITLE
[2.7.x] Users get a warn when using deprecated functionally in Session

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Session.scala
+++ b/core/play/src/main/scala/play/api/mvc/Session.scala
@@ -186,4 +186,19 @@ object Session extends CookieBaker[Session] with FallbackCookieDataCodec {
 
   @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
   override def serialize(session: Session): Map[String, String] = session.data
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def encode(data: Map[String, String]): String = super.encode(data)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def decode(encodedData: String): Map[String, String] = super.decode(encodedData)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def decodeCookieToMap(cookie: Option[Cookie]): Map[String, String] = super.decodeCookieToMap(cookie)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def decodeFromCookie(cookie: Option[Cookie]): Session = super.decodeFromCookie(cookie)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def encodeAsCookie(data: Session): Cookie = super.encodeAsCookie(data)
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -221,6 +221,9 @@ object BuildSettings {
       // These return Seq[Any] instead of Seq[String] #9385
       ProblemFilters.exclude[IncompatibleSignatureProblem]("views.html.helper.FieldElements.infos"),
       ProblemFilters.exclude[IncompatibleSignatureProblem]("views.html.helper.FieldElements.errors"),
+      // Deprecate Session methods
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.mvc.Session.decodeFromCookie"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.mvc.Session.encodeAsCookie"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
As reported by @lobax in #9816, when using `Session.decode`, but also any other encode/decode variation, a user will get a runtime error. 

This PR make sure that at least a deprecation warning is emitted whenever a user uses one of the Session methods that rely on deprecated functionally.

Fixes #9816