### PR TITLE
Add bloop and metals files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ generated.truststore
 *.log
 !.travis-jvmopts
 
+.bloop
+.metals
+metals.sbt
+
 # Scala-IDE specific
 .scala_dependencies
 .classpath


### PR DESCRIPTION
In case anyone is using https://scalameta.org/metals/ with this project, this adds the relevant files to `.gitignore` so they won't accidentally be committed.