### PR TITLE
swap names for hostUri and originUri

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -311,8 +311,8 @@ private[cors] trait AbstractCORSPolicy {
   }
 
   private def isSameOrigin(origin: String, request: RequestHeader): Boolean = {
-    val hostUri   = new URI(origin.toLowerCase(Locale.ENGLISH))
-    val originUri = new URI((if (request.secure) "https://" else "http://") + request.host.toLowerCase(Locale.ENGLISH))
-    (hostUri.getScheme, hostUri.getHost, hostUri.getPort) == (originUri.getScheme, originUri.getHost, originUri.getPort)
+    val originUri = new URI(origin.toLowerCase(Locale.ENGLISH))
+    val hostUri   = new URI((if (request.secure) "https://" else "http://") + request.host.toLowerCase(Locale.ENGLISH))
+    (originUri.getScheme, originUri.getHost, originUri.getPort) == (hostUri.getScheme, hostUri.getHost, hostUri.getPort)
   }
 }


### PR DESCRIPTION
As mentioned in #10928, the names for these identifiers should be swapped.