### PR TITLE
Don't reload/(re-)compile or even start an app when shutting down in DEV mode

### DIFF
--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -70,6 +70,7 @@ class AssetsMetadataProvider @Inject() (
     fileMimeTypes: FileMimeTypes,
     lifecycle: ApplicationLifecycle
 ) extends Provider[DefaultAssetsMetadata] {
+  private val logger = Logger(this.getClass)
   lazy val get = {
     import StaticAssetsMetadata.instance
     val assetsMetadata = new DefaultAssetsMetadata(env, config, fileMimeTypes)
@@ -77,6 +78,7 @@ class AssetsMetadataProvider @Inject() (
       instance = Some(assetsMetadata)
     }
     lifecycle.addStopHook(() => {
+      logger.debug("Cleaning AssetsMetadata instance")
       StaticAssetsMetadata.synchronized {
         // Set instance to None if this application was the last to set the instance.
         // Otherwise it's the responsibility of whoever set it last to unset it.

--- a/core/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/core/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -115,6 +115,7 @@ class DefaultApplicationLifecycle @Inject() () extends ApplicationLifecycle {
    * @return A future that will be redeemed once all hooks have executed.
    */
   override def stop(): Future[_] = {
+    logger.debug(s"Executing ApplicationLifecycle.stop() with ${hooks.size()} stop hook(s) registered")
     // run the code only once and memoize the result of the invocation in a Promise.future so invoking
     // the method many times causes a single run producing the same result in all cases.
     if (started.compareAndSet(false, true)) {

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -298,6 +298,7 @@ class NettyServer(
     // Do this last because the hooks were created before the server,
     // so the server might need them to run until the last moment.
     cs.addTask(CoordinatedShutdown.PhaseBeforeActorSystemTerminate, "user-provided-server-stop-hook") { () =>
+      logger.info("Running provided shutdown stop hooks")
       stopHook().map(_ => Done)
     }
     cs.addTask(CoordinatedShutdown.PhaseBeforeActorSystemTerminate, "shutdown-logger") { () =>

--- a/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -244,6 +244,7 @@ final class DevServerStart(
               Play.start(newApplication)
 
               lastState = Success(newApplication)
+              isShutdown = false
               lastState
             } catch {
               // No binary dependency on play-guice

--- a/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -165,6 +165,7 @@ final class DevServerStart(
         val appProvider = new ApplicationProvider {
           var lastState: Try[Application]                        = Failure(new PlayException("Not initialized", "?"))
           var lastLifecycle: Option[DefaultApplicationLifecycle] = None
+          var isShutdown                                         = false
 
           /**
            * Calls the BuildLink to recompile the application if files have changed and constructs a new application
@@ -178,12 +179,18 @@ final class DevServerStart(
             // Block here while the reload happens. Reloading may take seconds or minutes
             // so this is a potentially very long operation!
             // TODO: Make this method return a Future[Application] so we don't need to block more than one thread.
-            synchronized {
-              buildLink.reload match {
-                case cl: ClassLoader => reload(cl) // New application classes
-                case null            => lastState  // No change in the application classes
-                case NonFatal(t)     => Failure(t) // An error we can display
-                case t: Throwable    => throw t    // An error that we can't handle
+            if (isShutdown) {
+              // If the app was shutdown already, we return the old app (if it exists)
+              // This avoids that reload will be called which might triggers a compilation
+              lastState
+            } else {
+              synchronized {
+                buildLink.reload match {
+                  case cl: ClassLoader => reload(cl) // New application classes
+                  case null            => lastState  // No change in the application classes
+                  case NonFatal(t)     => Failure(t) // An error we can display
+                  case t: Throwable    => throw t    // An error that we can't handle
+                }
               }
             }
           }
@@ -198,10 +205,6 @@ final class DevServerStart(
 
               // First, stop the old application if it exists
               lastState.foreach(Play.stop)
-
-              // Basically no matter if the last state was a Success, we need to
-              // call all remaining hooks
-              lastLifecycle.foreach(cycle => Await.result(cycle.stop(), 10.minutes))
 
               // Create the new environment
               val environment = Environment(path, projectClassloader, Mode.Dev)
@@ -302,8 +305,9 @@ final class DevServerStart(
         // the Application and the Server use separate ActorSystems (e.g. DevMode).
         serverCs.addTask(CoordinatedShutdown.PhaseServiceStop, "shutdown-application-dev-mode") { () =>
           implicit val ctx = actorSystem.dispatcher
-          val stoppedApp   = appProvider.get.map(Play.stop)
-          Future.fromTry(stoppedApp).map(_ => Done)
+          val stoppedApp   = appProvider.lastState.map(Play.stop)
+          appProvider.isShutdown = true
+          Future(Done)
         }
 
         val serverContext = ServerProvider.Context(


### PR DESCRIPTION
Fixes #9043
Actually I experience myself quite often that Play (re-)compiles when I shutdown dev mode (e.g via enter or CTRL+D)

I tracked down the core problem:
https://github.com/playframework/playframework/blob/ce4dadbd8e46bf15b2f61b6e54d447b3e988d8b1/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala#L251-L257

The line 255 is calling `appProvider.get`, and this `get` call will reload the app which [will cause a compilation (if e.g. the app has not even started yet or a file changed)](https://github.com/playframework/playframework/blob/2.8.7/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala#L142). **But we don't want to reload the app and (re-)compile, we want to shut it down!**

Even worse, what happens next is that at some point later even the server tries to `get` an app to shutdown the logger:
https://github.com/playframework/playframework/blob/ce4dadbd8e46bf15b2f61b6e54d447b3e988d8b1/transport/server/play-server/src/main/scala/play/core/server/Server.scala#L48-L52
So the server now gets the app, which, if it was just newly created by the `shutdown-application-dev-mode` hook above, for some reason has not yet fully initialized its logging system and fails to shut it down correctly (actually I am not 100% sure how when the logging system will be initialized, it seems its lazy loaded by guice when the first request hits). And this is then causing the error message shown the [initial comment](https://github.com/playframework/playframework/issues/9043#issue-411916640) of the issue referenced.