### PR TITLE
Remove incorrect @varargs

### DIFF
--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -4,7 +4,6 @@
 
 package play.api.libs.typedmap
 
-import scala.annotation.varargs
 import scala.collection.immutable
 
 /**
@@ -110,7 +109,7 @@ private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Ma
     }
     new DefaultTypedMap(m2)
   }
-  @varargs def -(keys: TypedKey[_]*): TypedMap = {
+  def -(keys: TypedKey[_]*): TypedMap = {
     val m2 = keys.foldLeft(m) {
       case (m1, k) => m1 - k
     }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -215,6 +215,8 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.JavaCompatibleHttpRequestHandler.this"),
       // Refactor params of runEvolutions (ApplicationEvolutions however is private anyway)
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.db.evolutions.ApplicationEvolutions.runEvolutions"),
+      // Removed @varargs (which removed the array forwarder method)
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.typedmap.DefaultTypedMap.-"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
This `@varargs` annotation should have been removed in #8832 already, it is a mistake it still exists.
As you cann see here, the `@varargs` of the super class was removed back then:
https://github.com/playframework/playframework/pull/8832/files#diff-d15b4be34e92773af96fd33df2a56f77R75