### PR TITLE
Include akkaHttpVersion in PlayVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
           sbtVersion.value,
           jettyAlpnAgent.revision,
           Dependencies.akkaVersion,
+          Dependencies.akkaHttpVersion,
           (sourceManaged in Compile).value
         )
       )
@@ -232,6 +233,7 @@ lazy val SbtPluginProject = PlaySbtPluginProject("Sbt-Plugin", "dev-mode/sbt-plu
         sbtVersion.value,
         jettyAlpnAgent.revision,
         Dependencies.akkaVersion,
+        Dependencies.akkaHttpVersion,
         (sourceManaged in Compile).value
       )
     }.taskValue,

--- a/project/Tasks.scala
+++ b/project/Tasks.scala
@@ -13,6 +13,7 @@ object Generators {
       sbtVersion: String,
       jettyAlpnAgentVersion: String,
       akkaVersion: String,
+      akkaHttpVersion: String,
       dir: File
   ): Seq[File] = {
     val file = dir / "PlayVersion.scala"
@@ -24,6 +25,7 @@ object Generators {
           |  val scalaVersion = "$scalaVersion"
           |  val sbtVersion = "$sbtVersion"
           |  val akkaVersion = "$akkaVersion"
+          |  val akkaHttpVersion = "$akkaHttpVersion"
           |  private[play] val jettyAlpnAgentVersion = "$jettyAlpnAgentVersion"
           |}
           |""".stripMargin


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

N/A

## Purpose

Makes `akkaHttpVersion` available through `PlayVersion`.

## Background Context

N/A

## References

N/A
