### PR TITLE
Remove dependency from play-jdbc-api to play

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,7 @@ lazy val PlayJavaClusterSharding =
 
 lazy val PlayJdbcApiProject = PlayCrossBuiltProject("Play-JDBC-Api", "persistence/play-jdbc-api")
   .settings(
-    libraryDependencies += "javax.inject" % "javax.inject" % "1",
+    libraryDependencies += javaxInject,
   )
 
 lazy val PlayJdbcProject: Project = PlayCrossBuiltProject("Play-JDBC", "persistence/play-jdbc")

--- a/build.sbt
+++ b/build.sbt
@@ -143,16 +143,18 @@ lazy val PlayJavaClusterSharding =
     .dependsOn(PlayProject)
 
 lazy val PlayJdbcApiProject = PlayCrossBuiltProject("Play-JDBC-Api", "persistence/play-jdbc-api")
-  .dependsOn(PlayProject)
+  .settings(
+    libraryDependencies += "javax.inject" % "javax.inject" % "1",
+  )
 
 lazy val PlayJdbcProject: Project = PlayCrossBuiltProject("Play-JDBC", "persistence/play-jdbc")
   .settings(libraryDependencies ++= jdbcDeps)
-  .dependsOn(PlayJdbcApiProject)
+  .dependsOn(PlayJdbcApiProject, PlayProject)
   .dependsOn(PlaySpecs2Project % "test")
 
 lazy val PlayJdbcEvolutionsProject = PlayCrossBuiltProject("Play-JDBC-Evolutions", "persistence/play-jdbc-evolutions")
   .settings(libraryDependencies ++= derbyDatabase.map(_ % Test))
-  .dependsOn(PlayJdbcApiProject)
+  .dependsOn(PlayJdbcApiProject, PlayProject)
   .dependsOn(PlaySpecs2Project % "test")
   .dependsOn(PlayJdbcProject % "test->test")
   .dependsOn(PlayJavaJdbcProject % "test")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,6 +60,8 @@ object Dependencies {
   val findBugs   = "com.google.code.findbugs" % "jsr305"       % "3.0.2" // Needed by guava
   val mockitoAll = "org.mockito"              % "mockito-core" % "4.8.0"
 
+  val javaxInject = "javax.inject" % "javax.inject" % "1"
+
   val h2database = "com.h2database" % "h2" % "2.1.214"
 
   val derbyVersion = "10.15.2.0"
@@ -160,7 +162,7 @@ object Dependencies {
         playJson,
         guava,
         "jakarta.transaction" % "jakarta.transaction-api" % "2.0.1",
-        "javax.inject"        % "javax.inject"            % "1",
+        javaxInject,
         scalaReflect(scalaVersion),
         sslConfig
       ) ++ scalaParserCombinators(scalaVersion) ++ specs2Deps.map(_ % Test) ++ javaTestDeps


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
   I think we don't need update document
* [x] Have you added tests for any changed functionality?
   I think we don't need add tests

# Helpful things

## Fixes
No existed issue

## Purpose
`play-jdbc-api` declared a dependency to `play` but do not really depend on any `play`'s code.
This PR remove that _declaration_ dependency.

## Background Context
I use [anorm](/playframework/anorm) in some projects that use play and in some projects that do NOT use play.
To use anorm, we must [provide a connection](https://playframework.github.io/anorm/#executing-sql-queries), normally by using the `play-jdbc` module.
So I create a `play-jdbc-standalone` project which do NOT depends on Play (just copy code from `play-jdbc` with some minimal change.)
I can also copy code of `play-jdbc-api` but if this PR is merged then I don't need to do that 😄 