### PR TITLE
Re-enabling cross compilation for routes-compiler

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -266,6 +266,9 @@ object BuildSettings {
         }),
         mimaPreviousArtifacts := Set.empty,
       )
+      .settings(
+        crossScalaVersions := Seq(ScalaVersions.scala213, ScalaVersions.scala212)
+      )
   }
 
   /** A project that is in the Play runtime. */


### PR DESCRIPTION
## Fixes

Fixes #10333 

## Purpose

This PR re-enables cross compilation for `routes-compiler` artfifacts for `2.7.x` branch
Only `2.7.3` currently has `routes-compiler` artifacts built for both `2.12` and `2.13`
See discussion in  #10333 for more insights about the issue and proposed fix

@ignasi35
