### PR TITLE
fix warnings. use slash syntax instead of old `in`

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/test
@@ -1,5 +1,5 @@
 # Stage it, so it's easier to debug
 > playRoutes
 > compile
-> test:compile
+> Test/compile
 > test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/test
@@ -1,5 +1,5 @@
 # Stage it, so it's easier to debug
 > playRoutes
 > compile
-> test:compile
+> Test/compile
 > test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/test
@@ -1,5 +1,5 @@
 # Stage it, so it's easier to debug
 > playRoutes
 > compile
-> test:compile
+> Test/compile
 > test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/test
@@ -1,5 +1,5 @@
 # Stage it, so it's easier to debug
 > playRoutes
 > compile
-> test:compile
+> Test/compile
 > test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/test
@@ -1,5 +1,5 @@
 # Stage it, so it's easier to debug
 > playRoutes
 > compile
-> test:compile
+> Test/compile
 > test

--- a/documentation/manual/working/commonGuide/build/sbtDebugging.md
+++ b/documentation/manual/working/commonGuide/build/sbtDebugging.md
@@ -33,7 +33,7 @@ The show command shows the return value from any sbt task.  So for example, if y
 
 The output above has been formatted to ensure it fits cleanly on the screen, you may need to copy it to an editor to make sense of it if the task you run returns a long list of items.
 
-You can also specify a task a particular scope, eg `test:sources` or `compile:sources`, or for a particular project, `my-project/compile:sources`, and in some cases, where tasks are scoped by another task, you can specify that scope too, for example, to see everything that will be packaged into your projects jar file, you want to show the `mappings` task, scoped to the `packageBin` task:
+You can also specify a task a particular scope, eg `Test/sources` or `Compile/sources`, or for a particular project, `my-project/Compile/sources`, and in some cases, where tasks are scoped by another task, you can specify that scope too, for example, to see everything that will be packaged into your projects jar file, you want to show the `mappings` task, scoped to the `packageBin` task:
 
 ```
 [my-first-app] $ show compile:packageBin::mappings

--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -13,7 +13,7 @@ You can run tests from the sbt console.
 * To run only one test class, run `testOnly` followed by the name of the class i.e. `testOnly my.namespace.MyTest`.
 * To run only the tests that have failed, run `testQuick`.
 * To run tests continually, run a command with a tilde in front, i.e. `~testQuick`.
-* To access test helpers such as `FakeApplication` in console, run `test:console`.
+* To access test helpers such as `FakeApplication` in console, run `Test/console`.
 
 Testing in Play is based on [sbt](https://www.scala-sbt.org/), and a full description is available in the [testing documentation](https://www.scala-sbt.org/release/docs/Testing.html).
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -13,7 +13,7 @@ You can run tests from the Play console.
 * To run only one test class, run `test-only` followed by the name of the class i.e. `test-only my.namespace.MySpec`.
 * To run only the tests that have failed, run `test-quick`.
 * To run tests continually, run a command with a tilde in front, i.e. `~test-quick`.
-* To access test helpers such as `FakeRequest` in console, run `test:console`.
+* To access test helpers such as `FakeRequest` in console, run `Test/console`.
 
 Testing in Play is based on sbt, and a full description is available in the [testing sbt](https://www.scala-sbt.org/0.13/docs/Testing.html) chapter.
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -290,7 +290,7 @@ object Dependencies {
 
 /*
  * How to use this:
- *    $ sbt -J-XX:+UnlockCommercialFeatures -J-XX:+FlightRecorder -Dakka-http.sources=$HOME/code/akka-http '; project Play-Akka-Http-Server; test:run'
+ *    $ sbt -J-XX:+UnlockCommercialFeatures -J-XX:+FlightRecorder -Dakka-http.sources=$HOME/code/akka-http '; project Play-Akka-Http-Server; Test/run'
  *
  * Make sure Akka-HTTP has 2.12 as the FIRST version (or that scalaVersion := "2.12.13", otherwise it won't find the artifact
  *    crossScalaVersions := Seq("2.12.13", "2.11.12"),

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -247,11 +247,11 @@ object Docs {
   def allConfsTask(projectRef: ProjectRef, structure: BuildStructure): Task[Seq[(String, File)]] = {
     val projects = allApiProjects(projectRef.build, structure)
     val unmanagedResourcesTasks = projects.map { ref =>
-      def taskFromProject[T](task: TaskKey[T]) = (task in Compile in ref).get(structure.data)
+      def taskFromProject[T](task: TaskKey[T]) = (ref / Compile / task).get(structure.data)
 
-      val projectId = (moduleName in ref).get(structure.data)
+      val projectId = (ref / moduleName).get(structure.data)
 
-      val confs = (unmanagedResources in Compile in ref)
+      val confs = (ref / Compile / unmanagedResources)
         .get(structure.data)
         .map(_.map { resources =>
           (for {
@@ -278,7 +278,7 @@ object Docs {
   ): Task[Seq[File]] = {
     val projects = allApiProjects(projectRef.build, structure)
     val sourceTasks = projects.map { ref =>
-      def taskFromProject[T](task: TaskKey[T]) = (task in conf in ref).get(structure.data)
+      def taskFromProject[T](task: TaskKey[T]) = (ref / conf / task).get(structure.data)
 
       // Get all the Scala sources (not the Java ones)
       val filteredSources = taskFromProject(sources).map(_.map(_.filter(_.name.endsWith(extension))))
@@ -312,7 +312,7 @@ object Docs {
     val projects = allApiProjects(projectRef.build, structure)
     // Full classpath is necessary to ensure that scaladoc and javadoc can see the compiled classes of the other language.
     val tasks = projects.flatMap { p =>
-      (fullClasspath in Compile in p).get(structure.data)
+      (p / Compile / fullClasspath).get(structure.data)
     }
     tasks.join.map(_.flatten.map(_.data).distinct)
   }

--- a/scripts/it-test
+++ b/scripts/it-test
@@ -12,6 +12,6 @@ cd "$BASEDIR"
 
 start test "RUNNING IT TESTS FOR SCALA $SCALA_VERSION"
 
-runSbt "++${SCALA_VERSION} Play-Integration-Test/it:test"
+runSbt "++${SCALA_VERSION} Play-Integration-Test/It/test"
 
 end test "ALL IT TESTS PASSED"

--- a/scripts/local-pr-validation.sh
+++ b/scripts/local-pr-validation.sh
@@ -6,14 +6,14 @@
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 start validation "RUNNING FRAMEWORK VALIDATION"
-sbt headerCheck test:headerCheck javafmtCheckAll scalafmtCheckAll scalafmtSbtCheck
+sbt headerCheck Test/headerCheck javafmtCheckAll scalafmtCheckAll scalafmtSbtCheck
 start validation "FRAMEWORK VALIDATION DONE"
 
 pushd "$DOCUMENTATION"
 start doc-validation "RUNNING DOCUMENTATION VALIDATION"
-sbt headerCheck test:headerCheck javafmtCheckAll scalafmtCheckAll scalafmtSbtCheck || (
+sbt headerCheck Test/headerCheck javafmtCheckAll scalafmtCheckAll scalafmtSbtCheck || (
   echo "WARN: Format and/or license headers validaton failed."
-  echo "You need to run in sbt ';headerCreate ;test:headerCreate ;javafmtAll ;scalafmtAll ;scalafmtSbt'"
+  echo "You need to run in sbt ';headerCreate ;Test/headerCreate ;javafmtAll ;scalafmtAll ;scalafmtSbt'"
   echo "then commit the new changes or amend the existing commit."
   echo "See more information about amending commits in our docs:"
   echo "https://playframework.com/documentation/latest/WorkingWithGit"

--- a/scripts/scriptLib
+++ b/scripts/scriptLib
@@ -40,7 +40,7 @@ start() { echo -e "travis_fold:start:$1\033[33;1m[info] ---- $2\033[0m"   ; }
 end()   { echo -e "\ntravis_fold:end:$1\r\033[32;1m[info] ---- $2\033[0m" ; }
 
 runSbt() {
-  sbt "$AKKA_VERSION_OPTS" "$AKKA_HTTP_VERSION_OPTS" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
+  sbt "$AKKA_VERSION_OPTS" "$AKKA_HTTP_VERSION_OPTS" 'set Global / concurrentRestrictions += Tags.limitAll(1)' "$@" | grep --line-buffered -v 'Resolving \|Generating '
 }
 
 # Runs code formating validation in the current directory

--- a/scripts/validate-code
+++ b/scripts/validate-code
@@ -17,7 +17,7 @@ end mima "VALIDATED BINARY COMPATIBILITY"
 
 
 start headerCheck "VALIDATE FILE LICENSE HEADERS"
-runSbt +headerCheck +test:headerCheck +Play-Integration-Test/it:headerCheck +Play-Microbenchmark/test:headerCheck
+runSbt +headerCheck +Test/headerCheck +Play-Integration-Test/It/headerCheck +Play-Microbenchmark/Test/headerCheck
 end headerCheck "VALIDATED FILE LICENSE HEADERS"
 
 start checkAkkaModuleVersions "VALIDATE AKKA MODULE VERSIONS"
@@ -27,7 +27,7 @@ end checkAkkaModuleVersions "VALIDATED AKKA MODULE VERSIONS"
 
 start whitesource "RUNNING WHITESOURCE REPORT"
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    runSbt 'set credentials in ThisBuild += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies whitesourceUpdate
+    runSbt 'set ThisBuild / credentials += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies whitesourceUpdate
 else
     echo "[info]"
     echo "[info] This is a pull request so Whitesource WILL NOT RUN."

--- a/scripts/validate-docs
+++ b/scripts/validate-docs
@@ -10,7 +10,7 @@ cd "$DOCUMENTATION"
 start validate-docs "RUNNING DOCUMENTATION VALIDATION"
 runSbt evaluateSbtFiles
 runSbt validateDocs
-runSbt headerCheck test:headerCheck
+runSbt headerCheck Test/headerCheck
 
 scalafmtValidation "documentation"
 javafmtValidation "documentation"
@@ -24,7 +24,7 @@ end validate-docs "ALL DOCUMENTATION VALIDATION PASSED"
 # Only checks diffs inside the documentation directory
 git diff --exit-code . || (
   echo "ERROR: Documentation copyright or sources license header check failed, see differences above."
-  echo "To fix, run the './addMarkdownCopyright' script inside the documentation directory or 'sbt test:compile' at the root of the repo."
+  echo "To fix, run the './addMarkdownCopyright' script inside the documentation directory or 'sbt Test/compile' at the root of the repo."
   echo "After that you can update your pull request."
   false
 )


### PR DESCRIPTION


# Pull Request Checklist


* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes


## Purpose

fix warnings. avoid old style.

## Background Context


## References

https://github.com/sbt/sbt/commit/e6fec6b1db5f212a74bf5e3766b9b70f2d983f24
https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash