### PR TITLE
HTTP 400 instead of 500 on Unicode headers

### DIFF
--- a/core/play/src/main/scala/play/core/utils/AsciiSet.scala
+++ b/core/play/src/main/scala/play/core/utils/AsciiSet.scala
@@ -90,9 +90,7 @@ private[play] final class AsciiUnion(a: AsciiSet, b: AsciiSet) extends AsciiSet 
  */
 private[play] final class AsciiBitSet private[utils] (bitSet: JBitSet) extends AsciiSet {
   final def get(i: Int): Boolean = {
-    if (i < 0 || i > 255)
-      throw new IllegalArgumentException(s"Character $i cannot match AsciiSet because it is out of range")
-    getInternal(i)
+    i >= 0 && i <= 255 && getInternal(i)
   }
   private[utils] override def getInternal(i: Int): Boolean = bitSet.get(i)
   override def toBitSet: AsciiBitSet                       = this

--- a/transport/server/play-server/src/main/scala/play/core/server/common/InvalidHeaderCharacterException.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/InvalidHeaderCharacterException.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import play.api.mvc._
+
+/**
+ * This exception occurs when the Play server receives a request header
+ * where at least one character is illegal according to RFC2616 and RFC7230
+ *
+ * @param message The reason for the exception.
+ * @param character The invalid character.
+ */
+class InvalidHeaderCharacterException(message: String, val character: Char) extends Exception(message)

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -128,7 +128,7 @@ private[play] final class ServerResultUtils(
       if (i < string.length) {
         val c = string.charAt(i)
         if (!allowedSet.get(c))
-          throw new IllegalArgumentException(s"Invalid $setDescription character: '$c' (${c.toInt})")
+          throw new InvalidHeaderCharacterException(s"Invalid $setDescription character: '$c' (${c.toInt})", c)
         loop(i + 1)
       }
     }
@@ -156,30 +156,42 @@ private[play] final class ServerResultUtils(
     import play.core.Execution.Implicits.trampoline
 
     def handleConversionError(conversionError: Throwable): Future[R] = {
+      val isInvalidHeaderCharacter = conversionError.isInstanceOf[InvalidHeaderCharacterException]
+      val shouldLog = if (isInvalidHeaderCharacter) logger.isInfoEnabled else logger.isErrorEnabled
+      def log(message: String, error: Throwable) = if (isInvalidHeaderCharacter) logger.info(message, error) else logger.error(message, error)
+
       try {
         // Log some information about the error
-        if (logger.isErrorEnabled) {
+        if (shouldLog) {
           val prettyHeaders =
             result.header.headers.map { case (name, value) => s"<$name>: <$value>" }.mkString("[", ", ", "]")
           val msg =
             s"Exception occurred while converting Result with headers $prettyHeaders. Calling HttpErrorHandler to get alternative Result."
-          logger.error(msg, conversionError)
+          log(msg, conversionError)
         }
 
         // Call the HttpErrorHandler to generate an alternative error
-        errorHandler
-          .onServerError(
+        val futureErrorResult = if (isInvalidHeaderCharacter) {
+          errorHandler.onClientError(
+            requestHeader,
+            400,
+            s"Invalid header: ${conversionError.getMessage()}"
+          )
+        } else {
+          errorHandler.onServerError(
             requestHeader,
             new ServerResultException("Error converting Play Result for server backend", result, conversionError)
           )
-          .flatMap { errorResult =>
-            // Convert errorResult using normal conversion logic. This time use
-            // the DefaultErrorHandler if there are any problems, e.g. if the
-            // current HttpErrorHandler returns an invalid Result.
-            resultConversionWithErrorHandling(requestHeader, errorResult, DefaultHttpErrorHandler)(resultConverter)(
-              fallbackResponse
-            )
-          }
+        }
+        
+        futureErrorResult.flatMap { errorResult =>
+          // Convert errorResult using normal conversion logic. This time use
+          // the DefaultErrorHandler if there are any problems, e.g. if the
+          // current HttpErrorHandler returns an invalid Result.
+          resultConversionWithErrorHandling(requestHeader, errorResult, DefaultHttpErrorHandler)(resultConverter)(
+            fallbackResponse
+          )
+        }
       } catch {
         case NonFatal(onErrorError) =>
           // Conservatively handle exceptions thrown by HttpErrorHandlers by

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -157,8 +157,9 @@ private[play] final class ServerResultUtils(
 
     def handleConversionError(conversionError: Throwable): Future[R] = {
       val isInvalidHeaderCharacter = conversionError.isInstanceOf[InvalidHeaderCharacterException]
-      val shouldLog = if (isInvalidHeaderCharacter) logger.isInfoEnabled else logger.isErrorEnabled
-      def log(message: String, error: Throwable) = if (isInvalidHeaderCharacter) logger.info(message, error) else logger.error(message, error)
+      val shouldLog                = if (isInvalidHeaderCharacter) logger.isInfoEnabled else logger.isErrorEnabled
+      def log(message: String, error: Throwable) =
+        if (isInvalidHeaderCharacter) logger.info(message, error) else logger.error(message, error)
 
       try {
         // Log some information about the error
@@ -183,7 +184,7 @@ private[play] final class ServerResultUtils(
             new ServerResultException("Error converting Play Result for server backend", result, conversionError)
           )
         }
-        
+
         futureErrorResult.flatMap { errorResult =>
           // Convert errorResult using normal conversion logic. This time use
           // the DefaultErrorHandler if there are any problems, e.g. if the

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -128,7 +128,10 @@ private[play] final class ServerResultUtils(
       if (i < string.length) {
         val c = string.charAt(i)
         if (!allowedSet.get(c))
-          throw new InvalidHeaderCharacterException(s"Invalid $setDescription character: '$c' (${c.toInt})", c)
+          throw new InvalidHeaderCharacterException(
+            s"Invalid $setDescription character: '$c' (${c.toInt}) in string $string at position $i",
+            c
+          )
         loop(i + 1)
       }
     }

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -187,41 +187,49 @@ class ServerResultUtilsSpec extends Specification {
 
   "resultUtils.validateHeaderNameChars" should {
     "accept Foo" in {
-      resultUtils.validateHeaderNameChars("Foo") must not(throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars("Foo") must not(throwAn[InvalidHeaderCharacterException])
     }
     "accept allowed chars" in {
-      resultUtils.validateHeaderNameChars("!#$%&'*+-.^_`|~01239azAZ") must not(throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars("!#$%&'*+-.^_`|~01239azAZ") must not(throwAn[InvalidHeaderCharacterException])
     }
     "not accept control characters" in {
-      resultUtils.validateHeaderNameChars("\u0000") must (throwAn[IllegalArgumentException])
-      resultUtils.validateHeaderNameChars("\u0001") must (throwAn[IllegalArgumentException])
-      resultUtils.validateHeaderNameChars("\u001f") must (throwAn[IllegalArgumentException])
-      resultUtils.validateHeaderNameChars("\u00ff") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars("\u0000") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderNameChars("\u0001") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderNameChars("\u001f") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderNameChars("\u00ff") must (throwAn[InvalidHeaderCharacterException])
     }
     "not accept delimiters" in {
-      resultUtils.validateHeaderNameChars(":") must (throwAn[IllegalArgumentException])
-      resultUtils.validateHeaderNameChars(" ") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderNameChars(":") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderNameChars(" ") must (throwAn[InvalidHeaderCharacterException])
+    }
+    "not accept unicode" in {
+      resultUtils.validateHeaderNameChars("🦄") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderNameChars("你好") must (throwAn[InvalidHeaderCharacterException])
     }
   }
 
   "resultUtils.validateHeaderValueChars" should {
     "accept bar" in {
-      resultUtils.validateHeaderValueChars("bar") must not(throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars("bar") must not(throwAn[InvalidHeaderCharacterException])
     }
     "accept tokens" in {
-      resultUtils.validateHeaderValueChars("!#$%&'*+-.^_`|~01239azAZ") must not(throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars("!#$%&'*+-.^_`|~01239azAZ") must not(throwAn[InvalidHeaderCharacterException])
     }
     "accept separators" in {
-      resultUtils.validateHeaderValueChars("\"(),/:;<=>?@[\\]{}") must not(throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars("\"(),/:;<=>?@[\\]{}") must not(throwAn[InvalidHeaderCharacterException])
     }
     "accept space and htab" in {
-      resultUtils.validateHeaderValueChars(" \t") must not(throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars(" \t") must not(throwAn[InvalidHeaderCharacterException])
     }
     "not accept control characters" in {
-      resultUtils.validateHeaderValueChars("\u0000") must (throwAn[IllegalArgumentException])
-      resultUtils.validateHeaderValueChars("\u0001") must (throwAn[IllegalArgumentException])
-      resultUtils.validateHeaderValueChars("\u001f") must (throwAn[IllegalArgumentException])
-      resultUtils.validateHeaderValueChars("\u007f") must (throwAn[IllegalArgumentException])
+      resultUtils.validateHeaderValueChars("\u0000") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderValueChars("\u0001") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderValueChars("\u001f") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderValueChars("\u007f") must (throwAn[InvalidHeaderCharacterException])
+    }
+    "not accept unicode" in {
+      resultUtils.validateHeaderValueChars("🦄") must (throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderValueChars("你好") must (throwAn[InvalidHeaderCharacterException])
     }
   }
 }

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -213,7 +213,9 @@ class ServerResultUtilsSpec extends Specification {
       resultUtils.validateHeaderValueChars("bar") must not(throwAn[InvalidHeaderCharacterException])
     }
     "accept tokens" in {
-      resultUtils.validateHeaderValueChars("!#$%&'*+-.^_`|~01239azAZ") must not(throwAn[InvalidHeaderCharacterException])
+      resultUtils.validateHeaderValueChars("!#$%&'*+-.^_`|~01239azAZ") must not(
+        throwAn[InvalidHeaderCharacterException]
+      )
     }
     "accept separators" in {
       resultUtils.validateHeaderValueChars("\"(),/:;<=>?@[\\]{}") must not(throwAn[InvalidHeaderCharacterException])


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* ~~Have you checked that both Scala and Java APIs are updated?~~
* ~~Have you updated the documentation for both Scala and Java sections?~~
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10944

## Purpose

Return HTTP 400 instead of 500 when headers contain non-Ascii characters, and avoid writing error logs in such cases.

## Background Context

Another option would be to allow Unicode characters to go through, even though the RFCs do not allow it.
Even then, there would be more malicious cases (e.g. control characters) that should be rejected without causing server errors, so this fix would be required anyways.
