### PR TITLE
JsonHttpErrorHandler should treat stringified JSON correctly

### DIFF
--- a/core/play/src/main/java/play/http/HtmlOrJsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/HtmlOrJsonHttpErrorHandler.java
@@ -18,6 +18,7 @@ public class HtmlOrJsonHttpErrorHandler extends PreferredMediaTypeHttpErrorHandl
     LinkedHashMap<String, HttpErrorHandler> map = new LinkedHashMap<>();
     map.put("text/html", htmlHandler);
     map.put("application/json", jsonHandler);
+    map.put("application/problem+json", jsonHandler);
     return map;
   }
 

--- a/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
@@ -54,7 +54,7 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
           "onClientError invoked with non client error status code " + statusCode + ": " + message);
     }
 
-    // If the message param is surrounded by braces "{...}" it may is stringified JSON object, so
+    // If the message param is surrounded by braces "{...}" it may be a stringified JSON object, so
     // let's try to parse it as JSON. If parsed successfully let's just send this parsed JSON object
     // with the requestId merged into, if it can't be parsed however, we just send the message param
     // as string, like normal.

--- a/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
@@ -54,6 +54,10 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
           "onClientError invoked with non client error status code " + statusCode + ": " + message);
     }
 
+    // If the message param is surrounded by braces "{...}" it may is stringified JSON object, so
+    // let's try to parse it as JSON. If parsed successfully let's just send this parsed JSON object
+    // with the requestId merged into, if it can't be parsed however, we just send the message param
+    // as string, like normal.
     if (message != null && message.trim().startsWith("{") && message.trim().endsWith("}")) {
       // Looks like the message is a stringified JSON object already
       try {

--- a/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
@@ -67,7 +67,7 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
                 ((ObjectNode) // It's an ObjectNode for sure, we checked that in the if above
                         Json.parse(message))
                     .put("requestId", request.asScala().id())));
-      } catch (Exception e) {
+      } catch (RuntimeException e) {
         return sendMessageAsString(request, statusCode, message);
       }
     } else {

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -381,6 +381,10 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
       )
 
     if (play.api.http.Status.isClientError(statusCode)) {
+      // If the message param is surrounded by braces "{...}" it may is stringified JSON object, so
+      // let's try to parse it as JSON. If parsed successfully let's just send this parsed JSON object
+      // with the requestId merged into, if it can't be parsed however, we just send the message param
+      // as string, like normal.
       if (message != null && message.trim.startsWith("{") && message.trim.endsWith("}")) {
         // Looks like the message is a stringified JSON object already
         try {

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -381,7 +381,7 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
       )
 
     if (play.api.http.Status.isClientError(statusCode)) {
-      // If the message param is surrounded by braces "{...}" it may is stringified JSON object, so
+      // If the message param is surrounded by braces "{...}" it may be a stringified JSON object, so
       // let's try to parse it as JSON. If parsed successfully let's just send this parsed JSON object
       // with the requestId merged into, if it can't be parsed however, we just send the message param
       // as string, like normal.

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -397,7 +397,7 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
             )
           )
         } catch {
-          case _: Throwable => sendMessageAsString
+          case NonFatal(_) => sendMessageAsString
         }
       } else {
         sendMessageAsString

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -140,7 +140,7 @@ class JavaCSPReportSpec extends PlaySpecification {
       contentAsJson(result) must be_==(Json.obj("violation" -> "object-src https://45.55.25.245:8123/"))
     }
 
-    "fail when sending an unsupported media type (text/plain) in content type header" in withActionServer() {
+    "fail when receiving an unsupported media type (text/plain) in content type header" in withActionServer() {
       implicit app =>
         val request      = FakeRequest("POST", "/report-to").withTextBody("foo")
         val Some(result) = route(app, request)

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
@@ -121,7 +121,7 @@ class ScalaCSPReportSpec extends PlaySpecification {
       contentAsJson(result) must be_==(Json.obj("violation" -> "object-src https://45.55.25.245:8123/"))
     }
 
-    "fail when sending an unsupported media type (text/plain) in content type header" in withApplication() {
+    "fail when receiving an unsupported media type (text/plain) in content type header" in withApplication() {
       implicit app =>
         val request      = FakeRequest("POST", "/report-to").withTextBody("foo")
         val Some(result) = route(app, request)


### PR DESCRIPTION
When the `message` param of the `JsonHttpErrorHandler.onClientError` method is a stringified JSON, that json error handler should then just send this JSON (plus the requestId attached).
This totally makes sense if the framework or a dev want's to send more than just a message _string_ and/or want's to have better control of which json to send.

Also, the test I added, which was missing IMHO and definitely is correct (see RFC 7807, section 3: ["Problem Details JSON Object"](https://tools.ietf.org/html/rfc7807#section-3)), **only works with this fix applied**.
Without this fix, the json send to the client would squeeze the RFC 7807 JSON object into the `message` property as _string_ (escaping the quotes):
```
{"error":{"requestId":5,"message":"{\"title\":\"Unsupported Media Type\",\"status\":415,\"detail\":\"Content type must be one of application/x-www-form-urlencoded,text/json,application/json,application/csp-report but was Some(text/plain)\"}"}}
```
Therefore it turns out the "Unsupported Media Type" response never worked correctly... :cry: 
(Not just because the RFC 7807 JSON object is a string, but also the whole structure is wrong, there is no `error:` key in the RFC)

I am going to backport this to 2.8.x.