### PR TITLE
[2.8.x] jetty-alpn-agent 2.0.10, akka-http 10.1.12 and akka 2.6.5

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
@@ -52,17 +52,17 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
 
     def endpoints(extraConfig: Map[String, Any]): Seq[ServerEndpointRecipe] =
       Seq(
-        AkkaHttpServerEndpointRecipes.AkkaHttp11Plaintext,
-        AkkaHttpServerEndpointRecipes.AkkaHttp11Encrypted,
-        NettyServerEndpointRecipes.Netty11Plaintext,
-        NettyServerEndpointRecipes.Netty11Encrypted,
-      ).map(_.withExtraServerConfiguration(extraConfig))
+        AkkaHttpServerEndpointRecipes.AkkaHttp11Plaintext.withExtraServerConfiguration(extraConfig),
+        AkkaHttpServerEndpointRecipes.AkkaHttp11Encrypted.withExtraServerConfiguration(extraConfig),
+        NettyServerEndpointRecipes.Netty11Plaintext.withExtraServerConfiguration(extraConfig),
+        NettyServerEndpointRecipes.Netty11Encrypted.withExtraServerConfiguration(extraConfig),
+      )
 
     def akkaHttp2endpoints(extraConfig: Map[String, Any]): Seq[ServerEndpointRecipe] =
       Seq(
-        AkkaHttpServerEndpointRecipes.AkkaHttp20Plaintext,
-        AkkaHttpServerEndpointRecipes.AkkaHttp20Encrypted,
-      ).map(_.withExtraServerConfiguration(extraConfig))
+        AkkaHttpServerEndpointRecipes.AkkaHttp20Plaintext.withExtraServerConfiguration(extraConfig),
+        AkkaHttpServerEndpointRecipes.AkkaHttp20Encrypted.withExtraServerConfiguration(extraConfig),
+      )
 
     def doRequests(port: Int, trickle: Long, secure: Boolean = false) = {
       val body = new String(Random.alphanumeric.take(50 * 1024).toArray)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
   val acolyteVersion = "1.0.54"
   val acolyte        = "org.eu.acolyte" % "jdbc-driver" % acolyteVersion
 
-  val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.9"
+  val jettyAlpnAgent = "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.10"
 
   val jjwt = "io.jsonwebtoken" % "jjwt" % "0.9.1"
   // currently jjwt needs the JAXB Api package in JDK 9+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.3")
-  val akkaHttpVersion     = "10.1.11"
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.5")
+  val akkaHttpVersion     = "10.1.12"
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.1"
 

--- a/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -5,6 +5,7 @@
 package play.api.test
 
 import akka.annotation.ApiMayChange
+import com.typesafe.config.ConfigFactory
 import play.api.Application
 import play.api.Configuration
 import play.core.server.SelfSigned
@@ -13,6 +14,8 @@ import play.core.server.ServerConfig
 import play.core.server.ServerEndpoint
 import play.core.server.ServerEndpoints
 import play.core.server.ServerProvider
+
+import scala.collection.JavaConverters._
 
 /**
  * A recipe for making a [[ServerEndpoint]]. Recipes are often used
@@ -44,6 +47,7 @@ import play.core.server.ServerProvider
 
   def withDescription(newDescription: String): ServerEndpointRecipe
   def withServerProvider(newProvider: ServerProvider): ServerEndpointRecipe
+  def withExtraServerConfiguration(extraConfig: Map[String, Any]): ServerEndpointRecipe
 
   /**
    * Once a server has been started using this recipe, the running instance
@@ -96,6 +100,15 @@ import play.core.server.ServerProvider
       expectedServerAttr
     )
 
+  def withExtraServerConfiguration(extraConfig: Map[String, Any]): HttpServerEndpointRecipe =
+    new HttpServerEndpointRecipe(
+      description,
+      serverProvider,
+      Configuration(ConfigFactory.parseMap(extraConfig.asJava)).withFallback(serverConfiguration),
+      expectedHttpVersions,
+      expectedServerAttr
+    )
+
   override def toString: String = s"HttpServerEndpointRecipe($description)"
 }
 
@@ -142,6 +155,15 @@ import play.core.server.ServerProvider
       description,
       newProvider,
       extraServerConfiguration,
+      expectedHttpVersions,
+      expectedServerAttr
+    )
+
+  def withExtraServerConfiguration(extraConfig: Map[String, Any]): HttpsServerEndpointRecipe =
+    new HttpsServerEndpointRecipe(
+      description,
+      serverProvider,
+      Configuration(ConfigFactory.parseMap(extraConfig.asJava)).withFallback(serverConfiguration),
       expectedHttpVersions,
       expectedServerAttr
     )

--- a/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -47,7 +47,6 @@ import scala.collection.JavaConverters._
 
   def withDescription(newDescription: String): ServerEndpointRecipe
   def withServerProvider(newProvider: ServerProvider): ServerEndpointRecipe
-  def withExtraServerConfiguration(extraConfig: Map[String, Any]): ServerEndpointRecipe
 
   /**
    * Once a server has been started using this recipe, the running instance


### PR DESCRIPTION
Backport of #10268

Also upgrades akka to 2.6.5 because that was still missing in the 2.8.x branch.

Also the `withExtraServerConfiguration` method was **not** added to the trait for compatibility reasons (see last commit)