### PR TITLE
Use constants for config properties in ApplicationSecretGenerator

### DIFF
--- a/dev-mode/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
+++ b/dev-mode/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
@@ -32,7 +32,6 @@ class DocumentationHandler(repo: FileRepository, apiRepo: FileRepository, toClos
         "css"  -> "text/css",
         "png"  -> "image/png",
         "js"   -> "application/javascript",
-        "ico"  -> "application/javascript",
         "jpg"  -> "image/jpeg",
         "ico"  -> "image/x-icon"
       )


### PR DESCRIPTION
There are some repeated strings for config property names in ApplicationSecretGenerator. Maybe it will be better to use constants.

Kind regards