### PR TITLE
Initialize static Json objectMapper only once

### DIFF
--- a/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
+++ b/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
@@ -14,6 +14,8 @@ import javax.inject._
 import play.api.inject._
 import play.libs.Json
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 /**
  * Module that injects an object mapper to the JSON library on start and on stop.
  *
@@ -32,13 +34,17 @@ object ObjectMapperProvider {
 class ObjectMapperProvider @Inject() (lifecycle: ApplicationLifecycle, actorSystem: ActorSystem)
     extends Provider[ObjectMapper] {
 
+  private val staticObjectMapperInitialized = new AtomicBoolean(false)
+
   lazy val get: ObjectMapper = {
     val mapper =
       JacksonObjectMapperProvider
         .get(actorSystem)
         .getOrCreate(ObjectMapperProvider.BINDING_NAME, Option.empty)
     mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.PUBLIC_ONLY)
-    Json.setObjectMapper(mapper)
+    if (staticObjectMapperInitialized.compareAndSet(false, true)) {
+      Json.setObjectMapper(mapper)
+    }
 
     lifecycle.addStopHook { () =>
       Future.successful(Json.setObjectMapper(null))

--- a/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
+++ b/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
@@ -44,10 +44,10 @@ class ObjectMapperProvider @Inject() (lifecycle: ApplicationLifecycle, actorSyst
     mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.PUBLIC_ONLY)
     if (staticObjectMapperInitialized.compareAndSet(false, true)) {
       Json.setObjectMapper(mapper)
-    }
 
-    lifecycle.addStopHook { () =>
-      Future.successful(Json.setObjectMapper(null))
+      lifecycle.addStopHook { () =>
+        Future.successful(Json.setObjectMapper(null))
+      }
     }
     mapper
   }


### PR DESCRIPTION
The static object mapper, that can be retrieved via the static method [`Json.mapper()`](https://github.com/playframework/playframework/blob/ce4dadbd8e46bf15b2f61b6e54d447b3e988d8b1/core/play/src/main/java/play/libs/Json.java#L54-L66) and set via the static method [`Json.setObjectMapper`](https://github.com/playframework/playframework/blob/2.8.7/core/play/src/main/java/play/libs/Json.java#L204-L214), should only be set once.

Right now it would be overriden each time the provider's `get` method is called (when someone uses DI to inject an objectmapper). That is not so good, because when I use `Json.mapper()` and modify that mapper via a setter e.g. `Json.mapper().setVisibility(...)` I would expect that modified object mapper to persist as long I don't call `Json.setObjectMapper` myself again (usually never). Now it can happen that randomly, without real control, the static objectmapper gets overriden as soon as an injection happens...
Also, I don't think the original intention was to call `setObjectMapper` more than once if you look at the javadocs of the `setObjectMapper` method:

https://github.com/playframework/playframework/blob/ce4dadbd8e46bf15b2f61b6e54d447b3e988d8b1/core/play/src/main/java/play/libs/Json.java#L207-L208