### PR TITLE
[2.8.x] Allow file uploads with empty body or empty filenames

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -451,6 +451,11 @@ trait PlayBodyParsers extends BodyParserUtils {
    */
   def DefaultMaxDiskLength: Long = config.maxDiskBuffer
 
+  /**
+   * If empty file uploads are allowed (no matter if filename or file is empty)
+   */
+  def DefaultAllowEmptyFileUploads: Boolean = false
+
   // -- Text parser
 
   /**
@@ -922,8 +927,11 @@ trait PlayBodyParsers extends BodyParserUtils {
 
       case Some("multipart/form-data") =>
         logger.trace("Parsing AnyContent as multipartFormData")
-        multipartFormData(Multipart.handleFilePartAsTemporaryFile(temporaryFileCreator), maxLengthOrDefaultLarge)
-          .apply(request)
+        multipartFormData(
+          Multipart.handleFilePartAsTemporaryFile(temporaryFileCreator),
+          maxLengthOrDefaultLarge,
+          DefaultAllowEmptyFileUploads
+        ).apply(request)
           .map(_.right.map(m => AnyContentAsMultipartFormData(m)))
 
       case _ =>
@@ -951,6 +959,23 @@ trait PlayBodyParsers extends BodyParserUtils {
   /**
    * Parse the content as multipart/form-data
    *
+   * @param allowEmptyFiles If empty file uploads are allowed (no matter if filename or file is empty)
+   */
+  def multipartFormData(allowEmptyFiles: Boolean): BodyParser[MultipartFormData[TemporaryFile]] =
+    multipartFormData(Multipart.handleFilePartAsTemporaryFile(temporaryFileCreator), allowEmptyFiles = allowEmptyFiles)
+
+  /**
+   * Parse the content as multipart/form-data
+   *
+   * @param maxLength Max length (in bytes) allowed or returns EntityTooLarge HTTP response.
+   * @param allowEmptyFiles If empty file uploads are allowed (no matter if filename or file is empty)
+   */
+  def multipartFormData(maxLength: Long, allowEmptyFiles: Boolean): BodyParser[MultipartFormData[TemporaryFile]] =
+    multipartFormData(Multipart.handleFilePartAsTemporaryFile(temporaryFileCreator), maxLength, allowEmptyFiles)
+
+  /**
+   * Parse the content as multipart/form-data
+   *
    * @param filePartHandler Handles file parts.
    * @param maxLength Max length (in bytes) allowed or returns EntityTooLarge HTTP response.
    *
@@ -959,11 +984,27 @@ trait PlayBodyParsers extends BodyParserUtils {
    */
   def multipartFormData[A](
       filePartHandler: Multipart.FilePartHandler[A],
-      maxLength: Long = DefaultMaxDiskLength
+      maxLength: Long
+  ): BodyParser[MultipartFormData[A]] = multipartFormData(filePartHandler, maxLength, false)
+
+  /**
+   * Parse the content as multipart/form-data
+   *
+   * @param filePartHandler Handles file parts.
+   * @param maxLength Max length (in bytes) allowed or returns EntityTooLarge HTTP response.
+   * @param allowEmptyFiles If empty file uploads are allowed (no matter if filename or file is empty)
+   *
+   * @see [[DefaultMaxDiskLength]]
+   * @see [[Results.EntityTooLarge]]
+   */
+  def multipartFormData[A](
+      filePartHandler: Multipart.FilePartHandler[A],
+      maxLength: Long = DefaultMaxDiskLength,
+      allowEmptyFiles: Boolean = DefaultAllowEmptyFileUploads
   ): BodyParser[MultipartFormData[A]] = {
     BodyParser("multipartFormData") { request =>
       val bodyAccumulator =
-        Multipart.multipartParser(DefaultMaxTextLength, filePartHandler, errorHandler).apply(request)
+        Multipart.multipartParser(DefaultMaxTextLength, allowEmptyFiles, filePartHandler, errorHandler).apply(request)
       enforceMaxLength(request, maxLength, bodyAccumulator)
     }
   }

--- a/core/play/src/test/scala/play/mvc/DummyDelegatingMultipartFormDataBodyParser.java
+++ b/core/play/src/test/scala/play/mvc/DummyDelegatingMultipartFormDataBodyParser.java
@@ -30,8 +30,9 @@ public class DummyDelegatingMultipartFormDataBodyParser
           Materializer materializer,
           long maxMemoryBufferSize,
           long maxLength,
+          boolean allowEmptyFiles,
           HttpErrorHandler errorHandler) {
-    super(materializer, maxMemoryBufferSize, maxLength, errorHandler);
+    super(materializer, maxMemoryBufferSize, maxLength, allowEmptyFiles, errorHandler);
   }
 
   @Override

--- a/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
@@ -87,7 +87,7 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatch
       ByteString("--aabbccddeee--") // 15 bytes
     ),
     (
-      new DummyDelegatingMultipartFormDataBodyParser(materializer, 102400, 15, defaultHttpErrorHandler),
+      new DummyDelegatingMultipartFormDataBodyParser(materializer, 102400, 15, false, defaultHttpErrorHandler),
       Some("multipart/form-data; boundary=aabbccddeee"),
       ByteString("--aabbccddeee--") // 15 bytes
     ),


### PR DESCRIPTION
Slightly modified backport of #10236: Without the config, because that would break binary compatibility and also without the `@deprecation`s of course.
Without the config, users can still write their own custom body parser to allow empty files:
https://github.com/mkurz/play-empty-upload-allowed/blob/master/app/bodyparsers/CustomMultipartFormData.java
and
https://github.com/mkurz/play-empty-upload-allowed/blob/master/app/controllers/HomeController.java#L15