### PR TITLE
For CI jobs, print files used by sbt + env vars

### DIFF
--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -68,3 +68,14 @@ javafmtValidation() {
   end validate-javafmt "VALIDATE JAVA CODE FORMATTING"
   return $ret
 }
+
+start debug-env "SHOW FILES RELEVANT FOR THIS JOB AND ALL ENV VARIABLES"
+echo "$ cat /etc/sbt/jvmopts"
+cat /etc/sbt/jvmopts
+echo ""
+echo "$ cat /etc/sbt/sbtopts"
+cat /etc/sbt/sbtopts
+echo ""
+echo "$ env"
+env
+end debug-env "SHOWED FILES RELEVANT FOR THIS JOB AND ALL ENV VARIABLES"


### PR DESCRIPTION
This is nice to have for debugging.
Took me a while to figure out where `MaxPermSize` was set in #10819 - which was removed in Java 17 nightlies and causes sbt to fail.