### PR TITLE
Remove Whitesource checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
           name: published-local-jdk11
           paths: "$HOME/.ivy2/local/com.typesafe.play"
     - script: scripts/validate-code
-      name: "Code validations (format, binary compatibilty, whitesource, etc.)"
+      name: "Code validations (format, binary compatibility, etc.)"
     - script: scripts/validate-docs
       name: "Validate docs (links, sample code, etc.)"
     - script: scripts/validate-microbenchmarks

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -19,7 +19,6 @@ import interplay.ScalaVersions._
 import sbt._
 import sbt.Keys._
 import sbt.ScriptedPlugin.autoImport._
-import sbtwhitesource.WhiteSourcePlugin.autoImport._
 
 import scala.sys.process.stringToProcess
 import scala.util.control.NonFatal
@@ -294,10 +293,7 @@ object BuildSettings {
     // For sbt 0.13 this is what we need to avoid publishing. These settings can
     // be removed when we move to sbt 1.
     PgpKeys.publishSigned := {},
-    publish := {},
-    // We also don't need to track dependencies for unpublished projects
-    // so we need to disable WhiteSource plugin.
-    whitesourceIgnore := true
+    publish := {}
   )
 
   /** A project that runs in the sbt runtime. */

--- a/scripts/validate-code
+++ b/scripts/validate-code
@@ -19,16 +19,3 @@ end mima "VALIDATED BINARY COMPATIBILITY"
 start headerCheck "VALIDATE FILE LICENSE HEADERS"
 runSbt +headerCheck +test:headerCheck Play-Microbenchmark/test:headerCheck
 end headerCheck "VALIDATED FILE LICENSE HEADERS"
-
-
-start whitesource "RUNNING WHITESOURCE REPORT"
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    runSbt 'set credentials in ThisBuild += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies whitesourceUpdate
-else
-    echo "[info]"
-    echo "[info] This is a pull request so Whitesource WILL NOT RUN."
-    echo "[info] It only runs when integrating the code and should not run for PRs. See the page below for details:"
-    echo "[info] https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions"
-    echo "[info]"
-fi
-end whitesource "RUNNING WHITESOURCE REPORT"


### PR DESCRIPTION
## Purpose

Remove Whitesource checks as Lightbend has discontinued the use of the Whitesource service.
