### PR TITLE
useCoursier := false in metabuild of documentations

### DIFF
--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -3,6 +3,9 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
+// Required to use sbt 1.4.0
+ThisBuild / useCoursier := false
+
 lazy val plugins = (project in file(".")).dependsOn(playDocsPlugin)
 
 lazy val playDocsPlugin = ProjectRef(Path.fileProperty("user.dir").getParentFile, "Play-Docs-Sbt-Plugin")


### PR DESCRIPTION
This workaround allows Play documentations to use sbt 1.4.0-RC2.
For some reason Coursier seems to get confused about IO and brings in
only io 1.2.2 coming from sbt-native-packager.

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Ref https://github.com/sbt/sbt/issues/5915
