### PR TITLE
Access route parameters via request attribute

### DIFF
--- a/core/play/src/main/java/play/routing/Router.java
+++ b/core/play/src/main/java/play/routing/Router.java
@@ -52,6 +52,13 @@ public interface Router {
     /** Key for the {@link HandlerDef} used to handle the request. */
     public static final TypedKey<HandlerDef> HANDLER_DEF =
         new TypedKey<>(play.api.routing.Router.Attrs$.MODULE$.HandlerDef());
+
+    /**
+     * Key for the {@link scala.collection.immutable.Map} that stores the path and query params
+     * which get passed to the eventually called action method.
+     */
+    public static final TypedKey<scala.collection.immutable.Map<String, Object>> ROUTE_PARAMS =
+        new TypedKey<>(play.api.routing.Router.Attrs$.MODULE$.RouteParams());
   }
 
   class RouteDocumentation {

--- a/core/play/src/main/scala/play/api/routing/Router.scala
+++ b/core/play/src/main/scala/play/api/routing/Router.scala
@@ -124,6 +124,11 @@ object Router {
      * Key for the [[HandlerDef]] used to handle the request.
      */
     val HandlerDef: TypedKey[HandlerDef] = TypedKey("HandlerDef")
+
+    /**
+     * Key for the [[Map]] that stores the path and query params which get passed to the eventually called action method.
+     */
+    val RouteParams: TypedKey[Map[String, Any]] = TypedKey("RouteParams")
   }
 
   /**

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -489,4 +489,23 @@ a1 <- pa1.value
       }
     }
   }
+
+  /**
+   * Create a HandlerInvoker that attaches the route params to each request using request attributes.
+   * This method is called by the code-generated routes files.
+   */
+  def attachRouteParams[T](next: HandlerInvoker[T], routeParams: Map[String, Any]): HandlerInvoker[T] = {
+    // Precalculate the function that adds the route params to the request
+    val modifyRequestFunc: RequestHeader => RequestHeader = { (rh: RequestHeader) =>
+      rh.addAttr(play.api.routing.Router.Attrs.RouteParams, routeParams)
+    }
+    // Wrap the invoker with another invoker that preprocesses requests as they are made,
+    // adding the route params to each request.
+    new HandlerInvoker[T] {
+      override def call(call: => T): Handler = {
+        val nextHandler = next.call(call)
+        Handler.Stage.modifyRequest(modifyRequestFunc, nextHandler)
+      }
+    }
+  }
 }

--- a/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -130,6 +130,19 @@ package object templates {
     if (route.call.parameters.map(_.filterNot(_.isJavaRequest).size).getOrElse(0) < 22) tupleNames(route)
     else listNames(route)
 
+  /**
+   * Stores the route params into a Map
+   */
+  def routeParamsToMap(route: Route): String =
+    route.call.parameters
+      .filterNot(_.isEmpty)
+      .map { params =>
+        params.filterNot(_.isJavaRequest).map(x => s""" "${x.name}" -> ${safeKeyword(x.name)} """.trim).mkString(", ")
+      }
+      .filterNot(_.isEmpty)
+      .map("scala.collection.immutable.ListMap(" + _ + ")")
+      .getOrElse("scala.collection.immutable.ListMap()")
+
   val scalaReservedWords = List(
     "as",
     "abstract",

--- a/dev-mode/play-routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/play-routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -90,7 +90,7 @@ case include @ Include(path, router) => {
     @markLines(route)
     case @(routeIdentifier(route, index))(params@@_) =>
       call@(routeBinding(route)) @ob @localNames(route)
-        @(invokerIdentifier(route, index)).call(@if(route.call.passJavaRequest){
+        attachRouteParams(@(invokerIdentifier(route, index)), @(routeParamsToMap(route))).call(@if(route.call.passJavaRequest){
           req => }@injectedControllerMethodCall(route, dep.ident, x => if (x.isJavaRequest) "req" else safeKeyword(x.nameClean)))
       @cb
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/Application.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/Application.java
@@ -59,4 +59,37 @@ public class Application extends Controller {
   public Result interpolatorWarning(Http.Request req, String parameter) {
     return ok(req.uri() + " " + parameter);
   }
+  public Result routeParamsReqAttr(final Http.Request req, Long id, String clazz, java.util.Optional<Integer> page, List<String> items, List<String> books, Integer section) {
+
+    final String actionMethodParams =
+      "id=" + id + "[" + id.getClass().getName() + "]|" +
+      "class=" + clazz + "[" + clazz.getClass().getName() + "]|" +
+      "page=" + page + "[" + page.getClass().getName() + "]|" +
+      "items=" + items + "[" + items.getClass().getName() + "]|" +
+      "books=" + books + "[" + books.getClass().getName() + "]|" +
+      "section=" + section + "[" + section.getClass().getName() + "]";
+
+    final String javaAttrRouteParams = req.attrs().getOptional(play.routing.Router.Attrs.ROUTE_PARAMS).map(routeParamsMap ->
+      routeParamsMap.iterator().map(entryTuple -> entryTuple._1 + "=" + entryTuple._2 + "[" + entryTuple._2.getClass().getName() + "]").mkString("|")
+    ).get();
+
+    final String scalaAttrRouteParams = req.asScala().attrs().get(play.api.routing.Router.Attrs$.MODULE$.RouteParams()).map(routeParamsMap ->
+      routeParamsMap.iterator().map(entryTuple -> entryTuple._1 + "=" + entryTuple._2 + "[" + entryTuple._2.getClass().getName() + "]").mkString("|")
+    ).get();
+
+    return ok(
+      replaceScalaCollectionWrappers(
+        actionMethodParams + "\n" +
+        javaAttrRouteParams + "\n" +
+        scalaAttrRouteParams + "\n"
+      )
+    );
+  }
+
+  // The scripted tests run with Scala 2.12 and 2.13, which use different collection implementations
+  private static String replaceScalaCollectionWrappers(String source) {
+    return source
+      .replace("scala.collection.convert.JavaCollectionWrappers$SeqWrapper", "List") // used in Scala 2.13
+      .replace("scala.collection.convert.Wrappers$SeqWrapper", "List"); // used in Scala 2.12
+  }
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/conf/routes
@@ -64,6 +64,8 @@ GET         /routes                 controllers.Application.route(req: Request, 
 GET         /routes                 controllers.Application.route(req: Request, while)
 GET         /routestest             controllers.Application.routetest(req: Request, with)
 GET         /routestest             controllers.Application.routetest(req: Request, yield)
+# FYI: In the next route "class" is a Java and Scala reserved keyword
+GET         /:id/:class             controllers.Application.routeParamsReqAttr(req: Request, id: Long, class: String, page: java.util.Optional[java.lang.Integer], items: java.util.List[String], books: java.util.List[String], section: Int ?= 5)
 
 # Test for default values for scala keywords
 GET         /routesdefault          controllers.Application.routedefault(req: Request, type ?= "x")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/RouterSpec.scala
@@ -238,4 +238,11 @@ object RouterSpec extends PlaySpecification {
       }
     }
   }
+
+  "add route params the request using a request attribute" in new WithApplication() {
+    val result = route(implicitApp, FakeRequest(GET, "/23/abc?page=2&someOtherParam=34&page=4&books=Moby%20Dick&books=War%20and%20Peace")).get
+    contentAsString(result) must equalTo(
+      "id=23[java.lang.Long]|class=abc[java.lang.String]|page=Optional[2][java.util.Optional]|items=[][List]|books=[Moby Dick, War and Peace][List]|section=5[java.lang.Integer]\n" * 3
+    )
+  }
 }


### PR DESCRIPTION
Fixes #2983

~TODO~: To make this work I ~still need to~ change the generated `Routes.scala` file(s) in the `target` folder so current code like this:

```scala
  def routes: PartialFunction[RequestHeader, Handler] = {
  
    // @LINE:2
    case controllers_HomeController_index0_route(params@_) =>
      call(params.fromPath[Long]("id", None), params.fromPath[String]("class", None), params.fromQuery[Int]("page", None), params.fromQuery[java.util.List[String]]("items", None), params.fromQuery[java.util.List[String]]("books", None), params.fromQuery[Int]("section", Some(5))) { (id, _pf_escape_class, page, items, books, section) =>
        controllers_HomeController_index0_invoker.call(
          req => HomeController_0.index(req, id, _pf_escape_class, page, items, books, section))
      }
  }
```

will instead make use of the added `attachRouteParams` method:

```scala
  def routes: PartialFunction[RequestHeader, Handler] = {
  
    // @LINE:2
    case controllers_HomeController_index0_route(params@_) =>
      call(params.fromPath[Long]("id", None), params.fromPath[String]("class", None), params.fromQuery[Int]("page", None), params.fromQuery[java.util.List[String]]("items", None), params.fromQuery[java.util.List[String]]("books", None), params.fromQuery[Int]("section", Some(5))) { (id, _pf_escape_class, page, items, books, section) =>
        attachRouteParams(controllers_HomeController_index0_invoker, scala.collection.immutable.ListMap("id" -> id, "class" -> _pf_escape_class, "page" -> page, "items" -> items, "books" -> books, "section" -> section)).call(
          req => HomeController_0.index(req, id, _pf_escape_class, page, items, books, section))
      }
  }
```

BTW: I am using a [`ListMap`](https://www.scala-lang.org/api/current/scala/collection/immutable/ListMap.html) for now ~because Scala [currently does not have an immutable `LinkedHashMap`](https://github.com/scala/scala/pull/8644)~ (outdated, see comments below).

Note to myself: Disable routes generation with `routes in Compile := Seq.empty` in `build.sbt`