### PR TITLE
Update outdated links to scala-sbt.org in the documentation

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -41,7 +41,7 @@ If you want to grab the available source jars (this will take longer and it's po
 
 @[sbt-eclipse-plugin-skipParents](code/ide.sbt)
 
-or from the [sbt shell](https://www.scala-sbt.org/0.13/docs/Howto-Interactive-Mode.html), type:
+or from the [sbt shell](https://www.scala-sbt.org/1.x/docs/Howto-Interactive-Mode.html), type:
 
 ```bash
 [my-first-app] $ eclipse skip-parents=false
@@ -164,7 +164,7 @@ Start sbt:
 $ sbt
 ```
 
-Enter 'ensimeConfig' at the [sbt shell](https://www.scala-sbt.org/0.13/docs/Howto-Interactive-Mode.html). The plugin should generate a .ensime file in the root of your Play project.
+Enter 'ensimeConfig' at the [sbt shell](https://www.scala-sbt.org/1.x/docs/Howto-Interactive-Mode.html). The plugin should generate a .ensime file in the root of your Play project.
 
 ```bash
 [[play-scala-seed] $ ensimeConfig

--- a/documentation/manual/releases/release24/migration24/Migration24.md
+++ b/documentation/manual/releases/release24/migration24/Migration24.md
@@ -19,7 +19,7 @@ java.lang.UnsupportedClassVersionError: play/runsupport/classloader/ApplicationC
 
 A [java.lang.UnsupportedClassVersionError](https://docs.oracle.com/javase/8/docs/api/java/lang/UnsupportedClassVersionError.html) means that reading a Java class file with an older version of Java than the class file was compiled with is unsupported.
 
-> **Note:** Scala 2.10 does not have full support to all Java 8 language features, like static methods on interfaces. If your project has Java code using these new features present in Java 8, upgrade to use Scala 2.11.6+. See [sbt docs](https://www.scala-sbt.org/0.13/docs/Howto-Scala.html) to learn how to set `scalaVersion` to your project.
+> **Note:** Scala 2.10 does not have full support to all Java 8 language features, like static methods on interfaces. If your project has Java code using these new features present in Java 8, upgrade to use Scala 2.11.6+. See [sbt docs](https://www.scala-sbt.org/1.x/docs/Howto-Scala.html) to learn how to set `scalaVersion` to your project.
 
 ## Build changes
 

--- a/documentation/manual/working/commonGuide/build/BuildOverview.md
+++ b/documentation/manual/working/commonGuide/build/BuildOverview.md
@@ -9,7 +9,7 @@ sbt functions quite differently to many traditional build tasks.  Fundamentally,
 
 sbt breaks typical build executions up into very fine grained tasks, and any task at any point in the tree can be arbitrarily redefined in your build.  This makes sbt very powerful, but also requires a shift in thinking if you've come from other build tools that break your build up into very coarsely grained tasks.
 
-The documentation here describes Play's usage of sbt at a very high level.  As you start to use sbt more in your project, it is recommended that you follow the [sbt tutorial](https://www.scala-sbt.org/0.13/tutorial/index.html) to get an understanding for how sbt fits together.  Another resource that many people have found useful is [this series of blog posts](https://jazzy.id.au/2015/03/03/sbt-task-engine.html).
+The documentation here describes Play's usage of sbt at a very high level.  As you start to use sbt more in your project, it is recommended that you follow the [sbt tutorial](https://www.scala-sbt.org/1.x/docs/Getting-Started.html) to get an understanding for how sbt fits together.  Another resource that many people have found useful is [this series of blog posts](https://jazzy.id.au/2015/03/03/sbt-task-engine.html).
 
 ## Play application directory structure
 
@@ -38,7 +38,7 @@ The `name` line defines the name of your application and it will be the same as 
 
 The `version` line provides  the version of your application which is used as part of the name for the artifacts your build will produce.
 
-The `libraryDependencies` line specifies the libraries that your application depends on. You can see more details about [how to manage your dependencies in the sbt docs](https://www.scala-sbt.org/0.13/docs/Library-Management.html).
+The `libraryDependencies` line specifies the libraries that your application depends on. You can see more details about [how to manage your dependencies in the sbt docs](https://www.scala-sbt.org/1.x/docs/Library-Management.html).
 
 Finally, you need to enable an sbt plugin on your project to "Play-ify" it. This adds support for Play-specific features such as the twirl compiler and the routes compiler, and adds the necessary Play libraries to build your project and run the server. Generally you should use one of the following Play plugins for a Play application:
  - `PlayScala`: a standard Play Scala project.

--- a/documentation/manual/working/commonGuide/build/sbtDependencies.md
+++ b/documentation/manual/working/commonGuide/build/sbtDependencies.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
 # Managing library dependencies
 
-> **Note:** Some sections of this page were copied from the sbt manual, specifically from the [Library Dependencies](https://www.scala-sbt.org/0.13/docs/Library-Dependencies.html) page. You can refer to that page for a more detailed and updated version of the information here.
+> **Note:** Some sections of this page were copied from the sbt manual, specifically from the [Library Dependencies](https://www.scala-sbt.org/1.x/docs/Library-Dependencies.html) page. You can refer to that page for a more detailed and updated version of the information here.
 
 ## Unmanaged dependencies
 
@@ -59,6 +59,6 @@ sbt can search your local Maven repository if you add it as a repository:
 
 sbt has extensive documentation about how to manage conflict between your dependencies:
 
-[sbt: Dependencies Conflict Management](https://www.scala-sbt.org/0.13/docs/Library-Management.html#Conflict+Management)
+[sbt: Dependencies Conflict Management](https://www.scala-sbt.org/1.x/docs/Library-Management.html#Conflict+Management)
 
 You can also use [sbt-dependency-graph](https://github.com/jrudolph/sbt-dependency-graph) to have a better visualization of your dependency tree. See also our page about [[debugging sbt|sbtDebugging]] common problems.

--- a/documentation/manual/working/commonGuide/database/Developing-with-the-H2-Database.md
+++ b/documentation/manual/working/commonGuide/database/Developing-with-the-H2-Database.md
@@ -74,7 +74,7 @@ H2, by default, creates tables with upper case names. Sometimes you don't want t
 
 ## H2 Browser
 
-You can browse the contents of your database by typing `h2-browser` at the [sbt shell](https://www.scala-sbt.org/0.13/docs/Howto-Interactive-Mode.html).  An SQL browser will run in your web browser.
+You can browse the contents of your database by typing `h2-browser` at the [sbt shell](https://www.scala-sbt.org/1.x/docs/Howto-Interactive-Mode.html).  An SQL browser will run in your web browser.
 
 ## H2 Documentation
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -15,7 +15,7 @@ You can run tests from the Play console.
 * To run tests continually, run a command with a tilde in front, i.e. `~test-quick`.
 * To access test helpers such as `FakeRequest` in console, run `test:console`.
 
-Testing in Play is based on sbt, and a full description is available in the [testing sbt](https://www.scala-sbt.org/0.13/docs/Testing.html) chapter.
+Testing in Play is based on sbt, and a full description is available in the [testing sbt](https://www.scala-sbt.org/1.x/docs/Testing.html) chapter.
 
 ## Using specs2
 


### PR DESCRIPTION
## Purpose

This PR updates outdated links to scala-sbt.org in the documentation (except places where the description is specific to sbt 0.13).

## Background Context

sbt 0.13 and its documentation is outdated, so I thought that it should to refer to the 1.x version of the sbt documentation.

Ref) https://www.scala-sbt.org/0.13/docs/

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?