### PR TITLE
Remove empty ebean.properties from main project as it causes deprecat… Fixes #10141

### DIFF
--- a/core/play-java/src/main/resources/ebean.properties
+++ b/core/play-java/src/main/resources/ebean.properties
@@ -1,3 +1,0 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#


### PR DESCRIPTION
Remove empty ebean.properties from main project as it causes deprecation warning since ebean v12.2.x

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10141

## Purpose

Removing empty ebean.properties 

## Background Context

ebean.properties file as it does not belong to this project anymore since version 2.4 and it should be in separated plugin. also, the new version of bean (12.2.x) introduces some changes that causing to have a warning message in the console when the app startup.

