### PR TITLE
Fix parsing error in CSP reports

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -171,8 +171,8 @@ case class ScalaCSPReport(
     scriptSample: Option[String] = None,
     statusCode: Option[Int] = None,
     sourceFile: Option[String] = None,
-    lineNumber: Option[String] = None,
-    columnNumber: Option[String] = None
+    lineNumber: Option[Int] = None,
+    columnNumber: Option[Int] = None
 ) {
   def asJava: JavaCSPReport = {
     import scala.compat.java8.OptionConverters._
@@ -206,8 +206,8 @@ object ScalaCSPReport {
       .and((__ \ "script-sample").readNullable[String])
       .and((__ \ "status-code").readNullable[Int])
       .and((__ \ "source-file").readNullable[String])
-      .and((__ \ "line-number").readNullable[String])
-      .and((__ \ "column-number").readNullable[String])
+      .and((__ \ "line-number").readNullable[Int])
+      .and((__ \ "column-number").readNullable[Int])
     )(ScalaCSPReport.apply _)
 }
 
@@ -224,8 +224,8 @@ class JavaCSPReport(
     val scriptSample: Optional[String],
     val statusCode: Optional[Int],
     val sourceFile: Optional[String],
-    val lineNumber: Optional[String],
-    val columnNumber: Optional[String]
+    val lineNumber: Optional[Int],
+    val columnNumber: Optional[Int]
 ) {
   def asScala: ScalaCSPReport = {
     import scala.compat.java8.OptionConverters._

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -141,6 +141,31 @@ class JavaCSPReportSpec extends PlaySpecification {
       contentAsJson(result) must be_==(Json.obj("violation" -> "object-src https://45.55.25.245:8123/"))
     }
 
+    "work with inline script violation" in withActionServer() { implicit app =>
+      val inlineScriptJson = Json.parse(
+        """{
+          |"csp-report": {
+		      |    "blocked-uri": "inline",
+		      |    "column-number": 153,
+		      |    "document-uri": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "line-number": 1,
+		      |    "original-policy": "script-src 'self'; report-uri http://45.55.25.245:8123/csp/report-to;",
+		      |    "referrer": "",
+		      |    "source-file": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "violated-directive": "script-src"
+          |  }
+          |}
+        """.stripMargin
+      )
+
+      val request      = FakeRequest("POST", "/report-to").withJsonBody(inlineScriptJson)
+      val Some(result) = route(app, request)
+
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
+      contentAsJson(result) must be_==(Json.obj("violation" -> "script-src"))
+    }
+
     "fail when receiving an unsupported media type (text/plain) in content type header" in withActionServer() {
       implicit app =>
         val request      = FakeRequest("POST", "/report-to").withTextBody("foo")

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
@@ -122,6 +122,31 @@ class ScalaCSPReportSpec extends PlaySpecification {
       contentAsJson(result) must be_==(Json.obj("violation" -> "object-src https://45.55.25.245:8123/"))
     }
 
+    "work with inline script violation" in withApplication() { implicit app =>
+      val inlineScriptJson = Json.parse(
+        """{
+          |"csp-report": {
+		      |    "blocked-uri": "inline",
+		      |    "column-number": 153,
+		      |    "document-uri": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "line-number": 1,
+		      |    "original-policy": "script-src 'self'; report-uri http://45.55.25.245:8123/csp/report-to;",
+		      |    "referrer": "",
+		      |    "source-file": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "violated-directive": "script-src"
+          |  }
+          |}
+        """.stripMargin
+      )
+
+      val request      = FakeRequest("POST", "/report-to").withJsonBody(inlineScriptJson)
+      val Some(result) = route(app, request)
+
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
+      contentAsJson(result) must be_==(Json.obj("violation" -> "script-src"))
+    }
+
     "fail when receiving an unsupported media type (text/plain) in content type header" in withApplication() {
       implicit app =>
         val request      = FakeRequest("POST", "/report-to").withTextBody("foo")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes playframework/playframework#10876

## Purpose

Fix parsing errors in CSP report. Change `lineNumber` and `columnNumber` in `ScalaCSPreport` and `JavaCSPReport` to `Int`; Added tests.

## Background Context

These fields contain numbers, not Strings.

## References

playframework/playframework#10876
