### PR TITLE
Add application/wasm mime type to reference.conf

### DIFF
--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -691,6 +691,7 @@ play {
         w60=application/wordperfect60
         w61=application/wordperfect61
         w6w=application/msword
+        wasm=application/wasm
         wav=audio/wav
         wb1=application/x-qpro
         wbmp=image/vnd.wap.wbmp


### PR DESCRIPTION
## Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] ~Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?~
* [x] ~Have you added copyright headers to new files?~
* [x] ~Have you checked that both Scala and Java APIs are updated?~
* [x] ~Have you updated the documentation for both Scala and Java sections?~
* [x] ~Have you added tests for any changed functionality?~

## Purpose

The mime type `application/wasm` is required by [`WebAssembly.instantiateStreaming`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming).

## Background Context

* [Browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming#Browser_compatibility): Stable versions of Chrome, Firefox and Edge
* Specification: https://github.com/WebAssembly/design/blob/master/Web.md#webassemblyinstantiatestreaming
* Intent to register: https://github.com/WebAssembly/spec/issues/573