### PR TITLE
[2.8.x] Use ssl-config to 0.6.0

### DIFF
--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -38,6 +38,7 @@ object ScriptedTools extends AutoPlugin with ScriptedTools0 {
     // using this variant due to sbt#5405
     resolvers += "sonatype-service-local-releases"
       .at("https://oss.sonatype.org/service/local/repositories/releases/content/"), // sync ScriptedTools.scala
+    resolvers += Resolver.sonatypeRepo("snapshots"),
     // This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
     // the snapshot resolvers in `cron` builds.
     // If this is a cron job in Travis:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.15")
 
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.2"
+  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.0"
 
   val playJsonVersion = "2.8.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -288,7 +288,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.1.7"
+  val playWsStandaloneVersion = "2.1.7+3-cb4c8cfb-SNAPSHOT"
   val playWsDeps = Seq(
     "com.typesafe.play"                        %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play"                        %% "play-ws-standalone-xml" % playWsStandaloneVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18+31-9d0684d8-SNAPSHOT")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.15")
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.0"


### PR DESCRIPTION
See notes in https://github.com/playframework/play-ws/pull/638

Because the Play cron build uses the latest akka snaphot it uses a snapshot version which already upgraded ssl-config to 0.6.0. It looks like ssl-config is not binary compatible between 0.4.3 and 0.6.0, so we have to upgrade it in Play and play-ws as well.