### PR TITLE
Play File Watch 1.1.14 (was 1.1.13) for sbt 0.13

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -185,7 +185,7 @@ object Dependencies {
     )
   }
 
-  val playFileWatch = "com.lightbend.play" %% "play-file-watch" % "1.1.13"
+  val playFileWatch = "com.lightbend.play" %% "play-file-watch" % "1.1.14"
 
   def runSupportDependencies(sbtVersion: String): Seq[ModuleID] = {
     (CrossVersion.binarySbtVersion(sbtVersion) match {


### PR DESCRIPTION
This version brings the Scala 2.10 artifact back so it works with sbt 0.13.

https://github.com/playframework/play-file-watch/releases/tag/1.1.14