### PR TITLE
Use app materializer to execute action in akka-http backend

### DIFF
--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -73,10 +73,6 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
   override def mode: Mode                               = context.config.mode
   override def applicationProvider: ApplicationProvider = context.appProvider
 
-  // Remember that some user config may not be available in development mode due to its unusual ClassLoader.
-  private implicit val system: ActorSystem = context.actorSystem
-  private implicit val mat: Materializer   = context.materializer
-
   /** Helper to access server configuration under the `play.server` prefix. */
   private val serverConfig = context.config.configuration.get[Configuration]("play.server")
 
@@ -126,7 +122,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
    */
   protected def createAkkaHttpConfig(): Config =
     Configuration("akka.http.server.preview.enable-http2" -> http2Enabled)
-      .withFallback(Configuration(system.settings.config))
+      .withFallback(Configuration(context.actorSystem.settings.config))
       .underlying
 
   /** Play's parser settings for Akka HTTP. Initialized by a call to [[createParserSettings()]]. */
@@ -218,14 +214,14 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     // TODO: pass in Inet.SocketOption and LoggerAdapter params?
     val bindingFuture: Future[Http.ServerBinding] =
       try {
-        Http()
+        Http()(context.actorSystem)
           .bindAndHandleAsync(
             handler = handleRequest(_, connectionContext.isSecure),
             interface = context.config.address,
             port = port,
             connectionContext = connectionContext,
             settings = createServerSettings(port, connectionContext, secure)
-          )
+          )(context.materializer)
       } catch {
         // Http2SupportNotPresentException is private[akka] so we need to match the name
         case e: Throwable if e.getClass.getSimpleName == "Http2SupportNotPresentException" =>
@@ -350,7 +346,13 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     // default execution context used for executing the action
     implicit val defaultExecutionContext: ExecutionContext = tryApp match {
       case Success(app) => app.actorSystem.dispatcher
-      case Failure(_)   => system.dispatcher
+      case Failure(_)   => context.actorSystem.dispatcher
+    }
+
+    // materializer used for executing the action
+    implicit val mat: Materializer = tryApp match {
+      case Success(app) => app.materializer
+      case Failure(_)   => context.materializer
     }
 
     (handler, upgradeToWebSocket) match {
@@ -396,7 +398,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
       requestBodySource: Either[ByteString, Source[ByteString, _]],
       action: EssentialAction,
       errorHandler: HttpErrorHandler
-  )(implicit ec: ExecutionContext): Future[HttpResponse] = {
+  )(implicit ec: ExecutionContext, mat: Materializer): Future[HttpResponse] = {
     val futureAcc: Future[Accumulator[ByteString, Result]] = Future(action(taggedRequestHeader))
 
     val source = if (request.header[Expect].contains(Expect.`100-continue`)) {

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -11,7 +11,6 @@ import java.security.cert.X509Certificate
 import java.util.Locale
 
 import javax.net.ssl.SSLPeerUnverifiedException
-import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.settings.ParserSettings
@@ -32,7 +31,6 @@ import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
 import play.mvc.Http.HeaderNames
 
-import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -51,8 +49,11 @@ private[server] class AkkaModelConversion(
    * Convert an Akka `HttpRequest` to a `RequestHeader` and an `Enumerator`
    * for its body.
    */
-  def convertRequest(requestId: Long, remoteAddress: InetSocketAddress, secureProtocol: Boolean, request: HttpRequest)(
-      implicit fm: Materializer
+  def convertRequest(
+      requestId: Long,
+      remoteAddress: InetSocketAddress,
+      secureProtocol: Boolean,
+      request: HttpRequest
   ): (RequestHeader, Either[ByteString, Source[ByteString, Any]]) = {
     (
       convertRequestHeader(requestId, remoteAddress, secureProtocol, request),
@@ -156,9 +157,7 @@ private[server] class AkkaModelConversion(
   /**
    * Convert an Akka `HttpRequest` to an `Enumerator` of the request body.
    */
-  private def convertRequestBody(
-      request: HttpRequest
-  )(implicit fm: Materializer): Either[ByteString, Source[ByteString, Any]] = {
+  private def convertRequestBody(request: HttpRequest): Either[ByteString, Source[ByteString, Any]] = {
     request.entity match {
       case HttpEntity.Strict(_, data) =>
         Left(data)


### PR DESCRIPTION
...just like we do in the netty backend:
https://github.com/playframework/playframework/blob/d03d6343697ebaae108b4f10c8709bfc0a6660c8/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala#L287-L296

IMHO there is no reason why we should use the dev-mode's actor system materializer in the akka backend. Ideally we would use the dev-mode's actor system materializer only for bootstrapping the server, as soon as we have an app available we should use it. The netty backend does exactly that, which IMHO is correct.
That caught my eye while skimming through the code because of [a discussion](https://discuss.lightbend.com/t/exceeded-configured-max-open-requests-value-of-32/8217).