### PR TITLE
sbt-plugin: Try to fix ~run when using sbt 1.3+

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
@@ -129,7 +129,7 @@ object PlayConsoleInteractionMode extends PlayInteractionMode {
  * variable.
  */
 object StaticPlayNonBlockingInteractionMode extends PlayNonBlockingInteractionMode {
-  private var current: Option[Closeable] = None
+  private[sbt] var current: Option[Closeable] = None
 
   /**
    * Start the server, if not already started

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -98,7 +98,11 @@ object PlaySettings extends PlaySettingsCompat {
     PlayInternalKeys.playStop := {
       playInteractionMode.value match {
         case x: PlayNonBlockingInteractionMode => x.stop()
-        case _                                 => sys.error("Play interaction mode must be non blocking to stop it")
+        case _                                 =>
+          if (StaticPlayNonBlockingInteractionMode.current.isDefined)
+            StaticPlayNonBlockingInteractionMode.stop()
+          else
+            sys.error("Play interaction mode must be non blocking to stop it")
       }
     },
     shellPrompt := PlayCommands.playPrompt,


### PR DESCRIPTION
Requires allowing playStop to run, despite playInteractionMode.

This still needs finessing, but after hours and hundreds of lines of
code, this is the closest I got to solving this.  It's almost there, but
I think there are still easy failure modes that need addressing.