### PR TITLE
Fix classloader memory leak, due to ClassTag

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -37,9 +37,10 @@ object PlayCommands {
   val playCommonClassloaderTask = Def.task {
     val classpath = (dependencyClasspath in Compile).value
     val log       = streams.value.log
+    //we need to handle scala-library.jar from ivy cache, or scala-library-2.x.x from coursier, but not for example scala-library-next.jar
     lazy val commonJars: PartialFunction[java.io.File, java.net.URL] = {
       case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar"                       => jar.toURI.toURL
-      case jar if jar.getName.startsWith("scala-library-") || jar.getName == "scala-library.jar" => jar.toURI.toURL
+      case jar if jar.getName.startsWith("scala-library-2") || jar.getName == "scala-library.jar" => jar.toURI.toURL
     }
 
     if (commonClassLoader == null) {

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -39,7 +39,7 @@ object PlayCommands {
     val log       = streams.value.log
     //we need to handle scala-library.jar from ivy cache, or scala-library-2.x.x from coursier, but not for example scala-library-next.jar
     lazy val commonJars: PartialFunction[java.io.File, java.net.URL] = {
-      case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar"                       => jar.toURI.toURL
+      case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar"                        => jar.toURI.toURL
       case jar if jar.getName.startsWith("scala-library-2") || jar.getName == "scala-library.jar" => jar.toURI.toURL
     }
 

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -39,6 +39,7 @@ object PlayCommands {
     val log       = streams.value.log
     lazy val commonJars: PartialFunction[java.io.File, java.net.URL] = {
       case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar" => jar.toURI.toURL
+      case jar if jar.getName.startsWith("scala-library-") || jar.getName == "scala-library.jar" => jar.toURI.toURL
     }
 
     if (commonClassLoader == null) {

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -38,7 +38,7 @@ object PlayCommands {
     val classpath = (dependencyClasspath in Compile).value
     val log       = streams.value.log
     lazy val commonJars: PartialFunction[java.io.File, java.net.URL] = {
-      case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar" => jar.toURI.toURL
+      case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar"                       => jar.toURI.toURL
       case jar if jar.getName.startsWith("scala-library-") || jar.getName == "scala-library.jar" => jar.toURI.toURL
     }
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -343,7 +343,9 @@ object BuildSettings {
     scriptedLaunchOpts ++= Seq(
       s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
       "-Xmx512m",
-      "-XX:MaxMetaspaceSize=512m",
+      "-XX:MaxMetaspaceSize=300m",
+      "-XX:HeapDumpPath=/tmp/",
+      "-XX:+HeapDumpOnOutOfMemoryError",
       s"-Dscala.version=$scala212",
     ),
     scripted := scripted.tag(Tags.Test).evaluated,


### PR DESCRIPTION
# Pull Request Checklist

# Helpful things

## Fixes

Fixes classloader memory leak, due to `ClassTag`

## Purpose

Launches scripted tests with a limited metaspace size. With this change most of the tests fail. After analyzing the heap dump in yourkit profiler, one can see that `ClassTag#cache` is not allowing the classloaders created by play to be GCd. 

The fix is to separate the classloader that loads ClassTag from the classloaders that load the rest of the application classes (libraries and user code), and then the classloaders can be GCd.

I also opened a PR in scala (https://github.com/scala/scala/pull/9276/), but I also managed to fix it in play-plugin. As you can see in that PR discussion this is not a problem in scala 2.13, but the scripted tests only run with scala 2.12

## References

#9935
https://github.com/scala/scala/pull/9276/
