### PR TITLE
fork := true for "sbt run" not needed to set editor (it doesn't even work)

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -121,8 +121,6 @@ play.editor="http://localhost:63342/api/file/?file=%s&line=%s"
 You can also set play.editor from `build.sbt`:
 
 ```scala
-fork := true // required for "sbt run" to pick up javaOptions
-
 javaOptions += "-Dplay.editor=http://localhost:63342/api/file/?file=%s&line=%s"
 ```
 


### PR DESCRIPTION
`fork := true` doesn't even work for `sbt run`.
System properties set via `javaOptions += "-D...` does work, the reloader picks them up (I just tested this), so `fork := true` is definitely not needed.