### PR TITLE
Java forms should handle "foo[].bar" fields when using subforms (index missing)

### DIFF
--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -614,17 +614,7 @@ public class Form<T> {
   }
 
   protected void fillDataWith(Map<String, String> data, Map<String, String[]> urlFormEncoded) {
-    urlFormEncoded.forEach(
-        (key, values) -> {
-          if (key.endsWith("[]")) {
-            String k = key.substring(0, key.length() - 2);
-            for (int i = 0; i < values.length; i++) {
-              data.put(k + "[" + i + "]", values[i]);
-            }
-          } else if (values.length > 0) {
-            data.put(key, values[0]);
-          }
-        });
+    urlFormEncoded.forEach((key, values) -> fillDataWith(key, data, values.length, i -> values[i]));
   }
 
   protected Map<String, Http.MultipartFormData.FilePart<?>> requestFileData(Http.Request request) {
@@ -649,17 +639,38 @@ public class Form<T> {
                     }));
     final Map<String, Http.MultipartFormData.FilePart<?>> data = new HashMap<>();
     resolvedDuplicateKeys.forEach(
-        (key, values) -> {
-          if (key.endsWith("[]")) {
-            String k = key.substring(0, key.length() - 2);
-            for (int i = 0; i < values.size(); i++) {
-              data.put(k + "[" + i + "]", values.get(i));
-            }
-          } else if (!values.isEmpty()) {
-            data.put(key, values.get(0));
-          }
-        });
+        (key, values) -> fillDataWith(key, data, values.size(), i -> values.get(i)));
     return data;
+  }
+
+  protected <T> void fillDataWith(
+      final String key,
+      final Map<String, T> data,
+      final int valuesCount,
+      final Function<Integer, T> getValueByIndex) {
+    if (key.endsWith("[]") || key.contains("[].")) {
+      String leftPart = key; // e.g. foo[].bar[].boo[] or foo[].bar[].boo
+      String rightPart = "";
+      if (key.endsWith("[]")) {
+        leftPart = key.substring(0, key.length() - 2);
+      }
+      for (int splitPosition; (splitPosition = leftPart.lastIndexOf("[].")) != -1; ) {
+        if (key.endsWith("[]") || !rightPart.isEmpty()) { // is index already in use?
+          leftPart =
+              leftPart.substring(0, splitPosition) + "[0]" + leftPart.substring(splitPosition + 2);
+        } else {
+          rightPart = leftPart.substring(splitPosition + 2);
+          leftPart = leftPart.substring(0, splitPosition);
+        }
+      }
+      for (int i = 0; i < valuesCount; i++) {
+        data.put(
+            leftPart + "[" + i + "]" + rightPart,
+            getValueByIndex.apply(i)); // E.g. foo[0].bar[0].boo[<index>] or foo[0].bar[<index>].boo
+      }
+    } else if (valuesCount > 0) {
+      data.put(key, getValueByIndex.apply(0));
+    }
   }
 
   /**

--- a/web/play-java-forms/src/test/java/play/data/Letter.java
+++ b/web/play-java-forms/src/test/java/play/data/Letter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.data;
+
+import play.data.validation.Constraints;
+import play.libs.Files.TemporaryFile;
+import play.mvc.Http.MultipartFormData.FilePart;
+
+import java.util.List;
+
+public class Letter {
+
+  @Constraints.Required
+  @Constraints.MinLength(10)
+  private String address;
+
+  @Constraints.Required private FilePart<TemporaryFile> coverPage;
+
+  @Constraints.Required private List<FilePart<TemporaryFile>> letterPages;
+
+  public String getAddress() {
+    return address;
+  }
+
+  public void setAddress(String address) {
+    this.address = address;
+  }
+
+  public FilePart<TemporaryFile> getCoverPage() {
+    return coverPage;
+  }
+
+  public void setCoverPage(FilePart<TemporaryFile> coverPage) {
+    this.coverPage = coverPage;
+  }
+
+  public List<FilePart<TemporaryFile>> getLetterPages() {
+    return letterPages;
+  }
+
+  public void setLetterPages(List<FilePart<TemporaryFile>> letterPages) {
+    this.letterPages = letterPages;
+  }
+}

--- a/web/play-java-forms/src/test/java/play/data/Thesis.java
+++ b/web/play-java-forms/src/test/java/play/data/Thesis.java
@@ -22,6 +22,8 @@ public class Thesis {
 
   @Constraints.Required private List<FilePart<TemporaryFile>> bibliography;
 
+  @Constraints.Required private List<Letter> letters;
+
   public String getTitle() {
     return title;
   }
@@ -52,5 +54,13 @@ public class Thesis {
 
   public void setBibliography(List<FilePart<TemporaryFile>> bibliography) {
     this.bibliography = bibliography;
+  }
+
+  public List<Letter> getLetters() {
+    return letters;
+  }
+
+  public void setLetters(List<Letter> letters) {
+    this.letters = letters;
   }
 }

--- a/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -63,13 +63,80 @@ class DynamicFormSpec extends CommonFormSpec {
         myForm.hasErrors() must beEqualTo(false)
         myForm.hasGlobalErrors() must beEqualTo(false)
 
-        myForm.rawData().size() must beEqualTo(1)
-        myForm.files().size() must beEqualTo(5)
+        myForm.rawData().size() must beEqualTo(3)
+        myForm.files().size() must beEqualTo(10)
 
         myForm.get("title") must beEqualTo("How Scala works")
         myForm.field("title").value().asScala must beSome("How Scala works")
         myForm.field("title").file().asScala must beNone
         myForm.field("title").indexes() must beEqualTo(List.empty.asJava)
+
+        myForm.field("letters").indexes() must beEqualTo(List(0, 1).asJava)
+        myForm.field("letters").value().asScala must beNone
+        myForm.field("letters").file().asScala must beNone
+
+        myForm.field("letters[0].address").indexes() must beEqualTo(List.empty.asJava)
+        myForm.field("letters[0].address").value().asScala must beSome("Vienna")
+        myForm.field("letters[0].address").file().asScala must beNone
+        myForm.field("letters[0].address").indexes() must beEqualTo(List.empty.asJava)
+        myForm.field("letters[1].address").value().asScala must beSome("Berlin")
+        myForm.field("letters[1].address").file().asScala must beNone
+
+        checkFileParts(
+          Seq(myForm.file("letters[0].coverPage"), myForm.field("letters[0].coverPage").file().get()),
+          "letters[].coverPage",
+          "text/plain",
+          "first-letter-cover_page.txt",
+          "First Letter Cover Page"
+        )
+        myForm.field("letters[0].coverPage").value().asScala must beNone
+
+        checkFileParts(
+          Seq(myForm.file("letters[1].coverPage"), myForm.field("letters[1].coverPage").file().get()),
+          "letters[].coverPage",
+          "application/vnd.oasis.opendocument.text",
+          "second-letter-cover_page.odt",
+          "Second Letter Cover Page"
+        )
+        myForm.field("letters[1].coverPage").value().asScala must beNone
+
+        myForm.field("letters[0].letterPages").indexes() must beEqualTo(List(0, 1).asJava)
+        checkFileParts(
+          Seq(
+            myForm.file("letters[0].letterPages[0]"),
+            myForm.field("letters[0].letterPages[0]").file().get()
+          ),
+          "letters[].letterPages[]",
+          "application/msword",
+          "first-letter-page_1.doc",
+          "First Letter Page One"
+        )
+        myForm.field("letters[0].letterPages[0]").value().asScala must beNone
+
+        checkFileParts(
+          Seq(
+            myForm.file("letters[0].letterPages[1]"),
+            myForm.field("letters[0].letterPages[1]").file().get()
+          ),
+          "letters[].letterPages[]",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "first-letter-page_2.docx",
+          "First Letter Page Two"
+        )
+        myForm.field("letters[0].letterPages[1]").value().asScala must beNone
+
+        myForm.field("letters[1].letterPages").indexes() must beEqualTo(List(0).asJava)
+        checkFileParts(
+          Seq(
+            myForm.file("letters[1].letterPages[0]"),
+            myForm.field("letters[1].letterPages[0]").file().get()
+          ),
+          "letters[1].letterPages[]",
+          "application/rtf",
+          "second-letter-page_1.rtf",
+          "Second Letter Page One"
+        )
+        myForm.field("letters[1].letterPages[0]").value().asScala must beNone
 
         checkFileParts(
           Seq(myForm.file("document"), myForm.field("document").file().get()),

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -140,12 +140,17 @@ trait CommonFormSpec extends Specification {
       "latexFile"                -> createTemporaryFile("tex", "the final draft"),
       "codesnippetsFile"         -> createTemporaryFile("scala", "some code snippets"),
       "bibliographyBrianGoetz"   -> createTemporaryFile("epub", "Java Concurrency in Practice"),
-      "bibliographyJamesGosling" -> createTemporaryFile("mobi", "The Java Programming Language")
+      "bibliographyJamesGosling" -> createTemporaryFile("mobi", "The Java Programming Language"),
+      "firstLetterCoverPage"     -> createTemporaryFile("txt", "First Letter Cover Page"),
+      "firstLetterPage1"         -> createTemporaryFile("doc", "First Letter Page One"),
+      "firstLetterPage2"         -> createTemporaryFile("docx", "First Letter Page Two"),
+      "secondLetterCoverPage"    -> createTemporaryFile("odt", "Second Letter Cover Page"),
+      "secondLetterPage1"        -> createTemporaryFile("rtf", "Second Letter Page One"),
     )
 
   def createThesisRequestWithFileParts(files: Map[String, TemporaryFile]) =
     FormSpec.dummyMultipartRequest(
-      Map("title" -> Array("How Scala works")),
+      Map("title" -> Array("How Scala works"), "letters[].address" -> Array("Vienna", "Berlin")),
       List(
         new FilePart[TemporaryFile]("document", "best_thesis.pdf", "application/pdf", files("thesisDocFile")),
         new FilePart[TemporaryFile]("attachments[]", "final_draft.tex", "application/x-tex", files("latexFile")),
@@ -166,7 +171,37 @@ trait CommonFormSpec extends Specification {
           "The-Java-Programming-Language.mobi",
           "application/x-mobipocket-ebook",
           files("bibliographyJamesGosling")
-        )
+        ),
+        new FilePart[TemporaryFile](
+          "letters[].coverPage", // -> letters[0].coverPage
+          "first-letter-cover_page.txt",
+          "text/plain",
+          files("firstLetterCoverPage")
+        ),
+        new FilePart[TemporaryFile](
+          "letters[].letterPages[]", // -> letters[0].letterPages[0]
+          "first-letter-page_1.doc",
+          "application/msword",
+          files("firstLetterPage1")
+        ),
+        new FilePart[TemporaryFile](
+          "letters[].letterPages[]", // -> letters[0].letterPages[1]
+          "first-letter-page_2.docx",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          files("firstLetterPage2")
+        ),
+        new FilePart[TemporaryFile](
+          "letters[].coverPage", // -> letters[1].coverPage
+          "second-letter-cover_page.odt",
+          "application/vnd.oasis.opendocument.text",
+          files("secondLetterCoverPage")
+        ),
+        new FilePart[TemporaryFile](
+          "letters[1].letterPages[]", // -> letters[1].letterPages[0]
+          "second-letter-page_1.rtf",
+          "application/rtf",
+          files("secondLetterPage1")
+        ),
       )
     )
 }
@@ -570,6 +605,7 @@ trait FormSpec extends CommonFormSpec {
       user2form.field("emails").indexes() must beEqualTo(List(0).asJava)
       user2.getName must beEqualTo("Kiki")
       user2.getEmails.size must beEqualTo(1)
+      user2.getEmails.get(0) must beEqualTo("kiki@gmail.com")
 
       val user3form = formFactory
         .form(classOf[AnotherUser])
@@ -582,6 +618,8 @@ trait FormSpec extends CommonFormSpec {
       user3form.field("emails").indexes() must beEqualTo(List(0, 1).asJava)
       user3.getName must beEqualTo("Kiki")
       user3.getEmails.size must beEqualTo(2)
+      user3.getEmails.get(0) must beEqualTo("kiki@gmail.com")
+      user3.getEmails.get(1) must beEqualTo("kiki@zen.com")
 
       val user4form = formFactory
         .form(classOf[AnotherUser])
@@ -590,6 +628,7 @@ trait FormSpec extends CommonFormSpec {
       user4form.field("emails").indexes() must beEqualTo(List(0).asJava)
       user4.getName must beEqualTo("Kiki")
       user4.getEmails.size must beEqualTo(1)
+      user4.getEmails.get(0) must beEqualTo("kiki@gmail.com")
 
       val user5form = formFactory
         .form(classOf[AnotherUser])
@@ -600,6 +639,97 @@ trait FormSpec extends CommonFormSpec {
       user5form.field("emails").indexes() must beEqualTo(List(0, 1).asJava)
       user5.getName must beEqualTo("Kiki")
       user5.getEmails.size must beEqualTo(2)
+      user5.getEmails.get(0) must beEqualTo("kiki@gmail.com")
+      user5.getEmails.get(1) must beEqualTo("kiki@zen.com")
+
+      val user6form = formFactory
+        .form(classOf[AnotherJavaMainForm])
+        .bindFromRequest(
+          FormSpec.dummyRequest(
+            Map(
+              "entry.name"                  -> Array("Bill"),
+              "entry.value"                 -> Array("3"),
+              "entries[].name"              -> Array("Calvin", "John", "Edward"), //   -> entries[0|1|2].name
+              "entries[].value"             -> Array("14", "26", "76"), //             -> entries[0|1|2].value
+              "entries[].entries[].name"    -> Array("Robin Hood", "Donald Duck"), //  -> entries[0].entries[0|1].name
+              "entries[].entries[].street"  -> Array("Wall Street", "Main Street"), // -> entries[0].entries[0|1].street
+              "entries[].entries[].value"   -> Array("143", "196"), //                 -> entries[0].entries[0|1].value
+              "entries[].entries[].notes[]" -> Array("Note 1", "Note 2", "Note 3"), // -> entries[0].entries[0].notes[0|1|2]
+              // Now with some indices
+              "entries[].entries[1].notes[]"  -> Array("Note 4", "Note 5", "Note x", "Note y"),          // -> entries[0].entries[1].notes[0|1|2|3]
+              "entries[1].entries[].name"     -> Array("Batman", "Robin", "Joker"),                      // -> entries[1].entries[0|1|2].name
+              "entries[1].entries[].street"   -> Array("First Street", "Second Street", "Third Street"), // -> entries[1].entries[0|1|2].street
+              "entries[1].entries[].value"    -> Array("372", "641", "961"),                             // -> entries[1].entries[0|1|2].value
+              "entries[1].entries[].notes[]"  -> Array("Note 6", "Note 7"),                              // -> entries[1].entries[0].notes[0|1]
+              "entries[1].entries[1].notes[]" -> Array("Note 8", "Note 9", "Note 10"),                   // -> entries[1].entries[1].notes[0|1|2]
+            )
+          )
+        )
+      val user6 = user6form.get
+      user6form.field("entry").indexes().asScala must beEmpty
+      user6.getEntry.getName must beEqualTo("Bill")
+      user6.getEntry.getValue must beEqualTo(3)
+      user6.getEntry.getEntries must beNull
+      user6form.field("entry.entries").indexes().asScala must beEmpty
+
+      user6.getEntries.size must beEqualTo(3)
+      user6form.field("entries").indexes() must beEqualTo(List(0, 1, 2).asJava)
+
+      user6.getEntries.get(0).getName must beEqualTo("Calvin")
+      user6.getEntries.get(0).getValue must beEqualTo(14)
+      user6.getEntries.get(0).getEntries.size must beEqualTo(2)
+      user6form.field("entries[0].entries").indexes() must beEqualTo(List(0, 1).asJava)
+
+      user6.getEntries.get(0).getEntries.get(0).getName must beEqualTo("Robin Hood")
+      user6.getEntries.get(0).getEntries.get(0).getStreet must beEqualTo("Wall Street")
+      user6.getEntries.get(0).getEntries.get(0).getValue must beEqualTo(143)
+      user6.getEntries.get(0).getEntries.get(0).getNotes.size must beEqualTo(3)
+      user6form.field("entries[0].entries[0].notes").indexes() must beEqualTo(List(0, 1, 2).asJava)
+      user6.getEntries.get(0).getEntries.get(0).getNotes.get(0) must beEqualTo("Note 1")
+      user6.getEntries.get(0).getEntries.get(0).getNotes.get(1) must beEqualTo("Note 2")
+      user6.getEntries.get(0).getEntries.get(0).getNotes.get(2) must beEqualTo("Note 3")
+
+      user6.getEntries.get(0).getEntries.get(1).getName must beEqualTo("Donald Duck")
+      user6.getEntries.get(0).getEntries.get(1).getStreet must beEqualTo("Main Street")
+      user6.getEntries.get(0).getEntries.get(1).getValue must beEqualTo(196)
+      user6.getEntries.get(0).getEntries.get(1).getNotes.size must beEqualTo(4)
+      user6form.field("entries[0].entries[1].notes").indexes() must beEqualTo(List(0, 1, 2, 3).asJava)
+      user6.getEntries.get(0).getEntries.get(1).getNotes.get(0) must beEqualTo("Note 4")
+      user6.getEntries.get(0).getEntries.get(1).getNotes.get(1) must beEqualTo("Note 5")
+      user6.getEntries.get(0).getEntries.get(1).getNotes.get(2) must beEqualTo("Note x")
+      user6.getEntries.get(0).getEntries.get(1).getNotes.get(3) must beEqualTo("Note y")
+
+      user6.getEntries.get(1).getName must beEqualTo("John")
+      user6.getEntries.get(1).getValue must beEqualTo(26)
+      user6.getEntries.get(1).getEntries.size must beEqualTo(3)
+      user6form.field("entries[1].entries").indexes() must beEqualTo(List(0, 1, 2).asJava)
+      user6.getEntries.get(1).getEntries.get(0).getName must beEqualTo("Batman")
+      user6.getEntries.get(1).getEntries.get(0).getStreet must beEqualTo("First Street")
+      user6.getEntries.get(1).getEntries.get(0).getValue must beEqualTo(372)
+      user6.getEntries.get(1).getEntries.get(0).getNotes.size must beEqualTo(2)
+      user6form.field("entries[1].entries[0].notes").indexes() must beEqualTo(List(0, 1).asJava)
+      user6.getEntries.get(1).getEntries.get(0).getNotes.get(0) must beEqualTo("Note 6")
+      user6.getEntries.get(1).getEntries.get(0).getNotes.get(1) must beEqualTo("Note 7")
+
+      user6.getEntries.get(1).getEntries.get(1).getName must beEqualTo("Robin")
+      user6.getEntries.get(1).getEntries.get(1).getStreet must beEqualTo("Second Street")
+      user6.getEntries.get(1).getEntries.get(1).getValue must beEqualTo(641)
+      user6.getEntries.get(1).getEntries.get(1).getNotes.size must beEqualTo(3)
+      user6form.field("entries[1].entries[1].notes").indexes() must beEqualTo(List(0, 1, 2).asJava)
+      user6.getEntries.get(1).getEntries.get(1).getNotes.get(0) must beEqualTo("Note 8")
+      user6.getEntries.get(1).getEntries.get(1).getNotes.get(1) must beEqualTo("Note 9")
+      user6.getEntries.get(1).getEntries.get(1).getNotes.get(2) must beEqualTo("Note 10")
+
+      user6.getEntries.get(1).getEntries.get(2).getName must beEqualTo("Joker")
+      user6.getEntries.get(1).getEntries.get(2).getStreet must beEqualTo("Third Street")
+      user6.getEntries.get(1).getEntries.get(2).getValue must beEqualTo(961)
+      user6.getEntries.get(1).getEntries.get(2).getNotes must beNull
+      user6form.field("entries[1].entries[2].notes").indexes().asScala must beEmpty
+
+      user6.getEntries.get(2).getName must beEqualTo("Edward")
+      user6.getEntries.get(2).getValue must beEqualTo(76)
+      user6.getEntries.get(2).getEntries must beNull
+      user6form.field("entries[2].entries").indexes().asScala must beEmpty
     }
 
     "support optional deserialization of a common map" in {
@@ -650,14 +780,82 @@ trait FormSpec extends CommonFormSpec {
           myForm.hasErrors() must beEqualTo(false)
           myForm.hasGlobalErrors() must beEqualTo(false)
 
-          myForm.rawData().size() must beEqualTo(1)
-          myForm.files().size() must beEqualTo(5)
+          myForm.rawData().size() must beEqualTo(3)
+          myForm.files().size() must beEqualTo(10)
 
           val thesis = myForm.get
 
           thesis.getTitle must beEqualTo("How Scala works")
           myForm.field("title").value().asScala must beSome("How Scala works")
           myForm.field("title").file().asScala must beNone
+
+          thesis.getLetters().size() must beEqualTo(2)
+          myForm.field("letters").indexes() must beEqualTo(List(0, 1).asJava)
+
+          thesis.getLetters().get(0).getAddress must beEqualTo("Vienna")
+          myForm.field("letters[0].address").value().asScala must beSome("Vienna")
+          myForm.field("letters[0].address").file().asScala must beNone
+          thesis.getLetters().get(1).getAddress must beEqualTo("Berlin")
+          myForm.field("letters[1].address").value().asScala must beSome("Berlin")
+          myForm.field("letters[1].address").file().asScala must beNone
+
+          checkFileParts(
+            Seq(thesis.getLetters().get(0).getCoverPage, myForm.field("letters[0].coverPage").file().get()),
+            "letters[].coverPage",
+            "text/plain",
+            "first-letter-cover_page.txt",
+            "First Letter Cover Page"
+          )
+          myForm.field("letters[0].coverPage").value().asScala must beNone
+
+          checkFileParts(
+            Seq(thesis.getLetters().get(1).getCoverPage, myForm.field("letters[1].coverPage").file().get()),
+            "letters[].coverPage",
+            "application/vnd.oasis.opendocument.text",
+            "second-letter-cover_page.odt",
+            "Second Letter Cover Page"
+          )
+          myForm.field("letters[1].coverPage").value().asScala must beNone
+
+          thesis.getLetters().get(0).getLetterPages().size() must beEqualTo(2)
+          myForm.field("letters[0].letterPages").indexes() must beEqualTo(List(0, 1).asJava)
+          checkFileParts(
+            Seq(
+              thesis.getLetters().get(0).getLetterPages().get(0),
+              myForm.field("letters[0].letterPages[0]").file().get()
+            ),
+            "letters[].letterPages[]",
+            "application/msword",
+            "first-letter-page_1.doc",
+            "First Letter Page One"
+          )
+          myForm.field("letters[0].letterPages[0]").value().asScala must beNone
+
+          checkFileParts(
+            Seq(
+              thesis.getLetters().get(0).getLetterPages().get(1),
+              myForm.field("letters[0].letterPages[1]").file().get()
+            ),
+            "letters[].letterPages[]",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "first-letter-page_2.docx",
+            "First Letter Page Two"
+          )
+          myForm.field("letters[0].letterPages[1]").value().asScala must beNone
+
+          thesis.getLetters().get(1).getLetterPages().size() must beEqualTo(1)
+          myForm.field("letters[1].letterPages").indexes() must beEqualTo(List(0).asJava)
+          checkFileParts(
+            Seq(
+              thesis.getLetters().get(1).getLetterPages().get(0),
+              myForm.field("letters[1].letterPages[0]").file().get()
+            ),
+            "letters[1].letterPages[]",
+            "application/rtf",
+            "second-letter-page_1.rtf",
+            "Second Letter Page One"
+          )
+          myForm.field("letters[1].letterPages[0]").value().asScala must beNone
 
           checkFileParts(
             Seq(thesis.getDocument, myForm.field("document").file().get()),
@@ -716,11 +914,12 @@ trait FormSpec extends CommonFormSpec {
           .bindFromRequest(FormSpec.dummyMultipartRequest(Map("title" -> Array("How Scala works"))))
         myForm.hasErrors() must beEqualTo(true)
         myForm.hasGlobalErrors() must beEqualTo(false)
-        myForm.errors().size() must beEqualTo(3)
+        myForm.errors().size() must beEqualTo(4)
         myForm.files().size() must beEqualTo(0)
         myForm.error("document").get.message() must beEqualTo("error.required")
         myForm.error("attachments").get.message() must beEqualTo("error.required")
         myForm.error("bibliography").get.message() must beEqualTo("error.required")
+        myForm.error("letters").get.message() must beEqualTo("error.required")
       }
     }
 
@@ -987,27 +1186,45 @@ trait FormSpec extends CommonFormSpec {
 
     "correctly calculate indexes()" in {
       val dataPart = Map(
-        "someDataField[0]"  -> "foo",
-        "someDataField[1]"  -> "foo",
-        "someDataField[2]"  -> "foo",
-        "someDataField[4]"  -> "foo",
-        "someDataField[59]" -> "foo",
+        "someDataField[0]"              -> "foo",
+        "someDataField[1]"              -> "foo",
+        "someDataField[2]"              -> "foo",
+        "someDataField[4]"              -> "foo",
+        "someDataField[59]"             -> "foo",
+        "someDataField[70].member1"     -> "foo",
+        "someDataField[81].member2[95]" -> "foo",
+        "someDataField[81].member2[96]" -> "foo",
       ).asJava
       val filePart = Map(
-        "someFileField[0]"  -> null,
-        "someFileField[13]" -> null,
-        "someFileField[24]" -> null,
-        "someFileField[85]" -> null,
+        "someFileField[0]"              -> null,
+        "someFileField[13]"             -> null,
+        "someFileField[24]"             -> null,
+        "someFileField[85]"             -> null,
+        "someFileField[92].member8"     -> null,
+        "someFileField[96].member9[98]" -> null,
+        "someFileField[96].member9[99]" -> null,
       ).asJava.asInstanceOf[util.Map[String, Http.MultipartFormData.FilePart[_]]]
 
       val form: Form[Object] =
         new Form(null, null, dataPart, filePart, null, Optional.empty[Object](), null, null, null, null, null, null)
 
       val dataField = new Form.Field(form, "someDataField", null, null, null, null, null)
-      dataField.indexes() must beEqualTo(List(0, 1, 2, 4, 59).asJava)
+      dataField.indexes() must beEqualTo(List(0, 1, 2, 4, 59, 70, 81).asJava)
+
+      val subDataField1 = new Form.Field(form, "someDataField[70].member1", null, null, null, null, null)
+      subDataField1.indexes() must beEqualTo(List.empty.asJava)
+
+      val subDataField2 = new Form.Field(form, "someDataField[81].member2", null, null, null, null, null)
+      subDataField2.indexes() must beEqualTo(List(95, 96).asJava)
 
       val fileField = new Form.Field(form, "someFileField", null, null, null, null, null)
-      fileField.indexes() must beEqualTo(List(0, 13, 24, 85).asJava)
+      fileField.indexes() must beEqualTo(List(0, 13, 24, 85, 92, 96).asJava)
+
+      val subFileField1 = new Form.Field(form, "someFileField[92].member8", null, null, null, null, null)
+      subFileField1.indexes() must beEqualTo(List.empty.asJava)
+
+      val subFileField2 = new Form.Field(form, "someFileField[96].member9", null, null, null, null, null)
+      subFileField2.indexes() must beEqualTo(List(98, 99).asJava)
     }
 
     def fillNoBind(values: (String, String)*) = {
@@ -1408,6 +1625,20 @@ class JavaMainForm extends Constraints.Validatable[ValidationError] {
   override def validate = new ValidationError("entry", "validate of parent: I always get called!")
 }
 
+class AnotherJavaMainForm {
+
+  @BeanProperty
+  @Constraints.Required
+  @Size(max = 3)
+  @Valid
+  var entries: java.util.List[JavaChildForm] = _
+
+  @BeanProperty
+  @Constraints.Required
+  @Valid
+  var entry: JavaChildForm = _
+}
+
 @Constraints.Validate
 class JavaChildForm extends Constraints.Validatable[ValidationError] {
 
@@ -1439,6 +1670,9 @@ class JavaChildChildForm extends Constraints.Validatable[ValidationError] {
 
   @BeanProperty
   var value: java.lang.Integer = _
+
+  @BeanProperty
+  var notes: java.util.List[String] = _
 
   override def validate: ValidationError =
     if (value == null) new ValidationError("value", "validate of child of child: value can't be null!") else null


### PR DESCRIPTION
While working on #10471 I ran into an NPE exception when working with sub-forms when posting a field where the index was missing.

E.g. `foo[].bar` will throw an exception. However `foo[0].bar` (with explicit index) works as expected (because the underlying binder library from Spring can handle that syntax)

Also when posting lists/arrays (where the `[`/`]` brackets are at the end) everything works fine:
Play can handle `foo[0]` and and also `foo[]` (without index) - because Play will add the index automatically so the underyling binder can handle it.

This pull request makes Play to also automatically add an index to `foo[].bar` sub-form fields.