### PR TITLE
fix vulnerable guava version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
   val slf4j        = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % slf4jVersion)
   val slf4jSimple  = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
-  val guava      = "com.google.guava"         % "guava"        % "27.1-jre"
+  val guava      = "com.google.guava"         % "guava"        % "30.1.1-jre"
   val findBugs   = "com.google.code.findbugs" % "jsr305"       % "3.0.2" // Needed by guava
   val mockitoAll = "org.mockito"              % "mockito-core" % "2.23.4"
 


### PR DESCRIPTION
# Pull Request Checklist

* [yes] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [yes] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?

# Helpful things

## Purpose

This PR bumps the guava dependency of the 2.7 branch to stop bringing in a vulnerability (that is already bumped in master branch)

## Background Context

We are still using play 2.7 and I believe it is still supported.  There is a vulnerability in the depended version of guava, as follows:
https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415

