### PR TITLE
Add empty parentheses () to generated reverse route method depending on routes file

### DIFF
--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -314,20 +314,25 @@ package object templates {
    * Generate the parameter signature for the reverse route call for the given routes.
    */
   def reverseSignature(routes: Seq[Route]): String =
-    reverseParameters(routes)
-      .map(p =>
-        safeKeyword(p._1.name) + ":" + p._1.typeName + {
-          Option(routes.map(_.call.routeParams(p._2).default).distinct)
-            .filter(_.size == 1)
-            .flatMap(_.headOption)
-            .map {
-              case None          => ""
-              case Some(default) => " = " + default
+    routes.head.call.parameters
+      .map(_ =>
+        reverseParameters(routes)
+          .map(p =>
+            safeKeyword(p._1.name) + ":" + p._1.typeName + {
+              Option(routes.map(_.call.routeParams(p._2).default).distinct)
+                .filter(_.size == 1)
+                .flatMap(_.headOption)
+                .map {
+                  case None          => ""
+                  case Some(default) => " = " + default
+                }
+                .getOrElse("")
             }
-            .getOrElse("")
-        }
+          )
+          .mkString(", ")
       )
-      .mkString(", ")
+      .map("(" + _ + ")")
+      .getOrElse("")
 
   /**
    * Generate the reverse call

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/reverseRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/reverseRouter.scala.twirl
@@ -22,14 +22,14 @@ import @if(!i.startsWith("_root_.")){_root_.}@i}
   @for(((method, _), routes) <- groupRoutesByMethod(routes)) {@routes match {
   case Seq(route: Route) => {
     @markLines(route)
-    def @(method)(@reverseSignature(routes)): Call = @ob
+    def @(method)@(reverseSignature(routes)): Call = @ob
       @reverseRouteContext(route)
       @reverseCall(route)
     @cb
   }
   case _ => {
     @markLines(routes: _*)
-    def @(method)(@reverseSignature(routes)): Call = @ob
+    def @(method)@(reverseSignature(routes)): Call = @ob
     @defining(reverseParameters(routes)) { params =>
       (@reverseMatchParameters(params, true)) match @ob
       @reverseUniqueConstraints(routes, params) { (route, parameters, parameterConstraints, localNames) =>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/c/app/controllers/c/C.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/c/app/controllers/c/C.scala
@@ -10,9 +10,9 @@ import javax.inject.Inject
 class C @Inject()(c: ControllerComponents) extends AbstractController(c) {
 
   def index = Action {
-    controllers.a.routes.A.index()
-    controllers.b.routes.B.index()
-    controllers.c.routes.C.index()
+    controllers.a.routes.A.index
+    controllers.b.routes.B.index
+    controllers.c.routes.C.index
     Ok
   }
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
@@ -152,7 +152,7 @@ object RouterSpec extends PlaySpecification {
   "allow reverse routing of routes includes" in new WithApplication() {
     // Force the router to bootstrap the prefix
     implicitApp.injector.instanceOf[play.api.routing.Router]
-    controllers.module.routes.ModuleController.index().url must_== "/module/index"
+    controllers.module.routes.ModuleController.index.url must_== "/module/index"
   }
 
   "document the router" in new WithApplication() {
@@ -175,7 +175,7 @@ object RouterSpec extends PlaySpecification {
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {
-    controllers.routes.Application.hello().url must_== "/hello"
+    controllers.routes.Application.hello.url must_== "/hello"
   }
 
   "The assets reverse route support" should {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/RouterSpec.scala
@@ -151,7 +151,7 @@ object RouterSpec extends PlaySpecification {
   "allow reverse routing of routes includes" in new WithApplication() {
     // Force the router to bootstrap the prefix
     implicitApp.injector.instanceOf[play.api.routing.Router]
-    router.module.routes.ModuleController.index().url must_== "/module/index"
+    router.module.routes.ModuleController.index.url must_== "/module/index"
   }
 
   "document the router" in new WithApplication() {
@@ -172,7 +172,7 @@ object RouterSpec extends PlaySpecification {
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {
-    router.routes.Application.hello().url must_== "/hello"
+    router.routes.Application.hello.url must_== "/hello"
   }
 
   "The assets reverse route support" should {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
@@ -710,7 +710,7 @@ object RouterSpec extends PlaySpecification {
   "allow reverse routing of routes includes" in new WithApplication() {
     // Force the router to bootstrap the prefix
     implicitApp.injector.instanceOf[play.api.routing.Router]
-    controllers.module.routes.ModuleController.index().url must_== "/module/index"
+    controllers.module.routes.ModuleController.index.url must_== "/module/index"
   }
 
   "document the router" in new WithApplication() {
@@ -727,7 +727,7 @@ object RouterSpec extends PlaySpecification {
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {
-    controllers.routes.Application.hello().url must_== "/hello"
+    controllers.routes.Application.hello.url must_== "/hello"
   }
 
   "The assets reverse route support" should {

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/fullform.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/fullform.scala.html
@@ -1,7 +1,7 @@
 @* #full-form *@
 @(myForm: play.data.Form[User])(implicit messages: play.i18n.Messages)
 
-@helper.form(action = routes.Application.submit()) {
+@helper.form(action = routes.Application.submit) {
 
     @helper.inputText(myForm("email"))
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/helpers.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/helpers.scala.html
@@ -2,7 +2,7 @@
 
 <span class="form">
 @* #form *@
-@helper.form(action = routes.Application.submit()) {
+@helper.form(action = routes.Application.submit) {
 
 }
 @* #form *@
@@ -10,7 +10,7 @@
 
 <span class="form-with-id">
 @* #form-with-id *@
-@helper.form(action = routes.Application.submit(), Symbol("id") -> "myForm") {
+@helper.form(action = routes.Application.submit, Symbol("id") -> "myForm") {
 
 }
 @* #form-with-id *@

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -605,7 +605,7 @@ package scalaguide.forms.scalaforms {
         Ok(views.html.messages(userForm))
       }
 
-      def post() = TODO
+      def post = TODO
     }
 //#messages-request-controller
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/implicitMessages.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/implicitMessages.scala.html
@@ -6,7 +6,7 @@
 
 @import helper._
 
-@helper.form(action = routes.FormController.post()) {
+@helper.form(action = routes.FormController.post) {
 @CSRF.formField                     @* <- takes a RequestHeader    *@
 @helper.inputText(userForm("name")) @* <- takes a MessagesProvider *@
 @helper.inputText(userForm("age"))  @* <- takes a MessagesProvider *@

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/messages.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/messages.scala.html
@@ -6,7 +6,7 @@
 
 @import helper._
 
-@helper.form(action = routes.FormController.post()) {
+@helper.form(action = routes.FormController.post) {
   @CSRF.formField                     @* <- takes a RequestHeader    *@
   @helper.inputText(userForm("name")) @* <- takes a MessagesProvider *@
   @helper.inputText(userForm("age"))  @* <- takes a MessagesProvider *@

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/user.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/user.scala.html
@@ -19,7 +19,7 @@
 </div>
 
 @* #form-user *@
-@helper.form(action = routes.Application.userPost()) {
+@helper.form(action = routes.Application.userPost) {
   @helper.inputText(userForm("name"))
   @helper.inputText(userForm("age"))
 }
@@ -35,7 +35,7 @@
 }
 @* #global-errors *@
 
-@helper.form(action = routes.Application.userPost()) {
+@helper.form(action = routes.Application.userPost) {
   @* #form-user-parameters *@
   @helper.inputText(userForm("name"), Symbol("id") -> "name", Symbol("size") -> 30)
   @* #form-user-parameters *@


### PR DESCRIPTION
Fixes #10363 to avoid the Scala 2.13.3+ warning about `Auto-application to '()'...`

Right now the reverse router always adds parentheses `()` to the generated method. Always.
With this patch it will only add it when also the `conf/routes` files defines it.

The forward router already works correctly.

IMHO there is no need for more tests, because we already have _nine_ `routes-compiler-*` scripted tests:
https://github.com/playframework/playframework/tree/master/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin
(Besides the normal tests...)
So when the tests work, nothing is broken :wink: 