### PR TITLE
Add addAttrs(...) to Request

### DIFF
--- a/core/play-java/src/test/java/play/mvc/AttributesTest.java
+++ b/core/play-java/src/test/java/play/mvc/AttributesTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import play.core.j.RequestHeaderImpl;
+import play.libs.typedmap.TypedEntry;
 import play.libs.typedmap.TypedKey;
 
 import java.util.Arrays;
@@ -63,6 +64,55 @@ public final class AttributesTest {
 
     Http.RequestHeader newRequestHeader =
         requestHeader.addAttr(color, "red").addAttr(number, 5L).addAttr(color, "white");
+
+    assertTrue(newRequestHeader.attrs().containsKey(number));
+    assertTrue(newRequestHeader.attrs().containsKey(color));
+    assertEquals(((Long) 5L), newRequestHeader.attrs().get(number));
+    assertEquals("white", newRequestHeader.attrs().get(color));
+  }
+
+  @Test
+  public void testRequestHeader_addMultipleAttributes() {
+    final TypedKey<Long> number = TypedKey.create("number");
+    final TypedKey<String> color = TypedKey.create("color");
+
+    final Http.RequestHeader newRequestHeader =
+        requestHeader.addAttrs(new TypedEntry<>(color, "red"), new TypedEntry<>(number, 3L));
+
+    assertTrue(newRequestHeader.attrs().containsKey(color));
+    assertTrue(newRequestHeader.attrs().containsKey(number));
+    assertEquals("red", newRequestHeader.attrs().get(color));
+    assertEquals((Long) 3L, newRequestHeader.attrs().get(number));
+  }
+
+  @Test
+  public void testRequestHeader_KeepCurrentAttributesWhenAddingMultipleOnes() {
+    final TypedKey<Long> number = TypedKey.create("number");
+    final TypedKey<String> color = TypedKey.create("color");
+    final TypedKey<String> direction = TypedKey.create("direction");
+
+    Http.RequestHeader newRequestHeader =
+        requestHeader
+            .addAttr(color, "red")
+            .addAttrs(new TypedEntry<>(number, 5L), new TypedEntry<>(direction, "left"));
+
+    assertTrue(newRequestHeader.attrs().containsKey(number));
+    assertTrue(newRequestHeader.attrs().containsKey(direction));
+    assertTrue(newRequestHeader.attrs().containsKey(color));
+    assertEquals(((Long) 5L), newRequestHeader.attrs().get(number));
+    assertEquals("left", newRequestHeader.attrs().get(direction));
+    assertEquals("red", newRequestHeader.attrs().get(color));
+  }
+
+  @Test
+  public void testRequestHeader_OverrideExistingValueWhenAddingMultipleAttributes() {
+    final TypedKey<Long> number = TypedKey.create("number");
+    final TypedKey<String> color = TypedKey.create("color");
+
+    Http.RequestHeader newRequestHeader =
+        requestHeader
+            .addAttr(color, "red")
+            .addAttrs(new TypedEntry<>(number, 5L), new TypedEntry<>(color, "white"));
 
     assertTrue(newRequestHeader.attrs().containsKey(number));
     assertTrue(newRequestHeader.attrs().containsKey(color));

--- a/core/play/src/main/java/play/libs/typedmap/TypedEntry.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedEntry.java
@@ -28,4 +28,9 @@ public final class TypedEntry<A> {
   public A value() {
     return value;
   }
+
+  /** @return the Scala version for this entry. */
+  public play.api.libs.typedmap.TypedEntry<A> asScala() {
+    return new play.api.libs.typedmap.TypedEntry<>(this.key.asScala(), this.value);
+  }
 }

--- a/core/play/src/main/java/play/libs/typedmap/TypedMap.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedMap.java
@@ -79,11 +79,6 @@ public final class TypedMap {
     return new TypedMap(underlying.updated(key.asScala(), value));
   }
 
-  private static <A> play.api.libs.typedmap.TypedMap putEntry(
-      final play.api.libs.typedmap.TypedMap typedMap, final TypedEntry<A> entry) {
-    return typedMap.updated(entry.key().asScala(), entry.value());
-  }
-
   /**
    * Update the map with one entry, returning a new instance of the map.
    *
@@ -126,7 +121,7 @@ public final class TypedMap {
   public TypedMap putAll(TypedEntry<?>... entries) {
     play.api.libs.typedmap.TypedMap newUnderlying = underlying;
     for (TypedEntry<?> e : entries) {
-      newUnderlying = putEntry(newUnderlying, e);
+      newUnderlying = newUnderlying.$plus(e.asScala());
     }
     return new TypedMap(newUnderlying);
   }

--- a/core/play/src/main/java/play/libs/typedmap/TypedMap.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedMap.java
@@ -7,6 +7,8 @@ package play.libs.typedmap;
 import play.api.libs.typedmap.TypedMap$;
 import scala.compat.java8.OptionConverters;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -119,6 +121,16 @@ public final class TypedMap {
    * @return A new instance of the map with the new entries added.
    */
   public TypedMap putAll(TypedEntry<?>... entries) {
+    return putAll(Arrays.asList(entries));
+  }
+
+  /**
+   * Update the map with several entries, returning a new instance of the map.
+   *
+   * @param entries The new entries to add to the map.
+   * @return A new instance of the map with the new entries added.
+   */
+  public TypedMap putAll(List<TypedEntry<?>> entries) {
     play.api.libs.typedmap.TypedMap newUnderlying = underlying;
     for (TypedEntry<?> e : entries) {
       newUnderlying = newUnderlying.$plus(e.asScala());

--- a/core/play/src/main/java/play/libs/typedmap/TypedMap.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedMap.java
@@ -5,7 +5,6 @@
 package play.libs.typedmap;
 
 import play.api.libs.typedmap.TypedMap$;
-import play.libs.Scala;
 import scala.compat.java8.OptionConverters;
 
 import java.util.Optional;
@@ -86,6 +85,39 @@ public final class TypedMap {
   }
 
   /**
+   * Update the map with one entry, returning a new instance of the map.
+   *
+   * @param e1 The new entry to add to the map.
+   * @return A new instance of the map with the new entry added.
+   */
+  public TypedMap putAll(TypedEntry<?> e1) {
+    return new TypedMap(underlying.$plus(e1.asScala()));
+  }
+
+  /**
+   * Update the map with two entries, returning a new instance of the map.
+   *
+   * @param e1 The first new entry to add to the map.
+   * @param e2 The second new entry to add to the map.
+   * @return A new instance of the map with the new entries added.
+   */
+  public TypedMap putAll(TypedEntry<?> e1, TypedEntry<?> e2) {
+    return new TypedMap(underlying.$plus(e1.asScala(), e2.asScala()));
+  }
+
+  /**
+   * Update the map with three entries, returning a new instance of the map.
+   *
+   * @param e1 The first new entry to add to the map.
+   * @param e2 The second new entry to add to the map.
+   * @param e3 The third new entry to add to the map.
+   * @return A new instance of the map with the new entries added.
+   */
+  public TypedMap putAll(TypedEntry<?> e1, TypedEntry<?> e2, TypedEntry<?> e3) {
+    return new TypedMap(underlying.$plus(e1.asScala(), e2.asScala(), e3.asScala()));
+  }
+
+  /**
    * Update the map with several entries, returning a new instance of the map.
    *
    * @param entries The new entries to add to the map.
@@ -100,6 +132,39 @@ public final class TypedMap {
   }
 
   /**
+   * Removes a key from the map, returning a new instance of the map.
+   *
+   * @param k1 The key to remove.
+   * @return A new instance of the map with the entry removed.
+   */
+  public TypedMap remove(TypedKey<?> k1) {
+    return new TypedMap(underlying.$minus(k1.asScala()));
+  }
+
+  /**
+   * Removes two keys from the map, returning a new instance of the map.
+   *
+   * @param k1 The first key to remove.
+   * @param k2 The second key to remove.
+   * @return A new instance of the map with the entries removed.
+   */
+  public TypedMap remove(TypedKey<?> k1, TypedKey<?> k2) {
+    return new TypedMap(underlying.$minus(k1.asScala(), k2.asScala()));
+  }
+
+  /**
+   * Removes three keys from the map, returning a new instance of the map.
+   *
+   * @param k1 The first key to remove.
+   * @param k2 The second key to remove.
+   * @param k3 The third key to remove.
+   * @return A new instance of the map with the entries removed.
+   */
+  public TypedMap remove(TypedKey<?> k1, TypedKey<?> k2, TypedKey<?> k3) {
+    return new TypedMap(underlying.$minus(k1.asScala(), k2.asScala(), k3.asScala()));
+  }
+
+  /**
    * Removes keys from the map, returning a new instance of the map.
    *
    * @param keys The keys to remove.
@@ -108,7 +173,7 @@ public final class TypedMap {
   public TypedMap remove(TypedKey<?>... keys) {
     play.api.libs.typedmap.TypedMap newUnderlying = underlying;
     for (TypedKey<?> k : keys) {
-      newUnderlying = newUnderlying.$minus(Scala.varargs(k.asScala()));
+      newUnderlying = newUnderlying.$minus(k.asScala());
     }
     return new TypedMap(newUnderlying);
   }
@@ -123,6 +188,33 @@ public final class TypedMap {
   /** @return the empty <code>TypedMap</code> instance. */
   public static TypedMap empty() {
     return empty;
+  }
+
+  /**
+   * @param e1 typed entry
+   * @return a newly built <code>TypedMap</code> from a entry of key and value.
+   */
+  public static TypedMap create(TypedEntry<?> e1) {
+    return empty.putAll(e1);
+  }
+
+  /**
+   * @param e1 first typed entry
+   * @param e2 second typed entry
+   * @return a newly built <code>TypedMap</code> from a two entries of keys and values.
+   */
+  public static TypedMap create(TypedEntry<?> e1, TypedEntry<?> e2) {
+    return empty.putAll(e1, e2);
+  }
+
+  /**
+   * @param e1 first typed entry
+   * @param e2 second typed entry
+   * @param e3 third typed entry
+   * @return a newly built <code>TypedMap</code> from a three entries of keys and values.
+   */
+  public static TypedMap create(TypedEntry<?> e1, TypedEntry<?> e2, TypedEntry<?> e3) {
+    return empty.putAll(e1, e2, e3);
   }
 
   /**

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -278,6 +278,14 @@ public class Http {
     RequestHeader addAttrs(TypedEntry<?>... entries);
 
     /**
+     * Create a new versions of this object with the given attributes attached to it.
+     *
+     * @param entries The new attributes.
+     * @return The new version of this object with the new attributes.
+     */
+    RequestHeader addAttrs(List<TypedEntry<?>> entries);
+
+    /**
      * Create a new versions of this object with the given attribute removed.
      *
      * @param key The key of the attribute to remove.
@@ -514,6 +522,9 @@ public class Http {
 
     // Override return type
     Request addAttrs(TypedEntry<?>... entries);
+
+    // Override return type
+    Request addAttrs(List<TypedEntry<?>> entries);
 
     // Override return type
     Request removeAttr(TypedKey<?> key);

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -24,6 +24,7 @@ import play.libs.Files;
 import play.libs.Json;
 import play.libs.Scala;
 import play.libs.XML;
+import play.libs.typedmap.TypedEntry;
 import play.libs.typedmap.TypedKey;
 import play.libs.typedmap.TypedMap;
 import play.mvc.Http.Cookie.SameSite;
@@ -240,6 +241,14 @@ public class Http {
      * @return The new version of this object with the new attribute.
      */
     <A> RequestHeader addAttr(TypedKey<A> key, A value);
+
+    /**
+     * Create a new versions of this object with the given attributes attached to it.
+     *
+     * @param entries The new attributes.
+     * @return The new version of this object with the new attributes.
+     */
+    RequestHeader addAttrs(TypedEntry<?>... entries);
 
     /**
      * Create a new versions of this object with the given attribute removed.
@@ -466,6 +475,9 @@ public class Http {
 
     // Override return type
     <A> Request addAttr(TypedKey<A> key, A value);
+
+    // Override return type
+    Request addAttrs(TypedEntry<?>... entries);
 
     // Override return type
     Request removeAttr(TypedKey<?> key);

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -243,6 +243,33 @@ public class Http {
     <A> RequestHeader addAttr(TypedKey<A> key, A value);
 
     /**
+     * Create a new versions of this object with the given attribute attached to it.
+     *
+     * @param e1 The new attribute.
+     * @return The new version of this object with the new attribute.
+     */
+    RequestHeader addAttrs(TypedEntry<?> e1);
+
+    /**
+     * Create a new versions of this object with the given attributes attached to it.
+     *
+     * @param e1 The first new attribute.
+     * @param e2 The second new attribute.
+     * @return The new version of this object with the new attributes.
+     */
+    RequestHeader addAttrs(TypedEntry<?> e1, TypedEntry<?> e2);
+
+    /**
+     * Create a new versions of this object with the given attributes attached to it.
+     *
+     * @param e1 The first new attribute.
+     * @param e2 The second new attribute.
+     * @param e3 The third new attribute.
+     * @return The new version of this object with the new attributes.
+     */
+    RequestHeader addAttrs(TypedEntry<?> e1, TypedEntry<?> e2, TypedEntry<?> e3);
+
+    /**
      * Create a new versions of this object with the given attributes attached to it.
      *
      * @param entries The new attributes.
@@ -475,6 +502,15 @@ public class Http {
 
     // Override return type
     <A> Request addAttr(TypedKey<A> key, A value);
+
+    // Override return type
+    Request addAttrs(TypedEntry<?> e1);
+
+    // Override return type
+    Request addAttrs(TypedEntry<?> e1, TypedEntry<?> e2);
+
+    // Override return type
+    Request addAttrs(TypedEntry<?> e1, TypedEntry<?> e2, TypedEntry<?> e3);
 
     // Override return type
     Request addAttrs(TypedEntry<?>... entries);

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedEntry.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedEntry.scala
@@ -19,4 +19,9 @@ final case class TypedEntry[A](key: TypedKey[A], value: A) {
    * Convert the entry into a standard pair.
    */
   def toPair: (TypedKey[A], A) = (key, value)
+
+  /**
+   * @return The Java version for this entry.
+   */
+  def asJava: play.libs.typedmap.TypedEntry[A] = new play.libs.typedmap.TypedEntry[A](key.asJava, value)
 }

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -59,12 +59,66 @@ trait TypedMap {
   def updated[A](key: TypedKey[A], value: A): TypedMap
 
   /**
+   * Update the map with one entry, returning a new instance of the map.
+   *
+   * @param e1 The new entry to add to the map.
+   * @return A new instance of the map with the new entry added.
+   */
+  def +(e1: TypedEntry[_]): TypedMap
+
+  /**
+   * Update the map with two entries, returning a new instance of the map.
+   *
+   * @param e1 The first new entry to add to the map.
+   * @param e2 The second new entry to add to the map.
+   * @return A new instance of the map with the new entries added.
+   */
+  def +(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap
+
+  /**
+   * Update the map with three entries, returning a new instance of the map.
+   *
+   * @param e1 The first new entry to add to the map.
+   * @param e2 The second new entry to add to the map.
+   * @param e3 The third new entry to add to the map.
+   * @return A new instance of the map with the new entries added.
+   */
+  def +(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap
+
+  /**
    * Update the map with several entries, returning a new instance of the map.
    *
    * @param entries The new entries to add to the map.
    * @return A new instance of the map with the new entries added.
    */
   def +(entries: TypedEntry[_]*): TypedMap
+
+  /**
+   * Removes a key from the map, returning a new instance of the map.
+   *
+   * @param e1 The key to remove.
+   * @return A new instance of the map with the entry removed.
+   */
+  def -(e1: TypedKey[_]): TypedMap
+
+  /**
+   * Removes two keys from the map, returning a new instance of the map.
+   *
+   * @param e1 The first key to remove.
+   * @param e2 The second key to remove.
+   * @return A new instance of the map with the entries removed.
+   */
+  def -(e1: TypedKey[_], e2: TypedKey[_]): TypedMap
+
+  /**
+   * Removes three keys from the map, returning a new instance of the map.
+   *
+   * @param e1 The first key to remove.
+   * @param e2 The second key to remove.
+   * @param e3 The third key to remove.
+   * @return A new instance of the map with the entries removed.
+   */
+  def -(e1: TypedKey[_], e2: TypedKey[_], e3: TypedKey[_]): TypedMap
 
   /**
    * Removes keys from the map, returning a new instance of the map.
@@ -88,6 +142,21 @@ object TypedMap {
   val empty = new DefaultTypedMap(immutable.Map.empty)
 
   /**
+   * Builds a [[TypedMap]] from an entry of key and value.
+   */
+  def apply(e1: TypedEntry[_]): TypedMap = TypedMap.empty + e1
+
+  /**
+   * Builds a [[TypedMap]] from two entries of keys and values.
+   */
+  def apply(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap = TypedMap.empty + (e1, e2)
+
+  /**
+   * Builds a [[TypedMap]] from three entries of keys and values.
+   */
+  def apply(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap = TypedMap.empty + (e1, e2, e3)
+
+  /**
    * Builds a [[TypedMap]] from a list of keys and values.
    */
   def apply(entries: TypedEntry[_]*): TypedMap = {
@@ -103,13 +172,21 @@ private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Ma
   override def get[A](key: TypedKey[A]): Option[A]              = m.get(key).asInstanceOf[Option[A]]
   override def contains(key: TypedKey[_]): Boolean              = m.contains(key)
   override def updated[A](key: TypedKey[A], value: A): TypedMap = new DefaultTypedMap(m.updated(key, value))
+  override def +(e1: TypedEntry[_]): TypedMap                   = new DefaultTypedMap(m.updated(e1.key, e1.value))
+  override def +(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap =
+    new DefaultTypedMap(m + (e1.key -> e1.value) + (e2.key -> e2.value))
+  override def +(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap =
+    new DefaultTypedMap(m + (e1.key -> e1.value) + (e2.key -> e2.value) + (e3.key -> e3.value))
   override def +(entries: TypedEntry[_]*): TypedMap = {
     val m2 = entries.foldLeft(m) {
       case (m1, e) => m1.updated(e.key, e.value)
     }
     new DefaultTypedMap(m2)
   }
-  def -(keys: TypedKey[_]*): TypedMap = {
+  override def -(k1: TypedKey[_]): TypedMap                                   = new DefaultTypedMap(m - k1)
+  override def -(k1: TypedKey[_], k2: TypedKey[_]): TypedMap                  = new DefaultTypedMap(m - k1 - k2)
+  override def -(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap = new DefaultTypedMap(m - k1 - k2 - k3)
+  override def -(keys: TypedKey[_]*): TypedMap = {
     val m2 = keys.foldLeft(m) {
       case (m1, k) => m1 - k
     }

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -91,6 +91,10 @@ trait Request[+A] extends RequestHeader {
     new RequestImpl[A](connection, method, target, version, headers, newAttrs, body)
   override def addAttr[B](key: TypedKey[B], value: B): Request[A] =
     withAttrs(attrs.updated(key, value))
+  override def addAttrs(e1: TypedEntry[_]): Request[A]                    = withAttrs(attrs + e1)
+  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Request[A] = withAttrs(attrs + (e1, e2))
+  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): Request[A] =
+    withAttrs(attrs + (e1, e2, e3))
   override def addAttrs(entries: TypedEntry[_]*): Request[A] =
     withAttrs(attrs + (entries: _*))
   override def removeAttr(key: TypedKey[_]): Request[A] =

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -9,6 +9,7 @@ import java.util.Optional
 
 import play.api.i18n.Lang
 import play.api.i18n.Messages
+import play.api.libs.typedmap.TypedEntry
 import play.api.libs.typedmap.TypedKey
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.request.RemoteConnection
@@ -90,6 +91,8 @@ trait Request[+A] extends RequestHeader {
     new RequestImpl[A](connection, method, target, version, headers, newAttrs, body)
   override def addAttr[B](key: TypedKey[B], value: B): Request[A] =
     withAttrs(attrs.updated(key, value))
+  override def addAttrs(entries: TypedEntry[_]*): Request[A] =
+    withAttrs(attrs + (entries: _*))
   override def removeAttr(key: TypedKey[_]): Request[A] =
     withAttrs(attrs - key)
   override def withTransientLang(lang: Lang): Request[A] =

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -153,6 +153,33 @@ trait RequestHeader {
     withAttrs(attrs.updated(key, value))
 
   /**
+   * Create a new versions of this object with the given attribute attached to it.
+   *
+   * @param e1 The new attribute.
+   * @return The new version of this object with the new attribute.
+   */
+  def addAttrs(e1: TypedEntry[_]): RequestHeader = withAttrs(attrs + e1)
+
+  /**
+   * Create a new versions of this object with the given attributes attached to it.
+   *
+   * @param e1 The first new attribute.
+   * @param e2 The second new attribute.
+   * @return The new version of this object with the new attributes.
+   */
+  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): RequestHeader = withAttrs(attrs + (e1, e2))
+
+  /**
+   * Create a new versions of this object with the given attributes attached to it.
+   *
+   * @param e1 The first new attribute.
+   * @param e2 The second new attribute.
+   * @param e3 The third new attribute.
+   * @return The new version of this object with the new attributes.
+   */
+  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): RequestHeader = withAttrs(attrs + (e1, e2, e3))
+
+  /**
    * Create a new versions of this object with the given attributes attached to it.
    *
    * @param entries The new attributes.

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -12,6 +12,7 @@ import play.api.http.MediaRange
 import play.api.http.MediaType
 import play.api.i18n.Lang
 import play.api.i18n.Messages
+import play.api.libs.typedmap.TypedEntry
 import play.api.libs.typedmap.TypedKey
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.request._
@@ -150,6 +151,15 @@ trait RequestHeader {
    */
   def addAttr[A](key: TypedKey[A], value: A): RequestHeader =
     withAttrs(attrs.updated(key, value))
+
+  /**
+   * Create a new versions of this object with the given attributes attached to it.
+   *
+   * @param entries The new attributes.
+   * @return The new version of this object with the new attributes.
+   */
+  def addAttrs(entries: TypedEntry[_]*): RequestHeader =
+    withAttrs(attrs + (entries: _*))
 
   /**
    * Create a new versions of this object with the given attribute removed.

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -208,8 +208,9 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): JRequestHeader = withAttrs(attrs.putAll(e1, e2))
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): JRequestHeader =
     withAttrs(attrs.putAll(e1, e2, e3))
-  override def addAttrs(entries: TypedEntry[_]*): JRequestHeader = withAttrs(attrs.putAll(entries: _*))
-  override def removeAttr(key: TypedKey[_]): JRequestHeader      = withAttrs(attrs.remove(key))
+  override def addAttrs(entries: TypedEntry[_]*): JRequestHeader           = withAttrs(attrs.putAll(entries: _*))
+  override def addAttrs(entries: util.List[TypedEntry[_]]): JRequestHeader = withAttrs(attrs.putAll(entries))
+  override def removeAttr(key: TypedKey[_]): JRequestHeader                = withAttrs(attrs.remove(key))
 
   override def withBody(body: RequestBody): JRequest = new JRequestImpl(header.withBody(body))
 
@@ -278,8 +279,9 @@ class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(reque
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): JRequest = withAttrs(attrs.putAll(e1, e2))
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): JRequest =
     withAttrs(attrs.putAll(e1, e2, e3))
-  override def addAttrs(entries: TypedEntry[_]*): JRequest = withAttrs(attrs.putAll(entries: _*))
-  override def removeAttr(key: TypedKey[_]): JRequest      = withAttrs(attrs.remove(key))
+  override def addAttrs(entries: TypedEntry[_]*): JRequest           = withAttrs(attrs.putAll(entries: _*))
+  override def addAttrs(entries: util.List[TypedEntry[_]]): JRequest = withAttrs(attrs.putAll(entries))
+  override def removeAttr(key: TypedKey[_]): JRequest                = withAttrs(attrs.remove(key))
 
   override def body: RequestBody                     = request.body
   override def hasBody: Boolean                      = request.hasBody

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -255,7 +255,16 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override lazy val getHeaders: Http.Headers = header.headers.asJava
 }
 
-class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(request) with JRequest {
+/**
+ * trait needed as workaround for https://github.com/scala/bug/issues/11944
+ * Also see original pull request: https://github.com/playframework/playframework/pull/10199
+ * sealed so that lack of implementation can't be accidentally used elsewhere
+ */
+private[j] sealed trait RequestImplHelper extends JRequest {
+  override def addAttrs(entries: TypedEntry[_]*): JRequest = ???
+}
+
+class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(request) with RequestImplHelper {
   override def asScala: Request[RequestBody] = request
 
   override def attrs: TypedMap                                  = new TypedMap(asScala.attrs)

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -25,6 +25,7 @@ import play.api.Environment
 import play.api.mvc.request.RemoteConnection
 import play.api.mvc.request.RequestTarget
 import play.i18n
+import play.libs.typedmap.TypedEntry
 import play.libs.typedmap.TypedKey
 import play.libs.typedmap.TypedMap
 import play.mvc.Http.RequestBody
@@ -203,6 +204,7 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def attrs: TypedMap                                        = new TypedMap(header.attrs)
   override def withAttrs(newAttrs: TypedMap): JRequestHeader          = header.withAttrs(newAttrs.asScala).asJava
   override def addAttr[A](key: TypedKey[A], value: A): JRequestHeader = withAttrs(attrs.put(key, value))
+  override def addAttrs(entries: TypedEntry[_]*): JRequestHeader      = withAttrs(attrs.putAll(entries: _*))
   override def removeAttr(key: TypedKey[_]): JRequestHeader           = withAttrs(attrs.remove(key))
 
   override def withBody(body: RequestBody): JRequest = new JRequestImpl(header.withBody(body))
@@ -259,6 +261,7 @@ class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(reque
   override def attrs: TypedMap                                  = new TypedMap(asScala.attrs)
   override def withAttrs(newAttrs: TypedMap): JRequest          = new JRequestImpl(request.withAttrs(newAttrs.asScala))
   override def addAttr[A](key: TypedKey[A], value: A): JRequest = withAttrs(attrs.put(key, value))
+  override def addAttrs(entries: TypedEntry[_]*): JRequest      = withAttrs(attrs.putAll(entries: _*))
   override def removeAttr(key: TypedKey[_]): JRequest           = withAttrs(attrs.remove(key))
 
   override def body: RequestBody                     = request.body

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -201,11 +201,15 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def remoteAddress: String = header.remoteAddress
   override def secure: Boolean       = header.secure
 
-  override def attrs: TypedMap                                        = new TypedMap(header.attrs)
-  override def withAttrs(newAttrs: TypedMap): JRequestHeader          = header.withAttrs(newAttrs.asScala).asJava
-  override def addAttr[A](key: TypedKey[A], value: A): JRequestHeader = withAttrs(attrs.put(key, value))
-  override def addAttrs(entries: TypedEntry[_]*): JRequestHeader      = withAttrs(attrs.putAll(entries: _*))
-  override def removeAttr(key: TypedKey[_]): JRequestHeader           = withAttrs(attrs.remove(key))
+  override def attrs: TypedMap                                                = new TypedMap(header.attrs)
+  override def withAttrs(newAttrs: TypedMap): JRequestHeader                  = header.withAttrs(newAttrs.asScala).asJava
+  override def addAttr[A](key: TypedKey[A], value: A): JRequestHeader         = withAttrs(attrs.put(key, value))
+  override def addAttrs(e1: TypedEntry[_]): JRequestHeader                    = withAttrs(attrs.putAll(e1))
+  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): JRequestHeader = withAttrs(attrs.putAll(e1, e2))
+  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): JRequestHeader =
+    withAttrs(attrs.putAll(e1, e2, e3))
+  override def addAttrs(entries: TypedEntry[_]*): JRequestHeader = withAttrs(attrs.putAll(entries: _*))
+  override def removeAttr(key: TypedKey[_]): JRequestHeader      = withAttrs(attrs.remove(key))
 
   override def withBody(body: RequestBody): JRequest = new JRequestImpl(header.withBody(body))
 
@@ -267,11 +271,15 @@ private[j] sealed trait RequestImplHelper extends JRequest {
 class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(request) with RequestImplHelper {
   override def asScala: Request[RequestBody] = request
 
-  override def attrs: TypedMap                                  = new TypedMap(asScala.attrs)
-  override def withAttrs(newAttrs: TypedMap): JRequest          = new JRequestImpl(request.withAttrs(newAttrs.asScala))
-  override def addAttr[A](key: TypedKey[A], value: A): JRequest = withAttrs(attrs.put(key, value))
-  override def addAttrs(entries: TypedEntry[_]*): JRequest      = withAttrs(attrs.putAll(entries: _*))
-  override def removeAttr(key: TypedKey[_]): JRequest           = withAttrs(attrs.remove(key))
+  override def attrs: TypedMap                                          = new TypedMap(asScala.attrs)
+  override def withAttrs(newAttrs: TypedMap): JRequest                  = new JRequestImpl(request.withAttrs(newAttrs.asScala))
+  override def addAttr[A](key: TypedKey[A], value: A): JRequest         = withAttrs(attrs.put(key, value))
+  override def addAttrs(e1: TypedEntry[_]): JRequest                    = withAttrs(attrs.putAll(e1))
+  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): JRequest = withAttrs(attrs.putAll(e1, e2))
+  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): JRequest =
+    withAttrs(attrs.putAll(e1, e2, e3))
+  override def addAttrs(entries: TypedEntry[_]*): JRequest = withAttrs(attrs.putAll(entries: _*))
+  override def removeAttr(key: TypedKey[_]): JRequest      = withAttrs(attrs.remove(key))
 
   override def body: RequestBody                     = request.body
   override def hasBody: Boolean                      = request.hasBody

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -11,6 +11,7 @@ import play.api.http.HeaderNames._
 import play.api.http.HttpConfiguration
 import play.api.i18n.Lang
 import play.api.i18n.Messages
+import play.api.libs.typedmap.TypedEntry
 import play.api.libs.typedmap.TypedKey
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.request.DefaultRequestFactory
@@ -67,6 +68,34 @@ class RequestHeaderSpec extends Specification {
 
         requestHeader.attrs(y) must_== "white"
         requestHeader.attrs(x) must_== 3
+      }
+      "can add multiple attributes" in {
+        val x   = TypedKey[Int]("x")
+        val y   = TypedKey[Int]("y")
+        val req = dummyRequestHeader().addAttrs(TypedEntry(x, 3), TypedEntry(y, 4))
+        req.attrs(x) must_== 3
+        req.attrs(y) must_== 4
+      }
+      "keep current attributes when adding multiple ones" in {
+        val x = TypedKey[Int]
+        val y = TypedKey[Int]
+        val z = TypedKey[String]
+        dummyRequestHeader()
+          .withAttrs(TypedMap(z -> "hello"))
+          .addAttrs(TypedEntry(x, 3), TypedEntry(y, 4))
+          .attrs(z) must_== "hello"
+      }
+      "overrides current attribute value when adding multiple attributes" in {
+        val x = TypedKey[Int]
+        val y = TypedKey[Int]
+        val z = TypedKey[String]
+        val requestHeader = dummyRequestHeader()
+          .withAttrs(TypedMap(z -> "hello"))
+          .addAttrs(TypedEntry(x, 3), TypedEntry(y, 4), TypedEntry(z, "white"))
+
+        requestHeader.attrs(z) must_== "white"
+        requestHeader.attrs(x) must_== 3
+        requestHeader.attrs(y) must_== 4
       }
       "can set two attributes and get both back" in {
         val x = TypedKey[Int]("x")

--- a/core/play/src/test/scala/play/api/mvc/RequestSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestSpec.scala
@@ -6,6 +6,7 @@ package play.api.mvc
 
 import org.specs2.mutable.Specification
 import play.api.http.HttpConfiguration
+import play.api.libs.typedmap.TypedEntry
 import play.api.libs.typedmap.TypedKey
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.request.DefaultRequestFactory
@@ -16,6 +17,23 @@ import play.mvc.Http.RequestBody
 class RequestSpec extends Specification {
   "request" should {
     "have typed attributes" in {
+      "can set and get a single attribute" in {
+        val x = TypedKey[Int]("x")
+        dummyRequest().withAttrs(TypedMap(x -> 3)).attrs(x) must_== 3
+      }
+      "can set two attributes and get one back" in {
+        val x = TypedKey[Int]("x")
+        val y = TypedKey[String]("y")
+        dummyRequest().withAttrs(TypedMap(x -> 3, y -> "hello")).attrs(y) must_== "hello"
+      }
+      "getting a set attribute should be Some" in {
+        val x = TypedKey[Int]("x")
+        dummyRequest().withAttrs(TypedMap(x -> 5)).attrs.get(x) must beSome(5)
+      }
+      "getting a nonexistent attribute should be None" in {
+        val x = TypedKey[Int]("x")
+        dummyRequest().attrs.get(x) must beNone
+      }
       "can add single attribute" in {
         val x = TypedKey[Int]("x")
         dummyRequest().addAttr(x, 3).attrs(x) must_== 3
@@ -35,6 +53,55 @@ class RequestSpec extends Specification {
 
         request.attrs(y) must_== "white"
         request.attrs(x) must_== 3
+      }
+      "can add multiple attributes" in {
+        val x   = TypedKey[Int]("x")
+        val y   = TypedKey[Int]("y")
+        val req = dummyRequest().addAttrs(TypedEntry(x, 3), TypedEntry(y, 4))
+        req.attrs(x) must_== 3
+        req.attrs(y) must_== 4
+      }
+      "keep current attributes when adding multiple ones" in {
+        val x = TypedKey[Int]
+        val y = TypedKey[Int]
+        val z = TypedKey[String]
+        dummyRequest()
+          .withAttrs(TypedMap(z -> "hello"))
+          .addAttrs(TypedEntry(x, 3), TypedEntry(y, 4))
+          .attrs(z) must_== "hello"
+      }
+      "overrides current attribute value when adding multiple attributes" in {
+        val x = TypedKey[Int]
+        val y = TypedKey[Int]
+        val z = TypedKey[String]
+        val requestHeader = dummyRequest()
+          .withAttrs(TypedMap(z -> "hello"))
+          .addAttrs(TypedEntry(x, 3), TypedEntry(y, 4), TypedEntry(z, "white"))
+
+        requestHeader.attrs(z) must_== "white"
+        requestHeader.attrs(x) must_== 3
+        requestHeader.attrs(y) must_== 4
+      }
+      "can set two attributes and get both back" in {
+        val x = TypedKey[Int]("x")
+        val y = TypedKey[String]("y")
+        val r = dummyRequest().withAttrs(TypedMap(x -> 3, y -> "hello"))
+        r.attrs(x) must_== 3
+        r.attrs(y) must_== "hello"
+      }
+      "can set two attributes and remove one of them" in {
+        val x   = TypedKey[Int]("x")
+        val y   = TypedKey[String]("y")
+        val req = dummyRequest().withAttrs(TypedMap(x -> 3, y -> "hello")).removeAttr(x)
+        req.attrs.get(x) must beNone
+        req.attrs(y) must_== "hello"
+      }
+      "can set two attributes and remove both again" in {
+        val x   = TypedKey[Int]("x")
+        val y   = TypedKey[String]("y")
+        val req = dummyRequest().withAttrs(TypedMap(x -> 3, y -> "hello")).removeAttr(x).removeAttr(y)
+        req.attrs.get(x) must beNone
+        req.attrs.get(y) must beNone
       }
     }
   }

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -12,6 +12,7 @@ import play.api.http.HttpConfiguration
 import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.api.libs.Files.TemporaryFile
 import play.api.libs.json.JsValue
+import play.api.libs.typedmap.TypedEntry
 import play.api.libs.typedmap.TypedKey
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
@@ -57,6 +58,10 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
     new FakeRequest(request.withAttrs(attrs))
   override def addAttr[B](key: TypedKey[B], value: B): FakeRequest[A] =
     withAttrs(attrs.updated(key, value))
+  override def addAttrs(entries: TypedEntry[_]*): FakeRequest[A] =
+    withAttrs(attrs + (entries: _*))
+  override def removeAttr(key: TypedKey[_]): FakeRequest[A] =
+    withAttrs(attrs - key)
   override def withBody[B](body: B): FakeRequest[B] =
     new FakeRequest(request.withBody(body))
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -217,9 +217,12 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.db.evolutions.ApplicationEvolutions.runEvolutions"),
       // Removed @varargs (which removed the array forwarder method)
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.typedmap.DefaultTypedMap.-"),
-      // Add .addAttrs(...) method to Request/RequestHeader
+      // Add .addAttrs(...) varargs and override methods to Request/RequestHeader and TypedMap's
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.addAttrs"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.addAttrs"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.+"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.-"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.typedmap.DefaultTypedMap.-"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -217,6 +217,9 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.db.evolutions.ApplicationEvolutions.runEvolutions"),
       // Removed @varargs (which removed the array forwarder method)
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.typedmap.DefaultTypedMap.-"),
+      // Add .addAttrs(...) method to Request/RequestHeader
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.addAttrs"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.addAttrs"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
I had a case were this method would be useful. Also there are the `putAll` and `+` methods already on the Java/Scala `TypedMap`s already which take varargs, so we can just pass the varargs param on to them.