### PR TITLE
Use execute instead of executeQuery to lock evolutions

### DIFF
--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -268,7 +268,7 @@ private object ApplicationEvolutions {
       case _               => lockPlayEvolutionsLockSqls
     }
     try {
-      for (script <- lockScripts) s.executeQuery(applySchema(script, dbConfig.schema))
+      for (script <- lockScripts) s.execute(applySchema(script, dbConfig.schema))
     } catch {
       case e: SQLException =>
         if (attempts == 0) throw e


### PR DESCRIPTION
Fixes #9839

In MySQL/MariaDB the statement `set innodb_lock_wait_timeout = 1` is used, which obviously is not a (select) query and therefore causes an exception. Using just `query` is safe here because we don't care about what gets returned by the used method.