### PR TITLE
Make sure browser reloads after evolution autoApply in DEV

### DIFF
--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -528,6 +528,7 @@ class EvolutionsWebCommands @Inject() (
             checkedAlready = true
             if (autoApplyCount > 0) {
               buildLink.forceReload()
+              return Some(play.api.mvc.Results.Redirect(request.uri))
             }
           }
         }


### PR DESCRIPTION
`autoApply` in DEV mode actually works. However another browser refresh is needed so a new request is send to the app to trigger application reload (to re-initialze components that rely on the database and/or evolutions to be run).