### PR TITLE
Make sure Play's temp folder is unique

### DIFF
--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -256,9 +256,10 @@ object Files {
     private val references = Sets.newConcurrentHashSet[Reference[TemporaryFile]]()
 
     private val TempDirectoryPrefix = "playtemp"
-    private val playTempFolder: Path = {
-      val dir       = conf.get[String]("play.temporaryFile.dir")
-      val tmpFolder = Paths.get(s"$dir/$TempDirectoryPrefix/")
+    private lazy val playTempFolder: Path = {
+      val dir = Paths.get(conf.get[String]("play.temporaryFile.dir"))
+      JFiles.createDirectories(dir) // make sure dir exists, otherwise createTempDirectory fails
+      val tmpFolder = JFiles.createTempDirectory(dir, TempDirectoryPrefix)
       temporaryFileReaper.updateTempFolder(tmpFolder)
       tmpFolder
     }

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -441,9 +441,17 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       val conf       = Configuration.from(Map("play.temporaryFile.dir" -> customPath))
       val creator    = new DefaultTemporaryFileCreator(lifecycle, reaper, conf)
 
+      // tmp folder does not exist yet before first tmp file gets created
+      JFiles.exists(Paths.get(customPath)) must_== false
+
       creator.create("foo", "bar")
 
-      JFiles.exists(Paths.get(s"$customPath/playtemp")) must beTrue
+      // tmp folder exists after first tmp file got created
+      JFiles
+        .list(Paths.get(customPath))
+        .filter(JFiles.isDirectory(_))
+        .filter(_.getFileName.toString.startsWith("playtemp"))
+        .count() must_== 1
     }
   }
 


### PR DESCRIPTION
Fixes #10194

The code is the same like in OpenJDK which also uses a `SecureRandom`:
http://hg.openjdk.java.net/jdk/jdk/file/04e3d254c76b/src/java.base/share/classes/java/nio/file/TempFileHelper.java#l55