### PR TITLE
Overload HttpExecution.fromThread with ExecutionContextExecutor param

### DIFF
--- a/core/play/src/main/java/play/libs/concurrent/HttpExecution.java
+++ b/core/play/src/main/java/play/libs/concurrent/HttpExecution.java
@@ -36,6 +36,18 @@ public class HttpExecution {
    * @param delegate the delegate execution context.
    * @return the execution context wrapped in an {@link play.libs.concurrent.HttpExecutionContext}.
    */
+  public static ExecutionContextExecutor fromThread(ExecutionContextExecutor delegate) {
+    return HttpExecutionContext.fromThread(delegate);
+  }
+
+  /**
+   * An ExecutionContext that executes work on the given ExecutionContext. The current thread's
+   * context ClassLoader is captured when this method is called and preserved for all executed
+   * tasks.
+   *
+   * @param delegate the delegate execution context.
+   * @return the execution context wrapped in an {@link play.libs.concurrent.HttpExecutionContext}.
+   */
   public static ExecutionContextExecutor fromThread(Executor delegate) {
     return HttpExecutionContext.fromThread(delegate);
   }

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/Application.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/Application.java
@@ -28,7 +28,7 @@ public class Application extends Controller {
 
   public CompletionStage<Result> index() {
     // Wrap an existing thread pool, using the context from the current thread
-    Executor myEc = HttpExecution.fromThread((Executor) myExecutionContext);
+    Executor myEc = HttpExecution.fromThread(myExecutionContext);
     return supplyAsync(() -> intensiveComputation(), myEc)
         .thenApplyAsync(i -> ok("Got result: " + i), myEc);
   }


### PR DESCRIPTION
No casting needed anymore (see the docs I updated).

Also the Scala API has to overload (which will be called now), only the Java API is missing it:

https://github.com/playframework/playframework/blob/eede96629f260d5c2a9c361adbaa4a271b456fde/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala#L30
