### PR TITLE
Update ScalaAkka.md to add missing word

### DIFF
--- a/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
@@ -66,7 +66,7 @@ The above is good for injecting root actors, but many of the actors you create w
 
 In order to assist in dependency injecting child actors, Play utilises Guice's [AssistedInject](https://github.com/google/guice/wiki/AssistedInject) support.
 
-Let's say you have the following actor, which depends configuration to be injected, plus a key:
+Let's say you have the following actor, which depends on configuration to be injected, plus a key:
 
 @[injectedchild](code/ScalaAkka.scala)
 


### PR DESCRIPTION
This PR updates ScalaAkka.md

I believe the word `on` is missing from the following sentence

> Let's say you have the following actor, which depends **on** configuration to be injected, plus a key:

## Fixes
Documentation. Adds a missing word to ScalaAkka.md 

## Purpose

Fix a sentence with a missing word.

## Background Context

N/A

## References

N/A
