### PR TITLE
Make sure scripted jobs use the same commit like publish-local did

### DIFF
--- a/scripts/publish-local
+++ b/scripts/publish-local
@@ -19,3 +19,7 @@ start save-akka-version "SAVING AKKA_VERSION AND AKKA_HTTP_VERSION"
 echo "$AKKA_VERSION" > $HOME/.ivy2/local/com.typesafe.play/AKKA_VERSION
 echo "$AKKA_HTTP_VERSION" > $HOME/.ivy2/local/com.typesafe.play/AKKA_HTTP_VERSION
 end save-akka-version "SAVED AKKA_VERSION AND AKKA_HTTP_VERSION"
+
+start save-git-commit-hash "SAVING GIT COMMIT HASH"
+git rev-parse HEAD > $HOME/.ivy2/local/com.typesafe.play/PUBLISHED_LOCAL_COMMIT_HASH
+end save-git-commit-hash "SAVED GIT COMMIT HASH"

--- a/scripts/test-scripted
+++ b/scripts/test-scripted
@@ -14,6 +14,19 @@ shift
 cd "$BASEDIR"
 
 start scripted "RUNNING SCRIPTED TESTS FOR SBT $SBT_VERSION AND SCALA $SCALA_VERSION"
+
+# Make sure scripted tests run with the same git commit that was used for the publish-local job.
+# For each CI job the CI server always clones the latest up-to-date base branch and, if the current job is for a pull request,
+# then "fetches" the current pull request on top of it (just look at the logs of a PR job, you will see "git fetch origin +refs/pull/<#PR>/merge").
+# Now if another pull request gets merged in the time window during the publish-local and a scripted job, the base branches moves forward
+# and the CI server will now clone that newer base branch before "fetching" the current PR on it. Of course now the commit hash has changed and
+# the distance from the latest tag has increased, so the Play version set by dynver will be different than the one used for publish-local, resulting
+# in "unresolved dependencies" errors.
+PUBLISHED_LOCAL_COMMIT_HASH=$(cat $HOME/.ivy2/local/com.typesafe.play/PUBLISHED_LOCAL_COMMIT_HASH)
+git fetch origin ${PUBLISHED_LOCAL_COMMIT_HASH}
+git checkout ${PUBLISHED_LOCAL_COMMIT_HASH}
+echo "Checked out git commit ${PUBLISHED_LOCAL_COMMIT_HASH} which was used for publish-local in previous job"
+
 ls -alFhR ~/.ivy2 | grep play | grep jar
 ls -alFhR ~/.cache/coursier | grep play | grep jar
 runSbt ";project Sbt-Plugin;set scriptedSbt := \"${SBT_VERSION}\";set scriptedLaunchOpts += \"-Dscala.version=${SCALA_VERSION}\";show scriptedSbt;show scriptedLaunchOpts;scripted $@"


### PR DESCRIPTION
Please see the comment I added in the `test-scripted` file.

Now that [scala-steward runs monthly](https://github.com/playframework/playframework/pull/10823/files), it opens many pull requests at once, in parallel, increasing the chance that these pull requests fail, because of the problem I described in my comment. The problem existed before as well and pull requests failed every now and then, but I never really looked into it what the problem was, until now, when I realized what's going on.

Let's look at one of those failed pull requests: https://travis-ci.com/github/playframework/playframework/builds/225836519:
As you can see, the publish-local jobs [used the version](https://travis-ci.com/github/playframework/playframework/jobs/505156579#L624) `2.8.1+1156-e905d7a5`, so the distance from the `2.8.0` tag is 1156 and the current commit is e905d7a5 (being a merge commit GitHub provides as if the pull request already had been merged, which in reality didn't happen course). Now after that publish local **but before the (failed) scripted job started** one pull request (#10847) got merged. So based on the information in my comment, the master branch moved forward, and now the scripted jobs [use a different version](https://travis-ci.com/github/playframework/playframework/jobs/505156592#L1509):   `2.8.1+1158-5a053e91`. Distance got increased by 2 (1 commit for the version update + 1 merge commit) and of course the hash changed.

You can see the difference between the two master branches here:
* At the time the publish-local job started: https://github.com/playframework/playframework/commits/e905d7a5
* At the time the scripted job started: https://github.com/playframework/playframework/commits/5a053e91