### PR TITLE
Add UUID PathBindableExtractor

### DIFF
--- a/core/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
@@ -6,6 +6,8 @@ package play.api.routing.sird
 
 import play.api.mvc.PathBindable
 
+import java.util.UUID
+
 /**
  * An extractor that extracts from a String using a [[play.api.mvc.PathBindable]].
  */
@@ -74,4 +76,9 @@ trait PathBindableExtractors {
    * A double extractor.
    */
   val double = new PathBindableExtractor[Double]
+
+  /**
+   * A UUID extractor.
+   */
+  val uuid = new PathBindableExtractor[UUID]
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -299,6 +299,11 @@ object BuildSettings {
         "play.api.mvc.BaseControllerHelpers.play$api$mvc$BaseControllerHelpers$_setter_$defaultFormBinding_="
       ),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.BaseControllerHelpers.defaultFormBinding"),
+      // Add UUID PathBindableExtractors
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "play.api.routing.sird.PathBindableExtractors.play$api$routing$sird$PathBindableExtractors$_setter_$uuid_="
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.routing.sird.PathBindableExtractors.uuid"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Seems like it was missing since the beginning, when introducing `PathBindableExtractor`: https://github.com/playframework/playframework/pull/3964/files#diff-c4e9c1637b3d6926b61d0d20f01733ffd7c2915fedfc421f002e908b6e1aa41d