### PR TITLE
Don't substitute string "${schema}" in evolution files

### DIFF
--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -218,7 +218,7 @@ class DatabaseEvolutions(database: Database, schema: String = "") {
         script.statements.foreach { statement =>
           logger.debug(s"Execute: $statement")
           val start = System.currentTimeMillis()
-          execute(statement)
+          execute(statement, false)
           logger.debug(s"Finished in ${System.currentTimeMillis() - start}ms")
         }
         logAfter(script)
@@ -340,10 +340,10 @@ class DatabaseEvolutions(database: Database, schema: String = "") {
     }
   }
 
-  private def execute(sql: String)(implicit c: Connection): Boolean = {
+  private def execute(sql: String, replaceSchema: Boolean = true)(implicit c: Connection): Boolean = {
     val s = c.createStatement
     try {
-      s.execute(applySchema(sql))
+      s.execute(if (replaceSchema) applySchema(sql) else sql)
     } finally {
       s.close()
     }


### PR DESCRIPTION
While looking at the evolutions source I found a potential problem: Since #5485 it is possible to configure the db schema in which the generated evolution and lock tables will be saved to via the `play.evolutions.schema` config. As you can see in #5485 this was done by introducing the placeholder `${schema}` for those table's ddl scripts. However the implementation was dirty, because `${schema}` also gets replaced in the user defined sql scripts (1.sql, 2.sql,...) Neither was it the intention of that pull request, nor is that string substition documented. Therefore I fixed that now.

BTW: I will introduce a real string substition mechanism for evolutions files soon, because I needed this already for a client project and it would make evolutions more useful IMHO.