### PR TITLE
Rename HttpExecution[Context] to ClassLoaderExecution[Context]

### DIFF
--- a/core/play/src/main/java/play/libs/concurrent/ClassLoaderExecution.java
+++ b/core/play/src/main/java/play/libs/concurrent/ClassLoaderExecution.java
@@ -5,15 +5,15 @@
 package play.libs.concurrent;
 
 import java.util.concurrent.Executor;
-import play.core.j.HttpExecutionContext;
+import play.core.j.ClassLoaderExecutionContext;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.ExecutionContextExecutor;
 
 /**
  * ExecutionContexts that preserve the current thread's context ClassLoader by passing it through
- * {@link play.libs.concurrent.HttpExecutionContext}.
+ * {@link play.libs.concurrent.ClassLoaderExecutionContext}.
  */
-public class HttpExecution {
+public class ClassLoaderExecution {
 
   /**
    * An ExecutionContext that executes work on the given ExecutionContext. The current thread's
@@ -21,10 +21,11 @@ public class HttpExecution {
    * tasks.
    *
    * @param delegate the delegate execution context.
-   * @return the execution context wrapped in an {@link play.libs.concurrent.HttpExecutionContext}.
+   * @return the execution context wrapped in an {@link
+   *     play.libs.concurrent.ClassLoaderExecutionContext}.
    */
   public static ExecutionContextExecutor fromThread(ExecutionContext delegate) {
-    return HttpExecutionContext.fromThread(delegate);
+    return ClassLoaderExecutionContext.fromThread(delegate);
   }
 
   /**
@@ -33,10 +34,11 @@ public class HttpExecution {
    * tasks.
    *
    * @param delegate the delegate execution context.
-   * @return the execution context wrapped in an {@link play.libs.concurrent.HttpExecutionContext}.
+   * @return the execution context wrapped in an {@link
+   *     play.libs.concurrent.ClassLoaderExecutionContext}.
    */
   public static ExecutionContextExecutor fromThread(ExecutionContextExecutor delegate) {
-    return HttpExecutionContext.fromThread(delegate);
+    return ClassLoaderExecutionContext.fromThread(delegate);
   }
 
   /**
@@ -45,9 +47,10 @@ public class HttpExecution {
    * tasks.
    *
    * @param delegate the delegate execution context.
-   * @return the execution context wrapped in an {@link play.libs.concurrent.HttpExecutionContext}.
+   * @return the execution context wrapped in an {@link
+   *     play.libs.concurrent.ClassLoaderExecutionContext}.
    */
   public static ExecutionContextExecutor fromThread(Executor delegate) {
-    return HttpExecutionContext.fromThread(delegate);
+    return ClassLoaderExecutionContext.fromThread(delegate);
   }
 }

--- a/core/play/src/main/java/play/libs/concurrent/ClassLoaderExecutionContext.java
+++ b/core/play/src/main/java/play/libs/concurrent/ClassLoaderExecutionContext.java
@@ -22,19 +22,19 @@ import javax.inject.Singleton;
  *     CompletionStage&lt;WSResponse&gt; response = ws.url(...).get();
  *     CompletionStage&lt;Result&gt; result = response.thenApplyAsync(response -&gt; {
  *         return ok("Got response body " + ws.body() + " while executing request " + request().uri());
- *     }, httpExecutionContext.current());
+ *     }, clExecutionContext.current());
  * </pre>
  *
  * Note, this is not a Scala execution context, and is not intended to be used where Scala execution
  * contexts are required.
  */
 @Singleton
-public class HttpExecutionContext {
+public class ClassLoaderExecutionContext {
 
   private final Executor delegate;
 
   @Inject
-  public HttpExecutionContext(Executor delegate) {
+  public ClassLoaderExecutionContext(Executor delegate) {
     this.delegate = delegate;
   }
 
@@ -47,6 +47,6 @@ public class HttpExecutionContext {
    * @return An executor that will execute its tasks with the current ClassLoader.
    */
   public Executor current() {
-    return HttpExecution.fromThread(delegate);
+    return ClassLoaderExecution.fromThread(delegate);
   }
 }

--- a/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
+++ b/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
@@ -62,6 +62,6 @@ public abstract class CustomExecutionContext implements ExecutionContextExecutor
    * @return This executor that will execute its tasks with the current ClassLoader.
    */
   public Executor current() {
-    return HttpExecution.fromThread(this);
+    return ClassLoaderExecution.fromThread(this);
   }
 }

--- a/core/play/src/main/java/play/libs/concurrent/HttpExecution.java
+++ b/core/play/src/main/java/play/libs/concurrent/HttpExecution.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.libs.concurrent;
+
+import java.util.concurrent.Executor;
+import play.core.j.ClassLoaderExecutionContext;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.ExecutionContextExecutor;
+
+/** @deprecated Deprecated as of 2.9.0. Renamed to {@link ClassLoaderExecution}. */
+@Deprecated
+public class HttpExecution {
+
+  /**
+   * @deprecated Deprecated as of 2.9.0. Use to {@link
+   *     ClassLoaderExecution#fromThread(ExecutionContext)} instead.
+   */
+  @Deprecated
+  public static ExecutionContextExecutor fromThread(ExecutionContext delegate) {
+    return ClassLoaderExecutionContext.fromThread(delegate);
+  }
+
+  /**
+   * @deprecated Deprecated as of 2.9.0. Use to {@link
+   *     ClassLoaderExecution#fromThread(ExecutionContextExecutor)} instead.
+   */
+  @Deprecated
+  public static ExecutionContextExecutor fromThread(ExecutionContextExecutor delegate) {
+    return ClassLoaderExecutionContext.fromThread(delegate);
+  }
+
+  /**
+   * @deprecated Deprecated as of 2.9.0. Use to {@link ClassLoaderExecution#fromThread(Executor)}
+   *     instead.
+   */
+  @Deprecated
+  public static ExecutionContextExecutor fromThread(Executor delegate) {
+    return ClassLoaderExecutionContext.fromThread(delegate);
+  }
+}

--- a/core/play/src/main/java/play/libs/concurrent/HttpExecutionContext.java
+++ b/core/play/src/main/java/play/libs/concurrent/HttpExecutionContext.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.libs.concurrent;
+
+import java.util.concurrent.Executor;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/** @deprecated Deprecated as of 2.9.0. Renamed to {@link ClassLoaderExecutionContext}. */
+@Singleton
+public class HttpExecutionContext {
+
+  private final Executor delegate;
+
+  /** @deprecated Deprecated as of 2.9.0. Use to {@link ClassLoaderExecutionContext} instead. */
+  @Deprecated
+  @Inject
+  public HttpExecutionContext(Executor delegate) {
+    this.delegate = delegate;
+  }
+
+  /**
+   * @deprecated Deprecated as of 2.9.0. Use to {@link ClassLoaderExecutionContext#current()}}
+   *     instead.
+   */
+  @Deprecated
+  public Executor current() {
+    return ClassLoaderExecution.fromThread(delegate);
+  }
+}

--- a/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -27,6 +27,7 @@ import play.api.mvc.request.RequestFactory
 import play.api.routing.Router
 import play.core.j.JavaRouterAdapter
 import play.core.routing.GeneratedRouter
+import play.libs.concurrent.HttpExecutionContext
 import play.libs.concurrent.ClassLoaderExecutionContext
 
 import scala.concurrent.ExecutionContext
@@ -86,6 +87,7 @@ class BuiltinModule
         bind[ExecutionContextExecutor].toProvider[ExecutionContextProvider],
         bind[ExecutionContext].to(bind[ExecutionContextExecutor]),
         bind[Executor].to(bind[ExecutionContextExecutor]),
+        bind[HttpExecutionContext].toSelf,
         bind[ClassLoaderExecutionContext].toSelf,
         bind[play.core.j.JavaContextComponents].to[play.core.j.DefaultJavaContextComponents],
         bind[play.core.j.JavaHandlerComponents].to[play.core.j.DefaultJavaHandlerComponents],

--- a/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -27,7 +27,7 @@ import play.api.mvc.request.RequestFactory
 import play.api.routing.Router
 import play.core.j.JavaRouterAdapter
 import play.core.routing.GeneratedRouter
-import play.libs.concurrent.HttpExecutionContext
+import play.libs.concurrent.ClassLoaderExecutionContext
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
@@ -86,7 +86,7 @@ class BuiltinModule
         bind[ExecutionContextExecutor].toProvider[ExecutionContextProvider],
         bind[ExecutionContext].to(bind[ExecutionContextExecutor]),
         bind[Executor].to(bind[ExecutionContextExecutor]),
-        bind[HttpExecutionContext].toSelf,
+        bind[ClassLoaderExecutionContext].toSelf,
         bind[play.core.j.JavaContextComponents].to[play.core.j.DefaultJavaContextComponents],
         bind[play.core.j.JavaHandlerComponents].to[play.core.j.DefaultJavaHandlerComponents],
         bind[FileMimeTypes].toProvider[DefaultFileMimeTypesProvider]

--- a/core/play/src/main/scala/play/core/j/ClassLoaderExecutionContext.scala
+++ b/core/play/src/main/scala/play/core/j/ClassLoaderExecutionContext.scala
@@ -10,29 +10,29 @@ import play.utils.ExecCtxUtils
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 
-object HttpExecutionContext {
+object ClassLoaderExecutionContext {
 
   /**
-   * Create an HttpExecutionContext with values from the current thread.
+   * Create an ClassLoaderExecutionContext with values from the current thread.
    */
   def fromThread(delegate: ExecutionContext): ExecutionContextExecutor =
-    new HttpExecutionContext(
+    new ClassLoaderExecutionContext(
       Thread.currentThread().getContextClassLoader(),
       delegate
     )
 
   /**
-   * Create an HttpExecutionContext with values from the current thread.
+   * Create an ClassLoaderExecutionContext with values from the current thread.
    *
    * This method is necessary to prevent ambiguous method compile errors since ExecutionContextExecutor
    */
   def fromThread(delegate: ExecutionContextExecutor): ExecutionContextExecutor = fromThread(delegate: ExecutionContext)
 
   /**
-   * Create an HttpExecutionContext with values from the current thread.
+   * Create an ClassLoaderExecutionContext with values from the current thread.
    */
   def fromThread(delegate: Executor): ExecutionContextExecutor =
-    new HttpExecutionContext(
+    new ClassLoaderExecutionContext(
       Thread.currentThread().getContextClassLoader(),
       ExecutionContext.fromExecutor(delegate)
     )
@@ -52,7 +52,7 @@ object HttpExecutionContext {
  * Manages execution to ensure that the given context ClassLoader is set correctly
  * in the current thread. Actual execution is performed by a delegate ExecutionContext.
  */
-class HttpExecutionContext(contextClassLoader: ClassLoader, delegate: ExecutionContext)
+class ClassLoaderExecutionContext(contextClassLoader: ClassLoader, delegate: ExecutionContext)
     extends ExecutionContextExecutor {
   override def execute(runnable: Runnable) =
     delegate.execute(() => {
@@ -73,7 +73,7 @@ class HttpExecutionContext(contextClassLoader: ClassLoader, delegate: ExecutionC
     if (delegatePrepared eq delegate) {
       this
     } else {
-      new HttpExecutionContext(contextClassLoader, delegatePrepared)
+      new ClassLoaderExecutionContext(contextClassLoader, delegatePrepared)
     }
   }
 }

--- a/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala
+++ b/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.j
+
+import java.util.concurrent.Executor
+
+import play.utils.ExecCtxUtils
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
+
+@deprecated("Renamed to ClassLoaderExecutionContext", "2.9.0")
+object HttpExecutionContext {
+
+  @deprecated("Use ClassLoaderExecutionContext.fromThread instead", "2.9.0")
+  def fromThread(delegate: ExecutionContext): ExecutionContextExecutor =
+    ClassLoaderExecutionContext.fromThread(delegate)
+
+  @deprecated("Use ClassLoaderExecutionContext.fromThread instead", "2.9.0")
+  def fromThread(delegate: ExecutionContextExecutor): ExecutionContextExecutor = fromThread(delegate: ExecutionContext)
+
+  @deprecated("Use  instead", "2.9.0")
+  def fromThread(delegate: Executor): ExecutionContextExecutor = ClassLoaderExecutionContext.fromThread(delegate)
+
+  @deprecated("Use ClassLoaderExecutionContext.unprepared instead", "2.9.0")
+  def unprepared(delegate: ExecutionContext) = ClassLoaderExecutionContext.unprepared(delegate)
+}
+
+@deprecated("Renamed to ClassLoaderExecutionContext", "2.9.0")
+class HttpExecutionContext(contextClassLoader: ClassLoader, delegate: ExecutionContext)
+    extends ExecutionContextExecutor {
+
+  private val clecDelegate = new ClassLoaderExecutionContext(contextClassLoader, delegate)
+
+  @deprecated("Use ClassLoaderExecutionContext.execute instead", "2.9.0")
+  override def execute(runnable: Runnable) = clecDelegate.execute(runnable)
+
+  @deprecated("Use ClassLoaderExecutionContext.reportFailure instead", "2.9.0")
+  override def reportFailure(t: Throwable) = clecDelegate.reportFailure(t)
+
+  @deprecated("Use ClassLoaderExecutionContext.prepare instead", "2.9.0")
+  override def prepare(): ExecutionContext = clecDelegate.prepare()
+}

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -151,7 +151,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
 
     val trampolineWithContext: ExecutionContext = {
       val javaClassLoader = Thread.currentThread.getContextClassLoader
-      new HttpExecutionContext(javaClassLoader, trampoline)
+      new ClassLoaderExecutionContext(javaClassLoader, trampoline)
     }
     if (logger.isDebugEnabled) {
       val actionChain = Seq

--- a/documentation/manual/working/commonGuide/configuration/ThreadPools.md
+++ b/documentation/manual/working/commonGuide/configuration/ThreadPools.md
@@ -43,9 +43,9 @@ In most situations, the appropriate execution context to use will be the **Play 
 
 @[global-thread-pool](code/ThreadPools.scala)
 
-or using [`CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html) with an [`HttpExecutionContext`](api/java/play/libs/concurrent/HttpExecutionContext.html) in Java code:
+or using [`CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html) with an [`ClassLoaderExecutionContext`](api/java/play/libs/concurrent/ClassLoaderExecutionContext.html) in Java code:
 
-@[http-execution-context](code/detailedtopics/httpec/MyController.java)
+@[cl-execution-context](code/detailedtopics/clec/MyController.java)
 
 This execution context connects directly to the Application's `ActorSystem` and uses Akka's [default dispatcher][akka-default-dispatcher].
 
@@ -103,13 +103,13 @@ In some cases you may not be able to explicitly use the application classloader.
 
 ### Switching threads
 
-The problem with class loaders however is that as soon as control switches to another thread, you lose access to the original class loader. So if you were to map a `CompletionStage` using `thenApplyAsync`, or using `thenApply` at a point in time after the `Future` associated with that `CompletionStage` had completed, and you then try to access the original class loader, it probably won't work .  To address this, Play provides an [`HttpExecutionContext`](api/java/play/libs/concurrent/HttpExecutionContext.html).  This allows you to capture the current class loader in an `Executor`, which you can then pass to the `CompletionStage` `*Async` methods such as `thenApplyAsync()`, and when the executor executes your callback, it will ensure the class loader remains in scope.
+The problem with class loaders however is that as soon as control switches to another thread, you lose access to the original class loader. So if you were to map a `CompletionStage` using `thenApplyAsync`, or using `thenApply` at a point in time after the `Future` associated with that `CompletionStage` had completed, and you then try to access the original class loader, it probably won't work .  To address this, Play provides an [`ClassLoaderExecutionContext`](api/java/play/libs/concurrent/ClassLoaderExecutionContext.html).  This allows you to capture the current class loader in an `Executor`, which you can then pass to the `CompletionStage` `*Async` methods such as `thenApplyAsync()`, and when the executor executes your callback, it will ensure the class loader remains in scope.
 
-To use the `HttpExecutionContext`, inject it into your component, and then pass the current execution context anytime a `CompletionStage` is interacted with.  For example:
+To use the `ClassLoaderExecutionContext`, inject it into your component, and then pass the current execution context anytime a `CompletionStage` is interacted with.  For example:
 
-@[http-execution-context](code/detailedtopics/httpec/MyController.java)
+@[cl-execution-context](code/detailedtopics/clec/MyController.java)
 
-If you have a custom executor, you can wrap it in an `HttpExecutionContext` simply by passing it to the `HttpExecutionContext`s constructor.
+If you have a custom executor, you can wrap it in an `ClassLoaderExecutionContext` simply by passing it to the `ClassLoaderExecutionContext`s constructor.
 
 ## Best practices
 

--- a/documentation/manual/working/commonGuide/configuration/code/detailedtopics/clec/MyController.java
+++ b/documentation/manual/working/commonGuide/configuration/code/detailedtopics/clec/MyController.java
@@ -2,22 +2,22 @@
  * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package detailedtopics.httpec;
+package detailedtopics.clec;
 
-// #http-execution-context
+// #cl-execution-context
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
-import play.libs.concurrent.HttpExecutionContext;
+import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.*;
 
 public class MyController extends Controller {
 
-  private HttpExecutionContext httpExecutionContext;
+  private ClassLoaderExecutionContext clExecutionContext;
 
   @Inject
-  public MyController(HttpExecutionContext ec) {
-    this.httpExecutionContext = ec;
+  public MyController(ClassLoaderExecutionContext ec) {
+    this.clExecutionContext = ec;
   }
 
   public CompletionStage<Result> index() {
@@ -27,11 +27,11 @@ public class MyController extends Controller {
             answer -> {
               return ok("answer was " + answer).flashing("info", "Response updated!");
             },
-            httpExecutionContext.current());
+            clExecutionContext.current());
   }
 
   private static CompletionStage<String> calculateResponse() {
     return CompletableFuture.completedFuture("42");
   }
 }
-// #http-execution-context
+// #cl-execution-context

--- a/documentation/manual/working/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaAsync.md
@@ -34,23 +34,23 @@ Using `supplyAsync` creates a new task which will be placed on the fork join poo
 
 > Only the "\*Async" methods from `CompletionStage` provide asynchronous execution.
 
-## Using HttpExecutionContext
+## Using ClassLoaderExecutionContext
 
-You must supply the HTTP execution context explicitly as an executor when using a Java `CompletionStage` inside an [[Action|JavaActions]], to ensure that the classloader remains in scope.
+You must supply the classloader execution context explicitly as an executor when using a Java `CompletionStage` inside an [[Action|JavaActions]], to ensure that the classloader remains in scope.
 
-You can supply the [`play.libs.concurrent.HttpExecutionContext`](api/java/play/libs/concurrent/HttpExecutionContext.html) instance through dependency injection:
+You can supply the [`play.libs.concurrent.ClassLoaderExecutionContext`](api/java/play/libs/concurrent/ClassLoaderExecutionContext.html) instance through dependency injection:
 
-@[http-execution-context](../../../commonGuide/configuration/code/detailedtopics/httpec/MyController.java)
+@[cl-execution-context](../../../commonGuide/configuration/code/detailedtopics/clec/MyController.java)
 
-Please see [[Class loaders|ThreadPools#Class loaders]] for more information on using `HttpExecutionContext`.
+Please see [[Class loaders|ThreadPools#Class-loaders]] for more information on using `ClassLoaderExecutionContext`.
 
-## Using CustomExecutionContext and HttpExecution
+## Using CustomExecutionContext and ClassLoaderExecution
 
-Using a `CompletionStage` or an `HttpExecutionContext` is only half of the picture though! At this point you are still on Play's default ExecutionContext.  If you are calling out to a blocking API such as JDBC, then you still will need to have your ExecutionStage run with a different executor, to move it off Play's rendering thread pool.  You can do this by creating a subclass of [`play.libs.concurrent.CustomExecutionContext`](api/java/play/libs/concurrent/CustomExecutionContext.html) with a reference to the [custom dispatcher](https://doc.akka.io/docs/akka/2.6/dispatchers.html?language=java).
+Using a `CompletionStage` or an `ClassLoaderExecutionContext` is only half of the picture though! At this point you are still on Play's default ExecutionContext.  If you are calling out to a blocking API such as JDBC, then you still will need to have your ExecutionStage run with a different executor, to move it off Play's rendering thread pool.  You can do this by creating a subclass of [`play.libs.concurrent.CustomExecutionContext`](api/java/play/libs/concurrent/CustomExecutionContext.html) with a reference to the [custom dispatcher](https://doc.akka.io/docs/akka/2.6/dispatchers.html?language=java).
 
 Add the following imports:
 
-@[async-explicit-ec-imports](code/javaguide/async/controllers/Application.java)
+@[async-explicit-cl-imports](code/javaguide/async/controllers/Application.java)
 
 Define a custom execution context:
 
@@ -58,7 +58,7 @@ Define a custom execution context:
 
 You will need to define a custom dispatcher in `application.conf`, which is done [through Akka dispatcher configuration](https://doc.akka.io/docs/akka/2.6/dispatchers.html?language=java#setting-the-dispatcher-for-an-actor).
 
-Once you have the custom dispatcher, add in the explicit executor and wrap it with [`HttpException.fromThread`](api/java/play/libs/concurrent/HttpExecution.html#fromThread-java.util.concurrent.Executor-):
+Once you have the custom dispatcher, add in the explicit executor and wrap it with [`ClassLoaderExecution.fromThread`](api/java/play/libs/concurrent/ClassLoaderExecution.html#fromThread\(java.util.concurrent.Executor\)):
 
 @[async-explicit-ec](code/javaguide/async/controllers/Application.java)
 

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/Application.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/Application.java
@@ -7,14 +7,14 @@ package javaguide.async.controllers;
 import play.mvc.Result;
 import play.mvc.Controller;
 
-// #async-explicit-ec-imports
-import play.libs.concurrent.HttpExecution;
+// #async-explicit-cl-imports
+import play.libs.concurrent.ClassLoaderExecution;
 
 import javax.inject.Inject;
 import java.util.concurrent.Executor;
 import java.util.concurrent.CompletionStage;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
-// #async-explicit-ec-imports
+// #async-explicit-cl-imports
 
 // #async-explicit-ec
 public class Application extends Controller {
@@ -28,7 +28,7 @@ public class Application extends Controller {
 
   public CompletionStage<Result> index() {
     // Wrap an existing thread pool, using the context from the current thread
-    Executor myEc = HttpExecution.fromThread(myExecutionContext);
+    Executor myEc = ClassLoaderExecution.fromThread(myExecutionContext);
     return supplyAsync(() -> intensiveComputation(), myEc)
         .thenApplyAsync(i -> ok("Got result: " + i), myEc);
   }

--- a/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/JavaMarkerController.java
+++ b/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/JavaMarkerController.java
@@ -10,17 +10,17 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
-import play.libs.concurrent.HttpExecutionContext;
+import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
 
 public class JavaMarkerController extends Controller {
-  private final HttpExecutionContext httpExecutionContext;
+  private final ClassLoaderExecutionContext ClassLoaderExecutionContext;
 
   @Inject
-  public JavaMarkerController(HttpExecutionContext httpExecutionContext) {
-    this.httpExecutionContext = httpExecutionContext;
+  public JavaMarkerController(ClassLoaderExecutionContext ClassLoaderExecutionContext) {
+    this.ClassLoaderExecutionContext = ClassLoaderExecutionContext;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(JavaMarkerController.class);


### PR DESCRIPTION
Fixes #10218

FYI: First commit renamed the classes with help of IntelliJ, second commit readds those classes with deprecation notes.