### PR TITLE
Support sbt 1.4 virtual files when displaying error source

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -69,7 +69,7 @@ object PlayReload {
 
   object JFile {
     class FileOption(val anyOpt: Option[Any]) extends AnyVal {
-      def isEmpty: Boolean  = anyOpt.exists(_.isInstanceOf[java.io.File])
+      def isEmpty: Boolean  = !anyOpt.exists(_.isInstanceOf[java.io.File])
       def get: java.io.File = anyOpt.get.asInstanceOf[java.io.File]
     }
     def unapply(any: Option[Any]): FileOption = new FileOption(any)
@@ -78,7 +78,7 @@ object PlayReload {
   object VirtualFile {
     def unapply(value: Option[Any]): Option[Any] =
       value.filter { vf =>
-        val name = value.getClass.getSimpleName
+        val name = vf.getClass.getSimpleName
         (name == "BasicVirtualFileRef" || name == "MappedVirtualFile")
       }
   }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -77,7 +77,7 @@ object PlayReload {
   }
 
   object VirtualFile {
-    def unapply(value: Some[Any]): Option[Any] =
+    def unapply(value: Option[Any]): Option[Any] =
       value.filter { vf =>
         val name = value.getClass.getSimpleName
         (name == "BasicVirtualFileRef" || name == "MappedVirtualFile" )

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -102,10 +102,9 @@ object PlayReload {
               } else {
                 // It's an absolute path, sbt uses them e.g. for subprojects located outside of the base project
                 val id = vf.getClass.getMethod("id").invoke(vf).asInstanceOf[String]
-                val prefix = "file://" +
-                  (if (!id.startsWith("/")) {
-                     "/" // In Windows the sbt virtual file id does not start with a slash, but absolute paths in Java URIs need that
-                   } else "")
+                // In Windows the sbt virtual file id does not start with a slash, but absolute paths in Java URIs need that
+                val extraSlash = if (id.startsWith("/")) "" else "/"
+                val prefix     = "file://" + extraSlash
                 // The URI will be like file:///home/user/project/SomeClass.scala (Linux/Mac) or file:///C:/Users/user/project/SomeClass.scala (Windows)
                 Paths.get(URI.create(s"$prefix$id"));
               }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -28,6 +28,9 @@ import xsbti.Position
 import xsbti.Problem
 import xsbti.Severity
 
+import java.net.URI
+import java.nio.file.Paths
+
 object PlayReload {
   def taskFailureHandler(incomplete: Incomplete, streams: Option[Streams]): PlayException = {
     Incomplete
@@ -67,9 +70,39 @@ object PlayReload {
   def sourceMap(analysis: Analysis): Map[String, Source] = {
     analysis.relations.classes.reverseMap.flatMap {
       case (name, files) =>
-        files.headOption match {
-          case None       => Map.empty[String, Source]
-          case Some(file) => Map(name -> Source(file, MaybeGeneratedSource.unapply(file).flatMap(_.source)))
+        files.headOption // This is typically a set containing a single file, so we can use head here.
+          .asInstanceOf[Option[Any]] match {
+          case None => Map.empty[String, Source]
+          case Some(file) =>
+            file match {
+              case file: File => // sbt < 1.4
+                Map(name -> Source(file, MaybeGeneratedSource.unapply(file).flatMap(_.source)))
+              case vf => { // sbt 1.4+ virtual file, see #10486
+                vf.getClass.getSimpleName match {
+                  case "BasicVirtualFileRef" | "MappedVirtualFile" => {
+                    val names = vf.getClass.getMethod("names").invoke(vf).asInstanceOf[Array[String]]
+                    val path = if (names.head.startsWith("${")) { // check for ${BASE} or similar (in case it changes)
+                      // It's an relative path, skip the first element (which usually is "${BASE}")
+                      Paths.get(names.drop(1).head, names.drop(2): _*)
+                    } else {
+                      // It's an absolute path, sbt uses them e.g. for subprojects located outside of the base project
+                      val id = vf.getClass.getMethod("id").invoke(vf).asInstanceOf[String]
+                      val prefix = "file://" +
+                        (if (!id.startsWith("/")) {
+                           "/" // In Windows the sbt virtual file id does not start with a slash, but absolute paths in Java URIs need that
+                         } else "")
+                      // The URI will be like file:///home/user/project/SomeClass.scala (Linux/Mac) or file:///C:/Users/user/project/SomeClass.scala (Windows)
+                      Paths.get(URI.create(s"$prefix$id"));
+                    }
+                    Map(name -> Source(path.toFile, MaybeGeneratedSource.unapply(path.toFile).flatMap(_.source)))
+                  }
+                  case _ =>
+                    throw new RuntimeException(
+                      s"Can't handle class ${vf.getClass.getName} used for sourceMap"
+                    )
+                }
+              }
+            }
         }
     }
   }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -86,8 +86,7 @@ object PlayReload {
   def sourceMap(analysis: Analysis): Map[String, Source] = {
     analysis.relations.classes.reverseMap.flatMap {
       case (name, files) =>
-        files.headOption // This is typically a set containing a single file, so we can use head here.
-          .asInstanceOf[Option[Any]] match {
+        files.headOption match { // This is typically a set containing a single file, so we can use head here.
           case None => Map.empty[String, Source]
 
           case JFile(file) => // sbt < 1.4

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -67,42 +67,55 @@ object PlayReload {
     compileResult.left.map(inc => CompileFailure(taskFailureHandler(inc, streams()))).merge
   }
 
+
+  object JFile {
+    class FileOption(val anyOpt: Option[Any])  extends AnyVal  {
+      def isEmpty: Boolean = anyOpt.exists(_.isInstanceOf[java.io.File])
+      def get: java.io.File = anyOpt.get.asInstanceOf[java.io.File]
+    }
+    def unapply(any: Option[Any]): FileOption = new FileOption(any)
+  }
+
+  object VirtualFile {
+    def unapply(value: Some[Any]): Option[Any] =
+      value.filter { vf =>
+        val name = value.getClass.getSimpleName
+        (name == "BasicVirtualFileRef" || name == "MappedVirtualFile" )
+      }
+  }
+
   def sourceMap(analysis: Analysis): Map[String, Source] = {
     analysis.relations.classes.reverseMap.flatMap {
       case (name, files) =>
         files.headOption // This is typically a set containing a single file, so we can use head here.
           .asInstanceOf[Option[Any]] match {
           case None => Map.empty[String, Source]
-          case Some(file) =>
-            file match {
-              case file: File => // sbt < 1.4
-                Map(name -> Source(file, MaybeGeneratedSource.unapply(file).flatMap(_.source)))
-              case vf => { // sbt 1.4+ virtual file, see #10486
-                vf.getClass.getSimpleName match {
-                  case "BasicVirtualFileRef" | "MappedVirtualFile" => {
-                    val names = vf.getClass.getMethod("names").invoke(vf).asInstanceOf[Array[String]]
-                    val path = if (names.head.startsWith("${")) { // check for ${BASE} or similar (in case it changes)
-                      // It's an relative path, skip the first element (which usually is "${BASE}")
-                      Paths.get(names.drop(1).head, names.drop(2): _*)
-                    } else {
-                      // It's an absolute path, sbt uses them e.g. for subprojects located outside of the base project
-                      val id = vf.getClass.getMethod("id").invoke(vf).asInstanceOf[String]
-                      val prefix = "file://" +
-                        (if (!id.startsWith("/")) {
-                           "/" // In Windows the sbt virtual file id does not start with a slash, but absolute paths in Java URIs need that
-                         } else "")
-                      // The URI will be like file:///home/user/project/SomeClass.scala (Linux/Mac) or file:///C:/Users/user/project/SomeClass.scala (Windows)
-                      Paths.get(URI.create(s"$prefix$id"));
-                    }
-                    Map(name -> Source(path.toFile, MaybeGeneratedSource.unapply(path.toFile).flatMap(_.source)))
-                  }
-                  case _ =>
-                    throw new RuntimeException(
-                      s"Can't handle class ${vf.getClass.getName} used for sourceMap"
-                    )
-                }
+
+          case JFile(file) => // sbt < 1.4
+            Map(name -> Source(file, MaybeGeneratedSource.unapply(file).flatMap(_.source)))
+
+          case VirtualFile(vf) => // sbt 1.4+ virtual file, see #10486
+            val names = vf.getClass.getMethod("names").invoke(vf).asInstanceOf[Array[String]]
+            val path =
+              if (names.head.startsWith("${")) { // check for ${BASE} or similar (in case it changes)
+                // It's an relative path, skip the first element (which usually is "${BASE}")
+                Paths.get(names.drop(1).head, names.drop(2): _*)
+              } else {
+                // It's an absolute path, sbt uses them e.g. for subprojects located outside of the base project
+                val id = vf.getClass.getMethod("id").invoke(vf).asInstanceOf[String]
+                val prefix = "file://" +
+                  (if (!id.startsWith("/")) {
+                    "/" // In Windows the sbt virtual file id does not start with a slash, but absolute paths in Java URIs need that
+                  } else "")
+                // The URI will be like file:///home/user/project/SomeClass.scala (Linux/Mac) or file:///C:/Users/user/project/SomeClass.scala (Windows)
+                Paths.get(URI.create(s"$prefix$id"));
               }
-            }
+            Map(name -> Source(path.toFile, MaybeGeneratedSource.unapply(path.toFile).flatMap(_.source)))
+
+          case anyOther =>
+            throw new RuntimeException(
+              s"Can't handle class ${anyOther.getClass.getName} used for sourceMap"
+            )
         }
     }
   }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -67,10 +67,9 @@ object PlayReload {
     compileResult.left.map(inc => CompileFailure(taskFailureHandler(inc, streams()))).merge
   }
 
-
   object JFile {
-    class FileOption(val anyOpt: Option[Any])  extends AnyVal  {
-      def isEmpty: Boolean = anyOpt.exists(_.isInstanceOf[java.io.File])
+    class FileOption(val anyOpt: Option[Any]) extends AnyVal {
+      def isEmpty: Boolean  = anyOpt.exists(_.isInstanceOf[java.io.File])
       def get: java.io.File = anyOpt.get.asInstanceOf[java.io.File]
     }
     def unapply(any: Option[Any]): FileOption = new FileOption(any)
@@ -80,7 +79,7 @@ object PlayReload {
     def unapply(value: Option[Any]): Option[Any] =
       value.filter { vf =>
         val name = value.getClass.getSimpleName
-        (name == "BasicVirtualFileRef" || name == "MappedVirtualFile" )
+        (name == "BasicVirtualFileRef" || name == "MappedVirtualFile")
       }
   }
 
@@ -105,8 +104,8 @@ object PlayReload {
                 val id = vf.getClass.getMethod("id").invoke(vf).asInstanceOf[String]
                 val prefix = "file://" +
                   (if (!id.startsWith("/")) {
-                    "/" // In Windows the sbt virtual file id does not start with a slash, but absolute paths in Java URIs need that
-                  } else "")
+                     "/" // In Windows the sbt virtual file id does not start with a slash, but absolute paths in Java URIs need that
+                   } else "")
                 // The URI will be like file:///home/user/project/SomeClass.scala (Linux/Mac) or file:///C:/Users/user/project/SomeClass.scala (Windows)
                 Paths.get(URI.create(s"$prefix$id"));
               }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/app/controllers/HomeController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/app/controllers/HomeController.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers;
+
+import play.mvc.Controller;
+import play.mvc.Result;
+
+public class HomeController extends Controller {
+    public Result controllerFail() {
+        throw new RuntimeException("Exception thrown in controller");
+    }
+
+    public Result subProjectInsideFail() {
+        inside.Foo.fail();
+        return ok("should not reach this line");
+    }
+
+    public Result subProjectOutsideFail() {
+        outside.Bar.fail();
+        return ok("should not reach this line");
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt
@@ -1,0 +1,26 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayJava)
+  .settings(commonSettings: _*)
+  .settings(
+    libraryDependencies += guice,
+    PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
+  )
+  .dependsOn(`sub-project-inside`, `sub-project-outside`)
+  .aggregate(`sub-project-inside`, `sub-project-outside`)
+
+def commonSettings: Seq[Setting[_]] = Seq(
+  scalaVersion := sys.props("scala.version"),
+  updateOptions := updateOptions.value.withLatestSnapshots(false),
+  evictionWarningOptions in update ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),
+  // This makes it possible to run tests on the output regardless of scala version
+  crossPaths := false
+)
+
+lazy val `sub-project-inside` = (project in file("./modules/sub-project-inside"))
+  .settings(commonSettings: _*)
+
+lazy val `sub-project-outside` = ProjectRef(file("./dev-mode-runtime-error-source-sub-project-outside"), "sub-project-outside")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt.1
@@ -1,0 +1,51 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayJava)
+  .settings(commonSettings: _*)
+  .settings(
+    libraryDependencies += guice,
+    PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
+    InputKey[Unit]("makeRequestAndRecordResponseBody") := {
+      val args = Def.spaceDelimited("<path> <dest> ...").parsed
+
+      // <dest> is a relative path where the returned body will be stored/recorded
+      val path :: dest :: Nil = args
+
+      val destination = target.value / dest
+
+      println(s"Preparing to run request to $path...")
+
+      Future {
+        println(s"Firing request to $path...")
+        val (status, body) = ScriptedTools.callUrl(path)
+        println(s"Resource at $path returned HTTP $status")
+        IO.write(destination, body)
+      }
+    },
+    InputKey[Unit]("checkLinesPartially") := {
+      val args                  = Def.spaceDelimited("<source> <target>").parsed
+      val source :: target :: _ = args
+      ScriptedTools.checkLinesPartially(source, target)
+    }
+  )
+  .dependsOn(`sub-project-inside`, `sub-project-outside`)
+  .aggregate(`sub-project-inside`, `sub-project-outside`)
+
+def commonSettings: Seq[Setting[_]] = Seq(
+  scalaVersion := sys.props("scala.version"),
+  updateOptions := updateOptions.value.withLatestSnapshots(false),
+  evictionWarningOptions in update ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),
+  // This makes it possible to run tests on the output regardless of scala version
+  crossPaths := false
+)
+
+lazy val `sub-project-inside` = (project in file("./modules/sub-project-inside"))
+  .settings(commonSettings: _*)
+
+lazy val `sub-project-outside` = ProjectRef(file("../dev-mode-runtime-error-source-sub-project-outside"), "sub-project-outside")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/common-fail.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/common-fail.txt
@@ -1,0 +1,6 @@
+<title>Execution exception</title>
+<h1>Execution exception</h1>
+<body id="play-error-page">
+<div id="source-code">
+<pre data-file="
+<pre class="error" data-file="

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/conf/routes
@@ -1,0 +1,3 @@
+GET     /controller-fail                     controllers.HomeController.controllerFail
+GET     /sub-project-inside-fail             controllers.HomeController.subProjectInsideFail
+GET     /sub-project-outside-fail            controllers.HomeController.subProjectOutsideFail

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/controller-fail.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/controller-fail.txt
@@ -1,0 +1,10 @@
+<p id="detail" class="pre">[RuntimeException: Exception thrown in controller]</p>
+/app/controllers/HomeController.java" data-line="8"><span class="line">8</span><span class="code">import play.mvc.Result;</span></pre>
+/app/controllers/HomeController.java" data-line="9"><span class="line">9</span><span class="code"></span></pre>
+/app/controllers/HomeController.java" data-line="10"><span class="line">10</span><span class="code">public class HomeController extends Controller {</span></pre>
+/app/controllers/HomeController.java" data-line="11"><span class="line">11</span><span class="code">    public Result controllerFail() {</span></pre>
+/app/controllers/HomeController.java" data-line="12" ><span class="line">12</span><span class="code">        throw new RuntimeException(&quot;Exception thrown in controller&quot;);</span></pre>
+/app/controllers/HomeController.java" data-line="13"><span class="line">13</span><span class="code">    }</span></pre>
+/app/controllers/HomeController.java" data-line="14"><span class="line">14</span><span class="code"></span></pre>
+/app/controllers/HomeController.java" data-line="15"><span class="line">15</span><span class="code">    public Result subProjectInsideFail() {</span></pre>
+/app/controllers/HomeController.java" data-line="16"><span class="line">16</span><span class="code">        inside.Foo.fail();</span></pre>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/build.sbt
@@ -1,0 +1,14 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
+lazy val `sub-project-outside` = (project in file("."))
+  .settings(commonSettings: _*)
+
+def commonSettings: Seq[Setting[_]] = Seq(
+  scalaVersion := sys.props("scala.version"),
+  updateOptions := updateOptions.value.withLatestSnapshots(false),
+  evictionWarningOptions in update ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),
+  // This makes it possible to run tests on the output regardless of scala version
+  crossPaths := false
+)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package outside;
+
+public class Bar {
+    public static void fail() {
+        throw new RuntimeException("Exception thrown in sub-project-outside");
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/modules/sub-project-inside/src/main/scala/Foo.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/modules/sub-project-inside/src/main/scala/Foo.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package inside;
+
+public class Foo {
+    public static void fail() {
+        throw new RuntimeException("Exception thrown in sub-project-inside");
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-scripted-tools" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/sub-project-inside-fail.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/sub-project-inside-fail.txt
@@ -1,0 +1,8 @@
+<p id="detail" class="pre">[RuntimeException: Exception thrown in sub-project-inside]</p>
+/modules/sub-project-inside/src/main/scala/Foo.java" data-line="5"><span class="line">5</span><span class="code">package inside;</span></pre>
+/modules/sub-project-inside/src/main/scala/Foo.java" data-line="6"><span class="line">6</span><span class="code"></span></pre>
+/modules/sub-project-inside/src/main/scala/Foo.java" data-line="7"><span class="line">7</span><span class="code">public class Foo {</span></pre>
+/modules/sub-project-inside/src/main/scala/Foo.java" data-line="8"><span class="line">8</span><span class="code">    public static void fail() {</span></pre>
+/modules/sub-project-inside/src/main/scala/Foo.java" data-line="9" ><span class="line">9</span><span class="code">        throw new RuntimeException(&quot;Exception thrown in sub-project-inside&quot;);</span></pre>
+/modules/sub-project-inside/src/main/scala/Foo.java" data-line="10"><span class="line">10</span><span class="code">    }</span></pre>
+/modules/sub-project-inside/src/main/scala/Foo.java" data-line="11"><span class="line">11</span><span class="code">}</span></pre>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/sub-project-outside-fail.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/sub-project-outside-fail.txt
@@ -1,0 +1,8 @@
+<p id="detail" class="pre">[RuntimeException: Exception thrown in sub-project-outside]</p>
+/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java" data-line="5"><span class="line">5</span><span class="code">package outside;</span></pre>
+/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java" data-line="6"><span class="line">6</span><span class="code"></span></pre>
+/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java" data-line="7"><span class="line">7</span><span class="code">public class Bar {</span></pre>
+/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java" data-line="8"><span class="line">8</span><span class="code">    public static void fail() {</span></pre>
+/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java" data-line="9" ><span class="line">9</span><span class="code">        throw new RuntimeException(&quot;Exception thrown in sub-project-outside&quot;);</span></pre>
+/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java" data-line="10"><span class="line">10</span><span class="code">    }</span></pre>
+/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java" data-line="11"><span class="line">11</span><span class="code">}</span></pre>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/test
@@ -1,0 +1,47 @@
+##################################################################################################################
+# Note about the *-fail.txt files:
+# Because scripted tests run in a random /tmp/sbt_.../ folder we can't check the absolute file names in the HTML:
+# E.g. "<pre data-file="/tmp/sbt_edc0df79/..."
+##################################################################################################################
+
+# Clean up in case there was a failed run before
+$ delete ../dev-mode-runtime-error-source-sub-project-outside
+
+# Move the sub project out of the project's base directory.
+# Such an outside subproject is needed to test sbt 1.4+ virtual files with absolute paths.
+# Files _within_ the project's base directory on the other hand use relative paths with a ${BASE} prefix.
+$ copy dev-mode-runtime-error-source-sub-project-outside/build.sbt ../
+$ copy dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java ../
+$ delete dev-mode-runtime-error-source-sub-project-outside
+
+# Now that we have setup the outside subproject let's use the new build.sbt which references that outside subproject
+$ copy-file build.sbt.1 build.sbt
+$ delete build.sbt.1
+
+# Reload the new build.sbt
+> reload
+
+# Let's start the tests
+> compile
+> run
+
+> makeRequestAndRecordResponseBody /sub-project-outside-fail sub-project-outside-fail.txt
+# First request takes a bit longer, therefore 5 seconds
+$ sleep 5000
+> checkLinesPartially common-fail.txt target/sub-project-outside-fail.txt
+> checkLinesPartially sub-project-outside-fail.txt target/sub-project-outside-fail.txt
+
+> makeRequestAndRecordResponseBody /sub-project-inside-fail sub-project-inside-fail.txt
+$ sleep 2000
+> checkLinesPartially common-fail.txt target/sub-project-inside-fail.txt
+> checkLinesPartially sub-project-inside-fail.txt target/sub-project-inside-fail.txt
+
+> makeRequestAndRecordResponseBody /controller-fail controller-fail.txt
+$ sleep 2000
+> checkLinesPartially common-fail.txt target/controller-fail.txt
+> checkLinesPartially controller-fail.txt target/controller-fail.txt
+
+> playStop
+
+# Clean up the outside subproject
+$ delete ../dev-mode-runtime-error-source-sub-project-outside

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -206,4 +206,22 @@ object ScriptedTools extends AutoPlugin {
       }
     }
   }
+
+  def checkLinesPartially(source: String, target: String): Unit = {
+    val sourceLines = IO.readLines(new File(source))
+    val targetLines = IO.readLines(new File(target))
+
+    println("Source:")
+    println("-------")
+    println(sourceLines.mkString("\n"))
+    println("Target:")
+    println("-------")
+    println(targetLines.mkString("\n"))
+
+    sourceLines.foreach { sl =>
+      if (!targetLines.exists(_.contains(sl))) {
+        throw new RuntimeException(s"File $target didn't partially contain line:\n$sl")
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes #10486
Fixes #10497

Backport for 2.8.x: #10649
Backport for 2.7.x: #10650

sbt 1.4 introduced a virtual file system it is using internally. So instead of Java `File` objects, Play now receives [`BasicVirtualFileRef`](https://github.com/sbt/zinc/blob/v1.4.4/internal/compiler-interface/src/main/java/xsbti/BasicVirtualFileRef.java) and [`MappedVirtualFile`](https://github.com/sbt/zinc/blob/v1.4.4/internal/zinc-core/src/main/scala/sbt/internal/inc/MappedVirtualFile.scala) objects, which both are subclasses of the [`VirtualFileRef`](https://github.com/sbt/zinc/blob/v1.4.4/internal/compiler-interface/src/main/java/xsbti/VirtualFileRef.java) interface.
Fortunately, that `VirtualFileRef` interface has methods that, with some reflection kung fu, we can use to figure out the correct file system path which we want to display on a Play error page if an exception occured: [`id()`](https://github.com/sbt/zinc/blob/v1.4.4/internal/compiler-interface/src/main/java/xsbti/VirtualFileRef.java#L86-L96) and [`names()`](https://github.com/sbt/zinc/blob/v1.4.4/internal/compiler-interface/src/main/java/xsbti/VirtualFileRef.java#L98-L105).
Such virtual file objects wrap a path in two possible ways:
* If the file is located within the root (or base) project, its path is prefixed with `${BASE}` (like `${BASE}/app/controllers/HomeController.scala`
* If the file is located _outside_ of the root (or base) project, its path is _not_ prefixed, but absolute (like `/home/user/my_sub_project/src/main/scala/Foo.scala`) That is the case for example with sub-projects that are not contained within the base project.

I also added scripted tests to make sure future changes or sbt upgrades that break things will be noticed asap.

BTW: I also went that annoying extra kilometer and did test this patch and the scripted tests on Microsoft® Windows 10 to make sure that file system path stuff also works with these obscure backslash and c: style of doing things as well.

---

Making-of:
This pull request is inspired by the reflection porn done in lombok to make it support sbt's virtual file system.
Originally I submitted a patch (https://github.com/rzwitserloot/lombok/pull/2643) which was refused (because it was just a workaround) and instead the maintainer did his thing and came up with a [reflection heavy commit](https://github.com/rzwitserloot/lombok/commit/e1f82ac4d132769cfc272dccfc916aeba7181718) that actually worked and did fix that [bug](https://github.com/rzwitserloot/lombok/issues/2645). However soon I ran into another problem because files outside of a root project did not work yet, so I came up with an additional [fix](https://github.com/rzwitserloot/lombok/pull/2668).

Oh and yes, along the way I discovered another change of behaviour ins sbt: https://github.com/sbt/sbt/issues/6275 But that is not that relevant for this pull request here.

So yeah, as you can see, sbt 1.4 already caused me some headache...