### PR TITLE
Switch publishLocal to use Travis CI workspaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx
 stages:
   - validations
   - test
-  - publish-local
   - test-sbt
   - java11
 
@@ -35,6 +34,20 @@ jobs:
       name: "Validate docs (links, sample code, etc.)"
     - script: scripts/validate-microbenchmarks
       name: "Validate that microbenchmarks are runnable"
+    - name: "Run publishLocal"
+      script: scripts/publish-local
+      workspaces:
+        create:
+          name: published-local
+          paths: "$HOME/.ivy2/local/com.typesafe.play"
+    - name: "Run publishLocal on Java 11"
+      script: scripts/publish-local
+      env: TRAVIS_JDK=11
+      workspaces:
+        create:
+          name: published-local-jdk11
+          paths: "$HOME/.ivy2/local/com.typesafe.play"
+
 
     - stage: test
       script: scripts/test-scala-212
@@ -50,26 +63,31 @@ jobs:
     - script: scripts/it-test-scala-213
       name: "Run it tests for Scala 2.13"
 
-    - stage: publish-local
-      name: "Clean ~/.ivy2/local and cross-run publishLocal"
-      script: scripts/clean-and-cross-publish-local
-    - name: "Clean ~/.ivy2/local and cross-run publishLocal on Java 11"
-      script: scripts/clean-and-cross-publish-local
-      env: TRAVIS_JDK=11
-
     - stage: test-sbt
       name: "Run scripted tests (a) for sbt 0.13.x"
       script: scripts/test-scripted 0.13.x 'play-sbt-plugin/*1of3'
+      workspaces:
+        use: published-local
     - name: "Run scripted tests (b) for sbt 0.13.x"
       script: scripts/test-scripted 0.13.x 'play-sbt-plugin/*2of3'
+      workspaces:
+        use: published-local
     - name: "Run scripted tests (c) for sbt 0.13.x"
       script: scripts/test-scripted 0.13.x 'play-sbt-plugin/*3of3'
+      workspaces:
+        use: published-local
     - name: "Run scripted tests (a) for sbt 1.x"
       script: scripts/test-scripted 1.x 'play-sbt-plugin/*1of3'
+      workspaces:
+        use: published-local
     - name: "Run scripted tests (b) for sbt 1.x"
       script: scripts/test-scripted 1.x 'play-sbt-plugin/*2of3'
+      workspaces:
+        use: published-local
     - name: "Run scripted tests (c) for sbt 1.x"
       script: scripts/test-scripted 1.x 'play-sbt-plugin/*3of3'
+      workspaces:
+        use: published-local
 
     # Test against Java 11, but only for Scala 2.12
     - stage: java11
@@ -85,28 +103,39 @@ jobs:
     - name: "Run scripted tests (a) for sbt 1.x and Java 11"
       script: scripts/test-scripted 1.x 'play-sbt-plugin/*1of3'
       env: TRAVIS_JDK=11
+      workspaces:
+        use: published-local-jdk11
     - name: "Run scripted tests (b) for sbt 1.x and Java 11"
       script: scripts/test-scripted 1.x 'play-sbt-plugin/*2of3'
       env: TRAVIS_JDK=11
+      workspaces:
+        use: published-local-jdk11
     - name: "Run scripted tests (c) for sbt 1.x and Java 11"
       script: scripts/test-scripted 1.x 'play-sbt-plugin/*3of3'
       env: TRAVIS_JDK=11
-    
+      workspaces:
+        use: published-local-jdk11
+
     # Test against sbt 1.3.x, but only for cron builds
     - stage: sbt-1.3.x
       name: "Run tests for sbt 1.3.x"
       script: scripts/test-scripted-13x
       if: type = cron
+      workspaces:
+        use: published-local
 
 cache:
   directories:
     - "$HOME/.coursier/cache"
     - "$HOME/.ivy2/cache"
-    - "$HOME/.ivy2/local"
     - "$HOME/.jabba/jdk"
     - "$HOME/.sbt"
 
-before_cache: find $HOME/.sbt -name "*.lock" -delete
+before_cache:
+  - rm -rf $HOME/.ivy2/cache/com.typesafe.play/*
+  - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.play/*
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt  -name "*.lock"               -delete
 
 notifications:
   email:

--- a/scripts/publish-local
+++ b/scripts/publish-local
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
+# shellcheck source=scripts/scriptLib
+. "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
+
+cd "$BASEDIR"
+
+start clean "CLEANING IVY LOCAL REPO"
+rm -rf $HOME/.ivy2/local
+end clean "CLEANED IVY LOCAL REPO"
+
+start publish-local "CROSS-PUBLISHING PLAY LOCALLY FOR SBT SCRIPTED TESTS"
+runSbt +publishLocal
+end publish-local "CROSS-PUBLISHED PLAY LOCALLY FOR SBT SCRIPTED TESTS"


### PR DESCRIPTION
https://docs.travis-ci.com/user/using-workspaces/

Caches are meant to be a optimisation only, while workspaces are
intended for sharing files within a build.

The motivation for this change is to address the cache poisoning that
was occuring with cron builds publishing a SNAPSHOT version of Play
while depending on an Akka snapshot version, which was failing the
scripted stage of PR validation because they didn't use Akka's snapshot
resolver.