### PR TITLE
Show latest version of java supported in 2.8 in Requirements.md

### DIFF
--- a/documentation/manual/gettingStarted/Requirements.md
+++ b/documentation/manual/gettingStarted/Requirements.md
@@ -6,7 +6,7 @@ A Play application only needs to include the Play JAR files to run properly. The
 
 Play requires:
 
-1. Java SE 1.8 or higher
+1. Java versions SE 8 through SE 11, inclusive 
 1. [sbt](#Verifying-and-installing-sbt) - we recommend the latest version
 
 ## Verifying and installing Java


### PR DESCRIPTION
I tried building the [hello world](https://www.playframework.com/documentation/2.8.x/HelloWorldTutorial) and the requirements it linked did not mention that [up to java 11 is supported](https://discuss.lightbend.com/t/play-sample-on-windows-java-lang-illegalstateexception-unable-to-load-cache-item/8663)

Initially I tried with java 17 and got an error basically described in [Play Framework Scala Hello-World fail on Ubuntu 20](https://stackoverflow.com/questions/67291502/play-framework-scala-hello-world-fail-on-ubuntu-20)

After downgrading to java 11 it worked

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?