### PR TITLE
No need link to author in release drafts, @... is a link already

### DIFF
--- a/.github/release-drafter-2.8.x.yml
+++ b/.github/release-drafter-2.8.x.yml
@@ -4,7 +4,7 @@ tag-template: '$NEXT_PATCH_VERSION'
 filter-by-commitish: true
 commitish: 2.8.x
 
-change-template: '- $TITLE [#$NUMBER](https://github.com/playframework/playframework/issues/$NUMBER) by [@$AUTHOR](https://github.com/$AUTHOR)'
+change-template: '- $TITLE [#$NUMBER](https://github.com/playframework/playframework/issues/$NUMBER) by @$AUTHOR'
 template: |
   The Play Team is happy to announce the release of Play $NEXT_PATCH_VERSION.
   

--- a/.github/release-drafter-master.yml
+++ b/.github/release-drafter-master.yml
@@ -4,7 +4,7 @@ tag-template: '$NEXT_MINOR_VERSION'
 filter-by-commitish: true
 commitish: master
 
-change-template: '- $TITLE [#$NUMBER](https://github.com/playframework/playframework/issues/$NUMBER) by [@$AUTHOR](https://github.com/$AUTHOR)'
+change-template: '- $TITLE [#$NUMBER](https://github.com/playframework/playframework/issues/$NUMBER) by @$AUTHOR'
 template: |
   # :mega: Play $NEXT_MINOR_VERSION Released
   


### PR DESCRIPTION
GitHub improved their release pages: https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/

As written in [the docs as well](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) when you `@mention` a user in the notes they will be added at the bottom of the release notes, like:
<kbd><img width="400" src="https://user-images.githubusercontent.com/644927/149222490-7f28554d-0db5-4085-9f3b-a0a48b26e95f.png" /></kbd>

However, when releasing 2.8.13 I noticed that there was no one added (I had to modify the draft by hand instead)... That is because right now the authors are included in a link, which actually is a link to the author... So GitHub does not pick up the user because it's a link... 
However e.g. @mkurz already is a link to the user, so no reason to link again... (So we put a link in a link :wink:)
(I remember, when adding release-drafter, I just copied over a template from somewhere else, so I guess I never thought about that...)