### PR TITLE
Prefer -agentlib:jdwp= over -Xrunjdwp:

### DIFF
--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -27,7 +27,7 @@ The default way to test a Play application is with [JUnit](https://junit.org/jun
 
 > ```scala
 > javaOptions in Test ++= Seq(
->   "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9998",
+>   "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9998",
 >   "-Xms512M",
 >   "-Xmx1536M",
 >   "-Xss1M",


### PR DESCRIPTION
Using `-Xrunjdwp:` is outdated, better is to use `-agentlib:jdwp=` starting with Java 5: https://stackoverflow.com/questions/138511

Also [see what sbt uses](https://github.com/sbt/sbt/blob/v1.5.3/launcher-package/src/universal/bin/sbt.bat#L544) when running `sbt -jvm-debug 9999`:
```sh
if defined JVM_DEBUG_PORT (
  set _JAVA_OPTS=!_JAVA_OPTS! -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=!JVM_DEBUG_PORT!
)
```