### PR TITLE
Fix caffeine config

### DIFF
--- a/cache/play-caffeine-cache/src/main/resources/reference.conf
+++ b/cache/play-caffeine-cache/src/main/resources/reference.conf
@@ -12,8 +12,10 @@ play {
       defaults {
         initial-capacity = null
         maximum-size = 10000
-        weak-keys = null
         weak-keys = false
+        # Technically, weak-values and soft-values can't both be enabled at the same time.
+        # If applicable, make sure you just enable one of them to avoid undetermined behaviour.
+        weak-values = false
         soft-values = false
         record-stats = false
         executor = ${play.cache.dispatcher}


### PR DESCRIPTION
First, please have a look at how these configs get parsed [here](https://github.com/playframework/playframework/blob/2.8.2/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineParser.java#L53-L80).

Now, this is what I fixed:
- `weak-keys` was defined twice. No need.
- ~~`maximum-size` was missing in the config.~~ (fixed in #11317)
- `weak-values` was missing as well. Also **either** `weak-values` **or** `soft-values` should be set to `true` at a certain moment, not both at the same time, because if the "value strength" was set once, it can't be set to another value anymore, therefore setting both results in undertimed behaviour (we don't know which was set first). See the caffeine implementation: https://github.com/ben-manes/caffeine/blob/v3.1.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L555-L556
and
https://github.com/ben-manes/caffeine/blob/v3.1.1/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Caffeine.java#L591-L592

Adding this configs does not change the behaviour, so we can backport to 2.8.x