### PR TITLE
fix typo on the Assets Overview documentation page

### DIFF
--- a/documentation/manual/working/commonGuide/assets/AssetsOverview.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsOverview.md
@@ -153,7 +153,7 @@ In essence asset fingerprinting permits your static assets to be served with agg
 
 The above declaration of `pipelineStages` and the requisite `addSbtPlugin` declarations in your `plugins.sbt` for the plugins you require are your start point. You must then declare to Play what assets are to be versioned.
 
-There are two ways obtain the real path of a fingerprinted asset. The first way uses static state and supports the same style as normal reverse routing. It does so by looking up assets metadata that's set by a running Play application. The second way is to use configuration and inject an AssetsFinder to find your asset.
+There are two ways to obtain the real path of a fingerprinted asset. The first way uses static state and supports the same style as normal reverse routing. It does so by looking up assets metadata that's set by a running Play application. The second way is to use configuration and inject an AssetsFinder to find your asset.
 
 ### Using reverse routing and static state
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Purpose

Fix typo on the [Assets Overview documentation page](https://www.playframework.com/documentation/2.8.x/AssetsOverview#Reverse-routing-and-fingerprinting-for-public-assets) on the __Reverse routing and fingerprinting for public assets__ section

Before:
> There are two ways obtain the real path...


After:
> There are two ways **to** obtain the real path...