### PR TITLE
Support injecting default NamedCaffeineCache

### DIFF
--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -96,6 +96,7 @@ class CaffeineCacheModule
       Seq(
         bind[CaffeineCacheManager].toProvider[CacheManagerProvider],
         // alias the default cache to the unqualified implementation
+        bindDefault[NamedCaffeineCache[Any, Any]],
         bindDefault[AsyncCacheApi],
         bindDefault[JavaAsyncCacheApi],
         bindDefault[SyncCacheApi],


### PR DESCRIPTION
Right now you can inject the default cache like:
```java
@Inject
AsyncCacheApi cache;
```
which is equivalent to:
```java
@Inject
@NamedCache("play")
AsyncCacheApi cache;
```
(assuming [the default cache is called `play`](https://github.com/playframework/playframework/blob/2.8.2/cache/play-caffeine-cache/src/main/resources/reference.conf#L24))

I want to have the same for `NamedCaffeineCache`. Right now you always need to use `@NamedCache("play")` to inject the default one. I think this is not necessary and can be made easier. (I need to use `NamedCaffeineCache` to access statistics like: `namedCaffeineCache.synchronous().stats()`)