### PR TITLE
Upgrade guice to fix "Illegal reflective access" warnings

### DIFF
--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -29,6 +29,7 @@ object ScriptedTools extends AutoPlugin {
   override def trigger = allRequirements
 
   override def projectSettings: Seq[Def.Setting[_]] = Def.settings(
+    resolvers += "guice-betas".at("https://mcculls.github.io/guice-betas/maven2/"),
     // using this variant due to sbt#5405
     resolvers += "sonatype-service-local-releases"
       .at("https://oss.sonatype.org/service/local/repositories/releases/content/"), // sync ScriptedTools.scala

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -91,6 +91,7 @@ object BuildSettings {
       Resolver.typesafeRepo("releases"),
       Resolver.typesafeIvyRepo("releases"),
       Resolver.sbtPluginRepo("releases"), // weird sbt-pgp/play docs/vegemite issue
+      "guice-betas".at("https://mcculls.github.io/guice-betas/maven2/"),
     ),
     evictionSettings,
     ivyConfigurations ++= Seq(DocsApplication, SourcesApplication),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -122,7 +122,7 @@ object Dependencies {
     logback
   ).map(_ % Test)
 
-  val guiceVersion = "4.2.3"
+  val guiceVersion = "4.2.4-20200419-NEWAOP-BETA"
   val guiceDeps = Seq(
     "com.google.inject"            % "guice"                % guiceVersion,
     "com.google.inject.extensions" % "guice-assistedinject" % guiceVersion


### PR DESCRIPTION
There is an unofficial beta available which needs testing. It removes cglib from guice to get rid of all those warnings and better support for upcoming jdks.

See https://github.com/google/guice/issues/1133#issuecomment-616591934
and also https://github.com/mcculls/guice-betas/tree/gh-pages

Let's see what Travis says.