### PR TITLE
Update Anorm.md

### DIFF
--- a/documentation/manual/releases/release24/migration24/Anorm.md
+++ b/documentation/manual/releases/release24/migration24/Anorm.md
@@ -4,7 +4,7 @@
 Anorm has been pulled out of the core of Play into a separately managed project that can have its own lifecycle.  To add a dependency on it, use:
 
 ```scala
-libraryDependencies += "org.playframework.anorm" %% "anorm" % "2.6.2"
+libraryDependencies += "org.playframework.anorm" %% "anorm" % "2.6.7"
 ```
 
 The complete list can be found here: https://mvnrepository.com/artifact/org.playframework.anorm/anorm

--- a/documentation/manual/releases/release24/migration24/Anorm.md
+++ b/documentation/manual/releases/release24/migration24/Anorm.md
@@ -4,8 +4,10 @@
 Anorm has been pulled out of the core of Play into a separately managed project that can have its own lifecycle.  To add a dependency on it, use:
 
 ```scala
-libraryDependencies += "com.typesafe.play" %% "anorm" % "2.4.0"
+libraryDependencies += "org.playframework.anorm" %% "anorm" % "2.6.2"
 ```
+
+The complete list can be found here: https://mvnrepository.com/artifact/org.playframework.anorm/anorm
 
 > The release 2.4.0 of Anorm requires Java 8. The last version compatible with a JDK 1.6 or 1.7 is Anorm 2.3.9.
 


### PR DESCRIPTION
updated with correct sbt dependency. The old dependency points to com.typesafe and breaks the build.sbt. Also, link to the mvnrepository so that version compatible with different Scala versions(2.11, 2.12, 2.13 at this point) are easy to find.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
