### PR TITLE
Allow grouping options inside html selects

### DIFF
--- a/core/play/src/main/scala/views/helper/Helpers.scala
+++ b/core/play/src/main/scala/views/helper/Helpers.scala
@@ -137,6 +137,19 @@ package views.html.helper {
     def apply(options: java.util.List[String]): Seq[(String, String)]        = options.asScala.toSeq.map(v => v -> v)
   }
 
+  object optionsGrouped {
+    def apply(
+        optionsGrouped: Map[String, Map[String, String]]
+    ): Seq[(String, Seq[(String, String)])] = {
+      optionsGrouped.toSeq.map(m => (m._1, m._2.toSeq))
+    }
+    def apply(
+        optionsGrouped: java.util.Map[String, java.util.Map[String, String]]
+    ): Seq[(String, Seq[(String, String)])] = {
+      optionsGrouped.asScala.toSeq.map(m => (m._1, m._2.asScala.toSeq))
+    }
+  }
+
   object Implicits {
     implicit def toAttributePair(pair: (String, String)): (Symbol, String) = Symbol(pair._1) -> pair._2
   }

--- a/core/play/src/main/scala/views/helper/select.scala.html
+++ b/core/play/src/main/scala/views/helper/select.scala.html
@@ -22,21 +22,5 @@
  * @param handler The field constructor.
  *@
 @(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
-@input(field, args:_*) { (id, name, value, htmlArgs) =>
-    @defining( if( htmlArgs.contains(Symbol("multiple")) ) "%s[]".format(name) else name ) { selectName =>
-    @defining( field.indexes.nonEmpty && htmlArgs.contains(Symbol("multiple")) match {
-            case true => field.indexes.map( i => field("[%s]".format(i)).value ).flatten.toSet
-            case _ => field.value.toSet
-    }){ selectedValues =>
-        <select id="@id" name="@selectName" @toHtmlArgs(htmlArgs)>
-            @args.toMap.get(Symbol("_default")).map { defaultValue =>
-                <option class="blank" value="">@translate(defaultValue)</option>
-            }
-            @options.map { case (k, v) =>
-                @defining( selectedValues.contains(k) ) { selected =>
-                @defining( args.toMap.get(Symbol("_disabled")).exists { case s: Seq[_] => s.asInstanceOf[Seq[String]].contains(k) }){ disabled =>
-                <option value="@k"@if(selected){ selected="selected"}@if(disabled){ disabled}>@v</option>
-            }}}
-        </select>
-    }}
-}
+
+@selectGrouped(field, Seq("" -> options), args:_*)

--- a/core/play/src/main/scala/views/helper/selectGrouped.scala.html
+++ b/core/play/src/main/scala/views/helper/selectGrouped.scala.html
@@ -1,0 +1,62 @@
+@**
+ * Generate an HTML select.
+ *
+ * Example:
+ * {{{
+ * @selectGrouped(
+ *   field = myForm("mySelect"),
+ *   options = Seq(
+ *     "" -> Seq(
+ *       "opt1" -> "Option without a group",
+ *       "opt2" -> "Another option without group"
+ *     ),
+ *     "Group 1" -> Seq(
+ *       "opt3" -> "Option 3",
+ *       "opt4" -> "Option 4"
+ *     ),
+ *     "Group 2" -> Seq(
+ *       "opt5" -> "Option 5",
+ *       "opt6" -> "Option 6"
+ *     )
+ *    ),
+ *   Symbol("_default") -> "Choose One",
+ *   Symbol("_disabled") -> Seq("opt1", "opt3")
+ *   Symbol("_disabledGroups") -> Seq("Group 2")
+ *   Symbol("cust_att_name") -> "cust_att_value"
+ * )
+ * }}}
+ *
+ * @param field The form field.
+ * @param options Sequence of options as pairs of value and HTML.
+ * @param args Set of extra attributes.
+ * @param handler The field constructor.
+ *@
+@(field: play.api.data.Field, optionGroups: Seq[(String,Seq[(String,String)])], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
+@input(field, args:_*) { (id, name, value, htmlArgs) =>
+    @defining( if( htmlArgs.contains(Symbol("multiple")) ) "%s[]".format(name) else name ) { selectName =>
+    @defining( field.indexes.nonEmpty && htmlArgs.contains(Symbol("multiple")) match {
+            case true => field.indexes.map( i => field("[%s]".format(i)).value ).flatten.toSet
+            case _ => field.value.toSet
+    }){ selectedValues =>
+        <select id="@id" name="@selectName" @toHtmlArgs(htmlArgs)>
+            @args.toMap.get(Symbol("_default")).map { defaultValue =>
+                <option class="blank" value="">@translate(defaultValue)</option>
+            }
+            @optionGroups.map { case (group, options) =>
+                @if(!group.isEmpty) {
+                    @defining( args.toMap.get(Symbol("_disabledGroups")).exists { case s: Seq[_] => s.asInstanceOf[Seq[String]].contains(group)}){ disabledGroup =>
+                        <optgroup label="@group"@if(disabledGroup){ disabled}>
+                    }
+                }
+                @options.map { case (k, v) =>
+                    @defining( selectedValues.contains(k) ) { selected =>
+                    @defining( args.toMap.get(Symbol("_disabled")).exists { case s: Seq[_] => s.asInstanceOf[Seq[String]].contains(k) }){ disabled =>
+                    <option value="@k"@if(selected){ selected="selected"}@if(disabled){ disabled}>@v</option>
+                }}}
+                @if(!group.isEmpty) {
+                    </optgroup>
+                }
+            }
+        </select>
+    }}
+}

--- a/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -162,6 +162,31 @@ class HelpersSpec extends Specification {
     }
   }
 
+  "@selectGrouped" should {
+    "not create unnecessary optgroup" in {
+      val body = selectGrouped.apply(Form(single("foo" -> Forms.text))("foo"), Seq("" -> Seq("0" -> "test"))).body
+
+      body must not contain """<optgroup"""
+    }
+
+    "allow disabled groups" in {
+      val body = selectGrouped
+        .apply(
+          Form(single("foo" -> Forms.text))("foo"),
+          Seq(
+            ""        -> Seq("0" -> "test"),
+            "Group 1" -> Seq("1" -> "foo", "2" -> "bar"),
+            "Group 2" -> Seq("3" -> "boo", "4" -> "far")
+          ),
+          Symbol("_disabledGroups") -> Seq("Group 1")
+        )
+        .body
+
+      body must contain("""<optgroup label="Group 1" disabled>""")
+      body must contain("""<optgroup label="Group 2">""")
+    }
+  }
+
   "@repeat" should {
     val form                                   = Form(single("foo" -> Forms.seq(Forms.text)))
     def renderFoo(form: Form[?], min: Int = 1) =


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

This PR closes #9725 by implementing a new `selectGrouped` form-helper.

The new `selectGrouped` allows options to be grouped via its `optionGroups: Seq[(String,Seq[(String,String)])]` parameter. Options that should not be wrapped inside an `<optgroup>` element can be passed as options of the `""` (empty string) group.

A new optional argument was also introduced to allow disabling whole `<optgroup>` elements via the `_disabledGroups` Symbol.

**Example**
```
@selectGrouped(
   field = myForm("mySelect"),
   options = Seq(
     "" -> Seq(
       "opt1" -> "Option without a group",
       "opt2" -> "Another option without group"
     ),
     "Group 1" -> Seq(
       "opt3" -> "Option 3",
       "opt4" -> "Option 4"
     ),
     "Group 2" -> Seq(
       "opt5" -> "Option 5",
       "opt6" -> "Option 6"
     )
    ),
   Symbol("_default") -> "Choose One",
   Symbol("_disabled") -> Seq("opt1", "opt3")
   Symbol("_disabledGroups") -> Seq("Group 2")
   Symbol("cust_att_name") -> "cust_att_value"
 )
```

An additional helper `helper.optionsGrouped` has been added to `Helpers.scala` to help converting from java types to the required scala Seq. Similar to the already available `helper.options`.

## Background Context

The code from `select.scala.html` has been completely moved to `selectGrouped.scala.html`. The `select` doesn't contain any logic now and just subsequently calls the `selectGrouped` helper by wrapping its options inside a `""` group. The generated HTML of the `helper.select` is therefore exactly the same to what it was before.

I chose this approach in order to maintain full backwards-compatability by not changing the parameter types of `select.scala.html`. Additionally, by changing `select.scala.html` to subsequently call `selectGrouped.scala.html`, duplicate code for the same logic can be prevented and the DRY principle doesn't get violated.

## References

- Closes the issue #9725.
- The `<optgroup>` elements have been implemented according to the specifications seen here:
  https://developer.mozilla.org/de/docs/Web/HTML/Element/optgroup

## Diff

Because all of the code was moved from `select` to `selectGrouped`, the diff shown in the PR doesn't point out the actual code changes that happened to the creation of the `<select>` element. Below is a diff comparing the current `select.scala.html` with the new `selectGrouped.scala.html`.

```diff
diff --git a/select.scala.html b/selectGrouped.scala.html
index f722d3d..abe8d03 100644
--- a/select.scala.html
+++ b/selectGrouped.scala.html
@@ -3,15 +3,25 @@
  *
  * Example:
  * {{{
- * @select(
+ * @selectGrouped(
  *   field = myForm("mySelect"),
  *   options = Seq(
- *     "Foo" -> "foo text",
- *     "Bar" -> "bar text",
- *     "Baz" -> "baz text"
+ *     "" -> Seq(
+ *       "opt1" -> "Option without a group",
+ *       "opt2" -> "Another option without group"
+ *     ),
+ *     "Group 1" -> Seq(
+ *       "opt3" -> "Option 3",
+ *       "opt4" -> "Option 4"
+ *     ),
+ *     "Group 2" -> Seq(
+ *       "opt5" -> "Option 5",
+ *       "opt6" -> "Option 6"
+ *     )
  *    ),
  *   Symbol("_default") -> "Choose One",
- *   Symbol("_disabled") -> Seq("FooKey", "BazKey")
+ *   Symbol("_disabled") -> Seq("opt1", "opt3")
+ *   Symbol("_disabledGroups") -> Seq("Group 2")
  *   Symbol("cust_att_name") -> "cust_att_value"
  * )
  * }}}
@@ -21,7 +31,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
+@(field: play.api.data.Field, optionGroups: Seq[(String,Seq[(String,String)])], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     @defining( if( htmlArgs.contains(Symbol("multiple")) ) "%s[]".format(name) else name ) { selectName =>
     @defining( field.indexes.nonEmpty && htmlArgs.contains(Symbol("multiple")) match {
@@ -32,11 +42,21 @@
             @args.toMap.get(Symbol("_default")).map { defaultValue =>
                 <option class="blank" value="">@translate(defaultValue)</option>
             }
-            @options.map { case (k, v) =>
-                @defining( selectedValues.contains(k) ) { selected =>
-                @defining( args.toMap.get(Symbol("_disabled")).exists { case s: Seq[_] => s.asInstanceOf[Seq[String]].contains(k) }){ disabled =>
-                <option value="@k"@if(selected){ selected="selected"}@if(disabled){ disabled}>@v</option>
-            }}}
+            @optionGroups.map { case (group, options) =>
+                @if(!group.isEmpty) {
+                    @defining( args.toMap.get(Symbol("_disabledGroups")).exists { case s: Seq[_] => s.asInstanceOf[Seq[String]].contains(group)}){ disabledGroup =>
+                        <optgroup label="@group"@if(disabledGroup){ disabled}>
+                    }
+                }
+                @options.map { case (k, v) =>
+                    @defining( selectedValues.contains(k) ) { selected =>
+                    @defining( args.toMap.get(Symbol("_disabled")).exists { case s: Seq[_] => s.asInstanceOf[Seq[String]].contains(k) }){ disabled =>
+                    <option value="@k"@if(selected){ selected="selected"}@if(disabled){ disabled}>@v</option>
+                }}}
+                @if(!group.isEmpty) {
+                    </optgroup>
+                }
+            }
         </select>
     }}
 }
```
