### PR TITLE
shutdown-happy-path: make test more reliable

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/scala/controllers/HomeController.scala
@@ -45,6 +45,7 @@ class HomeController @Inject()(
   }
 
   def slow = Action.async {
+    logger.info(s"/slow got request, delaying response for 2 seconds")
     futures.delay(2.seconds).map(_ => Ok("DONE"))
   }
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/test
@@ -110,7 +110,7 @@ $ sleep 1000
 
 # Send a request to the slow action and record the result
 > makeRequestAndRecordResponseBody /slow slow-request.txt
-$ sleep 500
+$ sleep 1000
 
 # Stops the process by sending a SIGTERM
 > assertProcessIsStopped


### PR DESCRIPTION
To be backported to 2.8.x

## Fixes

Fixes #10334

## Purpose

make test less flakey

