### PR TITLE
Convert .travis-jvmopts to .sbtopts

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,6 @@
+-J-Xms2G
+-J-Xmx2G
+-J-Xss2M
+-J-XX:MaxInlineLevel=18
+-J-XX:MaxMetaspaceSize=1G
+-J-Dfile.encoding=UTF-8

--- a/.travis-jvmopts
+++ b/.travis-jvmopts
@@ -1,8 +1,0 @@
-# This is used to configure the sbt instance that Travis launches
-
--Xms2G
--Xmx2G
--Xss2M
--XX:MaxInlineLevel=18
--XX:MaxMetaspaceSize=1G
--Dfile.encoding=UTF-8


### PR DESCRIPTION
Without those, on my machine (both jdk8 and jdk11),
'sbt clean +publishLocal' would run out of memory throwing confusing errors
such as 'java.lang.NoClassDefFoundError: xsbt/DelegatingReporter$PositionImpl$'.
Apparently the JVM heuristics for selecting these values aren't very good yet,
and it would be helpful to supply some reasonable defaults as .sbtopts so new
contributors don't have to deal with this.