### PR TITLE
[doc] Add info on redirects with session

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
@@ -26,7 +26,7 @@ The Play session is not intended to be used as a cache. If you need to cache som
 
 The default name for the cookie is `PLAY_SESSION`. This can be changed by configuring the key `play.http.session.cookieName` in application.conf.
 
-If the name of the cookie is changed, the earlier cookie can be discarded using the same methods mentioned in [[Setting and discarding cookies|JavaResults]].
+If the name of the cookie is changed, the earlier cookie can be discarded using the same methods mentioned in [[Setting and discarding cookies|JavaResponse]].
 
 Please see [[Configuring Session Cookies|SettingsSession]] for more information for how to configure the session cookie parameters in `application.conf`.
 
@@ -60,8 +60,8 @@ If you want to discard the whole session, there is special operation:
 
 The Flash scope works exactly like the Session, but with two differences:
 
-- data are kept for only one request
-- the Flash cookie is not signed, making it possible for the user to modify it.
+* data are kept for only one request
+* the Flash cookie is not signed, making it possible for the user to modify it.
 
 > **Important:** The flash scope should only be used to transport success/error messages on simple non-Ajax applications. As the data are just kept for the next request and because there are no guarantees to ensure the request order in a complex Web application, the Flash scope is subject to race conditions.
 

--- a/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
@@ -5,11 +5,28 @@
 
 If you have to keep data across multiple HTTP requests, you can save them in the Session or the Flash scope. Data stored in the Session are available during the whole user session, and data stored in the flash scope are only available to the next request.
 
-It’s important to understand that Session and Flash data are not stored in the server but are added to each subsequent HTTP Request, using Cookies. This means that the data size is very limited (up to 4 KB) and that you can only store string values.
+## Working with Cookies
 
-Cookies are signed with a secret key so the client can’t modify the cookie data (or it will be invalidated). The Play session is not intended to be used as a cache. If you need to cache some data related to a specific session, you can use the Play built-in cache mechanism and use the session to store a unique ID to associate the cached data with a specific user.
+It’s important to understand that Session and Flash data are not stored in the server but are added to each subsequent HTTP Request, using HTTP cookies.  
+
+Because Session and Flash are implemented using cookies, there are some important implications.
+
+* The data size is very limited (up to 4 KB).
+* You can only store string values, although you can serialize JSON to the cookie.
+* Information in a cookie is visible to the browser, and so can expose sensitive data.
+* Cookie information is immutable to the original request, and only available to subsequent requests.
+
+The last point can be a source of confusion.  When you modify the cookie, you are providing information to the response, and Play must parse it again to see the updated value.  If you would like to ensure the session information is current then you should always pair modification of a session with a Redirect.
+
+The session cookie is signed with a secret key so the client can’t modify the cookie data (or it will be invalidated).
+
+The Play session is not intended to be used as a cache. If you need to cache some data related to a specific session, you can use the Play built-in cache mechanism and use the session to store a unique ID to associate the cached data with a specific user.
 
 ## Session Configuration
+
+The default name for the cookie is `PLAY_SESSION`. This can be changed by configuring the key `play.http.session.cookieName` in application.conf.
+
+If the name of the cookie is changed, the earlier cookie can be discarded using the same methods mentioned in [[Setting and discarding cookies|JavaResults]].
 
 Please see [[Configuring Session Cookies|SettingsSession]] for more information for how to configure the session cookie parameters in `application.conf`.
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -49,7 +49,8 @@ public class JavaSessionFlash extends WithApplication {
                 new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                   // #store-session
                   public Result login(Http.Request request) {
-                    return ok("Welcome!").addingToSession(request, "connected", "user@gmail.com");
+                    return redirect("/home")
+                        .addingToSession(request, "connected", "user@gmail.com");
                   }
                   // #store-session
                 },
@@ -66,7 +67,7 @@ public class JavaSessionFlash extends WithApplication {
                 new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                   // #remove-from-session
                   public Result logout(Http.Request request) {
-                    return ok("Bye").removingFromSession(request, "connected");
+                    return redirect("/home").removingFromSession(request, "connected");
                   }
                   // #remove-from-session
                 },
@@ -83,7 +84,7 @@ public class JavaSessionFlash extends WithApplication {
                 new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                   // #discard-whole-session
                   public Result logout() {
-                    return ok("Bye").withNewSession();
+                    return redirect("/home").withNewSession();
                   }
                   // #discard-whole-session
                 },

--- a/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
@@ -60,8 +60,8 @@ There is special operation that discards the whole session:
 
 The Flash scope works exactly like the Session, but with two differences:
 
-- data are kept for only one request
-- the Flash cookie is not signed, making it possible for the user to modify it.
+* data are kept for only one request
+* the Flash cookie is not signed, making it possible for the user to modify it.
 
 > **Important:** The Flash scope should only be used to transport success/error messages on simple non-Ajax applications. As the data are just kept for the next request and because there are no guarantees to ensure the request order in a complex Web application, the Flash scope is subject to race conditions.
 

--- a/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
@@ -3,17 +3,26 @@
 
 ## How it is different in Play
 
-If you have to keep data across multiple HTTP requests, you can save them in the Session or Flash scopes. Data stored in the Session are available during the whole user Session, and data stored in the Flash scope are available to the next request **only**.
+If you have to keep data across multiple HTTP requests, you can save them in the Session or the Flash scope. Data stored in the Session are available during the whole user session, and data stored in the flash scope are only available to the next request.
 
-It’s important to understand that Session and Flash data are not stored by the server but are added to each subsequent HTTP request, using the cookie mechanism. This means that the data size is very limited (up to 4 KB) and that you can only store string values. The default name for the cookie is `PLAY_SESSION`. This can be changed by configuring the key `play.http.session.cookieName` in application.conf.
+## Working with Cookies
 
-> If the name of the cookie is changed, the earlier cookie can be discarded using the same methods mentioned in [[Setting and discarding cookies|ScalaResults]].
+It’s important to understand that Session and Flash data are not stored in the server but are added to each subsequent HTTP Request, using HTTP cookies.  
 
-Of course, cookie values are signed with a secret key so the client can’t modify the cookie data (or it will be invalidated).
+Because Session and Flash are implemented using cookies, there are some important implications.
 
-The Play Session is not intended to be used as a cache. If you need to cache some data related to a specific Session, you can use the Play built-in cache mechanism and store a unique ID in the user Session to keep them related to a specific user.
+* The data size is very limited (up to 4 KB).
+* You can only store string values, although you can serialize JSON to the cookie.
+* Information in a cookie is visible to the browser, and so can expose sensitive data.
+* Cookie information is immutable to the original request, and only available to subsequent requests.
+
+The last point can be a source of confusion.  When you modify the cookie, you are providing information to the response, and Play must parse it again to see the updated value.  If you would like to ensure the session information is current then you should always pair modification of a session with a Redirect.
 
 ## Session Configuration
+
+The default name for the cookie is `PLAY_SESSION`. This can be changed by configuring the key `play.http.session.cookieName` in application.conf.
+
+If the name of the cookie is changed, the earlier cookie can be discarded using the same methods mentioned in [[Setting and discarding cookies|ScalaResults]].
 
 Please see [[Configuring Session Cookies|SettingsSession]] for more information for how to configure the session cookie parameters in `application.conf`.
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -43,7 +43,7 @@ package scalaguide.http.scalasessionflash {
           //#store-session
         }
 
-        assertAction(storeSession, OK, FakeRequest())(res => testSession(res, "connected", Some("user@gmail.com")))
+        assertAction(storeSession, SEE_OTHER, FakeRequest())(res => testSession(res, "connected", Some("user@gmail.com")))
       }
 
       "add data in the Session" in {
@@ -53,7 +53,7 @@ package scalaguide.http.scalasessionflash {
           //#add-session
         }
 
-        assertAction(addSession, OK, FakeRequest())(res => testSession(res, "saidHello", Some("yes")))
+        assertAction(addSession, SEE_OTHER, FakeRequest())(res => testSession(res, "saidHello", Some("yes")))
       }
 
       "remove data in the Session" in {
@@ -63,7 +63,7 @@ package scalaguide.http.scalasessionflash {
           //#remove-session
         }
 
-        assertAction(removeSession, OK, FakeRequest().withSession("theme" -> "blue"))(res =>
+        assertAction(removeSession, SEE_OTHER, FakeRequest().withSession("theme" -> "blue"))(res =>
           testSession(res, "theme", None)
         )
       }
@@ -74,7 +74,7 @@ package scalaguide.http.scalasessionflash {
           Redirect("/home").withNewSession
           //#discarding-session
         }
-        assertAction(discardingSession, OK, FakeRequest().withSession("theme" -> "blue"))(res =>
+        assertAction(discardingSession, SEE_OTHER, FakeRequest().withSession("theme" -> "blue"))(res =>
           testSession(res, "theme", None)
         )
       }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -39,7 +39,7 @@ package scalaguide.http.scalasessionflash {
       "Storing data in the Session" in {
         def storeSession = Action { implicit request =>
           //#store-session
-          Ok("Welcome!").withSession("connected" -> "user@gmail.com")
+          Redirect("/home").withSession("connected" -> "user@gmail.com")
           //#store-session
         }
 
@@ -49,7 +49,7 @@ package scalaguide.http.scalasessionflash {
       "add data in the Session" in {
         def addSession = Action { implicit request =>
           //#add-session
-          Ok("Hello World!").withSession(request.session + ("saidHello" -> "yes"))
+          Redirect("/home").withSession(request.session + ("saidHello" -> "yes"))
           //#add-session
         }
 
@@ -59,7 +59,7 @@ package scalaguide.http.scalasessionflash {
       "remove data in the Session" in {
         def removeSession = Action { implicit request =>
           //#remove-session
-          Ok("Theme reset!").withSession(request.session - "theme")
+          Redirect("/home").withSession(request.session - "theme")
           //#remove-session
         }
 
@@ -71,7 +71,7 @@ package scalaguide.http.scalasessionflash {
       "Discarding the whole session" in {
         def discardingSession = Action { implicit request =>
           //#discarding-session
-          Ok("Bye").withNewSession
+          Redirect("/home").withNewSession
           //#discarding-session
         }
         assertAction(discardingSession, OK, FakeRequest().withSession("theme" -> "blue"))(res =>

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -43,7 +43,9 @@ package scalaguide.http.scalasessionflash {
           //#store-session
         }
 
-        assertAction(storeSession, SEE_OTHER, FakeRequest())(res => testSession(res, "connected", Some("user@gmail.com")))
+        assertAction(storeSession, SEE_OTHER, FakeRequest())(res =>
+          testSession(res, "connected", Some("user@gmail.com"))
+        )
       }
 
       "add data in the Session" in {


### PR DESCRIPTION
## Purpose

This is a documentation change to make the behavior of session/flash clearer and recommend use of redirects to see the updated states.

## Background Context

This is a common problem, and the documentation makes this more confusing by using Ok() and not being explicit about what happens when you modify session data.

## References

* https://discuss.lightbend.com/t/session-issue-on-withsession-method/4596/5