### PR TITLE
Correct versions in release drafter template

### DIFF
--- a/.github/release-drafter-master.yml
+++ b/.github/release-drafter-master.yml
@@ -37,11 +37,11 @@ template: |
   * sbt-native-packager x.x.x
   * TODO...
   
-  As usual, you can see the more details of those new features in the [release highlights](https://www.playframework.com/documentation/$MAJOR.$MINOR.x/Highlights$MAJOR$MINOR) and learn how to migrate in [our migration guide](https://www.playframework.com/documentation/$MAJOR.$MINOR.x/Migration$MAJOR$MINOR).
+  As usual, you can see the more details of those new features in the [release highlights](https://www.playframework.com/documentation/$NEXT_MINOR_VERSION_MAJOR.$NEXT_MINOR_VERSION_MINOR.x/Highlights$NEXT_MINOR_VERSION_MAJOR$NEXT_MINOR_VERSION_MINOR) and learn how to migrate in [our migration guide](https://www.playframework.com/documentation/$NEXT_MINOR_VERSION_MAJOR.$NEXT_MINOR_VERSION_MINOR.x/Migration$NEXT_MINOR_VERSION_MAJOR$NEXT_MINOR_VERSION_MINOR).
   
-  ## :world_map: How to start or migrate to Play $MAJOR.$MINOR
+  ## :world_map: How to start or migrate to Play $NEXT_MINOR_VERSION_MAJOR.$NEXT_MINOR_VERSION_MINOR
   
-  To get started with Play, follow the instructions in our [Getting Started page](https://www.playframework.com/getting-started). And if you need to migrate from an older version to Play $MAJOR.$MINOR, see [our migration guide](https://www.playframework.com/documentation/$MAJOR.$MINOR.x/Migration$MAJOR$MINOR).
+  To get started with Play, follow the instructions in our [Getting Started page](https://www.playframework.com/getting-started). And if you need to migrate from an older version to Play $NEXT_MINOR_VERSION_MAJOR.$NEXT_MINOR_VERSION_MINOR, see [our migration guide](https://www.playframework.com/documentation/$NEXT_MINOR_VERSION_MAJOR.$NEXT_MINOR_VERSION_MINOR.x/Migration$NEXT_MINOR_VERSION_MAJOR$NEXT_MINOR_VERSION_MINOR).
   
   ## :bow: Thanks to our contributors
   


### PR DESCRIPTION
A patch was needed in release drafter: https://github.com/release-drafter/release-drafter/pull/823

Finally our release drafts look correct:
![image](https://user-images.githubusercontent.com/644927/141581658-2cc8bb72-08d9-4b5d-af45-5cac45420999.png)
Instead of:
![image](https://user-images.githubusercontent.com/644927/141581419-a9b2bc4a-8f78-4307-aaf8-e7fe8d93ce6e.png)
