### PR TITLE
Add onLoadMessage

### DIFF
--- a/dev-mode/run-support/src/main/scala/play/runsupport/Colors.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Colors.scala
@@ -29,4 +29,5 @@ object Colors {
   def white(str: String): String   = if (isANSISupported) (WHITE + str + RESET) else str
   def black(str: String): String   = if (isANSISupported) (BLACK + str + RESET) else str
   def yellow(str: String): String  = if (isANSISupported) (YELLOW + str + RESET) else str
+  def bold(str: String): String    = if (isANSISupported) (BOLD + str + RESET) else str
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Colors.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Colors.scala
@@ -17,4 +17,5 @@ object Colors {
   def white(str: String): String   = RunColors.white(str)
   def black(str: String): String   = RunColors.black(str)
   def yellow(str: String): String  = RunColors.yellow(str)
+  def bold(str: String): String    = RunColors.bold(str)
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -83,9 +83,9 @@ object PlaySettings {
             |
             |""".stripMargin +
         (if (javaVersion != "1.8" && javaVersion != "11" && javaVersion != "17")
-           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-              |  Java versions is ${sys.props("java.specification.version")}. Play supports only 8, 11 and 17.
-              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+              |  Java version is ${sys.props("java.specification.version")}. Play supports only 8, 11 and 17.
+              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
               |
               |""".stripMargin
          else "")

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -66,11 +66,12 @@ object PlaySettings {
   lazy val serviceSettings: Seq[Setting[_]] = Def.settings(
     onLoadMessage := {
       val javaVersion = sys.props("java.specification.version")
-      """|  __          _
-         |  \ \   _ __ | | __ _ _  _
-         |   \ \ | '_ \| |/ _' | || |
-         |   / / |  __/|_|\____|\__ /
-         |  /_/  |_|            |__/
+      """|  __              __
+         |  \ \     ____   / /____ _ __  __
+         |   \ \   / __ \ / // __ `// / / /
+         |   / /  / /_/ // // /_/ // /_/ /
+         |  /_/  / .___//_/ \__,_/ \__, /
+         |      /_/               /____/
          |""".stripMargin.linesIterator.map(Colors.green(_)).mkString("\n") +
         s"""|
             |

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -64,6 +64,32 @@ object PlaySettings {
 
   // Settings for a Play service (not a web project)
   lazy val serviceSettings: Seq[Setting[_]] = Def.settings(
+    onLoadMessage := {
+      val javaVersion = sys.props("java.specification.version")
+      """|  __          _
+         |  \ \   _ __ | | __ _ _  _
+         |   \ \ | '_ \| |/ _' | || |
+         |   / / |  __/|_|\____|\__ /
+         |  /_/  |_|            |__/
+         |""".stripMargin.linesIterator.map(Colors.green(_)).mkString("\n") +
+        s"""|
+            |
+            |Version ${play.core.PlayVersion.current} running Java ${System.getProperty("java.version")}
+            |
+            |${Colors.bold(
+             "Play is run entirely by the community. If you want to keep using it please consider donating:"
+           )}
+            |https://www.playframework.com/sponsors
+            |
+            |""".stripMargin +
+        (if (javaVersion != "1.8" && javaVersion != "11" && javaVersion != "17")
+           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+              |  Java versions is ${sys.props("java.specification.version")}. Play supports only 8, 11 and 17.
+              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+              |
+              |""".stripMargin
+         else "")
+    },
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-encoding", "utf8"),
     javacOptions in Compile ++= Seq("-encoding", "utf8", "-g"),
     playPlugin := false,


### PR DESCRIPTION
Until Play version 2.2 we [displayed a welcome message](https://www.playframework.com/documentation/2.2.x/resources/manual/gettingStarted/images/playNew.png) ([code](https://github.com/playframework/playframework/blob/2.2.x/framework/src/console/src/main/scala/Console.scala#L16-L27)). With version 2.3 Play switched to activator and as part of that [the welcome message was removed](https://github.com/playframework/playframework/commit/00573d82a02b1fbe03bfda808ac69416b06da6f8) but never restored (maybe back then James didn't know about the `onLoadMessage` setting).
Also Play 1 always displayed [a welcome screen](https://www.playframework.com/documentation/1.5.x/images/help), so does [sbt for its build since a while](https://github.com/sbt/sbt/commit/4c6e421d591c726594c62ac60da09715daf17e22).

The welcome message allows us to promote our sponsors page and, like sbt does, we can also warn users when they use an unsupported Java version (people open issues every now and then because they run Play on unsupported JVMs).

![image](https://user-images.githubusercontent.com/644927/147013423-78620189-c9be-4e18-94b3-c735fd91435e.png)

The same when running with an unsupported JVM version:
![image](https://user-images.githubusercontent.com/644927/147014200-7fb5d03b-e7dc-4343-9468-5d6a2c662ce7.png)