### PR TITLE
Akka-Http-Server: allow Headers.remove() to remove Content-Type and Content-Length

### DIFF
--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -391,7 +391,7 @@ final case class AkkaHeadersWrapper(
     copy(hs = this.hs ++ raw(headers))
 
   override def remove(keys: String*): Headers = {
-    val lowerCasedKeys = keys.map(_.toLowerCase)
+    val lowerCasedKeys = keys.map(_.toLowerCase(Locale.ROOT))
     copy(
       hs = hs.filterNot(h => lowerCasedKeys.exists(h.is)),
       knownContentLength =

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -393,9 +393,7 @@ final case class AkkaHeadersWrapper(
   override def remove(keys: String*): Headers = {
     val lowerCasedKeys = keys.map(_.toLowerCase)
     copy(
-      hs = hs.filterNot(h =>
-        lowerCasedKeys.exists(h.is)
-      ),
+      hs = hs.filterNot(h => lowerCasedKeys.exists(h.is)),
       knownContentLength =
         if (lowerCasedKeys.contains(CONTENT_LENGTH_LOWER_CASE))
           None

--- a/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
+++ b/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
@@ -57,7 +57,8 @@ class AkkaHeadersWrapperTest extends Specification {
     "remove the Content-Length header" in {
       val plainTextEntity = HttpEntity("Some payload")
       val request         = emptyRequest.copy(entity = plainTextEntity)
-      val headersWrapper  = AkkaHeadersWrapper(request, Some(plainTextEntity.contentLength.toString), request.headers, None, "some-uri")
+      val headersWrapper =
+        AkkaHeadersWrapper(request, Some(plainTextEntity.contentLength.toString), request.headers, None, "some-uri")
       headersWrapper(HeaderNames.CONTENT_LENGTH) mustEqual plainTextEntity.contentLength.toString
 
       val cleaned = headersWrapper.remove(HeaderNames.CONTENT_LENGTH)

--- a/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
+++ b/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
@@ -5,6 +5,7 @@
 package play.core.server.akkahttp
 
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
 import org.specs2.mutable.Specification
 import play.api.http.HeaderNames
 
@@ -29,6 +30,38 @@ class AkkaHeadersWrapperTest extends Specification {
         .get
         ._2
       actualHeaderValue mustEqual "text/plain; charset=UTF-8"
+    }
+
+    "remove a header" in {
+      val name            = "my-private-header"
+      val plainTextEntity = HttpEntity("Some payload")
+      val headers         = Seq(RawHeader(name, "asdf"))
+      val request         = emptyRequest.copy(entity = plainTextEntity, headers = headers)
+      val headersWrapper  = AkkaHeadersWrapper(request, None, request.headers, None, "some-uri")
+      headersWrapper(name) mustEqual "asdf"
+
+      val cleaned = headersWrapper.remove(name)
+      cleaned.get(name) must beNone
+    }
+
+    "remove the Content-Type header" in {
+      val plainTextEntity = HttpEntity("Some payload")
+      val request         = emptyRequest.copy(entity = plainTextEntity)
+      val headersWrapper  = AkkaHeadersWrapper(request, None, request.headers, None, "some-uri")
+      headersWrapper(HeaderNames.CONTENT_TYPE) mustEqual "text/plain; charset=UTF-8"
+
+      val cleaned = headersWrapper.remove(HeaderNames.CONTENT_TYPE)
+      cleaned.get(HeaderNames.CONTENT_TYPE) must beNone
+    }
+
+    "remove the Content-Length header" in {
+      val plainTextEntity = HttpEntity("Some payload")
+      val request         = emptyRequest.copy(entity = plainTextEntity)
+      val headersWrapper  = AkkaHeadersWrapper(request, Some(plainTextEntity.contentLength.toString), request.headers, None, "some-uri")
+      headersWrapper(HeaderNames.CONTENT_LENGTH) mustEqual plainTextEntity.contentLength.toString
+
+      val cleaned = headersWrapper.remove(HeaderNames.CONTENT_LENGTH)
+      cleaned.get(HeaderNames.CONTENT_LENGTH) must beNone
     }
   }
 }

--- a/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
+++ b/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
@@ -35,7 +35,7 @@ class AkkaHeadersWrapperTest extends Specification {
     "remove a header" in {
       val name            = "my-private-header"
       val plainTextEntity = HttpEntity("Some payload")
-      val headers         = Seq(RawHeader(name, "asdf"))
+      val headers         = scala.collection.immutable.Seq(RawHeader(name, "asdf"))
       val request         = emptyRequest.copy(entity = plainTextEntity, headers = headers)
       val headersWrapper  = AkkaHeadersWrapper(request, None, request.headers, None, "some-uri")
       headersWrapper(name) mustEqual "asdf"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Fixes Header.remove() in the specialized AkkaHeadersWrapper to support removing `Content-Type` and `Content-Length`.

This didn't work before because Content-Type and Content-Length are broken out into `knownContentLength` and `request.entity.contentType`

## Background Context

We ran into this issue in our Play proxy server which uses Headers.remove() to strip some incoming headers before proxying to the desired service