### PR TITLE
Document how to return a JSON String

### DIFF
--- a/documentation/manual/working/javaGuide/main/json/JavaJsonActions.md
+++ b/documentation/manual/working/javaGuide/main/json/JavaJsonActions.md
@@ -72,6 +72,10 @@ You can also return a Java object and have it automatically serialized to JSON b
 
 @[json-response-dao](code/javaguide/json/JavaJsonActions.java)
 
+If you already have a JSON `String` that you'd like to return, you can do that as well:
+
+@[json-response-string](code/javaguide/json/JavaJsonActions.java)
+
 ## Advanced usage
 
 There are two possible ways to customize the `ObjectMapper` for your application.

--- a/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
+++ b/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
@@ -218,7 +218,7 @@ public class JavaJsonActions extends WithApplication {
     // #json-response-string
     public Result sayHello() {
       String jsonString = "{\"exampleField1\": \"foobar\"}";
-      return ok(jsonString, "utf-8").as(play.mvc.Http.MimeTypes.JSON);
+      return ok(jsonString).as(play.mvc.Http.MimeTypes.JSON);
     }
     // #json-response-string
   }

--- a/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
+++ b/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
@@ -209,4 +209,17 @@ public class JavaJsonActions extends WithApplication {
     }
     // #json-response-dao
   }
+
+  static class JsonStringResponseAction extends MockJavaAction {
+    JsonStringResponseAction(JavaHandlerComponents javaHandlerComponents) {
+      super(javaHandlerComponents);
+    }
+
+    // #json-response-string
+    public Result sayHello() {
+      String jsonString = "{\"exampleField1\": \"foobar\"}";
+      return ok(jsonString, "utf-8").as(play.mvc.Http.MimeTypes.JSON);
+    }
+    // #json-response-string
+  }
 }


### PR DESCRIPTION
Closes https://github.com/playframework/playframework/issues/10219

I'm not sure if there's a better way to reference `"utf-8"` than creating the string myself. I would have used `Results.UTF8`, but it's `private`. I wonder if it should it be made `protected`?