### PR TITLE
Fix snapshot version: 2.9.0+... instead of 2.8.1+...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,13 +17,13 @@ import org.scalafmt.sbt.ScalafmtPlugin
 // Sanity-check: assert that version comes from a tag (e.g. not a too-shallow clone)
 // https://github.com/dwijnand/sbt-dynver/#sanity-checking-the-version
 Global / onLoad := (Global / onLoad).value.andThen { s =>
-  val v = version.value
-  if (dynverGitDescribeOutput.value.hasNoTags)
-    throw new MessageOnlyException(
-      s"Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Version: $v"
-    )
+  dynverAssertTagVersion.value
   s
 }
+
+// Correctly set next major release version
+ThisBuild / version ~= (_.replace("2.8.1", "2.9.0"))
+ThisBuild / dynver  ~= (_.replace("2.8.1", "2.9.0"))
 
 lazy val BuildLinkProject = PlayNonCrossBuiltProject("Build-Link", "dev-mode/build-link")
   .dependsOn(PlayExceptionsProject)


### PR DESCRIPTION
Having the current master snapshots published as `2.8.1+...` is very confusing IMHO, just look at https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/play/sbt-plugin_2.12_1.0/

Before (current master):
```
sbt:Play-Framework> show version
[info] Play-AHC-WS / version
[info] 	2.8.1+1150-06e85e2a
[info] Play / version
[info] 	2.8.1+1150-06e85e2a
...

sbt:Play-Framework> show dynver
[info] Play-AHC-WS / dynver
[info] 	2.8.1+1150-06e85e2a
[info] Play / dynver
[info] 	2.8.1+1150-06e85e2a
...
```

After (this pull request's commit):
```
sbt:Play-Framework> show version
[info] Play-AHC-WS / version
[info] 	2.9.0+1151-40c864d3
[info] Play / version
[info] 	2.9.0+1151-40c864d3
...

sbt:Play-Framework> show dynver
[info] Play-AHC-WS / dynver
[info] 	2.9.0+1151-40c864d3
[info] Play / dynver
[info] 	2.9.0+1151-40c864d3
...
```