### PR TITLE
Fixed `###replace:` tag that led to incorrect docs

### DIFF
--- a/documentation/manual/tutorial/code/javaguide/hello/HelloController.java
+++ b/documentation/manual/tutorial/code/javaguide/hello/HelloController.java
@@ -20,8 +20,8 @@ public class HelloController extends Controller {
 
   // #hello-world-index-action
   public Result index() {
-// ###replace: return ok(views.html.index.render("Your new application is ready.", assetsFinder));
-    return ok(javaguide.hello.html.index.render("Your new application is ready.", assetsFinder));
+    // ###replace: return ok(views.html.index.render("Your app is ready.", assetsFinder));
+    return ok(javaguide.hello.html.index.render("Your app is ready.", assetsFinder));
   }
   // #hello-world-index-action
 

--- a/documentation/manual/tutorial/code/javaguide/hello/HelloController.java
+++ b/documentation/manual/tutorial/code/javaguide/hello/HelloController.java
@@ -20,8 +20,7 @@ public class HelloController extends Controller {
 
   // #hello-world-index-action
   public Result index() {
-    // ###replace:        return ok(views.html.index.render("Your new application is
-    // ready.",assetsFinder));
+    // ###replace: return ok(views.html.index.render("Your new application is ready.", assetsFinder));
     return ok(javaguide.hello.html.index.render("Your new application is ready.", assetsFinder));
   }
   // #hello-world-index-action

--- a/documentation/manual/tutorial/code/javaguide/hello/HelloController.java
+++ b/documentation/manual/tutorial/code/javaguide/hello/HelloController.java
@@ -20,7 +20,7 @@ public class HelloController extends Controller {
 
   // #hello-world-index-action
   public Result index() {
-    // ###replace: return ok(views.html.index.render("Your new application is ready.", assetsFinder));
+// ###replace: return ok(views.html.index.render("Your new application is ready.", assetsFinder));
     return ok(javaguide.hello.html.index.render("Your new application is ready.", assetsFinder));
   }
   // #hello-world-index-action


### PR DESCRIPTION


## Fixes

Documentation that is incorrect: [before]( https://www.playframework.com/documentation/2.8.x/PlayApplicationOverview) 
```java
public Result index() {
       return ok(views.html.index.render("Your new application is
  return ok(javaguide.hello.html.index.render("Your new application is ready.", assetsFinder));
}
```

According to https://www.playframework.com/documentation/2.8.x/Documentation
```###replace: foo — Replace the next line with foo. You may optionally terminate this command with ###```

The code sample that was to be run, tested, and injected into the documentation was split into multiple lines (likely by an autoformatter) which made the documentation for the java example incorrect. 

This PR changes the 'replace' to one line, and also reduces the whitespace on the left to prevent the autoformatter from splitting the line into two.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

