### PR TITLE
Fix tail-recursive deserializer (Lagom's #3241)

### DIFF
--- a/core/play/src/main/scala/play/utils/JsonNodeDeserializer.scala
+++ b/core/play/src/main/scala/play/utils/JsonNodeDeserializer.scala
@@ -196,9 +196,6 @@ private class JsonNodeDeserializer extends JsonDeserializer[JsonNode] {
       case JsonTokenId.ID_EMBEDDED_OBJECT => (Some(fromEmbedded(jp, ctxt)), parserContext)
     }
 
-    // Read ahead
-    jp.nextToken()
-
     maybeValue match {
       case Some(v) if nextContext.isEmpty =>
         // done, no more tokens and got a value!
@@ -206,6 +203,8 @@ private class JsonNodeDeserializer extends JsonDeserializer[JsonNode] {
         v
 
       case maybeValue =>
+        // Read ahead
+        jp.nextToken()
         val toPass = maybeValue
           .map { v =>
             val previous :: stack = nextContext

--- a/core/play/src/test/java/play/utils/Child.java
+++ b/core/play/src/test/java/play/utils/Child.java
@@ -5,6 +5,7 @@
 package play.utils;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -18,7 +19,9 @@ public class Child {
   @NonNull String updatedBy;
 
   @JsonCreator
-  public Child(@NonNull Long updatedAt, @NonNull String updatedBy) {
+  public Child(
+      @JsonProperty("udpatedAt") @NonNull Long updatedAt,
+      @JsonProperty("udpatedBy") @NonNull String updatedBy) {
     this.updatedAt = updatedAt;
     this.updatedBy = updatedBy;
   }

--- a/core/play/src/test/java/play/utils/Child.java
+++ b/core/play/src/test/java/play/utils/Child.java
@@ -20,8 +20,8 @@ public class Child {
 
   @JsonCreator
   public Child(
-      @JsonProperty("udpatedAt") @NonNull Long updatedAt,
-      @JsonProperty("udpatedBy") @NonNull String updatedBy) {
+      @JsonProperty("updatedAt") @NonNull Long updatedAt,
+      @JsonProperty("updatedBy") @NonNull String updatedBy) {
     this.updatedAt = updatedAt;
     this.updatedBy = updatedBy;
   }

--- a/core/play/src/test/java/play/utils/Child.java
+++ b/core/play/src/test/java/play/utils/Child.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Objects;
+
+// refs https://github.com/lagom/lagom/issues/3241
+@JsonDeserialize(using = ChildDeserializer.class)
+public class Child {
+
+  @NonNull Long updatedAt;
+  @NonNull String updatedBy;
+
+  @JsonCreator
+  public Child(@NonNull Long updatedAt, @NonNull String updatedBy) {
+    this.updatedAt = updatedAt;
+    this.updatedBy = updatedBy;
+  }
+
+  public Long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Long updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  public void setUpdatedBy(String updatedBy) {
+    this.updatedBy = updatedBy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Child child = (Child) o;
+    return updatedAt.equals(child.updatedAt) && updatedBy.equals(child.updatedBy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(updatedAt, updatedBy);
+  }
+
+  @Override
+  public String toString() {
+    return "Child{" + "updatedAt=" + updatedAt + ", updatedBy='" + updatedBy + '\'' + '}';
+  }
+}

--- a/core/play/src/test/java/play/utils/Child.java
+++ b/core/play/src/test/java/play/utils/Child.java
@@ -15,13 +15,11 @@ import java.util.Objects;
 @JsonDeserialize(using = ChildDeserializer.class)
 public class Child {
 
-  @NonNull Long updatedAt;
-  @NonNull String updatedBy;
+  private final @NonNull Long updatedAt;
+  private final @NonNull String updatedBy;
 
   @JsonCreator
-  public Child(
-      @JsonProperty("updatedAt") @NonNull Long updatedAt,
-      @JsonProperty("updatedBy") @NonNull String updatedBy) {
+  public Child(@NonNull Long updatedAt, @NonNull String updatedBy) {
     this.updatedAt = updatedAt;
     this.updatedBy = updatedBy;
   }
@@ -30,16 +28,8 @@ public class Child {
     return updatedAt;
   }
 
-  public void setUpdatedAt(Long updatedAt) {
-    this.updatedAt = updatedAt;
-  }
-
   public String getUpdatedBy() {
     return updatedBy;
-  }
-
-  public void setUpdatedBy(String updatedBy) {
-    this.updatedBy = updatedBy;
   }
 
   @Override

--- a/core/play/src/test/java/play/utils/ChildDeserializer.java
+++ b/core/play/src/test/java/play/utils/ChildDeserializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+// refs https://github.com/lagom/lagom/issues/3241
+@SuppressWarnings("WeakerAccess")
+public class ChildDeserializer extends StdDeserializer<Child> {
+
+  public ChildDeserializer() {
+    this(null);
+  }
+
+  public ChildDeserializer(Class<?> vc) {
+    super(vc);
+  }
+
+  @Override
+  public Child deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+    JsonNode node = jp.readValueAsTree();
+    String updatedBy = node.get("updatedBy").asText();
+    Long updatedAt = node.get("updatedAt").asLong();
+
+    return new Child(updatedAt, updatedBy);
+  }
+}

--- a/core/play/src/test/java/play/utils/ChildDeserializer.java
+++ b/core/play/src/test/java/play/utils/ChildDeserializer.java
@@ -6,7 +6,6 @@ package play.utils;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 

--- a/core/play/src/test/java/play/utils/Parent.java
+++ b/core/play/src/test/java/play/utils/Parent.java
@@ -22,8 +22,8 @@ public class Parent {
   public Parent(
       @JsonProperty("createdAt") @NonNull Long createdAt,
       @JsonProperty("child") Child child,
-      @JsonProperty("udpatedAt") @NonNull Long updatedAt,
-      @JsonProperty("udpatedBy") @NonNull String updatedBy) {
+      @JsonProperty("updatedAt") @NonNull Long updatedAt,
+      @JsonProperty("updatedBy") @NonNull String updatedBy) {
     this.createdAt = createdAt;
     this.child = child;
     this.updatedAt = updatedAt;

--- a/core/play/src/test/java/play/utils/Parent.java
+++ b/core/play/src/test/java/play/utils/Parent.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Objects;
+
+// refs https://github.com/lagom/lagom/issues/3241
+public class Parent {
+
+  @NonNull Long createdAt;
+  Child child;
+  @NonNull Long updatedAt;
+  @NonNull String updatedBy;
+
+  @JsonCreator
+  public Parent(
+      @NonNull Long createdAt, Child child, @NonNull Long updatedAt, @NonNull String updatedBy) {
+    this.createdAt = createdAt;
+    this.child = child;
+    this.updatedAt = updatedAt;
+    this.updatedBy = updatedBy;
+  }
+
+  public Long getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Long createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public Child getChild() {
+    return child;
+  }
+
+  public void setChild(Child child) {
+    this.child = child;
+  }
+
+  public Long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Long updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  public void setUpdatedBy(String updatedBy) {
+    this.updatedBy = updatedBy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Parent parent = (Parent) o;
+    return createdAt.equals(parent.createdAt)
+        && child.equals(parent.child)
+        && updatedAt.equals(parent.updatedAt)
+        && updatedBy.equals(parent.updatedBy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(createdAt, child, updatedAt, updatedBy);
+  }
+
+  @Override
+  public String toString() {
+    return "Parent{"
+        + "createdAt="
+        + createdAt
+        + ", child="
+        + child
+        + ", updatedAt="
+        + updatedAt
+        + ", updatedBy='"
+        + updatedBy
+        + '\''
+        + '}';
+  }
+}

--- a/core/play/src/test/java/play/utils/Parent.java
+++ b/core/play/src/test/java/play/utils/Parent.java
@@ -13,10 +13,10 @@ import java.util.Objects;
 // refs https://github.com/lagom/lagom/issues/3241
 public class Parent {
 
-  @NonNull Long createdAt;
-  Child child;
-  @NonNull Long updatedAt;
-  @NonNull String updatedBy;
+  private final @NonNull Long createdAt;
+  private final Child child;
+  private final @NonNull Long updatedAt;
+  private final @NonNull String updatedBy;
 
   @JsonCreator
   public Parent(
@@ -34,32 +34,16 @@ public class Parent {
     return createdAt;
   }
 
-  public void setCreatedAt(Long createdAt) {
-    this.createdAt = createdAt;
-  }
-
   public Child getChild() {
     return child;
-  }
-
-  public void setChild(Child child) {
-    this.child = child;
   }
 
   public Long getUpdatedAt() {
     return updatedAt;
   }
 
-  public void setUpdatedAt(Long updatedAt) {
-    this.updatedAt = updatedAt;
-  }
-
   public String getUpdatedBy() {
     return updatedBy;
-  }
-
-  public void setUpdatedBy(String updatedBy) {
-    this.updatedBy = updatedBy;
   }
 
   @Override

--- a/core/play/src/test/java/play/utils/Parent.java
+++ b/core/play/src/test/java/play/utils/Parent.java
@@ -5,6 +5,7 @@
 package play.utils;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Objects;
@@ -19,7 +20,10 @@ public class Parent {
 
   @JsonCreator
   public Parent(
-      @NonNull Long createdAt, Child child, @NonNull Long updatedAt, @NonNull String updatedBy) {
+      @JsonProperty("createdAt") @NonNull Long createdAt,
+      @JsonProperty("child") Child child,
+      @JsonProperty("udpatedAt") @NonNull Long updatedAt,
+      @JsonProperty("udpatedBy") @NonNull String updatedBy) {
     this.createdAt = createdAt;
     this.child = child;
     this.updatedAt = updatedAt;

--- a/core/play/src/test/scala/play/utils/JsonNodeDeserializerSpec.scala
+++ b/core/play/src/test/scala/play/utils/JsonNodeDeserializerSpec.scala
@@ -186,11 +186,11 @@ abstract class BaseJacksonDeserializer(val implementationName: String) extends S
 
       val actual   = mapper.readValue(json, classOf[Parent]);
       val expected = new Parent(1234, new Child(555, "another-user"), 5678, "some-user")
-      actual.createdAt must equalTo(expected.createdAt)
-      actual.getChild.updatedAt must equalTo(expected.getChild.updatedAt)
-      actual.getChild.updatedBy must equalTo(expected.getChild.updatedBy)
-      actual.updatedAt must equalTo(expected.updatedAt)
-      actual.updatedBy must equalTo(expected.updatedBy)
+      actual.getCreatedAt must equalTo(expected.getCreatedAt)
+      actual.getChild.getUpdatedAt must equalTo(expected.getChild.getUpdatedAt)
+      actual.getChild.getUpdatedBy must equalTo(expected.getChild.getUpdatedBy)
+      actual.getUpdatedAt must equalTo(expected.getUpdatedAt)
+      actual.getUpdatedBy must equalTo(expected.getUpdatedBy)
     }
 
   }

--- a/core/play/src/test/scala/play/utils/JsonNodeDeserializerSpec.scala
+++ b/core/play/src/test/scala/play/utils/JsonNodeDeserializerSpec.scala
@@ -182,6 +182,14 @@ abstract class BaseJacksonDeserializer(val implementationName: String) extends S
       jsonNode.get("updatedAt").asLong() must equalTo(5678L)
       jsonNode.get("updatedBy").asText() must equalTo("some-user")
 
+      val actual = mapper.readValue(json, classOf[Parent]);
+
+      val expected = new Parent(1234, new Child(555, "another-user"), 5678, "some-user")
+      actual.createdAt must equalTo(expected.createdAt)
+      actual.getChild.updatedAt must equalTo(expected.getChild.updatedAt)
+      actual.getChild.updatedBy must equalTo(expected.getChild.updatedBy)
+      actual.updatedAt must equalTo(expected.updatedAt)
+      actual.updatedBy must equalTo(expected.updatedBy)
     }
 
   }

--- a/core/play/src/test/scala/play/utils/JsonNodeDeserializerSpec.scala
+++ b/core/play/src/test/scala/play/utils/JsonNodeDeserializerSpec.scala
@@ -4,12 +4,8 @@
 
 package play.utils
 
-import java.math.MathContext
-
-import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.json.JsonReadFeature
 import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.json.JsonMapper
 import org.specs2.mutable.Specification
@@ -162,6 +158,32 @@ abstract class BaseJacksonDeserializer(val implementationName: String) extends S
       val json = s"""{ "value" : ${Long.MaxValue}0000 }"""
       readNode(baseMapper(), json).isBigInteger must beTrue
     }
+
+    "read Parent/Child with a custom Deserializer" >> {
+      val json = {
+        """
+          |{
+          |  "createdAt": 1234,
+          |  "child": {
+          |    "updatedAt": 555,
+          |    "updatedBy": "another-user"
+          |  },
+          |  "updatedAt": 5678,
+          |  "updatedBy": "some-user"
+          |}
+          |""".stripMargin
+      }
+
+      val mapper   = baseMapper()
+      val jsonNode = mapper.readTree(json)
+      jsonNode.get("createdAt").asLong() must equalTo(1234L)
+      jsonNode.get("child").get("updatedAt").asLong() must equalTo(555)
+      jsonNode.get("child").get("updatedBy").asText() must equalTo("another-user")
+      jsonNode.get("updatedAt").asLong() must equalTo(5678L)
+      jsonNode.get("updatedBy").asText() must equalTo("some-user")
+
+    }
+
   }
 
 }


### PR DESCRIPTION
Fixes `JsonNodeDesrializer`. See https://github.com/lagom/lagom/issues/3241 for context and https://github.com/lagom/lagom/issues/3241#issuecomment-831292303 for a workaround.

When tail recursing, the previous implementation would advance the cursor even when the recursion was about to complete. As a consequence, when invoking Jackson's `readValue` (or `readValueAsTree`, or any equivalent) from within a deserialization the cursor would skip some events leading to skipped properties and data loss.