### PR TITLE
Switch to Jakarta JPA

### DIFF
--- a/documentation/manual/working/commonGuide/build/code/dependencies.sbt
+++ b/documentation/manual/working/commonGuide/build/code/dependencies.sbt
@@ -11,7 +11,7 @@ libraryDependencies += "org.apache.derby" % "derby" % "10.16.1.1" % "test"
 //#multi-deps
 libraryDependencies ++= Seq(
   "org.apache.derby" % "derby"          % "10.16.1.1",
-  "org.hibernate"    % "hibernate-core" % "5.4.32.Final"
+  "org.hibernate"    % "hibernate-core" % "6.2.3.Final"
 )
 //#multi-deps
 

--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -27,10 +27,11 @@ Next you have to create a proper `persistence.xml` JPA configuration file. Put i
 Here is a sample configuration file to use with Hibernate:
 
 ```xml
-<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
-             version="2.1">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
 
     <persistence-unit name="defaultPersistenceUnit" transaction-type="RESOURCE_LOCAL">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
@@ -61,7 +62,7 @@ This is a requirement by the [JPA specification](https://download.oracle.com/otn
 
 ## Using `play.db.jpa.JPAApi`
 
-Play offers you a convenient API to work with [Entity Manager](https://docs.oracle.com/javaee/7/api/javax/persistence/EntityManager.html) and Transactions. This API is defined by [`play.db.jpa.JPAApi`](api/java/play/db/jpa/JPAApi.html), which can be injected at other objects like the code below:
+Play offers you a convenient API to work with [Entity Manager](https://jakarta.ee/specifications/persistence/3.1/apidocs/jakarta.persistence/jakarta/persistence/entitymanager) and Transactions. This API is defined by [`play.db.jpa.JPAApi`](api/java/play/db/jpa/JPAApi.html), which can be injected at other objects like the code below:
 
 @[jpa-repository-api-inject](code/JPARepository.java)
 

--- a/documentation/manual/working/javaGuide/main/sql/code/JPARepository.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JPARepository.java
@@ -5,9 +5,9 @@
 package javaguide.sql;
 
 // #jpa-repository-api-inject
+import jakarta.persistence.*;
 import java.util.concurrent.*;
 import javax.inject.*;
-import javax.persistence.*;
 import play.db.jpa.JPAApi;
 
 @Singleton

--- a/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
+++ b/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
@@ -3,7 +3,7 @@
 //#jpa-sbt-dependencies
 libraryDependencies ++= Seq(
   javaJpa,
-  "org.hibernate" % "hibernate-core" % "5.4.32.Final" // replace by your jpa implementation
+  "org.hibernate" % "hibernate-core" % "6.2.3.Final" // replace by your jpa implementation
 )
 //#jpa-sbt-dependencies
 

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -5,6 +5,7 @@
 package play.db.jpa;
 
 import com.typesafe.config.Config;
+import jakarta.persistence.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -12,7 +13,6 @@ import java.util.function.Function;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import javax.persistence.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.db.DBApi;

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -4,9 +4,9 @@
 
 package play.db.jpa;
 
+import jakarta.persistence.EntityManager;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.persistence.EntityManager;
 
 /** JPA API. */
 public interface JPAApi {

--- a/persistence/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
+++ b/persistence/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
@@ -9,12 +9,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import jakarta.persistence.EntityManager;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;

--- a/persistence/play-java-jpa/src/test/java/play/db/jpa/TestEntity.java
+++ b/persistence/play-java-jpa/src/test/java/play/db/jpa/TestEntity.java
@@ -6,8 +6,8 @@ package play.db.jpa;
 
 import static java.util.stream.Collectors.toList;
 
+import jakarta.persistence.*;
 import java.util.*;
-import javax.persistence.*;
 
 @Entity
 public class TestEntity {

--- a/persistence/play-java-jpa/src/test/resources/META-INF/persistence.xml
+++ b/persistence/play-java-jpa/src/test/resources/META-INF/persistence.xml
@@ -1,11 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
-<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
-             version="2.1">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
 
     <persistence-unit name="defaultPersistenceUnit" transaction-type="RESOURCE_LOCAL">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -440,6 +440,10 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.test.TestBrowser.submit"),
       ProblemFilters.exclude[MissingTypesProblem]("play.api.test.TestBrowser"),
       ProblemFilters.exclude[MissingTypesProblem]("play.test.TestBrowser"),
+      // Switch to Jakarta Persistence
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.db.jpa.DefaultJPAApi.em"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.db.jpa.JPAApi.em"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.jpa.JPAApi.em"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,8 +106,8 @@ object Dependencies {
   ) ++ specs2Deps.map(_ % Test)
 
   val jpaDeps = Seq(
-    "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.2.Final",
-    "org.hibernate"                   % "hibernate-core"        % "5.4.32.Final" % "test"
+    "jakarta.persistence" % "jakarta.persistence-api" % "3.1.0",
+    "org.hibernate"       % "hibernate-core"          % "6.2.3.Final" % "test"
   )
 
   def scalaReflect(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {


### PR DESCRIPTION
**Update:** See [this comment below](https://github.com/playframework/playframework/pull/11079#issuecomment-1533826580).

~Hibernate switched from `hibernate-core` to `hibernate-core-jakarta` that's probably why scala-steward does not kick in for this artifacts anymore.~ Hibernate did not change the groupId, they just offered `*-jakarta` artifacts with the jakarta namespace for their 5.5. and 5.6 release before sunsetting the `*-jakarta` groupId again and moving their main artifact to the jakarta namespace.

See https://hibernate.org/orm/releases/5.5/#whats-new
> Hibernate ORM 5.5 adds new artifacts with the artifact id suffix "-jakarta" like hibernate-core-jakarta.
The hibernate-core-jakarta artifact implements the Jakarta JPA 3.0 specification, while the hibernate-core artifact still implements the Jakarta JPA 2.2 specification.