### PR TITLE
Remove autoApply handling from EvolutionsWebCommands (DEV mode)

### DIFF
--- a/core/play/src/main/java/play/BuiltInComponentsFromContext.java
+++ b/core/play/src/main/java/play/BuiltInComponentsFromContext.java
@@ -215,7 +215,7 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
     return new JavaCompatibleHttpRequestHandler(
             webCommands(),
             new OptionalDevContext(OptionConverters.toScala(devContext())),
-            router().asScala(),
+            () -> router().asScala(),
             scalaErrorHandler,
             httpConfiguration(),
             filters.asScala(),

--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -307,7 +307,14 @@ trait BuiltInComponents extends I18nComponents with AkkaComponents with AkkaType
   def httpFilters: Seq[EssentialFilter]
 
   lazy val httpRequestHandler: HttpRequestHandler =
-    new DefaultHttpRequestHandler(webCommands, devContext, router, httpErrorHandler, httpConfiguration, httpFilters)
+    new DefaultHttpRequestHandler(
+      webCommands,
+      devContext,
+      () => router,
+      httpErrorHandler,
+      httpConfiguration,
+      httpFilters
+    )
 
   lazy val application: Application = new DefaultApplication(
     environment,

--- a/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -5,6 +5,7 @@
 package play.api.http
 
 import javax.inject.Inject
+import javax.inject.Provider
 
 import play.api.ApplicationLoader.DevContext
 import play.api.http.Status._
@@ -99,7 +100,7 @@ object NotImplementedHttpRequestHandler extends HttpRequestHandler {
 class DefaultHttpRequestHandler(
     webCommands: WebCommands,
     optDevContext: Option[DevContext],
-    router: Router,
+    router: Provider[Router],
     errorHandler: HttpErrorHandler,
     configuration: HttpConfiguration,
     filters: Seq[EssentialFilter]
@@ -108,12 +109,36 @@ class DefaultHttpRequestHandler(
   def this(
       webCommands: WebCommands,
       optDevContext: OptionalDevContext,
-      router: Router,
+      router: Provider[Router],
       errorHandler: HttpErrorHandler,
       configuration: HttpConfiguration,
       filters: HttpFilters
   ) = {
     this(webCommands, optDevContext.devContext, router, errorHandler, configuration, filters.filters)
+  }
+
+  @deprecated("Use the main DefaultHttpRequestHandler constructor", "2.9.0")
+  def this(
+      webCommands: WebCommands,
+      optDevContext: Option[DevContext],
+      router: Router,
+      errorHandler: HttpErrorHandler,
+      configuration: HttpConfiguration,
+      filters: Seq[EssentialFilter]
+  ) = {
+    this(webCommands, optDevContext, () => router, errorHandler, configuration, filters)
+  }
+
+  @deprecated("Use the main DefaultHttpRequestHandler constructor", "2.9.0")
+  def this(
+      webCommands: WebCommands,
+      optDevContext: OptionalDevContext,
+      router: Router,
+      errorHandler: HttpErrorHandler,
+      configuration: HttpConfiguration,
+      filters: HttpFilters
+  ) = {
+    this(webCommands, optDevContext.devContext, () => router, errorHandler, configuration, filters.filters)
   }
 
   private val context = configuration.context.stripSuffix("/")
@@ -235,7 +260,7 @@ class DefaultHttpRequestHandler(
    * @return A handler to handle the request, if one can be found
    */
   def routeRequest(request: RequestHeader): Option[Handler] = {
-    router.handlerFor(request)
+    router.get().handlerFor(request)
   }
 }
 
@@ -252,7 +277,7 @@ class DefaultHttpRequestHandler(
 class JavaCompatibleHttpRequestHandler(
     webCommands: WebCommands,
     optDevContext: Option[DevContext],
-    router: Router,
+    router: Provider[Router],
     errorHandler: HttpErrorHandler,
     configuration: HttpConfiguration,
     filters: Seq[EssentialFilter],
@@ -262,13 +287,47 @@ class JavaCompatibleHttpRequestHandler(
   def this(
       webCommands: WebCommands,
       optDevContext: OptionalDevContext,
-      router: Router,
+      router: Provider[Router],
       errorHandler: HttpErrorHandler,
       configuration: HttpConfiguration,
       filters: HttpFilters,
       handlerComponents: JavaHandlerComponents
   ) = {
     this(webCommands, optDevContext.devContext, router, errorHandler, configuration, filters.filters, handlerComponents)
+  }
+
+  @deprecated("Use the main JavaCompatibleHttpRequestHandler constructor", "2.9.0")
+  def this(
+      webCommands: WebCommands,
+      optDevContext: Option[DevContext],
+      router: Router,
+      errorHandler: HttpErrorHandler,
+      configuration: HttpConfiguration,
+      filters: Seq[EssentialFilter],
+      handlerComponents: JavaHandlerComponents
+  ) = {
+    this(webCommands, optDevContext, () => router, errorHandler, configuration, filters, handlerComponents)
+  }
+
+  @deprecated("Use the main JavaCompatibleHttpRequestHandler constructor", "2.9.0")
+  def this(
+      webCommands: WebCommands,
+      optDevContext: OptionalDevContext,
+      router: Router,
+      errorHandler: HttpErrorHandler,
+      configuration: HttpConfiguration,
+      filters: HttpFilters,
+      handlerComponents: JavaHandlerComponents
+  ) = {
+    this(
+      webCommands,
+      optDevContext.devContext,
+      () => router,
+      errorHandler,
+      configuration,
+      filters.filters,
+      handlerComponents
+    )
   }
 
   // This is a Handler that, when evaluated, converts its underlying JavaHandler into

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/controllers/UsersController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/controllers/UsersController.java
@@ -20,6 +20,8 @@ public class UsersController extends Controller {
     @Inject
     public UsersController(Database db) {
         this.db = db;
+
+        insertRow(db, "PlayerFromControllerInit");
     }
 
     public Result list() {
@@ -38,6 +40,14 @@ public class UsersController extends Controller {
             return result;
         });
         return ok(views.html.index.render(users));
+    }
+
+    public static void insertRow(Database db, String text) {
+        db.withConnection(connection -> {
+            PreparedStatement stmt = connection.prepareStatement("INSERT INTO users (username) VALUES (?)");
+            stmt.setString(1, text);
+            stmt.execute();
+        });
     }
 
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/startup/Startup.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/startup/Startup.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package startup;
+
+import play.api.db.evolutions.ApplicationEvolutions;
+import play.db.Database;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class Startup {
+
+    @Inject
+    public Startup(Database db, ApplicationEvolutions evolutions) {
+        if(evolutions.upToDate()) {
+            // When autoApply = false the only way to make this work is to add the upToDate check
+            controllers.UsersController.insertRow(db, "PlayerFromStartupInit");
+        }
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/startup/StartupModule.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/startup/StartupModule.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package startup;
+
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class StartupModule extends Module {
+
+    @Override
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Arrays.asList(bindClass(Startup.class).toSelf().eagerly());
+    }
+
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/views/index.scala.html
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/views/index.scala.html
@@ -13,8 +13,7 @@
     <tbody>
       @for(user <- users) {
         <tr>
-          <td>@{user.id}</td>
-          <td>@{user.username}</td>
+          <td>@{user.id}_@{user.username}</td>
         </tr>
       }
     </tbody>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/changes/2.sql
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/changes/2.sql
@@ -2,8 +2,8 @@
 
 # --- !Ups
 
-INSERT INTO users VALUES (2, 'Player2');
+INSERT INTO users(username) VALUES ('PlayerFromSecondEvolution');
 
 # --- !Downs
 
-DELETE FROM users WHERE id = 2;
+DELETE FROM users WHERE username = 'PlayerFromSecondEvolution';

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/changes/3.sql
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/changes/3.sql
@@ -2,7 +2,7 @@
 
 # --- !Ups
 
-INSERT INTO users VALUES (3, 'Player3');
+INSERT INTO users(username) VALUES ('PlayerFromThirdEvolution');
 
 
 WRONG COMMAND TO FAIL THE MIGRATION

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/conf/application.conf
@@ -1,2 +1,3 @@
 db.default.driver=org.h2.Driver
 db.default.url="jdbc:h2:mem:auto_apply_evolutions_false"
+play.modules.enabled += "startup.StartupModule"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/conf/evolutions/default/1.sql
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/conf/evolutions/default/1.sql
@@ -8,7 +8,7 @@ CREATE TABLE users (
     PRIMARY KEY (id)
 );
 
-INSERT INTO users VALUES (1, 'Player1');
+INSERT INTO users(username) VALUES ('PlayerFromFirstEvolution');
 
 # --- !Downs
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/test
@@ -3,7 +3,7 @@
 # Needs evolution since autoApply=false for this test
 > verifyResourceContains / 500 evolution
 > applyEvolutions /@evolutions/apply/default
-> verifyResourceContains / 200 Player1
+> verifyResourceContains / 200 1_PlayerFromFirstEvolution 2_PlayerFromStartupInit 3_PlayerFromControllerInit
 
 # Add a new evolution so that it will be triggered again
 $ copy-file changes/2.sql conf/evolutions/default/2.sql
@@ -12,7 +12,7 @@ $ sleep 2000
 
 > verifyResourceContains / 500 evolution
 > applyEvolutions /@evolutions/apply/default
-> verifyResourceContains / 200 Player2
+> verifyResourceContains / 200 4_PlayerFromSecondEvolution 5_PlayerFromStartupInit 6_PlayerFromControllerInit
 
 # Copy evolution with invalid commands
 $ copy-file changes/3.sql conf/evolutions/default/3.sql
@@ -27,7 +27,7 @@ $ sleep 2000
 
 # And it can be market as resolved
 > applyEvolutions /@evolutions/resolve/default/3
-> verifyResourceContains / 200 Player3
+> verifyResourceContains / 200 7_PlayerFromThirdEvolution
 
 > playStop
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/controllers/UsersController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/controllers/UsersController.java
@@ -20,6 +20,8 @@ public class UsersController extends Controller {
     @Inject
     public UsersController(Database db) {
         this.db = db;
+
+        insertRow(db, "PlayerFromControllerInit");
     }
 
     public Result list() {
@@ -38,6 +40,14 @@ public class UsersController extends Controller {
             return result;
         });
         return ok(views.html.index.render(users));
+    }
+
+    public static void insertRow(Database db, String text) {
+        db.withConnection(connection -> {
+            PreparedStatement stmt = connection.prepareStatement("INSERT INTO users (username) VALUES (?)");
+            stmt.setString(1, text);
+            stmt.execute();
+        });
     }
 
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/startup/Startup.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/startup/Startup.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package startup;
+
+import play.db.Database;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class Startup {
+
+    @Inject
+    public Startup(Database db) {
+        // This works even without injecting play.api.db.evolutions.ApplicationEvolutions,
+        // because it looks like ApplicationEvolutions gets initialized first.
+        // Therefore the order in which (eager) components get initialzed matters.
+        // Of course, it's always safer to just inject ApplicationEvolutions.
+        controllers.UsersController.insertRow(db, "PlayerFromStartupInit");
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/startup/StartupModule.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/startup/StartupModule.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package startup;
+
+import com.typesafe.config.Config;
+import play.Environment;
+import play.inject.Binding;
+import play.inject.Module;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class StartupModule extends Module {
+
+    @Override
+    public List<Binding<?>> bindings(final Environment environment, final Config config) {
+        return Arrays.asList(bindClass(Startup.class).toSelf().eagerly());
+    }
+
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/views/index.scala.html
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/views/index.scala.html
@@ -13,8 +13,7 @@
     <tbody>
       @for(user <- users) {
         <tr>
-          <td>@{user.id}</td>
-          <td>@{user.username}</td>
+          <td>@{user.id}_@{user.username}</td>
         </tr>
       }
     </tbody>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/changes/2.sql
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/changes/2.sql
@@ -2,8 +2,8 @@
 
 # --- !Ups
 
-INSERT INTO users VALUES (2, 'Player2');
+INSERT INTO users(username) VALUES ('PlayerFromSecondEvolution');
 
 # --- !Downs
 
-DELETE FROM users WHERE id = 2;
+DELETE FROM users WHERE username = 'PlayerFromSecondEvolution';

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/conf/application.conf
@@ -1,3 +1,4 @@
 db.default.driver=org.h2.Driver
 db.default.url="jdbc:h2:mem:auto_apply_evolutions_true"
 play.evolutions.db.default.autoApply=true
+play.modules.enabled += "startup.StartupModule"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/conf/evolutions/default/1.sql
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/conf/evolutions/default/1.sql
@@ -8,7 +8,7 @@ CREATE TABLE users (
     PRIMARY KEY (id)
 );
 
-INSERT INTO users VALUES (1, 'Player1');
+INSERT INTO users(username) VALUES ('PlayerFromFirstEvolution');
 
 # --- !Downs
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/test
@@ -1,14 +1,14 @@
 > run
 
 # Evolutions will be applied automatically since autoApply=true
-> verifyResourceContains / 200 Player1
+> verifyResourceContains / 200 1_PlayerFromFirstEvolution 2_PlayerFromStartupInit 3_PlayerFromControllerInit
 
 # Add a new evolution to verify that it will be applied automatically
 $ copy-file changes/2.sql conf/evolutions/default/2.sql
 # Give the file watcher some time to react
 $ sleep 2000
 
-> verifyResourceContains / 200 Player2
+> verifyResourceContains / 200 4_PlayerFromSecondEvolution 5_PlayerFromStartupInit 6_PlayerFromControllerInit
 
 > playStop
 
@@ -20,5 +20,5 @@ $ sleep 2000
 > runProd --no-exit-sbt
 $ sleep 4000
 $ exists target/universal/stage/RUNNING_PID
-> verifyResourceContains / 200 Player1
+> verifyResourceContains / 200 1_PlayerFromFirstEvolution 2_PlayerFromSecondEvolution 3_PlayerFromStartupInit 4_PlayerFromControllerInit
 > stopProd --no-exit-sbt

--- a/documentation/manual/working/scalaGuide/main/application/code/ScalaHttpRequestHandlers.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/ScalaHttpRequestHandlers.scala
@@ -36,6 +36,7 @@ package virtualhost {
 
 //#virtualhost
   import javax.inject.Inject
+  import javax.inject.Provider
   import play.api.http._
   import play.api.mvc.RequestHeader
 
@@ -45,8 +46,8 @@ package virtualhost {
       errorHandler: HttpErrorHandler,
       configuration: HttpConfiguration,
       filters: HttpFilters,
-      fooRouter: foo.Routes,
-      barRouter: bar.Routes
+      fooRouter: Provider[foo.Routes],
+      barRouter: Provider[bar.Routes]
   ) extends DefaultHttpRequestHandler(
         webCommands,
         optionalDevContext,
@@ -57,8 +58,8 @@ package virtualhost {
       ) {
     override def routeRequest(request: RequestHeader): Option[Handler] = {
       request.host match {
-        case "foo.example.com" => fooRouter.routes.lift(request)
-        case "bar.example.com" => barRouter.routes.lift(request)
+        case "foo.example.com" => fooRouter.get.routes.lift(request)
+        case "bar.example.com" => barRouter.get.routes.lift(request)
         case _                 => super.routeRequest(request)
       }
     }

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -73,8 +73,10 @@ class ApplicationEvolutions @Inject() (
 
             environment.mode match {
               case Mode.Test => evolutions.evolve(db, scripts, dbConfig.autocommit, dbConfig.schema)
-              case Mode.Dev =>
-                invalidDatabaseRevisions += 1 // In DEV mode EvolutionsWebCommands solely handles evolutions
+              case Mode.Dev if !dbConfig.autoApply =>
+                invalidDatabaseRevisions += 1 // In DEV mode EvolutionsWebCommands handle non-autoApply evolutions
+              case Mode.Dev if dbConfig.autoApply =>
+                evolutions.evolve(db, scripts, dbConfig.autocommit, dbConfig.schema)
               case Mode.Prod if !hasDown && dbConfig.autoApply =>
                 evolutions.evolve(db, scripts, dbConfig.autocommit, dbConfig.schema)
               case Mode.Prod if hasDown && dbConfig.autoApply && dbConfig.autoApplyDowns =>

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -503,7 +503,6 @@ class EvolutionsWebCommands @Inject() (
 
       case _ => {
         synchronized {
-          var autoApplyCount = 0
           if (!checkedAlready) {
             dbApi
               .databases()
@@ -515,20 +514,11 @@ class EvolutionsWebCommands @Inject() (
                   reader,
                   (db, dbConfig, scripts, hasDown) => {
                     import Evolutions.toHumanReadableScript
-
-                    if (dbConfig.autoApply) {
-                      evolutions.evolve(db, scripts, dbConfig.autocommit, dbConfig.schema)
-                      autoApplyCount += 1
-                    } else {
-                      throw InvalidDatabaseRevision(db, toHumanReadableScript(scripts))
-                    }
+                    throw InvalidDatabaseRevision(db, toHumanReadableScript(scripts))
                   }
                 )
               )
             checkedAlready = true
-            if (autoApplyCount > 0) {
-              buildLink.forceReload()
-            }
           }
         }
         None

--- a/transport/client/play-ahc-ws/src/test/scala/play/libs/ws/WSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/libs/ws/WSSpec.scala
@@ -4,8 +4,8 @@
 
 package play.libs.ws
 
+import akka.actor.ActorSystem
 import akka.stream.Materializer
-import akka.stream.testkit.NoMaterializer
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.test._
@@ -18,11 +18,7 @@ class WSSpec extends PlaySpecification with WsTestClient {
 
   "WSClient.url().post(InputStream)" should {
     "uploads the stream" in {
-      var mat: Materializer = NoMaterializer
-
       Server.withRouterFromComponents() { components =>
-        mat = components.materializer
-
         import components.{ defaultActionBuilder => Action }
         import play.api.routing.sird.{ POST => SirdPost }
         import play.api.routing.sird._
@@ -37,6 +33,7 @@ class WSSpec extends PlaySpecification with WsTestClient {
         }
       } { implicit port =>
         withClient { ws =>
+          val mat    = Materializer.matFromSystem(ActorSystem())
           val javaWs = new AhcWSClient(ws.underlying[AsyncHttpClient], mat)
           val input  = this.getClass.getClassLoader.getResourceAsStream("play/libs/ws/play_full_color.png")
           val rep    = javaWs.url(s"http://localhost:$port/").post(input).toCompletableFuture.get()


### PR DESCRIPTION
@gmethvin Check this out.

I implemented your suggestions:
* In DEV mode autoApply now runs evolutions on `ApplicationEvolutions` init. This makes your workaround (where you pretend prod mode) obsolete. However only relevant when autoApply = true.
* Inject the router as `Provider[]`. Relevant for autoApply = false, so controllers won't be initialized before webcommands aren't handled.

I adjusted the existing scripted tests to cover all use cases:
* DB access from controller constructor
* DB access from eager singleton