### PR TITLE
Remove outdated line in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,6 @@ cache:
     - "$HOME/.sbt"
 
 before_cache:
-  - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.play/*
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
   - find $HOME/.sbt  -name "*.lock"               -delete
 


### PR DESCRIPTION
I can not see the sense of this line (anymore).
@marcospereira Since you removed a similiar line in 9d54e038de02c58819cec77fc419b89f1f957427 / #10014  - that line here can be removed as well or not? Actually both lines were added together in #9928

However, meanwhile things changed: We use sbt-dynver and sbt 1.5.0 (which uses coursier) now and also MiMa [uses coursier now to resolve dependencies](https://github.com/lightbend/mima/releases/tag/0.8.0).

i was interested, so I purged my `.ivy2` folder (which I wanted to do anyway to save some disk space) and published-local the Play master branch. Only after running `scripted` tests that folder was filled with files when the scripted tests are looking for deps (because scripted test still use sbt 1.2.8, which still uses ivy resolution).
```
$ tree -a .ivy2/cache/scala_*/sbt_*/com.typesafe.play/
.ivy2/cache/scala_2.12/sbt_1.0/com.typesafe.play/
├── sbt-plugin
│   ├── ivy-2.8.1+1169-d03d6343.xml
│   └── ivydata-2.8.1+1169-d03d6343.properties
└── sbt-scripted-tools
    ├── ivy-2.8.1+1169-d03d6343.xml
    └── ivydata-2.8.1+1169-d03d6343.properties

2 directories, 4 files
```
The `ivydata-*.properties` will be deleted before storing the cache, which leaves just the xml files. Now that we are using dynver, there is no need to delete them.