### PR TITLE
Avoid -Dconfig.resource from killing dev-mode.

### DIFF
--- a/core/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -357,7 +357,7 @@ class ConfigurationSpec extends Specification {
 
       val direct = Map(
         "config.resource" -> "application.from-direct.res.conf",
-        "config.resource" -> "application.from-direct.file.conf",
+        "config.file"     -> "application.from-direct.file.conf",
       )
 
       val cl = new InMemoryResourceClassLoader(


### PR DESCRIPTION
See the in-line comments for details.

This re-introduces some logic that had been removed in
1b69712bb4df23f7dd6b194e06dbc3c96c2617ed.

Fixes #9972.