### PR TITLE
show that adding to the filter chain is needed

### DIFF
--- a/documentation/manual/working/commonGuide/filters/GzipEncoding.md
+++ b/documentation/manual/working/commonGuide/filters/GzipEncoding.md
@@ -11,6 +11,22 @@ To enable the gzip filter, add the filter to `application.conf`:
 play.filters.enabled += "play.filters.gzip.GzipFilter"
 ```
 
+And then in your Filters.scala include it in your filter chain:
+
+```
+import javax.inject.Inject
+import play.api.http.HttpFilters
+import org.pac4j.play.filters.SecurityFilter
+import play.filters.gzip.GzipFilter
+
+class Filters @Inject()(securityFilter: SecurityFilter, gzipFilter: GzipFilter) extends HttpFilters {
+
+  def filters = Seq(securityFilter, gzipFilter)
+
+}
+
+```
+
 ## Configuring the gzip filter
 
 The gzip filter supports a small number of tuning configuration options, which can be configured from `application.conf`.  To see the available configuration options, see the Play filters [`reference.conf`](resources/confs/filters-helpers/reference.conf).


### PR DESCRIPTION
I did spend some time figuring out why my page wasn't gzip'ed

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Reading through the documentation it wasn't clear to me that I also need to add the gzipFilter to my filterchain in Filters.scala after enabling it in `application.conf`


