### PR TITLE
Upgrade versions

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -24,7 +24,10 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jsr310" },
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" },
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-pcollections" },
-  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-guava" }
+  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-guava" },
+  // these will get updated along with selenium-api, so no need to update them separately
+  { groupId = "org.seleniumhq.selenium", artifactId = "selenium-support" },
+  { groupId = "org.seleniumhq.selenium", artifactId = "selenium-firefox-driver" }
 ]
 
 updates.pin = [
@@ -36,6 +39,13 @@ updates.pin = [
   { groupId = "com.zaxxer", artifactId = "HikariCP", version = "4." },
   // caffeine 3+ requires Java 11. See https://github.com/ben-manes/caffeine/releases/tag/v3.0.0
   { groupId = "com.github.ben-manes.caffeine", version = "2." },
+  // FluentLenium 4+ requires Java 11.
+  // See https://github.com/FluentLenium/FluentLenium/releases/tag/v4.0.0 and https://fluentlenium.com/quickstart/#choose-the-right-version
+  { groupId = "org.fluentlenium", version = "3." },
+  // FluentLenium 3 only works with Selenium 3
+  { groupId = "org.seleniumhq.selenium", artifactId = "selenium-api", version = "3." },
+  // Selenium 3 is only compatible with htmlunit-driver 2, see https://github.com/SeleniumHQ/htmlunit-driver/releases/tag/2.56.0
+  { groupId = "org.seleniumhq.selenium", artifactId = "htmlunit-driver", version = "2." },
   // Hibernate Validator 7.0 is jakarta.validation based, 6.2 is javax.validation based
   // and the Spring libraries we use still depends on Hibernate Validator 6.x
   // See https://github.com/playframework/playframework/pull/10616#issuecomment-758273638

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=pat
 stages:
   - validations
   - test
-  - cron-test-sbt-1.5.x
+  - test-sbt-1.5.x
   - java8
 
 jobs:
@@ -64,11 +64,10 @@ jobs:
     - script: scripts/test-docs $TEST_SCALA_2_13
       name: "Run documentation tests 2.13"
 
-    # Test against sbt 1.5.x, but only for cron builds
-    - stage: cron-test-sbt-1.5.x
+    # Test against sbt 1.5.x
+    - stage: test-sbt-1.5.x
       name: "Run tests for 1.5.x and Scala 2.13.x"
       script: scripts/test-scripted $SCRIPTED_SBT_1_5 $TEST_SCALA_2_13
-      if: type = cron
       workspaces:
         use: published-local
 

--- a/build.sbt
+++ b/build.sbt
@@ -256,6 +256,7 @@ lazy val PlayLogback = PlayCrossBuiltProject("Play-Logback", "core/play-logback"
 lazy val PlayWsProject = PlayCrossBuiltProject("Play-WS", "transport/client/play-ws")
   .settings(
     libraryDependencies ++= playWsDeps,
+    excludeDependencies += "com.typesafe.play" %% "twirl-api",
     (Test / parallelExecution) := false,
     // quieten deprecation warnings in tests
     (Test / scalacOptions) := (Test / scalacOptions).value.diff(Seq("-deprecation"))
@@ -266,6 +267,7 @@ lazy val PlayWsProject = PlayCrossBuiltProject("Play-WS", "transport/client/play
 lazy val PlayAhcWsProject = PlayCrossBuiltProject("Play-AHC-WS", "transport/client/play-ahc-ws")
   .settings(
     libraryDependencies ++= playAhcWsDeps,
+    excludeDependencies += "com.typesafe.play" %% "twirl-api",
     (Test / parallelExecution) := false,
     // quieten deprecation warnings in tests
     (Test / scalacOptions) := (Test / scalacOptions).value.diff(Seq("-deprecation"))
@@ -277,6 +279,7 @@ lazy val PlayAhcWsProject = PlayCrossBuiltProject("Play-AHC-WS", "transport/clie
 
 lazy val PlayOpenIdProject = PlayCrossBuiltProject("Play-OpenID", "web/play-openid")
   .settings(
+    excludeDependencies += "com.typesafe.play" %% "twirl-api",
     (Test / parallelExecution) := false,
     // quieten deprecation warnings in tests
     (Test / scalacOptions) := (Test / scalacOptions).value.diff(Seq("-deprecation"))
@@ -312,6 +315,7 @@ lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Te
     mimaPreviousArtifacts := Set.empty,
     (IntegrationTest / fork) := true,
     (IntegrationTest / javaOptions) += "-Dfile.encoding=UTF8",
+    excludeDependencies += "com.typesafe.play" %% "twirl-api",
   )
   .dependsOn(
     PlayProject       % "it->test",
@@ -345,6 +349,8 @@ lazy val PlayMicrobenchmarkProject = PlayCrossBuiltProject("Play-Microbenchmark"
     (Jmh / generateJmhSourcesAndResources) := (Jmh / generateJmhSourcesAndResources).dependsOn((Test / compile)).value,
     (Jmh / run / mainClass) := Some("org.openjdk.jmh.Main"),
     (Test / parallelExecution) := false,
+    excludeDependencies += "org.specs2" %% "specs2-junit",
+    excludeDependencies += "com.typesafe.play" %% "twirl-api",
     mimaPreviousArtifacts := Set.empty
   )
   .dependsOn(

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/conf/application.conf
@@ -8,8 +8,8 @@ play.server {
       child {
         SO_KEEPALIVE = true
         TCP_NODELAY = true
-        TCP_FASTOPEN = 3
         TCP_FASTOPEN_CONNECT = true
+        "io.netty.channel.ChannelOption#TCP_FASTOPEN" = 3
         "io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT" = false
         bar = "xyz"
       }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/conf/application.conf
@@ -8,9 +8,9 @@ play.server {
       child {
         SO_KEEPALIVE = true
         TCP_NODELAY = true
+        TCP_FASTOPEN = 3
         TCP_FASTOPEN_CONNECT = true
         "io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT" = false
-        "io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN" = 3
         bar = "xyz"
       }
     }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/expected-application-log.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/expected-application-log.txt
@@ -6,10 +6,10 @@
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to true at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_BACKLOG to 256 at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_CORK to true at bootstrapping
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_FASTOPEN to 3
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_FASTOPEN_CONNECT to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_NODELAY to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_KEEPALIVE to true
 [WARN] play.core.server.NettyServer - Ignoring unknown Netty channel option: bar
 [WARN] play.core.server.NettyServer - Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html
-[DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN to 3
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to false

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/expected-application-log.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/expected-application-log.txt
@@ -6,10 +6,10 @@
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to true at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_BACKLOG to 256 at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_CORK to true at bootstrapping
-[DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_FASTOPEN to 3
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_FASTOPEN_CONNECT to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_NODELAY to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_KEEPALIVE to true
 [WARN] play.core.server.NettyServer - Ignoring unknown Netty channel option: bar
 [WARN] play.core.server.NettyServer - Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.ChannelOption#TCP_FASTOPEN to 3
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to false

--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -8,11 +8,11 @@ lazy val plugins = (project in file(".")).dependsOn(playDocsPlugin)
 lazy val playDocsPlugin = ProjectRef(Path.fileProperty("user.dir").getParentFile, "Play-Docs-Sbt-Plugin")
 
 // Required for Production.md
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 
 // Add headers to example sources
-addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.3.1")
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.5.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.6.1")
+addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.0.7")
 
 // Required for Tutorial

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,7 @@ object Dependencies {
   val scalaJava8Compat                   = "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
   val scalaParserCombinators             = Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.0")
 
-  val springFrameworkVersion = "5.3.13"
+  val springFrameworkVersion = "5.3.14"
 
   val javaDeps = Seq(
     scalaJava8Compat,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -225,9 +225,9 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-cluster-sharding-typed" % akkaVersion
   )
 
-  val fluentleniumVersion = "3.7.1"
+  val fluentleniumVersion = "3.10.1"
   // This is the selenium version compatible with the FluentLenium version declared above.
-  // See http://mvnrepository.com/artifact/org.fluentlenium/fluentlenium-core/3.5.2
+  // See http://mvnrepository.com/artifact/org.fluentlenium/fluentlenium-core/3.10.1
   val seleniumVersion = "3.141.59"
 
   val testDependencies = Seq(junit, junitInterface, guava, findBugs, logback) ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,11 +93,11 @@ object Dependencies {
 
   val joda = Seq(
     "joda-time" % "joda-time"    % "2.10.13",
-    "org.joda"  % "joda-convert" % "2.2.1"
+    "org.joda"  % "joda-convert" % "2.2.2"
   )
 
   val javaFormsDeps = Seq(
-    "org.hibernate.validator" % "hibernate-validator" % "6.2.0.Final",
+    "org.hibernate.validator" % "hibernate-validator" % "6.2.1.Final",
     ("org.springframework" % "spring-context" % springFrameworkVersion)
       .exclude("org.springframework", "spring-aop")
       .exclude("org.springframework", "spring-beans")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.17")
-  val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.14")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18")
+  val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.15")
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.0"
 
@@ -16,7 +16,7 @@ object Dependencies {
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.10"
 
-  val specs2Version = "4.13.0"
+  val specs2Version = "4.13.1"
   val specs2Deps = Seq(
     "specs2-core",
     "specs2-junit",
@@ -263,7 +263,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.1.2+300-e8072af1"
+  val playWsStandaloneVersion = "2.1.6"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone"      % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-xml"  % playWsStandaloneVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,16 +7,16 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.14")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.17")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.14")
 
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.3"
+  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.0"
 
   val playJsonVersion = "2.9.2"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.10"
 
-  val specs2Version = "4.12.12"
+  val specs2Version = "4.13.0"
   val specs2Deps = Seq(
     "specs2-core",
     "specs2-junit",
@@ -80,8 +80,8 @@ object Dependencies {
   )
 
   def scalaReflect(scalaVersion: String) = "org.scala-lang" % "scala-reflect" % scalaVersion % "provided"
-  val scalaJava8Compat                   = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
-  val scalaParserCombinators             = Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2")
+  val scalaJava8Compat                   = "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
+  val scalaParserCombinators             = Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.0")
 
   val springFrameworkVersion = "5.3.13"
 
@@ -165,7 +165,7 @@ object Dependencies {
   val okHttp = "com.squareup.okhttp3" % "okhttp" % "4.9.3"
 
   def routesCompilerDependencies(scalaVersion: String) = {
-    specs2Deps.map(_ % Test) ++ Seq(specsMatcherExtra % Test) ++ scalaParserCombinators ++ (logback % Test :: Nil)
+    specs2Deps.map(_ % Test) ++ Seq(specsMatcherExtra % Test) ++ Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2") ++ (logback % Test :: Nil)
   }
 
   private def sbtPluginDep(moduleId: ModuleID, sbtVersion: String, scalaVersion: String) = {
@@ -193,7 +193,7 @@ object Dependencies {
       slf4jSimple,
       playFileWatch,
       sbtDep("com.typesafe.sbt" % "sbt-twirl"           % BuildInfo.sbtTwirlVersion),
-      sbtDep("com.typesafe.sbt" % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
+      sbtDep("com.github.sbt"   % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
       sbtDep("com.typesafe.sbt" % "sbt-web"             % "1.4.4"),
       sbtDep("com.typesafe.sbt" % "sbt-js-engine"       % "1.2.3"),
       logback             % Test
@@ -263,7 +263,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.1.3"
+  val playWsStandaloneVersion = "2.1.2+300-e8072af1"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone"      % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-xml"  % playWsStandaloneVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,15 +4,15 @@ enablePlugins(BuildInfoPlugin)
 
 // when updating sbtNativePackager version, be sure to also update the documentation links in
 // documentation/manual/working/commonGuide/production/Deploying.md
-val sbtNativePackager  = "1.8.1"
+val sbtNativePackager  = "1.9.6"
 val mima               = "1.0.1"
 val sbtJavaFormatter   = "0.5.0"
 val sbtJmh             = "0.4.3"
 val webjarsLocatorCore = "0.48"
 val sbtHeader          = "5.6.0"
 val scalafmt           = "2.0.1"
-val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.5.1") // sync with documentation/project/plugins.sbt
-val interplay: String  = sys.props.getOrElse("interplay.version", "3.0.3")
+val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.5.0+263-c57d350b+20210831-0025-SNAPSHOT") // sync with documentation/project/plugins.sbt
+val interplay: String  = sys.props.getOrElse("interplay.version", "3.0.3+31-bc4c66d7")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackager,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,12 +4,12 @@ enablePlugins(BuildInfoPlugin)
 
 // when updating sbtNativePackager version, be sure to also update the documentation links in
 // documentation/manual/working/commonGuide/production/Deploying.md
-val sbtNativePackager  = "1.9.6"
+val sbtNativePackager  = "1.9.7"
 val mima               = "1.0.1"
-val sbtJavaFormatter   = "0.5.0"
+val sbtJavaFormatter   = "0.7.0"
 val sbtJmh             = "0.4.3"
 val webjarsLocatorCore = "0.48"
-val sbtHeader          = "5.6.0"
+val sbtHeader          = "5.6.1"
 val scalafmt           = "2.0.1"
 val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.5.0+263-c57d350b+20210831-0025-SNAPSHOT") // sync with documentation/project/plugins.sbt
 val interplay: String  = sys.props.getOrElse("interplay.version", "3.0.3+31-bc4c66d7")

--- a/project/project/buildinfo.sbt
+++ b/project/project/buildinfo.sbt
@@ -2,4 +2,4 @@
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")

--- a/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -333,6 +333,11 @@ public class AhcWSRequest implements WSRequest {
   }
 
   @Override
+  public WSRequest setDisableUrlEncoding(boolean disableUrlEncoding) {
+    return converter.apply(request.setDisableUrlEncoding(disableUrlEncoding));
+  }
+
+  @Override
   public WSRequest setVirtualHost(String virtualHost) {
     return converter.apply(request.setVirtualHost(virtualHost));
   }
@@ -392,6 +397,11 @@ public class AhcWSRequest implements WSRequest {
   @Override
   public Optional<Boolean> getFollowRedirects() {
     return request.getFollowRedirects();
+  }
+
+  @Override
+  public Optional<Boolean> getDisableUrlEncoding() {
+    return request.getDisableUrlEncoding();
   }
 
   @Override

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
@@ -127,6 +127,10 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
     underlying.withFollowRedirects(follow)
   }
 
+  override def withDisableUrlEncoding(disableUrlEncoding: Boolean): Self = toWSRequest {
+    underlying.withDisableUrlEncoding(disableUrlEncoding)
+  }
+
   override def withRequestTimeout(timeout: Duration): Self = toWSRequest {
     underlying.withRequestTimeout(timeout)
   }


### PR DESCRIPTION
**This is WIP**


Fixes #10971

Replaces #10901 and #10900
IMHO it makes sense to just upgrade all at once to fix all that conflicts in one place.
Currently I just pushed unreleased deps, which I just build on my machine for now.

**TODO**
- [x] Wait for Scala 2.12.15 (Due Sept. ~1st~ 7th)
- [x] Make interplay use Scala 2.12.15
- [x] Release interplay 3.0.4
- [x] Release milestone for play-ws (e.g. 2.2.0-M1)
- [x] Release milestone for twirl (probably. 1.6.0-M1), with https://github.com/playframework/twirl/pull/439 merged
- [x] Wait for sbt-native-packager 1.9.5, hopefully with https://github.com/sbt/sbt-native-packager/pull/1455 merged