### PR TITLE
curl retry when installing jabba on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ env:
   matrix:
     - TRAVIS_JDK=11
 
-before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+before_install:
+  - curl --version # for debug purpose
+  - curl -L -v --retry 5 -o jabba-install.sh https://git.io/jabba
+  - bash jabba-install.sh && . ~/.jabba/jabba.sh
 install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=patch) && jabba use "$_" && java -Xmx32m -version
 
 stages:


### PR DESCRIPTION
`--retry` has an exponential backoff, so `5` retries should be good enough.

Fixes #10045.