### PR TITLE
Swap deprecated Lazy Stream to LazyList

### DIFF
--- a/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -54,10 +54,10 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
 
       // We only apply logback-test.xml in Test mode. See https://github.com/playframework/playframework/issues/8361
       val testConfigs = env.mode match {
-        case Mode.Test => Stream(TEST_AUTOCONFIG_FILE)
-        case _         => Stream.empty
+        case Mode.Test => LazyList(TEST_AUTOCONFIG_FILE)
+        case _         => LazyList.empty
       }
-      (testConfigs ++ Stream(
+      (testConfigs ++ LazyList(
         AUTOCONFIG_FILE,
         if (env.mode == Mode.Dev) "logback-play-dev.xml" else "logback-play-default.xml"
       )).flatMap(env.resource).headOption

--- a/core/play/src/main/scala/play/api/http/MediaRange.scala
+++ b/core/play/src/main/scala/play/api/http/MediaRange.scala
@@ -107,7 +107,7 @@ object MediaRange {
    */
   def preferred(acceptableRanges: Seq[MediaRange], availableMediaTypes: Seq[String]): Option[String] = {
     val acceptableTypes = for {
-      mediaRange <- acceptableRanges.sorted.toStream
+      mediaRange <- acceptableRanges.sorted.to(LazyList)
       mt         <- availableMediaTypes if mediaRange.accepts(mt)
     } yield mt
     acceptableTypes.headOption

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -159,7 +159,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
         .reverse
       logger.debug("### Start of action order")
       actionChain
-        .zip(Stream.from(1))
+        .zip(LazyList.from(1))
         .foreach({
           case (action, index) =>
             logger.debug(

--- a/core/play/src/main/scala/play/core/system/WebCommands.scala
+++ b/core/play/src/main/scala/play/core/system/WebCommands.scala
@@ -39,6 +39,6 @@ class DefaultWebCommands extends WebCommands {
   }
 
   def handleWebCommand(request: RequestHeader, buildLink: BuildLink, path: File): Option[Result] = synchronized {
-    handlers.toStream.flatMap { _.handleWebCommand(request, buildLink, path).toSeq }.headOption
+    handlers.to(LazyList).flatMap { _.handleWebCommand(request, buildLink, path).to(Seq) }.headOption
   }
 }


### PR DESCRIPTION

# Helpful things

- Removes compilation warnings about deprecated `Stream` collections in Scala 2.13

## Purpose

- Changes part of getting the project to compile clean on Scala 2.13


