### PR TITLE
In DEV mode, only set the editor in the error handler if config is valid

### DIFF
--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -502,10 +502,15 @@ class JsonHttpErrorHandler(environment: Environment, sourceMapper: Option[Source
  */
 object DefaultHttpErrorHandler
     extends DefaultHttpErrorHandler(HttpErrorConfig(showDevErrors = true, playEditor = None), None, None) {
+  private val logger = Logger(getClass)
   private lazy val setEditor: Unit =
     Try(Configuration.load(Environment.simple())) match {
       case Success(conf) => conf.getOptional[String]("play.editor").foreach(setPlayEditor)
-      case Failure(_)    => // Very likely invalid config, not able to set the editor
+      case Failure(t) =>
+        logger.error(
+          "Can't read play.editor config because the configuration can't be loaded. This usually means there's a syntax error in your conf files.",
+          t
+        )
     }
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {


### PR DESCRIPTION
Fixes #9020
If `application.conf` is invalid the error handler will be called. So far so good, normal behaviour.
But now the default error handler tries to actually read that invalid config, which will of course fail, because, yeah, the config is invalid ;) So this ends up failing as well and now no result will be produced and [this bizarre and completely useles error message](https://github.com/playframework/playframework/issues/9020#issue-408672151) will be thrown by the akka-http backend.
(Actually it was not me, but @ctoomey [who deserves all the credit](https://github.com/playframework/playframework/issues/9020#issuecomment-564184187))
I can confirm the [reproducer posted in the original issue](https://github.com/SattaiLanfear/play27malformedconf/) now runs fine.