### PR TITLE
Remove routeAndCall(...) methods that depended on StaticRoutesGenerator

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -317,6 +317,8 @@ object BuildSettings {
       ),
       ProblemFilters
         .exclude[ReversedMissingMethodProblem]("play.api.db.evolutions.EvolutionsDatasourceConfig.substitutionsEscape"),
+      // Remove routeAndCall(...) methods that depended on StaticRoutesGenerator
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.test.Helpers.routeAndCall"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/testkit/play-test/src/main/java/play/test/Helpers.java
+++ b/testkit/play-test/src/main/java/play/test/Helpers.java
@@ -333,61 +333,6 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
   }
 
   /**
-   * Route and call the request, respecting the given timeout.
-   *
-   * @param app The application used while routing and executing the request
-   * @param requestBuilder The request builder
-   * @param timeout The amount of time, in milliseconds, to wait for the body to be produced.
-   * @return the result
-   */
-  public static Result routeAndCall(Application app, RequestBuilder requestBuilder, long timeout) {
-    try {
-      @SuppressWarnings("unchecked")
-      Class<? extends Router> routerClass =
-          (Class<? extends Router>) RequestBuilder.class.getClassLoader().loadClass("Routes");
-      return routeAndCall(app, routerClass, requestBuilder, timeout);
-    } catch (RuntimeException e) {
-      throw e;
-    } catch (Throwable t) {
-      throw new RuntimeException(t);
-    }
-  }
-
-  /**
-   * Route and call the request, respecting the given timeout.
-   *
-   * @param app The application used while routing and executing the request
-   * @param router The router type
-   * @param requestBuilder The request builder
-   * @param timeout The amount of time, in milliseconds, to wait for the body to be produced.
-   * @return the result
-   */
-  public static Result routeAndCall(
-      Application app,
-      Class<? extends Router> router,
-      RequestBuilder requestBuilder,
-      long timeout) {
-    try {
-      Request request = requestBuilder.build();
-      Router routes =
-          (Router)
-              router
-                  .getClassLoader()
-                  .loadClass(router.getName() + "$")
-                  .getDeclaredField("MODULE$")
-                  .get(null);
-      return routes
-          .route(request)
-          .map(handler -> invokeHandler(app.asScala(), handler, request, timeout))
-          .orElse(null);
-    } catch (RuntimeException e) {
-      throw e;
-    } catch (Throwable t) {
-      throw new RuntimeException(t);
-    }
-  }
-
-  /**
    * Route and call the request.
    *
    * @param app The application used while routing and executing the request


### PR DESCRIPTION
This code does not longer work now that the `StaticRoutesGenerator` got removed in #8049
There is no replacement, but actually there is an overload which takes a `Router` anyway. Actually the `routeAndCall` methods are meant to be used with the routing DSL, where you create a router anyway. For non routing DSL `route(...)` should be used instead.

"Fixes" #8177