### PR TITLE
Add HttpErrorInfo request attribute to track origins of errors

### DIFF
--- a/core/play/src/main/java/play/http/HttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/HttpErrorHandler.java
@@ -4,6 +4,8 @@
 
 package play.http;
 
+import play.api.http.HttpErrorInfo;
+import play.libs.typedmap.TypedKey;
 import play.mvc.Http.RequestHeader;
 import play.mvc.Result;
 
@@ -34,4 +36,10 @@ public interface HttpErrorHandler {
    * @return a CompletionStage with the Result.
    */
   CompletionStage<Result> onServerError(RequestHeader request, Throwable exception);
+
+  /** Request attributes used by the error handler. */
+  class Attrs {
+    public static final TypedKey<HttpErrorInfo> HTTP_ERROR_INFO =
+        new TypedKey<>(play.api.http.HttpErrorHandler.Attrs$.MODULE$.HttpErrorInfo());
+  }
 }

--- a/core/play/src/main/java/play/http/HttpErrorInfo.java
+++ b/core/play/src/main/java/play/http/HttpErrorInfo.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.http;
+
+public abstract class HttpErrorInfo {
+  public abstract String origin();
+}

--- a/core/play/src/main/java/play/http/HttpErrorInfo.java
+++ b/core/play/src/main/java/play/http/HttpErrorInfo.java
@@ -4,6 +4,27 @@
 
 package play.http;
 
+import akka.annotation.ApiMayChange;
+
+/**
+ * Used as request attribute which gets attached to the request that gets passed to an error
+ * handler. Contains additional information useful for handling an error.
+ */
+@ApiMayChange
 public abstract class HttpErrorInfo {
+  /**
+   * The origin of where the error handler was initially called.<br>
+   * Play currently adds following values:
+   *
+   * <ul>
+   *   <li>{@code server-backend} - The error handler was called in either the Netty or Akka-HTTP
+   *       server backend.
+   *   <li>{@code csrf-filter} - The error handler was called in CSRF filter code.
+   *   <li>{@code csp-filter} - The error handler was called in CSP filter code.
+   *   <li>{@code allowed-hosts-filter} - The error handler was called in Allowed hosts filter code.
+   * </ul>
+   *
+   * Third party modules may add their own origins.
+   */
   public abstract String origin();
 }

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -11,6 +11,7 @@ import play.api._
 import play.api.http.Status._
 import play.api.inject.Binding
 import play.api.libs.json._
+import play.api.libs.typedmap.TypedKey
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
@@ -108,6 +109,13 @@ object HttpErrorHandler {
       JavaHttpErrorHandlerDelegate,
       DefaultHttpErrorHandler
     ](environment, configuration, "play.http.errorHandler", "ErrorHandler")
+  }
+
+  /**
+   * Request attributes used by the error handler.
+   */
+  object Attrs {
+    val HttpErrorInfo: TypedKey[HttpErrorInfo] = TypedKey("HttpErrorInfo")
   }
 }
 

--- a/core/play/src/main/scala/play/api/http/HttpErrorInfo.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorInfo.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.http
+
+case class HttpErrorInfo(
+    origin: String
+) extends play.http.HttpErrorInfo

--- a/core/play/src/main/scala/play/api/http/HttpErrorInfo.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorInfo.scala
@@ -4,6 +4,27 @@
 
 package play.api.http
 
+import akka.annotation.ApiMayChange
+
+/**
+ * Used as request attribute which gets attached to the request that gets passed to an error
+ * handler. Contains additional information useful for handling an error.
+ */
+@ApiMayChange
 case class HttpErrorInfo(
+    /**
+     * The origin of where the error handler was initially called.<br>
+     * Play currently adds following values:
+     *
+     * <ul>
+     * <li>{@code server-backend} - The error handler was called in either the Netty or Akka-HTTP
+     * server backend.
+     * <li>{@code csrf-filter} - The error handler was called in CSRF filter code.
+     * <li>{@code csp-filter} - The error handler was called in CSP filter code.
+     * <li>{@code allowed-hosts-filter} - The error handler was called in Allowed hosts filter code.
+     * </ul>
+     *
+     * Third party modules may add their own origins.
+     */
     origin: String
 ) extends play.http.HttpErrorInfo

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -31,6 +31,7 @@ import play.api._
 import play.api.http.DefaultHttpErrorHandler
 import play.api.http.HeaderNames
 import play.api.http.HttpErrorHandler
+import play.api.http.HttpErrorInfo
 import play.api.http.{ HttpProtocol => PlayHttpProtocol }
 import play.api.http.Status
 import play.api.internal.libs.concurrent.CoordinatedShutdownSupport
@@ -412,7 +413,11 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
       }
       .recoverWith {
         case _: EntityStreamSizeException =>
-          errorHandler.onClientError(taggedRequestHeader, Status.REQUEST_ENTITY_TOO_LARGE, "Request Entity Too Large")
+          errorHandler.onClientError(
+            taggedRequestHeader.addAttr(HttpErrorHandler.Attrs.HttpErrorInfo, HttpErrorInfo("server-backend")),
+            Status.REQUEST_ENTITY_TOO_LARGE,
+            "Request Entity Too Large"
+          )
         case e: Throwable =>
           errorHandler.onServerError(taggedRequestHeader, e)
       }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -105,7 +105,11 @@ private[play] class PlayRequestHandler(
       val unparsedTarget = modelConversion(tryApp).createUnparsedRequestTarget(request)
       val requestHeader  = modelConversion(tryApp).createRequestHeader(channel, request, unparsedTarget)
       val debugHeader    = attachDebugInfo(requestHeader)
-      val result         = errorHandler(tryApp).onClientError(debugHeader, statusCode, if (message == null) "" else message)
+      val result = errorHandler(tryApp).onClientError(
+        debugHeader.addAttr(HttpErrorHandler.Attrs.HttpErrorInfo, HttpErrorInfo("server-backend")),
+        statusCode,
+        if (message == null) "" else message
+      )
       // If there's a problem in parsing the request, then we should close the connection, once done with it
       debugHeader -> Server.actionForResult(result.map(_.withHeaders(HeaderNames.CONNECTION -> "close")))
     }

--- a/web/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -10,6 +10,8 @@ import java.util.function.Function;
 
 import javax.inject.Inject;
 
+import play.api.http.HttpErrorHandler;
+import play.api.http.HttpErrorInfo;
 import play.api.http.SessionConfiguration;
 import play.api.libs.crypto.CSRFTokenSigner;
 import play.api.mvc.RequestHeader;
@@ -128,7 +130,13 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
       Http.Request req, RequestHeader taggedRequest, String msg) {
     CSRFErrorHandler handler = configurator.apply(this.configuration);
     return handler
-        .handle(taggedRequest.asJava(), msg)
+        .handle(
+            taggedRequest
+                .addAttr(
+                    HttpErrorHandler.Attrs$.MODULE$.HttpErrorInfo(),
+                    new HttpErrorInfo("csrf-filter"))
+                .asJava(),
+            msg)
         .thenApply(
             result -> {
               if (CSRF.getToken(taggedRequest).isEmpty()) {

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -18,7 +18,10 @@ import akka.stream.stage._
 import akka.util.ByteString
 import play.api.MarkerContexts.SecurityMarkerContext
 import play.api.http.HttpEntity
+import play.api.http.HttpErrorHandler
+import play.api.http.HttpErrorInfo
 import play.api.http.HeaderNames._
+import play.api.http.HttpErrorHandler.Attrs
 import play.api.http.SessionConfiguration
 import play.api.libs.crypto.CSRFTokenSigner
 import play.api.libs.streams.Accumulator
@@ -547,7 +550,7 @@ class CSRFActionHelper(
   def clearTokenIfInvalid(request: RequestHeader, errorHandler: ErrorHandler, msg: String): Future[Result] = {
     import play.core.Execution.Implicits.trampoline
 
-    errorHandler.handle(request, msg).map { result =>
+    errorHandler.handle(request.addAttr(Attrs.HttpErrorInfo, HttpErrorInfo("csrf-filter")), msg).map { result =>
       CSRF
         .getToken(request)
         .fold(

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -280,6 +280,9 @@ object CSRF {
 
   class CSRFHttpErrorHandler @Inject() (httpErrorHandler: HttpErrorHandler) extends ErrorHandler {
     import play.api.http.Status.FORBIDDEN
+
+    // The req param already has HttpErrorInfo("csrf-filter") in its attributes, no need to add them here.
+    // (It gets set when calling the CSRF ErrorHandler's handle(...) method)
     def handle(req: RequestHeader, msg: String) = httpErrorHandler.onClientError(req, FORBIDDEN, msg)
   }
 

--- a/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -12,6 +12,7 @@ import play.api.MarkerContexts.SecurityMarkerContext
 import play.api.Configuration
 import play.api.Logger
 import play.api.http.HttpErrorHandler
+import play.api.http.HttpErrorInfo
 import play.api.http.Status
 import play.api.inject._
 import play.api.libs.streams.Accumulator
@@ -52,7 +53,13 @@ case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandle
       next(req)
     } else {
       logger.warn(s"Host not allowed: ${req.host}")(SecurityMarkerContext)
-      Accumulator.done(errorHandler.onClientError(req, Status.BAD_REQUEST, s"Host not allowed: ${req.host}"))
+      Accumulator.done(
+        errorHandler.onClientError(
+          req.addAttr(HttpErrorHandler.Attrs.HttpErrorInfo, HttpErrorInfo("allowed-hosts-filter")),
+          Status.BAD_REQUEST,
+          s"Host not allowed: ${req.host}"
+        )
+      )
     }
   }
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -106,32 +106,57 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
         _.withCookies("foo" -> "bar")
           .addHttpHeaders(HeaderName -> "nocheck")
           .post(Map("foo" -> "bar"))
-      )(_.status must_== errorStatusCode)
+      )(response => {
+        if (errorStatusCode == UNAUTHORIZED) {
+          response.body must startingWith("Origin: csrf-filter /")
+        }
+        response.status must_== errorStatusCode
+      })
     }
     "reject requests with ajax header" in {
       csrfCheckRequest(
         _.withCookies("foo" -> "bar")
           .addHttpHeaders("X-Requested-With" -> "a spoon")
           .post(Map("foo" -> "bar"))
-      )(_.status must_== errorStatusCode)
+      )(response => {
+        if (errorStatusCode == UNAUTHORIZED) {
+          response.body must startingWith("Origin: csrf-filter /")
+        }
+        response.status must_== errorStatusCode
+      })
     }
     "reject requests with different token in body" in {
       csrfCheckRequest(req =>
         addToken(req, generate)
           .post(Map("foo" -> "bar", TokenName -> generate))
-      )(_.status must_== errorStatusCode)
+      )(response => {
+        if (errorStatusCode == UNAUTHORIZED) {
+          response.body must startingWith("Origin: csrf-filter /")
+        }
+        response.status must_== errorStatusCode
+      })
     }
     "reject requests with token in session but none elsewhere" in {
       csrfCheckRequest(req =>
         addToken(req, generate)
           .post(Map("foo" -> "bar"))
-      )(_.status must_== errorStatusCode)
+      )(response => {
+        if (errorStatusCode == UNAUTHORIZED) {
+          response.body must startingWith("Origin: csrf-filter /")
+        }
+        response.status must_== errorStatusCode
+      })
     }
     "reject requests with token in body but not in session" in {
       csrfCheckRequest(
         _.withSession("foo" -> "bar")
           .post(Map("foo" -> "bar", TokenName -> generate))
-      )(_.status must_== errorStatusCode)
+      )(response => {
+        if (errorStatusCode == UNAUTHORIZED) {
+          response.body must startingWith("Origin: csrf-filter /")
+        }
+        response.status must_== errorStatusCode
+      })
     }
 
     // add to response

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -12,12 +12,14 @@ import play.core.j.JavaAction
 import play.core.j.JavaActionAnnotations
 import play.core.j.JavaHandlerComponents
 import play.core.routing.HandlerInvokerFactory
+import play.http.HttpErrorHandler
 import play.mvc.Http.RequestHeader
 import play.mvc.Http.{ Request => JRequest }
 import play.mvc.Controller
 import play.mvc.Result
 import play.mvc.Results
 
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
@@ -145,7 +147,16 @@ object JavaCSRFActionSpec {
 
   class CustomErrorHandler extends CSRFErrorHandler {
     def handle(req: RequestHeader, msg: String) = {
-      CompletableFuture.completedFuture(Results.unauthorized(msg))
+      CompletableFuture.completedFuture(
+        Results.unauthorized(
+          "Origin: " + req
+            .attrs()
+            .getOptional(HttpErrorHandler.Attrs.HTTP_ERROR_INFO)
+            .asScala
+            .map(_.origin)
+            .getOrElse("<not set>") + " / " + msg
+        )
+      )
     }
   }
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
@@ -5,6 +5,7 @@
 package play.filters.csrf
 
 import play.api.Application
+import play.api.http.HttpErrorHandler
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.WSRequest
 import play.api.libs.ws.WSResponse
@@ -59,6 +60,14 @@ class ScalaCSRFActionSpec extends CSRFCommonSpecs {
 
   class CustomErrorHandler extends CSRF.ErrorHandler {
     import play.api.mvc.Results.Unauthorized
-    def handle(req: RequestHeader, msg: String) = Future.successful(Unauthorized(msg))
+    def handle(req: RequestHeader, msg: String) =
+      Future.successful(
+        Unauthorized(
+          "Origin: " + req.attrs
+            .get(HttpErrorHandler.Attrs.HttpErrorInfo)
+            .map(_.origin)
+            .getOrElse("<not set>") + " / " + msg
+        )
+      )
   }
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -6,7 +6,9 @@ package play.filters.hosts
 
 import javax.inject.Inject
 import com.typesafe.config.ConfigFactory
+import org.specs2.matcher.MatchResult
 import play.api.http.HeaderNames
+import play.api.http.HttpErrorHandler
 import play.api.http.HttpFilters
 import play.api.inject._
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -24,7 +26,9 @@ import play.api.Application
 import play.api.Configuration
 import play.api.Environment
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Await
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
@@ -63,8 +67,12 @@ class AllowedHostsFilterSpec extends PlaySpecification {
   private val okWithHost = (req: RequestHeader) => Ok(req.host)
 
   def newApplication(result: RequestHeader => Result, config: String): Application = {
+    val properties = Map(
+      "play.http.errorHandler" -> classOf[CustomErrorHandler].getName
+    )
+    val conf = ConfigFactory.parseString(config).withFallback(ConfigFactory.parseMap(properties.asJava))
     new GuiceApplicationBuilder()
-      .configure(Configuration(ConfigFactory.parseString(config)))
+      .configure(Configuration(conf))
       .overrides(
         bind[ActionHandler].to(ActionHandler(result)),
         bind[Router].to[MyRouter],
@@ -99,11 +107,17 @@ class AllowedHostsFilterSpec extends PlaySpecification {
     running(TestServer(testServerPort, app))(block(ws))
   }
 
+  def statusBadRequest(app: Application, hostHeader: String, uri: String = "/"): MatchResult[String] = {
+    val response = request(app, hostHeader, uri)
+    status(response) must_== BAD_REQUEST
+    contentAsString(response) must startingWith(s"Origin: allowed-hosts-filter / Host not allowed: ")
+  }
+
   "the allowed hosts filter" should {
     "disallow non-local hosts with default config" in withApplication(okWithHost, "") { app =>
       status(request(app, "localhost")) must_== OK
-      status(request(app, "typesafe.com")) must_== BAD_REQUEST
-      status(request(app, "")) must_== BAD_REQUEST
+      statusBadRequest(app, "typesafe.com")
+      statusBadRequest(app, "")
     }
 
     "only allow specific hosts specified in configuration" in withApplication(
@@ -114,8 +128,8 @@ class AllowedHostsFilterSpec extends PlaySpecification {
     ) { app =>
       status(request(app, "example.com")) must_== OK
       status(request(app, "EXAMPLE.net")) must_== OK
-      status(request(app, "example.org")) must_== BAD_REQUEST
-      status(request(app, "foo.example.com")) must_== BAD_REQUEST
+      statusBadRequest(app, "example.org")
+      statusBadRequest(app, "foo.example.com")
     }
 
     "allow defining host suffixes in configuration" in withApplication(
@@ -145,7 +159,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       """.stripMargin
     ) { app =>
       status(request(app, "")) must_== OK
-      status(request(app, "example.net")) must_== BAD_REQUEST
+      statusBadRequest(app, "example.net")
       status(route(app, FakeRequest().withHeaders(HeaderNames.HOST -> "")).get) must_== OK
     }
 
@@ -156,7 +170,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       """.stripMargin
     ) { app =>
       status(request(app, "example.com:80")) must_== OK
-      status(request(app, "google.com:80")) must_== BAD_REQUEST
+      statusBadRequest(app, "google.com:80")
     }
 
     "restrict host headers based on port" in withApplication(
@@ -165,7 +179,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
         |play.filters.hosts.allowed = [".example.com:8080"]
       """.stripMargin
     ) { app =>
-      status(request(app, "example.com:80")) must_== BAD_REQUEST
+      statusBadRequest(app, "example.com:80")
       status(request(app, "www.example.com:8080")) must_== OK
       status(request(app, "example.com:8080")) must_== OK
     }
@@ -183,8 +197,8 @@ class AllowedHostsFilterSpec extends PlaySpecification {
     "not allow malformed ports" in withApplication(okWithHost, """
                                                                  |play.filters.hosts.allowed = [".mozilla.org"]
       """.stripMargin) { app =>
-      status(request(app, "addons.mozilla.org:@passwordreset.net")) must_== BAD_REQUEST
-      status(request(app, "addons.mozilla.org: www.securepasswordreset.com")) must_== BAD_REQUEST
+      statusBadRequest(app, "addons.mozilla.org:@passwordreset.net")
+      statusBadRequest(app, "addons.mozilla.org: www.securepasswordreset.com")
     }
 
     "validate hosts in absolute URIs" in withApplication(
@@ -194,7 +208,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       """.stripMargin
     ) { app =>
       status(request(app, "www.securepasswordreset.com", "https://addons.mozilla.org/en-US/firefox/users/pwreset")) must_== OK
-      status(request(app, "addons.mozilla.org", "https://www.securepasswordreset.com/en-US/firefox/users/pwreset")) must_== BAD_REQUEST
+      statusBadRequest(app, "addons.mozilla.org", "https://www.securepasswordreset.com/en-US/firefox/users/pwreset")
     }
 
     "not allow bypassing with X-Forwarded-Host header" in withServer(
@@ -217,7 +231,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
         |      """.stripMargin
     ) { app =>
       status(request(app, "good.com")) must_== OK
-      status(request(app, "evil.com")) must_== BAD_REQUEST
+      statusBadRequest(app, "evil.com")
     }
 
     "not protect tagged routes when using a route modifier whiteList" in
@@ -318,4 +332,18 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       status(request(app, "evil.com")) must_== OK
     }
   }
+}
+
+class CustomErrorHandler extends HttpErrorHandler {
+  def onClientError(request: RequestHeader, statusCode: Int, message: String) =
+    Future.successful(
+      Results.Status(statusCode)(
+        "Origin: " + request.attrs
+          .get(HttpErrorHandler.Attrs.HttpErrorInfo)
+          .map(_.origin)
+          .getOrElse("<not set>") + " / " + message
+      )
+    )
+  def onServerError(request: RequestHeader, exception: Throwable) =
+    Future.successful(Results.BadRequest)
 }


### PR DESCRIPTION
Please read this comment, it should explain the motivation behind this pull request: https://github.com/playframework/playframework/issues/6171#issuecomment-625131455

I tried to keep the `HttpErrorInfo` class as generic as possible, so we can extend it later for other uses cases, maybe one day we want to attach more infos to the request passed to an error handler.

With this pull request I started to add the `HttpErrorInfo` attribute to `onClientErrors` thrown by filters and the server backends for now. We can extend that in later pull requests, if someone comes up with the need for more origin tracking.
For me personally I need to know if the 413 request entity too large came from the server backend or [a body parser](https://github.com/playframework/playframework/blob/2.8.1/core/play/src/main/scala/play/api/mvc/BodyParsers.scala#L807).