### PR TITLE
Create a unique version number when setting akka.version

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -112,8 +112,10 @@ object BuildSettings {
     ),
     bintrayPackage := "play-sbt-plugin",
     playPublishingPromotionSettings,
-    version ~= {
-      v => v + sys.props.get("akka.version").map("-akka-" + _).getOrElse("")
+    version ~= { v =>
+      v +
+        sys.props.get("akka.version").map("-akka-" + _).getOrElse("") +
+        sys.props.get("akka.http.version").map("-akka-http-" + _).getOrElse("")
     },
     apiURL := {
       val v = version.value

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -112,6 +112,9 @@ object BuildSettings {
     ),
     bintrayPackage := "play-sbt-plugin",
     playPublishingPromotionSettings,
+    version ~= {
+      v => v + sys.props.get("akka.version").map("-akka-" + _).getOrElse("")
+    },
     apiURL := {
       val v = version.value
       if (isSnapshot.value) {


### PR DESCRIPTION
This avoids creating artifacts that have the same version number but
depend on a different Akka version.

In particular this is intended to fix the failure at #10047, where
we see a single play version depend on different akka versions. The
theory is that those are play artifacts from different builds.