### PR TITLE
Form Mapping#unbindAndValidate should apply global verifications

### DIFF
--- a/core/play/src/main/scala/play/core/hidden/ObjectMappings.scala
+++ b/core/play/src/main/scala/play/core/hidden/ObjectMappings.scala
@@ -50,7 +50,7 @@ class ObjectMapping$times[R, $aParams](apply: Function$times[$aParams, R], unapp
       ${g("val a% = field%.unbindAndValidate(v%)", "\n      ")}
 
       (${g("a%._1", " ++ ")}) ->
-        (${g("a%._2", " ++ ")})
+        (collectErrors(value) ++ ${g("a%._2", " ++ ")})
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -88,7 +88,9 @@ $scriptSource
 """)
 
 println((for (i <- 1 to 22) yield generate(i)).mkString(""))
+
  */
+
 
 class ObjectMapping1[R, A1](apply: Function1[A1, R], unapply: Function1[R, Option[(A1)]], f1: (String, Mapping[A1]), val key: String = "", val constraints: Seq[Constraint[R]] = Nil) extends Mapping[R] with ObjectMapping {
 
@@ -118,7 +120,7 @@ class ObjectMapping1[R, A1](apply: Function1[A1, R], unapply: Function1[R, Optio
       val a1 = field1.unbindAndValidate(v1)
 
       (a1._1) ->
-        (a1._2)
+        (collectErrors(value) ++ a1._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -166,7 +168,7 @@ class ObjectMapping2[R, A1, A2](apply: Function2[A1, A2, R], unapply: Function1[
       val a2 = field2.unbindAndValidate(v2)
 
       (a1._1 ++ a2._1) ->
-        (a1._2 ++ a2._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -218,7 +220,7 @@ class ObjectMapping3[R, A1, A2, A3](apply: Function3[A1, A2, A3, R], unapply: Fu
       val a3 = field3.unbindAndValidate(v3)
 
       (a1._1 ++ a2._1 ++ a3._1) ->
-        (a1._2 ++ a2._2 ++ a3._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -274,7 +276,7 @@ class ObjectMapping4[R, A1, A2, A3, A4](apply: Function4[A1, A2, A3, A4, R], una
       val a4 = field4.unbindAndValidate(v4)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -334,7 +336,7 @@ class ObjectMapping5[R, A1, A2, A3, A4, A5](apply: Function5[A1, A2, A3, A4, A5,
       val a5 = field5.unbindAndValidate(v5)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -398,7 +400,7 @@ class ObjectMapping6[R, A1, A2, A3, A4, A5, A6](apply: Function6[A1, A2, A3, A4,
       val a6 = field6.unbindAndValidate(v6)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -466,7 +468,7 @@ class ObjectMapping7[R, A1, A2, A3, A4, A5, A6, A7](apply: Function7[A1, A2, A3,
       val a7 = field7.unbindAndValidate(v7)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -538,7 +540,7 @@ class ObjectMapping8[R, A1, A2, A3, A4, A5, A6, A7, A8](apply: Function8[A1, A2,
       val a8 = field8.unbindAndValidate(v8)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -614,7 +616,7 @@ class ObjectMapping9[R, A1, A2, A3, A4, A5, A6, A7, A8, A9](apply: Function9[A1,
       val a9 = field9.unbindAndValidate(v9)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -694,7 +696,7 @@ class ObjectMapping10[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](apply: Functio
       val a10 = field10.unbindAndValidate(v10)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -778,7 +780,7 @@ class ObjectMapping11[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](apply: Fu
       val a11 = field11.unbindAndValidate(v11)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -866,7 +868,7 @@ class ObjectMapping12[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](appl
       val a12 = field12.unbindAndValidate(v12)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -958,7 +960,7 @@ class ObjectMapping13[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13]
       val a13 = field13.unbindAndValidate(v13)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1054,7 +1056,7 @@ class ObjectMapping14[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a14 = field14.unbindAndValidate(v14)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1154,7 +1156,7 @@ class ObjectMapping15[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a15 = field15.unbindAndValidate(v15)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1 ++ a15._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1258,7 +1260,7 @@ class ObjectMapping16[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a16 = field16.unbindAndValidate(v16)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1 ++ a15._1 ++ a16._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1366,7 +1368,7 @@ class ObjectMapping17[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a17 = field17.unbindAndValidate(v17)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1 ++ a15._1 ++ a16._1 ++ a17._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1478,7 +1480,7 @@ class ObjectMapping18[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a18 = field18.unbindAndValidate(v18)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1 ++ a15._1 ++ a16._1 ++ a17._1 ++ a18._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1594,7 +1596,7 @@ class ObjectMapping19[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a19 = field19.unbindAndValidate(v19)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1 ++ a15._1 ++ a16._1 ++ a17._1 ++ a18._1 ++ a19._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2 ++ a19._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2 ++ a19._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1714,7 +1716,7 @@ class ObjectMapping20[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a20 = field20.unbindAndValidate(v20)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1 ++ a15._1 ++ a16._1 ++ a17._1 ++ a18._1 ++ a19._1 ++ a20._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2 ++ a19._2 ++ a20._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2 ++ a19._2 ++ a20._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1838,7 +1840,7 @@ class ObjectMapping21[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a21 = field21.unbindAndValidate(v21)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1 ++ a15._1 ++ a16._1 ++ a17._1 ++ a18._1 ++ a19._1 ++ a20._1 ++ a21._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2 ++ a19._2 ++ a20._2 ++ a21._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2 ++ a19._2 ++ a20._2 ++ a21._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1966,7 +1968,7 @@ class ObjectMapping22[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
       val a22 = field22.unbindAndValidate(v22)
 
       (a1._1 ++ a2._1 ++ a3._1 ++ a4._1 ++ a5._1 ++ a6._1 ++ a7._1 ++ a8._1 ++ a9._1 ++ a10._1 ++ a11._1 ++ a12._1 ++ a13._1 ++ a14._1 ++ a15._1 ++ a16._1 ++ a17._1 ++ a18._1 ++ a19._1 ++ a20._1 ++ a21._1 ++ a22._1) ->
-        (a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2 ++ a19._2 ++ a20._2 ++ a21._2 ++ a22._2)
+        (collectErrors(value) ++ a1._2 ++ a2._2 ++ a3._2 ++ a4._2 ++ a5._2 ++ a6._2 ++ a7._2 ++ a8._2 ++ a9._2 ++ a10._2 ++ a11._2 ++ a12._2 ++ a13._2 ++ a14._2 ++ a15._2 ++ a16._2 ++ a17._2 ++ a18._2 ++ a19._2 ++ a20._2 ++ a21._2 ++ a22._2)
     }.getOrElse(Map.empty[String, String] -> Seq(FormError(key, "unbind.failed")))
   }
 
@@ -1981,3 +1983,4 @@ class ObjectMapping22[R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13,
   val mappings = Seq(this) ++ field1.mappings ++ field2.mappings ++ field3.mappings ++ field4.mappings ++ field5.mappings ++ field6.mappings ++ field7.mappings ++ field8.mappings ++ field9.mappings ++ field10.mappings ++ field11.mappings ++ field12.mappings ++ field13.mappings ++ field14.mappings ++ field15.mappings ++ field16.mappings ++ field17.mappings ++ field18.mappings ++ field19.mappings ++ field20.mappings ++ field21.mappings ++ field22.mappings
 
 }
+

--- a/core/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormSpec.scala
@@ -285,9 +285,10 @@ class FormSpec extends Specification {
     "validate global constraints on fillAndValidate" in {
       val passwordForm = Form(
         tuple(
-          "password" -> text,
+          "password"      -> text,
           "passwordAgain" -> text
-        ).verifying("passwords must match", t => t._1 == t._2))
+        ).verifying("passwords must match", t => t._1 == t._2)
+      )
       val filledAndValidated = passwordForm.fillAndValidate(("value", "not-same-value"))
       filledAndValidated.hasGlobalErrors must beTrue
       filledAndValidated.globalErrors must_=== Seq(FormError("", "passwords must match"))

--- a/core/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormSpec.scala
@@ -281,6 +281,17 @@ class FormSpec extends Specification {
       )
       failingValidatorForm.fill("foo").errors must beEmpty
     }
+
+    "validate global constraints on fillAndValidate" in {
+      val passwordForm = Form(
+        tuple(
+          "password" -> text,
+          "passwordAgain" -> text
+        ).verifying("passwords must match", t => t._1 == t._2))
+      val filledAndValidated = passwordForm.fillAndValidate(("value", "not-same-value"))
+      filledAndValidated.hasGlobalErrors must beTrue
+      filledAndValidated.globalErrors must_=== Seq(FormError("", "passwords must match"))
+    }
   }
 
   "render form using field[Type] syntax" in {


### PR DESCRIPTION
### Play Version
2.8.0 (has been present since at least 2.6.x)

### API
Scala

### Operating System
Mac OS X

### JDK
openjdk version "11.0.5" 2019-10-15
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.5+10)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.5+10, mixed mode)

### Library Dependencies

N/A

### Expected Behavior

1. Create mapping with a global verification, eg

>  val formMapping = mapping("first" -> nonEmptyText,
>   "last" -> nonEmptyText)(Person.apply _)(Person.unapply _).verifying(p => p.first != p.last)

2. Unit test via 

> formMapping.unbindAndValidate(Person("Jackson", "Jackson")

3. Expect one global validation error that first name is equal to last name

### Actual Behavior

3. No validation error.

### Reproducible Test Case

https://github.com/flicken/playframework-AndValidate/blob/master/src/test/scala/andvalidate/AndValidateSpec.scala

```
package andvalidate

import play.api.data._
import play.api.data.Forms._

class AndValidateSpec extends org.specs2.mutable.Specification with org.specs2.matcher.EitherMatchers {

  case class Person(first: String, last: String)

  val formMapping = mapping("first" -> nonEmptyText,
    "last" -> nonEmptyText)(Person.apply _)(Person.unapply _).verifying(p => p.first != p.last)

  val form = Form(formMapping)

  private def shouldHaveGlobalError(validatedForm: Form[Person]) = {
    validatedForm.errors.size should_== 1
    validatedForm.globalErrors.size should_== 1
    validatedForm.hasGlobalErrors should_== true
  }

  private def shouldHaveLocalError(validatedForm: Form[Person]) = {
    validatedForm.errors.size should_== 1
    validatedForm.globalErrors.size should_== 0
    validatedForm.hasGlobalErrors should_== false
  }

  private def shouldHaveError(either: Either[Seq[FormError],Person]) = {
    either.isLeft should_== true
    either.left.get.size should_== 1
  }

  private def shouldHaveError(tuple: (Map[String,String], Seq[FormError])) = {
    tuple._2.size should_== 1
  }

  "Form" should {
    "use local constraints on bind" in {
      shouldHaveLocalError(form.bind(Map("first" -> "", "last" -> "Jackson")))
    }

    "use local constraints on fillAndValidate" in {
      shouldHaveLocalError(form.fillAndValidate(Person("", "Jackson")))
    }

    "use global constraints on bind" in {
      shouldHaveGlobalError(form.bind(Map("first" -> "Jackson", "last" -> "Jackson")))
    }

    "use global constraints on fillAndValidate" in {
      shouldHaveGlobalError(form.fillAndValidate(Person("Jackson", "Jackson")))
    }
  }

  "Mapping" should {
    "use local constraints on bind" in {
      shouldHaveError(formMapping.bind(Map("first" -> "", "last" -> "Jackson")))
    }

    "use local constraints on unbindAndValidate" in {
      shouldHaveError(formMapping.unbindAndValidate(Person("", "Jackson")))
    }

    "use global constraints on bind" in {
      shouldHaveError(formMapping.bind(Map("first" -> "Jackson", "last" -> "Jackson")))
    }

    "use global constraints on unbindAndValidate" in {
      shouldHaveError(formMapping.unbindAndValidate(Person("Jackson", "Jackson")))
    }
  }

}

```

