### PR TITLE
update `unmanagedSourceDirectories` setting for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
       jimfs % Test,
     (Compile / unmanagedSourceDirectories) ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, v)) if v >= 13 => (Compile / sourceDirectory).value / s"java-scala-2.13+" :: Nil
+        case Some((2, 13) | (3, _))  => (Compile / sourceDirectory).value / s"java-scala-2.13+" :: Nil
         case Some((2, v)) if v <= 12 => (Compile / sourceDirectory).value / s"java-scala-2.13-" :: Nil
         case _                       => Nil
       }


### PR DESCRIPTION
# Pull Request Checklist



* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?



# Helpful things

## Fixes


## Purpose

prepare Scala 3 build.
I think we can use [`java-scala-2.13+/play/libs/CrossScala.java`](https://github.com/playframework/playframework/blob/d1f59e95892c69b1bd7e03d63997bb8c54a8de8a/core/play/src/main/java-scala-2.13%2B/play/libs/CrossScala.java) if Scala 3. because Scala 2.13.x and 3.0.x shared same scala-library jar.

## Background Context


## References

