### PR TITLE
ConsoleReader should be blocking in sbt 1.4+ since System.in already is non-blocking

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
@@ -5,6 +5,9 @@
 package play.sbt
 
 import java.io.Closeable
+import java.io.FileDescriptor
+import java.io.FileInputStream
+import java.io.FilterInputStream
 import java.io.InputStream
 import java.io.OutputStream
 import jline.console.ConsoleReader
@@ -56,27 +59,36 @@ trait PlayNonBlockingInteractionMode extends PlayInteractionMode {
  *  wait on jline.
  */
 object PlayConsoleInteractionMode extends PlayInteractionMode {
-  // This wraps the InputStream with some sleep statements so it becomes interruptible.
-  private[play] final class SystemInWrapper(val poll: FiniteDuration) extends InputStream {
-    @tailrec override def read(): Int = {
-      if (System.in.available() > 0) {
-        System.in.read()
-      } else {
+
+  /**
+   * This wraps the InputStream with some sleep statements so it becomes interruptible.
+   * Only used in sbt versions <= 1.3
+   */
+  private[play] class InputStreamWrapperSbtLegacy(is: InputStream, val poll: Duration) extends FilterInputStream(is) {
+    @tailrec final override def read(): Int =
+      if (is.available() != 0) is.read()
+      else {
         Thread.sleep(poll.toMillis)
         read()
       }
-    }
 
-    override def read(b: Array[Byte]): Int = read(b, 0, b.length)
+    @tailrec final override def read(b: Array[Byte]): Int =
+      if (is.available() != 0) is.read(b)
+      else {
+        Thread.sleep(poll.toMillis)
+        read(b)
+      }
 
-    @tailrec override def read(b: Array[Byte], off: Int, len: Int): Int = {
-      if (System.in.available() > 0) {
-        System.in.read(b, off, len)
-      } else {
+    @tailrec final override def read(b: Array[Byte], off: Int, len: Int): Int =
+      if (is.available() != 0) is.read(b, off, len)
+      else {
         Thread.sleep(poll.toMillis)
         read(b, off, len)
       }
-    }
+  }
+
+  private[play] final class SystemInWrapper() extends InputStream {
+    override def read(): Int = System.in.read()
   }
 
   private[play] final class SystemOutWrapper extends OutputStream {
@@ -90,7 +102,20 @@ object PlayConsoleInteractionMode extends PlayInteractionMode {
   }
 
   private def createReader: ConsoleReader =
-    new ConsoleReader(new SystemInWrapper(poll = 2.milliseconds), new SystemOutWrapper())
+    if (System.in.getClass.getName == "java.io.BufferedInputStream") {
+      // sbt <= 1.3:
+      // In sbt <= 1.3 we need to create a non-blocking input stream reader, so sbt is able to interrupt the thread
+      // (e.g. when user hits Ctrl-C to cancel)
+      val originalIn = new FileInputStream(FileDescriptor.in)
+      val in         = new InputStreamWrapperSbtLegacy(originalIn, 2.milliseconds)
+      new ConsoleReader(in, System.out)
+    } else {
+      // sbt 1.4+ (class name is "sbt.internal.util.Terminal$proxyInputStream$"):
+      // sbt makes System.in non-blocking starting with 1.4.0, therefore we shouldn't
+      // create a non-blocking input stream reader ourselves, but just wrap System.in
+      // and System.out (otherwise we end up in a deadlock, console will hang, not accepting inputs)
+      new ConsoleReader(new SystemInWrapper(), new SystemOutWrapper())
+    }
 
   private def withConsoleReader[T](f: ConsoleReader => T): T = {
     val consoleReader = createReader


### PR DESCRIPTION
Fixes #11032

In #9420 we made the `run` command interruptible by adding a couple of sleep statements, so that when hitting CTRL+C sbt had the chance to interrupt the thread.
To fix #10864 Greg now switched from `FileDescriptor.in` to `System.in` in #10890, which totally make sense, however it isn't that easy. Starting with sbt 1.4 `System.in` is non-blocking, therefore the patch introduced in #9420 makes the sbt console hang when waiting for an input. The problem is that `read()` recursively calls itself in the same thread that is supposed to read data from System.in, but because of the endless loop it never has the chance to do so.
Anyway, [this comment](https://github.com/sbt/sbt/issues/6515#issuecomment-843565236) confirms exactly what I debugged:

> They shouldn't need to create a non blocking input stream reader because sbt makes System.in non-blocking starting with 1.4.0.

To solve this we create the exact same (legacy) `ConsoleReader` when using sbt <=1.3, that [already was used](https://github.com/playframework/playframework/blob/2.8.8/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala#L61-L90) before Greg's patch, and yes it still uses `FileDescriptor.in`, but that does not matter because until sbt 1.4.x that was totally ok, because there was not client mode yet.
For sbt 1.4+ we now create a blocking `ConsoleReader` which just wraps `System.in`/`System.out`, basically [the solution Greg referred to](https://github.com/sbt/jline2/commit/6821546aaeea30df2615fb5d3b4a34b78812da65) in his pull request.