### PR TITLE
sbt-plugin: handle AssertionError from zinc compilation

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -38,7 +38,7 @@ object PlayReload {
             .find(_.severity == Severity.Error)
             .map(CompilationException)
             .getOrElse(UnexpectedException(Some("The compilation failed without reporting any problem!"), Some(e)))
-        case e: Exception => UnexpectedException(unexpected = Some(e))
+        case e => UnexpectedException(unexpected = Some(e))
       }
       .getOrElse {
         UnexpectedException(Some("The compilation task failed without any exception!"))

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -38,7 +38,7 @@ object PlayReload {
             .find(_.severity == Severity.Error)
             .map(CompilationException)
             .getOrElse(UnexpectedException(Some("The compilation failed without reporting any problem!"), Some(e)))
-        case e => UnexpectedException(unexpected = Some(e))
+        case NonFatal(e) => UnexpectedException(unexpected = Some(e))
       }
       .getOrElse {
         UnexpectedException(Some("The compilation task failed without any exception!"))

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -6,6 +6,8 @@ package play.sbt.run
 
 import java.util.Optional
 
+import scala.util.control.NonFatal
+
 import sbt._
 import sbt.Keys._
 import sbt.internal.Output


### PR DESCRIPTION
## Fixes

Fixes handling of `AssertionError` from zinc compilation.
I am testing my work project with sbt 1.4.0-RC2 and found that this bug is hiding an exception from zinc and showing this instead:

```
[error] a.a.OneForOneStrategy - java.lang.AssertionError: assertion failed: Created a Compilations with duplicate compilations (of class java.lang.AssertionError)
akka.actor.ActorInitializationException: akka://play-dev-mode/system/Materializers/StreamSupervisor-1/TLS-for-flow-2-1: exception during creation
	at akka.actor.ActorInitializationException$.apply(Actor.scala:196)
	at akka.actor.ActorCell.create(ActorCell.scala:661)
	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:513)
	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:535)
	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:295)
	at akka.dispatch.Mailbox.run(Mailbox.scala:230)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
Caused by: scala.MatchError: java.lang.AssertionError: assertion failed: Created a Compilations with duplicate compilations (of class java.lang.AssertionError)
	at play.sbt.run.PlayReload$.$anonfun$taskFailureHandler$1(PlayReload.scala:35)
	at scala.Option.map(Option.scala:230)
	at play.sbt.run.PlayReload$.taskFailureHandler(PlayReload.scala:35)
	at play.sbt.run.PlayReload$.compileFailure(PlayReload.scala:28)
	at play.sbt.run.PlayReload$.$anonfun$compile$3(PlayReload.scala:63)
	at scala.util.Either$LeftProjection.map(Either.scala:573)
	at play.sbt.run.PlayReload$.compile(PlayReload.scala:63)
	at play.sbt.run.PlayRun$.$anonfun$playRunTask$4(PlayRun.scala:78)
	at play.runsupport.Reloader.$anonfun$reload$1(Reloader.scala:496)
	at play.runsupport.Reloader$$anon$1.run(Reloader.scala:57)
```

The root cause exception was already reported to sbt project in https://github.com/sbt/sbt/issues/5911


