### PR TITLE
hikari pool name: default to db config name rather than autoincrement id

### DIFF
--- a/persistence/play-jdbc/src/main/resources/reference.conf
+++ b/persistence/play-jdbc/src/main/resources/reference.conf
@@ -84,7 +84,9 @@ play {
         # The maximum number of connections to make.
         maximumPoolSize = 10
 
-        # If non null, sets the name of the connection pool. Primarily used for stats reporting.
+        # If non null, sets the name of the connection pool.
+        # Defaults to the database configuration item name.
+        # Primarily used for stats reporting.
         poolName = null
 
         # This property controls whether the pool will "fail fast" if the pool cannot be seeded with

--- a/persistence/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -54,7 +54,7 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
     Try {
       logger.info(s"Creating Pool for datasource '$name'")
 
-      val hikariConfig      = new HikariCPConfig(dbConfig, config).toHikariConfig
+      val hikariConfig      = new HikariCPConfig(name, dbConfig, config).toHikariConfig
       val datasource        = new HikariDataSource(hikariConfig)
       val wrappedDataSource = ConnectionPool.wrapToLogSql(datasource, configuration)
 
@@ -88,7 +88,7 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
 /**
  * HikariCP config
  */
-private[db] class HikariCPConfig(dbConfig: DatabaseConfig, configuration: Configuration) {
+private[db] class HikariCPConfig(name: String, dbConfig: DatabaseConfig, configuration: Configuration) {
   def toHikariConfig: HikariConfig = {
     val hikariConfig = new HikariConfig()
 
@@ -123,7 +123,7 @@ private[db] class HikariCPConfig(dbConfig: DatabaseConfig, configuration: Config
     config.get[Option[String]]("connectionTestQuery").foreach(hikariConfig.setConnectionTestQuery)
     config.get[Option[Int]]("minimumIdle").foreach(hikariConfig.setMinimumIdle)
     hikariConfig.setMaximumPoolSize(config.get[Int]("maximumPoolSize"))
-    config.get[Option[String]]("poolName").foreach(hikariConfig.setPoolName)
+    hikariConfig.setPoolName(config.get[Option[String]]("poolName").getOrElse(s"HikariPool-$name"))
 
     // Infrequently used
     hikariConfig.setInitializationFailTimeout(config.get[Long]("initializationFailTimeout"))

--- a/persistence/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -88,7 +88,18 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
 /**
  * HikariCP config
  */
-private[db] class HikariCPConfig(name: String, dbConfig: DatabaseConfig, configuration: Configuration) {
+private[db] class HikariCPConfig private (
+    maybeName: Option[String],
+    dbConfig: DatabaseConfig,
+    configuration: Configuration
+) {
+  def this(name: String, dbConfig: DatabaseConfig, configuration: Configuration) =
+    this(Some(name), dbConfig, configuration)
+
+  @deprecated("Use constructor with name", "2.9.0")
+  def this(dbConfig: DatabaseConfig, configuration: Configuration) =
+    this(None, dbConfig, configuration)
+
   def toHikariConfig: HikariConfig = {
     val hikariConfig = new HikariConfig()
 
@@ -123,7 +134,10 @@ private[db] class HikariCPConfig(name: String, dbConfig: DatabaseConfig, configu
     config.get[Option[String]]("connectionTestQuery").foreach(hikariConfig.setConnectionTestQuery)
     config.get[Option[Int]]("minimumIdle").foreach(hikariConfig.setMinimumIdle)
     hikariConfig.setMaximumPoolSize(config.get[Int]("maximumPoolSize"))
-    hikariConfig.setPoolName(config.get[Option[String]]("poolName").getOrElse(s"HikariPool-$name"))
+    config
+      .get[Option[String]]("poolName")
+      .orElse(maybeName.map(name => s"HikariPool-$name"))
+      .foreach(hikariConfig.setPoolName)
 
     // Infrequently used
     hikariConfig.setInitializationFailTimeout(config.get[Long]("initializationFailTimeout"))

--- a/persistence/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -149,6 +149,7 @@ class HikariCPConfigSpec extends Specification {
 
       "poolName" in new Configs {
         val config = from("hikaricp.poolName" -> "bar")
+        new HikariCPConfig(dbConfig, config).toHikariConfig.getPoolName must beEqualTo("bar")
         new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getPoolName must beEqualTo("bar")
       }
 

--- a/persistence/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -15,7 +15,7 @@ class HikariCPConfigSpec extends Specification {
   "When reading configuration" should {
     "set dataSourceClassName when present" in new Configs {
       val config = from("hikaricp.dataSourceClassName" -> "org.postgresql.ds.PGPoolingDataSource")
-      new HikariCPConfig(DatabaseConfig(None, None, None, None, None), config).toHikariConfig.getDataSourceClassName must beEqualTo(
+      new HikariCPConfig("foo", DatabaseConfig(None, None, None, None, None), config).toHikariConfig.getDataSourceClassName must beEqualTo(
         "org.postgresql.ds.PGPoolingDataSource"
       )
     }
@@ -25,99 +25,113 @@ class HikariCPConfigSpec extends Specification {
         "hikaricp.dataSource.user"     -> "user",
         "hikaricp.dataSource.password" -> "password"
       )
-      val hikariConfig: HikariConfig = new HikariCPConfig(dbConfig, config).toHikariConfig
+      val hikariConfig: HikariConfig = new HikariCPConfig("foo", dbConfig, config).toHikariConfig
 
       hikariConfig.getDataSourceProperties.getProperty("user") must beEqualTo("user")
       hikariConfig.getDataSourceProperties.getProperty("password") must beEqualTo("password")
     }
 
     "set database url" in new Configs {
-      new HikariCPConfig(dbConfig, reference).toHikariConfig.getJdbcUrl must beEqualTo("jdbc:h2:mem:")
+      new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getJdbcUrl must beEqualTo("jdbc:h2:mem:")
     }
 
     "set connectionInitSql config" in new Configs {
       val config = from("hikaricp.connectionInitSql" -> "SELECT 1")
-      new HikariCPConfig(dbConfig, config).toHikariConfig.getConnectionInitSql must beEqualTo("SELECT 1")
+      new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getConnectionInitSql must beEqualTo("SELECT 1")
     }
 
     "respect the defaults as" in {
       "autoCommit to true" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.isAutoCommit must beTrue
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.isAutoCommit must beTrue
       }
 
       "connectionTimeout to 30 seconds" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getConnectionTimeout must beEqualTo(30.seconds.toMillis)
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getConnectionTimeout must beEqualTo(
+          30.seconds.toMillis
+        )
       }
 
       "idleTimeout to 10 minutes" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getIdleTimeout must beEqualTo(10.minutes.toMillis)
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getIdleTimeout must beEqualTo(10.minutes.toMillis)
       }
 
       "maxLifetime to 30 minutes" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getMaxLifetime must beEqualTo(30.minutes.toMillis)
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getMaxLifetime must beEqualTo(30.minutes.toMillis)
       }
 
       "validationTimeout to 5 seconds" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getValidationTimeout must beEqualTo(5.seconds.toMillis)
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getValidationTimeout must beEqualTo(
+          5.seconds.toMillis
+        )
       }
 
       "minimumIdle to 10" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getMinimumIdle must beEqualTo(10)
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getMinimumIdle must beEqualTo(10)
       }
 
       "maximumPoolSize to 10" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getMaximumPoolSize must beEqualTo(10)
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getMaximumPoolSize must beEqualTo(10)
       }
 
       "initializationFailTimeout to -1" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getInitializationFailTimeout must beEqualTo(-1)
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getInitializationFailTimeout must beEqualTo(-1)
       }
 
       "isolateInternalQueries to false" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.isIsolateInternalQueries must beFalse
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.isIsolateInternalQueries must beFalse
       }
 
       "allowPoolSuspension to false" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.isAllowPoolSuspension must beFalse
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.isAllowPoolSuspension must beFalse
       }
 
       "readOnly to false" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.isReadOnly must beFalse
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.isReadOnly must beFalse
       }
 
       "registerMBeans to false" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.isRegisterMbeans must beFalse
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.isRegisterMbeans must beFalse
       }
 
       "leakDetectionThreshold to 0 (zero)" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.getLeakDetectionThreshold must beEqualTo(0)
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getLeakDetectionThreshold must beEqualTo(0)
+      }
+    }
+
+    "generate a dynamic default for property" in {
+      "poolName" in new Configs {
+        new HikariCPConfig("foo", dbConfig, reference).toHikariConfig.getPoolName must beEqualTo("HikariPool-foo")
       }
     }
 
     "override the defaults for property" in {
       "autoCommit" in new Configs {
         val config = from("hikaricp.autoCommit" -> "false")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.isAutoCommit must beFalse
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.isAutoCommit must beFalse
       }
 
       "connectionTimeout" in new Configs {
         val config = from("hikaricp.connectionTimeout" -> "40 seconds")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.getConnectionTimeout must beEqualTo(40.seconds.toMillis)
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getConnectionTimeout must beEqualTo(
+          40.seconds.toMillis
+        )
       }
 
       "idleTimeout" in new Configs {
         val config = from("hikaricp.idleTimeout" -> "5 minutes")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.getIdleTimeout must beEqualTo(5.minutes.toMillis)
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getIdleTimeout must beEqualTo(5.minutes.toMillis)
       }
 
       "maxLifetime" in new Configs {
         val config = from("hikaricp.maxLifetime" -> "15 minutes")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.getMaxLifetime must beEqualTo(15.minutes.toMillis)
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getMaxLifetime must beEqualTo(15.minutes.toMillis)
       }
 
       "validationTimeout" in new Configs {
         val config = from("hikaricp.validationTimeout" -> "10 seconds")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.getValidationTimeout must beEqualTo(10.seconds.toMillis)
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getValidationTimeout must beEqualTo(
+          10.seconds.toMillis
+        )
       }
 
       "minimumIdle" in new Configs {
@@ -125,37 +139,42 @@ class HikariCPConfigSpec extends Specification {
           "hikaricp.minimumIdle"     -> "20",
           "hikaricp.maximumPoolSize" -> "40"
         )
-        new HikariCPConfig(dbConfig, config).toHikariConfig.getMinimumIdle must beEqualTo(20)
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getMinimumIdle must beEqualTo(20)
       }
 
       "maximumPoolSize" in new Configs {
         val config = from("hikaricp.maximumPoolSize" -> "20")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.getMaximumPoolSize must beEqualTo(20)
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getMaximumPoolSize must beEqualTo(20)
+      }
+
+      "poolName" in new Configs {
+        val config = from("hikaricp.poolName" -> "bar")
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getPoolName must beEqualTo("bar")
       }
 
       "initializationFailTimeout" in new Configs {
         val config = from("hikaricp.initializationFailTimeout" -> "10")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.getInitializationFailTimeout must beEqualTo(10)
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getInitializationFailTimeout must beEqualTo(10)
       }
 
       "isolateInternalQueries" in new Configs {
         val config = from("hikaricp.isolateInternalQueries" -> "true")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.isIsolateInternalQueries must beTrue
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.isIsolateInternalQueries must beTrue
       }
 
       "allowPoolSuspension" in new Configs {
         val config = from("hikaricp.allowPoolSuspension" -> "true")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.isAllowPoolSuspension must beTrue
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.isAllowPoolSuspension must beTrue
       }
 
       "readOnly" in new Configs {
         val config = from("hikaricp.readOnly" -> "true")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.isReadOnly must beTrue
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.isReadOnly must beTrue
       }
 
       "leakDetectionThreshold" in new Configs {
         val config = from("hikaricp.leakDetectionThreshold" -> "3 seconds")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.getLeakDetectionThreshold must beEqualTo(3000L)
+        new HikariCPConfig("foo", dbConfig, config).toHikariConfig.getLeakDetectionThreshold must beEqualTo(3000L)
       }
     }
   }


### PR DESCRIPTION
## Purpose

This makes JMX/thread/logs troubleshooting easier when dealing with many datasources, by overriding the built-in opaque, auto-increment default `HikariPool-xxxx` with a semantic name.

https://github.com/brettwooldridge/HikariCP/blob/HikariCP-3.4.1/src/main/java/com/zaxxer/hikari/HikariConfig.java#L1078-L1102

## Background Context

As far as I can tell, database config names are unique across a Play app instance, and in the case where we have several apps running on the same JVM, it does not seem to be a problem as:
- Threads names don't need to be unique
- I don't see how/why pools of different apps would share the same [metrics registry/trackers](https://github.com/brettwooldridge/HikariCP/blob/a51e6a07e856db5f0bce969d83126a0e4dad676a/src/main/java/com/zaxxer/hikari/HikariConfig.java#L627-L672) (which might trigger some weird behavior, but looking at the code, I couldn't find any potential failure)