### PR TITLE
Add CustomExecutionContext.current()

### DIFF
--- a/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
+++ b/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
@@ -8,6 +8,8 @@ import akka.actor.ActorSystem;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.ExecutionContextExecutor;
 
+import java.util.concurrent.Executor;
+
 /**
  * Provides a custom execution context from an Akka dispatcher.
  *
@@ -50,5 +52,17 @@ public abstract class CustomExecutionContext implements ExecutionContextExecutor
   @Override
   public void reportFailure(Throwable cause) {
     executionContext.reportFailure(cause);
+  }
+
+  /**
+   * Get this executor associated with the current ClassLoader.
+   *
+   * <p>Note that the returned executor is only valid for the current ClassLoader. It should be used
+   * in a transient fashion, long lived references to it should not be kept.
+   *
+   * @return This executor that will execute its tasks with the current ClassLoader.
+   */
+  public Executor current() {
+    return HttpExecution.fromThread(this);
   }
 }


### PR DESCRIPTION
Adds basically the same method [like we have in `HttpExecutionContext`](https://github.com/playframework/playframework/blob/2.8.1/core/play/src/main/java/play/libs/concurrent/HttpExecutionContext.java#L49-L51) so we can simply call `someCustomEc.current()` to als pass on the classloader easily. IMHO it's just simpler and shorter than wrapping `HttpExecution.fromThread(someCustomEc)` each time.