### PR TITLE
Shutdown dev server when pressing CTRL+C during run

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
@@ -35,8 +35,8 @@ trait PlayInteractionMode {
  * This is provided, rather than adding a new flag to PlayInteractionMode, to preserve binary compatibility.
  */
 trait PlayNonBlockingInteractionMode extends PlayInteractionMode {
-  def waitForCancel()           = ()
-  def doWithoutEcho(f: => Unit) = f
+  override def waitForCancel()           = ()
+  override def doWithoutEcho(f: => Unit) = f
 
   /**
    * Start the server, if not already started
@@ -114,7 +114,7 @@ object PlayConsoleInteractionMode extends PlayInteractionMode {
       doWithoutEcho(waitEOF())
     }
   }
-  def doWithoutEcho(f: => Unit): Unit = {
+  override def doWithoutEcho(f: => Unit): Unit = {
     withConsoleReader { consoleReader =>
       val terminal = consoleReader.getTerminal
       terminal.setEchoEnabled(false)

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -112,19 +112,21 @@ object PlayRun extends PlayRunCompat {
 
         val maybeContinuous: Option[Watched] = watchContinuously(state, Keys.sbtVersion.value)
 
-        maybeContinuous match {
-          case Some(watched) =>
-            // ~ run mode
-            interaction.doWithoutEcho {
-              twiddleRunMonitor(watched, state, devModeServer.buildLink, Some(PlayWatchState.empty))
-            }
-          case None =>
-            // run mode
-            interaction.waitForCancel()
+        try {
+          maybeContinuous match {
+            case Some(watched) =>
+              // ~ run mode
+              interaction.doWithoutEcho {
+                twiddleRunMonitor(watched, state, devModeServer.buildLink, Some(PlayWatchState.empty))
+              }
+            case None =>
+              // run mode
+              interaction.waitForCancel()
+          }
+        } finally {
+          devModeServer.close()
+          println()
         }
-
-        devModeServer.close()
-        println()
     }
   }
 


### PR DESCRIPTION
While working on #11061 I found out that the current behaviour when pressing CTRL+C while the `run` command is blocking is not good:
```
[myproject] $ run

--- (Running the application, auto-reloading is enabled) ---

[info] p.c.s.AkkaHttpServer - Listening for HTTP on /127.0.0.1:9000

(Server started, use Enter to stop and go back to the console...)

<------------------------------------------ PRESSING CTRL+C HERE ------------------------------------------>

[warn] Canceling execution...
Cancelled: run
[error] Cancelled: run
[error] Use 'last' for the full log.
[myproject] $

<----------------------------- but dev server still running in the background ------------------------------>

[myproject] $ exit
[info] shutting down sbt server
<------------------------- dev server eventually shuts down when exiting sbt/jvm --------------------------->
[info] p.c.s.AkkaHttpServer - Stopping Akka HTTP server...
[info] p.c.s.AkkaHttpServer - Terminating server binding for /127.0.0.1:9000
[info] p.c.s.AkkaHttpServer - Running provided shutdown stop hooks
```

This is far from ideal, specially when executing `run` again, a second dev server will be started but fails, because the port already is assigned (also who knows what other problems that would cause).

The fix is quite easy: Just call the `devModeServer.close()` in a finally clause, so when the thread (that prints "Server started, use Enter...") which blocks gets interrupted by sbt, will still execute the finally clause before it dies. Tested and works great.

(I think this is specially useful for new users which sometimes are used to shutdown processes with ctrl+c)