### PR TITLE
Displaying a sponsor button to promote Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+open_collective: playframework # Replace with a single Open Collective username


### PR DESCRIPTION
Let's add a sponsor button, which links to https://opencollective.com/playframework, like [babel](https://github.com/babel/babel) has:
![image](https://user-images.githubusercontent.com/644927/141646639-e6f1ed9c-00e3-44e6-a9fd-06354e36ab42.png)

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

