### PR TITLE
Config to set Caffeine's internal executor

### DIFF
--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineCacheComponents.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineCacheComponents.java
@@ -44,13 +44,12 @@ import play.components.ConfigurationComponents;
 public interface CaffeineCacheComponents extends ConfigurationComponents, AkkaComponents {
   default AsyncCacheApi cacheApi(String name) {
     CaffeineCacheManager caffeineCacheManager =
-        new CaffeineCacheManager(config().getConfig("play.cache.caffeine"));
+        new CaffeineCacheManager(config().getConfig("play.cache.caffeine"), actorSystem());
 
     play.api.cache.AsyncCacheApi scalaAsyncCacheApi =
         new CaffeineCacheApi(
             NamedCaffeineCacheProvider$.MODULE$.getNamedCache(
-                name, caffeineCacheManager, configuration()),
-            executionContext());
+                name, caffeineCacheManager, configuration()));
     return new DefaultAsyncCacheApi(scalaAsyncCacheApi);
   }
 

--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineExecutionContext.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineExecutionContext.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.cache.caffeine;
+
+import akka.actor.ActorSystem;
+import play.libs.concurrent.CustomExecutionContext;
+
+public class CaffeineExecutionContext extends CustomExecutionContext {
+
+  public CaffeineExecutionContext(final ActorSystem actorSystem, final String name) {
+    super(actorSystem, name);
+  }
+}

--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineParser.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineParser.java
@@ -80,7 +80,7 @@ public final class CaffeineParser {
         break;
       case "executor":
         if (!config.getIsNull(key)) {
-          cacheBuilder.executor(actorSystem.dispatchers().lookup(config.getString(key)));
+          cacheBuilder.executor(new CaffeineExecutionContext(actorSystem, config.getString(key)));
         }
         break;
       default:

--- a/cache/play-caffeine-cache/src/main/resources/reference.conf
+++ b/cache/play-caffeine-cache/src/main/resources/reference.conf
@@ -15,6 +15,7 @@ play {
         weak-keys = false
         soft-values = false
         record-stats = false
+        executor = ${play.cache.dispatcher}
       }
       caches {}
     }
@@ -22,7 +23,7 @@ play {
     bindCaches = []
     # The name of the default cache to use in caffeine
     defaultCache = "play"
-    # The dispatcher used for get, set, remove,...  operations on the cache. By default Play's default dispatcher is used.
+    # The dispatcher internally used by Caffeine. By default Caffeine uses ForkJoinPool.commonPool().
     dispatcher = null
   }
 }

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheManager.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheManager.scala
@@ -7,13 +7,14 @@ package play.api.cache.caffeine
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
+import akka.actor.ActorSystem
 import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.typesafe.config.Config
 import play.cache.caffeine.CaffeineParser
 import play.cache.caffeine.NamedCaffeineCache
 
-class CaffeineCacheManager(private var config: Config) {
+class CaffeineCacheManager(private var config: Config, private var actorSystem: ActorSystem) {
   private val cacheMap: ConcurrentMap[String, NamedCaffeineCache[_, _]] =
     new ConcurrentHashMap(16)
 
@@ -40,7 +41,7 @@ class CaffeineCacheManager(private var config: Config) {
       if (caches.hasPath(cacheName))
         caches.getConfig(cacheName).withFallback(defaults)
       else defaults
-    cacheBuilder = CaffeineParser.from(cacheConfig).expireAfter(defaultExpiry)
+    cacheBuilder = CaffeineParser.from(cacheConfig, actorSystem).expireAfter(defaultExpiry)
     cacheBuilder
   }
 }

--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -119,9 +119,9 @@ By default, Play will try to create caches with names from `play.cache.bindCache
 
 ## Setting the execution context
 
-By default, all Caffeine and EhCache operations are blocking, and async implementations will block threads in the default execution context.
-Usually this is okay if you are using Play's default configuration, which only stores elements in memory since reads should be relatively fast.
-However, depending on how cache was configured, this blocking I/O might be too costly.
+By default, Caffeine and EhCache store elements in memory. Therefore reads from and writes to the cache should be very fast, because there is hardly any blocking I/O.
+However, depending on how a cache was configured (e.g. by using [EhCache's `DiskStore`](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html)), there might be blocking I/O which can become too costly, because even the async implementations will block threads in the default execution context.
+
 For such a case you can configure a different [Akka dispatcher](https://doc.akka.io/docs/akka/2.6/dispatchers.html?language=scala#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the cache plugin makes use of it:
 
 ```
@@ -135,6 +135,9 @@ contexts {
   }
 }
 ```
+
+When using Caffeine, this will set Caffeine's [internal executor](https://github.com/ben-manes/caffeine/blob/v2.8.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L281-L303).
+For EhCache, Play will run any EhCache operation in a Future on a thread of the given dispatcher.
 
 ## Caching HTTP responses
 

--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -136,7 +136,19 @@ contexts {
 }
 ```
 
-When using Caffeine, this will set Caffeine's [internal executor](https://github.com/ben-manes/caffeine/blob/v2.8.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L281-L303).
+### Caffeine
+
+When using Caffeine, this will set Caffeine's [internal executor](https://github.com/ben-manes/caffeine/blob/v2.8.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L281-L303). Actually, setting `play.cache.dispatcher` sets `play.cache.caffeine.defaults.executor`. Like [described above](#Accessing-different-caches) you can therefore set different executors for different caches:
+
+```
+    play.cache.caffeine.user-cache = {
+        executor = "contexts.anotherBlockingCacheDispatcher"
+        ...
+    }
+```
+
+### EhCache
+
 For EhCache, Play will run any EhCache operation in a Future on a thread of the given dispatcher.
 
 ## Caching HTTP responses

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -119,9 +119,9 @@ By default, Play will try to create caches with names from `play.cache.bindCache
 
 ## Setting the execution context
 
-By default, all Caffeine and EhCache operations are blocking, and async implementations will block threads in the default execution context.
-Usually this is okay if you are using Play's default configuration, which only stores elements in memory since reads should be relatively fast.
-However, depending on how cache was configured, this blocking I/O might be too costly.
+By default, Caffeine and EhCache store elements in memory. Therefore reads from and writes to the cache should be very fast, because there is hardly any blocking I/O.
+However, depending on how a cache was configured (e.g. by using [EhCache's `DiskStore`](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html)), there might be blocking I/O which can become too costly, because even the async implementations will block threads in the default execution context.
+
 For such a case you can configure a different [Akka dispatcher](https://doc.akka.io/docs/akka/2.6/dispatchers.html?language=scala#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the cache plugin makes use of it:
 
 ```
@@ -135,6 +135,9 @@ contexts {
   }
 }
 ```
+
+When using Caffeine, this will set Caffeine's [internal executor](https://github.com/ben-manes/caffeine/blob/v2.8.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L281-L303).
+For EhCache, Play will run any EhCache operation in a Future on a thread of the given dispatcher.
 
 ## Caching HTTP responses
 

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -136,7 +136,19 @@ contexts {
 }
 ```
 
-When using Caffeine, this will set Caffeine's [internal executor](https://github.com/ben-manes/caffeine/blob/v2.8.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L281-L303).
+### Caffeine
+
+When using Caffeine, this will set Caffeine's [internal executor](https://github.com/ben-manes/caffeine/blob/v2.8.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L281-L303). Actually, setting `play.cache.dispatcher` sets `play.cache.caffeine.defaults.executor`. Like [described above](#Accessing-different-caches) you can therefore set different executors for different caches:
+
+```
+    play.cache.caffeine.user-cache = {
+        executor = "contexts.anotherBlockingCacheDispatcher"
+        ...
+    }
+```
+
+### EhCache
+
 For EhCache, Play will run any EhCache operation in a Future on a thread of the given dispatcher.
 
 ## Caching HTTP responses

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -263,6 +263,11 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Result.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Result.this"),
       ProblemFilters.exclude[IncompatibleSignatureProblem]("play.api.mvc.Result.unapply"),
+      // Config which sets Caffeine's internal executor, also switched to trampoline where useful
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.cache.caffeine.CacheManagerProvider.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.cache.caffeine.CaffeineCacheApi.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.cache.caffeine.CaffeineCacheManager.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.cache.caffeine.CaffeineParser.from"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
`play.cache.dispatcher` will set Caffeine's [internal executor](https://github.com/ben-manes/caffeine/blob/v2.8.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L281-L303) now.

Fixes #10216