### PR TITLE
Make public DatabaseEvolutions.databaseEvolutions()

### DIFF
--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -216,7 +216,7 @@ class DatabaseEvolutions(database: Database, schema: String = "", metaTable: Str
   /**
    * Read evolutions from the database.
    */
-  private def databaseEvolutions(): Seq[Evolution] = {
+  def databaseEvolutions(): Seq[Evolution] = {
     implicit val connection = database.getConnection(autocommit = true)
 
     try {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Without direct access to the top-level method that returns all Evolutions in the database, any code that wants to do this while preserving the DB representation needs to reimplement or copy-paste several hundred lines of code from DatabaseEvolutions for interacting directly with the play_evolutions table. By making this one method public, such customization can be done with maybe 20 lines of non-boilerplate code.

## Background Context

Customizing the conflict-detection and -resolution behavior is a desirable use-case. For example:

* ignoring changes in very old evolutions, or in a set of known-bad historical evolutions
* comparisons of scripts that are tolerant to differing line ending conventions