### PR TITLE
Allow customization of error message when JSON error handler failed

### DIFF
--- a/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
@@ -79,7 +79,7 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
     } catch (Exception e) {
       logger.error("Error while handling error", e);
       return CompletableFuture.completedFuture(
-          Results.internalServerError(fatalErrorMessage(request, e)));
+          Results.internalServerError(fatalErrorJson(request, e)));
     }
   }
 
@@ -97,7 +97,7 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
    * @return An error JSON which will be send as last resort in case handling a server error with
    *     this error handler failed.
    */
-  protected JsonNode fatalErrorMessage(RequestHeader request, Throwable exception) {
+  protected JsonNode fatalErrorJson(RequestHeader request, Throwable exception) {
     return Json.newObject();
   }
 

--- a/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
@@ -78,8 +78,27 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
       }
     } catch (Exception e) {
       logger.error("Error while handling error", e);
-      return CompletableFuture.completedFuture(Results.internalServerError());
+      return CompletableFuture.completedFuture(
+          Results.internalServerError(fatalErrorMessage(request, e)));
     }
+  }
+
+  /**
+   * Invoked when handling a server error with this error handler failed.
+   *
+   * <p>As a last resort this method allows you to return a (simple) error message that will be send
+   * along with a "500 Internal Server Error" response. It's highly recommended to just return a
+   * simple JsonNode, without doing any fancy processing inside the method (like accessing
+   * files,...) that could throw exceptions. This is your last chance to send a meaningful error
+   * message when everything else failed.
+   *
+   * @param request The request that triggered the server error.
+   * @param exception The server error.
+   * @return An error JSON which will be send as last resort in case handling a server error with
+   *     this error handler failed.
+   */
+  protected JsonNode fatalErrorMessage(RequestHeader request, Throwable exception) {
+    return Json.newObject();
   }
 
   /**

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -259,9 +259,25 @@ class DefaultHttpErrorHandler(
     } catch {
       case NonFatal(e) =>
         logger.error("Error while handling error", e)
-        Future.successful(InternalServerError)
+        Future.successful(InternalServerError(fatalErrorMessage(request, e)))
     }
   }
+
+  /**
+   * Invoked when handling a server error with this error handler failed.
+   *
+   * <p>As a last resort this method allows you to return a (simple) error message that will be send
+   * along with a "500 Internal Server Error" response. It's highly recommended to just return a
+   * simple string, without doing any fancy processing inside the method (like accessing files,...)
+   * that could throw exceptions. This is your last chance to send a meaningful error message when
+   * everything else failed.
+   *
+   * @param request   The request that triggered the server error.
+   * @param exception The server error.
+   * @return An error message which will be send as last resort in case handling a server error with
+   *         this error handler failed.
+   */
+  protected def fatalErrorMessage(request: RequestHeader, exception: Throwable) = ""
 
   /**
    * Responsible for logging server errors.
@@ -404,8 +420,24 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
     } catch {
       case NonFatal(e) =>
         logger.error("Error while handling error", e)
-        Future.successful(InternalServerError)
+        Future.successful(InternalServerError(fatalErrorMessage(request, e)))
     }
+
+  /**
+   * Invoked when handling a server error with this error handler failed.
+   *
+   * <p>As a last resort this method allows you to return a (simple) error message that will be send
+   * along with a "500 Internal Server Error" response. It's highly recommended to just return a
+   * simple JsonNode, without doing any fancy processing inside the method (like accessing files,...)
+   * that could throw exceptions. This is your last chance to send a meaningful error message when
+   * everything else failed.
+   *
+   * @param request   The request that triggered the server error.
+   * @param exception The server error.
+   * @return An error JSON which will be send as last resort in case handling a server error with
+   *         this error handler failed.
+   */
+  protected def fatalErrorMessage(request: RequestHeader, exception: Throwable): JsValue = Json.obj()
 
   protected def devServerError(request: RequestHeader, exception: UsefulException): JsValue = {
     error(

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -420,7 +420,7 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
     } catch {
       case NonFatal(e) =>
         logger.error("Error while handling error", e)
-        Future.successful(InternalServerError(fatalErrorMessage(request, e)))
+        Future.successful(InternalServerError(fatalErrorJson(request, e)))
     }
 
   /**
@@ -437,7 +437,7 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
    * @return An error JSON which will be send as last resort in case handling a server error with
    *         this error handler failed.
    */
-  protected def fatalErrorMessage(request: RequestHeader, exception: Throwable): JsValue = Json.obj()
+  protected def fatalErrorJson(request: RequestHeader, exception: Throwable): JsValue = Json.obj()
 
   protected def devServerError(request: RequestHeader, exception: UsefulException): JsValue = {
     error(

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -277,7 +277,7 @@ class DefaultHttpErrorHandler(
    * @return An error message which will be send as last resort in case handling a server error with
    *         this error handler failed.
    */
-  protected def fatalErrorMessage(request: RequestHeader, exception: Throwable) = ""
+  protected def fatalErrorMessage(request: RequestHeader, exception: Throwable): String = ""
 
   /**
    * Responsible for logging server errors.


### PR DESCRIPTION
Same like #10121, however let's also add this for the JSON error handlers (and for Scala's http error handler, which I forgot in the original pull request).