### PR TITLE
[2.7.x] Add onLoadMessage

### DIFF
--- a/dev-mode/run-support/src/main/scala/play/runsupport/Colors.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Colors.scala
@@ -29,4 +29,5 @@ object Colors {
   def white(str: String): String   = if (isANSISupported) (WHITE + str + RESET) else str
   def black(str: String): String   = if (isANSISupported) (BLACK + str + RESET) else str
   def yellow(str: String): String  = if (isANSISupported) (YELLOW + str + RESET) else str
+  def bold(str: String): String    = if (isANSISupported) (BOLD + str + RESET) else str
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Colors.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Colors.scala
@@ -17,4 +17,5 @@ object Colors {
   def white(str: String): String   = RunColors.white(str)
   def black(str: String): String   = RunColors.black(str)
   def yellow(str: String): String  = RunColors.yellow(str)
+  def bold(str: String): String    = RunColors.bold(str)
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -68,9 +68,9 @@ object PlaySettings extends PlaySettingsCompat {
             |
             |""".stripMargin +
         (if (javaVersion != "1.8")
-           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-              |  Java versions is ${sys.props("java.specification.version")}. Play supports only 8.
-              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+              |  Java version is ${sys.props("java.specification.version")}. Play supports only 8.
+              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
               |
               |""".stripMargin
          else "")

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -50,11 +50,12 @@ object PlaySettings extends PlaySettingsCompat {
   lazy val serviceSettings = Seq[Setting[_]](
     onLoadMessage := {
       val javaVersion = sys.props("java.specification.version")
-      """|  __          _
-         |  \ \   _ __ | | __ _ _  _
-         |   \ \ | '_ \| |/ _' | || |
-         |   / / |  __/|_|\____|\__ /
-         |  /_/  |_|            |__/
+      """|  __              __
+         |  \ \     ____   / /____ _ __  __
+         |   \ \   / __ \ / // __ `// / / /
+         |   / /  / /_/ // // /_/ // /_/ /
+         |  /_/  / .___//_/ \__,_/ \__, /
+         |      /_/               /____/
          |""".stripMargin.linesIterator.map(Colors.green(_)).mkString("\n") +
         s"""|
             |

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -48,6 +48,32 @@ object PlaySettings extends PlaySettingsCompat {
 
   // Settings for a Play service (not a web project)
   lazy val serviceSettings = Seq[Setting[_]](
+    onLoadMessage := {
+      val javaVersion = sys.props("java.specification.version")
+      """|  __          _
+         |  \ \   _ __ | | __ _ _  _
+         |   \ \ | '_ \| |/ _' | || |
+         |   / / |  __/|_|\____|\__ /
+         |  /_/  |_|            |__/
+         |""".stripMargin.linesIterator.map(Colors.green(_)).mkString("\n") +
+        s"""|
+            |
+            |Version ${play.core.PlayVersion.current} running Java ${System.getProperty("java.version")}
+            |
+            |${Colors.bold(
+             "Play is run entirely by the community. If you want to keep using it please consider donating:"
+           )}
+            |https://www.playframework.com/sponsors
+            |
+            |""".stripMargin +
+        (if (javaVersion != "1.8")
+           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+              |  Java versions is ${sys.props("java.specification.version")}. Play supports only 8.
+              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+              |
+              |""".stripMargin
+         else "")
+    },
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-encoding", "utf8"),
     javacOptions in Compile ++= Seq("-encoding", "utf8", "-g"),
     playPlugin := false,


### PR DESCRIPTION
Backport of #11070, but just checking for Java 8, because Java 11 is only officially supported since Play 2.8: https://www.playframework.com/documentation/2.8.x/Highlights28#Java-11-support