### PR TITLE
Set name of default cache config to "play.cache.caffeine"

### DIFF
--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineCacheComponents.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineCacheComponents.java
@@ -44,7 +44,7 @@ import play.components.ConfigurationComponents;
 public interface CaffeineCacheComponents extends ConfigurationComponents, AkkaComponents {
   default AsyncCacheApi cacheApi(String name) {
     CaffeineCacheManager caffeineCacheManager =
-        new CaffeineCacheManager(config().getConfig("play.cache.defaultCache"));
+        new CaffeineCacheManager(config().getConfig("play.cache.caffeine"));
 
     play.api.cache.AsyncCacheApi scalaAsyncCacheApi =
         new CaffeineCacheApi(


### PR DESCRIPTION
This pull request enables compile-time injection of named caches using Caffeine in Java. Updated name of cache config reflects that in play.api.cache.caffeine.CaffeineCacheComponents.