### PR TITLE
Tests for CSP errors, which should be in RFC 7807 format

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -66,7 +66,7 @@ class DefaultCSPReportBodyParser @Inject() (parsers: PlayBodyParsers)(implicit e
                 Right(report)
               case JsError(errors) =>
                 Left(
-                  createErrorResult(request, "Could not parse CSP", errors = Some(JsError.toJson(errors)))
+                  createErrorResult(request, "Bad Request", "Could not parse CSP", Some(JsError.toJson(errors)))
                 )
             }
           })

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -9,8 +9,6 @@ import java.util.Locale
 import akka.util.ByteString
 import play.api.mvc._
 import javax.inject._
-import play.api.http.ContentTypes
-import play.api.http.MediaType
 import play.api.http.Status
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
@@ -18,7 +16,6 @@ import play.api.libs.streams
 import play.api.libs.streams.Accumulator
 import play.api.mvc
 
-import scala.beans.BeanProperty
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -69,15 +66,7 @@ class DefaultCSPReportBodyParser @Inject() (parsers: PlayBodyParsers)(implicit e
                 Right(report)
               case JsError(errors) =>
                 Left(
-                  Results
-                    .BadRequest(
-                      Json.obj(
-                        "title"  -> "Could not parse CSP",
-                        "status" -> Status.BAD_REQUEST,
-                        "errors" -> JsError.toJson(errors)
-                      )
-                    )
-                    .as("application/problem+json")
+                  createErrorResult(request, "Could not parse CSP", errors = JsError.toJson(errors))
                 )
             }
           })
@@ -103,21 +92,42 @@ class DefaultCSPReportBodyParser @Inject() (parsers: PlayBodyParsers)(implicit e
           val validTypes =
             Seq("application/x-www-form-urlencoded", "text/json", "application/json", "application/csp-report")
           val msg = s"Content type must be one of ${validTypes.mkString(",")} but was $contentType"
-
-          val problemJson = Json.obj(
-            "title"  -> "Unsupported Media Type",
-            "status" -> Status.UNSUPPORTED_MEDIA_TYPE,
-            "detail" -> msg
-          )
-          val f = createBadResult(Json.stringify(problemJson), Status.UNSUPPORTED_MEDIA_TYPE)
-          f(request).map(Left.apply)
+          Left(createErrorResult(request, "Unsupported Media Type", msg, statusCode = Status.UNSUPPORTED_MEDIA_TYPE))
         }
     }
   }
 
+  @deprecated("Use createErrorResult instead", "2.9.0")
   protected def createBadResult(msg: String, statusCode: Int = Status.BAD_REQUEST): RequestHeader => Future[Result] = {
     request =>
       parsers.errorHandler.onClientError(request, statusCode, msg).map(_.as("application/problem+json"))
+  }
+
+  protected def createErrorResult(
+      request: RequestHeader,
+      title: String,
+      detail: String = "",
+      errors: JsObject = Json.obj(),
+      statusCode: Int = Status.BAD_REQUEST
+  ): Result = {
+    Results
+      .Status(statusCode)(
+        Json.obj(
+          "requestId" -> request.id,
+          "title"     -> title,
+          "status"    -> statusCode,
+        ) ++ (if (detail.nonEmpty) {
+                Json.obj("detail" -> detail)
+              } else {
+                Json.obj()
+              }) ++
+          (if (errors.fields.nonEmpty) {
+             Json.obj("errors" -> errors)
+           } else {
+             Json.obj()
+           })
+      )
+      .as("application/problem+json")
   }
 
   import play.mvc.Http

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -187,8 +187,9 @@ class JavaCSPReportSpec extends PlaySpecification {
       fullJson - "requestId" must be_==(
         JsObject(
           Seq(
-            "title"  -> JsString("Could not parse CSP"),
+            "title"  -> JsString("Bad Request"),
             "status" -> JsNumber(Status.BAD_REQUEST),
+            "detail" -> JsString("Could not parse CSP"),
             "errors" -> JsObject(
               Seq(
                 "obj.document-uri" ->

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -7,7 +7,12 @@ package play.filters.csp
 import java.util.concurrent.CompletableFuture
 
 import play.api.Application
+import play.api.http.Status
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsArray
+import play.api.libs.json.JsNumber
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsString
 import play.api.libs.json.Json
 import play.api.test._
 import play.core.j._
@@ -45,7 +50,12 @@ class JavaCSPReportSpec extends PlaySpecification {
 
   def withActionServer[T](config: (String, String)*)(block: Application => T): T = {
     val app = GuiceApplicationBuilder()
-      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
+      .configure(
+        Map(config: _*) ++ Map(
+          "play.http.secret.key"   -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b",
+          "play.http.errorHandler" -> "play.http.JsonHttpErrorHandler"
+        )
+      )
       .appRoutes(implicit app => { case _ => javaAction[JavaCSPReportSpec.MyAction]("cspReport", myAction.cspReport) })
       .build()
     block(app)
@@ -71,6 +81,8 @@ class JavaCSPReportSpec extends PlaySpecification {
       val request      = FakeRequest("POST", "/report-to").withJsonBody(chromeJson)
       val Some(result) = route(app, request)
 
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
       contentAsJson(result) must be_==(Json.obj("violation" -> "child-src https://45.55.25.245:8123/"))
     }
 
@@ -91,6 +103,8 @@ class JavaCSPReportSpec extends PlaySpecification {
       val request      = FakeRequest("POST", "/report-to").withJsonBody(firefoxJson)
       val Some(result) = route(app, request)
 
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
       contentAsJson(result) must be_==(Json.obj("violation" -> "img-src https://45.55.25.245:8123/"))
     }
 
@@ -110,6 +124,8 @@ class JavaCSPReportSpec extends PlaySpecification {
       val request      = FakeRequest("POST", "/report-to").withJsonBody(webkitJson)
       val Some(result) = route(app, request)
 
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
       contentAsJson(result) must be_==(Json.obj("violation" -> "default-src https://45.55.25.245:8123/"))
     }
 
@@ -120,7 +136,78 @@ class JavaCSPReportSpec extends PlaySpecification {
       )
       val Some(result) = route(app, request)
 
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
       contentAsJson(result) must be_==(Json.obj("violation" -> "object-src https://45.55.25.245:8123/"))
+    }
+
+    "fail when receiving an unsupported media type (text/plain) in content type header" in withActionServer() {
+      implicit app =>
+        val request      = FakeRequest("POST", "/report-to").withTextBody("foo")
+        val Some(result) = route(app, request)
+
+        status(result) must_=== Status.UNSUPPORTED_MEDIA_TYPE
+        contentType(result) must beSome("application/problem+json")
+        val fullJson = contentAsJson(result).asInstanceOf[JsObject]
+        // The value of "requestId" is not constant, it changes, so we just check for its existence
+        fullJson.fields.filter(_._1 == "requestId").size must_=== 1
+        // Lets remove "requestId" now
+        fullJson - "requestId" must be_==(
+          JsObject(
+            Seq(
+              "title"  -> JsString("Unsupported Media Type"),
+              "status" -> JsNumber(Status.UNSUPPORTED_MEDIA_TYPE),
+              "detail" -> JsString(
+                "Content type must be one of application/x-www-form-urlencoded,text/json,application/json,application/csp-report but was Some(text/plain)"
+              ),
+            )
+          )
+        )
+    }
+
+    "fail when receiving invalid csp-report JSON" in withActionServer() { implicit app =>
+      val invalidCspReportJson = Json.parse(
+        """{
+          | "csp-report": {
+          |    "foo": "bar"
+          |  }
+          |}
+        """.stripMargin
+      )
+
+      val request      = FakeRequest("POST", "/report-to").withJsonBody(invalidCspReportJson)
+      val Some(result) = route(app, request)
+
+      status(result) must_=== Status.BAD_REQUEST
+      contentType(result) must beSome("application/problem+json")
+      val fullJson = contentAsJson(result).asInstanceOf[JsObject]
+      // The value of "requestId" is not constant, it changes, so we just check for its existence
+      fullJson.fields.filter(_._1 == "requestId").size must_=== 1
+      // Lets remove "requestId" now
+      fullJson - "requestId" must be_==(
+        JsObject(
+          Seq(
+            "title"  -> JsString("Could not parse CSP"),
+            "status" -> JsNumber(Status.BAD_REQUEST),
+            "errors" -> JsObject(
+              Seq(
+                "obj.document-uri" ->
+                  JsArray(
+                    Seq(
+                      JsObject(Seq("msg" -> JsArray(Seq(JsString("error.path.missing"))), "args" -> JsArray(Seq.empty)))
+                    )
+                  ),
+                "obj.violated-directive" ->
+                  JsArray(
+                    Seq(
+                      JsObject(Seq("msg" -> JsArray(Seq(JsString("error.path.missing"))), "args" -> JsArray(Seq.empty)))
+                    )
+                  ),
+              )
+            )
+          )
+        )
+      )
     }
   }
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
@@ -168,8 +168,9 @@ class ScalaCSPReportSpec extends PlaySpecification {
       fullJson - "requestId" must be_==(
         JsObject(
           Seq(
-            "title"  -> JsString("Could not parse CSP"),
+            "title"  -> JsString("Bad Request"),
             "status" -> JsNumber(Status.BAD_REQUEST),
+            "detail" -> JsString("Could not parse CSP"),
             "errors" -> JsObject(
               Seq(
                 "obj.document-uri" ->

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
@@ -7,6 +7,10 @@ package play.filters.csp
 import com.typesafe.config.ConfigFactory
 import javax.inject.Inject
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsArray
+import play.api.libs.json.JsNumber
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsString
 import play.api.libs.json.Json
 import play.api.mvc.AbstractController
 import play.api.mvc.ControllerComponents
@@ -14,6 +18,7 @@ import play.api.test.FakeRequest
 import play.api.test.PlaySpecification
 import play.api.Application
 import play.api.Configuration
+import play.api.http.Status
 
 import scala.reflect.ClassTag
 
@@ -31,6 +36,7 @@ class ScalaCSPReportSpec extends PlaySpecification {
 
   def withApplication[T]()(block: Application => T): T = {
     val app = new GuiceApplicationBuilder()
+      .configure(Map("play.http.errorHandler" -> "play.api.http.JsonHttpErrorHandler"))
       .appRoutes(implicit app => { case _ => myAction.cspReport })
       .build()
     running(app)(block(app))
@@ -56,6 +62,8 @@ class ScalaCSPReportSpec extends PlaySpecification {
       val request      = FakeRequest("POST", "/report-to").withJsonBody(chromeJson)
       val Some(result) = route(app, request)
 
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
       contentAsJson(result) must be_==(Json.obj("violation" -> "child-src https://45.55.25.245:8123/"))
     }
 
@@ -76,6 +84,8 @@ class ScalaCSPReportSpec extends PlaySpecification {
       val request      = FakeRequest("POST", "/report-to").withJsonBody(firefoxJson)
       val Some(result) = route(app, request)
 
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
       contentAsJson(result) must be_==(Json.obj("violation" -> "img-src https://45.55.25.245:8123/"))
     }
 
@@ -95,6 +105,8 @@ class ScalaCSPReportSpec extends PlaySpecification {
       val request      = FakeRequest("POST", "/report-to").withJsonBody(webkitJson)
       val Some(result) = route(app, request)
 
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
       contentAsJson(result) must be_==(Json.obj("violation" -> "default-src https://45.55.25.245:8123/"))
     }
 
@@ -105,7 +117,78 @@ class ScalaCSPReportSpec extends PlaySpecification {
       )
       val Some(result) = route(app, request)
 
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
       contentAsJson(result) must be_==(Json.obj("violation" -> "object-src https://45.55.25.245:8123/"))
+    }
+
+    "fail when receiving an unsupported media type (text/plain) in content type header" in withApplication() {
+      implicit app =>
+        val request      = FakeRequest("POST", "/report-to").withTextBody("foo")
+        val Some(result) = route(app, request)
+
+        status(result) must_=== Status.UNSUPPORTED_MEDIA_TYPE
+        contentType(result) must beSome("application/problem+json")
+        val fullJson = contentAsJson(result).asInstanceOf[JsObject]
+        // The value of "requestId" is not constant, it changes, so we just check for its existence
+        fullJson.fields.filter(_._1 == "requestId").size must_=== 1
+        // Lets remove "requestId" now
+        fullJson - "requestId" must be_==(
+          JsObject(
+            Seq(
+              "title"  -> JsString("Unsupported Media Type"),
+              "status" -> JsNumber(Status.UNSUPPORTED_MEDIA_TYPE),
+              "detail" -> JsString(
+                "Content type must be one of application/x-www-form-urlencoded,text/json,application/json,application/csp-report but was Some(text/plain)"
+              ),
+            )
+          )
+        )
+    }
+
+    "fail when receiving invalid csp-report JSON" in withApplication() { implicit app =>
+      val invalidCspReportJson = Json.parse(
+        """{
+          | "csp-report": {
+          |    "foo": "bar"
+          |  }
+          |}
+        """.stripMargin
+      )
+
+      val request      = FakeRequest("POST", "/report-to").withJsonBody(invalidCspReportJson)
+      val Some(result) = route(app, request)
+
+      status(result) must_=== Status.BAD_REQUEST
+      contentType(result) must beSome("application/problem+json")
+      val fullJson = contentAsJson(result).asInstanceOf[JsObject]
+      // The value of "requestId" is not constant, it changes, so we just check for its existence
+      fullJson.fields.filter(_._1 == "requestId").size must_=== 1
+      // Lets remove "requestId" now
+      fullJson - "requestId" must be_==(
+        JsObject(
+          Seq(
+            "title"  -> JsString("Could not parse CSP"),
+            "status" -> JsNumber(Status.BAD_REQUEST),
+            "errors" -> JsObject(
+              Seq(
+                "obj.document-uri" ->
+                  JsArray(
+                    Seq(
+                      JsObject(Seq("msg" -> JsArray(Seq(JsString("error.path.missing"))), "args" -> JsArray(Seq.empty)))
+                    )
+                  ),
+                "obj.violated-directive" ->
+                  JsArray(
+                    Seq(
+                      JsObject(Seq("msg" -> JsArray(Seq(JsString("error.path.missing"))), "args" -> JsArray(Seq.empty)))
+                    )
+                  ),
+              )
+            )
+          )
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
The `Unsupported Media Type` error is **not** delegated to the error handler anymore.