### PR TITLE
Avoid thread switching for in-memory cache operations

### DIFF
--- a/cache/play-caffeine-cache/src/main/resources/reference.conf
+++ b/cache/play-caffeine-cache/src/main/resources/reference.conf
@@ -22,7 +22,7 @@ play {
     bindCaches = []
     # The name of the default cache to use in caffeine
     defaultCache = "play"
-    # The dispatcher used for get, set, remove,...  operations on the cache. By default Play's default dispatcher is used.
+    # The dispatcher used for get, set, remove,...  operations on the cache. By default the current active thread is used.
     dispatcher = null
   }
 }

--- a/cache/play-ehcache/src/main/resources/reference.conf
+++ b/cache/play-ehcache/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ play {
     createBoundCaches = true
     # The name of the default cache to use in ehcache
     defaultCache = "play"
-    # The dispatcher used for get, set, remove,...  operations on the cache. By default Play's default dispatcher is used.
+    # The dispatcher used for get, set, remove,...  operations on the cache. By default the current active thread is used.
     dispatcher = null
   }
 

--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -119,9 +119,9 @@ By default, Play will try to create caches with names from `play.cache.bindCache
 
 ## Setting the execution context
 
-By default, all Caffeine and EhCache operations are blocking, and async implementations will block threads in the default execution context.
-Usually this is okay if you are using Play's default configuration, which only stores elements in memory since reads should be relatively fast.
-However, depending on how cache was configured, this blocking I/O might be too costly.
+By default, Caffeine and EhCache store elements in memory. Therefore reads from and writes to the cache should be very fast, because there is hardly any blocking I/O.
+To not slow done cache operations by unnecessary thread switching, which can be quite costly, Play's Caffeine and EhCache async implementations do not switch threads at all and therefore always stay on the caller thread of an operation.
+However, depending on how a cache was configured, there might be blocking I/O which can become too costly (e.g. [EhCache's `DiskStore`](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html)).
 For such a case you can configure a different [Akka dispatcher](https://doc.akka.io/docs/akka/2.6/dispatchers.html?language=scala#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the cache plugin makes use of it:
 
 ```

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -119,9 +119,9 @@ By default, Play will try to create caches with names from `play.cache.bindCache
 
 ## Setting the execution context
 
-By default, all Caffeine and EhCache operations are blocking, and async implementations will block threads in the default execution context.
-Usually this is okay if you are using Play's default configuration, which only stores elements in memory since reads should be relatively fast.
-However, depending on how cache was configured, this blocking I/O might be too costly.
+By default, Caffeine and EhCache store elements in memory. Therefore reads from and writes to the cache should be very fast, because there is hardly any blocking I/O.
+To not slow done cache operations by unnecessary thread switching, which can be quite costly, Play's Caffeine and EhCache async implementations do not switch threads at all and therefore always stay on the caller thread of an operation.
+However, depending on how a cache was configured, there might be blocking I/O which can become too costly (e.g. [EhCache's `DiskStore`](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html)).
 For such a case you can configure a different [Akka dispatcher](https://doc.akka.io/docs/akka/2.6/dispatchers.html?language=scala#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the cache plugin makes use of it:
 
 ```

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -215,6 +215,10 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.JavaCompatibleHttpRequestHandler.this"),
       // Refactor params of runEvolutions (ApplicationEvolutions however is private anyway)
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.db.evolutions.ApplicationEvolutions.runEvolutions"),
+      // Avoid thread switching for cache operations by default, stay on the same thread via trampoline
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("play.api.cache.caffeine.CaffeineCacheComponents.executionContext"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.cache.ehcache.EhCacheComponents.executionContext"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Caffeine and (by default) EhCache store elements in memory and therefore hardly any blocking occurs, I mean it's just cpu work. Right now the async implemention use the default execution context for cache set/get operations, which IMHO does not make any sense really, because very likely the caller thread is in this execution context already and now (I guess) the operation could switch to another thread in that ec. This does not help at all, even if such a set/get operation would block, you just block a thread from the default thread pool. Then why not just stay on the same thread anyway?
Assuming caffeine and ehcache is very fast, I think there is no point for thread switching at all, except when you really switch to another thread pool via `play.cache.dispatcher` (because you store cache on the disk or use an external process like memcached or similiar).

WDYT?