### PR TITLE
Refactor: replaced some deprecated / redundant logic

### DIFF
--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -32,13 +32,12 @@ object Route {
    * Create a params extractor from the given method and path pattern.
    */
   def apply(method: String, pathPattern: PathPattern) = new ParamsExtractor {
-    def unapply(request: RequestHeader): Option[RouteParams] = {
+    def unapply(request: RequestHeader): Option[RouteParams] =
       if (method == request.method) {
         pathPattern(request.path).map { groups => RouteParams(groups, request.queryString) }
       } else {
         None
       }
-    }
   }
 }
 
@@ -46,9 +45,8 @@ object Route {
  * An included router
  */
 class Include(val router: Router) {
-  def unapply(request: RequestHeader): Option[Handler] = {
+  def unapply(request: RequestHeader): Option[Handler] =
     router.routes.lift(request)
-  }
 }
 
 /**
@@ -61,14 +59,13 @@ object Include {
 case class Param[T](name: String, value: Either[String, T])
 
 case class RouteParams(path: Map[String, Either[Throwable, String]], queryString: Map[String, Seq[String]]) {
-  def fromPath[T](key: String, default: Option[T] = None)(implicit binder: PathBindable[T]): Param[T] = {
+  def fromPath[T](key: String, default: Option[T] = None)(implicit binder: PathBindable[T]): Param[T] =
     Param(
       key,
       path.get(key).map(v => v.fold(t => Left(t.getMessage), binder.bind(key, _))).getOrElse {
         default.map(d => Right(d)).getOrElse(Left("Missing parameter: " + key))
       }
     )
-  }
 
   def fromQuery[T](key: String, default: Option[T] = None)(implicit binder: QueryStringBindable[T]): Param[T] = {
     val bindResult = binder.bind(key, queryString)
@@ -101,13 +98,11 @@ abstract class GeneratedRouter extends Router {
     errorHandler.onClientError(request, play.api.http.Status.BAD_REQUEST, error)
   }
 
-  def call(generator: => Handler): Handler = {
+  def call(generator: => Handler): Handler =
     generator
-  }
 
-  def call[P](pa: Param[P])(generator: (P) => Handler): Handler = {
+  def call[P](pa: Param[P])(generator: (P) => Handler): Handler =
     pa.value.fold(badRequest, generator)
-  }
 
   // Keep the old versions for avoiding compiler failures while building for Scala 2.10,
   // and for avoiding warnings when building for newer Scala versions

--- a/core/play/src/main/scala/play/core/routing/package.scala
+++ b/core/play/src/main/scala/play/core/routing/package.scala
@@ -10,14 +10,12 @@ import play.utils.UriEncoding
  * The play.core.routing package contains all the code necessary for Play's code generated routers.
  */
 package object routing {
-  def dynamicString(dynamic: String): String = {
+  def dynamicString(dynamic: String): String =
     UriEncoding.encodePathSegment(dynamic, "utf-8")
-  }
 
-  def queryString(items: List[Option[String]]) = {
+  def queryString(items: List[Option[String]]) =
     Option(items.filter(_.isDefined).map(_.get).filterNot(_.isEmpty))
       .filterNot(_.isEmpty)
       .map("?" + _.mkString("&"))
       .getOrElse("")
-  }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose
The purpose of this PR is to refactor deprecated/redundant logic.
*I replaced some packages, but I end up reverting 2 of them for supporting Scala 2.12

- ~~collection.JavaConverters is deprecated from Scala 2.13.0, so I replaced~~
  - ~~reference: [JavaConverters](https://www.scala-lang.org/api/current/scala/collection/JavaConverters$.html)~~
- Either is right-biased, so removed `.right` from for comprehensions.
  - reference: [scala.util Either](https://www.scala-lang.org/api/current/scala/util/Either.html)
- ~~Symbol mapValues is deprecated, so replaced to `.view.mapValues`~~
  - ~~reference: IntelliJ sugguestion~~

- removed curly braces if code can be written in one liners

## Background Context
- I found some deprecated codes, so tried to replace them.


## References
N/A