### PR TITLE
Add type annotation for Optional.empty

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -183,7 +183,7 @@ object Docs {
     val sources    = apiDocsJavaSources.value.toList
     val classpath  = apiDocsClasspath.value.toList
     val outputDir  = apiDocsDir.value / "java"
-    val incToolOpt = IncToolOptions.create(Optional.empty(), false)
+    val incToolOpt = IncToolOptions.create(Optional.empty[ClassFileManager](), false)
     val log        = streams.value.log
     val reporter   = new LoggedReporter(10, log)
 


### PR DESCRIPTION
With sbt 1.4.x, the type is inferred as Optional[Nothing] rather than
Optional[ClassFileManager].

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
