### PR TITLE
Provide a formBinding out of the box

### DIFF
--- a/core/play/src/main/scala/play/api/data/Form.scala
+++ b/core/play/src/main/scala/play/api/data/Form.scala
@@ -105,7 +105,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
    *                 of the JSON. `parse.DefaultMaxTextLength` is recommended to passed for this parameter.
    * @return a copy of this form, filled with the new data
    */
-  def bind(data: JsValue, maxChars: Int): Form[T] = bind(FormUtils.fromJson(data, maxChars))
+  def bind(data: JsValue, maxChars: Long): Form[T] = bind(FormUtils.fromJson(data, maxChars))
 
   /**
    * Binds request data to this form, i.e. handles form submission.

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -494,7 +494,6 @@ trait PlayBodyParsers extends BodyParserUtils {
   // -- General purpose
 
   def formBinding(maxChars: Long = DefaultMaxTextLength): FormBinding = new DefaultFormBinding(maxChars)
-  implicit val defaultFormBinding: FormBinding                        = formBinding(DefaultMaxTextLength)
 
   // -- Text parser
 

--- a/core/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/core/play/src/main/scala/play/api/mvc/Controller.scala
@@ -5,12 +5,12 @@
 package play.api.mvc
 
 import javax.inject.Inject
+import play.api.data.FormBinding
 import play.api.http._
 import play.api.i18n.Lang
 import play.api.i18n.Langs
 import play.api.i18n.MessagesApi
 import play.twirl.api.Html
-import play.twirl.api.HtmlFormat
 
 import scala.concurrent.ExecutionContext
 
@@ -74,6 +74,8 @@ trait BaseControllerHelpers extends ControllerHelpers {
    * }}}
    */
   def parse: PlayBodyParsers = controllerComponents.parsers
+
+  implicit val defaultFormBinding: FormBinding = parse.formBinding(parse.DefaultMaxTextLength)
 
   /**
    * The default execution context provided by Play. You should use this for non-blocking code only. You can do so by

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -104,32 +104,14 @@ The API for body parser was mixing `Integer` and `Long` to define buffer lengths
 
 Some payloads expand in memory when being parsed. So, the memory representation takes more space than the plaintext representation read from the wire. JSON is one of these formats. In order to prevent attacks that could lead to out of memory errors causing Denial-of-Service, body parsing and form binding must honour the `play.http.parser.maxMemoryBuffer`.
 
-The value of `play.http.parser.maxMemoryBuffer` is honored ouf of the box. If you are a user of the Play Scala API, you will need to declare a new implicit value providing the appropriate instance of a `FormBinding`: 
-
-_Before_
-
-```scala
-    val formValidationResult = form.bindFromRequest
-```
-
-_After_
+The value of `play.http.parser.maxMemoryBuffer` is honored ouf of the box. You can also use a form binding with a customized limit using:
 
 ```scala
 // Assuming you have:
 class MyController @Inject()(cc: MessagesControllerComponents) {
-  implicit val fb = cc.parsers.defaultFormBinding
-  val formValidationResult = form.bindFromRequest
   ...
-} 
-```
-
-You can also use a form binding with a customized limit using:
-
-```scala
-// Assuming you have:
-class MyController @Inject()(cc: MessagesControllerComponents) {
-  implicit val fb = cc.parsers.formBinding(300*1024) // limit to 300KiB
-  val formValidationResult = form.bindFromRequest
+  val formBinding = cc.parsers.formBinding(300*1024) // limit to 300KiB
+  val formValidationResult = form.bindFromRequest()(request, formBinding)
   ...
 }
 ```
@@ -139,9 +121,6 @@ Finally, in tests, you probably don't need to read the value from `Config` and a
 ````scala
 import play.api.data.FormBinding.Implicits._
 ```  
-
-The `FormBinding.Implicits._` implicits can be used from production code but that is discouraged since they use hardcoded values that don't honor the `play.http.parser.maxMemoryBuffer` configuration.
-
 
 ### New fields and methods added to `FilePart` and `FileInfo`
 

--- a/documentation/manual/releases/release27/migration27/Migration27.md
+++ b/documentation/manual/releases/release27/migration27/Migration27.md
@@ -102,21 +102,22 @@ The API for body parser was mixing `Integer` and `Long` to define buffer lengths
 
 ### Parser `maxMemoryBuffer` limits
 
-Some payloads expand in memory when being parsed. So, the memory representation takes more space than the plaintext representation read from the wire. JSON is one of these formats. In order to prevent attacks that could lead to out of memory errors causing Denial-of-Service, body parsing and form binding must honour the `play.http.parser.maxMemoryBuffer`.
+Some payloads expand in memory when being parsed. So, the memory representation takes more space than the plaintext representation read from the wire. JSON is one of these formats. In order to prevent attacks that could lead to out of memory errors causing Denial-of-Service, body parsing and form binding must honour the `play.http.parser.maxMemoryBuffer` setting.
 
-The value of `play.http.parser.maxMemoryBuffer` is honored ouf of the box. You can also use a form binding with a customized limit using:
+It is also possible to relax the `maxMemoryBuffer` in specific cases. It is possible the JSON representation and the expanded representation differ in size and you need to use different limits. You can use a form binding with a customized limit using:
 
 ```scala
 // Assuming you have:
 class MyController @Inject()(cc: MessagesControllerComponents) {
   ...
+  // create a new formBinding instance with increased limit 
   val formBinding = cc.parsers.formBinding(300*1024) // limit to 300KiB
   val formValidationResult = form.bindFromRequest()(request, formBinding)
   ...
 }
 ```
 
-Finally, in tests, you probably don't need to read the value from `Config` and a default, hardcoded value is fine. In that case you can simply:
+Controllers will always have a `FormBinding` instance build to honor the `play.http.parser.maxMemoryBuffer`. If you use the Forms from code outside a Controller, you may need to provide a `FormBinding`. For example, is you write unit tests you can use a `FormBinding` provided in `play.api.data.FormBinding.Implicits._` which uses a hardcoded limit which is good enough for tests. Add the implicit in scope: 
 
 ````scala
 import play.api.data.FormBinding.Implicits._

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -31,7 +31,6 @@ package scalaguide.forms.scalaforms {
 // #validation-imports
   import play.api.data.validation.Constraints._
 // #validation-imports
-  import play.api.data.FormBinding.Implicits._
 
   @RunWith(classOf[JUnitRunner])
   class ScalaFormsSpec extends Specification with ControllerHelpers {
@@ -53,6 +52,7 @@ package scalaguide.forms.scalaforms {
 
       "generate from request" in new WithApplication {
         import play.api.libs.json.Json
+        import play.api.data.FormBinding.Implicits._
 
         val controller = app.injector.instanceOf[controllers.Application]
         val userForm   = controller.userForm
@@ -97,6 +97,7 @@ package scalaguide.forms.scalaforms {
         val userForm   = controller.userFormConstraints
 
         implicit val request = FakeRequest().withFormUrlEncodedBody("name" -> "", "age" -> "25")
+        import play.api.data.FormBinding.Implicits._
 
         val boundForm = userForm.bindFromRequest
         boundForm.hasErrors must beTrue
@@ -106,6 +107,7 @@ package scalaguide.forms.scalaforms {
         val controller = app.injector.instanceOf[controllers.Application]
         val userForm   = controller.userFormConstraintsAdHoc
 
+        import play.api.data.FormBinding.Implicits._
         implicit val request = FakeRequest().withFormUrlEncodedBody("name" -> "Johnny Utah", "age" -> "25")
 
         val boundForm = userForm.bindFromRequest

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -24,7 +24,6 @@ class IdController @Inject() (val openIdClient: OpenIdClient, c: ControllerCompo
 //#dependency
 
 class ScalaOpenIdSpec extends PlaySpecification {
-  import play.api.data.FormBinding.Implicits._
 
   "Scala OpenId" should {
     "be injectable" in new WithApplication() with Injecting {

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -24,7 +24,6 @@ class IdController @Inject() (val openIdClient: OpenIdClient, c: ControllerCompo
 //#dependency
 
 class ScalaOpenIdSpec extends PlaySpecification {
-
   "Scala OpenId" should {
     "be injectable" in new WithApplication() with Injecting {
       val controller =

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -235,6 +235,12 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.defaultFormBinding"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.formBinding$default$1"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.formBinding"),
+      // fix types on Json parsing limits
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.data.Form.bind"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "play.api.mvc.BaseControllerHelpers.play$api$mvc$BaseControllerHelpers$_setter_$defaultFormBinding_="
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.BaseControllerHelpers.defaultFormBinding"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Follow-up to #10543
Relocating the default implicit means user code will, in most cases, be source-compatible. Controllers code should be source compatible and unit tests for forms may require the manual addition of the implicit (as documented in the migration guide in #10543 ).