### PR TITLE
use `Iterable` instead of deprecated `Traversable`

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/core/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -146,7 +146,7 @@ case class DiscardingCookie(
 /**
  * The HTTP cookies set.
  */
-trait Cookies extends Traversable[Cookie] {
+trait Cookies extends Iterable[Cookie] {
 
   /**
    * Optionally returns the cookie associated with a key.
@@ -395,7 +395,7 @@ object CookieHeaderMerging {
    * Merge the elements in a sequence so that there is only one occurrence of
    * elements when mapped by a discriminator function.
    */
-  private def mergeOn[A, B](input: Traversable[A], f: A => B): Seq[A] = {
+  private def mergeOn[A, B](input: Iterable[A], f: A => B): Seq[A] = {
     val withMergeValue: Seq[(B, A)] = input.toSeq.map(el => (f(el), el))
     ListMap(withMergeValue: _*).values.toSeq
   }
@@ -404,7 +404,7 @@ object CookieHeaderMerging {
    * Merges the cookies contained in a `Set-Cookie` header so that there's
    * only one cookie for each name/path/domain triple.
    */
-  def mergeSetCookieHeaderCookies(unmerged: Traversable[Cookie]): Seq[Cookie] = {
+  def mergeSetCookieHeaderCookies(unmerged: Iterable[Cookie]): Seq[Cookie] = {
     // See rfc6265#section-4.1.2
     // Secure and http-only attributes are not considered when testing if
     // two cookies are overlapping.
@@ -415,7 +415,7 @@ object CookieHeaderMerging {
    * Merges the cookies contained in a `Cookie` header so that there's
    * only one cookie for each name.
    */
-  def mergeCookieHeaderCookies(unmerged: Traversable[Cookie]): Seq[Cookie] = {
+  def mergeCookieHeaderCookies(unmerged: Iterable[Cookie]): Seq[Cookie] = {
     mergeOn(unmerged, (c: Cookie) => c.name)
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix warings

## Purpose

## Background Context

## References

- https://github.com/scala/scala/blob/v2.13.8/src/library/scala/package.scala#L50-L53
- https://app.travis-ci.com/github/playframework/playframework/jobs/556754628#L1170

```
[warn] /home/travis/build/playframework/playframework/core/play/src/main/scala/play/api/mvc/Cookie.scala:149:23: type Traversable in package scala is deprecated (since 2.13.0): Use Iterable instead of Traversable
[warn] trait Cookies extends Traversable[Cookie] {
```