### PR TITLE
align indent in `forwardsRouter.scala.twirl`

### DIFF
--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -23,8 +23,8 @@ class Routes(
   val prefix: String
 ) extends GeneratedRouter @ob
 
-   @@javax.inject.Inject()
-   def this(errorHandler: play.api.http.HttpErrorHandler@for(dep <- deps) {,
+  @@javax.inject.Inject()
+  def this(errorHandler: play.api.http.HttpErrorHandler@for(dep <- deps) {,
     @markLines(dep.rule)
     @dep.ident: @dep.clazz}
   ) = this(errorHandler, @for(dep <- deps){@dep.ident, }"/")


### PR DESCRIPTION

# Pull Request Checklist


* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?



# Helpful things

## Fixes


## Purpose

avoid `Line is indented too far to the left` warning in Scala 3

## Background Context


## References

