### PR TITLE
Correct the HostMatcher logic to get host and port

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -81,7 +81,7 @@ private[hosts] case class HostMatcher(pattern: String) {
   // Get and normalize the host and port
   // Returns None for no port but Some(-1) for an invalid/non-numeric port
   private def getHostAndPort(s: String) = {
-    val (h, p) = s.trim.split(":", 2) match {
+    val (h, p) = s.trim.split(""":(?=\d*$)""", 2) match {
       case Array(h, p) if p.nonEmpty && p.forall(_.isDigit) => (h, Some(p.toInt))
       case Array(h, _)                                      => (h, Some(-1))
       case Array(h, _*)                                     => (h, None)

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -173,6 +173,16 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       statusBadRequest(app, "google.com:80")
     }
 
+    "support host headers with IPv6 addresses" in withApplication(
+      okWithHost,
+      """
+        |play.filters.hosts.allowed = ["[::]:9000"]
+      """.stripMargin
+    ) { app =>
+      status(request(app, "[::]:9000")) must_== OK
+      statusBadRequest(app, "[::1]:9000")
+    }
+
     "restrict host headers based on port" in withApplication(
       okWithHost,
       """


### PR DESCRIPTION
The original implementation split at the first possible colon (:), which works fine until you use IPv6 IPs as hosts, which contain at least 2 additional colons. The new implementation splits only on the last colon, the rest of the logic has been kept unchanged. A test reproducing the problem and confirming the fix has been added.

# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)? - **no issues to reference**
* [X] Have you added copyright headers to new files? - **no new files**
* [X] Have you checked that both Scala and Java APIs are updated? - **no java API**
* [X] Have you updated the documentation for both Scala and Java sections? - **no documentation necessary**
* [X] Have you added tests for any changed functionality?

# Helpful things

## Fixes

No issue to reference. I found this problem today and fixed it.

## Purpose

It fixes the AllowedHostsFilter to accept IPv6 addresses in the form of `[::]:9000`.

## Background Context

The original implementation's assumption that the port will be separated by the only colon breaks with IPv6, I correct the assumption to: The port is separated by the last colon. This allows to keep the rest of the logic completely untouched.

## References
No
