### PR TITLE
Finally deprecate .ajax() of js reverse router

### DIFF
--- a/core/play/src/main/java/play/routing/JavaScriptReverseRouter.java
+++ b/core/play/src/main/java/play/routing/JavaScriptReverseRouter.java
@@ -15,12 +15,27 @@ public class JavaScriptReverseRouter {
    * Generates a JavaScript reverse router.
    *
    * @param name the router's name
+   * @param host the host to use for the reverse route
+   * @param routes the reverse routes for this router
+   * @return the router
+   */
+  public static JavaScript create(String name, String host, JavaScriptReverseRoute... routes) {
+    return play.api.routing.JavaScriptReverseRouter.apply(name, host, Scala.varargs(routes));
+  }
+
+  /**
+   * Generates a JavaScript reverse router.
+   *
+   * @param name the router's name
    * @param ajaxMethod which asynchronous call method the user's browser will use (e.g.
    *     "jQuery.ajax")
    * @param host the host to use for the reverse route
    * @param routes the reverse routes for this router
    * @return the router
+   * @deprecated Deprecated as of 2.9.0 Use {@link #create(String, String,
+   *     JavaScriptReverseRoute...)} instead.
    */
+  @Deprecated
   public static JavaScript create(
       String name, String ajaxMethod, String host, JavaScriptReverseRoute... routes) {
     return play.api.routing.JavaScriptReverseRouter.apply(

--- a/core/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
+++ b/core/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
@@ -35,12 +35,23 @@ object JavaScriptReverseRouter {
    * @param routes the routes to include in this JavaScript router
    * @return the JavaScript code
    */
+  def apply(name: String /* TODO: add = "Router" when the deprecated apply methods are removed */ )(
+      routes: JavaScriptReverseRoute*
+  )(implicit request: RequestHeader): JavaScript = {
+    apply(name, None, request.host, routes: _*)
+  }
+
+  def apply(name: String, host: String, routes: JavaScriptReverseRoute*): JavaScript =
+    apply(name, None, host, routes: _*)
+
+  @deprecated("Use method without ajaxMethod param instead.", "2.9.0")
   def apply(name: String = "Router", ajaxMethod: Option[String] = Some("jQuery.ajax"))(
       routes: JavaScriptReverseRoute*
   )(implicit request: RequestHeader): JavaScript = {
     apply(name, ajaxMethod, request.host, routes*)
   }
 
+  @deprecated("Use method without ajaxMethod param instead.", "2.9.0")
   def apply(name: String, ajaxMethod: Option[String], host: String, routes: JavaScriptReverseRoute*): JavaScript =
     JavaScript {
       import play.twirl.api.utils.StringEscapeUtils.{ escapeEcmaScript => esc }

--- a/core/play/src/main/scala/views/helper/javascriptRouter.scala.html
+++ b/core/play/src/main/scala/views/helper/javascriptRouter.scala.html
@@ -23,5 +23,5 @@
  *@
 @(name:String = "Router")(routes: play.api.routing.JavaScriptReverseRoute*)(implicit request: play.api.mvc.RequestHeader)
 @script(Symbol("type") -> "text/javascript") {
-    @Html(play.api.routing.JavaScriptReverseRouter(name)(routes: _*).body.replace("/", "\\/"))
+    @Html(play.api.routing.JavaScriptReverseRouter(name, Some("jQuery.ajax"))(routes: _*).body.replace("/", "\\/"))
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/utils/JavaScriptRouterGenerator.scala
@@ -17,7 +17,6 @@ object JavaScriptRouterGenerator {
     val jsFile = play.api.routing
       .JavaScriptReverseRouter(
         "jsRoutes",
-        None,
         host,
         Application.index,
         Application.post,

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -17,7 +17,6 @@ object JavaScriptRouterGenerator {
     val jsFile = play.api.routing
       .JavaScriptReverseRouter(
         "jsRoutes",
-        None,
         host,
         Assets.versioned,
         Application.index,

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/utils/JavaScriptRouterGenerator.scala
@@ -17,7 +17,6 @@ object JavaScriptRouterGenerator {
     val jsFile = play.api.routing
       .JavaScriptReverseRouter(
         "jsRoutes",
-        None,
         host,
         Application.index,
         Application.post,

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -15,7 +15,6 @@ object JavaScriptRouterGenerator {
     val jsFile = play.api.routing
       .JavaScriptReverseRouter(
         "jsRoutes",
-        None,
         "localhost",
         Assets.versioned,
         Application.index,

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -120,6 +120,21 @@ Following classes have been renamed:
 | `HttpExecutionContext` | `ClassLoaderExecutionContext` |
 | `HttpExecution`        | `ClassLoaderExecution`        |
 
+### Deprecated the Javascript route's `ajax()` method
+
+The `ajax()` method is not documented anymore since Play 2.2 already. Since that, warnings for its removal where displayed in the according docs for the [Scala API](https://www.playframework.com/documentation/2.8.x/ScalaJavascriptRouting#jQuery-ajax-method-support) and the [Java API](https://www.playframework.com/documentation/2.8.x/JavaJavascriptRouter#jQuery-ajax-method-support).
+The next Play version will eventually remove this method, therefore if you still use it you should finally migrate. Using jQuery as an example:
+
+```javascript
+jsRoutes.controllers.Users.list().ajax({success: /* ... */, error: /* ... */})
+```
+
+would become
+
+```javascript
+$.ajax(jsRoutes.controllers.Users.list()).done( /* */ ).fail( /* */ )
+```
+
 ### Deprecated APIs were removed
 
 Many APIs that were deprecated in earlier versions were removed in Play 2.9. If you are still using them we recommend migrating to the new APIs before upgrading to Play 2.9. Check the Javadocs and Scaladocs for migration notes. See also the [[migration guide for Play 2.8|Migration28]] for more information.

--- a/documentation/manual/working/javaGuide/advanced/routing/JavaJavascriptRouter.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/JavaJavascriptRouter.md
@@ -64,13 +64,3 @@ ws.onmessage = function(msg) {
         /*...*/
 };
 ```
-
-## jQuery ajax method support
-
-> **Note:** Built-in support for jQuery's ajax function will be removed in a future release. This section on the built-in support is provided for reference purposes only. Please do not use the router's ajax function in new code and consider upgrading existing code as soon as possible. The previous section on using the router documents how jQuery should be used.
-
-If jQuery isn't your thing, or if you'd like to decorate the jQuery ajax method in some way, you can provide a function to the router to use to perform ajax queries. This function must accept the object that is passed to the ``ajax`` router method, and should expect the router to have set the ``type`` and ``url`` properties on it to the appropriate method and url for the router request.
-
-To define this function, in your action pass the ``ajaxMethod`` method parameter, eg:
-
-@[javascript-router-resource-custom-method](code/javaguide/binder/controllers/Application.java)

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/controllers/Application.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/controllers/Application.java
@@ -18,7 +18,6 @@ public class Application extends Controller {
   public Result javascriptRoutes(Http.Request request) {
     return ok(JavaScriptReverseRouter.create(
             "jsRoutes",
-            "jQuery.ajax",
             request.host(),
             routes.javascript.Users.list(),
             routes.javascript.Users.get()))
@@ -26,18 +25,4 @@ public class Application extends Controller {
   }
 
   // #javascript-router-resource
-
-  public Result javascriptRoutes2(Http.Request request) {
-    return ok(
-        // #javascript-router-resource-custom-method
-        JavaScriptReverseRouter.create(
-            "jsRoutes",
-            "myAjaxMethod",
-            request.host(),
-            routes.javascript.Users.list(),
-            routes.javascript.Users.get())
-        // #javascript-router-resource-custom-method
-        )
-        .as(Http.MimeTypes.JAVASCRIPT);
-  }
 }

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaJavascriptRouting.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaJavascriptRouting.md
@@ -64,13 +64,3 @@ ws.onmessage = function(msg) {
         /*...*/
 };
 ```
-
-## jQuery ajax method support
-
-> **Note:** Built-in support for jQuery's ajax function will be removed in a future release. This section on the built-in support is provided for reference purposes only. Please do not use the router's ajax function in new code and consider upgrading existing code as soon as possible. The previous section on using the router documents how jQuery should be used.
-
-If jQuery isn't your thing, or if you'd like to decorate the jQuery ajax method in some way, you can provide a function to the router to use to perform ajax queries. This function must accept the object that is passed to the ``ajax`` router method, and should expect the router to have set the ``type`` and ``url`` properties on it to the appropriate method and url for the router request.
-
-To define this function, in your action pass the ``ajaxMethod`` method parameter, eg:
-
-@[javascript-router-resource-custom-method](code/scalaguide/binder/controllers/Users.scala)

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/Users.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/Users.scala
@@ -22,17 +22,6 @@ class Application @Inject() (components: ControllerComponents) extends AbstractC
     ).as(MimeTypes.JAVASCRIPT)
   }
   // #javascript-router-resource
-
-  def javascriptRoutes2: Action[AnyContent] = Action { implicit request =>
-    Ok(
-      // #javascript-router-resource-custom-method
-      JavaScriptReverseRouter("jsRoutes", Some("myAjaxFunction"))(
-        routes.javascript.Users.list,
-        routes.javascript.Users.get
-      )
-      // #javascript-router-resource-custom-method
-    ).as(MimeTypes.JAVASCRIPT)
-  }
 }
 
 class Users @Inject() (components: ControllerComponents) extends AbstractController(components) {


### PR DESCRIPTION
All information can be found here: https://github.com/playframework/playframework/pull/9313#issuecomment-577875946

IMHO we could just remove the `ajax()` method straight away, however let's mention it in the migration notes once more so people become aware of its removal.