### PR TITLE
Makes val lazy to prevent circular dependency on DI

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/core/play/src/main/scala/play/api/mvc/Controller.scala
@@ -76,7 +76,7 @@ trait BaseControllerHelpers extends ControllerHelpers {
    */
   def parse: PlayBodyParsers = controllerComponents.parsers
 
-  implicit val defaultFormBinding: FormBinding = parse.formBinding(parse.DefaultMaxTextLength)
+  implicit lazy val defaultFormBinding: FormBinding = parse.formBinding(parse.DefaultMaxTextLength)
 
   /**
    * The default execution context provided by Play. You should use this for non-blocking code only. You can do so by


### PR DESCRIPTION
When adding `defaultFormBinding: FormBinding` as a `val` we introduced a circular dependency on DI for users of  `InjectedController` (which is discouraged).

The problem becomes more apparent because webjars-play provides some tools which use `InjectedController`.

See https://travis-ci.com/github/playframework/play-samples/jobs/457151496

Note this issue affects both Java and Scala users as long as there's an intermediate piece on the DI cake that uses `InjectedController` and even if there's not use of forms.


This fixes a regression introduced in Play `2.8.6` and `2.7.8`.