### PR TITLE
revert changes to playCommonClassloaderTask since we are using scala 2.12.13

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -37,10 +37,8 @@ object PlayCommands {
   val playCommonClassloaderTask = Def.task {
     val classpath = (dependencyClasspath in Compile).value
     val log       = streams.value.log
-    //we need to handle scala-library.jar from ivy cache, or scala-library-2.x.x from coursier, but not for example scala-library-next.jar
     lazy val commonJars: PartialFunction[java.io.File, java.net.URL] = {
-      case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar"                        => jar.toURI.toURL
-      case jar if jar.getName.startsWith("scala-library-2") || jar.getName == "scala-library.jar" => jar.toURI.toURL
+      case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar" => jar.toURI.toURL
     }
 
     if (commonClassLoader == null) {


### PR DESCRIPTION
Reverts the changes introduced in #10500 to workaround a classtag leak. Since meanwhile the classtag leak was fixed in scala 2.12.13 (https://github.com/scala/scala/pull/9276) the workaround can be reverted.

Since in #10500 we also reduced the MaxMetaspaceSize, hopefully the tests will also caught any regressions

