### PR TITLE
Added description about guice dependency to BuildOverview that was re…

### DIFF
--- a/documentation/manual/working/commonGuide/build/BuildOverview.md
+++ b/documentation/manual/working/commonGuide/build/BuildOverview.md
@@ -45,6 +45,12 @@ Finally, you need to enable an sbt plugin on your project to "Play-ify" it. This
  - `PlayJava`: a standard Play Java project, with the [[forms|JavaForms]] module.
  - `PlayMinimalJava`: a minimal Play Java project, without forms support.
 
+By default, the `PlayJava` and `PlayScala` plugins do not depend on any specific dependency injection solution. If you want to use Play's Guice module, add `guice` to your library dependencies:	
+
+```scala	
+libraryDependencies += guice	
+``` 
+
 ### Using scala for building
 
 sbt is also able to construct the build requirements from scala files inside your project's `project` folder. The recommended practice is to use `build.sbt` but there are times when using scala directly is required. If you find yourself, perhaps because you're migrating an older project, then here are a few useful imports:


### PR DESCRIPTION
…moved in commit of ee2493fb2933339233b1ab9c83d3b7d1d9a353c6.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10614

## Purpose

I added a necessary but missing build steps to the documentation.

## Background Context

The [Play 2.6 Migration Guide](https://www.playframework.com/documentation/2.8.x/Migration26) mentions guice dependency, and the documentation from that time also mentions it.
There is no mention in the later migration guides that it is no longer required.
It is still wrote in build.sbt in the official example project and in the template .
Only the official documentation does not mention it.

## References

https://www.playframework.com/documentation/2.8.x/Migration26
https://www.playframework.com/documentation/2.8.x/Migration27
https://www.playframework.com/documentation/2.8.x/Migration28
https://github.com/playframework/playframework/commit/ee2493fb2933339233b1ab9c83d3b7d1d9a353c6#diff-b0321335ccb161fe1d9ba0309444e35029b8c828644cc65ebeb4e7fa73bdaea8
https://github.com/playframework/play-scala-seed.g8/blob/2.8.x/src/main/g8/build.sbt
https://developer.lightbend.com/start/?group=play&project=play-samples-play-scala-starter-example