### PR TITLE
bump: Akka 2.6.17 and Akka HTTP 10.1.15 for Play 2.8.9

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.16")
-  val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.14")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.17")
+  val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.15")
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.2"
 


### PR DESCRIPTION
## Purpose

Updates to the current Akka and Akka HTTP versions.
Akka HTTP 10.1.15 includes some important security fixes.

## Background Context

[Akka 2.6.17 release notes](https://akka.io/blog/news/2021/10/15/akka-2.6.17-released)
[Akka HTTP 1.1.15 release notes](https://doc.akka.io/docs/akka-http/10.1/release-notes/10.1.x.html#10-1-15)
