### PR TITLE
No need to target jdk 1.6 anymore for plugins

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -330,10 +330,6 @@ object BuildSettings {
       .enablePlugins(PlayLibrary, AutomateHeaderPlugin)
       .settings(
         playCommonSettings,
-        (javacOptions in compile) ~= (_.map {
-          case "1.8" => "1.6"
-          case other => other
-        }),
         mimaPreviousArtifacts := Set.empty,
       )
   }


### PR DESCRIPTION
master branch uses interplay 3 already which dropped support for 0.13. Not that sbt 0.13 is gone there is no need to target sbt plugins for java 1.6 anymore.
Also see https://github.com/playframework/interplay/pull/101/files#diff-9f23263fad304b1ca48c64c38db7d8f20fbd47120c76899715b9913021ab96eeL26