### PR TITLE
add parentheses for lambda param

### DIFF
--- a/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -163,11 +163,11 @@ class CachedSpec extends PlaySpecification {
     }
   }
 
-  val dummyAction = Action { request: Request[_] =>
+  val dummyAction = Action { (request: Request[_]) =>
     Results.Ok(Random.nextInt().toString)
   }
 
-  val notFoundAction = Action { request: Request[_] =>
+  val notFoundAction = Action { (request: Request[_]) =>
     Results.NotFound(Random.nextInt().toString)
   }
 

--- a/core/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
@@ -135,7 +135,7 @@ trait HeadActionSpec
     }
 
     val CustomAttr = TypedKey[String]("CustomAttr")
-    val attrAction = ActionBuilder.ignoringBody { rh: RequestHeader =>
+    val attrAction = ActionBuilder.ignoringBody { (rh: RequestHeader) =>
       val attrComment = rh.attrs.get(CustomAttr)
       val headers = Array.empty[(String, String)] ++
         rh.attrs.get(CustomAttr).map("CustomAttr" -> _)

--- a/core/play-integration-test/src/it/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
@@ -43,7 +43,7 @@ class AkkaHttpCustomServerProviderSpec
   def requestWithMethod[A: AsResult](endpointRecipe: ServerEndpointRecipe, method: String, body: RequestBody)(
       f: Either[Int, String] => A
   ): Fragment =
-    appFactory.withOkHttpEndpoints(Seq(endpointRecipe)) { okEndpoint: OkHttpEndpoint =>
+    appFactory.withOkHttpEndpoints(Seq(endpointRecipe)) { (okEndpoint: OkHttpEndpoint) =>
       val response                   = okEndpoint.configuredCall("/")(_.method(method, body))
       val param: Either[Int, String] = if (response.code == 200) Right(response.body.string) else Left(response.code)
       f(param)
@@ -61,7 +61,7 @@ class AkkaHttpCustomServerProviderSpec
       _ must beLeft(501)
     )
     "reject a long header value" in appFactory.withOkHttpEndpoints(Seq(AkkaHttp11Plaintext)) {
-      okEndpoint: OkHttpEndpoint =>
+      (okEndpoint: OkHttpEndpoint) =>
         val response = okEndpoint.configuredCall("/")(
           _.addHeader("X-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "abc")
         )
@@ -104,7 +104,7 @@ class AkkaHttpCustomServerProviderSpec
       })
 
     "accept a long header value" in appFactory.withOkHttpEndpoints(Seq(customAkkaHttpEndpoint)) {
-      okEndpoint: OkHttpEndpoint =>
+      (okEndpoint: OkHttpEndpoint) =>
         val response = okEndpoint.configuredCall("/")(
           _.addHeader("X-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "abc")
         )

--- a/core/play-integration-test/src/it/scala/play/it/http/FlashCookieSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/FlashCookieSpec.scala
@@ -62,7 +62,7 @@ class FlashCookieSpec
    */
   implicit class CookieEndpointBaker(val appFactory: ApplicationFactory) {
     def withAllCookieEndpoints[A: AsResult](block: CookieEndpoint => A): Fragment = {
-      appFactory.withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
+      appFactory.withAllOkHttpEndpoints { (okEndpoint: OkHttpEndpoint) =>
         block(new CookieEndpoint {
           import JavaConverters._
           def call(path: String, cookies: List[okhttp3.Cookie]): (okhttp3.Response, List[okhttp3.Cookie]) = {
@@ -96,7 +96,7 @@ class FlashCookieSpec
 
   "the flash cookie" should {
     "be set for first request and removed on next request" in withFlashCookieApp().withAllCookieEndpoints {
-      fcep: CookieEndpoint =>
+      (fcep: CookieEndpoint) =>
         // Make a request that returns a flash cookie
         val (response1, cookies1) = fcep.call("/flash", Nil)
         response1.code must equalTo(SEE_OTHER)
@@ -120,7 +120,7 @@ class FlashCookieSpec
     }
 
     "allow the setting of additional cookies when cleaned up" in withFlashCookieApp().withAllCookieEndpoints {
-      fcep: CookieEndpoint =>
+      (fcep: CookieEndpoint) =>
         // Get a flash cookie
         val (response1, cookies1) = fcep.call("/flash", Nil)
         response1.code must equalTo(SEE_OTHER)
@@ -143,7 +143,7 @@ class FlashCookieSpec
 
     "honor the configuration for play.http.flash.sameSite" in {
       "by not sending SameSite when configured to null" in withFlashCookieApp(Map("play.http.flash.sameSite" -> null))
-        .withAllCookieEndpoints { fcep: CookieEndpoint =>
+        .withAllCookieEndpoints { (fcep: CookieEndpoint) =>
           val (response, cookies) = fcep.call("/flash", Nil)
           response.code must equalTo(SEE_OTHER)
           response.header(SET_COOKIE) must not contain ("SameSite")
@@ -151,7 +151,7 @@ class FlashCookieSpec
 
       "by sending SameSite=Lax when configured with 'lax'" in withFlashCookieApp(
         Map("play.http.flash.sameSite" -> "lax")
-      ).withAllCookieEndpoints { fcep: CookieEndpoint =>
+      ).withAllCookieEndpoints { (fcep: CookieEndpoint) =>
         val (response, cookies) = fcep.call("/flash", Nil)
         response.code must equalTo(SEE_OTHER)
         response.header(SET_COOKIE) must contain("SameSite=Lax")
@@ -159,7 +159,7 @@ class FlashCookieSpec
 
       "by sending SameSite=Strict when configured with 'strict'" in withFlashCookieApp(
         Map("play.http.flash.sameSite" -> "lax")
-      ).withAllCookieEndpoints { fcep: CookieEndpoint =>
+      ).withAllCookieEndpoints { (fcep: CookieEndpoint) =>
         val (response, cookies) = fcep.call("/flash", Nil)
         response.code must equalTo(SEE_OTHER)
         response.header(SET_COOKIE) must contain("SameSite=Lax")
@@ -168,7 +168,7 @@ class FlashCookieSpec
 
     "honor configuration for flash.secure" in {
       "by making cookies secure when set to true" in withFlashCookieApp(Map("play.http.flash.secure" -> true))
-        .withAllCookieEndpoints { fcep: CookieEndpoint =>
+        .withAllCookieEndpoints { (fcep: CookieEndpoint) =>
           val (response, cookies) = fcep.call("/flash", Nil)
           response.code must equalTo(SEE_OTHER)
           val cookie = cookies.find(_.name == flashCookieBaker.COOKIE_NAME)
@@ -176,7 +176,7 @@ class FlashCookieSpec
         }
 
       "by not making cookies secure when set to false" in withFlashCookieApp(Map("play.http.flash.secure" -> false))
-        .withAllCookieEndpoints { fcep: CookieEndpoint =>
+        .withAllCookieEndpoints { (fcep: CookieEndpoint) =>
           val (response, cookies) = fcep.call("/flash", Nil)
           response.code must equalTo(SEE_OTHER)
           val cookie = cookies.find(_.name == flashCookieBaker.COOKIE_NAME)

--- a/core/play-integration-test/src/it/scala/play/it/http/FormFieldOrderSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/FormFieldOrderSpec.scala
@@ -19,12 +19,12 @@ class FormFieldOrderSpec
     val contentType = "application/x-www-form-urlencoded"
 
     val fakeAppFactory: ApplicationFactory = withAction { actionBuilder =>
-      actionBuilder { request: Request[AnyContent] =>
+      actionBuilder { (request: Request[AnyContent]) =>
         // Check precondition. This needs to be an x-www-form-urlencoded request body
         request.contentType must beSome(contentType)
         // The following just ingests the request body and converts it to a sequence of strings of the form name=value
         val pairs: Seq[String] = {
-          request.body.asFormUrlEncoded.map { params: Map[String, Seq[String]] =>
+          request.body.asFormUrlEncoded.map { (params: Map[String, Seq[String]]) =>
             {
               for ((key: String, value: Seq[String]) <- params) yield key + "=" + value.mkString
             }.toSeq
@@ -38,7 +38,7 @@ class FormFieldOrderSpec
       }
     }
 
-    "preserve form field order" in fakeAppFactory.withAllOkHttpEndpoints { okep: OkHttpEndpoint =>
+    "preserve form field order" in fakeAppFactory.withAllOkHttpEndpoints { (okep: OkHttpEndpoint) =>
       val request = new okhttp3.Request.Builder()
         .url(okep.endpoint.pathUrl("/"))
         .post(okhttp3.RequestBody.create(okhttp3.MediaType.parse(contentType), urlEncoded))

--- a/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
@@ -40,7 +40,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
   "Play's idle timeout support" should {
 
     def withServerAndConfig(extraConfig: Map[String, Any] = Map.empty): ApplicationFactory = {
-      withConfigAndRouter(extraConfig) { components: BuiltInComponents =>
+      withConfigAndRouter(extraConfig) { (components: BuiltInComponents) =>
         Router.from {
           case _ =>
             EssentialAction { rh =>
@@ -79,7 +79,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
         "play.server.http.idleTimeout"  -> null,
         "play.server.https.idleTimeout" -> null
       )
-      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { endpoint: ServerEndpoint =>
+      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { (endpoint: ServerEndpoint) =>
         // We are interested to know that the server started correctly with "null"
         // configurations. So there is no need to wait for a longer time.
         val responses = doRequests(endpoint.port, trickle = 200L, secure = "https" == endpoint.scheme)
@@ -94,7 +94,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
         "play.server.http.idleTimeout"  -> "infinite",
         "play.server.https.idleTimeout" -> "infinite"
       )
-      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { endpoint: ServerEndpoint =>
+      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { (endpoint: ServerEndpoint) =>
         // We are interested to know that the server started correctly with "infinite"
         // configurations. So there is no need to wait for a longer time.
         val responses = doRequests(endpoint.port, trickle = 200L, secure = "https" == endpoint.scheme)
@@ -106,7 +106,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
 
     "support sub-second timeouts" in {
       val extraConfig = timeouts(httpTimeout = 300.millis, httpsTimeout = 300.millis)
-      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { endpoint: ServerEndpoint =>
+      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { (endpoint: ServerEndpoint) =>
         doRequests(endpoint.port, trickle = 400L, secure = "https" == endpoint.scheme) must throwA[IOException].like {
           case e => (e must beAnInstanceOf[SocketException]).or(e.getCause must beAnInstanceOf[SocketException])
         }
@@ -115,7 +115,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
 
     "support a separate timeout for https" in {
       val extraConfig = timeouts(1.second, httpsTimeout = 400.millis)
-      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { endpoint: ServerEndpoint =>
+      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { (endpoint: ServerEndpoint) =>
         if (endpoint.scheme == "http") {
           val responses = doRequests(endpoint.port, trickle = 200L)
           responses.length must_== 2
@@ -131,7 +131,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
 
     "support multi-second timeouts" in {
       val extraConfig = timeouts(httpTimeout = 1500.millis, httpsTimeout = 1500.millis)
-      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { endpoint: ServerEndpoint =>
+      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { (endpoint: ServerEndpoint) =>
         doRequests(endpoint.port, trickle = 2600L, secure = "https" == endpoint.scheme) must throwA[IOException].like {
           case e => (e must beAnInstanceOf[SocketException]).or(e.getCause must beAnInstanceOf[SocketException])
         }
@@ -140,7 +140,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
 
     "not timeout for slow requests with a sub-second timeout" in {
       val extraConfig = timeouts(httpTimeout = 700.millis, httpsTimeout = 700.millis)
-      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { endpoint: ServerEndpoint =>
+      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { (endpoint: ServerEndpoint) =>
         val responses = doRequests(endpoint.port, trickle = 400L, secure = "https" == endpoint.scheme)
         responses.length must_== 2
         responses(0).status must_== 200
@@ -150,7 +150,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
 
     "not timeout for slow requests with a multi-second timeout" in {
       val extraConfig = timeouts(httpTimeout = 1500.millis, httpsTimeout = 1500.millis)
-      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { endpoint: ServerEndpoint =>
+      withServerAndConfig(extraConfig).withEndpoints(endpoints(extraConfig)) { (endpoint: ServerEndpoint) =>
         val responses = doRequests(endpoint.port, trickle = 1000L, secure = "https" == endpoint.scheme)
         responses.length must_== 2
         responses(0).status must_== 200
@@ -161,7 +161,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
     "always be infinite when using akka-http HTTP/2" in {
       // See https://github.com/akka/akka-http/pull/2776
       val extraConfig = timeouts(httpTimeout = 100.millis, httpsTimeout = 100.millis) // will be ignored
-      withServerAndConfig(extraConfig).withEndpoints(akkaHttp2endpoints(extraConfig)) { endpoint: ServerEndpoint =>
+      withServerAndConfig(extraConfig).withEndpoints(akkaHttp2endpoints(extraConfig)) { (endpoint: ServerEndpoint) =>
         val responses = doRequests(endpoint.port, trickle = 1500L, secure = "https" == endpoint.scheme)
         responses.length must_== 2
         responses(0).status must_== 200

--- a/core/play-integration-test/src/it/scala/play/it/http/SecureFlagSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/SecureFlagSpec.scala
@@ -20,19 +20,19 @@ class SecureFlagSpec
 
   /** An ApplicationFactory with a single action that returns the request's `secure` flag. */
   val secureFlagAppFactory: ApplicationFactory = withAction { actionBuilder =>
-    actionBuilder { request: Request[_] =>
+    actionBuilder { (request: Request[_]) =>
       Results.Ok(request.secure.toString)
     }
   }
 
   "Play https server" should {
     "show that by default requests are secure only if the protocol is secure" in secureFlagAppFactory
-      .withAllOkHttpEndpoints { okep: OkHttpEndpoint =>
+      .withAllOkHttpEndpoints { (okep: OkHttpEndpoint) =>
         val response = okep.call("/")
         response.body.string must ===((okep.endpoint.scheme == "https").toString)
       }
     "show that requests are secure if X_FORWARDED_PROTO is https" in secureFlagAppFactory.withAllOkHttpEndpoints {
-      okep: OkHttpEndpoint =>
+      (okep: OkHttpEndpoint) =>
         val request = okep
           .requestBuilder("/")
           .addHeader(X_FORWARDED_PROTO, "https")
@@ -42,7 +42,7 @@ class SecureFlagSpec
         response.body.string must ===("true")
     }
     "show that requests are insecure if X_FORWARDED_PROTO is http" in secureFlagAppFactory.withAllOkHttpEndpoints {
-      okep: OkHttpEndpoint =>
+      (okep: OkHttpEndpoint) =>
         val request = okep
           .requestBuilder("/")
           .addHeader(X_FORWARDED_PROTO, "http")

--- a/core/play-integration-test/src/it/scala/play/it/http/UriHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/UriHandlingSpec.scala
@@ -21,20 +21,20 @@ class UriHandlingSpec
     with OkHttpEndpointSupport
     with ApplicationFactories {
   private def makeRequest[T: AsResult](path: String)(block: (ServerEndpoint, okhttp3.Response) => T): Fragment =
-    withRouter { components: BuiltInComponents =>
+    withRouter { (components: BuiltInComponents) =>
       import components.{ defaultActionBuilder => Action }
       import sird.UrlContext
       Router.from {
         case sird.GET(p"/path") =>
-          Action { request: Request[_] =>
+          Action { (request: Request[_]) =>
             Results.Ok(request.queryString)
           }
         case _ =>
-          Action { request: Request[_] =>
+          Action { (request: Request[_]) =>
             Results.Ok(request.path + queryToString(request.queryString))
           }
       }
-    }.withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
+    }.withAllOkHttpEndpoints { (okEndpoint: OkHttpEndpoint) =>
       val response: okhttp3.Response = okEndpoint.call(path)
       block(okEndpoint.endpoint, response)
     }

--- a/core/play-integration-test/src/it/scala/play/it/libs/ScalaWSSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/ScalaWSSpec.scala
@@ -132,7 +132,7 @@ trait ScalaWSSpec
         Server.withRouterFromComponents() { c =>
           {
             case _ =>
-              c.defaultActionBuilder { req: Request[AnyContent] =>
+              c.defaultActionBuilder { (req: Request[AnyContent]) =>
                 Results.Ok(req.headers.keys.filter(_.equalsIgnoreCase("authorization")).mkString)
               }
           }
@@ -213,7 +213,7 @@ trait ScalaWSSpec
     Server.withRouterFromComponents() { components =>
       {
         case _ =>
-          components.defaultActionBuilder(echo) { req: Request[Source[ByteString, _]] =>
+          components.defaultActionBuilder(echo) { (req: Request[Source[ByteString, _]]) =>
             Ok.chunked(req.body)
           }
       }
@@ -236,7 +236,7 @@ trait ScalaWSSpec
     Server.withRouterFromComponents() { c =>
       {
         case _ =>
-          c.defaultActionBuilder { req: Request[AnyContent] =>
+          c.defaultActionBuilder { (req: Request[AnyContent]) =>
             val contentLength    = req.headers.get(CONTENT_LENGTH)
             val transferEncoding = req.headers.get(TRANSFER_ENCODING)
             Ok(s"Content-Length: ${contentLength.getOrElse(-1)}; Transfer-Encoding: ${transferEncoding.getOrElse(-1)}")

--- a/core/play-integration-test/src/it/scala/play/it/routing/ServerSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/routing/ServerSpec.scala
@@ -74,7 +74,7 @@ trait ServerSpec extends Specification with BeforeAll {
         withServer(
           Server.forRouter(
             JavaMode.DEV,
-            asJavaFunction { components: JBuiltInComponents =>
+            asJavaFunction { (components: JBuiltInComponents) =>
               RoutingDsl
                 .fromComponents(components)
                 .GET("/something")

--- a/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
@@ -254,15 +254,15 @@ private[server] object ServerReloadingSpec {
           Results.Redirect("/getflash").flashing("foo" -> "bar")
         }
       case GET(p"/getflash") =>
-        action { request: Request[_] =>
+        action { (request: Request[_]) =>
           Results.Ok(request.flash.data.get("foo").toString)
         }
       case GET(p"/getremoteaddress") =>
-        action { request: Request[_] =>
+        action { (request: Request[_]) =>
           Results.Ok(request.remoteAddress)
         }
       case GET(p"/getserverconfigcachereloads") =>
-        action { request: Request[_] =>
+        action { (request: Request[_]) =>
           val reloadCount: Option[Int] = request.attrs.get(ServerDebugInfo.Attr).map(_.serverConfigCacheReloads)
           Results.Ok(reloadCount.toString)
         }

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -42,7 +42,7 @@ trait EndpointIntegrationSpecification extends SpecLike with PendingUntilFixed w
      * }}}
      */
     def withEndpoints[A: AsResult](endpoints: Seq[ServerEndpointRecipe])(block: ServerEndpoint => A): Fragment = {
-      endpoints.map { endpointRecipe: ServerEndpointRecipe =>
+      endpoints.map { (endpointRecipe: ServerEndpointRecipe) =>
         s"with ${endpointRecipe.description}" >> {
           ServerEndpointRecipe.withEndpoint(endpointRecipe, appFactory)(block)
         }

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
@@ -19,7 +19,7 @@ class EndpointIntegrationSpecificationSpec
     with OkHttpEndpointSupport {
   "Endpoints" should {
     "respond with the highest supported HTTP protocol" in {
-      withResult(Results.Ok("Hello")).withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
+      withResult(Results.Ok("Hello")).withAllOkHttpEndpoints { (okEndpoint: OkHttpEndpoint) =>
         val response: Response = okEndpoint.call("/")
         val protocol           = response.protocol
         if (okEndpoint.endpoint.protocols.contains(HTTP_2_0)) {
@@ -32,11 +32,11 @@ class EndpointIntegrationSpecificationSpec
         response.body.string must_== "Hello"
       }
     }
-    "respond with the correct server attribute" in withAction { Action: DefaultActionBuilder =>
-      Action { request: Request[_] =>
+    "respond with the correct server attribute" in withAction { (Action: DefaultActionBuilder) =>
+      Action { (request: Request[_]) =>
         Results.Ok(request.attrs.get(RequestAttrKey.Server).toString)
       }
-    }.withAllOkHttpEndpoints { okHttpEndpoint: OkHttpEndpoint =>
+    }.withAllOkHttpEndpoints { (okHttpEndpoint: OkHttpEndpoint) =>
       val response: Response = okHttpEndpoint.call("/")
       response.body.string must_== okHttpEndpoint.endpoint.serverAttribute.toString
     }

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSpec.scala
@@ -14,7 +14,7 @@ import play.api.test.PlaySpecification
 class OkHttpEndpointSpec extends PlaySpecification with EndpointIntegrationSpecification with OkHttpEndpointSupport {
   "OkHttpEndpoint" should {
     "make a request and get a response" in {
-      withResult(Results.Ok("Hello")).withAllOkHttpEndpoints { okEndpoint: OkHttpEndpoint =>
+      withResult(Results.Ok("Hello")).withAllOkHttpEndpoints { (okEndpoint: OkHttpEndpoint) =>
         val response: Response = okEndpoint.call("/")
         response.body.string must_== "Hello"
       }

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -102,7 +102,7 @@ trait OkHttpEndpointSupport {
      * }}}
      */
     def withOkHttpEndpoints[A: AsResult](endpoints: Seq[ServerEndpointRecipe])(block: OkHttpEndpoint => A): Fragment =
-      appFactory.withEndpoints(endpoints) { endpoint: ServerEndpoint =>
+      appFactory.withEndpoints(endpoints) { (endpoint: ServerEndpoint) =>
         withOkHttpEndpoint(endpoint)(block)
       }
 
@@ -120,7 +120,7 @@ trait OkHttpEndpointSupport {
      * }}}
      */
     def withAllOkHttpEndpoints[A: AsResult](block: OkHttpEndpoint => A): Fragment =
-      appFactory.withAllEndpoints { endpoint: ServerEndpoint =>
+      appFactory.withAllEndpoints { (endpoint: ServerEndpoint) =>
         withOkHttpEndpoint(endpoint)(block)
       }
   }

--- a/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSpec.scala
@@ -14,7 +14,7 @@ import play.api.test.PlaySpecification
 class WSEndpointSpec extends PlaySpecification with EndpointIntegrationSpecification with WSEndpointSupport {
   "WSEndpoint" should {
     "make a request and get a response" in {
-      withResult(Results.Ok("Hello")).withAllWSEndpoints { endpointClient: WSEndpoint =>
+      withResult(Results.Ok("Hello")).withAllWSEndpoints { (endpointClient: WSEndpoint) =>
         val response: WSResponse = endpointClient.makeRequest("/")
         response.body must_== "Hello"
       }

--- a/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSupport.scala
@@ -124,7 +124,7 @@ trait WSEndpointSupport {
      * }}}
      */
     def withAllWSEndpoints[A: AsResult](block: WSEndpoint => A): Fragment =
-      appFactory.withAllEndpoints { endpoint: ServerEndpoint =>
+      appFactory.withAllEndpoints { (endpoint: ServerEndpoint) =>
         withWSEndpoint(endpoint)(block)
       }
   }

--- a/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -72,7 +72,7 @@ private[routing] class RouterBuilderHelper(
                 case Left(error) => ActionBuilder.ignoringBody(Results.BadRequest(error))
                 case Right(parameters) =>
                   import play.core.Execution.Implicits.trampoline
-                  ActionBuilder.ignoringBody.async(bodyParser) { request: Request[RequestBody] =>
+                  ActionBuilder.ignoringBody.async(bodyParser) { (request: Request[RequestBody]) =>
                     handleUsingRequest(parameters, request)
                   }
               }

--- a/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -205,7 +205,7 @@ class DefaultHttpRequestHandler(
     // user when the access the web page through a browser.
     //
     // In prod mode this code will not be run.
-    val webCommandResult: Option[Result] = optDevContext.flatMap { devContext: DevContext =>
+    val webCommandResult: Option[Result] = optDevContext.flatMap { (devContext: DevContext) =>
       webCommands.handleWebCommand(request, devContext.buildLink, devContext.buildLink.projectPath)
     }
 

--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -166,7 +166,7 @@ trait DefaultWriteables extends LowPriorityWriteables {
     }
 
     Writeable[MultipartFormData[A]](
-      transform = { form: MultipartFormData[A] =>
+      transform = { (form: MultipartFormData[A]) =>
         formatDataParts(form.dataParts) ++ ByteString(form.files.flatMap { file =>
           val fileBytes = aWriteable.transform(file)
           filePartHeader(file) ++ fileBytes ++ codec.encode("\r\n")

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -480,7 +480,7 @@ a1 <- pa1.value.right
     val underlyingInvoker: HandlerInvoker[T] = hif.createInvoker(fakeCall, handlerDef)
 
     // Precalculate the function that adds routing information to the request
-    val modifyRequestFunc: RequestHeader => RequestHeader = { rh: RequestHeader =>
+    val modifyRequestFunc: RequestHeader => RequestHeader = { (rh: RequestHeader) =>
       rh.addAttr(play.api.routing.Router.Attrs.HandlerDef, handlerDef)
     }
 

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -174,7 +174,7 @@ class ResultsSpec extends Specification {
       testWithCookies(List(preferencesCookie), List(sessionCookie), Some(Set(preferencesCookie, sessionCookie)))
     }
 
-    "support clearing a language cookie using withoutLang" in withApplication { app: Application =>
+    "support clearing a language cookie using withoutLang" in withApplication { (app: Application) =>
       implicit val messagesApi = app.injector.instanceOf[MessagesApi]
       val cookie               = cookieHeaderEncoding.decodeSetCookieHeader(bake(Ok.clearingLang).header.headers("Set-Cookie")).head
       cookie.name must_== Play.langCookieName

--- a/core/play/src/test/scala/play/core/routing/GeneratedRouterSpec.scala
+++ b/core/play/src/test/scala/play/core/routing/GeneratedRouterSpec.scala
@@ -69,7 +69,7 @@ object GeneratedRouterSpec extends Specification {
         Seq("Tag")
       )
       val request = FakeRequest()
-      routeToHandler(handler, handlerDef, request) { routedHandler: Handler =>
+      routeToHandler(handler, handlerDef, request) { (routedHandler: Handler) =>
         routedHandler must haveInterface[Handler.Stage]
         val (preprocessedRequest, preprocessedHandler) = Handler.applyStages(request, routedHandler)
         preprocessedHandler must_== handler
@@ -92,7 +92,7 @@ object GeneratedRouterSpec extends Specification {
         Seq("Tag")
       )
       val request = FakeRequest()
-      routeToHandler(controller.index, handlerDef, request) { routedHandler: Handler =>
+      routeToHandler(controller.index, handlerDef, request) { (routedHandler: Handler) =>
         routedHandler must haveInterface[Handler.Stage]
         val (preprocessedRequest, preprocessedHandler) = Handler.applyStages(request, routedHandler)
         preprocessedHandler must haveInterface[JavaHandler]

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -18,7 +18,7 @@ object PlayCommands {
 
   // ----- Play prompt
 
-  val playPrompt = { state: State =>
+  val playPrompt = { (state: State) =>
     val extracted = Project.extract(state)
     import extracted._
 
@@ -69,7 +69,7 @@ object PlayCommands {
     )
   }
 
-  val h2Command = Command.command("h2-browser") { state: State =>
+  val h2Command = Command.command("h2-browser") { (state: State) =>
     try {
       val commonLoader  = Project.runTask(playCommonClassloader, state).get._2.toEither.right.get
       val h2ServerClass = commonLoader.loadClass("org.h2.tools.Server")

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -174,7 +174,7 @@ object PlaySettings {
           val docDirectory    = (doc in Compile).value
           val docDirectoryLen = docDirectory.getCanonicalPath.length
           val pathFinder      = docDirectory ** "*"
-          pathFinder.get.map { docFile: File =>
+          pathFinder.get.map { (docFile: File) =>
             docFile -> ("share/doc/api/" + docFile.getCanonicalPath.substring(docDirectoryLen))
           }
         }
@@ -186,7 +186,7 @@ object PlaySettings {
     }.value,
     mappings in Universal ++= {
       val pathFinder = baseDirectory.value * "README*"
-      pathFinder.get.map { readmeFile: File =>
+      pathFinder.get.map { (readmeFile: File) =>
         readmeFile -> readmeFile.getName
       }
     },

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -83,7 +83,7 @@ object RoutesCompiler extends AutoPlugin {
         }
         .join
         .map {
-          aggTasks: Seq[Seq[RoutesCompilerTask]] =>
+          (aggTasks: Seq[Seq[RoutesCompilerTask]]) =>
             // Aggregated tasks need to have forwards router compilation disabled and reverse router compilation enabled.
             val reverseRouterTasks = aggTasks.flatten.map { task =>
               task.copy(forwardsRouter = false, reverseRouter = true)
@@ -127,7 +127,7 @@ object RoutesCompiler extends AutoPlugin {
           Def.optional(aggregateReverseRoutes in dep)(_.map(_.map(_.project)).getOrElse(Nil))
         }
         .join
-        .apply { aggregated: Seq[Seq[ProjectReference]] =>
+        .apply { (aggregated: Seq[Seq[ProjectReference]]) =>
           val localProject = LocalProject(projectRef.project)
           // Return false if this project is aggregated by one of our dependencies
           !aggregated.flatten.contains(localProject)
@@ -185,7 +185,7 @@ object RoutesCompiler extends AutoPlugin {
       log: Logger
   ): Seq[File] = {
     val ops = tasks.map(task => RoutesCompilerOp(task, generator.id, PlayVersion.current))
-    val (products, errors) = syncIncremental(cacheDirectory, ops) { opsToRun: Seq[RoutesCompilerOp] =>
+    val (products, errors) = syncIncremental(cacheDirectory, ops) { (opsToRun: Seq[RoutesCompilerOp]) =>
       val errs = Seq.newBuilder[RoutesCompilationError]
 
       val opResults: Map[RoutesCompilerOp, OpResult] = opsToRun.map { op =>

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -82,11 +82,11 @@ object PlayReload {
     // Stolen from https://github.com/sbt/sbt/blob/v1.4.8/main/src/main/scala/sbt/Defaults.scala#L2299-L2316
     // Slightly modified because reportAbsolutePath and fileConverter settings do not exist pre sbt 1.4 yet
     def foldMappers(mappers: Seq[Position => Option[Position]]) =
-      mappers.foldRight({ p: Position =>
+      mappers.foldRight({ (p: Position) =>
         toAbsoluteSource(p) // Fallback if sourcePositionMappers is empty
       }) {
         (mapper, previousPosition) =>
-          { p: Position =>
+          { (p: Position) =>
             // To each mapper we pass the position with the absolute source
             mapper(toAbsoluteSource(p)).getOrElse(previousPosition(p))
           }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -46,7 +46,7 @@ package scalaguide.http.scalabodyparsers {
     "A scala body parser" should {
       "parse request as json" in new WithController() {
         //#access-json-body
-        def save = Action { request: Request[AnyContent] =>
+        def save = Action { (request: Request[AnyContent]) =>
           val body: AnyContent          = request.body
           val jsonBody: Option[JsValue] = body.asJson
 
@@ -65,7 +65,7 @@ package scalaguide.http.scalabodyparsers {
 
       "body parser json" in new WithController() {
         //#body-parser-json
-        def save = Action(parse.json) { request: Request[JsValue] =>
+        def save = Action(parse.json) { (request: Request[JsValue]) =>
           Ok("Got: " + (request.body \ "name").as[String])
         }
         //#body-parser-json
@@ -74,7 +74,7 @@ package scalaguide.http.scalabodyparsers {
 
       "body parser tolerantJson" in new WithController() {
         //#body-parser-tolerantJson
-        def save = Action(parse.tolerantJson) { request: Request[JsValue] =>
+        def save = Action(parse.tolerantJson) { (request: Request[JsValue]) =>
           Ok("Got: " + (request.body \ "name").as[String])
         }
         //#body-parser-tolerantJson
@@ -83,7 +83,7 @@ package scalaguide.http.scalabodyparsers {
 
       "body parser file" in new WithController() {
         //#body-parser-file
-        def save = Action(parse.file(to = new File("/tmp/upload"))) { request: Request[File] =>
+        def save = Action(parse.file(to = new File("/tmp/upload"))) { (request: Request[File]) =>
           Ok("Saved the request content to " + request.body)
         }
         //#body-parser-file
@@ -101,7 +101,7 @@ package scalaguide.http.scalabodyparsers {
         val text = "hello"
         //#body-parser-limit-text
         // Accept only 10KB of data.
-        def save = Action(parse.text(maxLength = 1024 * 10)) { request: Request[String] =>
+        def save = Action(parse.text(maxLength = 1024 * 10)) { (request: Request[String]) =>
           Ok("Got: " + text)
         }
         //#body-parser-limit-text

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
@@ -53,7 +53,7 @@ class ScalaOAuthSpec extends PlaySpecification {
           }
         }
 
-        def authenticate = Action { request: Request[AnyContent] =>
+        def authenticate = Action { (request: Request[AnyContent]) =>
           request
             .getQueryString("oauth_verifier")
             .map { verifier =>

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -208,7 +208,7 @@ object Docs {
     def javadocLinkRegex(javadocURL: String): Regex = ("""\"(\Q""" + javadocURL + """\E)#([^"]*)\"""").r
 
     def hasJavadocLink(f: File): Boolean =
-      externalJavadocLinks.exists { javadocURL: String =>
+      externalJavadocLinks.exists { (javadocURL: String) =>
         javadocLinkRegex(javadocURL).findFirstIn(IO.read(f)).nonEmpty
       }
 

--- a/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -82,7 +82,7 @@ class FakesSpec extends PlaySpecification {
 
   def contentTypeForFakeRequest[T](request: FakeRequest[AnyContentAsJson])(implicit mat: Materializer): String = {
     var testContentType: Option[String] = None
-    val action = Action { request: Request[_] =>
+    val action = Action { (request: Request[_]) =>
       testContentType = request.headers.get(CONTENT_TYPE); Ok
     }
     val headers   = new WrappedRequest(request)

--- a/testkit/play-test/src/main/scala/play/api/test/ApplicationFactory.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ApplicationFactory.scala
@@ -49,12 +49,12 @@ import play.api.routing.Router
   }
 
   final def withAction(createAction: DefaultActionBuilder => Action[_]): ApplicationFactory = withRouter {
-    components: BuiltInComponents =>
+    (components: BuiltInComponents) =>
       val action = createAction(components.defaultActionBuilder)
       Router.from { case _ => action }
   }
 
-  final def withResult(result: Result): ApplicationFactory = withAction { Action: DefaultActionBuilder =>
+  final def withResult(result: Result): ApplicationFactory = withAction { (Action: DefaultActionBuilder) =>
     Action { result }
   }
 }

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -344,7 +344,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
   }
 
   def patchFakeApp = {
-    val routes: (Application) => PartialFunction[(String, String), Handler] = { app: Application =>
+    val routes: (Application) => PartialFunction[(String, String), Handler] = { (app: Application) =>
       {
         case ("PATCH", "/") =>
           val action = app.injector.instanceOf(classOf[DefaultActionBuilder])

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
@@ -29,7 +29,7 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
     }
 
     "work with a cache defined using ehcache through jcache" in new WithApplication(
-      GuiceApplicationBuilder(loadConfiguration = { env: Environment =>
+      GuiceApplicationBuilder(loadConfiguration = { (env: Environment) =>
         val settings = Map(
           "play.ws.cache.enabled"              -> "true",
           "play.ws.cache.cachingProviderName"  -> classOf[JCacheCachingProvider].getName,
@@ -46,7 +46,7 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
     }
 
     "work with a cache defined using caffeine through jcache" in new WithApplication(
-      GuiceApplicationBuilder(loadConfiguration = { env: Environment =>
+      GuiceApplicationBuilder(loadConfiguration = { (env: Environment) =>
         val settings = Map(
           "play.ws.cache.enabled"              -> "true",
           "play.ws.cache.cachingProviderName"  -> classOf[CaffeineCachingProvider].getName,

--- a/transport/client/play-ahc-ws/src/test/scala/play/libs/ws/WSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/libs/ws/WSSpec.scala
@@ -24,7 +24,7 @@ class WSSpec extends PlaySpecification with WsTestClient {
         import play.api.routing.sird._
         {
           case SirdPost(p"/") =>
-            Action { req: Request[AnyContent] =>
+            Action { (req: Request[AnyContent]) =>
               req.body.asRaw.fold[Result](BadRequest) { raw =>
                 val size = raw.size
                 Ok(s"size=$size")

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -190,7 +190,7 @@ private[server] class AkkaModelConversion(
     resultUtils.resultConversionWithErrorHandling(requestHeaders, unvalidated, errorHandler) { unvalidated =>
       // Convert result
 
-      resultUtils.validateResult(requestHeaders, unvalidated, errorHandler).fast.map { validated: Result =>
+      resultUtils.validateResult(requestHeaders, unvalidated, errorHandler).fast.map { (validated: Result) =>
         val convertedHeaders = convertHeaders(validated.header.headers)
         val entity           = convertResultBody(requestHeaders, validated, protocol)
         val intStatus        = validated.header.status

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -187,7 +187,7 @@ private[server] object ForwardedHeaderHandler {
           }
           .toMap))
 
-        params.map { paramMap: Map[String, String] =>
+        params.map { (paramMap: Map[String, String]) =>
           ForwardedEntry(paramMap.get("for"), paramMap.get("proto"))
         }
       }

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
@@ -38,7 +38,7 @@ private[play] abstract class ReloadCache[+T] {
 
   private[play] final def reloadCount: Int = reloadCounter.get
 
-  private val reloadCache: Try[Application] => T = new InlineCache[Try[Application], T]({ tryApp: Try[Application] =>
+  private val reloadCache: Try[Application] => T = new InlineCache[Try[Application], T]({ (tryApp: Try[Application]) =>
     reloadCounter.incrementAndGet()
     reloadValue(tryApp)
   })

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -68,7 +68,7 @@ private[play] final class ServerResultUtils(
       val exception                   = new ServerResultException("HTTP 1.0 client does not support chunked response", result, null)
       val errorResult: Future[Result] = httpErrorHandler.onServerError(request, exception)
       import play.core.Execution.Implicits.trampoline
-      errorResult.map { originalErrorResult: Result =>
+      errorResult.map { (originalErrorResult: Result) =>
         // Update the original error with a new status code and a "Connection: close" header
         import originalErrorResult.{ header => h }
         val newHeader = h.copy(

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -68,7 +68,7 @@ class ServerResultUtilsSpec extends Specification {
       cookieResult(None, Ok) must beNone
     }
     "send flash if new" in {
-      cookieResult(None, Ok.flashing("a" -> "b")) must beSome { cookies: Seq[Cookie] =>
+      cookieResult(None, Ok.flashing("a" -> "b")) must beSome { (cookies: Seq[Cookie]) =>
         cookies.length must_== 1
         val cookie = cookies(0)
         cookie.name must_== "PLAY_FLASH"
@@ -76,7 +76,7 @@ class ServerResultUtilsSpec extends Specification {
       }
     }
     "clear flash when received" in {
-      cookieResult(Some("PLAY_FLASH" -> "\"a=b\"; Path=/"), Ok) must beSome { cookies: Seq[Cookie] =>
+      cookieResult(Some("PLAY_FLASH" -> "\"a=b\"; Path=/"), Ok) must beSome { (cookies: Seq[Cookie]) =>
         cookies.length must_== 1
         val cookie = cookies(0)
         cookie.name must_== "PLAY_FLASH"
@@ -85,7 +85,7 @@ class ServerResultUtilsSpec extends Specification {
     }
     "leave other cookies untouched when clearing" in {
       cookieResult(Some("PLAY_FLASH" -> "\"a=b\"; Path=/"), Ok.withCookies(Cookie("cookie", "value"))) must beSome {
-        cookies: Seq[Cookie] =>
+        (cookies: Seq[Cookie]) =>
           cookies.length must_== 2
           cookies.find(_.name == "PLAY_FLASH") must beSome.like {
             case cookie => cookie.value must_== ""
@@ -97,7 +97,7 @@ class ServerResultUtilsSpec extends Specification {
     }
     "clear old flash value when different value sent" in {
       cookieResult(Some("PLAY_FLASH" -> "\"a=b\"; Path=/"), Ok.flashing("c" -> "d")) must beSome {
-        cookies: Seq[Cookie] =>
+        (cookies: Seq[Cookie]) =>
           cookies.length must_== 1
           val cookie = cookies(0)
           cookie.name must_== "PLAY_FLASH"


### PR DESCRIPTION


# Pull Request Checklist
* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose

prepare Scala 3

```
scala> Option(1).map{ a => a }
val res0: Option[Int] = Some(1)

scala> Option(1).map{ a: Int => a }
1 |Option(1).map{ a: Int => a }
  |                      ^
  |parentheses are required around the parameter of a lambda
  |This construct can be rewritten automatically under -rewrite -source 3.0-migration.
```

## Background Context


## References
