### PR TITLE
Fix docs: change oracle jdk link to open jdk link

### DIFF
--- a/documentation/manual/gettingStarted/Installing.md
+++ b/documentation/manual/gettingStarted/Installing.md
@@ -21,7 +21,7 @@ OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_222-b10)
 OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 ```
 
-If you don't have the JDK, you have to install it from [Oracle's JDK Site](https://www.oracle.com/technetwork/java/javase/downloads/index.html).
+If you don't have the JDK, you have to install it from [Adoptium](https://adoptium.net/).
 
 ## Installing Play with sbt
 

--- a/documentation/manual/gettingStarted/Requirements.md
+++ b/documentation/manual/gettingStarted/Requirements.md
@@ -25,7 +25,7 @@ OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_222-b10)
 OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 ```
 
-You can obtain Java SE from [Oracle’s JDK Site](https://www.oracle.com/technetwork/java/javase/downloads/index.html). 
+You can obtain Java SE from [Adoptium](https://adoptium.net/).
 
 ## Verifying and installing sbt
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #10938 

## Purpose

This pull request changes existing links to oracle JDK(which is commercial) to open JDK to prevent readers from accidentally installing commercial software.
[Adoptium](https://adoptium.net/) is selected for the new link because it is the rebrand to popular open JDK [AdoptOpenJDK](https://adoptopenjdk.net/).

## Background Context

- This pull request changes a link to oracle JDK to open JDK on [Requirement page](https://www.playframework.com/documentation/2.8.x/Requirements).
- Currently, Installing.md seems not used(It will redirect to the requirement page if you type https://www.playframework.com/documentation/2.8.x/Installing). But I changed it too in case it will be used again.
- The word “oracle” is mentioned in many files, but as far as I searched, they are mostly links to oracle documentation for Java features except this change.


## References

I will create another pull request on [playframework/playframework.com](https://github.com/playframework/playframework.com) to change the link on [getting-started](https://www.playframework.com/getting-started) page. (see playframework/playframework.com#445)
