### PR TITLE
[2.8.x]: interplay 2.1.4 and run scripted tests for sbt 1.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,12 @@ jobs:
     - name: "Run scripted tests (c) for sbt 1.x and Java 11"
       script: scripts/test-scripted 1.x 'play-sbt-plugin/*3of3'
       env: TRAVIS_JDK=11
+    
+    # Test against sbt 1.3.x, but only for cron builds
+    - stage: sbt-1.3.x
+      name: "Run tests for sbt 1.3.x"
+      script: scripts/test-scripted-13x
+      # if: type = cron
 
 cache:
   directories:

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -23,10 +23,10 @@ Where the "x" in `2.8.x` is the minor version of Play you want to use, for insta
 Although Play 2.8 still supports sbt 0.13, we recommend that you use sbt 1. This new version is supported and actively maintained. To update, change your `project/build.properties` so that it reads:
 
 ```properties
-sbt.version=1.3.3
+sbt.version=1.3.4
 ```
 
-At the time of this writing `1.3.3` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version releases and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
+At the time of this writing `1.3.4` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version releases and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
 
 ## API Changes
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -282,7 +282,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.1.0"
+  val playWsStandaloneVersion = "2.1.1"
   val playWsDeps = Seq(
     "com.typesafe.play"                        %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play"                        %% "play-ws-standalone-xml" % playWsStandaloneVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.0")
-  val akkaHttpVersion     = "10.1.10"
+  val akkaHttpVersion     = "10.1.11"
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.1"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ val webjarsLocatorCore = "0.43"
 val sbtHeader          = "5.2.0"
 val scalafmt           = "2.0.1"
 val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.5.0") // sync with documentation/project/plugins.sbt
-val interplay: String  = sys.props.getOrElse("interplay.version", "2.1.3")
+val interplay: String  = sys.props.getOrElse("interplay.version", "2.1.4")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackager,

--- a/scripts/test-scripted-13x
+++ b/scripts/test-scripted-13x
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
+# shellcheck source=scripts/scriptLib
+. "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
+
+SBT_VERSION="1.3.4"
+
+start scripted "RUNNING SCRIPTED TESTS FOR SBT $SBT_VERSION"
+runSbt ";project Sbt-Plugin;set scriptedSbt := \"${SBT_VERSION}\";scripted"
+end scripted "ALL SCRIPTED TESTS PASSED"


### PR DESCRIPTION
Play sbt-plugin should work for sbt 1.2.8 too, so it should not be built for sbt 1.3.4, which 2.8.0-RC2 was.

## References

- https://github.com/lagom/lagom/pull/2479#issuecomment-559851001
- https://github.com/playframework/interplay/pull/99

## Status

WIP since it depends on a release of interplay after https://github.com/playframework/interplay/pull/99.