### PR TITLE
Replace generic matchers on specific builtin matchers in tests

### DIFF
--- a/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -20,11 +20,11 @@ class BindersSpec extends Specification {
       subject.unbind("key", uuid) must be_==(uuid.toString)
     }
     "Bind parameter to UUID" in {
-      subject.bind("key", uuid.toString) must be_==(Right(uuid))
+      subject.bind("key", uuid.toString) must beRight(uuid)
     }
     "Fail on unparseable UUID" in {
-      subject.bind("key", "bad-uuid") must be_==(
-        Left("Cannot parse parameter key as UUID: Invalid UUID string: bad-uuid")
+      subject.bind("key", "bad-uuid") must beLeft(
+        "Cannot parse parameter key as UUID: Invalid UUID string: bad-uuid"
       )
     }
   }
@@ -36,11 +36,11 @@ class BindersSpec extends Specification {
       subject.unbind("key", uuid) must be_==("key=" + uuid.toString)
     }
     "Bind parameter to UUID" in {
-      subject.bind("key", Map("key" -> Seq(uuid.toString))) must be_==(Some(Right(uuid)))
+      subject.bind("key", Map("key" -> Seq(uuid.toString))) must beSome(Right(uuid))
     }
     "Fail on unparseable UUID" in {
-      subject.bind("key", Map("key" -> Seq("bad-uuid"))) must be_==(
-        Some(Left("Cannot parse parameter key as UUID: Invalid UUID string: bad-uuid"))
+      subject.bind("key", Map("key" -> Seq("bad-uuid"))) must beSome(
+        Left("Cannot parse parameter key as UUID: Invalid UUID string: bad-uuid")
       )
     }
     "Unbind with keys needing encode" in {
@@ -59,7 +59,7 @@ class BindersSpec extends Specification {
       subject.unbind("key", pathString) must equalTo(pathString)
     }
     "Bind Path string as string without any decoding" in {
-      subject.bind("key", pathString) must equalTo(Right(pathString))
+      subject.bind("key", pathString) must beRight(pathString)
     }
   }
 
@@ -98,11 +98,11 @@ class BindersSpec extends Specification {
                    |failed to parse q: failed: man
                    |failed to parse q: failed: from""".stripMargin.replaceAll(System.lineSeparator, "\n") // Windows compatibility
 
-      brokenSeqBinder.bind("q", params) must equalTo(Some(Left(err)))
+      brokenSeqBinder.bind("q", params) must beSome(Left(err))
     }
 
     "preserve the order of bound parameters" in {
-      seqBinder.bind("q", params) must equalTo(Some(Right(values)))
+      seqBinder.bind("q", params) must beSome(Right(values))
     }
 
     "return the empty list when the key is not found" in {
@@ -119,15 +119,15 @@ class BindersSpec extends Specification {
       subject.unbind("key", char) must equalTo("key=" + char.toString)
     }
     "Bind query string as char" in {
-      subject.bind("key", Map("key" -> Seq(string))) must equalTo(Some(Right(char)))
+      subject.bind("key", Map("key" -> Seq(string))) must beSome(Right(char))
     }
     "Fail on length > 1" in {
-      subject.bind("key", Map("key" -> Seq("foo"))) must be_==(
-        Some(Left("Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length."))
+      subject.bind("key", Map("key" -> Seq("foo"))) must beSome(
+        Left("Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length.")
       )
     }
     "Be None on empty" in {
-      subject.bind("key", Map("key" -> Seq(""))) must equalTo(None)
+      subject.bind("key", Map("key" -> Seq(""))) must beNone
     }
     "Unbind with keys needing encode" in {
       val boundValue = subject.unbind("ke=y", char)
@@ -144,15 +144,15 @@ class BindersSpec extends Specification {
       subject.unbind("key", char) must equalTo("key=" + char.toString)
     }
     "Bind query string as char" in {
-      subject.bind("key", Map("key" -> Seq(string))) must equalTo(Some(Right(char)))
+      subject.bind("key", Map("key" -> Seq(string))) must beSome(Right(char))
     }
     "Fail on length > 1" in {
-      subject.bind("key", Map("key" -> Seq("foo"))) must be_==(
-        Some(Left("Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length."))
+      subject.bind("key", Map("key" -> Seq("foo"))) must beSome(
+        Left("Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length.")
       )
     }
     "Be None on empty" in {
-      subject.bind("key", Map("key" -> Seq(""))) must equalTo(None)
+      subject.bind("key", Map("key" -> Seq(""))) must beNone
     }
     "Unbind with keys needing encode" in {
       val boundValue = subject.unbind("ke=y", char)
@@ -169,25 +169,25 @@ class BindersSpec extends Specification {
       subject.unbind("key", short) must equalTo("key=" + short.toString)
     }
     "Bind query string as short" in {
-      subject.bind("key", Map("key" -> Seq(string))) must equalTo(Some(Right(short)))
+      subject.bind("key", Map("key" -> Seq(string))) must beSome(Right(short))
     }
     "Fail on value must contain only digits" in {
-      subject.bind("key", Map("key" -> Seq("foo"))) must be_==(
-        Some(Left("Cannot parse parameter key as Short: For input string: \"foo\""))
+      subject.bind("key", Map("key" -> Seq("foo"))) must beSome(
+        Left("Cannot parse parameter key as Short: For input string: \"foo\"")
       )
     }
     "Fail on value < -32768" in {
-      subject.bind("key", Map("key" -> Seq("-32769"))) must be_==(
-        Some(Left("Cannot parse parameter key as Short: Value out of range. Value:\"-32769\" Radix:10"))
+      subject.bind("key", Map("key" -> Seq("-32769"))) must beSome(
+        Left("Cannot parse parameter key as Short: Value out of range. Value:\"-32769\" Radix:10")
       )
     }
     "Fail on value > 32767" in {
-      subject.bind("key", Map("key" -> Seq("32768"))) must be_==(
-        Some(Left("Cannot parse parameter key as Short: Value out of range. Value:\"32768\" Radix:10"))
+      subject.bind("key", Map("key" -> Seq("32768"))) must beSome(
+        Left("Cannot parse parameter key as Short: Value out of range. Value:\"32768\" Radix:10")
       )
     }
     "Be None on empty" in {
-      subject.bind("key", Map("key" -> Seq(""))) must equalTo(None)
+      subject.bind("key", Map("key" -> Seq(""))) must beNone
     }
     "Unbind with keys needing encode" in {
       val boundValue = subject.unbind("ke=y", short)
@@ -204,16 +204,16 @@ class BindersSpec extends Specification {
       subject.unbind("key", char) must equalTo(char.toString)
     }
     "Bind Path string as char" in {
-      subject.bind("key", string) must equalTo(Right(char))
+      subject.bind("key", string) must beRight(char)
     }
     "Fail on length > 1" in {
-      subject.bind("key", "foo") must be_==(
-        Left("Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length.")
+      subject.bind("key", "foo") must beLeft(
+        "Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length."
       )
     }
     "Fail on empty" in {
-      subject.bind("key", "") must be_==(
-        Left("Cannot parse parameter key with value '' as Char: key must be exactly one digit in length.")
+      subject.bind("key", "") must beLeft(
+        "Cannot parse parameter key with value '' as Char: key must be exactly one digit in length."
       )
     }
   }
@@ -227,23 +227,23 @@ class BindersSpec extends Specification {
       subject.unbind("key", char) must equalTo(char.toString)
     }
     "Bind Path string as char" in {
-      subject.bind("key", string) must equalTo(Right(char))
+      subject.bind("key", string) must beRight(char)
     }
     "Fail on length > 1" in {
-      subject.bind("key", "foo") must be_==(
-        Left("Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length.")
+      subject.bind("key", "foo") must beLeft(
+        "Cannot parse parameter key with value 'foo' as Char: key must be exactly one digit in length."
       )
     }
     "Fail on empty" in {
-      subject.bind("key", "") must be_==(
-        Left("Cannot parse parameter key with value '' as Char: key must be exactly one digit in length.")
+      subject.bind("key", "") must beLeft(
+        "Cannot parse parameter key with value '' as Char: key must be exactly one digit in length."
       )
     }
   }
 
   "AnyVal PathBindable" should {
     "Bind Long String as Demo" in {
-      implicitly[PathBindable[Demo]].bind("key", "10") must equalTo(Right(Demo(10L)))
+      implicitly[PathBindable[Demo]].bind("key", "10") must beRight(Demo(10L))
     }
     "Unbind Hase as String" in {
       implicitly[PathBindable[Hase]].unbind("key", Hase("Disney_Land")) must equalTo("Disney_Land")
@@ -252,7 +252,7 @@ class BindersSpec extends Specification {
 
   "AnyVal QueryStringBindable" should {
     "Bind Long String as Demo" in {
-      implicitly[QueryStringBindable[Demo]].bind("key", Map("key" -> Seq("10"))) must equalTo(Some(Right(Demo(10L))))
+      implicitly[QueryStringBindable[Demo]].bind("key", Map("key" -> Seq("10"))) must beSome(Right(Demo(10L)))
     }
     "Unbind with keys needing encode (String)" in {
       val boundValue = implicitly[QueryStringBindable[Demo]].unbind("ke=y", Demo(11L))

--- a/core/play/src/test/scala/play/core/routing/RouterSpec.scala
+++ b/core/play/src/test/scala/play/core/routing/RouterSpec.scala
@@ -56,13 +56,13 @@ class RouterSpec extends Specification {
     val pathStringInvalid     = "/path/to/invalide%2"
 
     "Bind Path string as string" in {
-      pathPattern(pathString).get("foo") must beEqualTo(Right("some file"))
+      pathPattern(pathString).get("foo") must beRight("some file")
     }
     "Bind Path with incorrectly encoded string as string" in {
-      pathPattern(pathNonEncodedString1).get("foo") must beEqualTo(Right("bar:baz"))
+      pathPattern(pathNonEncodedString1).get("foo") must beRight("bar:baz")
     }
     "Bind Path with incorrectly encoded string as string" in {
-      pathPattern(pathNonEncodedString2).get("foo") must beEqualTo(Right("bar: baz"))
+      pathPattern(pathNonEncodedString2).get("foo") must beRight("bar: baz")
     }
     "Fail on unparseable Path string" in {
       val Left(e) = pathPattern(pathStringInvalid).get("foo")
@@ -72,7 +72,7 @@ class RouterSpec extends Specification {
     "multipart path is not decoded" in {
       val pathPattern = PathPattern(Seq(StaticPart("/path/"), StaticPart("to/"), DynamicPart("foo", ".+", false)))
       val pathString  = "/path/to/this/is/some%20file/with/id"
-      pathPattern(pathString).get("foo") must beEqualTo(Right("this/is/some%20file/with/id"))
+      pathPattern(pathString).get("foo") must beRight("this/is/some%20file/with/id")
     }
   }
 


### PR DESCRIPTION
There are many lines like that: `subject.bind("key", uuid.toString) must be_==(Right(uuid))`
It can be replaced on `subject.bind("key", uuid.toString) must beRight(uuid)` .

Kind regards