### PR TITLE
CSP Reports fix with fallback for Strings

### DIFF
--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -41,6 +41,10 @@ Play 2.9 contains multiple API changes. As usual, we follow our policy of deprec
 
 Many APIs that were deprecated in earlier versions were removed in Play 2.9. If you are still using them we recommend migrating to the new APIs before upgrading to Play 2.9. Check the Javadocs and Scaladocs for migration notes. See also the [[migration guide for Play 2.8|Migration28]] for more information.
 
+### Changing CSP report types
+
+There has been some changes in CSP reports, according to [w3.org specification](https://www.w3.org/TR/CSP2/). Since Play 2.9 fields `lineNumber` and `columnNumber` are Longs. If your implementation bases on these fields being Strings, Play will fallback to parsing them from String to Long and throw an error only if parsing fails. It is however encouraged to use number types, not Strings, as this may be changed when CSP3 comes out.
+
 ## Configuration changes
 
 This section lists changes and deprecations in configurations.

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -171,8 +171,8 @@ case class ScalaCSPReport(
     scriptSample: Option[String] = None,
     statusCode: Option[Int] = None,
     sourceFile: Option[String] = None,
-    lineNumber: Option[String] = None,
-    columnNumber: Option[String] = None
+    lineNumber: Option[Long] = None,
+    columnNumber: Option[Long] = None
 ) {
   def asJava: JavaCSPReport = {
     import scala.compat.java8.OptionConverters._
@@ -194,6 +194,20 @@ case class ScalaCSPReport(
 }
 
 object ScalaCSPReport {
+
+  implicit val longOrStringToLongRead: Reads[Long] = {
+    case JsString(s) =>
+      try{
+        JsSuccess(s.toLong)
+      } catch {
+        case _: NumberFormatException =>
+          JsError(Seq(JsPath -> Seq(JsonValidationError("Could not parse line or column number in CSP Report; Inappropriate format"))))
+      }
+    case JsNumber(s) =>
+      JsSuccess(s.toLong)
+    case _ => JsError(Seq(JsPath -> Seq(JsonValidationError("Could not parse line or column number in CSP Report; Expected a number or a String"))))
+  }
+
   implicit val reads: Reads[ScalaCSPReport] = (
     (__ \ "document-uri")
       .read[String]
@@ -206,8 +220,8 @@ object ScalaCSPReport {
       .and((__ \ "script-sample").readNullable[String])
       .and((__ \ "status-code").readNullable[Int])
       .and((__ \ "source-file").readNullable[String])
-      .and((__ \ "line-number").readNullable[String])
-      .and((__ \ "column-number").readNullable[String])
+      .and((__ \ "line-number").readNullable[Long](longOrStringToLongRead))
+      .and((__ \ "column-number").readNullable[Long](longOrStringToLongRead))
     )(ScalaCSPReport.apply _)
 }
 
@@ -224,8 +238,8 @@ class JavaCSPReport(
     val scriptSample: Optional[String],
     val statusCode: Optional[Int],
     val sourceFile: Optional[String],
-    val lineNumber: Optional[String],
-    val columnNumber: Optional[String]
+    val lineNumber: Optional[Long],
+    val columnNumber: Optional[Long]
 ) {
   def asScala: ScalaCSPReport = {
     import scala.compat.java8.OptionConverters._

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -197,15 +197,28 @@ object ScalaCSPReport {
 
   implicit val longOrStringToLongRead: Reads[Long] = {
     case JsString(s) =>
-      try{
+      try {
         JsSuccess(s.toLong)
       } catch {
         case _: NumberFormatException =>
-          JsError(Seq(JsPath -> Seq(JsonValidationError("Could not parse line or column number in CSP Report; Inappropriate format"))))
+          JsError(
+            Seq(
+              JsPath -> Seq(
+                JsonValidationError("Could not parse line or column number in CSP Report; Inappropriate format")
+              )
+            )
+          )
       }
     case JsNumber(s) =>
       JsSuccess(s.toLong)
-    case _ => JsError(Seq(JsPath -> Seq(JsonValidationError("Could not parse line or column number in CSP Report; Expected a number or a String"))))
+    case _ =>
+      JsError(
+        Seq(
+          JsPath -> Seq(
+            JsonValidationError("Could not parse line or column number in CSP Report; Expected a number or a String")
+          )
+        )
+      )
   }
 
   implicit val reads: Reads[ScalaCSPReport] = (

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -141,6 +141,56 @@ class JavaCSPReportSpec extends PlaySpecification {
       contentAsJson(result) must be_==(Json.obj("violation" -> "object-src https://45.55.25.245:8123/"))
     }
 
+    "work with inline script violation" in withActionServer() { implicit app =>
+      val inlineScriptJson = Json.parse(
+        """{
+          |"csp-report": {
+		      |    "blocked-uri": "inline",
+		      |    "column-number": 153,
+		      |    "document-uri": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "line-number": 1,
+		      |    "original-policy": "script-src 'self'; report-uri http://45.55.25.245:8123/csp/report-to;",
+		      |    "referrer": "",
+		      |    "source-file": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "violated-directive": "script-src"
+          |  }
+          |}
+        """.stripMargin
+      )
+
+      val request      = FakeRequest("POST", "/report-to").withJsonBody(inlineScriptJson)
+      val Some(result) = route(app, request)
+
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
+      contentAsJson(result) must be_==(Json.obj("violation" -> "script-src"))
+    }
+
+    "work with inline script violation when String implementation is used" in withActionServer() { implicit app =>
+      val inlineScriptJson = Json.parse(
+        """{
+          |"csp-report": {
+		      |    "blocked-uri": "inline",
+		      |    "column-number": "153",
+		      |    "document-uri": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "line-number": "1",
+		      |    "original-policy": "script-src 'self'; report-uri http://45.55.25.245:8123/csp/report-to;",
+		      |    "referrer": "",
+		      |    "source-file": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "violated-directive": "script-src"
+          |  }
+          |}
+        """.stripMargin
+      )
+
+      val request      = FakeRequest("POST", "/report-to").withJsonBody(inlineScriptJson)
+      val Some(result) = route(app, request)
+
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
+      contentAsJson(result) must be_==(Json.obj("violation" -> "script-src"))
+    }
+
     "fail when receiving an unsupported media type (text/plain) in content type header" in withActionServer() {
       implicit app =>
         val request      = FakeRequest("POST", "/report-to").withTextBody("foo")

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
@@ -122,6 +122,56 @@ class ScalaCSPReportSpec extends PlaySpecification {
       contentAsJson(result) must be_==(Json.obj("violation" -> "object-src https://45.55.25.245:8123/"))
     }
 
+    "work with inline script violation" in withApplication() { implicit app =>
+      val inlineScriptJson = Json.parse(
+        """{
+          |"csp-report": {
+		      |    "blocked-uri": "inline",
+		      |    "column-number": 153,
+		      |    "document-uri": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "line-number": 1,
+		      |    "original-policy": "script-src 'self'; report-uri http://45.55.25.245:8123/csp/report-to;",
+		      |    "referrer": "",
+		      |    "source-file": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "violated-directive": "script-src"
+          |  }
+          |}
+        """.stripMargin
+      )
+
+      val request      = FakeRequest("POST", "/report-to").withJsonBody(inlineScriptJson)
+      val Some(result) = route(app, request)
+
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
+      contentAsJson(result) must be_==(Json.obj("violation" -> "script-src"))
+    }
+
+    "work with inline script violation when String implementation is used" in withApplication() { implicit app =>
+      val inlineScriptJson = Json.parse(
+        """{
+          |"csp-report": {
+		      |    "blocked-uri": "inline",
+		      |    "column-number": "153",
+		      |    "document-uri": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "line-number": "1",
+		      |    "original-policy": "script-src 'self'; report-uri http://45.55.25.245:8123/csp/report-to;",
+		      |    "referrer": "",
+		      |    "source-file": "http://45.55.25.245:8123/csp?os=OS%20X&device=&browser_version=37.0&browser=firefox&os_version=Yosemite",
+		      |    "violated-directive": "script-src"
+          |  }
+          |}
+        """.stripMargin
+      )
+
+      val request      = FakeRequest("POST", "/report-to").withJsonBody(inlineScriptJson)
+      val Some(result) = route(app, request)
+
+      status(result) must_=== Status.OK
+      contentType(result) must beSome("application/json")
+      contentAsJson(result) must be_==(Json.obj("violation" -> "script-src"))
+    }
+
     "fail when receiving an unsupported media type (text/plain) in content type header" in withApplication() {
       implicit app =>
         val request      = FakeRequest("POST", "/report-to").withTextBody("foo")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10876 

## Purpose

Fix CSP report types. Add fallback for Strings as discussed
