### PR TITLE
Release drafter should use correct version + 2.8.x branch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,7 @@
 # Config for https://github.com/toolmantim/release-drafter
-name-template: 'Play $NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: 'Play $NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
+filter-by-commitish: true
 
 change-template: '- $TITLE [#$NUMBER](https://github.com/playframework/playframework/issues/$NUMBER) by [@$AUTHOR](https://github.com/$AUTHOR)'
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - master
+      - 2.8.x
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Currently the release drafted for master branch is wrongly titled `Play 2.8.8`

Also I want to enable the release drafter for the 2.8.x branch, not sure if that is all it needs.

Lets see.