### PR TITLE
Remove obsolete helper used for developing akka-http play backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,20 +127,21 @@ lazy val PlayNettyServerProject = PlayCrossBuiltProject("Play-Netty-Server", "tr
   .settings(libraryDependencies ++= netty)
   .dependsOn(PlayServerProject)
 
-import AkkaDependency._
 lazy val PlayAkkaHttpServerProject =
   PlayCrossBuiltProject("Play-Akka-Http-Server", "transport/server/play-akka-http-server")
     .dependsOn(PlayServerProject, StreamsProject)
     .dependsOn(PlayGuiceProject % "test")
     .settings(
-      libraryDependencies ++= specs2Deps.map(_ % "test")
+      libraryDependencies ++= specs2Deps.map(_ % "test"),
+      libraryDependencies += akkaHttp
     )
-    .addAkkaModuleDependency("akka-http-core")
 
 lazy val PlayAkkaHttp2SupportProject =
   PlayCrossBuiltProject("Play-Akka-Http2-Support", "transport/server/play-akka-http2-support")
     .dependsOn(PlayAkkaHttpServerProject)
-    .addAkkaModuleDependency("akka-http2-support")
+    .settings(
+      libraryDependencies += akkaHttp2Support
+    )
 
 lazy val PlayClusterSharding = PlayCrossBuiltProject("Play-Cluster-Sharding", "cluster/play-cluster-sharding")
   .settings(libraryDependencies ++= clusterDependencies)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -287,38 +287,3 @@ object Dependencies {
     "com.shapesecurity" % "salvation" % salvationVersion % Test
   )
 }
-
-/*
- * How to use this:
- *    $ sbt -J-XX:+UnlockCommercialFeatures -J-XX:+FlightRecorder -Dakka-http.sources=$HOME/code/akka-http '; project Play-Akka-Http-Server; Test/run'
- *
- * Make sure Akka-HTTP has 2.12 as the FIRST version (or that scalaVersion := "2.12.14", otherwise it won't find the artifact
- *    crossScalaVersions := Seq("2.12.14", "2.11.12"),
- */
-object AkkaDependency {
-  // Needs to be a URI like git://github.com/akka/akka.git#master or file:///xyz/akka
-  val akkaSourceDependencyUri   = sys.props.getOrElse("akka-http.sources", "")
-  val shouldUseSourceDependency = akkaSourceDependencyUri != ""
-  val akkaRepository            = uri(akkaSourceDependencyUri)
-
-  implicit class RichProject(project: Project) {
-
-    /** Adds either a source or a binary dependency, depending on whether the above settings are set */
-    def addAkkaModuleDependency(module: String, config: String = ""): Project =
-      if (shouldUseSourceDependency) {
-        val moduleRef = ProjectRef(akkaRepository, module)
-        val withConfig: ClasspathDependency =
-          if (config == "") {
-            println("  Using Akka-HTTP directly from sources, from: " + akkaSourceDependencyUri)
-            moduleRef
-          } else moduleRef % config
-
-        project.dependsOn(withConfig)
-      } else {
-        project.settings(libraryDependencies += {
-          val dep = "com.typesafe.akka" %% module % Dependencies.akkaHttpVersion
-          if (config == "") dep else dep % config
-        })
-      }
-  }
-}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -154,6 +154,10 @@ object Dependencies {
     ("io.netty" % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
   ) ++ specs2Deps.map(_ % Test)
 
+  val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
+
+  val akkaHttp2Support = "com.typesafe.akka" %% "akka-http2-support" % akkaHttpVersion
+
   val cookieEncodingDependencies = slf4j
 
   val jimfs = "com.google.jimfs" % "jimfs" % "1.2"


### PR DESCRIPTION
This code was added here https://github.com/playframework/playframework/commit/c81dbfaa4a51da8b42b69bc12efe9a63f6868553#diff-a7128390b01737066cea724216ef9341188fa29b0dc84db5024feec2966d68ddR257 ("useful setup for co-developing akka-http and the akka-http play backend") - when developing Play's akka-http backend.
At that time akka-http was just in its [early <= 10.0.6 days](https://github.com/akka/akka-http/tags?after=v10.0.8).

Does actually someone still use this helper? I never did and I think its not necessary anymore, since the play akka-http backend is stable and just requires normal akka-http upgrades (and maybe necessary code adjustments), but not active developing anymore.

If you think its still necessary please just close this PR, its ok for me.