### PR TITLE
[2.7.x] Let user overwrite limit memory size on form binding

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/action/FormActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/FormActionSpec.scala
@@ -21,6 +21,8 @@ import play.api.test.WsTestClient
 import play.api.routing.Router
 
 class FormActionSpec extends PlaySpecification with WsTestClient {
+  import FormBinding.Implicits._
+
   case class User(
       name: String,
       email: String,

--- a/core/play/src/main/scala/play/api/data/Form.scala
+++ b/core/play/src/main/scala/play/api/data/Form.scala
@@ -14,6 +14,7 @@ import play.api.data.format._
 import play.api.data.validation._
 import play.api.http.HttpVerbs
 import play.api.libs.json.JsValue
+import play.api.mvc.{BodyParsers, MultipartFormData, PlayBodyParsers}
 import play.api.templates.PlayMagic.translate
 import scala.util.control.NoStackTrace
 
@@ -111,30 +112,8 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
    *
    * @return a copy of this form filled with the new data
    */
-  def bindFromRequest()(implicit request: play.api.mvc.Request[_]): Form[T] = {
-    bindFromRequest {
-      ((request.body match {
-        case body: play.api.mvc.AnyContent if body.asFormUrlEncoded.isDefined => body.asFormUrlEncoded.get
-        case body: play.api.mvc.AnyContent if body.asMultipartFormData.isDefined =>
-          body.asMultipartFormData.get.asFormUrlEncoded
-        case body: play.api.mvc.AnyContent if body.asJson.isDefined =>
-          FormUtils.fromJson(body.asJson.get, Form.FromJsonMaxChars).mapValues(Seq(_))
-        case body: Map[_, _]                         => body.asInstanceOf[Map[String, Seq[String]]]
-        case body: play.api.mvc.MultipartFormData[_] => body.asFormUrlEncoded
-        case body: Either[_, play.api.mvc.MultipartFormData[_]] =>
-          body match {
-            case Right(b) => b.asFormUrlEncoded
-            case Left(_)  => Map.empty[String, Seq[String]]
-          }
-        case body: play.api.libs.json.JsValue => FormUtils.fromJson(body, Form.FromJsonMaxChars).mapValues(Seq(_))
-        case _                                => Map.empty[String, Seq[String]]
-      }) ++ {
-        request.method.toUpperCase match {
-          case HttpVerbs.POST | HttpVerbs.PUT | HttpVerbs.PATCH => Map.empty
-          case _                                                => request.queryString
-        }
-      }).toMap
-    }
+  def bindFromRequest()(implicit request: play.api.mvc.Request[_], formBinding: FormBinding): Form[T] = {
+    bindFromRequest(formBinding(request))
   }
 
   def bindFromRequest(data: Map[String, Seq[String]]): Form[T] = {
@@ -1093,3 +1072,47 @@ trait ObjectMapping {
 case class FormJsonExpansionTooLarge(limit: Long)
     extends RuntimeException(s"Binding form from JSON exceeds form expansion limit of $limit")
     with NoStackTrace
+
+trait FormBinding {
+  def apply(request: play.api.mvc.Request[_]): Map[String, Seq[String]]
+}
+
+object FormBinding {
+  object Implicits {
+    implicit val formBinding: FormBinding = new DefaultFormBinding(Form.FromJsonMaxChars)
+  }
+}
+
+class DefaultFormBinding(maxChars: Long) extends FormBinding {
+
+  def apply(request: play.api.mvc.Request[_]): Map[String, Seq[String]] =
+    ((request.body match {
+      case body: play.api.mvc.AnyContent if body.asFormUrlEncoded.isDefined => body.asFormUrlEncoded.get
+      case body: play.api.mvc.AnyContent if body.asMultipartFormData.isDefined =>
+        multipartFormParse(body.asMultipartFormData.get)
+      case body: play.api.mvc.AnyContent if body.asJson.isDefined =>
+        jsonParse(body.asJson.get)
+      case body: Map[_, _] => body.asInstanceOf[Map[String, Seq[String]]]
+      case body: play.api.mvc.MultipartFormData[_] => multipartFormParse(body)
+      case body: Either[_, play.api.mvc.MultipartFormData[_]] =>
+        body match {
+          case Right(b) => multipartFormParse(b)
+          case Left(_) => Map.empty[String, Seq[String]]
+        }
+      case body: play.api.libs.json.JsValue => jsonParse(body)
+      case _ => Map.empty[String, Seq[String]]
+    }) ++ {
+      request.method.toUpperCase match {
+        case HttpVerbs.POST | HttpVerbs.PUT | HttpVerbs.PATCH => Map.empty
+        case _ => request.queryString
+      }
+    }).toMap
+
+  protected def multipartFormParse(body: MultipartFormData[_]): Map[String, Seq[String]] = {
+    body.asFormUrlEncoded
+  }
+
+  protected def jsonParse(jsValue: JsValue): Map[String, Seq[String]] = {
+    FormUtils.fromJson(jsValue, maxChars).mapValues(Seq(_))
+  }
+}

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -20,7 +20,7 @@ import akka.stream.scaladsl.StreamConverters
 import akka.stream.stage._
 import akka.util.ByteString
 import play.api._
-import play.api.data.Form
+import play.api.data.{DefaultFormBinding, Form, FormBinding}
 import play.api.http.Status._
 import play.api.http._
 import play.api.libs.Files.SingletonTemporaryFileCreator
@@ -492,6 +492,8 @@ trait PlayBodyParsers extends BodyParserUtils {
 
   // -- Text parser
 
+  def formBinding: FormBinding = new DefaultFormBinding(DefaultMaxTextLength)
+
   /**
    * Parses the body as text without checking the Content-Type.
    *
@@ -742,7 +744,7 @@ trait PlayBodyParsers extends BodyParserUtils {
       parser(requestHeader).map { resultOrBody =>
         resultOrBody.right.flatMap { body =>
           form
-            .bindFromRequest()(Request[AnyContent](requestHeader, body))
+            .bindFromRequest()(Request[AnyContent](requestHeader, body), formBinding)
             .fold(formErrors => Left(onErrors(formErrors)), a => Right(a))
         }
       }

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -5,7 +5,6 @@
 package play.api.mvc
 
 import java.io._
-import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets._
 import java.nio.charset._
 import java.nio.file.Files
@@ -20,7 +19,9 @@ import akka.stream.scaladsl.StreamConverters
 import akka.stream.stage._
 import akka.util.ByteString
 import play.api._
-import play.api.data.{DefaultFormBinding, Form, FormBinding}
+import play.api.data.DefaultFormBinding
+import play.api.data.Form
+import play.api.data.FormBinding
 import play.api.http.Status._
 import play.api.http._
 import play.api.libs.Files.SingletonTemporaryFileCreator
@@ -474,7 +475,7 @@ trait PlayBodyParsers extends BodyParserUtils {
    * You can configure it in application.conf:
    *
    * {{{
-   * play.http.parser.maxMemoryBuffer = 512k
+   * play.http.parser.maxMemoryBuffer = 100k
    * }}}
    */
   def DefaultMaxTextLength: Long = config.maxMemoryBuffer
@@ -490,9 +491,12 @@ trait PlayBodyParsers extends BodyParserUtils {
    */
   def DefaultMaxDiskLength: Long = config.maxDiskBuffer
 
-  // -- Text parser
+  // -- General purpose
 
-  def formBinding: FormBinding = new DefaultFormBinding(DefaultMaxTextLength)
+  def formBinding(maxChars: Long = DefaultMaxTextLength): FormBinding = new DefaultFormBinding(maxChars)
+  implicit val defaultFormBinding: FormBinding                        = formBinding(DefaultMaxTextLength)
+
+  // -- Text parser
 
   /**
    * Parses the body as text without checking the Content-Type.
@@ -740,11 +744,12 @@ trait PlayBodyParsers extends BodyParserUtils {
   ): BodyParser[A] =
     BodyParser { requestHeader =>
       import play.core.Execution.Implicits.trampoline
-      val parser = anyContent(maxLength)
+      val parser  = anyContent(maxLength)
+      val binding = formBinding(maxLength.getOrElse(DefaultMaxTextLength))
       parser(requestHeader).map { resultOrBody =>
         resultOrBody.right.flatMap { body =>
           form
-            .bindFromRequest()(Request[AnyContent](requestHeader, body), formBinding)
+            .bindFromRequest()(Request[AnyContent](requestHeader, body), binding)
             .fold(formErrors => Left(onErrors(formErrors)), a => Right(a))
         }
       }

--- a/core/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormSpec.scala
@@ -18,6 +18,8 @@ import play.api.mvc.MultipartFormData
 import play.core.test.FakeRequest
 
 class FormSpec extends Specification {
+  import FormBinding.Implicits._
+
   "A form" should {
     "have an error due to a malformed email" in {
       val f5 = ScalaForms.emailForm.fillAndValidate(("john@", "John"))

--- a/core/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormSpec.scala
@@ -18,7 +18,7 @@ import play.api.mvc.MultipartFormData
 import play.core.test.FakeRequest
 
 class FormSpec extends Specification {
-  import FormBinding.Implicits._
+  import FormBinding.Implicits.formBinding
 
   "A form" should {
     "have an error due to a malformed email" in {

--- a/core/play/src/test/scala/play/api/data/FormUtilsSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormUtilsSpec.scala
@@ -96,6 +96,23 @@ class FormUtilsSpec extends Specification {
       }) must throwA[FormJsonExpansionTooLarge]
     }
 
+    "abort parsing when maximum memory is used" in {
+      // Even when the JSON is small, if the memory limit is exceed the parsing must stop.
+      val keyLength = 10
+      val itemCount = 10
+      val maxChars  = 3 // yeah, maxChars is only 3 chars. We want to hit the limit.
+      (try {
+        val jsString = Json.parse(s""" "${"a" * keyLength}" """)
+        FormUtils.fromJson(
+          jsString,
+          maxChars
+        )
+      } catch {
+        case _: OutOfMemoryError =>
+          ko("OutOfMemoryError")
+      }) must throwA[FormJsonExpansionTooLarge]
+    }
+
     "not run out of heap when converting arrays with very long keys" in {
       // a similar scenario to the previous one but this would cause OOME if it weren't for the limit
       val keyLength = 10000

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -116,18 +116,22 @@ _After_
 
 ```scala
 // Assuming you have:
-//   class MyController @Inject()(cc: MessagesControllerComponents)
-    implicit val fb = cc.parsers.defaultFormBinding
-    val formValidationResult = form.bindFromRequest
+class MyController @Inject()(cc: MessagesControllerComponents) {
+  implicit val fb = cc.parsers.defaultFormBinding
+  val formValidationResult = form.bindFromRequest
+  ...
+} 
 ```
 
 You can also use a form binding with a customized limit using:
 
 ```scala
 // Assuming you have:
-//   class MyController @Inject()(cc: MessagesControllerComponents)
-    implicit val fb = cc.parsers.formBinding(300*1024) // limit to 300KiB
-    val formValidationResult = form.bindFromRequest
+class MyController @Inject()(cc: MessagesControllerComponents) {
+  implicit val fb = cc.parsers.formBinding(300*1024) // limit to 300KiB
+  val formValidationResult = form.bindFromRequest
+  ...
+}
 ```
 
 Finally, in tests, you probably don't need to read the value from `Config` and a default, hardcoded value is fine. In that case you can simply:
@@ -136,7 +140,7 @@ Finally, in tests, you probably don't need to read the value from `Config` and a
 import play.api.data.FormBinding.Implicits._
 ```  
 
-The `FormBinding.Implicits._` implicits can be used from production code but that is discouraged since they use hardcoded values that don't honor `play.http.parser.maxMemoruBuffer`.
+The `FormBinding.Implicits._` implicits can be used from production code but that is discouraged since they use hardcoded values that don't honor the `play.http.parser.maxMemoruBuffer` configuration.
 
 
 ### New fields and methods added to `FilePart` and `FileInfo`

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -31,6 +31,7 @@ package scalaguide.forms.scalaforms {
 // #validation-imports
   import play.api.data.validation.Constraints._
 // #validation-imports
+  import play.api.data.FormBinding.Implicits._
 
   @RunWith(classOf[JUnitRunner])
   class ScalaFormsSpec extends Specification with ControllerHelpers {

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
@@ -12,6 +12,7 @@ import play.api.mvc._
 import play.api.test._
 
 import scala.concurrent.Future
+import play.api.data.FormBinding.Implicits._
 
 class ExampleControllerSpec extends PlaySpecification with Results {
   "Example Page#index" should {

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleMessagesSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleMessagesSpec.scala
@@ -16,6 +16,7 @@ class ExampleMessagesSpec extends PlaySpecification with ControllerHelpers {
   import play.api.data.Forms._
   import play.api.data.Form
   import play.api.i18n._
+  import play.api.data.FormBinding.Implicits._
 
   case class UserData(name: String, age: Int)
 

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -24,6 +24,8 @@ class IdController @Inject() (val openIdClient: OpenIdClient, c: ControllerCompo
 //#dependency
 
 class ScalaOpenIdSpec extends PlaySpecification {
+  import play.api.data.FormBinding.Implicits._
+
   "Scala OpenId" should {
     "be injectable" in new WithApplication() with Injecting {
       val controller =

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -227,6 +227,14 @@ object BuildSettings {
       // Limit JSON parsing resources
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.data.FormUtils.fromJson$default$1"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.data.FormUtils.fromJson"), // is private
+      // Honour maxMemoryBuffer when binding Json to form
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.data.Form.bindFromRequest"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "play.api.mvc.PlayBodyParsers.play$api$mvc$PlayBodyParsers$_setter_$defaultFormBinding_="
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.defaultFormBinding"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.formBinding$default$1"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.formBinding"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/web/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/web/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -303,8 +303,8 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
   public DynamicForm bind(Lang lang, TypedMap attrs, JsonNode data, String... allowedFields) {
     logger.warn(
         "Binding json field from form with a hardcoded max size of {} bytes. This is deprecated. Use bind(Lang, TypedMap, JsonNode, Long, String...) instead.",
-        FROM_JSON_MAX_CHARS);
-    return bind(lang, attrs, data, FROM_JSON_MAX_CHARS, allowedFields);
+        maxJsonChars());
+    return bind(lang, attrs, data, maxJsonChars(), allowedFields);
   }
 
   @Override

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -90,8 +90,6 @@ public class Form<T> {
 
   private static final String INVALID_MSG_KEY = "error.invalid";
 
-  protected static final long FROM_JSON_MAX_CHARS = Form$.MODULE$.FromJsonMaxChars();
-
   /** Defines a form element's display name. */
   @Retention(RUNTIME)
   @Target({ANNOTATION_TYPE})
@@ -574,6 +572,10 @@ public class Form<T> {
     this.directFieldAccess = directFieldAccess;
   }
 
+  protected long maxJsonChars() {
+    return config.getMemorySize("play.http.parser.maxMemoryBuffer").toBytes();
+  }
+
   protected Map<String, String> requestData(Http.Request request) {
 
     Map<String, String[]> urlFormEncoded = new HashMap<>();
@@ -587,13 +589,12 @@ public class Form<T> {
     }
 
     Map<String, String> jsonData = new HashMap<>();
-    long maxMemoryBuffer = config.getMemorySize("play.http.parser.maxMemoryBuffer").toBytes();
     if (request.body().asJson() != null) {
       jsonData =
           play.libs.Scala.asJava(
               play.api.data.FormUtils.fromJson(
                   play.api.libs.json.Json.parse(play.libs.Json.stringify(request.body().asJson())),
-                  maxMemoryBuffer));
+                  maxJsonChars()));
     }
 
     Map<String, String> data = new HashMap<>();
@@ -797,8 +798,8 @@ public class Form<T> {
   public Form<T> bind(Lang lang, TypedMap attrs, JsonNode data, String... allowedFields) {
     logger.warn(
         "Binding json field from form with a hardcoded max size of {} bytes. This is deprecated. Use bind(Lang, TypedMap, JsonNode, Int, String...) instead.",
-        FROM_JSON_MAX_CHARS);
-    return bind(lang, attrs, data, FROM_JSON_MAX_CHARS, allowedFields);
+        maxJsonChars());
+    return bind(lang, attrs, data, maxJsonChars(), allowedFields);
   }
 
   /**


### PR DESCRIPTION
Improves #10496 to avoiding using a hardcoded memory limit when binding a request to a form.

Supersedes #10534 and #10539

This PR puts together ideas and code previously pushed to #10534 and #10539 with some extra feedback from offline discussions.