### PR TITLE
Do not extend AnyVal which triggers wrong QueryString/PathBindable

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/models/UserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/models/UserId.scala
@@ -24,4 +24,4 @@ object UserId {
       )
 }
 
-case class UserId(id: String) extends AnyVal
+case class UserId(id: String)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/models/UserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/models/UserId.scala
@@ -24,4 +24,4 @@ object UserId {
       )
 }
 
-case class UserId(id: String) extends AnyVal
+case class UserId(id: String)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/models/UserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/models/UserId.scala
@@ -24,4 +24,4 @@ object UserId {
       )
 }
 
-case class UserId(id: String) extends AnyVal
+case class UserId(id: String)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/models/UserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/models/UserId.scala
@@ -24,4 +24,4 @@ object UserId {
       )
 }
 
-case class UserId(id: String) extends AnyVal
+case class UserId(id: String)


### PR DESCRIPTION
I have no idea why in #7621 those `UserId` classes were made to `extends AnyVal`. Back when that pull request was merged, that didn't matter. Let's again look at the code of that pull request (and that code still is alive in master):

https://github.com/playframework/playframework/blob/b2645bd3bf508546f377f926457bf64d83897951/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/models/UserId.scala#L12-L27

As you can see an `implicit` pathBindable and queryStringBindable were added as well. Great, that worked.

However, a couple of month later following pull requests were merged as well: #8076 and #8093
Merging those two pull request made the above pathBindable/queryStringBindable useless, because now the newly added Path/QueryStringBindable's for AnyVal kick in and the above ones just get ignored.

I ran into this when hacking on scripted tests and changed the above bindables, but nothing happend...Took me a while to figure out what's actually going on. When removing the `AnyVal` extends, above binders will be used again.
I think that was the original meaning and sense of those binders, not introducing them so they are dead code...