### PR TITLE
[2.7.x] Allow file uploads with empty body or empty filenames

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -49,6 +49,14 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
        |
        |text field with unquoted name and colon
        |--aabbccddee
+       |Content-Disposition: form-data; name="empty_text"
+       |
+       |
+       |--aabbccddee
+       |Content-Disposition: form-data; name=""
+       |
+       |empty name should work
+       |--aabbccddee
        |Content-Disposition: form-data; name="arr[]"
        |
        |array value 0
@@ -111,6 +119,11 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
        |the fifth file (with empty filename)
        |
        |--aabbccddee
+       |Content-Disposition: form-data; name="empty_file_empty_filename"; filename=""
+       |Content-Type: application/octet-stream
+       |
+       |
+       |--aabbccddee
        |Content-Disposition: form-data; name="empty_file_bottom"; filename="empty_file_not_followed_by_any_other_part.txt"
        |Content-Type: text/plain
        |
@@ -125,11 +138,13 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
   def checkResult(result: Either[Result, MultipartFormData[TemporaryFile]]) = {
     result must beRight.like {
       case parts =>
-        parts.dataParts must haveLength(7)
+        parts.dataParts must haveLength(9)
         parts.dataParts.get("text1") must beSome(Seq("the first text field"))
         parts.dataParts.get("text2:colon") must beSome(Seq("the second text field"))
         parts.dataParts.get("noQuotesText1") must beSome(Seq("text field with unquoted name"))
         parts.dataParts.get("noQuotesText1:colon") must beSome(Seq("text field with unquoted name and colon"))
+        parts.dataParts.get("empty_text") must beSome(Seq(""))
+        parts.dataParts.get("") must beSome(Seq("empty name should work"))
         parts.dataParts.get("arr[]").get must contain(("array value 0"))
         parts.dataParts.get("arr[]").get must contain(("array value 1"))
         parts.dataParts.get("orderedarr[0]") must beSome(Seq("ordered array value 0"))
@@ -159,7 +174,7 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
         parts.file("file_with_newline_only") must beSome.like {
           case filePart => PlayIO.readFileAsString(filePart.ref) must_== "\r\n"
         }
-        parts.badParts must haveLength(4)
+        parts.badParts must haveLength(5)
         parts.badParts must contain(
           (BadPart(
             Map(
@@ -187,11 +202,97 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
         parts.badParts must contain(
           (BadPart(
             Map(
+              "content-disposition" -> """form-data; name="empty_file_empty_filename"; filename=""""",
+              "content-type"        -> "application/octet-stream"
+            )
+          ))
+        )
+        parts.badParts must contain(
+          (BadPart(
+            Map(
               "content-disposition" -> """form-data; name="empty_file_bottom"; filename="empty_file_not_followed_by_any_other_part.txt"""",
               "content-type"        -> "text/plain"
             )
           ))
         )
+    }
+  }
+
+  def checkResultEmptyFileAllowed(result: Either[Result, MultipartFormData[TemporaryFile]]) = {
+    result must beRight.like {
+      case parts =>
+        parts.dataParts must haveLength(9)
+        parts.dataParts.get("text1") must beSome(Seq("the first text field"))
+        parts.dataParts.get("text2:colon") must beSome(Seq("the second text field"))
+        parts.dataParts.get("noQuotesText1") must beSome(Seq("text field with unquoted name"))
+        parts.dataParts.get("noQuotesText1:colon") must beSome(Seq("text field with unquoted name and colon"))
+        parts.dataParts.get("empty_text") must beSome(Seq(""))
+        parts.dataParts.get("") must beSome(Seq("empty name should work"))
+        parts.dataParts.get("arr[]").get must contain(("array value 0"))
+        parts.dataParts.get("arr[]").get must contain(("array value 1"))
+        parts.dataParts.get("orderedarr[0]") must beSome(Seq("ordered array value 0"))
+        parts.dataParts.get("orderedarr[1]") must beSome(Seq("ordered array value 1"))
+        parts.files must haveLength(10)
+        parts.file("file1") must beSome.like {
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== "the first file\r\n"
+            filePart.fileSize must_== 16
+          }
+        }
+        parts.file("file2") must beSome.like {
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== "the second file\r\n"
+            filePart.fileSize must_== 17
+          }
+        }
+        parts.file("file3") must beSome.like {
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== "the third file (with 'Content-Disposition: file' instead of 'form-data' as used in webhook callbacks of some scanners, see issue #8527)\r\n"
+            filePart.fileSize must_== 137
+          }
+        }
+        parts.file("file_with_space_only") must beSome.like {
+          case filePart => PlayIO.readFileAsString(filePart.ref) must_== " "
+        }
+        parts.file("file_with_newline_only") must beSome.like {
+          case filePart => PlayIO.readFileAsString(filePart.ref) must_== "\r\n"
+        }
+        parts.file("empty_file_middle") must beSome.like {
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== ""
+            filePart.fileSize must_== 0
+            filePart.filename must_== "empty_file_followed_by_other_part.txt"
+          }
+        }
+        parts.file("file4") must beSome.like {
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== "the fourth file (with empty filename)\r\n"
+            filePart.fileSize must_== 39
+            filePart.filename must_== ""
+          }
+        }
+        parts.file("file5") must beSome.like {
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== "the fifth file (with empty filename)\r\n"
+            filePart.fileSize must_== 38
+            filePart.filename must_== ""
+          }
+        }
+        parts.file("empty_file_empty_filename") must beSome.like {
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== ""
+            filePart.fileSize must_== 0
+            filePart.filename must_== ""
+          }
+        }
+        parts.file("empty_file_bottom") must beSome.like {
+          case filePart => {
+            PlayIO.readFileAsString(filePart.ref) must_== ""
+            filePart.fileSize must_== 0
+            filePart.filename must_== "empty_file_not_followed_by_any_other_part.txt"
+          }
+        }
+        parts.badParts must haveLength(0)
     }
   }
 
@@ -226,6 +327,20 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
       checkResult(result)
     }
 
+    "parse some content with empty file allowed" in new WithApplication() {
+      val parser = parse
+        .multipartFormData(allowEmptyFiles = true)
+        .apply(
+          FakeRequest().withHeaders(
+            CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+          )
+        )
+
+      val result = await(parser.run(Source.single(ByteString(body))))
+
+      checkResultEmptyFileAllowed(result)
+    }
+
     "parse some content that arrives one byte at a time" in new WithApplication() {
       val parser = parse.multipartFormData.apply(
         FakeRequest().withHeaders(
@@ -237,6 +352,21 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
       val result = await(parser.run(Source(bytes)))
 
       checkResult(result)
+    }
+
+    "parse some content that arrives one byte at a time with empty file allowed" in new WithApplication() {
+      val parser = parse
+        .multipartFormData(allowEmptyFiles = true)
+        .apply(
+          FakeRequest().withHeaders(
+            CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+          )
+        )
+
+      val bytes  = body.getBytes.map(byte => ByteString(byte)).toVector
+      val result = await(parser.run(Source(bytes)))
+
+      checkResultEmptyFileAllowed(result)
     }
 
     "return bad request for invalid body" in new WithApplication() {

--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -438,6 +438,20 @@ public interface BodyParser<A> {
     public MultipartFormData(PlayBodyParsers parsers) {
       super(parsers.multipartFormData(), JavaParsers::toJavaMultipartFormData);
     }
+
+    public MultipartFormData(PlayBodyParsers parsers, boolean allowEmptyFiles) {
+      super(parsers.multipartFormData(allowEmptyFiles), JavaParsers::toJavaMultipartFormData);
+    }
+
+    public MultipartFormData(PlayBodyParsers parsers, long maxLength) {
+      super(parsers.multipartFormData(maxLength), JavaParsers::toJavaMultipartFormData);
+    }
+
+    public MultipartFormData(PlayBodyParsers parsers, long maxLength, boolean allowEmptyFiles) {
+      super(
+          parsers.multipartFormData(maxLength, allowEmptyFiles),
+          JavaParsers::toJavaMultipartFormData);
+    }
   }
 
   /** Don't parse the body. */
@@ -609,7 +623,18 @@ public interface BodyParser<A> {
       this.maxLength = maxLength;
       this.materializer = materializer;
       this.errorHandler = errorHandler;
-      delegate = multipartParser();
+      delegate = multipartParser(false);
+    }
+
+    public DelegatingMultipartFormDataBodyParser(
+        Materializer materializer,
+        long maxLength,
+        boolean allowEmptyFiles,
+        play.api.http.HttpErrorHandler errorHandler) {
+      this.maxLength = maxLength;
+      this.materializer = materializer;
+      this.errorHandler = errorHandler;
+      delegate = multipartParser(allowEmptyFiles);
     }
 
     /**
@@ -623,9 +648,11 @@ public interface BodyParser<A> {
         createFilePartHandler();
 
     /** Calls out to the Scala API to create a multipart parser. */
-    private play.api.mvc.BodyParser<play.api.mvc.MultipartFormData<A>> multipartParser() {
+    private play.api.mvc.BodyParser<play.api.mvc.MultipartFormData<A>> multipartParser(
+        boolean allowEmptyFiles) {
       ScalaFilePartHandler filePartHandler = new ScalaFilePartHandler();
-      return Multipart.multipartParser(maxLength, filePartHandler, errorHandler, materializer);
+      return Multipart.multipartParser(
+          maxLength, allowEmptyFiles, filePartHandler, errorHandler, materializer);
     }
 
     private class ScalaFilePartHandler

--- a/core/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/core/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -39,9 +39,22 @@ object Multipart {
    * Parses the stream into a stream of [[play.api.mvc.MultipartFormData.Part]] to be handled by `partHandler`.
    *
    * @param maxMemoryBufferSize The maximum amount of data to parse into memory.
+   * @param errorHandler The error handler to call when an error occurs.
    * @param partHandler The accumulator to handle the parts.
    */
   def partParser[A](maxMemoryBufferSize: Long, errorHandler: HttpErrorHandler)(
+      partHandler: Accumulator[Part[Source[ByteString, _]], Either[Result, A]]
+  )(implicit mat: Materializer): BodyParser[A] = partParser(maxMemoryBufferSize, false, errorHandler)(partHandler)
+
+  /**
+   * Parses the stream into a stream of [[play.api.mvc.MultipartFormData.Part]] to be handled by `partHandler`.
+   *
+   * @param maxMemoryBufferSize The maximum amount of data to parse into memory.
+   * @param allowEmptyFiles If file uploads are allowed to contain no data in the body
+   * @param errorHandler The error handler to call when an error occurs.
+   * @param partHandler The accumulator to handle the parts.
+   */
+  def partParser[A](maxMemoryBufferSize: Long, allowEmptyFiles: Boolean, errorHandler: HttpErrorHandler)(
       partHandler: Accumulator[Part[Source[ByteString, _]], Either[Result, A]]
   )(implicit mat: Materializer): BodyParser[A] = BodyParser { request =>
     val maybeBoundary = for {
@@ -53,7 +66,7 @@ object Multipart {
     maybeBoundary
       .map { boundary =>
         val multipartFlow = Flow[ByteString]
-          .via(new BodyPartParser(boundary, maxMemoryBufferSize, maxHeaderBuffer))
+          .via(new BodyPartParser(boundary, maxMemoryBufferSize, maxHeaderBuffer, allowEmptyFiles))
           .splitWhen(_.isLeft)
           .prefixAndTail(1)
           .map {
@@ -81,13 +94,30 @@ object Multipart {
    *
    * @param maxMemoryBufferSize The maximum amount of data to parse into memory.
    * @param filePartHandler The accumulator to handle the file parts.
+   * @param errorHandler The error handler to call when an error occurs.
    */
   def multipartParser[A](
       maxMemoryBufferSize: Long,
       filePartHandler: FilePartHandler[A],
       errorHandler: HttpErrorHandler
+  )(implicit mat: Materializer): BodyParser[MultipartFormData[A]] =
+    multipartParser(maxMemoryBufferSize, false, filePartHandler, errorHandler)
+
+  /**
+   * Parses the request body into a Multipart body.
+   *
+   * @param maxMemoryBufferSize The maximum amount of data to parse into memory.
+   * @param allowEmptyFiles If empty file uploads are allowed (no matter if filename or file is empty)
+   * @param filePartHandler The accumulator to handle the file parts.
+   * @param errorHandler The error handler to call when an error occurs.
+   */
+  def multipartParser[A](
+      maxMemoryBufferSize: Long,
+      allowEmptyFiles: Boolean,
+      filePartHandler: FilePartHandler[A],
+      errorHandler: HttpErrorHandler
   )(implicit mat: Materializer): BodyParser[MultipartFormData[A]] = BodyParser { request =>
-    partParser(maxMemoryBufferSize, errorHandler) {
+    partParser(maxMemoryBufferSize, allowEmptyFiles, errorHandler) {
       val handleFileParts = Flow[Part[Source[ByteString, _]]].mapAsync(1) {
         case filePart: FilePart[Source[ByteString, _]] =>
           filePartHandler(FileInfo(filePart.key, filePart.filename, filePart.contentType, filePart.dispositionType))
@@ -213,7 +243,7 @@ object Multipart {
 
         dispositionType <- values.keys.find(key => key == "form-data" || key == "file")
         partName        <- values.get("name")
-        fileName        <- values.get("filename").filter(_.trim.nonEmpty)
+        fileName        <- values.get("filename")
         contentType = headers.get("content-type")
       } yield (partName, fileName, contentType, dispositionType)
     }
@@ -270,8 +300,16 @@ object Multipart {
    *
    * see: http://tools.ietf.org/html/rfc2046#section-5.1.1
    */
-  private final class BodyPartParser(boundary: String, maxMemoryBufferSize: Long, maxHeaderSize: Int)
-      extends GraphStage[FlowShape[ByteString, RawPart]] {
+  private final class BodyPartParser(
+      boundary: String,
+      maxMemoryBufferSize: Long,
+      maxHeaderSize: Int,
+      allowEmptyFiles: Boolean
+  ) extends GraphStage[FlowShape[ByteString, RawPart]] {
+    def this(boundary: String, maxMemoryBufferSize: Long, maxHeaderSize: Int) {
+      this(boundary, maxMemoryBufferSize, maxHeaderSize, false)
+    }
+
     require(boundary.nonEmpty, "'boundary' parameter of multipart Content-Type must be non-empty")
     require(
       boundary.charAt(boundary.length - 1) != ' ',
@@ -392,19 +430,28 @@ object Multipart {
               val totalMemoryBufferSize = memoryBufferSize + headersSize
 
               headers match {
-                case FileInfoMatcher(partName, fileName, contentType, dispositionType) =>
-                  checkEmptyBody(input, partStart, totalMemoryBufferSize)(
-                    newInput =>
-                      handleFilePart(
-                        newInput,
-                        partStart,
-                        totalMemoryBufferSize,
-                        partName,
-                        fileName,
-                        contentType,
-                        dispositionType
+                case FileInfoMatcher(partName, fileName, contentType, dispositionType) => {
+                  def processFilePart(in: ByteString) = handleFilePart(
+                    in,
+                    partStart,
+                    totalMemoryBufferSize,
+                    partName,
+                    fileName,
+                    contentType,
+                    dispositionType
+                  )
+                  if (allowEmptyFiles) {
+                    processFilePart(input)
+                  } else {
+                    if (fileName.trim.nonEmpty) {
+                      checkEmptyBody(input, partStart, totalMemoryBufferSize)(newInput => processFilePart(newInput))(
+                        newInput => handleBadPart(newInput, partStart, totalMemoryBufferSize, headers)
                       )
-                  )(newInput => handleBadPart(newInput, partStart, totalMemoryBufferSize, headers))
+                    } else {
+                      handleBadPart(input, partStart, totalMemoryBufferSize, headers)
+                    }
+                  }
+                }
                 case PartInfoMatcher(name) =>
                   handleDataPart(input, partStart, memoryBufferSize + name.length, name)
                 case _ =>


### PR DESCRIPTION
Like #10237 but for the 2.7.x branch.
It's almost the same, except in the 2.7.x branch we did not yet have the files:
- `DummyDelegatingMultipartFormDataBodyParser.java` and
- `MaxLengthBodyParserSpec.scala`

but that does not matter here anyway.