### PR TITLE
Reinstate skipping HttpPipeliningSpec in CI

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecification.scala
@@ -53,6 +53,13 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
     }
   }
 
+  implicit class UntilFastCIServer[T: AsResult](t: => T) {
+    def skipOnSlowCIServer: Result = {
+      if (isContinuousIntegration) Skipped()
+      else ResultExecution.execute(AsResult(t))
+    }
+  }
+
   /**
    * Override the standard TestServer factory method.
    */

--- a/core/play-integration-test/src/it/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/HttpPipeliningSpec.scala
@@ -47,7 +47,7 @@ trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecifi
       responses(0).body must beLeft("long")
       responses(1).status must_== 200
       responses(1).body must beLeft("short")
-    }
+    }.skipOnSlowCIServer
 
     "wait for the first response body to return before returning the second" in withServer(EssentialAction { req =>
       req.path match {
@@ -71,6 +71,6 @@ trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecifi
       responses(0).body.right.get._1 must containAllOf(Seq("chunk", "chunk", "chunk")).inOrder
       responses(1).status must_== 200
       responses(1).body must beLeft("short")
-    }
+    }.skipOnSlowCIServer
   }
 }


### PR DESCRIPTION
https://travis-ci.com/playframework/playframework/jobs/263296783 failed,
so it would appear those tests should continue to be skipped in CI.