### PR TITLE
replace deprecated hibernate-jpa-2.1-api dependency with official javax.persistence-api

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,7 +75,7 @@ object Dependencies {
   ) ++ specs2Deps.map(_  % Test)
 
   val jpaDeps = Seq(
-    "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.2.Final",
+    "javax.persistence"               % "javax.persistence-api" % "2.2" % "provided",
     "org.hibernate"                   % "hibernate-core"        % "5.4.27.Final" % "test"
   )
 


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10785 

## Purpose

This PR replaces the deprecated `org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.2.0.Final` with `javax.persistence:javax.persistence-api:2.2` as stated in the project page as well -> https://github.com/hibernate/hibernate-jpa-api

New dependency added as `provided` to make sure that it'll be available during compilation but not part of the dependencies, since Hibernate already has a dependency to its supported version of JPA. This way, unless there's no breaking changes in the new JPA APIs, users can upgrade their Hibernate version without having multiple versions of the JPA API.

Also, instead of current JPA 2.1, JPA 2.2 API added since current supported Hibernate version, 5.4.x, supports 2.2 + this is compile-only, Hibernate 5.4 brings JPA 2.2 dependency anyway.

Note: I didn't update the persistence.xml file in the `play-java-jpa/src/test/resources/META-INF`, if requested, I can also update it to 2.2.

## Background Context

To remove deprecated libraries.

## References

Are there any relevant issues / PRs / mailing lists discussions?
