### PR TITLE
Fix reference.conf "router.Routes" FCQN comment

### DIFF
--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -25,7 +25,7 @@ play {
 
     # The router.
     # Used by Play's built in DI support to locate and bind a request handler.  Must be the FQCN of a Play router.
-    # If null, will attempt to load a class called Routes in the root package, otherwise if that's not found, an empty
+    # If null, will attempt to load a class called router.Routes, otherwise if that's not found, an empty
     # router will be bound.
     router = null
 


### PR DESCRIPTION
## Fixes

Updates the comment to match [the location used by play](https://github.com/playframework/playframework/blob/92828167e88c419b712bb699ec8a87952b5d643f/core/play/src/main/scala/play/api/routing/Router.scala#L87). Moved in #4106. Placing a file in `_root_.Routes` is currently ignored by play 2.8.