### PR TITLE
Dev server should not exit when it receives EOF (-1)

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
@@ -126,9 +126,7 @@ object PlayConsoleInteractionMode extends PlayInteractionMode {
     withConsoleReader { consoleReader =>
       def waitEOF(): Unit = {
         consoleReader.readCharacter() match {
-          case 4 | 13 | -1 =>
-          // Note: we have to listen to -1 for jline2, for some reason...
-          // STOP on Ctrl-D, Enter or EOF.
+          case 4 | 13 => // STOP on Ctrl-D or Enter
           case 11 =>
             consoleReader.clearScreen(); waitEOF()
           case 10 =>


### PR DESCRIPTION
Fixes #11086

**TLDR:** After quite some testing I am almost 100% sure we don't need to quit the `sbt run` task on `EOF` (-1). `EOF` will never be received when using `CTRL+D` or the enter key (at least when using Linux/bash)

@MikeEngUSA @gmethvin Can you please test? I published a snapshot that is based on Play 2.8.12 with this PR applied. The version is `2.8.12+1-f35a1c22-SNAPSHOT`, you also have to add `resolvers += Resolver.sonatypeRepo("snapshots")` to both your `project/plugins.sbt` and `build.sbt`.
This is the project I used for testing: https://github.com/mkurz/play-eof-test/blob/master/project/plugins.sbt As you can see I also published a second snapshot (`2.8.12+2-f95484fb-SNAPSHOT`) which also [prints out the character that was received](https://github.com/mkurz/playframework/commit/f95484fb3c7550dbceb3e88bf287f217bea0cd07). You can use that as well if you want to get more insights. It could happen that when you test piping you get floated with `-1`...
If you both test on MacOS and Windows with [a few sbt versions](https://github.com/mkurz/play-eof-test/blob/master/project/build.properties) (not need to test all, maybe 1.6.1, 1.3.13 and 0.13.18?) by running `sbt run` as well as `sbt run > console.log 2>&1` and maybe @MikeEngUSA the various IntelliJ run configs, and everything is OK I will merge this and cut Play 2.8.13. Thanks!

---

Long story:

In #10890 we switched to `System.in`, which, starting with sbt 1.4+, is now non-blocking (that's why #11061 was required as well).

Now, when using `System.in`, what's happening on my Ubuntu machine and obviously also on Windows, is that when piping `sbt`s input/output, Play (jline?) receives `EOF` (-1) for some reason. This wasn't the case when using `FileDescriptor.in`. (Or maybe that's because `System.in` is non-blocking in sbt 1.4+ and `FileDescriptor.in` isn't? To be honest I don't know exactly).

For some reason, when switching to sbt in Play 2.2, the `run` task should also exit when it receives `EOF`/`-1`.
Here is the commit that introduced that: https://github.com/playframework/playframework/commit/bfbc16586d1307ddae51b5bf4f886ec6e4bb14da#diff-e5676a6f7f1849c865bd5e36be5293eea204aed23eec93a5421f39f14116fff8R31
The comment "_Note: we have to listen to -1 for jline2, for some reason..._" indicates that there was something fishy going on back then, maybe a bug in jline that made it necessary to also treat -1 as `CTRL-D` in some environments? I don't know. Because neither the comment nor the pull request this commit was included in didn't go into more details why catching `-1` is necessary, I had a look if I can find a jline bug that could have caused problems back then: So maybe https://github.com/jline/jline2/commit/39bbc9208f0a50bc20f8214a4f4f1005297d6850 or https://github.com/jline/jline2/commit/cae777dfeaa62bfd1aa362acad4b97decf6c91da could have been the reason to also listen for `-1`. However I don't know and will probably never know. There is also [this thread](https://github.com/jline/jline2/pull/67) where someone says `ctrl-D` sends `null` (instead of 4), but then some says `"...both Ctrl+C and Ctrl+D are read as litteral 3 and 4..."` so it seems there was at least something going on back then.

What's interesting as well is, that _before_ the commit I referenced above (which made it into Play 2.2.0-M3), the `waitForKey` was _not_ listening for `-1`: https://github.com/playframework/playframework/blob/2.2.0-M2/framework/src/sbt-plugin/src/main/scala/PlayRun.scala#L24 (this is from the `2.2.0-M2` tag)

Anyway.
Because it is not clear to me why `EOF` should be treated like `CTRL-D` (4), I did quite some testing to find out if there is a scenario that causes `EOF` (-1) to be received.  And I could **not** find one, at least not when using Ubuntu.
To test, I just printed the detected char out on the console, see https://github.com/mkurz/playframework/commit/f95484fb3c7550dbceb3e88bf287f217bea0cd07
Testing in with sbt `0.13.18`, `1.3.13`, `1.4.9`, `1.5.8` and `1.6.1` with `sbt run` it alway correctly printed `4` for `CTRL+D` and `13` for the enter key. `-1` was never seen. Only when piping via `sbt run > console.log 2>&1` or using Intellij's `Play 2 App` the output gets floated with `-1` (that's why when reacting to `-1` previously to this PR has stopped the run task immediately)