### PR TITLE
use CollectionConverters instead of deprecated JavaConverters

### DIFF
--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -60,7 +60,7 @@ trait CaffeineCacheComponents {
  */
 class CaffeineCacheModule
     extends SimpleModule((environment, configuration) => {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
 
       val defaultCacheName = configuration.underlying.getString("play.cache.defaultCache")
       val bindCaches       = configuration.underlying.getStringList("play.cache.bindCaches").asScala

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheManager.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheManager.scala
@@ -39,7 +39,7 @@ class CaffeineCacheManager(private val config: Config, private val actorSystem: 
   }
 
   def cacheNames: Set[String] = {
-    scala.collection.JavaConverters.asScalaSet(cacheMap.keySet()).toSet
+    scala.jdk.CollectionConverters.SetHasAsScala(cacheMap.keySet()).asScala.toSet
   }
 
   private[caffeine] def getCacheBuilder(cacheName: String): Caffeine[_, _] = {

--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/caffeine/CaffeineCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/caffeine/CaffeineCacheApiSpec.scala
@@ -72,7 +72,7 @@ class CaffeineCacheApiSpec extends PlaySpecification {
         "play.cache.bindCaches" -> Seq("custom")
       )
     ) {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val caffeineCacheManager: CaffeineCacheManager = app.injector.instanceOf[CaffeineCacheManager]
       caffeineCacheManager.getCache("custom")
       caffeineCacheManager.getCache("custom-two")

--- a/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -63,7 +63,7 @@ trait EhCacheComponents {
  */
 class EhCacheModule
     extends SimpleModule((environment, configuration) => {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
 
       val defaultCacheName  = configuration.underlying.getString("play.cache.defaultCache")
       val bindCaches        = configuration.underlying.getStringList("play.cache.bindCaches").asScala

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -202,7 +202,7 @@ final case class GuiceApplicationBuilder(
    * @return Returns true if one of the keys contains a deprecated value, otherwise false
    */
   def shouldDisplayLoggerDeprecationMessage(appConfiguration: Configuration): Boolean = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     import scala.collection.mutable
 
     val deprecatedValues = List("DEBUG", "WARN", "ERROR", "INFO", "TRACE", "OFF")

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -24,7 +24,7 @@ import play.api.Environment
 import play.api.Mode
 import play.api.PlayException
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
 class GuiceLoadException(message: String) extends RuntimeException(message)
@@ -169,7 +169,7 @@ abstract class GuiceBuilder[Self] protected (
    * Libraries like Guiceberry and Jukito that want to handle injector creation may find this helpful.
    */
   def createModule(): GuiceModule = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val injectorModule = GuiceableModule.guice(
       Seq(
         bind[GuiceInjector].toSelf,

--- a/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -34,7 +34,7 @@ import play.i18n.MessagesApi
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 import scala.concurrent.Future
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NoStackTrace
 
 class HttpErrorHandlerSpec extends Specification {

--- a/core/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
@@ -104,7 +104,7 @@ trait HeadActionSpec
       val getHeaders: HttpHeaders = responses(1).underlying[NettyResponse].getHeaders
 
       // Exclude `Date` header because it can vary between requests
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val firstHeaders  = headHeaders.remove(DATE)
       val secondHeaders = getHeaders.remove(DATE)
 

--- a/core/play-integration-test/src/it/scala/play/it/http/AkkaRequestTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/AkkaRequestTimeoutSpec.scala
@@ -20,7 +20,7 @@ import play.core.server._
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.util.Random
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class AkkaRequestTimeoutSpec extends PlaySpecification with AkkaHttpIntegrationSpecification {
   "play.server.akka.requestTimeout configuration" should {

--- a/core/play-integration-test/src/it/scala/play/it/http/FlashCookieSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/FlashCookieSpec.scala
@@ -18,7 +18,7 @@ import play.core.server.ServerEndpoint
 import play.it.test.EndpointIntegrationSpecification
 import play.it.test.OkHttpEndpointSupport
 
-import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters
 
 class FlashCookieSpec
     extends PlaySpecification
@@ -64,7 +64,7 @@ class FlashCookieSpec
     def withAllCookieEndpoints[A: AsResult](block: CookieEndpoint => A): Fragment = {
       appFactory.withAllOkHttpEndpoints { (okEndpoint: OkHttpEndpoint) =>
         block(new CookieEndpoint {
-          import JavaConverters._
+          import CollectionConverters._
           def call(path: String, cookies: List[okhttp3.Cookie]): (okhttp3.Response, List[okhttp3.Cookie]) = {
             var responseCookies: List[okhttp3.Cookie] = null
             val cookieJar = new CookieJar {

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -47,7 +47,7 @@ class GuiceJavaActionCompositionSpec extends JavaActionCompositionSpec {
 
 class BuiltInComponentsJavaActionCompositionSpec extends JavaActionCompositionSpec {
   def context(initialSettings: Map[String, AnyRef]): play.ApplicationLoader.Context = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     play.ApplicationLoader.create(play.Environment.simple(), initialSettings.asJava)
   }
 

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionSpec.scala
@@ -48,7 +48,7 @@ class GuiceJavaActionSpec extends JavaActionSpec {
 
 class BuiltInComponentsJavaActionSpec extends JavaActionSpec {
   def context(initialSettings: Map[String, AnyRef]): play.ApplicationLoader.Context = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     play.ApplicationLoader.create(play.Environment.simple(), initialSettings.asJava)
   }
 

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
@@ -43,7 +43,7 @@ class JavaHttpErrorHandlingSpec
   ): ApplicationFactory = new ApplicationFactory {
     override def create(): ScalaApplication = {
       val components = new BuiltInComponentsFromContext(applicationContext) with RoutingDslComponents {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         import scala.compat.java8.OptionConverters
 
         // Add the web command handler if it is available

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
@@ -14,7 +14,7 @@ import play.mvc.Http
 import play.mvc.Http.RequestBody
 import play.mvc.Http.RequestImpl
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class JavaRequestsSpec extends PlaySpecification with Mockito {
   "JavaHelpers" should {
@@ -39,7 +39,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
     }
 
     "create a request with a helper that can do cookies" in {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
 
       val cookie1                      = Cookie("name1", "value1")
       val requestHeader: RequestHeader = FakeRequest().withCookies(cookie1)
@@ -54,7 +54,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
     }
 
     "create a request with a helper that can do cookies" in {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
 
       val cookie1 = Cookie("name1", "value1")
 

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -30,7 +30,7 @@ import play.mvc.Http.Flash
 import play.mvc.Http.Session
 import play.mvc._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class NettyJavaResultsHandlingSpec    extends JavaResultsHandlingSpec with NettyIntegrationSpecification
 class AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with AkkaHttpIntegrationSpecification
@@ -499,7 +499,7 @@ trait JavaResultsHandlingSpec
         .withCookies(new Http.Cookie("bar", "KitKat", 1000, "/", "example.com", false, true, null))
         .withCookies(new Http.Cookie("bar", "Mars", 1000, "/", "example.com", false, true, null))
 
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val cookies      = result.cookies().iterator().asScala.toList
       val cookieValues = cookies.map(_.value)
       cookieValues must not contain ("KitKat")
@@ -558,7 +558,7 @@ trait JavaResultsHandlingSpec
 
     "chunk comet results from string" in makeRequest(new MockController {
       def action(request: Http.Request) = {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val dataSource  = akka.stream.javadsl.Source.from(List("a", "b", "c").asJava)
         val cometSource = dataSource.via(Comet.string("callback"))
         Results.ok().chunked(cometSource)

--- a/core/play-integration-test/src/it/scala/play/it/http/SessionCookieSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/SessionCookieSpec.scala
@@ -29,7 +29,7 @@ trait SessionCookieSpec extends PlaySpecification with ServerIntegrationSpecific
     Server.withApplicationFromContext() { context =>
       new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
         import play.api.routing.sird.{ GET => SirdGet, _ }
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
 
         override def configuration: Configuration =
           Configuration(ConfigFactory.parseMap(additionalConfiguration.asJava)).withFallback(super.configuration)

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/FormBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/FormBodyParserSpec.scala
@@ -22,7 +22,7 @@ import play.api.test.Injecting
 import play.api.test.PlaySpecification
 import play.api.test.WithApplication
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
 
 class FormBodyParserSpec extends PlaySpecification {

--- a/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketClient.scala
@@ -176,7 +176,7 @@ object WebSocketClient {
           val clientConnection =
             Flow.fromSinkAndSource(Sink.fromSubscriber(subscriber), Source.fromPublisher(publisher))
 
-          import scala.collection.JavaConverters._
+          import scala.jdk.CollectionConverters._
           val responseHeaders = resp.headers().entries().asScala.toList.map(entry => (entry.getKey, entry.getValue))
           onConnected(responseHeaders, webSocketProtocol(clientConnection))
 

--- a/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -344,7 +344,7 @@ trait WebSocketSpec
       import play.core.routing.HandlerInvokerFactory
       import play.core.routing.HandlerInvokerFactory._
 
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
 
       implicit def toHandler[J <: AnyRef](
           javaHandler: => J

--- a/core/play-integration-test/src/it/scala/play/it/libs/JavaFormSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/JavaFormSpec.scala
@@ -9,7 +9,7 @@ import play.data.validation.Constraints.Required
 
 import scala.annotation.meta.field
 import scala.beans.BeanProperty
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class JavaFormSpec extends PlaySpecification {
   "A Java form" should {

--- a/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -11,7 +11,7 @@ import play.mvc.Http.RequestBody
 import play.mvc.Result
 import play.utils.UriEncoding
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/core/play-java/src/test/scala/play/libs/XPathSpec.scala
+++ b/core/play-java/src/test/scala/play/libs/XPathSpec.scala
@@ -5,7 +5,7 @@
 package play.libs
 
 import org.specs2.mutable.Specification
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class XPathSpec extends Specification {
   //XPathFactory.newInstance() used internally by XPath is not thread safe so forcing sequential execution

--- a/core/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -23,7 +23,7 @@ import akka.japi.function.{ Function => JFn }
 import org.reactivestreams.Subscription
 
 class AccumulatorSpec extends org.specs2.mutable.Specification {
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   def withMaterializer[T](block: Materializer => T): T = {
     val system = ActorSystem("test")

--- a/core/play/src/main/scala/play/api/Configuration.scala
+++ b/core/play/src/main/scala/play/api/Configuration.scala
@@ -15,7 +15,7 @@ import com.typesafe.config._
 import play.twirl.api.utils.StringEscapeUtils
 import play.utils.PlayIO
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal

--- a/core/play/src/main/scala/play/api/Logger.scala
+++ b/core/play/src/main/scala/play/api/Logger.scala
@@ -13,7 +13,7 @@ import org.slf4j.Marker
 
 import scala.collection.mutable
 import scala.language.implicitConversions
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Typical logger interface.

--- a/core/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/core/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -72,7 +72,7 @@ object LoggerConfigurator {
       config: Configuration,
       optionalProperties: Map[String, String]
   ): Map[String, String] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val mutableMap = new scala.collection.mutable.HashMap[String, String]()
     mutableMap.put("application.home", env.rootPath.getAbsolutePath)
 

--- a/core/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/core/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -17,7 +17,7 @@ import play.api.Logger
 import play.api.mvc.EssentialFilter
 import play.utils.Reflect
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Provides filters to the [[play.api.http.HttpRequestHandler]].

--- a/core/play/src/main/scala/play/api/i18n/Langs.scala
+++ b/core/play/src/main/scala/play/api/i18n/Langs.scala
@@ -14,7 +14,7 @@ import play.api.Logger
 
 import scala.util.Try
 import scala.util.control.NonFatal
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * A Lang supported by the application.

--- a/core/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/core/play/src/main/scala/play/api/i18n/Messages.scala
@@ -593,7 +593,7 @@ class DefaultMessagesApiProvider @Inject() (
   }
 
   protected def loadMessages(file: String): Map[String, String] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     environment.classLoader
       .getResources(joinPaths(messagesPrefix, file))

--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -14,7 +14,7 @@ import java.util.OptionalLong
 import java.util.UUID
 import scala.annotation._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 import reflect.ClassTag

--- a/core/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/core/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -225,7 +225,7 @@ trait CookieHeaderEncoding {
   val SetCookieHeaderSeparator      = ";;"
   val SetCookieHeaderSeparatorRegex = SetCookieHeaderSeparator.r
 
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   // We use netty here but just as an API to handle cookies encoding
 
@@ -648,7 +648,7 @@ trait JWTCookieDataCodec extends CookieDataCodec {
   override def decode(encodedString: String): Map[String, String] = {
     import io.jsonwebtoken._
 
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     try {
       // Get all the claims
@@ -722,7 +722,7 @@ object JWTCookieDataCodec {
       clock: java.time.Clock
   ) {
     import io.jsonwebtoken._
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     private val jwtClock = new Clock {
       override def now(): Date = java.util.Date.from(clock.instant())

--- a/core/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/core/play/src/main/scala/play/api/mvc/Headers.scala
@@ -9,7 +9,7 @@ import java.util.Locale
 import play.api.http.HeaderNames
 import play.core.utils.CaseInsensitiveOrdered
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -29,7 +29,7 @@ import play.api.libs.typedmap.TypedMap
 import play.core.utils.CaseInsensitiveOrdered
 import play.core.utils.HttpHeaderParameterEncoding
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.immutable.TreeMap
 import scala.concurrent.ExecutionContext
 

--- a/core/play/src/main/scala/play/api/templates/Templates.scala
+++ b/core/play/src/main/scala/play/api/templates/Templates.scala
@@ -8,7 +8,7 @@ import java.util.Optional
 
 import play.twirl.api.Html
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 /** Defines a magic helper for Play templates. */

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -28,7 +28,7 @@ import play.libs.AnnotationUtils
 import play.mvc.Http.{ Request => JRequest }
 import play.mvc.Http.{ RequestImpl => JRequestImpl }
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -36,7 +36,7 @@ import play.mvc.Http.{ RequestHeader => JRequestHeader }
 import play.mvc.Http.{ RequestImpl => JRequestImpl }
 import play.mvc.Http
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters
 
 /**

--- a/core/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -11,7 +11,7 @@ import play.api.libs.Files.TemporaryFile
 
 import akka.stream.Materializer
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import play.api.mvc._
 import play.libs.Files.DelegateTemporaryFile
 import play.libs.Files.{ TemporaryFile => JTemporaryFile }

--- a/core/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/core/play/src/main/scala/play/core/j/JavaResults.scala
@@ -7,13 +7,13 @@ package play.core.j
 import play.mvc.{ ResponseHeader => JResponseHeader }
 
 import scala.annotation.varargs
-import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters
 import scala.language.reflectiveCalls
 
 object JavaResultExtractor {
   @varargs
   def withHeader(responseHeader: JResponseHeader, nameValues: String*): JResponseHeader = {
-    import JavaConverters._
+    import CollectionConverters._
     if (nameValues.length % 2 != 0) {
       throw new IllegalArgumentException(
         "Unmatched name - withHeaders must be invoked with an even number of string arguments"

--- a/core/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
@@ -9,7 +9,7 @@ import javax.inject.Inject
 import play.mvc.Http.RequestHeader
 import play.routing.Router.RouteDocumentation
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -44,7 +44,7 @@ object FormUrlEncodedParser {
    * @return A Map of keys to the sequence of values for that key
    */
   def parseAsJava(data: String, encoding: String): java.util.Map[String, java.util.List[String]] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     parse(data, encoding).map {
       case (key, values) =>
         key -> values.asJava
@@ -58,7 +58,7 @@ object FormUrlEncodedParser {
    * @return A Map of keys to the sequence of array values for that key
    */
   def parseAsJavaArrayValues(data: String, encoding: String): java.util.Map[String, Array[String]] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     parse(data, encoding).map {
       case (key, values) =>
         key -> values.toArray

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -14,7 +14,7 @@ import play.api.mvc._
 import play.api.routing.HandlerDef
 import play.api.routing.Router
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * A route

--- a/core/play/src/main/scala/views/helper/Helpers.scala
+++ b/core/play/src/main/scala/views/helper/Helpers.scala
@@ -6,7 +6,7 @@ import play.api.data.FormError
 import play.api.templates.PlayMagic.translate
 import play.twirl.api._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 
 package views.html.helper {

--- a/core/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -341,7 +341,7 @@ class ConfigurationSpec extends Specification {
     }
 
     "InMemoryResourceClassLoader should return one resource" in {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val cl  = new InMemoryResourceClassLoader("reference.conf" -> "foo = ${bar}")
       val url = new URL(null, "bytes:///reference.conf", (_: URL) => throw new IOException)
 

--- a/core/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -20,7 +20,7 @@ import play.core.cookie.encoding.ServerCookieEncoder
 
 class HttpConfigurationSpec extends Specification {
   "HttpConfiguration" should {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     def properties = {
       Map(

--- a/core/play/src/test/scala/play/api/templates/TemplatesSpec.scala
+++ b/core/play/src/test/scala/play/api/templates/TemplatesSpec.scala
@@ -20,7 +20,7 @@ import play.api.mvc.Results
 import play.mvc.{ Results => JResults }
 import play.twirl.api.Html
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class TemplatesSpec extends Specification {
   "toHtmlArgs" should {

--- a/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
@@ -25,7 +25,7 @@ import play.libs.streams.Accumulator
 import play.http.DefaultHttpErrorHandler
 import play.libs.F
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatchers {

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -15,7 +15,7 @@ import play.api.mvc.request.RequestTarget
 import play.mvc.Http.HeaderNames
 
 import scala.compat.java8.OptionConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class RequestHeaderSpec extends Specification {
   private def requestHeader(headers: (String, String)*): RequestHeader = {

--- a/core/play/src/test/scala/play/mvc/ResponseHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/ResponseHeaderSpec.scala
@@ -5,7 +5,7 @@
 package play.mvc
 
 import org.specs2.mutable.Specification
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 class ResponseHeaderSpec extends Specification {

--- a/persistence/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -114,7 +114,7 @@ private[db] class HikariCPConfig private (
     dbConfig.username.foreach(hikariConfig.setUsername)
     dbConfig.password.foreach(hikariConfig.setPassword)
 
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val dataSourceConfig = config.get[Configuration]("dataSource")
     dataSourceConfig.underlying.root().keySet().asScala.foreach { key =>

--- a/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -15,7 +15,7 @@ import play.core.server.ServerEndpoint
 import play.core.server.ServerEndpoints
 import play.core.server.ServerProvider
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * A recipe for making a [[ServerEndpoint]]. Recipes are often used

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -52,7 +52,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
         .asInstanceOf[AhcWSRequest]
       val req: AHCRequest = r.underlying.buildRequest()
 
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val paramsList: scala.collection.Seq[Param] = req.getQueryParams.asScala
       paramsList.exists(p => (p.getName == "foo") && (p.getValue == "foo1")) must beTrue
       paramsList.exists(p => (p.getName == "foo") && (p.getValue == "foo2")) must beTrue
@@ -60,7 +60,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
     }
 
     "support http headers" in {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val req: AHCRequest = makeAhcRequest("http://playframework.com/")
         .addHttpHeaders("key" -> "value1", "key" -> "value2")
         .asInstanceOf[AhcWSRequest]
@@ -79,7 +79,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
   }
 
   "not make Content-Type header if there is Content-Type in headers already" in {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val req: AHCRequest = makeAhcRequest("http://playframework.com/")
       .addHttpHeaders("content-type" -> "fake/contenttype; charset=utf-8")
       .withBody(<aaa>value1</aaa>)
@@ -141,7 +141,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
   }
 
   "Have form params on POST of content type application/x-www-form-urlencoded when signed" in {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val consumerKey  = ConsumerKey("key", "secret")
     val requestToken = RequestToken("token", "secret")
     val calc         = OAuthCalculator(consumerKey, requestToken)
@@ -176,7 +176,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
   }
 
   "Remove a user defined content length header if we are parsing body explicitly when signed" in {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val consumerKey  = ConsumerKey("key", "secret")
     val requestToken = RequestToken("token", "secret")
     val calc         = OAuthCalculator(consumerKey, requestToken)
@@ -197,7 +197,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
   }
 
   "Verify Content-Type header is passed through correctly" in {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val req: AHCRequest = makeAhcRequest("http://playframework.com/")
       .addHttpHeaders("Content-Type" -> "text/plain; charset=US-ASCII")
       .withBody("HELLO WORLD")

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -41,7 +41,7 @@ import play.core.server.netty._
 import play.core.server.ssl.ServerSSLEngine
 import play.server.SSLEngineProvider
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyHeadersWrapper.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyHeadersWrapper.scala
@@ -6,7 +6,7 @@ package play.core.server.netty
 
 import io.netty.handler.codec.http._
 import play.api.mvc._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * An implementation of Play `Headers` that wraps the raw Netty headers and

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -37,7 +37,7 @@ import play.core.server.common.ForwardedHeaderHandler
 import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.Failure

--- a/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -21,7 +21,7 @@ import play.utils.PlayIO
 import play.utils.Threads
 
 import java.util.concurrent.atomic.AtomicBoolean
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.Failure

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -81,7 +81,7 @@ case class CORSConfig(
   def withServeForbiddenOrigins(serveForbiddenOrigins: Boolean): CORSConfig =
     copy(serveForbiddenOrigins = serveForbiddenOrigins)
 
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
   import scala.compat.java8.FunctionConverters._
   import java.util.{ function => juf }
 

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
@@ -45,12 +45,12 @@ case class CSPConfig(
   }
 
   def withHashes(hashes: java.util.List[CSPHashConfig]): CSPConfig = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     copy(hashes = hashes.asScala.toSeq)
   }
 
   def withDirectives(directives: java.util.List[CSPDirective]): CSPConfig = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     copy(directives = directives.asScala.toSeq)
   }
 }
@@ -79,7 +79,7 @@ object CSPConfig {
    * @return a CSPConfig instance.
    */
   def fromUnprefixedConfiguration(config: Configuration): CSPConfig = {
-    import collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val reportOnly = config.get[Boolean]("reportOnly")
 

--- a/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -91,7 +91,7 @@ private[hosts] case class HostMatcher(pattern: String) {
 }
 
 case class AllowedHostsConfig(allowed: Seq[String], shouldProtect: RequestHeader => Boolean = _ => true) {
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
   import play.mvc.Http.{ RequestHeader => JRequestHeader }
   import scala.compat.java8.FunctionConverters._
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPProcessorSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPProcessorSpec.scala
@@ -15,7 +15,7 @@ import com.shapesecurity.salvation.directiveValues.HashSource.HashAlgorithm
 import com.shapesecurity.salvation.directives.DirectiveValue
 import com.shapesecurity.salvation.directives.UpgradeInsecureRequestsDirective
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class CSPProcessorSpec extends PlaySpecification {
   "shouldFilterRequest" should {

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -267,7 +267,7 @@ object JavaCSPReportSpec {
   class MyAction extends Controller {
     @BodyParser.Of(classOf[CSPReportBodyParser])
     def cspReport(request: Http.Request): Result = {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val cspReport: JavaCSPReport = request.body.as(classOf[JavaCSPReport])
       val json                     = play.libs.Json.toJson(Map("violation" -> cspReport.violatedDirective).asJava)
       Results.ok(json).as(play.mvc.Http.MimeTypes.JSON)

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -26,7 +26,7 @@ import play.api.Application
 import play.api.Configuration
 import play.api.Environment
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/web/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
+++ b/web/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
@@ -6,7 +6,7 @@ package play.core.j
 
 /** Defines a magic helper for Play templates in a Java Forms context. */
 object PlayFormsMagicForJava {
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
   import scala.compat.java8.OptionConverters
   import scala.language.implicitConversions
 

--- a/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -28,7 +28,7 @@ import play.mvc.Http.RequestBuilder
 import views.html.helper.FieldConstructor.defaultField
 import views.html.helper.inputText
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -45,7 +45,7 @@ import play.twirl.api.Html
 
 import javax.validation.constraints.Size
 import scala.beans.BeanProperty
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 class RuntimeDependencyInjectionFormSpec extends FormSpec {

--- a/web/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -13,7 +13,7 @@ import play.data.validation.Constraints.Required
 import play.libs.typedmap.TypedMap
 
 import scala.beans.BeanProperty
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class PartialValidationSpec extends Specification {
   val messagesApi = new DefaultMessagesApi()

--- a/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -145,7 +145,7 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
    * For internal use
    */
   def verifiedId(queryString: java.util.Map[String, Array[String]]): Future[UserInfo] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     verifiedId(queryString.asScala.toMap.mapValues(_.toSeq).toMap)
   }
 

--- a/web/play-openid/src/test/scala/play/api/libs/openid/package.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/package.scala
@@ -9,7 +9,7 @@ import play.shaded.ahc.io.netty.handler.codec.http.QueryStringDecoder
 import java.net.MalformedURLException
 import java.net.URL
 import util.control.Exception._
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import scala.language.implicitConversions
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix warnings

## Purpose

## Background Context

- https://github.com/playframework/playframework/pull/10956 play dropped Scala 2.12 support

## References

