### PR TITLE
Let user overwrite limit sizes for json payloads

### DIFF
--- a/core/play/src/test/scala/play/api/data/FormUtilsSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormUtilsSpec.scala
@@ -96,23 +96,6 @@ class FormUtilsSpec extends Specification {
       }) must throwA[FormJsonExpansionTooLarge]
     }
 
-    "abort parsing when maximum memory is used" in {
-      // Even when the JSON is small, if the memory limit is exceed the parsing must stop.
-      val keyLength = 10
-      val itemCount = 10
-      val maxChars  = 3 // yeah, maxChars is only 3 chars. We want to hit the limit.
-      (try {
-        val jsString = Json.parse(s""" "${"a" * keyLength}" """)
-        FormUtils.fromJson(
-          jsString,
-          maxChars
-        )
-      } catch {
-        case _: OutOfMemoryError =>
-          ko("OutOfMemoryError")
-      }) must throwA[FormJsonExpansionTooLarge]
-    }
-
     "not run out of heap when converting arrays with very long keys" in {
       // a similar scenario to the previous one but this would cause OOME if it weren't for the limit
       val keyLength = 10000

--- a/core/play/src/test/scala/play/api/data/FormUtilsSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormUtilsSpec.scala
@@ -96,6 +96,23 @@ class FormUtilsSpec extends Specification {
       }) must throwA[FormJsonExpansionTooLarge]
     }
 
+    "abort parsing when maximum memory is used" in {
+      // Even when the JSON is small, if the memory limit is exceed the parsing must stop.
+      val keyLength = 10
+      val itemCount = 10
+      val maxChars  = 3 // yeah, maxChars is only 3 chars. We want to hit the limit.
+      (try {
+        val jsString = Json.parse(s""" "${"a" * keyLength}" """)
+        FormUtils.fromJson(
+          jsString,
+          maxChars
+        )
+      } catch {
+        case _: OutOfMemoryError =>
+          ko("OutOfMemoryError")
+      }) must throwA[FormJsonExpansionTooLarge]
+    }
+
     "not run out of heap when converting arrays with very long keys" in {
       // a similar scenario to the previous one but this would cause OOME if it weren't for the limit
       val keyLength = 10000

--- a/web/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/web/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -303,8 +303,8 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
   public DynamicForm bind(Lang lang, TypedMap attrs, JsonNode data, String... allowedFields) {
     logger.warn(
         "Binding json field from form with a hardcoded max size of {} bytes. This is deprecated. Use bind(Lang, TypedMap, JsonNode, Long, String...) instead.",
-        FROM_JSON_MAX_CHARS);
-    return bind(lang, attrs, data, FROM_JSON_MAX_CHARS, allowedFields);
+        maxJsonChars());
+    return bind(lang, attrs, data, maxJsonChars(), allowedFields);
   }
 
   @Override

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -90,8 +90,6 @@ public class Form<T> {
 
   private static final String INVALID_MSG_KEY = "error.invalid";
 
-  protected static final long FROM_JSON_MAX_CHARS = Form$.MODULE$.FromJsonMaxChars();
-
   /** Defines a form element's display name. */
   @Retention(RUNTIME)
   @Target({ANNOTATION_TYPE})
@@ -574,6 +572,10 @@ public class Form<T> {
     this.directFieldAccess = directFieldAccess;
   }
 
+  protected long maxJsonChars() {
+    return config.getMemorySize("play.http.parser.maxMemoryBuffer").toBytes();
+  }
+
   protected Map<String, String> requestData(Http.Request request) {
 
     Map<String, String[]> urlFormEncoded = new HashMap<>();
@@ -587,13 +589,12 @@ public class Form<T> {
     }
 
     Map<String, String> jsonData = new HashMap<>();
-    long maxMemoryBuffer = config.getMemorySize("play.http.parser.maxMemoryBuffer").toBytes();
     if (request.body().asJson() != null) {
       jsonData =
           play.libs.Scala.asJava(
               play.api.data.FormUtils.fromJson(
                   play.api.libs.json.Json.parse(play.libs.Json.stringify(request.body().asJson())),
-                  maxMemoryBuffer));
+                  maxJsonChars()));
     }
 
     Map<String, String> data = new HashMap<>();
@@ -797,8 +798,8 @@ public class Form<T> {
   public Form<T> bind(Lang lang, TypedMap attrs, JsonNode data, String... allowedFields) {
     logger.warn(
         "Binding json field from form with a hardcoded max size of {} bytes. This is deprecated. Use bind(Lang, TypedMap, JsonNode, Int, String...) instead.",
-        FROM_JSON_MAX_CHARS);
-    return bind(lang, attrs, data, FROM_JSON_MAX_CHARS, allowedFields);
+        maxJsonChars());
+    return bind(lang, attrs, data, maxJsonChars(), allowedFields);
   }
 
   /**


### PR DESCRIPTION
This is an alternative to #10534 

The purpose is to improve the implementation introduced in #10496 (which uses a hardcoded value) trying to always use Play's `"play.http.parser.maxMemoryBuffer"` value.
