### PR TITLE
Java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,11 @@ jobs:
       name: "Code validations (format, binary compatibilty, whitesource, etc.)"
 #   - script: scripts/validate-docs
 #     name: "Validate docs (links, sample code, etc.)"
-    - script: scripts/validate-microbenchmarks
+    - script:
+        - echo "(mb before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 16 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
+        - echo "(mb after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/validate-microbenchmarks
       name: "Validate that microbenchmarks are runnable"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,17 @@ jobs:
 
 
     - stage: test
-      script: scripts/it-test $TEST_SCALA_2_13
+      script:
+        - echo "(it before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 16 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
+        - echo "(it after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/it-test $TEST_SCALA_2_13
       name: "Run it tests for Scala 2.13"
-    - script: scripts/it-test $TEST_SCALA_2_12
+    - script:
+        - echo "(it before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 16 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
+        - echo "(it after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/it-test $TEST_SCALA_2_12
       name: "Run it tests for Scala 2.12"
     - script: scripts/test $TEST_SCALA_2_13
       name: "Run tests for Scala 2.13"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ before_install:
   - . ~/.jabba/jabba.sh 
 install: jabba install 1.17.0-custom=tgz+https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_x64_linux_hotspot_2021-05-06-23-30.tar.gz && jabba use 1.17.0-custom && java -Xmx32m -version
 
+after_script:
+  - echo "(before unset) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+  - unset JAVA_TOOL_OPTIONS
+  - echo "(after unset) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+
 stages:
   - validations
   - test
@@ -53,18 +58,37 @@ jobs:
       name: "Code validations (format, binary compatibilty, whitesource, etc.)"
 #   - script: scripts/validate-docs
 #     name: "Validate docs (links, sample code, etc.)"
-      # skip validate-microbenchmarks for now because it would also need --add-exports=java.base/sun.security.x509=ALL-UNNAMED
-#   - script: scripts/validate-microbenchmarks
-#     name: "Validate that microbenchmarks are runnable"
+    - script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/validate-microbenchmarks
+      name: "Validate that microbenchmarks are runnable"
 
     - stage: test
-      script: scripts/it-test $TEST_SCALA_2_13
+      script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/it-test $TEST_SCALA_2_13
       name: "Run it tests for Scala 2.13"
-    - script: scripts/it-test $TEST_SCALA_2_12
+    - script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/it-test $TEST_SCALA_2_12
       name: "Run it tests for Scala 2.12"
-    - script: scripts/test $TEST_SCALA_2_13
+    - script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/test $TEST_SCALA_2_13
       name: "Run tests for Scala 2.13"
-    - script: scripts/test $TEST_SCALA_2_12
+    - script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/test $TEST_SCALA_2_12
       name: "Run tests for Scala 2.12"
     - script: scripts/test-docs $TEST_SCALA_2_13
       name: "Run documentation tests 2.13"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ jobs:
           paths: "$HOME/.ivy2/local/com.typesafe.play"
     - script: scripts/validate-code
       name: "Code validations (format, binary compatibilty, whitesource, etc.)"
-    - script: scripts/validate-docs
-      name: "Validate docs (links, sample code, etc.)"
+#   - script: scripts/validate-docs
+#     name: "Validate docs (links, sample code, etc.)"
     - script: scripts/validate-microbenchmarks
       name: "Validate that microbenchmarks are runnable"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ jobs:
       name: "Code validations (format, binary compatibilty, whitesource, etc.)"
 #   - script: scripts/validate-docs
 #     name: "Validate docs (links, sample code, etc.)"
-    - script: scripts/validate-microbenchmarks
-      name: "Validate that microbenchmarks are runnable"
-
+      # skip validate-microbenchmarks for now because it would also need --add-exports=java.base/sun.security.x509=ALL-UNNAMED
+#   - script: scripts/validate-microbenchmarks
+#     name: "Validate that microbenchmarks are runnable"
 
     - stage: test
       script: scripts/it-test $TEST_SCALA_2_13

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - curl --version # for debug purpose
   - if [ ! -f ~/.jabba/jabba.sh ]; then curl -L -v --retry 5 -o jabba-install.sh https://git.io/jabba && bash jabba-install.sh; fi
   - . ~/.jabba/jabba.sh 
-install: jabba install 1.17.0-custom=tgz+https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_x64_linux_hotspot_2021-05-06-23-30.tar.gz && jabba use 1.17.0-custom && java -Xmx32m -version
+install: jabba install 1.17.0-custom=tgz+https://github.com/adoptium/temurin17-binaries/releases/download/jdk17-2021-07-09-12-54-beta/OpenJDK17-jdk_x64_linux_hotspot_2021-07-09-12-54.tar.gz && jabba use 1.17.0-custom && java -Xmx32m -version
 
 after_script:
   - echo "(before unset) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,26 +62,14 @@ jobs:
       name: "Code validations (format, binary compatibilty, whitesource, etc.)"
 #   - script: scripts/validate-docs
 #     name: "Validate docs (links, sample code, etc.)"
-    - script:
-        - echo "(mb before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
-        - echo "(mb after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - scripts/validate-microbenchmarks
+    - script: scripts/validate-microbenchmarks
       name: "Validate that microbenchmarks are runnable"
 
 
     - stage: test
-      script:
-        - echo "(it before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
-        - echo "(it after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - scripts/it-test $TEST_SCALA_2_13
+      script: scripts/it-test $TEST_SCALA_2_13
       name: "Run it tests for Scala 2.13"
-    - script:
-        - echo "(it before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
-        - echo "(it after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - scripts/it-test $TEST_SCALA_2_12
+    - script: scripts/it-test $TEST_SCALA_2_12
       name: "Run it tests for Scala 2.12"
     - script: scripts/test $TEST_SCALA_2_13
       name: "Run tests for Scala 2.13"

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,13 +68,13 @@ jobs:
     - stage: test
       script:
         - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
         - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
         - scripts/it-test $TEST_SCALA_2_13
       name: "Run it tests for Scala 2.13"
     - script:
         - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
         - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
         - scripts/it-test $TEST_SCALA_2_12
       name: "Run it tests for Scala 2.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - TEST_SCALA_2_12: "2.12.13"
     - TEST_SCALA_2_13: "2.13.5"
   jobs:
-    - TRAVIS_JDK=16
+    - TRAVIS_JDK=17
 
 before_install:
   - |
@@ -31,11 +31,11 @@ before_install:
   - curl --version # for debug purpose
   - if [ ! -f ~/.jabba/jabba.sh ]; then curl -L -v --retry 5 -o jabba-install.sh https://git.io/jabba && bash jabba-install.sh; fi
   - . ~/.jabba/jabba.sh 
-install: jabba install 1.16.0-custom=tgz+https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz && jabba use 1.16.0-custom && java -Xmx32m -version
+install: jabba install 1.17.0-custom=tgz+https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_x64_linux_hotspot_2021-05-06-23-30.tar.gz && jabba use 1.17.0-custom && java -Xmx32m -version
 
 before_script:
   - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-  - if [ "$TRAVIS_JDK" = 16 ]; then export JAVA_TOOL_OPTIONS="--add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+  - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="--add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
   - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
 
 after_script:
@@ -64,7 +64,7 @@ jobs:
 #     name: "Validate docs (links, sample code, etc.)"
     - script:
         - echo "(mb before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 16 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
         - echo "(mb after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
         - scripts/validate-microbenchmarks
       name: "Validate that microbenchmarks are runnable"
@@ -73,13 +73,13 @@ jobs:
     - stage: test
       script:
         - echo "(it before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 16 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
         - echo "(it after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
         - scripts/it-test $TEST_SCALA_2_13
       name: "Run it tests for Scala 2.13"
     - script:
         - echo "(it before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 16 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
         - echo "(it after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
         - scripts/it-test $TEST_SCALA_2_12
       name: "Run it tests for Scala 2.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - TEST_SCALA_2_12: "2.12.13"
     - TEST_SCALA_2_13: "2.13.5"
   jobs:
-    - TRAVIS_JDK=11
+    - TRAVIS_JDK=16
 
 before_install:
   - |
@@ -31,15 +31,13 @@ before_install:
   - curl --version # for debug purpose
   - if [ ! -f ~/.jabba/jabba.sh ]; then curl -L -v --retry 5 -o jabba-install.sh https://git.io/jabba && bash jabba-install.sh; fi
   - . ~/.jabba/jabba.sh 
-install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=patch) && jabba use "$_" && java -Xmx32m -version
+install: jabba install 1.16.0-custom=tgz+https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz && jabba use 1.16.0-custom && java -Xmx32m -version
 
 stages:
   - validations
   - test
   - test-sbt-1.3.x
-  - cron-test-sbt-1.3.x
-  - cron-test-sbt-1.5.x
-  - java8
+  - test-sbt-1.5.x
 
 jobs:
   include:
@@ -49,13 +47,6 @@ jobs:
       workspaces:
         create:
           name: published-local
-          paths: "$HOME/.ivy2/local/com.typesafe.play"
-    - name: "Run publishLocal on Java 8"
-      script: scripts/publish-local
-      env: TRAVIS_JDK=8
-      workspaces:
-        create:
-          name: published-local-jdk8
           paths: "$HOME/.ivy2/local/com.typesafe.play"
     - script: scripts/validate-code
       name: "Code validations (format, binary compatibilty, whitesource, etc.)"
@@ -92,47 +83,15 @@ jobs:
       script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*3of3'
       workspaces:
         use: published-local
-
-    # Test against Java 8, but only for Scala 2.12
-    - stage: java8
-      script: scripts/test $TEST_SCALA_2_12
-      env: TRAVIS_JDK=8
-      name: "Run tests for Scala 2.12 and Java 8"
-    - script: scripts/it-test $TEST_SCALA_2_12
-      env: TRAVIS_JDK=8
-      name: "Run it tests for Scala 2.12 and Java 8"
-    - script: scripts/test-docs $TEST_SCALA_2_12
-      env: TRAVIS_JDK=8
-      name: "Run documentation tests for Scala 2.12 and Java 8"
-    - name: "Run scripted tests (a) for sbt 1.3.x and Scala 2.12.x and Java 8"
-      script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*1of3'
-      env: TRAVIS_JDK=8
-      workspaces:
-        use: published-local-jdk8
-    - name: "Run scripted tests (b) for sbt 1.3.x and Scala 2.12.x and Java 8"
-      script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*2of3'
-      env: TRAVIS_JDK=8
-      workspaces:
-        use: published-local-jdk8
-    - name: "Run scripted tests (c) for sbt 1.3.x and Scala 2.12.x and Java 8"
-      script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*3of3'
-      env: TRAVIS_JDK=8
-      workspaces:
-        use: published-local-jdk8
-
-    # Test against sbt 1.3.x and Scala 2.13.x, but only for cron builds
-    # (sbt 1.3.x / Scala 2.12.x was tested above already)
-    - stage: cron-test-sbt-1.3.x
-      name: "Run tests for sbt 1.3.x and Scala 2.13.x"
+    - name: "Run tests for sbt 1.3.x and Scala 2.13.x"
       script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_13
-      if: type = cron
       workspaces:
         use: published-local
-    # Test against sbt 1.5.x, but only for cron builds
-    - stage: cron-test-sbt-1.5.x
+
+    # Test against sbt 1.5.x
+    - stage: test-sbt-1.5.x
       name: "Run tests for 1.5.x and Scala 2.13.x"
       script: scripts/test-scripted $SCRIPTED_SBT_1_5 $TEST_SCALA_2_13
-      if: type = cron
       workspaces:
         use: published-local
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,16 @@ before_install:
   - . ~/.jabba/jabba.sh 
 install: jabba install 1.16.0-custom=tgz+https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz && jabba use 1.16.0-custom && java -Xmx32m -version
 
+before_script:
+  - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+  - if [ "$TRAVIS_JDK" = 16 ]; then export JAVA_TOOL_OPTIONS="--add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+  - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+
+after_script:
+  - echo "(before unset) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+  - unset JAVA_TOOL_OPTIONS
+  - echo "(after unset) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+
 stages:
   - validations
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-group: dev
+group: edge
 
 # Only build non-pushes (so PRs, API requests & cron jobs) OR tags OR forks OR main branch builds
 # https://docs.travis-ci.com/user/conditional-builds-stages-jobs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
 #     name: "Validate docs (links, sample code, etc.)"
     - script:
         - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.ssl=ALL-UNNAMED"; fi
         - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
         - scripts/validate-microbenchmarks
       name: "Validate that microbenchmarks are runnable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+group: dev
 
 # Only build non-pushes (so PRs, API requests & cron jobs) OR tags OR forks OR main branch builds
 # https://docs.travis-ci.com/user/conditional-builds-stages-jobs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,6 @@ before_install:
   - . ~/.jabba/jabba.sh 
 install: jabba install 1.17.0-custom=tgz+https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_x64_linux_hotspot_2021-05-06-23-30.tar.gz && jabba use 1.17.0-custom && java -Xmx32m -version
 
-before_script:
-  - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-  - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="--add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
-  - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-
-after_script:
-  - echo "(before unset) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-  - unset JAVA_TOOL_OPTIONS
-  - echo "(after unset) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-
 stages:
   - validations
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,26 +97,46 @@ jobs:
 
     - stage: test-sbt-1.3.x
       name: "Run scripted tests (a) for sbt 1.3.x and Scala 2.12.x"
-      script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*1of3'
+      script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*1of3'
       workspaces:
         use: published-local
     - name: "Run scripted tests (b) for sbt 1.3.x and Scala 2.12.x"
-      script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*2of3'
+      script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*2of3'
       workspaces:
         use: published-local
     - name: "Run scripted tests (c) for sbt 1.3.x and Scala 2.12.x"
-      script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*3of3'
+      script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_12 'play-sbt-plugin/*3of3'
       workspaces:
         use: published-local
     - name: "Run tests for sbt 1.3.x and Scala 2.13.x"
-      script: scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_13
+      script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/test-scripted $SCRIPTED_SBT_1_3 $TEST_SCALA_2_13
       workspaces:
         use: published-local
 
     # Test against sbt 1.5.x
     - stage: test-sbt-1.5.x
       name: "Run tests for 1.5.x and Scala 2.13.x"
-      script: scripts/test-scripted $SCRIPTED_SBT_1_5 $TEST_SCALA_2_13
+      script:
+        - echo "(before set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - if [ "$TRAVIS_JDK" = 17 ]; then export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED"; fi
+        - echo "(after set) JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+        - scripts/test-scripted $SCRIPTED_SBT_1_5 $TEST_SCALA_2_13
       workspaces:
         use: published-local
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
@@ -17,4 +17,4 @@ lazy val root = (project in file("."))
     }
   )
 
-javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())
+// FYI: here javaOptions in Test ++=... does not work, because we use "run" in the test script

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
@@ -14,5 +14,6 @@ lazy val root = (project in file("."))
       val args                = Def.spaceDelimited("<path> <status> ...").parsed
       val path :: status :: _ = args
       ScriptedTools.verifyResourceContainsSsl(path, status.toInt)
-    }
+    },
+    javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())
   )

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
@@ -14,6 +14,7 @@ lazy val root = (project in file("."))
       val args                = Def.spaceDelimited("<path> <status> ...").parsed
       val path :: status :: _ = args
       ScriptedTools.verifyResourceContainsSsl(path, status.toInt)
-    },
-    javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())
+    }
   )
+
+javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/build.sbt
@@ -20,4 +20,4 @@ libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
 
-javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())
+//javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/build.sbt
@@ -19,3 +19,5 @@ evictionWarningOptions in update ~= (_.withWarnTransitiveEvictions(false).withWa
 libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
+
+javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
@@ -20,4 +20,4 @@ libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
 
-javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())
+//javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
@@ -19,3 +19,5 @@ evictionWarningOptions in update ~= (_.withWarnTransitiveEvictions(false).withWa
 libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
+
+javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
@@ -20,3 +20,5 @@ evictionWarningOptions in update ~= (_.withWarnTransitiveEvictions(false).withWa
 libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
+
+javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
@@ -21,4 +21,4 @@ libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
 
-javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())
+//javaOptions in Test ++= (if(!System.getProperty("java.version").startsWith("1.8.")) Seq("--add-exports=java.base/sun.security.x509=ALL-UNNAMED") else Seq())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -158,7 +158,7 @@ object Dependencies {
 
   val jimfs = "com.google.jimfs" % "jimfs" % "1.2"
 
-  val okHttp = "com.squareup.okhttp3" % "okhttp" % "4.9.1"
+  val okHttp = "com.squareup.okhttp3" % "okhttp" % "5.0.0-alpha.2"
 
   def routesCompilerDependencies(scalaVersion: String) = {
     specs2Deps.map(_ % Test) ++ Seq(specsMatcherExtra % Test) ++ scalaParserCombinators ++ (logback % Test :: Nil)


### PR DESCRIPTION
### :point_right: If you are looking for a way run Play 2.8.x with Java 17... Yes, that is possible since Play 2.8.15: https://github.com/playframework/playframework/releases/tag/2.8.15

<hr>

Let's see how well Play plays with Java ~16~ 17.
The goal here is to make Play work with upcoming [Java 17 (release date: 2021/09/14)](https://openjdk.java.net/projects/jdk/17/) as early as possible, because just like Java 11, Java 17 will be a LTS version.

- [x] validate (see below)
- [x] compile
- [x] publishLocal
- [x] tests
- [x] integration tests (see below)
- [x] scripted tests

<hr>

**WIP: ---add-exports**

scripted tests:
https://travis-ci.com/github/playframework/playframework/jobs/498243543#L5170-L5174

<hr>

**Microbenchmark and integration tests with akka's http2 endpoint fail**

Failed Integration tests: https://travis-ci.com/github/playframework/playframework/jobs/498389129
See all the `java.net.SocketTimeoutException`s, http2 does not start. Also see the bottom of the logs, you will see the `InaccessibleObjectException`s.

Failed microbenchmarks: https://travis-ci.com/github/playframework/playframework/jobs/498367902#L1934-L1942
<details>
  <summary>Error log</summary>

```
...
[info] # JMH version: 1.25
[info] # VM version: JDK 16, OpenJDK 64-Bit Server VM, 16+36
[info] # VM invoker: /home/travis/.jabba/jdk/1.16.0-custom/bin/java
[info] # VM options: --add-exports=java.base/sun.security.x509=ALL-UNNAMED -XX:MaxMetaspaceSize=384m -Xmx512m -Xms128m
[info] # Warmup: <none>
[info] # Measurement: 1 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: play.microbenchmark.it.HelloWorldBenchmark.helloWorld
[info] # Parameters: (endpoint = ak-20-enc, reqsPerConn = 5)
[info] # Run progress: 88.89% complete, ETA 00:00:13
[info] # Fork: 1 of 1
[info] Picked up JAVA_TOOL_OPTIONS: --add-exports=java.base/sun.security.x509=ALL-UNNAMED
[info] Iteration   1: ERROR a.a.OneForOneStrategy - Unable to make public void sun.security.ssl.SSLEngineImpl.setHandshakeApplicationProtocolSelector(java.util.function.BiFunction) accessible: module java.base does not "opens sun.security.ssl" to unnamed module @5a2e4553
[info] akka.actor.ActorInitializationException: akka://application/system/Materializers/StreamSupervisor-0/TLS-for-flow-1-1: exception during creation
[info] 	at akka.actor.ActorInitializationException$.apply(Actor.scala:196)
[info] Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make public void sun.security.ssl.SSLEngineImpl.setHandshakeApplicationProtocolSelector(java.util.function.BiFunction) accessible: module java.base does not "opens sun.security.ssl" to unnamed module @5a2e4553
[info] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
...
```
</details>

* ~Will this be fixed when [upgrading to akka-http 10.2.x](https://github.com/playframework/playframework/pull/10411)?~ The problem is okhttp.
* Workaround for now: `--add-opens=java.base/sun.security.ssl=ALL-UNNAMED`

<hr>

**Validate docs fail (but not relevant for now)**
https://travis-ci.com/github/playframework/playframework/jobs/497685525#L4256
<details>
  <summary>Error log</summary>

```
[error] java.lang.RuntimeException: Error creating extended parser class: Could not determine whether class 'play.doc.CodeReferenceParser$$parboiled' has already been loaded
[error] 	at org.parboiled.Parboiled.createParser(Parboiled.java:58)
[error] 	at org.pegdown.plugins.PegDownPlugins$Builder.withPlugin(PegDownPlugins.java:126)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.parseMarkdownFile$1(PlayDocsValidation.scala:125)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.$anonfun$generateMarkdownRefReportTask$3(PlayDocsValidation.scala:209)
[error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
[error] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
[error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[error] 	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
[error] 	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
[error] 	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.$anonfun$generateMarkdownRefReportTask$1(PlayDocsValidation.scala:209)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error] 	at sbt.Execute.work(Execute.scala:291)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
[error] 	at java.base/java.lang.Thread.run(Thread.java:831)
[error] Caused by: java.lang.RuntimeException: Could not determine whether class 'play.doc.CodeReferenceParser$$parboiled' has already been loaded
[error] 	at org.parboiled.transform.AsmUtils.findLoadedClass(AsmUtils.java:213)
[error] 	at org.parboiled.transform.ParserTransformer.transformParser(ParserTransformer.java:35)
[error] 	at org.parboiled.Parboiled.createParser(Parboiled.java:54)
[error] 	at org.pegdown.plugins.PegDownPlugins$Builder.withPlugin(PegDownPlugins.java:126)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.parseMarkdownFile$1(PlayDocsValidation.scala:125)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.$anonfun$generateMarkdownRefReportTask$3(PlayDocsValidation.scala:209)
[error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
[error] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
[error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[error] 	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
[error] 	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
[error] 	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.$anonfun$generateMarkdownRefReportTask$1(PlayDocsValidation.scala:209)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error] 	at sbt.Execute.work(Execute.scala:291)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
[error] 	at java.base/java.lang.Thread.run(Thread.java:831)
[error] Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.findLoadedClass(java.lang.String) accessible: module java.base does not "opens java.lang" to unnamed module @79600226
[error] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
[error] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
[error] 	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
[error] 	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
[error] 	at org.parboiled.transform.AsmUtils.findLoadedClass(AsmUtils.java:206)
[error] 	at org.parboiled.transform.ParserTransformer.transformParser(ParserTransformer.java:35)
[error] 	at org.parboiled.Parboiled.createParser(Parboiled.java:54)
[error] 	at org.pegdown.plugins.PegDownPlugins$Builder.withPlugin(PegDownPlugins.java:126)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.parseMarkdownFile$1(PlayDocsValidation.scala:125)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.$anonfun$generateMarkdownRefReportTask$3(PlayDocsValidation.scala:209)
[error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
[error] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
[error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[error] 	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
[error] 	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
[error] 	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
[error] 	at com.typesafe.play.docs.sbtplugin.PlayDocsValidation$.$anonfun$generateMarkdownRefReportTask$1(PlayDocsValidation.scala:209)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error] 	at sbt.Execute.work(Execute.scala:291)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
[error] 	at java.base/java.lang.Thread.run(Thread.java:831)
[error] (generateMarkdownRefReport) Error creating extended parser class: Could not determine whether class 'play.doc.CodeReferenceParser$$parboiled' has already been loaded
```
</details>

[Line that causes the exception](https://github.com/playframework/playframework/blob/2.8.8/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala#L125).
Problem: play-docs [depends on unmaintained pegdown 1.6.0](https://github.com/playframework/play-doc/blob/2.1.0/build.sbt#L11) (which is discussed [here](https://github.com/playframework/play-doc/issues/35) already), which [depends on outdated parboiled-java 1.1.7](https://github.com/sirthias/pegdown/blob/1.6.0/build.sbt#L36), which [depends on outdated ASM version 5.0.3](https://github.com/sirthias/parboiled/blob/1.1.7/project/Dependencies.scala#L15) that has no support for newer JDKs. Even current parboiled 1.3.1 (which is the latest versions as time of this writing) only [includes ASM 7.1](https://github.com/sirthias/parboiled/blob/1.3.1/project/Dependencies.scala#L15), which still does not support Java 16. Only parboiled's master branch already [depends on latest ASM 9.1](https://github.com/sirthias/parboiled/blob/35e0524d8261a89be2dfa947d75c318a3b2eeb75/project/Dependencies.scala#L15).
However, this problem is not urgent and does not block Play from supporting Java 17, because this is "just" about "Validate docs (links, sample code, etc.)". We can and will continue running this jobs with Java 8, and even if ditch Java 8, we will probably only move the Java 11 as next step which will still work. So I think we are good for a couple more years (I mean in theory, we can even run this validation jobs with Java 8/11 forever).
We could also try to just override the ASM dependency, maybe that would be enough(?)