### PR TITLE
throw error if RoutesCompiler generate duplicate routes files

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -194,11 +194,15 @@ object RoutesCompiler extends AutoPlugin {
   ): Seq[File] = {
     val ops                = tasks.map(task => RoutesCompilerOp(task, generator.id, PlayVersion.current))
     val (products, errors) = syncIncremental(cacheDirectory, ops) { (opsToRun: Seq[RoutesCompilerOp]) =>
-      val errs = Seq.newBuilder[RoutesCompilationError]
+      val errs    = Seq.newBuilder[RoutesCompilationError]
+      val results = Seq.newBuilder[(File, File)]
 
       val opResults: Map[RoutesCompilerOp, OpResult] = opsToRun.map { op =>
         play.routes.compiler.RoutesCompiler.compile(op.task, generator, generatedDir) match {
           case Right(inputs) =>
+            inputs.foreach { i =>
+              results += (i -> op.task.file)
+            }
             op -> OpSuccess(Set(op.task.file), inputs.toSet)
 
           case Left(details) =>
@@ -206,6 +210,21 @@ object RoutesCompiler extends AutoPlugin {
             op -> OpFailure
         }
       }.toMap
+
+      results.result.groupBy(_._1).filter(_._2.size > 1).toList.flatMap(_._2) match {
+        case x if x.isEmpty => // success
+        case duplicate      =>
+          errs ++= duplicate.map {
+            case (output, input) =>
+              RoutesCompilationError(
+                source = input,
+                message =
+                  s"found duplicate generated routes files ${input} ${output} https://github.com/playframework/playframework/issues/8423",
+                line = None,
+                column = None
+              )
+          }
+      }
 
       opResults -> errs.result()
     }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/app/controllers/sample/Controller1.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/app/controllers/sample/Controller1.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers.sample;
+
+import play.mvc.*;
+
+public class Controller1 extends Controller {
+
+    public Result index() {
+        return null;
+    }
+
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/app/controllers/sample/Controller2.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/app/controllers/sample/Controller2.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers.sample;
+
+import play.mvc.*;
+
+public class Controller2 extends Controller {
+
+    public Result index() {
+        return null;
+    }
+
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/build.sbt
@@ -1,0 +1,5 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+enablePlugins(PlayJava)
+
+scalaVersion := "2.13.12"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/conf/routes
@@ -1,0 +1,4 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+->      /c1       sample1.Routes
+->      /c2       sample2.Routes

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/conf/sample1.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/conf/sample1.routes
@@ -1,0 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+GET     /      controllers.sample.Controller1.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/conf/sample2.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/conf/sample2.routes
@@ -1,0 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+GET     /      controllers.sample.Controller2.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/project/plugins.sbt
@@ -1,0 +1,4 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-issue-8423/test
@@ -1,0 +1,3 @@
+-> playRoutes
+> set generateReverseRouter := false
+> compile


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Partially Fixes(?) https://github.com/playframework/playframework/issues/8423

## Purpose

throw error if ` when two routes files refer to different controllers in same package`

## Background Context


## References
- https://github.com/playframework/playframework/issues/8423
- https://github.com/marcospereira/play-reverse-route-generation-problem
- https://github.com/playframework/playframework/issues/6719
- https://github.com/diamondo25/playframework-routes-bug