### PR TITLE
[doc] Add note to show using AHC client directly

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -252,6 +252,8 @@ Or, you can run the `WSClient` completely standalone without involving a running
 
 @[ws-standalone](code/javaguide/ws/Standalone.java)
 
+This can be useful in cases where there is a specific HTTP client option that isn't accessible from config.
+
 If you want to run `WSClient` standalone, but still use [[configuration|JavaWS#configuring-ws]] (including [[SSL|WsSSL]]), you can use a configuration parser like this:
 
 @[ws-standalone-with-config](code/javaguide/ws/StandaloneWithConfig.java)

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/Standalone.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/Standalone.java
@@ -8,6 +8,7 @@ package javaguide.ws;
 import akka.actor.ActorSystem;
 import akka.stream.Materializer;
 
+import akka.stream.SystemMaterializer;
 import play.shaded.ahc.org.asynchttpclient.*;
 import play.libs.ws.*;
 import play.libs.ws.ahc.*;
@@ -25,7 +26,7 @@ public class Standalone {
     // Set up Akka
     String name = "wsclient";
     ActorSystem system = ActorSystem.create(name);
-    Materializer materializer = Materializer.matFromSystem(system);
+    Materializer materializer = SystemMaterializer.get(system).materializer();
 
     // Set up AsyncHttpClient directly from config
     AsyncHttpClientConfig asyncHttpClientConfig =

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -263,6 +263,8 @@ Or, you can run the `WSClient` completely standalone without involving a running
 
 @[ws-standalone](code/ScalaWSStandalone.scala)
 
+This can be useful in cases where there is a specific HTTP client option that isn't accessible from config.
+
 Again, once you are done with your custom client work, you **must** close the client:
 
 @[close-client](code/ScalaWSSpec.scala)

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -51,7 +51,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
 
   val system = ActorSystem()
 
-  implicit val materializer = Materializer.matFromSystem(system)
+  implicit val materializer = SystemMaterializer(actorSystem).materializer
   implicit val ec           = system.dispatcher
 
   val parse  = PlayBodyParsers()
@@ -549,8 +549,8 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       import play.api.libs.ws.ahc._
 
       // usually injected through @Inject()(implicit mat: Materializer)
-      val mat: akka.stream.Materializer = app.materializer
-      val wsClient                      = AhcWSClient()(mat)
+      implicit val materializer = app.materializer     
+      val wsClient                      = AhcWSClient()
       //#simple-ws-custom-client
 
       wsClient.close()
@@ -571,6 +571,9 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       val wsConfig           = AhcWSClientConfigFactory.forConfig(configuration.underlying, environment.classLoader)
       val mat                = app.materializer
       val wsClient: WSClient = AhcWSClient(wsConfig)(mat)
+
+      // You can also use an explicit AHC cilent
+      // val wsClient: WSClient = AhcWSClient(new StandaloneAhcWSClient(asyncHttpClient))(mat)
 
       //#ws-custom-client
 

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -571,10 +571,6 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       val wsConfig           = AhcWSClientConfigFactory.forConfig(configuration.underlying, environment.classLoader)
       val mat                = app.materializer
       val wsClient: WSClient = AhcWSClient(wsConfig)(mat)
-
-      // You can also use an explicit AHC cilent
-      // val wsClient: WSClient = AhcWSClient(new StandaloneAhcWSClient(asyncHttpClient))(mat)
-
       //#ws-custom-client
 
       //#close-client

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -24,6 +24,7 @@ import play.api.mvc._
 import play.api.libs.ws._
 import play.api.http.HttpEntity
 import akka.actor.ActorSystem
+import akka.stream.SystemMaterializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
 
@@ -51,7 +52,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
 
   val system = ActorSystem()
 
-  implicit val materializer = SystemMaterializer(actorSystem).materializer
+  implicit val materializer = SystemMaterializer(system).materializer
   implicit val ec           = system.dispatcher
 
   val parse  = PlayBodyParsers()

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -549,8 +549,8 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       import play.api.libs.ws.ahc._
 
       // usually injected through @Inject()(implicit mat: Materializer)
-      implicit val materializer = app.materializer     
-      val wsClient                      = AhcWSClient()
+      implicit val materializer = app.materializer
+      val wsClient              = AhcWSClient()
       //#simple-ws-custom-client
 
       wsClient.close()

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSStandalone.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSStandalone.scala
@@ -4,9 +4,10 @@
 
 //#ws-standalone
 import akka.actor.ActorSystem
-import akka.stream.Materializer
+import akka.stream.{Materializer, SystemMaterializer}
 import play.api.libs.ws._
-import play.api.libs.ws.ahc.AhcWSClient
+import play.api.libs.ws.ahc.{AhcWSClient, StandaloneAhcWSClient}
+import play.shaded.ahc.org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, DefaultAsyncHttpClient, DefaultAsyncHttpClientConfig}
 
 import scala.concurrent.Future
 
@@ -15,8 +16,15 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     implicit val system       = ActorSystem()
-    implicit val materializer = Materializer.matFromSystem
-    val wsClient              = AhcWSClient()
+
+    val asyncHttpClientConfig = new DefaultAsyncHttpClientConfig.Builder()
+      .setMaxRequestRetry(0)
+      .setShutdownQuietPeriod(0)
+      .setShutdownTimeout(0).build
+    val asyncHttpClient = new DefaultAsyncHttpClient(asyncHttpClientConfig)
+
+    implicit val materializer = SystemMaterializer(system).materializer
+    val wsClient: WSClient    = new AhcWSClient(new StandaloneAhcWSClient(asyncHttpClient))
 
     call(wsClient)
       .andThen { case _ => wsClient.close() }

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSStandalone.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSStandalone.scala
@@ -4,10 +4,15 @@
 
 //#ws-standalone
 import akka.actor.ActorSystem
-import akka.stream.{Materializer, SystemMaterializer}
+import akka.stream.Materializer
+import akka.stream.SystemMaterializer
 import play.api.libs.ws._
-import play.api.libs.ws.ahc.{AhcWSClient, StandaloneAhcWSClient}
-import play.shaded.ahc.org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, DefaultAsyncHttpClient, DefaultAsyncHttpClientConfig}
+import play.api.libs.ws.ahc.AhcWSClient
+import play.api.libs.ws.ahc.StandaloneAhcWSClient
+import play.shaded.ahc.org.asynchttpclient.AsyncHttpClient
+import play.shaded.ahc.org.asynchttpclient.AsyncHttpClientConfig
+import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClient
+import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClientConfig
 
 import scala.concurrent.Future
 
@@ -15,12 +20,13 @@ object Main {
   import scala.concurrent.ExecutionContext.Implicits._
 
   def main(args: Array[String]): Unit = {
-    implicit val system       = ActorSystem()
+    implicit val system = ActorSystem()
 
     val asyncHttpClientConfig = new DefaultAsyncHttpClientConfig.Builder()
       .setMaxRequestRetry(0)
       .setShutdownQuietPeriod(0)
-      .setShutdownTimeout(0).build
+      .setShutdownTimeout(0)
+      .build
     val asyncHttpClient = new DefaultAsyncHttpClient(asyncHttpClientConfig)
 
     implicit val materializer = SystemMaterializer(system).materializer


### PR DESCRIPTION
## Purpose

This is a documentation workaround for issues like https://github.com/playframework/play-ws/issues/418 where there's an AHC config setting that isn't accessible from the WS config layer.

It adds a note to the documentation, and changes the Scala standalone example to match the Java one.  

It also updates to use `SystemMaterializer` to be compatible with https://github.com/playframework/play-ws/pull/463

I'll add a play-ws PR that covers this in the readme as well.


