### PR TITLE
avoid deprecated Either methods

### DIFF
--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -803,9 +803,9 @@ public interface BodyParser<A> {
           .map(
               result -> {
                 if (result.isLeft()) {
-                  return F.Either.Left(result.left().get().asJava());
+                  return F.Either.Left(result.swap().toOption().get().asJava());
                 } else {
-                  final play.api.mvc.MultipartFormData<A> scalaData = result.right().get();
+                  final play.api.mvc.MultipartFormData<A> scalaData = result.toOption().get();
                   return F.Either.Right(new DelegatingMultipartFormData(scalaData));
                 }
               },

--- a/core/play/src/main/java/play/mvc/BodyParsers.java
+++ b/core/play/src/main/java/play/mvc/BodyParsers.java
@@ -58,9 +58,9 @@ public class BodyParsers {
     return javaAccumulator.map(
         result -> {
           if (result.isLeft()) {
-            return F.Either.Left(result.left().get().asJava());
+            return F.Either.Left(result.swap().toOption().get().asJava());
           } else {
-            return F.Either.Right(transform.apply(result.right().get()));
+            return F.Either.Right(transform.apply(result.toOption().get()));
           }
         },
         JavaParsers.trampoline());

--- a/core/play/src/main/scala/play/api/data/Form.scala
+++ b/core/play/src/main/scala/play/api/data/Form.scala
@@ -800,7 +800,7 @@ case class RepeatedMapping[T](
     val allErrorsOrItems: Seq[Either[Seq[FormError], T]] =
       RepeatedMapping.indexes(key, data).map(i => wrapped.withPrefix(s"$key[$i]").bind(data))
     if (allErrorsOrItems.forall(_.isRight)) {
-      Right(allErrorsOrItems.map(_.right.get).toList).flatMap(applyConstraints)
+      Right(allErrorsOrItems.map(_.toOption.get).toList).flatMap(applyConstraints)
     } else {
       Left(allErrorsOrItems.collect { case Left(errors) => errors }.flatten)
     }
@@ -890,7 +890,6 @@ case class OptionalMapping[T](wrapped: Mapping[T], constraints: Seq[Constraint[O
       .collectFirst { case Some(v) => v }
       .map(_ => wrapped.bind(data).map(Some(_)))
       .getOrElse(Right(None))
-      .right
       .flatMap(applyConstraints)
   }
 

--- a/core/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
@@ -18,7 +18,7 @@ class PathBindableExtractor[T](implicit pb: PathBindable[T]) {
    * Extract s to T if it can be bound, otherwise don't match.
    */
   def unapply(s: String): Option[T] = {
-    pb.bind("anon", s).right.toOption
+    pb.bind("anon", s).toOption
   }
 
   /**

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -111,350 +111,350 @@ abstract class GeneratedRouter extends Router {
   // format: off
   def call[A1, A2](pa1: Param[A1], pa2: Param[A2])(generator: Function2[A1, A2, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value}
       yield (a1, a2))
       .fold(badRequest, { case (a1, a2) => generator(a1, a2) })
   }
 
   def call[A1, A2, A3](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3])(generator: Function3[A1, A2, A3, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value}
       yield (a1, a2, a3))
       .fold(badRequest, { case (a1, a2, a3) => generator(a1, a2, a3) })
   }
 
   def call[A1, A2, A3, A4](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4])(generator: Function4[A1, A2, A3, A4, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value}
       yield (a1, a2, a3, a4))
       .fold(badRequest, { case (a1, a2, a3, a4) => generator(a1, a2, a3, a4) })
   }
 
   def call[A1, A2, A3, A4, A5](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5])(generator: Function5[A1, A2, A3, A4, A5, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value}
       yield (a1, a2, a3, a4, a5))
       .fold(badRequest, { case (a1, a2, a3, a4, a5) => generator(a1, a2, a3, a4, a5) })
   }
 
   def call[A1, A2, A3, A4, A5, A6](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6])(generator: Function6[A1, A2, A3, A4, A5, A6, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value}
       yield (a1, a2, a3, a4, a5, a6))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6) => generator(a1, a2, a3, a4, a5, a6) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7])(generator: Function7[A1, A2, A3, A4, A5, A6, A7, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value}
       yield (a1, a2, a3, a4, a5, a6, a7))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7) => generator(a1, a2, a3, a4, a5, a6, a7) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8])(generator: Function8[A1, A2, A3, A4, A5, A6, A7, A8, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8) => generator(a1, a2, a3, a4, a5, a6, a7, a8) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9])(generator: Function9[A1, A2, A3, A4, A5, A6, A7, A8, A9, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10])(generator: Function10[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11])(generator: Function11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12])(generator: Function12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13])(generator: Function13[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13], pa14: Param[A14])(generator: Function14[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right
- a14 <- pa14.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value
+ a14 <- pa14.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13], pa14: Param[A14], pa15: Param[A15])(generator: Function15[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right
- a14 <- pa14.value.right
- a15 <- pa15.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value
+ a14 <- pa14.value
+ a15 <- pa15.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13], pa14: Param[A14], pa15: Param[A15], pa16: Param[A16])(generator: Function16[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right
- a14 <- pa14.value.right
- a15 <- pa15.value.right
- a16 <- pa16.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value
+ a14 <- pa14.value
+ a15 <- pa15.value
+ a16 <- pa16.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13], pa14: Param[A14], pa15: Param[A15], pa16: Param[A16], pa17: Param[A17])(generator: Function17[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right
- a14 <- pa14.value.right
- a15 <- pa15.value.right
- a16 <- pa16.value.right
- a17 <- pa17.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value
+ a14 <- pa14.value
+ a15 <- pa15.value
+ a16 <- pa16.value
+ a17 <- pa17.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13], pa14: Param[A14], pa15: Param[A15], pa16: Param[A16], pa17: Param[A17], pa18: Param[A18])(generator: Function18[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right
- a14 <- pa14.value.right
- a15 <- pa15.value.right
- a16 <- pa16.value.right
- a17 <- pa17.value.right
- a18 <- pa18.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value
+ a14 <- pa14.value
+ a15 <- pa15.value
+ a16 <- pa16.value
+ a17 <- pa17.value
+ a18 <- pa18.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13], pa14: Param[A14], pa15: Param[A15], pa16: Param[A16], pa17: Param[A17], pa18: Param[A18], pa19: Param[A19])(generator: Function19[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right
- a14 <- pa14.value.right
- a15 <- pa15.value.right
- a16 <- pa16.value.right
- a17 <- pa17.value.right
- a18 <- pa18.value.right
- a19 <- pa19.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value
+ a14 <- pa14.value
+ a15 <- pa15.value
+ a16 <- pa16.value
+ a17 <- pa17.value
+ a18 <- pa18.value
+ a19 <- pa19.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13], pa14: Param[A14], pa15: Param[A15], pa16: Param[A16], pa17: Param[A17], pa18: Param[A18], pa19: Param[A19], pa20: Param[A20])(generator: Function20[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right
- a14 <- pa14.value.right
- a15 <- pa15.value.right
- a16 <- pa16.value.right
- a17 <- pa17.value.right
- a18 <- pa18.value.right
- a19 <- pa19.value.right
- a20 <- pa20.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value
+ a14 <- pa14.value
+ a15 <- pa15.value
+ a16 <- pa16.value
+ a17 <- pa17.value
+ a18 <- pa18.value
+ a19 <- pa19.value
+ a20 <- pa20.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) })
   }
 
   def call[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](pa1: Param[A1], pa2: Param[A2], pa3: Param[A3], pa4: Param[A4], pa5: Param[A5], pa6: Param[A6], pa7: Param[A7], pa8: Param[A8], pa9: Param[A9], pa10: Param[A10], pa11: Param[A11], pa12: Param[A12], pa13: Param[A13], pa14: Param[A14], pa15: Param[A15], pa16: Param[A16], pa17: Param[A17], pa18: Param[A18], pa19: Param[A19], pa20: Param[A20], pa21: Param[A21])(generator: Function21[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, Handler]): Handler = {
     (for {
-a1 <- pa1.value.right
- a2 <- pa2.value.right
- a3 <- pa3.value.right
- a4 <- pa4.value.right
- a5 <- pa5.value.right
- a6 <- pa6.value.right
- a7 <- pa7.value.right
- a8 <- pa8.value.right
- a9 <- pa9.value.right
- a10 <- pa10.value.right
- a11 <- pa11.value.right
- a12 <- pa12.value.right
- a13 <- pa13.value.right
- a14 <- pa14.value.right
- a15 <- pa15.value.right
- a16 <- pa16.value.right
- a17 <- pa17.value.right
- a18 <- pa18.value.right
- a19 <- pa19.value.right
- a20 <- pa20.value.right
- a21 <- pa21.value.right}
+a1 <- pa1.value
+ a2 <- pa2.value
+ a3 <- pa3.value
+ a4 <- pa4.value
+ a5 <- pa5.value
+ a6 <- pa6.value
+ a7 <- pa7.value
+ a8 <- pa8.value
+ a9 <- pa9.value
+ a10 <- pa10.value
+ a11 <- pa11.value
+ a12 <- pa12.value
+ a13 <- pa13.value
+ a14 <- pa14.value
+ a15 <- pa15.value
+ a16 <- pa16.value
+ a17 <- pa17.value
+ a18 <- pa18.value
+ a19 <- pa19.value
+ a20 <- pa20.value
+ a21 <- pa21.value}
       yield (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21))
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) })
   }

--- a/core/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/core/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -168,7 +168,7 @@ backslash.dummy=\a\b\c\e\f
     "parse file" in {
       val parser = new Messages.MessagesParser(new MessageSource { def read = testMessageFile }, "messages")
 
-      val messages = parser.parse.right.toSeq.flatten.map(x => x.key -> x.pattern).toMap
+      val messages = parser.parse.toSeq.flatten.map(x => x.key -> x.pattern).toMap
 
       messages("simplekey") must ===("value")
       messages("key.with.dots") must ===("value")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix warnings

## Purpose



## Background Context


## References

- https://github.com/scala/scala/pull/5135
- https://app.travis-ci.com/github/playframework/playframework/jobs/556754629#L1120


```
[warn] /home/travis/build/playframework/playframework/core/play/src/main/scala/play/api/data/Form.scala:803:42: method get in class RightProjection is deprecated (since 2.13.0): Use `Either.toOption.get` instead
[warn]       Right(allErrorsOrItems.map(_.right.get).toList).flatMap(applyConstraints)
[warn]                                          ^
[warn] /home/travis/build/playframework/playframework/core/play/src/main/scala/play/api/data/Form.scala:803:36: method right in class Either is deprecated (since 2.13.0): Either is now right-biased, use methods directly on Either
[warn]       Right(allErrorsOrItems.map(_.right.get).toList).flatMap(applyConstraints)
[warn]                                    ^
[warn] /home/travis/build/playframework/playframework/core/play/src/main/scala/play/api/data/Form.scala:893:8: method right in class Either is deprecated (since 2.13.0): Either is now right-biased, use methods directly on Either
[warn]       .right
[warn]        ^
```