### PR TITLE
Fix slf4j/logback issue in EvolutionsReaderSpec

### DIFF
--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -520,7 +520,7 @@ class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends R
   def loadResource(db: String, revision: Int): Option[InputStream] = {
     @tailrec def findPaddedRevisionResource(paddedRevision: String, uri: Option[URI]): Option[InputStream] = {
       if (paddedRevision.length > 15) {
-        uri.map(u => u.toURL().openStream()) // Revision string has reached max padding
+        uri.map(u => u.toURL.openStream()) // Revision string has reached max padding
       } else {
         val evolution = {
           // First try a file on the filesystem
@@ -535,11 +535,13 @@ class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends R
         for {
           u <- uri
           e <- evolution
-        } yield logger.warn(
-          s"Ignoring evolution script ${e.toString.substring(e.toString.lastIndexOf('/') + 1)}, using ${u.toString
-            .substring(u.toString.lastIndexOf('/') + 1)} instead already"
-        )
-        findPaddedRevisionResource("0" + paddedRevision, uri.orElse(evolution))
+        } {
+          val original   = e.toString.substring(e.toString.lastIndexOf('/') + 1)
+          val substitute = u.toString.substring(u.toString.lastIndexOf('/') + 1)
+          logger.warn(s"Ignoring evolution script $original, using $substitute instead already")
+        }
+
+        findPaddedRevisionResource(s"0$paddedRevision", uri.orElse(evolution))
       }
     }
     findPaddedRevisionResource(revision.toString, None)

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
@@ -12,7 +12,22 @@ import play.api.Logger
 import play.api.Mode
 
 object EvolutionsReaderSpec {
+  initLogback()
   val defaultEvolutionsApiLogger = Logger(classOf[DefaultEvolutionsApi])
+
+  @scala.annotation.tailrec
+  private def initLogback(attempts: Int = 0): Unit = {
+    val factory = org.slf4j.LoggerFactory.getILoggerFactory
+    if (factory.isInstanceOf[org.slf4j.helpers.SubstituteLoggerFactory]) {
+      if (attempts < 30) {
+        java.util.concurrent.TimeUnit.MILLISECONDS.sleep(100L)
+        initLogback(attempts + 1)
+      } else {
+        val msg = s"Failed to initialise Logback after $attempts attempts"
+        throw new ExceptionInInitializerError(msg)
+      }
+    }
+  }
 }
 
 class EvolutionsReaderSpec extends Specification {


### PR DESCRIPTION
Avoids:

    [error]    java.lang.ClassCastException: class org.slf4j.helpers.SubstituteLogger cannot be cast to class ch.qos.logback.classic.Logger (org.slf4j.helpers.SubstituteLogger and ch.qos.logback.classic.Logger are in unnamed module of loader 'app') (LogbackCapturingAppender.scala:19)
    [error] play.api.db.evolutions.LogbackCapturingAppender.<init>(LogbackCapturingAppender.scala:19)
    [error] play.api.db.evolutions.LogbackCapturingAppender$.attachForLogger(LogbackCapturingAppender.scala:62)
    [error] play.api.db.evolutions.LogbackCapturingAppender$.apply(LogbackCapturingAppender.scala:51)
    [error] play.api.db.evolutions.EvolutionsReaderSpec.$anonfun$new$3(EvolutionsReaderSpec.scala:16)
    [error] play.api.db.evolutions.EvolutionsReaderSpec.withLogbackCapturingAppender(EvolutionsReaderSpec.scala:64)
    [error] play.api.db.evolutions.EvolutionsReaderSpec.$anonfun$new$2(EvolutionsReaderSpec.scala:15)