### PR TITLE
Add missing _root_ to controllers.AssetsComponents

### DIFF
--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -115,7 +115,7 @@ package routers {
   class MyComponents(context: Context)
       extends BuiltInComponentsFromContext(context)
       with HttpFiltersComponents
-      with controllers.AssetsComponents {
+      with _root_.controllers.AssetsComponents {
     lazy val barRoutes             = new bar.Routes(httpErrorHandler)
     lazy val applicationController = new controllers.Application(controllerComponents)
 


### PR DESCRIPTION
This fixes the [documentation](https://www.playframework.com/documentation/2.8.x/ScalaCompileTimeDependencyInjection#Providing-a-router) (see: 'To use this router in an actual application') to reflect the working code found in the compile time di [sample project](https://github.com/playframework/play-samples/blob/2.8.x/play-scala-compile-di-example/app/MyApplicationLoader.scala).

Without `_root_` in the documentation the following error occurs:

> type AssetsComponents is not a member of package play.api.controllers

`_root_.controllers.AssetsComponents` is the correct import path.


# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?