### PR TITLE
Updating log4j ref in docs to 2.16.0

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -217,9 +217,9 @@ From there, a custom logging framework can be used.  Here, Log4J 2 is used as an
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.15.0",
-  "org.apache.logging.log4j" % "log4j-api" % "2.15.0",
-  "org.apache.logging.log4j" % "log4j-core" % "2.15.0"
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.16.0",
+  "org.apache.logging.log4j" % "log4j-api" % "2.16.0",
+  "org.apache.logging.log4j" % "log4j-core" % "2.16.0"
 )
 ```
 


### PR DESCRIPTION
For [CVE-2021-45046](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046).