### PR TITLE
Rewind `tolerantText` buffer between failures

### DIFF
--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -316,6 +316,9 @@ public interface BodyParser<A> {
       final Function<Charset, F.Either<Exception, String>> decode =
           (Charset encodingToTry) -> {
             try {
+              // Make sure we are at the beginning of the buffer - previous decoding attempts may
+              // have managed to advance through a part of the buffer before failing.
+              byteBuffer.rewind();
               CharsetDecoder decoder =
                   encodingToTry.newDecoder().onMalformedInput(CodingErrorAction.REPORT);
               return F.Either.Right(decoder.decode(byteBuffer).toString());

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -468,6 +468,9 @@ trait PlayBodyParsers extends BodyParserUtils {
         import java.nio.charset.CodingErrorAction
         val decoder = encodingToTry.newDecoder.onMalformedInput(CodingErrorAction.REPORT)
         try {
+          // Make sure we are at the beginning of the buffer - previous decoding attempts may have
+          // managed to advance through a part of the buffer before failing.
+          byteBuffer.rewind()
           Success(decoder.decode(byteBuffer).toString)
         } catch {
           case e: CharacterCodingException =>

--- a/core/play/src/test/scala/play/api/mvc/TextBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/TextBodyParserSpec.scala
@@ -121,6 +121,14 @@ class TextBodyParserSpec extends Specification with AfterAll {
         }
       }
 
+      "as UTF-8 for undefined even if US-ASCII could parse a prefix" in {
+        val body        = ByteString("Oekraïene") // 'Oekra' can be decoded by US-ASCII
+        val postRequest = FakeRequest("POST", "/").withBody(body).withHeaders("Content-Type" -> "text/plain")
+        tolerantParse(postRequest, body) must beRight.like {
+          case text => text must beEqualTo("Oekraïene")
+        }
+      }
+
       "as UTF-8 even if the guessed encoding is utterly wrong" in {
         // This is not a full solution, so anything where we have a potentially valid encoding is seized on, even
         // when it's not the best one.

--- a/core/play/src/test/scala/play/mvc/TextBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/TextBodyParserSpec.scala
@@ -134,6 +134,15 @@ class TextBodyParserSpec extends Specification with AfterAll with MustMatchers {
         }
       }
 
+      "as UTF-8 for undefined even if US-ASCII could parse a prefix" in {
+        val body = ByteString("Oekraïene") // 'Oekra' can be decoded by US-ASCII
+        val postRequest =
+          new Http.RequestBuilder().method("POST").body(new RequestBody(body), "text/plain").req
+        tolerantParse(req(postRequest), body) must beRight.like {
+          case text => text must beEqualTo("Oekraïene")
+        }
+      }
+
       "as UTF-8 even if the guessed encoding is utterly wrong" in {
         // This is not a full solution, so anything where we have a potentially valid encoding is seized on, even
         // when it's not the best one.


### PR DESCRIPTION
`tolerantText` needs to make sure it is at the beginning of the byte
buffer every time it retries to decode. This is because previous
decoding attempts may have managed to decode a prefix, in which case,
the byte buffer cursor will no longer be pointing at the front of the
buffer.

This manifests as `tolerantText` potentially "dropping" a prefix off of
the decoded text.

Fixes #10181 