### PR TITLE
QueryStringBindable.unbind(): Do-do-do URLEncode for all queryString keys!

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -280,6 +280,15 @@ object QueryStringBindable {
   import scala.language.experimental.macros
 
   /**
+   * URL-encoding for all bindable string-parts.
+   *
+   * @param source Source char sequence for encoding.
+   * @return URL-encoded string, if source string have had special characters.
+   */
+  private def _urlEncode(source: String): String =
+    URLEncoder.encode(source, "utf-8")
+
+  /**
    * A helper class for creating QueryStringBindables to map the value of a single key
    *
    * @param parse a function to parse the param value
@@ -296,7 +305,8 @@ object QueryStringBindable {
         catch { case e: Exception => Left(error(key, e)) }
       }
 
-    def unbind(key: String, value: A) = key + "=" + serialize(value)
+    def unbind(key: String, value: A) =
+      _urlEncode(key) + "=" + serialize(value)
   }
 
   /**
@@ -309,8 +319,7 @@ object QueryStringBindable {
 
     // Use an option here in case users call index(null) in the routes -- see #818
     def unbind(key: String, value: String) =
-      URLEncoder.encode(Option(key).getOrElse(""), "utf-8") + "=" + URLEncoder
-        .encode(Option(value).getOrElse(""), "utf-8")
+      _urlEncode(key) + "=" + Option(value).fold("")(_urlEncode)
   }
 
   /**
@@ -325,7 +334,8 @@ object QueryStringBindable {
           Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
         }
       }
-    def unbind(key: String, value: Char) = s"$key=$value"
+    def unbind(key: String, value: Char) =
+      s"${_urlEncode(key)}=$value"
   }
 
   /**

--- a/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -43,6 +43,11 @@ class BindersSpec extends Specification {
         Some(Left("Cannot parse parameter key as UUID: Invalid UUID string: bad-uuid"))
       )
     }
+    "Unbind with keys needing encode" in {
+      val u          = UUID.randomUUID()
+      val boundValue = subject.unbind("ke=y", u)
+      boundValue must beEqualTo("ke%3Dy=" + u.toString)
+    }
   }
 
   "URL Path string binder" should {
@@ -64,7 +69,7 @@ class BindersSpec extends Specification {
       val boundValue = bindableString.unbind("key", null)
       boundValue must beEqualTo("key=")
     }
-    "unbind with keys needing encode" in {
+    "unbind with keys needing encode String" in {
       import QueryStringBindable._
       val boundValue = bindableString.unbind("ke=y", "bar")
       boundValue must beEqualTo("ke%3Dy=bar")
@@ -124,6 +129,10 @@ class BindersSpec extends Specification {
     "Be None on empty" in {
       subject.bind("key", Map("key" -> Seq(""))) must equalTo(None)
     }
+    "Unbind with keys needing encode" in {
+      val boundValue = subject.unbind("ke=y", char)
+      boundValue must beEqualTo("ke%3Dy=" + string)
+    }
   }
 
   "URL QueryStringBindable Java Character" should {
@@ -144,6 +153,10 @@ class BindersSpec extends Specification {
     }
     "Be None on empty" in {
       subject.bind("key", Map("key" -> Seq(""))) must equalTo(None)
+    }
+    "Unbind with keys needing encode" in {
+      val boundValue = subject.unbind("ke=y", char)
+      boundValue must beEqualTo("ke%3Dy=" + string)
     }
   }
 
@@ -175,6 +188,10 @@ class BindersSpec extends Specification {
     }
     "Be None on empty" in {
       subject.bind("key", Map("key" -> Seq(""))) must equalTo(None)
+    }
+    "Unbind with keys needing encode" in {
+      val boundValue = subject.unbind("ke=y", short)
+      boundValue must beEqualTo("ke%3Dy=" + string)
     }
   }
 
@@ -237,8 +254,16 @@ class BindersSpec extends Specification {
     "Bind Long String as Demo" in {
       implicitly[QueryStringBindable[Demo]].bind("key", Map("key" -> Seq("10"))) must equalTo(Some(Right(Demo(10L))))
     }
+    "Unbind with keys needing encode (String)" in {
+      val boundValue = implicitly[QueryStringBindable[Demo]].unbind("ke=y", Demo(11L))
+      boundValue must beEqualTo("ke%3Dy=11")
+    }
     "Unbind Hase as String" in {
       implicitly[QueryStringBindable[Hase]].unbind("key", Hase("Disney_Land")) must equalTo("key=Disney_Land")
+    }
+    "Unbind with keys needing encode (String)" in {
+      val boundValue = implicitly[QueryStringBindable[Hase]].unbind("ke=y", Hase("Kremlin"))
+      boundValue must beEqualTo("ke%3Dy=Kremlin")
     }
   }
 
@@ -272,4 +297,5 @@ class BindersSpec extends Specification {
       subject.bind("key", Map("key" -> Seq(""))) must beNone
     }
   }
+
 }

--- a/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -69,10 +69,10 @@ class BindersSpec extends Specification {
       val boundValue = bindableString.unbind("key", null)
       boundValue must beEqualTo("key=")
     }
-    "unbind with keys needing encode String" in {
+    "unbind with keys and values needing encode String" in {
       import QueryStringBindable._
-      val boundValue = bindableString.unbind("ke=y", "bar")
-      boundValue must beEqualTo("ke%3Dy=bar")
+      val boundValue = bindableString.unbind("ke=y", "b=ar")
+      boundValue must beEqualTo("ke%3Dy=b%3Dar")
     }
   }
 
@@ -261,9 +261,9 @@ class BindersSpec extends Specification {
     "Unbind Hase as String" in {
       implicitly[QueryStringBindable[Hase]].unbind("key", Hase("Disney_Land")) must equalTo("key=Disney_Land")
     }
-    "Unbind with keys needing encode (String)" in {
-      val boundValue = implicitly[QueryStringBindable[Hase]].unbind("ke=y", Hase("Kremlin"))
-      boundValue must beEqualTo("ke%3Dy=Kremlin")
+    "Unbind with keys and values needing encode (String)" in {
+      val boundValue = implicitly[QueryStringBindable[Hase]].unbind("ke=y", Hase("Kre=mlin"))
+      boundValue must beEqualTo("ke%3Dy=Kre%3Dmlin")
     }
   }
 
@@ -297,5 +297,4 @@ class BindersSpec extends Specification {
       subject.bind("key", Map("key" -> Seq(""))) must beNone
     }
   }
-
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
@@ -171,7 +171,7 @@ object RouterSpec extends PlaySpecification {
   "reverse routes complex query params " in new WithApplication() {
     controllers.routes.Application
       .takeListTickedParam(List(1, 2, 3))
-      .url must_== "/take-list-tick-param?b[]=1&b[]=2&b[]=3"
+      .url must_== "/take-list-tick-param?b%5B%5D=1&b%5B%5D=2&b%5B%5D=3"  // ?b[]=1&b[]=2&b[]=3
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/RouterSpec.scala
@@ -168,7 +168,8 @@ object RouterSpec extends PlaySpecification {
   }
 
   "reverse routes complex query params " in new WithApplication() {
-    router.routes.Application.takeListTickedParam(List(1, 2, 3)).url must_== "/take-list-tick-param?b[]=1&b[]=2&b[]=3"
+    val actual = router.routes.Application.takeListTickedParam(List(1, 2, 3)).url
+    actual must_== "/take-list-tick-param?b%5B%5D=1&b%5B%5D=2&b%5B%5D=3"    // ?b[]=1&b[]=2&b[]=3
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {

--- a/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
@@ -51,3 +51,8 @@ For a class like:
 A simple example of the binder's use binding the `:from` and `:to` query string parameters:
 
 @[bind](code/javaguide/binder/models/AgeRange.java)
+
+`intBinder.unbind()` automatically apply Form URL Enconding, as well as all others Play standard binders do, so all special characters are safely URL-encoded. If you constructing unbinded-string manually and do not use standard Play binders inside your `unbind()` method implementation, do not forget to apply form-url-encode key/value parts.
+
+@[unbind](code/javaguide/binder/models/CartItem.java)
+

--- a/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
@@ -52,7 +52,7 @@ A simple example of the binder's use binding the `:from` and `:to` query string 
 
 @[bind](code/javaguide/binder/models/AgeRange.java)
 
-`intBinder.unbind()` automatically apply Form URL Enconding, as well as all others Play standard binders do, so all special characters are safely URL-encoded. If you constructing unbinded-string manually and do not use standard Play binders inside your `unbind()` method implementation, do not forget to apply form-url-encode key/value parts.
+All binders Play provides automatically apply form URL encoding in their `unbind` methods, so all special characters are safely URL encoded. This doesn't happen automatically however when implementing custom binders, therefore make sure to encode key/value parts if necessary:
 
 @[unbind](code/javaguide/binder/models/CartItem.java)
 

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/CartItem.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/CartItem.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package javaguide.binder.models;
+
+import java.net.URLEncoder;
+import java.util.Map;
+import java.util.Optional;
+
+import play.libs.F;
+import play.libs.F.*;
+import play.mvc.QueryStringBindable;
+
+// #declaration
+public class CartItem implements QueryStringBindable<CartItem> {
+
+  public String identifier;
+  // #declaration
+
+  @Override
+  public Optional<CartItem> bind(String key, Map<String, String[]> data) {
+
+    try {
+      identifier = data.get("identifier")[0];
+      return Optional.of(this);
+
+    } catch (Exception e) { // no parameter match return None
+      return Optional.empty();
+    }
+  }
+
+  // #unbind
+  @Override
+  public String unbind(String key) {
+    String identifierEncoded;
+    try {
+      identifierEncoded = URLEncoder.encode(identifier, "utf-8");
+    } catch (Exception e) {
+      // should never happen
+      identifierEncoded = identifier;
+    }
+
+    return new StringBuilder()
+        // Key string does not contains special characters, and does not need Form-URL-encoding:
+        .append("identifier")
+        .append('=')
+        // Value string may contain special characters, do encode:
+        .append(identifierEncoded)
+        .toString();
+  }
+  // #unbind
+
+  @Override
+  public String javascriptUnbind() {
+    return new StringBuilder().append("identifier=").append(identifier).append(";").toString();
+  }
+}

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/CartItem.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/CartItem.java
@@ -37,12 +37,12 @@ public class CartItem implements QueryStringBindable<CartItem> {
     try {
       identifierEncoded = URLEncoder.encode(identifier, "utf-8");
     } catch (Exception e) {
-      // should never happen
+      // Should never happen
       identifierEncoded = identifier;
     }
 
     return new StringBuilder()
-        // Key string does not contains special characters, and does not need Form-URL-encoding:
+        // Key string doesn't contain special characters and doesn't need form URL encoding:
         .append("identifier")
         .append('=')
         // Value string may contain special characters, do encode:

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
@@ -52,7 +52,7 @@ A simple example of the binder's use binding the `:from` and `:to` query string 
 
 @[bind](code/scalaguide/binder/models/AgeRange.scala)
 
-`intBinder.unbind()` automatically apply Form URL Enconding, as well as all others Play standard binders do, so all special characters are safely URL-encoded. If you constructing unbinded-string manually and do not use standard Play binders inside your `unbind()` method implementation, do not forget to apply form-url-encode key/value parts.
+All binders Play provides automatically apply form URL encoding in their `unbind` methods, so all special characters are safely URL encoded. This doesn't happen automatically however when implementing custom binders, therefore make sure to encode key/value parts if necessary:
 
 @[unbind](code/scalaguide/binder/models/CartItem.scala)
 

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
@@ -51,3 +51,8 @@ For a class definition:
 A simple example of the binder's use binding the `:from` and `:to` query string parameters:
 
 @[bind](code/scalaguide/binder/models/AgeRange.scala)
+
+`intBinder.unbind()` automatically apply Form URL Enconding, as well as all others Play standard binders do, so all special characters are safely URL-encoded. If you constructing unbinded-string manually and do not use standard Play binders inside your `unbind()` method implementation, do not forget to apply form-url-encode key/value parts.
+
+@[unbind](code/scalaguide/binder/models/CartItem.scala)
+

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/CartItem.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/CartItem.scala
@@ -29,9 +29,9 @@ object CartItem {
       }
       //#unbind
       override def unbind(key: String, cartItem: CartItem): String = {
-        // If we don't use play's QueryStringBindable[String].unbind() for some reason, will construct result string manually.
-        // Key part is constant does not contain any special character, but
-        // value part may contain special characters => need Form URL encoding for cartItem.identifier:
+        // If we don't use Play's QueryStringBindable[String].unbind() for some reason, we need to construct the result string manually.
+        // The key is constant and does not contain any special character, but
+        // value may contain special characters => need form URL encoding for cartItem.identifier:
         "identifier=" + URLEncoder.encode(cartItem.identifier, "utf-8")
       }
       //#unbind

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/CartItem.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/CartItem.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package scalaguide.binder.models
+
+import java.net.URLEncoder
+import scala.Left
+import scala.Right
+import play.api.mvc.PathBindable
+import play.Logger
+import play.api.mvc.QueryStringBindable
+
+//#declaration
+case class CartItem(identifier: String) {}
+//#declaration
+object CartItem {
+  implicit def queryStringBindable(implicit strBinder: QueryStringBindable[String]) =
+    new QueryStringBindable[CartItem] {
+      override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, CartItem]] = {
+        for {
+          identifierEither <- strBinder.bind("identifier", params)
+        } yield {
+          identifierEither match {
+            case Right(identifier) => Right(CartItem(identifier))
+            case _                 => Left("Unable to bind an CartItem identifier")
+          }
+        }
+      }
+      //#unbind
+      override def unbind(key: String, cartItem: CartItem): String = {
+        // If we don't use play's QueryStringBindable[String].unbind() for some reason, will construct result string manually.
+        // Key part is constant does not contain any special character, but
+        // value part may contain special characters => need Form URL encoding for cartItem.identifier:
+        "identifier=" + URLEncoder.encode(cartItem.identifier, "utf-8")
+      }
+      //#unbind
+    }
+}


### PR DESCRIPTION
Fixes #10369 - Let's DO `URLEncode.encode()` for all queryString keys in QSB.unbind().
Unify unbind() behaviour over all query-string binders.

Currently, different binders handle qs-keys differently (look at `res3`):
```
$ sbt console
import play.api.mvc.QueryStringBindable

scala> QueryStringBindable.bindableChar.unbind( "items[1]", '1' )
val res1: String = items[1]=1

scala> QueryStringBindable.bindableInt.unbind( "items[1]", 1 )
val res2: String = items[1]=1

scala> QueryStringBindable.bindableString.unbind( "items[1]", "1" )
val res3: String = items%5B1%5D=1

scala> QueryStringBindable.bindableDouble.unbind( "items[1]", 1 )
val res4: String = items[1]=1.0
```
Special characters like `[`, `]` and others MUST be Form-URL-encoded according to [RFC](https://tools.ietf.org/html/rfc3986#section-2.2).
Added documentation about applying `URLEncode` for handy-implemented unbinders.
Added tests for several common types of `QueryStringBindable`s.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10369
