### PR TITLE
Removes reference to noop settings

### DIFF
--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -220,10 +220,6 @@ Therefore, this change should not affect you at all, since all browsers adhere t
 
 If you still want to send this exact header however, you can still do that by using the `withHeader(s)` methods from [`Scala's`](api/scala/play/api/mvc/Result.html#withHeaders\(headers:\(String,String\)*\):play.api.mvc.Result) or [`Java's`](api/java/play/mvc/Result.html#withHeader-java.lang.String-java.lang.String-) `Result` class.
 
-### sbt: The `playOmnidoc` key now defaults to `false`
-
-The Play's sbt plugin key `playOmnidoc`, which used to default to `true` (for non-snapshot version of Play) now defaults to `false` (and does so in sbt's `Global` scope).  The impact is that any Play app that previously enabled the `PlayDocsPlugin` won't get all the documentation they used when running the app and going to `http://localhost:9000/@documentation`.  You can reverse this change by setting `ThisBuild / playOmnidoc := true` in your sbt build.
-
 ## Dependency graph changes
 
 Until Play 2.7.0, [`"com.typesafe.play" %% "play-test"` artifact](https://mvnrepository.com/artifact/com.typesafe.play/play-test_2.13/2.7.3) was including both Akka HTTP and Netty server backends. This creates unstable behavior for your tests and, also, made them possibly use a different server than the production code, depending on how the classpath is sorted. In Play 2.8, `play-test` depends on `play-server` instead, and then the tests will use the same server provider that the application uses. If, for some reason, you need add a provider to our tests, you can do that by adding either Akka HTTP or Netty server dependencies as a `"test"` dependency. For example:


### PR DESCRIPTION
Refs #9902 

Targets `2.8.x` so it's removed from the published site asap.