### PR TITLE
JPMS Automatic-Module-Name for all jars published for 2.8.x branch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ import sbt.Keys.parallelExecution
 import sbt._
 import sbt.io.Path._
 import org.scalafmt.sbt.ScalafmtPlugin
+import play.AutomaticModuleName
 
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed
 dynverVTagPrefix in ThisBuild := false
@@ -28,6 +29,7 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 }
 
 lazy val BuildLinkProject = PlayNonCrossBuiltProject("Build-Link", "dev-mode/build-link")
+  .settings(AutomaticModuleName.settings("com.typesafe.play.build.link"))
   .dependsOn(PlayExceptionsProject)
 
 // run-support project is only compiled against sbt scala version
@@ -36,6 +38,7 @@ lazy val RunSupportProject = PlaySbtProject("Run-Support", "dev-mode/run-support
     target := target.value / "run-support",
     libraryDependencies ++= runSupportDependencies((sbtVersion in pluginCrossBuild).value)
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.run.support"))
   .dependsOn(BuildLinkProject)
 
 lazy val RoutesCompilerProject = PlayDevelopmentProject("Routes-Compiler", "dev-mode/routes-compiler")
@@ -44,6 +47,7 @@ lazy val RoutesCompilerProject = PlayDevelopmentProject("Routes-Compiler", "dev-
     libraryDependencies ++= routesCompilerDependencies(scalaVersion.value),
     TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.routes.compiler"))
 
 lazy val SbtRoutesCompilerProject = PlaySbtProject("Sbt-Routes-Compiler", "dev-mode/routes-compiler")
   .enablePlugins(SbtTwirl)
@@ -52,16 +56,20 @@ lazy val SbtRoutesCompilerProject = PlaySbtProject("Sbt-Routes-Compiler", "dev-m
     libraryDependencies ++= routesCompilerDependencies(scalaVersion.value),
     TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.sbt.routes.compiler"))
 
 lazy val StreamsProject = PlayCrossBuiltProject("Play-Streams", "core/play-streams")
   .settings(libraryDependencies ++= streamsDependencies)
+  .settings(AutomaticModuleName.settings("com.typesafe.play.streams"))
 
 lazy val PlayExceptionsProject = PlayNonCrossBuiltProject("Play-Exceptions", "core/play-exceptions")
+  .settings(AutomaticModuleName.settings("com.typesafe.play.exceptions"))
 
 lazy val PlayJodaFormsProject = PlayCrossBuiltProject("Play-Joda-Forms", "web/play-joda-forms")
   .settings(
     libraryDependencies ++= joda
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.joda.forms"))
   .dependsOn(PlayProject, PlaySpecs2Project % "test")
 
 lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
@@ -106,6 +114,7 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
     Docs.apiDocsIncludeManaged := true
   )
   .settings(Docs.playdocSettings: _*)
+  .settings(AutomaticModuleName.settings("com.typesafe.play"))
   .dependsOn(
     BuildLinkProject,
     StreamsProject
@@ -113,6 +122,7 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
 
 lazy val PlayServerProject = PlayCrossBuiltProject("Play-Server", "transport/server/play-server")
   .settings(libraryDependencies ++= playServerDependencies)
+  .settings(AutomaticModuleName.settings("com.typesafe.play.server"))
   .dependsOn(
     PlayProject,
     PlayGuiceProject % "test"
@@ -120,11 +130,13 @@ lazy val PlayServerProject = PlayCrossBuiltProject("Play-Server", "transport/ser
 
 lazy val PlayNettyServerProject = PlayCrossBuiltProject("Play-Netty-Server", "transport/server/play-netty-server")
   .settings(libraryDependencies ++= netty)
+  .settings(AutomaticModuleName.settings("com.typesafe.play.server.netty"))
   .dependsOn(PlayServerProject)
 
 import AkkaDependency._
 lazy val PlayAkkaHttpServerProject =
   PlayCrossBuiltProject("Play-Akka-Http-Server", "transport/server/play-akka-http-server")
+    .settings(AutomaticModuleName.settings("com.typesafe.play.server.akka.http"))
     .dependsOn(PlayServerProject, StreamsProject)
     .dependsOn(PlayGuiceProject % "test")
     .settings(
@@ -134,6 +146,7 @@ lazy val PlayAkkaHttpServerProject =
 
 lazy val PlayAkkaHttp2SupportProject =
   PlayCrossBuiltProject("Play-Akka-Http2-Support", "transport/server/play-akka-http2-support")
+    .settings(AutomaticModuleName.settings("com.typesafe.play.server.akka.http2"))
     .dependsOn(PlayAkkaHttpServerProject)
     .addAkkaModuleDependency("akka-http2-support")
 
@@ -147,26 +160,31 @@ lazy val PlayJavaClusterSharding =
     .dependsOn(PlayProject)
 
 lazy val PlayJdbcApiProject = PlayCrossBuiltProject("Play-JDBC-Api", "persistence/play-jdbc-api")
+  .settings(AutomaticModuleName.settings("com.typesafe.play.persistence.jdbc.api"))
   .dependsOn(PlayProject)
 
 lazy val PlayJdbcProject: Project = PlayCrossBuiltProject("Play-JDBC", "persistence/play-jdbc")
   .settings(libraryDependencies ++= jdbcDeps)
+  .settings(AutomaticModuleName.settings("com.typesafe.play.persistence.jdbc"))
   .dependsOn(PlayJdbcApiProject)
   .dependsOn(PlaySpecs2Project % "test")
 
 lazy val PlayJdbcEvolutionsProject = PlayCrossBuiltProject("Play-JDBC-Evolutions", "persistence/play-jdbc-evolutions")
   .settings(libraryDependencies += derbyDatabase % Test)
+  .settings(AutomaticModuleName.settings("com.typesafe.play.persistence.jdbc.evolutions"))
   .dependsOn(PlayJdbcApiProject)
   .dependsOn(PlaySpecs2Project % "test")
   .dependsOn(PlayJdbcProject % "test->test")
   .dependsOn(PlayJavaJdbcProject % "test")
 
 lazy val PlayJavaJdbcProject = PlayCrossBuiltProject("Play-Java-JDBC", "persistence/play-java-jdbc")
+  .settings(AutomaticModuleName.settings("com.typesafe.play.persistence.java.jdbc"))
   .dependsOn(PlayJdbcProject % "compile->compile;test->test", PlayJavaProject)
   .dependsOn(PlaySpecs2Project % "test", PlayGuiceProject % "test")
 
 lazy val PlayJpaProject = PlayCrossBuiltProject("Play-Java-JPA", "persistence/play-java-jpa")
   .settings(libraryDependencies ++= jpaDeps)
+  .settings(AutomaticModuleName.settings("com.typesafe.play.persistence.java.jpa"))
   .dependsOn(PlayJavaJdbcProject % "compile->compile;test->test")
   .dependsOn(PlayJdbcEvolutionsProject % "test")
   .dependsOn(PlaySpecs2Project % "test")
@@ -176,6 +194,7 @@ lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "testkit/play-test
     libraryDependencies ++= testDependencies ++ Seq(h2database % "test"),
     parallelExecution in Test := false
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.testkit.test"))
   .dependsOn(
     PlayGuiceProject,
     PlayServerProject,
@@ -189,10 +208,12 @@ lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "testkit/play-
     libraryDependencies ++= specs2Deps,
     parallelExecution in Test := false
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.testkit.specs2"))
   .dependsOn(PlayTestProject)
 
 lazy val PlayJavaProject = PlayCrossBuiltProject("Play-Java", "core/play-java")
   .settings(libraryDependencies ++= javaDeps ++ javaTestDeps)
+  .settings(AutomaticModuleName.settings("com.typesafe.play.java"))
   .dependsOn(
     PlayProject       % "compile;test->test",
     PlayTestProject   % "test",
@@ -204,6 +225,7 @@ lazy val PlayJavaFormsProject = PlayCrossBuiltProject("Play-Java-Forms", "web/pl
   .settings(
     libraryDependencies ++= javaDeps ++ javaFormsDeps ++ javaTestDeps
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.java.forms"))
   .dependsOn(
     PlayJavaProject % "compile;test->test"
   )
@@ -213,10 +235,12 @@ lazy val PlayDocsProject = PlayCrossBuiltProject("Play-Docs", "dev-mode/play-doc
   .settings(
     libraryDependencies ++= playDocsDependencies
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.docs"))
   .dependsOn(PlayAkkaHttpServerProject)
 
 lazy val PlayGuiceProject = PlayCrossBuiltProject("Play-Guice", "core/play-guice")
   .settings(libraryDependencies ++= guiceDeps ++ specs2Deps.map(_ % "test"))
+  .settings(AutomaticModuleName.settings("com.typesafe.play.guice"))
   .dependsOn(
     PlayProject % "compile;test->test"
   )
@@ -250,6 +274,7 @@ lazy val PlayLogback = PlayCrossBuiltProject("Play-Logback", "core/play-logback"
     // quieten deprecation warnings in tests
     scalacOptions in Test := (scalacOptions in Test).value.diff(Seq("-deprecation"))
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.logback"))
   .dependsOn(PlayProject)
   .dependsOn(PlaySpecs2Project % "test")
 
@@ -260,6 +285,7 @@ lazy val PlayWsProject = PlayCrossBuiltProject("Play-WS", "transport/client/play
     // quieten deprecation warnings in tests
     scalacOptions in Test := (scalacOptions in Test).value.diff(Seq("-deprecation"))
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.ws.client"))
   .dependsOn(PlayProject)
   .dependsOn(PlayTestProject % "test")
 
@@ -270,6 +296,7 @@ lazy val PlayAhcWsProject = PlayCrossBuiltProject("Play-AHC-WS", "transport/clie
     // quieten deprecation warnings in tests
     scalacOptions in Test := (scalacOptions in Test).value.diff(Seq("-deprecation"))
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.ws.ahc.client"))
   .dependsOn(PlayWsProject, PlayCaffeineCacheProject % "test")
   .dependsOn(PlaySpecs2Project % "test")
   .dependsOn(PlayTestProject % "test->test")
@@ -281,6 +308,7 @@ lazy val PlayOpenIdProject = PlayCrossBuiltProject("Play-OpenID", "web/play-open
     // quieten deprecation warnings in tests
     scalacOptions in Test := (scalacOptions in Test).value.diff(Seq("-deprecation"))
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.openid"))
   .dependsOn(PlayAhcWsProject)
   .dependsOn(PlaySpecs2Project % "test")
 
@@ -289,6 +317,7 @@ lazy val PlayFiltersHelpersProject = PlayCrossBuiltProject("Filters-Helpers", "w
     libraryDependencies ++= playFilterDeps,
     parallelExecution in Test := false
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.filters.helpers"))
   .dependsOn(
     PlayProject,
     PlayTestProject           % "test",
@@ -324,6 +353,7 @@ lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Te
       )
     }
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.test.integration"))
   .dependsOn(
     PlayProject       % "it->test",
     PlayLogback       % "it->test",
@@ -369,6 +399,7 @@ lazy val PlayMicrobenchmarkProject = PlayCrossBuiltProject("Play-Microbenchmark"
     parallelExecution in Test := false,
     mimaPreviousArtifacts := Set.empty
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.microbenchmark"))
   .dependsOn(
     PlayProject                % "test->test",
     PlayLogback                % "test->test",
@@ -386,6 +417,7 @@ lazy val PlayCacheProject = PlayCrossBuiltProject("Play-Cache", "cache/play-cach
   .settings(
     libraryDependencies ++= playCacheDeps
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.cache"))
   .dependsOn(
     PlayProject,
     PlaySpecs2Project % "test"
@@ -395,6 +427,7 @@ lazy val PlayEhcacheProject = PlayCrossBuiltProject("Play-Ehcache", "cache/play-
   .settings(
     libraryDependencies ++= playEhcacheDeps
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.cache.ehcache"))
   .dependsOn(
     PlayProject,
     PlayCacheProject,
@@ -405,6 +438,7 @@ lazy val PlayCaffeineCacheProject = PlayCrossBuiltProject("Play-Caffeine-Cache",
   .settings(
     libraryDependencies ++= playCaffeineDeps
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.cache.caffeine"))
   .dependsOn(
     PlayProject,
     PlayCacheProject,
@@ -416,6 +450,7 @@ lazy val PlayJCacheProject = PlayCrossBuiltProject("Play-JCache", "cache/play-jc
   .settings(
     libraryDependencies ++= jcacheApi
   )
+  .settings(AutomaticModuleName.settings("com.typesafe.play.cache.jcache"))
   .dependsOn(
     PlayProject,
     PlayCaffeineCacheProject % "test", // provide a cachemanager implementation

--- a/project/AutomaticModuleName.scala
+++ b/project/AutomaticModuleName.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+package play
+
+import sbt.{Def, _}
+import sbt.Keys._
+
+/**
+  * Helper to set Automatic-Module-Name in projects.
+  *
+  * !! DO NOT BE TEMPTED INTO AUTOMATICALLY DERIVING THE NAMES FROM PROJECT NAMES !!
+  *
+  * The names carry a lot of implications and DO NOT have to always align 1:1 with the group ids or package names,
+  * though there should be of course a strong relationship between them.
+  */
+object AutomaticModuleName  {
+  private val AutomaticModuleName = "Automatic-Module-Name"
+
+  def settings(name: String): Seq[Def.Setting[Task[Seq[PackageOption]]]] = Seq(
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(AutomaticModuleName → name)
+  )
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

Trying to introduce Automatic-Module-Name, basically recreating a 2 year old PR https://github.com/playframework/playframework/pull/8472 for the v2.8.x branch

## Fixes

Fixes nothing, added support for Java 9 Modules but adding Automatic-Module-Name to the MANIFEST.MF file

## Purpose

Add Automatic-Module-Name to the MANIFEST.MF so for anyone wanting to start moving to Java 9+ can start moving.

## Background Context

Tried to use play with Java 11, and discovered play_2.12.jar doesn't work as a file based module name as is converted to play.2.12 which is invalid name. So searched issues and pull requests and came across https://github.com/playframework/playframework/pull/8472 which is 2 years old, tried to get it working as patch for 2.8.x, but didn't automatically work for me, so recreated it.

Personally I don't mind what the Automatically-Module-Name but from last few years of experience it's useful if it matches package and/or groupId/artifactId so you can search for it easily. Everything that creates a jar that is published I believe i've given a Automatic-Module-Name.

## References

Are there any relevant issues / PRs / mailing lists discussions?
