### PR TITLE
Routes compiler: Remove generation date, keep the source relative

### DIFF
--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
@@ -53,7 +53,10 @@ object InjectedRoutesGenerator extends RoutesGenerator {
     val folder = namespace.map(_.replace('.', '/') + "/").getOrElse("") + "/"
 
     val sourceInfo =
-      RoutesSourceInfo(task.file.getCanonicalPath.replace(File.separator, "/"), new java.util.Date().toString)
+      RoutesSourceInfo(
+        new File(".").toURI.relativize(task.file.toURI).getPath.replace(File.separator, "/"),
+        new java.util.Date().toString
+      )
     val routes = rules.collect { case r: Route => r }
 
     val routesPrefixFiles = Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace))

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -6,7 +6,6 @@
   deps: Seq[Dependency[Rule]], rules: Seq[Dependency[Rule]], includes: Seq[Dependency[Include]])
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
-// @@DATE:@sourceInfo.date
 
 @for(p <- pkg) {package @p}
 

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/javaWrappers.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/javaWrappers.scala.twirl
@@ -3,7 +3,6 @@
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], packageName: Option[String], controllers: Seq[String])
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
-// @@DATE:@sourceInfo.date
 
 @{packageName.map("package " + _ + ";").getOrElse("")}
 

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/javascriptReverseRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/javascriptReverseRouter.scala.twirl
@@ -3,7 +3,6 @@
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], imports: Seq[String], packageName: Option[String], routes: Seq[Route], namespaceReverseRouter: Boolean, useInjector: Route => Boolean)
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
-// @@DATE:@sourceInfo.date
 
 import play.api.routing.JavaScriptReverseRoute
 

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/reverseRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/reverseRouter.scala.twirl
@@ -3,7 +3,6 @@
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], imports: Seq[String], packageName: Option[String], routes: Seq[Route], namespaceReverseRouter: Boolean, useInjector: Route => Boolean)
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
-// @@DATE:@sourceInfo.date
 
 import play.api.mvc.Call
 

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/routesPrefix.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/static/routesPrefix.scala.twirl
@@ -3,7 +3,6 @@
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], useInjector: Route => Boolean)
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
-// @@DATE:@sourceInfo.date
 
 @* Can't put in the root package because Java can't refer to the root package *@
 package @pkg.getOrElse("_routes_") @ob


### PR DESCRIPTION
Fixes #10490

Necessary to make a build reproducible and for sbt's 1.4 remote cache feature.

Date was never used.
Source is used only here:
https://github.com/playframework/playframework/blob/202ca0a18dc3e6555eb0ebc73afdc7c2b10480b2/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala#L58-L59

Comments generated before this patch:
```
// @GENERATOR:play-routes-compiler
// @SOURCE:/home/mkurz/play-test-project/conf/routes
// @DATE:Tue Feb 16 18:47:10 CET 2021
```
With this patch:
```
// @GENERATOR:play-routes-compiler
// @SOURCE:conf/routes
```

Did manual testing, works great (means the error page get's shown highlighting an invalid line in the routes file if there is one)