### PR TITLE
Upgrade akka and akka-http

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.10")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.13")
   val akkaHttpVersion     = "10.1.13"
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.13")
-  val akkaHttpVersion     = "10.1.13"
+  val akkaHttpVersion     = "10.1.14"
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.2"
 


### PR DESCRIPTION
https://akka.io/blog/news/2021/02/23/akka-2.6.13-released
https://github.com/akka/akka-http/releases/tag/v10.1.14

**Note that this release may need your project to upgrade to the latest Scala version to compile (Scala 2.13.4+ or 2.12.13+)**
See #10713