### PR TITLE
Set MaxMetaspaceSize to 512m (like it was 4 month ago)

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -382,7 +382,7 @@ object BuildSettings {
     scriptedLaunchOpts ++= Seq(
       s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
       "-Xmx512m",
-      "-XX:MaxMetaspaceSize=300m",
+      "-XX:MaxMetaspaceSize=512m",
       "-XX:HeapDumpPath=/tmp/",
       "-XX:+HeapDumpOnOutOfMemoryError",
     ),


### PR DESCRIPTION
In #10500 the value was changed from 512m to 300m.
Since then every now and then we get a `OutOfMemoryError`.
I suggest to just increase the value again.
Also @jtjeferreira could [not reproduce the problem locally](https://github.com/playframework/playframework/issues/10676#issuecomment-774770245)... Maybe it's just that garbage collection on CI is "to slow" or whatever, I don't know, I don't have a PhD in garbage collection...

I think 512m was fine the last years and it's ok to just use that value again.