### PR TITLE
Switch JsonHttpErrorHandler to RFC 7807 and handle application/problem+json

### DIFF
--- a/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -81,23 +81,27 @@ class HttpErrorHandlerSpec extends Specification {
 
       "answer a JSON error message on bad request" in {
         val json = responseBody(errorHandler.onClientError(FakeRequest(), 400))
-        (json \ "error" \ "requestId").get must beAnInstanceOf[JsNumber]
-        (json \ "error" \ "message").get must beAnInstanceOf[JsString]
+        (json \ "requestId").get must beAnInstanceOf[JsNumber]
+        (json \ "title").get must beAnInstanceOf[JsString]
+        (json \ "status").get must_=== JsNumber(400)
       }
       "answer a JSON error message on forbidden" in {
         val json = responseBody(errorHandler.onClientError(FakeRequest(), 403))
-        (json \ "error" \ "requestId").get must beAnInstanceOf[JsNumber]
-        (json \ "error" \ "message").get must beAnInstanceOf[JsString]
+        (json \ "requestId").get must beAnInstanceOf[JsNumber]
+        (json \ "title").get must beAnInstanceOf[JsString]
+        (json \ "status").get must_=== JsNumber(403)
       }
       "answer a JSON error message on not found" in {
         val json = responseBody(errorHandler.onClientError(FakeRequest(), 404))
-        (json \ "error" \ "requestId").get must beAnInstanceOf[JsNumber]
-        (json \ "error" \ "message").get must beAnInstanceOf[JsString]
+        (json \ "requestId").get must beAnInstanceOf[JsNumber]
+        (json \ "title").get must beAnInstanceOf[JsString]
+        (json \ "status").get must_=== JsNumber(404)
       }
       "answer a JSON error message on a generic client error" in {
         val json = responseBody(errorHandler.onClientError(FakeRequest(), 418))
-        (json \ "error" \ "requestId").get must beAnInstanceOf[JsNumber]
-        (json \ "error" \ "message").get must beAnInstanceOf[JsString]
+        (json \ "requestId").get must beAnInstanceOf[JsNumber]
+        (json \ "title").get must beAnInstanceOf[JsString]
+        (json \ "status").get must_=== JsNumber(418)
       }
       "refuse to render something that isn't a client error" in {
         responseBody(errorHandler.onClientError(FakeRequest(), 500)) must throwAn[IllegalArgumentException]
@@ -105,21 +109,24 @@ class HttpErrorHandlerSpec extends Specification {
       }
       "answer a JSON error message on a server error" in {
         val json                 = responseBody(errorHandler.onServerError(FakeRequest(), new RuntimeException()))
-        val id                   = json \ "error" \ "id"
-        val requestId            = json \ "error" \ "requestId"
-        val exceptionTitle       = json \ "error" \ "exception" \ "title"
-        val exceptionDescription = json \ "error" \ "exception" \ "description"
-        val exceptionCause       = json \ "error" \ "exception" \ "stacktrace"
+        val id                   = json \ "id"
+        val requestId            = json \ "requestId"
+        val status               = json \ "status"
+        val exceptionTitle       = json \ "title"
+        val exceptionDescription = json \ "detail"
+        val exceptionCause       = json \ "stacktrace"
 
         if (isProdMode) {
           id.get must beAnInstanceOf[JsString]
-          requestId.toOption must beNone
-          exceptionTitle.toOption must beNone
-          exceptionDescription.toOption must beNone
-          exceptionCause.toOption must beNone
+          requestId.get must beAnInstanceOf[JsNumber]
+          status.get must_=== JsNumber(500)
+          exceptionTitle.get must_=== JsString("Internal server error")
+          exceptionDescription.toOption must beEmpty
+          exceptionCause.toOption must beEmpty
         } else {
           id.get must beAnInstanceOf[JsString]
           requestId.get must beAnInstanceOf[JsNumber]
+          status.get must_=== JsNumber(500)
           exceptionTitle.get must beAnInstanceOf[JsString]
           exceptionDescription.get must beAnInstanceOf[JsString]
           exceptionCause.get must beAnInstanceOf[JsArray]

--- a/core/play/src/main/java/play/http/HtmlOrJsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/HtmlOrJsonHttpErrorHandler.java
@@ -18,6 +18,7 @@ public class HtmlOrJsonHttpErrorHandler extends PreferredMediaTypeHttpErrorHandl
     LinkedHashMap<String, HttpErrorHandler> map = new LinkedHashMap<>();
     map.put("text/html", htmlHandler);
     map.put("application/json", jsonHandler);
+    map.put("application/problem+json", jsonHandler);
     return map;
   }
 

--- a/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
@@ -22,6 +22,7 @@ import play.mvc.Http.RequestHeader;
 import play.mvc.Result;
 import play.mvc.Results;
 
+import static play.mvc.Http.Status.INTERNAL_SERVER_ERROR;
 /**
  * An alternative default HTTP error handler which will render errors as JSON messages instead of
  * HTML pages.
@@ -55,9 +56,10 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
 
     ObjectNode result = Json.newObject();
     result.put("requestId", request.asScala().id());
-    result.put("message", message);
+    result.put("title", message);
+    result.put("status", statusCode);
 
-    return CompletableFuture.completedFuture(Results.status(statusCode, error(result)));
+    return CompletableFuture.completedFuture(Results.status(statusCode, result));
   }
 
   @Override
@@ -140,17 +142,15 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
    * @param exception The exception.
    */
   protected JsonNode devServerError(RequestHeader request, UsefulException exception) {
-    ObjectNode exceptionJson = Json.newObject();
-    exceptionJson.put("title", exception.title);
-    exceptionJson.put("description", exception.description);
-    exceptionJson.set("stacktrace", formatDevServerErrorException(exception.cause));
-
     ObjectNode result = Json.newObject();
     result.put("id", exception.id);
     result.put("requestId", request.asScala().id());
-    result.set("exception", exceptionJson);
+    result.put("status", INTERNAL_SERVER_ERROR);
+    result.put("title", exception.title);
+    result.put("detail", exception.description);
+    result.set("stacktrace", formatDevServerErrorException(exception.cause));
 
-    return error(result);
+    return result;
   }
 
   /**
@@ -181,13 +181,10 @@ public class JsonHttpErrorHandler implements HttpErrorHandler {
   protected JsonNode prodServerError(RequestHeader request, UsefulException exception) {
     ObjectNode result = Json.newObject();
     result.put("id", exception.id);
+    result.put("requestId", request.asScala().id());
+    result.put("status", INTERNAL_SERVER_ERROR);
+    result.put("title", "Internal server error");
 
-    return error(result);
-  }
-
-  private JsonNode error(JsonNode content) {
-    ObjectNode result = Json.newObject();
-    result.set("error", content);
     return result;
   }
 }

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -64,7 +64,11 @@ trait HttpErrorHandler {
 class HtmlOrJsonHttpErrorHandler @Inject() (
     htmlHandler: DefaultHttpErrorHandler,
     jsonHandler: JsonHttpErrorHandler
-) extends PreferredMediaTypeHttpErrorHandler("text/html" -> htmlHandler, "application/json" -> jsonHandler)
+) extends PreferredMediaTypeHttpErrorHandler(
+      "text/html"                -> htmlHandler,
+      "application/json"         -> jsonHandler,
+      "application/problem+json" -> jsonHandler
+    )
 
 /**
  * An [[HttpErrorHandler]] that delegates to one of several [[HttpErrorHandler]]s based on media type preferences.
@@ -72,7 +76,8 @@ class HtmlOrJsonHttpErrorHandler @Inject() (
  * For example, to create an error handler that handles JSON and HTML, with JSON preferred by the app as default:
  * {{{
  *   override lazy val httpErrorHandler = PreferredMediaTypeHttpErrorHandler(
- *     "application/json" -> new JsonHttpErrorHandler()
+ *     "application/json" -> new JsonHttpErrorHandler(),
+ *     "application/problem+json" -> new JsonHttpErrorHandler(),
  *     "text/html" -> new HtmlHttpErrorHandler(),
  *   )
  * }}}
@@ -430,9 +435,6 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
     this(environment, optionalSourceMapper.sourceMapper)
   }
 
-  @inline
-  private final def error(content: JsObject): JsObject = Json.obj("error" -> content)
-
   /**
    * Invoked when a client error occurs, that is, an error in the 4xx series.
    *
@@ -442,7 +444,9 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
    */
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
     if (play.api.http.Status.isClientError(statusCode)) {
-      Future.successful(Results.Status(statusCode)(error(Json.obj("requestId" -> request.id, "message" -> message))))
+      Future.successful(
+        Results.Status(statusCode)(Json.obj("requestId" -> request.id, "title" -> message, "status" -> statusCode))
+      )
     } else {
       throw new IllegalArgumentException(
         s"onClientError invoked with non client error status code $statusCode: $message"
@@ -495,16 +499,13 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
   protected def fatalErrorJson(request: RequestHeader, exception: Throwable): JsValue = Json.obj()
 
   protected def devServerError(request: RequestHeader, exception: UsefulException): JsValue = {
-    error(
-      Json.obj(
-        "id"        -> exception.id,
-        "requestId" -> request.id,
-        "exception" -> Json.obj(
-          "title"       -> exception.title,
-          "description" -> exception.description,
-          "stacktrace"  -> formatDevServerErrorException(exception.cause)
-        )
-      )
+    Json.obj(
+      "id"         -> exception.id,
+      "requestId"  -> request.id,
+      "status"     -> INTERNAL_SERVER_ERROR,
+      "title"      -> exception.title,
+      "detail"     -> exception.description,
+      "stacktrace" -> formatDevServerErrorException(exception.cause)
     )
   }
 
@@ -517,7 +518,12 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
     JsArray(ExceptionUtils.getStackFrames(exception).map(s => JsString(s.trim)))
 
   protected def prodServerError(request: RequestHeader, exception: UsefulException): JsValue =
-    error(Json.obj("id" -> exception.id))
+    Json.obj(
+      "id"        -> exception.id,
+      "requestId" -> request.id,
+      "status"    -> INTERNAL_SERVER_ERROR,
+      "title"     -> "Internal server error"
+    )
 
   /**
    * Responsible for logging server errors.


### PR DESCRIPTION
The `JsonHttpErrorHandler` should return a RFC 7807 compliant JSON object. (see RFC 7807, section 3: ["Problem Details JSON Object"](https://tools.ietf.org/html/rfc7807#section-3)).
This way the `JsonHttpErrorHandler` can now also be used by default when the client accepts `application/problem+json`.