### PR TITLE
use new community sonatype profile

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -2,7 +2,6 @@
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
 import java.util.regex.Pattern
-
 import com.jsuereth.sbtpgp.PgpKeys
 import com.typesafe.tools.mima.core.ProblemFilters
 import com.typesafe.tools.mima.core._
@@ -22,6 +21,7 @@ import sbt.ScriptedPlugin.autoImport._
 
 import scala.sys.process.stringToProcess
 import scala.util.control.NonFatal
+import xerial.sbt.Sonatype.autoImport.sonatypeProfileName
 
 object BuildSettings {
   val snapshotBranch: String = {
@@ -70,6 +70,8 @@ object BuildSettings {
 
   /** These settings are used by all projects. */
   def playCommonSettings: Seq[Setting[_]] = Def.settings(
+    // overwrite Interplay settings to new Sonatype profile
+    sonatypeProfileName := "com.typesafe.play",
     fileHeaderSettings,
     homepage := Some(url("https://playframework.com")),
     ivyLoggingLevel := UpdateLogging.DownloadOnly,


### PR DESCRIPTION
We need this to be able to publish to `com.typesafe.play`. This is a new sonatype profile that accepts artifacts for group id `com.typesafe.play`. 

Lightbend's profile `com.typesafe` is not configured anymore for artifacts in group id `com.typesafe.play`.

We need this to move forward with the 2.8.9 release.