### PR TITLE
Enable ClassLoading hooks in DevMode

### DIFF
--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -141,7 +141,8 @@ object Reloader {
 
   val createURLClassLoader: ClassLoaderCreator = (name, urls, parent) => new NamedURLClassLoader(name, urls, parent)
 
-  val createDelegatedResourcesClassLoader: ClassLoaderCreator = (name, urls, parent) => new DelegatedResourcesClassLoader(name, urls, parent)
+  val createDelegatedResourcesClassLoader: ClassLoaderCreator = (name, urls, parent) =>
+    new DelegatedResourcesClassLoader(name, urls, parent)
 
   def assetsClassLoader(allAssets: Seq[(String, File)])(parent: ClassLoader): ClassLoader =
     new AssetsClassLoader(parent, allAssets)
@@ -523,9 +524,9 @@ class Reloader(
 
               if (triggered || shouldReload || currentApplicationClassLoader.isEmpty) {
                 // Create a new classloader
-                val version = classLoaderVersion.incrementAndGet
-                val name    = "ReloadableClassLoader(v" + version + ")"
-                val urls    = Reloader.urls(classpath)
+                val version                = classLoaderVersion.incrementAndGet
+                val name                   = "ReloadableClassLoader(v" + version + ")"
+                val urls                   = Reloader.urls(classpath)
                 val loader: URLClassLoader = createClassLoader(name, urls, baseLoader)
                 currentApplicationClassLoader = Some(loader)
                 loader

--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -36,7 +36,7 @@ object Reloader {
 
   case class Source(file: File, original: Option[File])
 
-  type ClassLoaderCreator = (String, Array[URL], ClassLoader) => ClassLoader
+  type ClassLoaderCreator = (String, Array[URL], ClassLoader) => URLClassLoader
 
   val SystemProperty = "-D([^=]+)=(.*)".r
 
@@ -526,7 +526,7 @@ class Reloader(
                 val version = classLoaderVersion.incrementAndGet
                 val name    = "ReloadableClassLoader(v" + version + ")"
                 val urls    = Reloader.urls(classpath)
-                val loader  = createClassLoader(name, urls, baseLoader)
+                val loader: URLClassLoader = createClassLoader(name, urls, baseLoader)
                 currentApplicationClassLoader = Some(loader)
                 loader
               } else {

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -111,6 +111,8 @@ object PlaySettings extends PlaySettingsCompat {
     // filter out asset directories from the classpath (supports sbt-web 1.0 and 1.1)
     playReloaderClasspath ~= { _.filter(_.get(WebKeys.webModulesLib.key).isEmpty) },
     playCommonClassloader := PlayCommands.playCommonClassloaderTask.value,
+    playDependencyClassLoader := PlayRun.createURLClassLoader,
+    playReloaderClassLoader := PlayRun.createDelegatedResourcesClassLoader,
     playCompileEverything := getPlayCompileEverything(PlayCommands.playCompileEverythingTask.value),
     playReload := PlayCommands.playReloadTask.value,
     ivyLoggingLevel := UpdateLogging.DownloadOnly,

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -53,12 +53,14 @@ object PlayRun extends PlayRunCompat {
   val generatedSourceHandlers = SbtTwirl.defaultFormats.map { case (k, v) => ("scala." + k, twirlSourceHandler) }
 
   val playDefaultRunTask =
-    playRunTask(playRunHooks,
+    playRunTask(
+      playRunHooks,
       playDependencyClasspath,
       playDependencyClassLoader,
       playReloaderClasspath,
       playReloaderClassLoader,
-      playAssetsClassLoader)
+      playAssetsClassLoader
+    )
 
   /**
    * This method is public API, used by sbt-echo, which is used by Activator:


### PR DESCRIPTION
Fixes #8206

I'm keeping this DRAFT as we review it's completeness. The codebase has undergone a few changes since 927fb83d and I wouldn't be surprised if we need to chain the `Classloader`'s in a slightly different way to instrumentation properly working.

I'm targeting `2.8.x` with the aim to get this available on a PATCH release as soon as we can. I think it'd be great to backport to `2.7.x` too but I'm not adding the `needs-backport` label yet.