### PR TITLE
Fix docs: Flash cookie is signed

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
@@ -58,10 +58,9 @@ If you want to discard the whole session, there is special operation:
 
 ## Flash scope
 
-The Flash scope works exactly like the Session, but with two differences:
+The Flash scope works exactly like the Session, but with one difference:
 
 * data are kept for only one request
-* the Flash cookie is not signed, making it possible for the user to modify it.
 
 > **Important:** The flash scope should only be used to transport success/error messages on simple non-Ajax applications. As the data are just kept for the next request and because there are no guarantees to ensure the request order in a complex Web application, the Flash scope is subject to race conditions.
 

--- a/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
@@ -58,10 +58,9 @@ There is special operation that discards the whole session:
 
 ## Flash scope
 
-The Flash scope works exactly like the Session, but with two differences:
+The Flash scope works exactly like the Session, but with one difference:
 
 * data are kept for only one request
-* the Flash cookie is not signed, making it possible for the user to modify it.
 
 > **Important:** The Flash scope should only be used to transport success/error messages on simple non-Ajax applications. As the data are just kept for the next request and because there are no guarantees to ensure the request order in a complex Web application, the Flash scope is subject to race conditions.
 


### PR DESCRIPTION
Fixes the docs in:
* https://www.playframework.com/documentation/2.6.x/ScalaSessionFlash
* https://www.playframework.com/documentation/2.6.x/JavaSessionFlash

Since 9d6d39911c37bdaa6890e7916b9177e2376974b7 (Play 2.6) the flash cookie also gets signed.
