### PR TITLE
update play-ws 2.1.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -288,7 +288,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.1.5"
+  val playWsStandaloneVersion = "2.1.6"
   val playWsDeps = Seq(
     "com.typesafe.play"                        %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play"                        %% "play-ws-standalone-xml" % playWsStandaloneVersion,


### PR DESCRIPTION
Need to bump play-ws version once more because 2.1.5 was build with jdk11 instead of jdk8