### PR TITLE
Restore Jackson visibility defaults

### DIFF
--- a/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
+++ b/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
@@ -5,9 +5,10 @@
 package play.core
 
 import scala.concurrent.Future
-
 import akka.actor.ActorSystem
 import akka.serialization.jackson.JacksonObjectMapperProvider
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.PropertyAccessor
 import com.fasterxml.jackson.databind.ObjectMapper
 import javax.inject._
 import play.api.inject._
@@ -36,7 +37,9 @@ class ObjectMapperProvider @Inject() (lifecycle: ApplicationLifecycle, actorSyst
       JacksonObjectMapperProvider
         .get(actorSystem)
         .getOrCreate(ObjectMapperProvider.BINDING_NAME, Option.empty)
+    mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.PUBLIC_ONLY)
     Json.setObjectMapper(mapper)
+
     lifecycle.addStopHook { () =>
       Future.successful(Json.setObjectMapper(null))
     }


### PR DESCRIPTION
Try to ensure the `ObjectMapper` managed by Akka and identified as `"play"` uses the same defaults an `ObjectMapper` provided in Play 2.7.

This is a quick solution we may or may not merge (and just keep as inspiration for users to implement their workaround). The long-term solution is to wait for https://github.com/akka/akka/pull/29797 and set the visibility default for `"play"`'s `ObjectMapper` in `reference-override.conf`; and then, undo the workaround in `ObjectMapperModule` introduced in this PR.

Refs #10523 

see also https://github.com/akka/akka/pull/29797 