### PR TITLE
[2.8x] Fix cron job by upgrading akka + scalaJava8Compat (for Scala 2.13 only)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val SbtRoutesCompilerProject = PlaySbtProject("Sbt-Routes-Compiler", "dev-m
   )
 
 lazy val StreamsProject = PlayCrossBuiltProject("Play-Streams", "core/play-streams")
-  .settings(libraryDependencies ++= streamsDependencies)
+  .settings(libraryDependencies ++= streamsDependencies(scalaVersion.value))
 
 lazy val PlayExceptionsProject = PlayNonCrossBuiltProject("Play-Exceptions", "core/play-exceptions")
 
@@ -204,7 +204,7 @@ lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "testkit/play-
   .dependsOn(PlayTestProject)
 
 lazy val PlayJavaProject = PlayCrossBuiltProject("Play-Java", "core/play-java")
-  .settings(libraryDependencies ++= javaDeps ++ javaTestDeps)
+  .settings(libraryDependencies ++= javaDeps(scalaVersion.value) ++ javaTestDeps)
   .dependsOn(
     PlayProject       % "compile;test->test",
     PlayTestProject   % "test",
@@ -214,7 +214,7 @@ lazy val PlayJavaProject = PlayCrossBuiltProject("Play-Java", "core/play-java")
 
 lazy val PlayJavaFormsProject = PlayCrossBuiltProject("Play-Java-Forms", "web/play-java-forms")
   .settings(
-    libraryDependencies ++= javaDeps ++ javaFormsDeps ++ javaTestDeps
+    libraryDependencies ++= javaDeps(scalaVersion.value) ++ javaFormsDeps ++ javaTestDeps
   )
   .dependsOn(
     PlayJavaProject % "compile;test->test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.14")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.16")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.14")
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.2"
@@ -85,8 +85,12 @@ object Dependencies {
     "org.hibernate"                   % "hibernate-core"        % "5.4.30.Final" % "test"
   )
 
-  def scalaReflect(scalaVersion: String) = "org.scala-lang"         % "scala-reflect"       % scalaVersion % "provided"
-  val scalaJava8Compat                   = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
+  def scalaReflect(scalaVersion: String) = "org.scala-lang" % "scala-reflect" % scalaVersion % "provided"
+  def scalaJava8Compat(scalaVersion: String) =
+    "org.scala-lang.modules" %% "scala-java8-compat" % (CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, major)) if major >= 13 => "1.0.0"
+      case _                               => "0.9.1"
+    })
   def scalaParserCombinators(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, major)) if major >= 11 => Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2")
     case _                               => Nil
@@ -94,11 +98,12 @@ object Dependencies {
 
   val springFrameworkVersion = "5.2.13.RELEASE"
 
-  val javaDeps = Seq(
-    scalaJava8Compat,
-    // Used by the Java routing DSL
-    "net.jodah"         % "typetools" % "0.5.0"
-  ) ++ specs2Deps.map(_ % Test)
+  def javaDeps(scalaVersion: String) =
+    Seq(
+      scalaJava8Compat(scalaVersion),
+      // Used by the Java routing DSL
+      "net.jodah"         % "typetools" % "0.5.0"
+    ) ++ specs2Deps.map(_ % Test)
 
   val joda = Seq(
     "joda-time" % "joda-time"    % "2.10.10",
@@ -153,7 +158,7 @@ object Dependencies {
         "jakarta.transaction" % "jakarta.transaction-api" % "1.3.3",
         "javax.inject"        % "javax.inject"            % "1",
         scalaReflect(scalaVersion),
-        scalaJava8Compat,
+        scalaJava8Compat(scalaVersion),
         sslConfig
       ) ++ scalaParserCombinators(scalaVersion) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
 
@@ -229,11 +234,12 @@ object Dependencies {
     "com.typesafe.play" %% "play-doc" % playDocVersion
   ) ++ playdocWebjarDependencies
 
-  val streamsDependencies = Seq(
-    "org.reactivestreams" % "reactive-streams" % "1.0.3",
-    "com.typesafe.akka"   %% "akka-stream"     % akkaVersion,
-    scalaJava8Compat
-  ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
+  def streamsDependencies(scalaVersion: String) =
+    Seq(
+      "org.reactivestreams" % "reactive-streams" % "1.0.3",
+      "com.typesafe.akka"   %% "akka-stream"     % akkaVersion,
+      scalaJava8Compat(scalaVersion)
+    ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
 
   val playServerDependencies = specs2Deps.map(_ % Test) ++ Seq(
     guava   % Test,


### PR DESCRIPTION
After merging #10963 another [problem unfolded](https://app.travis-ci.com/github/playframework/playframework/jobs/534232661#L15136-L15139): Now that the cron jobs use the correct and therefore latest akka snapshot again (from the sonatype repo now instead from repo.akka.io) that latest akka snapshot is now 2.6.16-xxx-SNAPSHOT. Before 2.6.14-xxx-SNAPSHOT from repo.akka.io was used (if I remember correctly).
Now the problem is, because we use that latest and greatest akka snapshot, akka upgraded its `scala-java8-compat` library [recently to 1.0.0](https://github.com/akka/akka/pull/30375). That is a problem when running scripted tests with sbt 1.5.x because that latest and greatest sbt version checks for deps compatibily so we end up with broken sbt 1.5 scripted tests:
```
[info] [error] 	* org.scala-lang.modules:scala-java8-compat_2.13:1.0.0 (early-semver) is selected over {0.9.1, 0.9.1}
[info] [error] 	    +- com.typesafe.akka:akka-actor_2.13:2.6.16+39-942186ac-SNAPSHOT (depends on 1.0.0)
[info] [error] 	    +- com.typesafe.play:play_2.13:2.8.8+66-81239e45-akka-2.6.16+39-942186ac-SNAPSHOT-akka-http-10.1.14+6-971cf72c-SNAPSHOT (depends on 0.9.1)
[info] [error] 	    +- com.typesafe.play:play-streams_2.13:2.8.8+66-81239e45-akka-2.6.16+39-942186ac-SNAPSHOT-akka-http-10.1.14+6-971cf72c-SNAPSHOT (depends on 0.9.1)
```

So this pull request here does almost the same like #10900 does for the master branch, it upgrades `scala-java8-compat` to 1.0.0 (and also akka to 2.6.16, seems like scala steward didn't do that for us yet), **but** instead of dropping Scala 2.12, which we do in the master branch ([see this comment why](https://github.com/playframework/playframework/pull/10900/#issuecomment-901934994)) but we don't want to do for the 2.8.x branch, we have to conditionally, use scala-java8-compat depending on the Scala version. 