### PR TITLE
Remove play.akka.config setting

### DIFF
--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -871,9 +871,6 @@ play {
     # How long Play should wait for Akka to shutdown before timing it.  If "infinite" or null, waits indefinitely.
     shutdown-timeout = infinite
 
-    # The location to read Play's Akka configuration from
-    config = "akka"
-
     # The blocking IO dispatcher, used for serving files/resources from the file system or classpath.
     blockingIoDispatcher {
       fork-join-executor {

--- a/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -229,12 +229,8 @@ object ActorSystemProvider {
       val akkaTimeoutDuration = java.time.Duration.ofMillis(normalisedDuration.toMillis)
 
       val akkaTimeoutKey = "akka.coordinated-shutdown.phases.actor-system-terminate.timeout"
-      config
-        .get[Config](config.get[String]("play.akka.config"))
-        // Need to fallback to root config so we can lookup dispatchers defined outside the main namespace
-        .withFallback(config.underlying)
-        // Need to manually merge and override akkaTimeoutKey because `null` is meaningful in playTimeoutKey
-        .withValue(akkaTimeoutKey, ConfigValueFactory.fromAnyRef(akkaTimeoutDuration))
+      // Need to manually merge and override akkaTimeoutKey because `null` is meaningful in playTimeoutKey
+      config.underlying.withValue(akkaTimeoutKey, ConfigValueFactory.fromAnyRef(akkaTimeoutDuration))
     }
 
     val name = config.get[String]("play.akka.actor-system")

--- a/core/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
+++ b/core/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
@@ -13,7 +13,6 @@ class PlayGlobalAppSpec extends Specification {
     PlayCoreTestApplication(
       Map(
         "play.allowGlobalApplication"                                     -> allowGlobalApp,
-        "play.akka.config"                                                -> "akka",
         "play.akka.actor-system"                                          -> "global-app-spec",
         "akka.coordinated-shutdown.phases.actor-system-terminate.timeout" -> "90 second",
         "akka.coordinated-shutdown.exit-jvm"                              -> "off"

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -62,6 +62,19 @@ Configuration error [
 
 You can resolve such an error by setting the secret to contain the required amount of bits / bytes, like in this example at least 32 bytes of completely random input, such as `head -c 32 /dev/urandom | base64` or by the application secret generator, using `playGenerateSecret` or `playUpdateSecret`.
 
+### Removed `play.akka.config` setting
+
+Akka itself always looks up its settings from within an (hardcoded) `akka` prefix from the config it gets passed. This actually has nothing to do with Play, this is just how Akka works.
+By default, Play tells Akka to load its actor system settings directly from the application config root path, so you usually configure Play's actor system in `application.conf` inside `akka.*`.
+
+Until Play 2.9 you could use the config `play.akka.config` to tell Play to load its Akka settings from another location, in case you wanted to use the `akka.*` settings for another Akka actor system. This config has now been removed for two reasons:
+
+* That config was never well documented, e.g the docs did not mention that even if you set `play.akka.config = "my-akka"`, the `akka.*` settings from the config root path would still be loaded as fallback. That meant that if you changed something in the `akka.*` config, the actor system defined in `my-akka.akka.*` would also be effected. Therefore such two actor systems never existed indepentedly from each other, so the promise `play.akka.config` made (allowing `akka.*` to be used solely for another Akka actor system) was not kept.
+
+* Second, Play actually expects the actor system config to reside in `akka.*`, because it sets various configs within that prefix so everything works nicely. If you would use a complete different actor system for Play, your application would likely work not correctly anymore.
+
+Because of these reasons, starting from Play 2.9 the `akka.*` config is dedicated only to Play's Akka config and can not be changed anymore. You can still use your own actor systems of course, just ensure you don't read their configuration from Play's `akka` config from the root path.
+
 ## Defaults changes
 
 Some default values used by Play had changed and that can have an impact on your application. This section details the default changes.

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -69,7 +69,7 @@ By default, Play tells Akka to load its actor system settings directly from the 
 
 Until Play 2.9 you could use the config `play.akka.config` to tell Play to load its Akka settings from another location, in case you wanted to use the `akka.*` settings for another Akka actor system. This config has now been removed for two reasons:
 
-* That config was never well documented, e.g the docs did not mention that even if you set `play.akka.config = "my-akka"`, the `akka.*` settings from the config root path would still be loaded as fallback. That meant that if you changed something in the `akka.*` config, the actor system defined in `my-akka.akka.*` would also be effected. Therefore such two actor systems never existed indepentedly from each other, so the promise `play.akka.config` made (allowing `akka.*` to be used solely for another Akka actor system) was not kept.
+* That config was never well documented, e.g the docs did not mention that even if you set `play.akka.config = "my-akka"`, the `akka.*` settings from the config root path would still be loaded as fallback. That meant that if you changed something in the `akka.*` config, the actor system defined in `my-akka.akka.*` would also be affected. Therefore such two actor systems never existed independently from each other, so the promise `play.akka.config` made (allowing `akka.*` to be used solely for another Akka actor system) was not kept.
 
 * Second, Play actually expects the actor system config to reside in `akka.*`, because it sets various configs within that prefix so everything works nicely. If you would use a complete different actor system for Play, your application would likely work not correctly anymore.
 

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -64,7 +64,7 @@ You can resolve such an error by setting the secret to contain the required amou
 
 ### Removed `play.akka.config` setting
 
-Akka itself always looks up its settings from within an (hardcoded) `akka` prefix from the config it gets passed. This actually has nothing to do with Play, this is just how Akka works.
+When bootstrapping an actor system Akka looks up its settings from within an (hardcoded) `akka` prefix within the "root" config it got passed. This actually has nothing to do with Play, this is just how Akka works.
 By default, Play tells Akka to load its actor system settings directly from the application config root path, so you usually configure Play's actor system in `application.conf` inside `akka.*`.
 
 Until Play 2.9 you could use the config `play.akka.config` to tell Play to load its Akka settings from another location, in case you wanted to use the `akka.*` settings for another Akka actor system. This config has now been removed for two reasons:

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -73,7 +73,7 @@ Until Play 2.9 you could use the config `play.akka.config` to tell Play to load 
 
 * Second, Play actually expects the actor system config to reside in `akka.*`, because it sets various configs within that prefix so everything works nicely. If you would use a complete different actor system for Play, your application would likely work not correctly anymore.
 
-Because of these reasons, starting from Play 2.9 the `akka.*` config is dedicated only to Play's Akka config and can not be changed anymore. You can still use your own actor systems of course, just ensure you don't read their configuration from Play's `akka` config from the root path.
+Because of these reasons, starting from Play 2.9 the `akka.*` prefix is dedicated only to Play's Akka config and can not be changed anymore. You can still use your own actor systems of course, just ensure you don't read their configuration from Play's `akka` prefix from the root path.
 
 ## Defaults changes
 

--- a/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
+++ b/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
@@ -94,21 +94,6 @@ The default actor system configuration is read from the Play application configu
 
 For Akka logging configuration, see [[configuring logging|SettingsLogger]].
 
-### Changing configuration prefix
-
-In case you want to use the `akka.*` settings for another Akka actor system, you can tell Play to load its Akka settings from another location.
-
-```
-play.akka.config = "my-akka"
-```
-
-Now settings will be read from the `my-akka` prefix instead of the `akka` prefix.
-
-```
-my-akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 64
-my-akka.actor.debug.receive = on
-```
-
 ### Built-in actor system name
 
 By default the name of the Play actor system is `application`. You can change this via an entry in the `conf/application.conf`:
@@ -118,6 +103,14 @@ play.akka.actor-system = "custom-name"
 ```
 
 > **Note:** This feature is useful if you want to put your play application `ActorSystem` in an akka cluster.
+
+## Using your own Actor system
+
+While we recommend you use the built in actor system, as it sets up everything such as the correct classloader, lifecycle hooks, etc, there is nothing stopping you from using your own actor system.  It is important however to ensure you do the following:
+
+* Register a [[stop hook|ScalaDependencyInjection#Stopping/cleaning-up]] to shut the actor system down when Play shuts down
+* Pass in the correct classloader from the Play [Environment](api/scala/play/api/Application.html) otherwise Akka won't be able to find your applications classes
+* Ensure that you don't read your akka configuration from the default `akka` config, which is used by Play's actor system already, as this will cause problems such as when the systems try to bind to the same remote ports
 
 ## Executing a block of code asynchronously
 

--- a/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
@@ -97,21 +97,6 @@ akka.actor.debug.receive = on
 
 For Akka logging configuration, see [[configuring logging|SettingsLogger]].
 
-### Changing configuration prefix
-
-In case you want to use the `akka.*` settings for another Akka actor system, you can tell Play to load its Akka settings from another location.
-
-```
-play.akka.config = "my-akka"
-```
-
-Now settings will be read from the `my-akka` prefix instead of the `akka` prefix.
-
-```
-my-akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 64
-my-akka.actor.debug.receive = on
-```
-
 ### Built-in actor system name
 
 By default the name of the Play actor system is `application`. You can change this via an entry in the `conf/application.conf`:
@@ -128,7 +113,7 @@ While we recommend you use the built in actor system, as it sets up everything s
 
 * Register a [[stop hook|ScalaDependencyInjection#Stopping/cleaning-up]] to shut the actor system down when Play shuts down
 * Pass in the correct classloader from the Play [Environment](api/scala/play/api/Application.html) otherwise Akka won't be able to find your applications classes
-* Ensure that either you change the location that Play reads its akka configuration from using `play.akka.config`, or that you don't read your akka configuration from the default `akka` config, as this will cause problems such as when the systems try to bind to the same remote ports
+* Ensure that you don't read your akka configuration from the default `akka` config, which is used by Play's actor system already, as this will cause problems such as when the systems try to bind to the same remote ports
 
 
 ## Akka Coordinated Shutdown


### PR DESCRIPTION
Please read the migration notes I added, it explains the reasons to delete that config. IMHO that config was never implemented correctly and is prone to cause problems.

Fixes #6183