### PR TITLE
fix Int overflow in BodyParsers.anyContent(maxLength: Option[Long])

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -918,7 +918,7 @@ trait PlayBodyParsers extends BodyParserUtils {
   def anyContent(maxLength: Option[Long]): BodyParser[AnyContent] = BodyParser("anyContent") { request =>
     import Execution.Implicits.trampoline
 
-    def maxLengthOrDefault          = maxLength.fold(DefaultMaxTextLength)(_.toInt)
+    def maxLengthOrDefault          = maxLength.getOrElse(DefaultMaxTextLength)
     def maxLengthOrDefaultLarge     = maxLength.getOrElse(DefaultMaxDiskLength)
     val contentType: Option[String] = request.contentType.map(_.toLowerCase(Locale.ENGLISH))
     contentType match {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

fix Int overflow. please see test case

## Purpose


## Background Context


## References

use `Long` since https://github.com/playframework/playframework/pull/8627
