### PR TITLE
[2.8.x] Scala 2.13.2 / 2.12.11 & sbt 1.3.10

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -77,8 +77,8 @@ lazy val main = Project("Play-Documentation", file("."))
     unmanagedResourceDirectories in Test ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
     // Don't include sbt files in the resources
     excludeFilter in (Test, unmanagedResources) := (excludeFilter in (Test, unmanagedResources)).value || "*.sbt",
-    crossScalaVersions := Seq("2.13.1", "2.12.10"),
-    scalaVersion := "2.13.1",
+    crossScalaVersions := Seq("2.13.2", "2.12.11"),
+    scalaVersion := "2.13.2",
     fork in Test := true,
     javaOptions in Test ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) Lightbend Inc. <https://www.lightbend.com>")),

--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -38,7 +38,7 @@ This will build and publish Play for the default Scala version. If you want to p
 Or to publish for a specific Scala version:
 
 ```bash
-> ++ 2.13.1 publishLocal
+> ++ 2.13.2 publishLocal
 ```
 
 ## Build the documentation

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -12,7 +12,7 @@ You can select which version of Scala you would like to use by setting the `scal
 For Scala 2.12:
 
 ```scala
-scalaVersion := "2.12.10"
+scalaVersion := "2.12.11"
 ```
 
 For Scala 2.11:
@@ -30,7 +30,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayService)
   .enablePlugins(RoutesCompiler) // place routes in src/main/resources, or remove if using SIRD/RoutingDsl
   .settings(
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.12.11",
     libraryDependencies ++= Seq(
       guice, // remove if not using Play's Guice loader
       akkaHttpServer, // or use nettyServer for Netty

--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -12,7 +12,7 @@ You can select which version of Scala you would like to use by setting the `scal
 For Scala 2.12:
 
 ```scala
-scalaVersion := "2.12.10"
+scalaVersion := "2.12.11"
 ```
 
 For Scala 2.11:
@@ -24,7 +24,7 @@ scalaVersion := "2.11.12"
 For Scala 2.13:
 
 ```scala
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.2"
 ```
 
 ## Lifecycle managed by Akka's Coordinated Shutdown

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -23,10 +23,10 @@ Where the "x" in `2.8.x` is the minor version of Play you want to use, for insta
 Although Play 2.8 still supports sbt 0.13, we recommend that you use sbt 1. This new version is supported and actively maintained. To update, change your `project/build.properties` so that it reads:
 
 ```properties
-sbt.version=1.3.5
+sbt.version=1.3.10
 ```
 
-At the time of this writing `1.3.5` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version releases and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
+At the time of this writing `1.3.10` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version releases and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
 
 ## API Changes
 
@@ -47,14 +47,14 @@ Play 2.8 support Scala 2.12 and 2.13, but not 2.11, which has reached its end of
 To set the Scala version in sbt, simply set the `scalaVersion` key, for example:
 
 ```scala
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.2"
 ```
 
 If you have a single project build, then this setting can just be placed on its own line in `build.sbt`.  However, if you have a multi-project build, then the scala version setting must be set on each project.  Typically, in a multi-project build, you will have some common settings shared by every project, this is the best place to put the setting, for example:
 
 ```scala
 def commonSettings = Seq(
-  scalaVersion := "2.13.1"
+  scalaVersion := "2.13.2"
 )
 
 val projectA = (project in file("projectA"))

--- a/documentation/manual/working/commonGuide/build/sbtDependencies.md
+++ b/documentation/manual/working/commonGuide/build/sbtDependencies.md
@@ -37,7 +37,7 @@ If you use `groupID %% artifactID % revision` rather than `groupID % artifactID 
 
 @[explicit-scala-version-dep](code/dependencies.sbt)
 
-Assuming the `scalaVersion` for your build is `2.13.1`, the following is identical (note the double `%%` after `"org.scala-tools"`):
+Assuming the `scalaVersion` for your build is `2.13.2`, the following is identical (note the double `%%` after `"org.scala-tools"`):
 
 @[auto-scala-version-dep](code/dependencies.sbt)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -312,8 +312,8 @@ object Dependencies {
  * How to use this:
  *    $ sbt -J-XX:+UnlockCommercialFeatures -J-XX:+FlightRecorder -Dakka-http.sources=$HOME/code/akka-http '; project Play-Akka-Http-Server; test:run'
  *
- * Make sure Akka-HTTP has 2.12 as the FIRST version (or that scalaVersion := "2.12.10", otherwise it won't find the artifact
- *    crossScalaVersions := Seq("2.12.10", "2.11.12"),
+ * Make sure Akka-HTTP has 2.12 as the FIRST version (or that scalaVersion := "2.12.11", otherwise it won't find the artifact
+ *    crossScalaVersions := Seq("2.12.11", "2.11.12"),
  */
 object AkkaDependency {
   // Needs to be a URI like git://github.com/akka/akka.git#master or file:///xyz/akka

--- a/scripts/it-test-scala-212
+++ b/scripts/it-test-scala-212
@@ -9,6 +9,6 @@ cd "$BASEDIR"
 
 start test "RUNNING IT TESTS FOR SCALA 2.12"
 
-runSbt "++2.12.10 Play-Integration-Test/it:test"
+runSbt "++2.12.11 Play-Integration-Test/it:test"
 
 end test "ALL IT TESTS PASSED"

--- a/scripts/test-docs-212
+++ b/scripts/test-docs-212
@@ -8,5 +8,5 @@
 cd "$DOCUMENTATION"
 
 start test "RUNNING DOCUMENTATION TESTS"
-runSbt "++2.12.10 test"
+runSbt "++2.12.11 test"
 end test "ALL DOCUMENTATION TESTS PASSED"

--- a/scripts/test-scala-212
+++ b/scripts/test-scala-212
@@ -9,6 +9,6 @@ cd "$BASEDIR"
 
 start test "RUNNING TESTS FOR SCALA 2.12"
 
-runSbt "++2.12.10 test"
+runSbt "++2.12.11 test"
 
 end test "ALL TESTS PASSED"

--- a/scripts/test-scripted-13x
+++ b/scripts/test-scripted-13x
@@ -5,7 +5,7 @@
 # shellcheck source=scripts/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-SBT_VERSION="1.3.4"
+SBT_VERSION="1.3.10"
 
 start scripted "RUNNING SCRIPTED TESTS FOR SBT $SBT_VERSION"
 runSbt ";project Sbt-Plugin;set scriptedSbt := \"${SBT_VERSION}\";scripted"


### PR DESCRIPTION
Backports #10217
No change except that in the 2.8.x branch there doesn't exist a `Migration29.md`.