### PR TITLE
[2.8.x] Add release-drafter workflow for 2.8.x branch + docs update

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - 2.8.x
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-2.8.x.yml # located in .github/ in default branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -26,7 +26,7 @@ Although Play 2.8 still supports sbt 0.13, we recommend that you use sbt 1. This
 sbt.version=1.3.10
 ```
 
-At the time of this writing `1.3.10` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version releases and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
+At the time of this writing `1.3.10` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version [releases](https://github.com/playframework/playframework/releases) and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
 
 ## API Changes
 

--- a/documentation/manual/tutorial/Tutorials.md
+++ b/documentation/manual/tutorial/Tutorials.md
@@ -47,6 +47,14 @@ The Play community also has a number of tutorials and templates that cover aspec
 
 This is an incomplete list of several helpful blog posts, and because some of the blog posts have been written a while ago, this section is organized by Play version.
 
+### 2.8.x
+
+#### Play Framework Tutorials and other contents
+
+* [Forms Tutorial in Play Framework](https://petrepopescu.tech/2021/01/building-a-form-in-play-framework/): In this tutorial you will learn how to handle forms in Play Framework, complete with error handling and displaying in using the Twirl template engine.
+* [Building a REST API in Play Framework](https://petrepopescu.tech/2021/02/building-a-rest-api-in-play-framework/): This article shows how to create an application using Play Framework and Java with `GET`, `POST`, `PUT` and `DELETE` APIs for CRUD operations.
+* [Handling Exceptions and Errors in Play Framework](https://petrepopescu.tech/2021/03/handling-exceptions-and-errors-in-play-framework/): A tutorial on how to handle exceptions in Play Framework so that propper return codes are send back to the client with a response body that provides the needed information about the error.
+
 ### 2.6.x
 
 #### Play Framework Tutorials and other contents


### PR DESCRIPTION
This activates the workflow for release drafter with the config (`.github/release-drafter-2.8.x.yml`) that gets added to the default (=master) branch via #10774
Also same doc updates like in #10774