### PR TITLE
Clean up eliminate warnings tackle deprecations

### DIFF
--- a/core/play-guice/src/main/java/play/libs/akka/BinderAccessor.java
+++ b/core/play-guice/src/main/java/play/libs/akka/BinderAccessor.java
@@ -16,7 +16,7 @@ class BinderAccessor {
     if (module instanceof AbstractModule) {
       try {
         Method method = AbstractModule.class.getDeclaredMethod("binder");
-        if (!method.isAccessible()) {
+        if (!method.canAccess(module)) {
           method.setAccessible(true);
         }
         return (Binder) method.invoke(module);

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -169,7 +169,6 @@ abstract class GuiceBuilder[Self] protected (
    * Libraries like Guiceberry and Jukito that want to handle injector creation may find this helpful.
    */
   def createModule(): GuiceModule = {
-    import scala.jdk.CollectionConverters._
     val injectorModule = GuiceableModule.guice(
       Seq(
         bind[GuiceInjector].toSelf,

--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/AkkaGuiceSupport.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/AkkaGuiceSupport.scala
@@ -52,7 +52,7 @@ trait AkkaGuiceSupport {
 
   private def accessBinder: Binder = {
     val method: Method = classOf[AbstractModule].getDeclaredMethod("binder")
-    if (!method.isAccessible) {
+    if (!method.canAccess(this)) {
       method.setAccessible(true)
     }
     method.invoke(this).asInstanceOf[Binder]

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
@@ -39,7 +39,6 @@ class JavaRequestsSpec extends PlaySpecification {
     }
 
     "create a request with a helper that can do cookies" in {
-      import scala.jdk.CollectionConverters._
 
       val cookie1                      = Cookie("name1", "value1")
       val requestHeader: RequestHeader = FakeRequest().withCookies(cookie1)
@@ -54,7 +53,6 @@ class JavaRequestsSpec extends PlaySpecification {
     }
 
     "create a request with a helper that can do cookies" in {
-      import scala.jdk.CollectionConverters._
 
       val cookie1 = Cookie("name1", "value1")
 

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -485,7 +485,6 @@ trait JavaResultsHandlingSpec
         .withCookies(new Http.Cookie("bar", "KitKat", 1000, "/", "example.com", false, true, null))
         .withCookies(new Http.Cookie("bar", "Mars", 1000, "/", "example.com", false, true, null))
 
-      import scala.jdk.CollectionConverters._
       val cookies      = result.cookies().iterator().asScala.toList
       val cookieValues = cookies.map(_.value)
       cookieValues must not contain "KitKat"
@@ -544,7 +543,6 @@ trait JavaResultsHandlingSpec
 
     "chunk comet results from string" in makeRequest(new MockController {
       def action(request: Http.Request) = {
-        import scala.jdk.CollectionConverters._
         val dataSource  = akka.stream.javadsl.Source.from(List("a", "b", "c").asJava)
         val cometSource = dataSource.via(Comet.string("callback"))
         Results.ok().chunked(cometSource)

--- a/core/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/core/play/src/main/scala/play/core/j/JavaResults.scala
@@ -5,7 +5,6 @@
 package play.core.j
 
 import scala.annotation.varargs
-import scala.jdk.CollectionConverters
 import scala.language.reflectiveCalls
 
 import play.mvc.{ ResponseHeader => JResponseHeader }
@@ -13,7 +12,7 @@ import play.mvc.{ ResponseHeader => JResponseHeader }
 object JavaResultExtractor {
   @varargs
   def withHeader(responseHeader: JResponseHeader, nameValues: String*): JResponseHeader = {
-    import CollectionConverters._
+    import scala.jdk.CollectionConverters._
     if (nameValues.length % 2 != 0) {
       throw new IllegalArgumentException(
         "Unmatched name - withHeaders must be invoked with an even number of string arguments"

--- a/core/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/core/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -152,8 +152,8 @@ class MessagesSpec extends Specification {
   val testMessageFile = """
 # this is a comment
 simplekey=value
-key.with.dots=value
-key.with.dollar$sign=value
+key.with.dots=value1
+key.with.dollar$sign=value2
 multiline.unix=line1\
 line2
 multiline.dos=line1\
@@ -166,13 +166,13 @@ backslash.dummy=\a\b\c\e\f
 
   "MessagesPlugin" should {
     "parse file" in {
-      val parser = new Messages.MessagesParser(new MessageSource { def read = testMessageFile }, "messages")
+      val parser = new Messages.MessagesParser(new MessageSource { def read: String = testMessageFile }, "messages")
 
       val messages = parser.parse.toSeq.flatten[Messages.Message].map(x => x.key -> x.pattern).toMap
 
       messages("simplekey") must ===("value")
-      messages("key.with.dots") must ===("value")
-      messages("key.with.dollar$sign") must ===("value")
+      messages("key.with.dots") must ===("value1")
+      messages("key.with.dollar$sign") must ===("value2")
       messages("multiline.unix") must ===("line1line2")
       messages("multiline.dos") must ===("line1line2")
       messages("multiline.inline") must ===("line1\nline2")

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileReaperSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileReaperSpec.scala
@@ -45,8 +45,8 @@ class TemporaryFileReaperSpec(implicit ee: ExecutionEnv) extends Specification w
       val config = TemporaryFileReaperConfiguration(
         enabled = false,
         olderThan = 1.seconds,
-        initialDelay = 0 seconds,
-        interval = 100 millis
+        initialDelay = 0.seconds,
+        interval = 100.millis
       )
 
       val file = parentDirectory.resolve("notcollected.txt")

--- a/persistence/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -154,6 +154,6 @@ class DatabasesSpec extends Specification {
 
   trait WithDatabase extends After {
     def db: Database
-    def after = () // db.shutdown()
+    def after: Unit = () // db.shutdown()
   }
 }

--- a/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
@@ -37,7 +37,7 @@ private[server] object PathAndQueryParser {
       try {
         new URI(unsafePath).getRawPath
       } catch {
-        case _ =>
+        case _: Throwable =>
           // If the URI has an invalid path, this will trigger a 400 (bad request) error.
           // Also it's probably a good idea to throw our own IllegalStateException were we have
           // control over the message that will be passed to the error handler instead of just passing on the

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -189,7 +189,7 @@ object WebSocketFlowHandler {
         setHandler(
           appOut,
           new OutHandler {
-            override def onPull() = {
+            override def onPull(): Unit = {
               // We always pull from the remote in when the app pulls, even if closing, since if we get a message from
               // the client and we're still open, we still want to send it.
               if (!hasBeenPulled(remoteIn)) {
@@ -197,7 +197,7 @@ object WebSocketFlowHandler {
               }
             }
 
-            override def onDownstreamFinish() = {
+            override def onDownstreamFinish(cause: Throwable): Unit = {
               if (state == Open) {
                 serverInitiatedClose(CloseMessage(Some(CloseCodes.Regular)))
               }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [NA] Have you added copyright headers to new files?
* [NA] Have you checked that both Scala and Java APIs are updated?
* [NA] Have you updated the documentation for both Scala and Java sections?
* [NA] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

Compiling the codebase with Scala 2.13.5 generates a ton of warnings. This PR eliminates a lot of them (but not all).

## Background Context

Maintaining a project with that many warnings isn't right.

## References


