### PR TITLE
Rename methods for consistency - resolves playframework#8779

### DIFF
--- a/core/play/src/main/scala/play/api/i18n/I18nSupport.scala
+++ b/core/play/src/main/scala/play/api/i18n/I18nSupport.scala
@@ -117,7 +117,7 @@ trait I18NSupportLowPriorityImplicits {
      * @return the new result
      */
     def withoutLang(implicit messagesApi: MessagesApi): Result = {
-      messagesApi.clearLang(result)
+      messagesApi.withoutLang(result)
     }
 
     @deprecated("Use withoutLang", "2.7.0")

--- a/core/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/core/play/src/main/scala/play/api/i18n/Messages.scala
@@ -407,7 +407,13 @@ trait MessagesApi {
   /**
    * Given a [[Result]], return a new [[Result]] with the lang cookie discarded.
    */
-  def clearLang(result: Result): Result
+  def withoutLang(result: Result): Result
+
+  /**
+   * Given a [[Result]], return a new [[Result]] with the lang cookie discarded.
+   */
+  @deprecated("Use withoutLang", "2.9.0")
+  def clearLang(result: Result): Result = withoutLang(result)
 
   /**
    * Name for the language Cookie.
@@ -534,7 +540,7 @@ class DefaultMessagesApi @Inject() (
     result.withCookies(cookie)
   }
 
-  override def clearLang(result: Result): Result = {
+  override def withoutLang(result: Result): Result = {
     val discardingCookie = DiscardingCookie(
       langCookieName,
       path = httpConfiguration.session.path,
@@ -543,6 +549,8 @@ class DefaultMessagesApi @Inject() (
     )
     result.discardingCookies(discardingCookie)
   }
+
+  override def clearLang(result: Result): Result = withoutLang(result)
 }
 
 @Singleton

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -496,7 +496,7 @@ trait LegacyI18nSupport {
       messagesApi.setLang(result, lang)
 
     /**
-     * Clears the user's language by discarding the language cookie set by withLang
+     * Reset the user's language by discarding the language cookie set by withLang
      *
      * For example:
      * {{{
@@ -505,8 +505,11 @@ trait LegacyI18nSupport {
      *
      * @return the new result
      */
-    def clearingLang: Result =
-      messagesApi.clearLang(result)
+    def withoutLang: Result =
+      messagesApi.withoutLang(result)
+
+    @deprecated("Use withoutLang", "2.9.0")
+    def clearingLang: Result = withoutLang
   }
 }
 

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -67,6 +67,25 @@ val projectB = (project in file("projectB"))
   .settings(commonSettings)
 ```
 
+
+### Renaming towards more consistent methods name
+
+Some methods where renamed to enhance consistency accross different APIs, esspecialy methods for adding, removing and clearing data.
+To enable a smooth migration, the older methods are now depreciated and will be removed in a future version.
+
+Methods renamed in trait [`play.api.i18n.MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) 
+
+| **Deprecated method**                         | **New method**
+| ----------------------------------------------|-------------------------------------------
+| `clearLang(result: Result)`                   | `withoutLang(result: Result)`
+
+Methods renamed in object [`play.api.mvc.Results`](api/scala/play/api/mvc/Results.html)
+
+| **Deprecated method**                         | **New method**
+| ----------------------------------------------|-------------------------------------------
+| `clearingLang(result: Result)`                | `withoutLang(result: Result)`
+
+
 ### Deprecated APIs were removed
 
 Many APIs that were deprecated in earlier versions were removed in Play 2.9. If you are still using them we recommend migrating to the new APIs before upgrading to Play 2.9. Check the Javadocs and Scaladocs for migration notes. See also the [[migration guide for Play 2.8|Migration28]] for more information.

--- a/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
@@ -19,7 +19,7 @@ class MyMessagesApi extends MessagesApi {
   override def preferred(request: RequestHeader): Messages                                 = ???
   override def langCookieHttpOnly: Boolean                                                 = ???
   override def langCookieSameSite: Option[SameSite]                                        = ???
-  override def clearLang(result: Result): Result                                           = ???
+  override def withoutLang(result: Result): Result                                         = ???
   override def langCookieSecure: Boolean                                                   = ???
   override def langCookieName: String                                                      = ???
   override def langCookieMaxAge: Option[Int]                                               = ???

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -321,6 +321,8 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.test.Helpers.routeAndCall"),
       // Remove CrossScala (parent class of play.libs.Scala)
       ProblemFilters.exclude[MissingTypesProblem]("play.libs.Scala"),
+      // Renaming clearLang to withoutLang
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.i18n.MessagesApi.withoutLang")
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [X] Have you added copyright headers to new files?
* [X] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [X] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Continues #8779

## Purpose

Renaming `Results.clearingLang` to `Results.withoutLang` for consistency with other method naming. Also renames MessageApi methods to follow this naming convention

## Background Context

Hacktoberfest, plus having time to work on play framework this seemed a good first issue

## References

Are there any relevant issues / PRs / mailing lists discussions?
