### PR TITLE
Correctly shutdown current active LoggerConfigurator on app (re)load in DEV mode

### DIFF
--- a/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -19,6 +19,14 @@ import org.slf4j.LoggerFactory
 import play.api._
 
 class LogbackLoggerConfigurator extends LoggerConfigurator {
+
+  // Usually a LoggerConfigurator gets configured when building an app.
+  // However, there is a special case in dev mode: The DevServer initially configures a LoggerConfigurator
+  // _before_ an app gets build. In that case the init(...) method below gets called. We track that call with this boolean flag
+  // to avoid unsetting the app mode when the LoggerConfigurator gets shut down.
+  // Also see play.core.server.DevServerStart (where loggerConfigurator.init(...) gets called)
+  private var initializedWithoutApp = false
+
   def loggerFactory: ILoggerFactory = {
     LoggerFactory.getILoggerFactory
   }
@@ -27,6 +35,7 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
    * Initialize the Logger when there's no application ClassLoader available.
    */
   def init(rootPath: java.io.File, mode: Mode): Unit = {
+    initializedWithoutApp = true
     val properties   = Map("application.home" -> rootPath.getAbsolutePath)
     val resourceName = if (mode == Mode.Dev) "logback-play-dev.xml" else "logback-play-default.xml"
     val resourceUrl  = Option(this.getClass.getClassLoader.getResource(resourceName))
@@ -145,8 +154,10 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
 
       org.slf4j.bridge.SLF4JBridgeHandler.uninstall()
 
-      // Unset the global application mode for logging
-      play.api.Logger.unsetApplicationMode()
+      if (!initializedWithoutApp) {
+        // Unset the global application mode for logging
+        play.api.Logger.unsetApplicationMode()
+      }
     }
   }
 }

--- a/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -239,6 +239,10 @@ final class DevServerStart(
                 // because the app that will be build configures its own LoggerConfigurator later (but then by using the app's classloader)
                 initialLoggerConfigurator.foreach(_.shutdown())
                 initialLoggerConfigurator = None
+                // However, if we build an app _not the first time_, but there was an app running before (= lastState is success), we make sure
+                // to shut down that old app's LoggerConfigurator, just before the app that will be build configures its own
+                lastState.foreach(app => LoggerConfigurator(app.classloader).foreach(lc => lc.shutdown()))
+                // FYI: initialLoggerConfigurator and lastState will never both be set at the same time, so in the lines above at most only one shutdown() gets called
 
                 loader.load(context)
               }

--- a/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -153,7 +153,11 @@ final class DevServerStart(
         // This is usually done by Application itself when it's instantiated, which for other types of ApplicationProviders,
         // is usually instantiated along with or before the provider.  But in dev mode, no application exists initially, so
         // configure it here.
-        LoggerConfigurator(classLoader) match {
+        // The initialLoggerConfigurator will always be the LogbackLoggerConfigurator, because we don't have an app
+        // available yet, so we can't access and read the app's logger-configurator.properties (if it has one), but only
+        // the logger-configurator.properties Play ships with (which references the LogbackLoggerConfigurator)
+        var initialLoggerConfigurator = LoggerConfigurator(classLoader)
+        initialLoggerConfigurator match {
           case Some(loggerConfigurator) =>
             loggerConfigurator.init(path, Mode.Dev)
           case None =>
@@ -230,6 +234,12 @@ final class DevServerStart(
                   devContext = Some(ApplicationLoader.DevContext(sourceMapper, buildLink))
                 )
                 val loader = ApplicationLoader(context)
+
+                // Before building a new app _the first time_, we make sure to shutdown the (Logback)LoggerConfigurator created initally by the dev server above,
+                // because the app that will be build configures its own LoggerConfigurator later (but then by using the app's classloader)
+                initialLoggerConfigurator.foreach(_.shutdown())
+                initialLoggerConfigurator = None
+
                 loader.load(context)
               }
 


### PR DESCRIPTION
  **(IMHO this PR fixes a potential memory leak in dev mode)**

Before I come to the problem this PR fixes, let's first have a look at how, in a default Play app, the `LoggerConfigurator` gets set up:

When an app gets build via Guice, at some point the `injector` gets created. For this the `applicationModule()` is needed:

https://github.com/playframework/playframework/blob/44886b0607f7b5a37a4f475b6c32e23cbcef1297/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala#L193-L200

The `applicationModule()` method now configures the `LoggerFactory`:

https://github.com/playframework/playframework/blob/44886b0607f7b5a37a4f475b6c32e23cbcef1297/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala#L108-L112

And this is done by "configuring" the `LoggerConfigurator` (`lc.configure(...)`):

https://github.com/playframework/playframework/blob/44886b0607f7b5a37a4f475b6c32e23cbcef1297/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala#L134-L140

Even when not using Guice, we tell people they should call `lc.configure(...)` themselves. See [here](https://www.playframework.com/documentation/2.8.x/SettingsLogger#Using-a-custom-application-loader), [here](https://www.playframework.com/documentation/2.8.x/ScalaCompileTimeDependencyInjection#Configuring-Logging), [here](https://www.playframework.com/documentation/2.8.x/JavaCompileTimeDependencyInjection#Configuring-Logging) and [here](https://www.playframework.com/documentation/2.8.x/ScalaEmbeddingPlayAkkaHttp#Logging-configuration).

OK, so now we know that **each time we create a new app**, a `LoggerConfigurator` gets set up by calling `lc.configure(...)`.

**Now, let's have a look at PROD mode:**

In prod mode, a single app gets created and a server (netty or akka-http) gets started _afterwards_. Now when shutting down the "application" (usually the os process), it means the http server and the app get shutdown together.
Now, when that shutdown happens, basically the last thing that happens is that also the `LoggerConfigurator` (that was configured during bootstrapping the app) gets shut down by the http server (at the point this happens in the below `stop` method the app was shut down already):

https://github.com/playframework/playframework/blob/44886b0607f7b5a37a4f475b6c32e23cbcef1297/transport/server/play-server/src/main/scala/play/core/server/Server.scala#L48-L52

So great, the app and http-server get started, a `LoggerConfigurator` gets configured during bootstrapping the app, and when the whole thing gets shut down, the `LoggerConfigurator` will be shut down as well. On re-start, the same happens again. So no problem here.

**But now, let's have a look at DEV mode:**

Dev mode is different. In dev mode, unlike prod, an http server get's started first, and afterwards an app gets build, and usually (if you change a file), that app gets shut down, a new app will be build again, and so forth. Only when you quit dev mode, when you hit the `return` key on your keyboard, the current running app gets shut down and finally also the http server will be shut down as well.
The problems now are:
 * During this dev reload cycles, the current active `LoggerConfigurator` never gets shutdown. Even worse, every time a new app gets created, of course, a new `LoggerConfigurator` gets configured... Only at the very end, when you hit return and the http-server gets shutdown, the `LoggerConfigurator` of the last app finally gets shut down by the http-server's `stop` method (like described above in prod mode). Any `LoggerConfigurator`s set up before however never cleaned up their resources...
 * Since the dev server starts an http-server _before_ an app gets build, it sets up a special `LoggerConfigurator` before the first app gets build. And again, also that special `LoggerConfigurator` never gets shutdown... When the first app gets started, that first app then just goes ahead and configures its own `LoggerConfigurator`... The special `LoggerConfigurator` set up is done here: https://github.com/playframework/playframework/blob/44886b0607f7b5a37a4f475b6c32e23cbcef1297/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala#L150-L159

So you see, in dev mode the current active `LoggerConfigurator` never cleanly gets shutdown, which could lead to memory leaks or other problems with the logging infrastructure.

And there is even one more unfortunate side effect because of this behaviour:
The `LogbackLoggerConfigurator` (which is the default) sets the application mode when it gets configured:
https://github.com/playframework/playframework/blob/44886b0607f7b5a37a4f475b6c32e23cbcef1297/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala#L71-L72
and unsets it again on shut down:
https://github.com/playframework/playframework/blob/44886b0607f7b5a37a4f475b6c32e23cbcef1297/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala#L144-L145

Now look what those methods do:
https://github.com/playframework/playframework/blob/44886b0607f7b5a37a4f475b6c32e23cbcef1297/core/play/src/main/scala/play/api/Logger.scala#L275-L303

If in dev mode, when many `LoggerConfigurator`s will be set up (but never shut down) because of reload cycles, the `_appsRunning` counter in this code increases more and more, but never decreases anymore. Actually, in normal dev mode there is always just one running app _at a time_, even though different apps run _one after another_, but here the `_appsRunning` counter just increases. That also means, that when the http-server gets shut down and finally the `unsetApplicationMode` method gets called once, the counter is way to high, and `_mode` will never be set to `None`, although there is no app running anymore. Also in between reload cycles, when briefly no app is running, `_mode` will not be set to `None`.

With this PR all of the above problems are fixed. I did _a lot_ of testing by e.g. adding breakpoints to these `[unset]setApplicationMode` methods and also to the `shutdown`, `init` and `configure` methods of the [`LogbackLoggerConfigurator`](https://github.com/playframework/playframework/blob/2.8.8/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala) and can confirm that now there is always just one active `LoggerConfigurator` that cleanly gets shut down before the next `LoggerConfigurator` gets configured. Also the app counter increases to 1 and gets set back to 0 when an app shuts down and then again 1 -> 0 -> 1 -> 0 ,etc. which means also `_mode` gets set to `None` correctly when no app is running.