### PR TITLE
suport return * when no credentials config

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -140,7 +140,7 @@ object CORSConfig {
   private[cors] def fromUnprefixedConfiguration(config: Configuration): CORSConfig = {
     CORSConfig(
       allowedOrigins = config.get[Option[Seq[String]]]("allowedOrigins") match {
-        case Some(allowed) => Origins.Matching(allowed.toSet)
+        case Some(allowed) => if (allowed.contains("*")) Origins.All else Origins.Matching(allowed.toSet)
         case None          => Origins.All
       },
       isHttpMethodAllowed = config

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
@@ -402,5 +402,40 @@ trait CORSCommonSpec extends PlaySpecification {
       header(ACCESS_CONTROL_MAX_AGE, result) must beNone
       header(VARY, result) must beSome(ORIGIN)
     }
+
+    val allowAllOrigins = Map("play.filters.cors.allowedOrigins" -> Seq("*", "http://example.org"))
+
+    "allow a cors request with any origin" in withApplication(allowAllOrigins) { app =>
+      val result = route(app, fakeRequest().withHeaders(ORIGIN -> "http://localhost:9000")).get
+
+      status(result) must_== OK
+      header(ACCESS_CONTROL_ALLOW_CREDENTIALS, result) must beSome("true")
+      header(ACCESS_CONTROL_ALLOW_HEADERS, result) must beNone
+      header(ACCESS_CONTROL_ALLOW_METHODS, result) must beNone
+      header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("http://localhost:9000")
+      header(ACCESS_CONTROL_EXPOSE_HEADERS, result) must beNone
+      header(ACCESS_CONTROL_MAX_AGE, result) must beNone
+      header(VARY, result) must beSome(ORIGIN)
+    }
+
+    val allowAllOriginsNoCredentialsConf = Map(
+      "play.filters.cors.allowedOrigins"      -> Seq("*"),
+      "play.filters.cors.supportsCredentials" -> "false"
+    )
+
+    "allow a cors request with any origin and no credentials" in withApplication(conf = allowAllOriginsNoCredentialsConf
+    ) { app =>
+      val result = route(app, fakeRequest().withHeaders(ORIGIN -> "http://example.org")).get
+
+      status(result) must_== OK
+      header(ACCESS_CONTROL_ALLOW_CREDENTIALS, result) must beNone
+      header(ACCESS_CONTROL_ALLOW_HEADERS, result) must beNone
+      header(ACCESS_CONTROL_ALLOW_METHODS, result) must beNone
+      header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("*")
+      header(ACCESS_CONTROL_EXPOSE_HEADERS, result) must beNone
+      header(ACCESS_CONTROL_MAX_AGE, result) must beNone
+      header(VARY, result) must beSome(ORIGIN)
+    }
+
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #9880

## Purpose

What does this PR do?
To support both `null` and `*` in `play.filters.cors.allowedOrigins` to allow any origin to access the resource.
```
play.filters.cors.allowedOrigins = null
OR
play.filters.cors.allowedOrigins = ["*"]
```

## Background Context

This is my first commit to Play, be happy to hear your advices.

## References

NO
