### PR TITLE
fix `mapValues` warnings

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/FormBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/FormBodyParserSpec.scala
@@ -84,7 +84,7 @@ class FormBodyParserSpec extends PlaySpecification {
       val contentType = bodyCharset.fold(MimeTypes.FORM)(charset => s"${MimeTypes.FORM};charset=$charset")
       val req         = new play.mvc.Http.RequestBuilder().header(CONTENT_TYPE, contentType).build()
       val result      = parser(req).run(bs, mat).toCompletableFuture.get
-      result.right.get.asScala.mapValues(_.toSeq).toMap must_== bodyData
+      result.right.get.asScala.view.mapValues(_.toSeq).toMap must_== bodyData
     }
 
     "parse bodies in UTF-8" in new WithApplication() {

--- a/core/play-integration-test/src/it/scala/play/it/tools/HttpBin.scala
+++ b/core/play-integration-test/src/it/scala/play/it/tools/HttpBin.scala
@@ -33,7 +33,7 @@ object HttpBinApplication {
     def writes(r: RequestHeader): JsValue = Json.obj(
       "origin"  -> r.remoteAddress,
       "url"     -> "",
-      "args"    -> r.queryString.mapValues(_.head).toMap[String, String],
+      "args"    -> r.queryString.view.mapValues(_.head).toMap[String, String],
       "headers" -> r.headers.toSimpleMap
     )
   }
@@ -54,7 +54,7 @@ object HttpBinApplication {
           Json.obj("json" -> e)
         // X-WWW-Form-Encoded
         case f: Map[String, Seq[String]] @unchecked =>
-          Json.obj("form" -> JsObject(f.mapValues(x => JsString(x.mkString(", "))).toSeq))
+          Json.obj("form" -> JsObject(f.view.mapValues(x => JsString(x.mkString(", "))).toSeq))
         // Anything else
         case m: play.api.mvc.AnyContentAsMultipartFormData @unchecked =>
           Json.obj(
@@ -148,7 +148,7 @@ object HttpBinApplication {
   def responseHeaders(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/response-header") =>
       Action { request =>
-        Ok("").withHeaders(request.queryString.mapValues(_.mkString(",")).toSeq: _*)
+        Ok("").withHeaders(request.queryString.view.mapValues(_.mkString(",")).toSeq: _*)
       }
   }
 
@@ -187,7 +187,7 @@ object HttpBinApplication {
   def cookiesSet(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/cookies/set") =>
       Action { request =>
-        Redirect("/cookies").withCookies(request.queryString.mapValues(_.head).toSeq.map {
+        Redirect("/cookies").withCookies(request.queryString.view.mapValues(_.head).toSeq.map {
           case (k, v) => Cookie(k, v)
         }: _*)
       }

--- a/core/play/src/main/scala/play/api/Configuration.scala
+++ b/core/play/src/main/scala/play/api/Configuration.scala
@@ -127,7 +127,7 @@ object Configuration {
    */
   def from(data: Map[String, Any]): Configuration = {
     def toJava(data: Any): Any = data match {
-      case map: Map[_, _]        => map.mapValues(toJava).toMap.asJava
+      case map: Map[_, _]        => map.view.mapValues(toJava).toMap.asJava
       case iterable: Iterable[_] => iterable.map(toJava).asJava
       case v                     => v
     }

--- a/core/play/src/main/scala/play/api/data/Form.scala
+++ b/core/play/src/main/scala/play/api/data/Form.scala
@@ -256,6 +256,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
     val messages = provider.messages
     val map = errors
       .groupBy(_.key)
+      .view
       .mapValues(_.map(e => messages(e.message, e.args.map(translate): _*)))
     Json.toJson(map)
   }
@@ -1092,5 +1093,5 @@ class DefaultFormBinding(maxChars: Long) extends FormBinding {
   }
   private def multipartFormParse(body: MultipartFormData[_]) = body.asFormUrlEncoded
 
-  private def jsonParse(jsValue: JsValue) = FormUtils.fromJson(jsValue, maxChars).mapValues(Seq(_))
+  private def jsonParse(jsValue: JsValue) = FormUtils.fromJson(jsValue, maxChars).view.mapValues(Seq(_))
 }

--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -628,7 +628,7 @@ object QueryStringBindable {
             .getDeclaredConstructor()
             .newInstance()
             .asInstanceOf[T]
-            .bind(key, params.mapValues(_.toArray).toMap.asJava)
+            .bind(key, params.view.mapValues(_.toArray).toMap.asJava)
           if (o.isPresent) {
             Some(Right(o.get))
           } else {

--- a/core/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/core/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -196,7 +196,7 @@ object Cookies extends CookieHeaderEncoding {
     super.mergeCookieHeader(cookieHeader, cookies)
 
   def apply(cookies: Seq[Cookie]): Cookies = new Cookies {
-    lazy val cookiesByName = cookies.groupBy(_.name).mapValues(_.head)
+    lazy val cookiesByName = cookies.groupBy(_.name).view.mapValues(_.head)
 
     override def get(name: String) = cookiesByName.get(name)
 
@@ -236,6 +236,7 @@ trait CookieHeaderEncoding {
       fromMap(
         decodeSetCookieHeader(headerValue)
           .groupBy(_.name)
+          .view
           .mapValues(_.head)
           .toMap
       )
@@ -247,6 +248,7 @@ trait CookieHeaderEncoding {
       fromMap(
         decodeCookieHeader(headerValue)
           .groupBy(_.name)
+          .view
           .mapValues(_.head)
           .toMap
       )
@@ -656,7 +658,7 @@ trait JWTCookieDataCodec extends CookieDataCodec {
 
       // Pull out the JWT data claim and only return that.
       val data = claimMap(jwtConfiguration.dataClaim).asInstanceOf[java.util.Map[String, AnyRef]]
-      data.asScala.mapValues { v =>
+      data.asScala.view.mapValues { v =>
         v.toString
       }.toMap
     } catch {

--- a/core/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/core/play/src/main/scala/play/api/mvc/Headers.scala
@@ -103,9 +103,12 @@ class Headers(protected var _headers: Seq[(String, String)]) {
    * Transform the Headers to a Map by ignoring multiple values.
    */
   lazy val toSimpleMap: Map[String, String] =
-    TreeMap.newBuilder[String, String](CaseInsensitiveOrdered).++=(toMap.mapValues(_.headOption.getOrElse(""))).result()
+    TreeMap
+      .newBuilder[String, String](CaseInsensitiveOrdered)
+      .++=(toMap.view.mapValues(_.headOption.getOrElse("")))
+      .result()
 
-  lazy val asJava: play.mvc.Http.Headers = new play.mvc.Http.Headers(this.toMap.mapValues(_.asJava).toMap.asJava)
+  lazy val asJava: play.mvc.Http.Headers = new play.mvc.Http.Headers(this.toMap.view.mapValues(_.asJava).toMap.asJava)
 
   /**
    * A headers map with all keys normalized to lowercase
@@ -114,6 +117,7 @@ class Headers(protected var _headers: Seq[(String, String)]) {
     .map {
       case (name, value) => name.toLowerCase(Locale.ENGLISH) -> value
     }
+    .view
     .mapValues(_.toSet)
     .toMap
 

--- a/core/play/src/main/scala/play/api/routing/sird/QueryStringExtractors.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/QueryStringExtractors.scala
@@ -39,6 +39,7 @@ object QueryStringParameterExtractor {
           }
         }
         .groupBy(_._1)
+        .view
         .mapValues(_.toSeq.map(_._2))
         .toMap
     }

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -188,7 +188,7 @@ trait JavaHelpers {
 
 object JavaHelpers extends JavaHelpers {
   def javaMapOfListToImmutableScalaMapOfSeq[A, B](javaMap: java.util.Map[A, java.util.List[B]]): Map[A, Seq[B]] = {
-    javaMap.asScala.mapValues(_.asScala.toSeq).toMap
+    javaMap.asScala.view.mapValues(_.asScala.toSeq).toMap
   }
 }
 
@@ -219,7 +219,7 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def acceptLanguages: util.List[i18n.Lang] = header.acceptLanguages.map(new play.i18n.Lang(_)).asJava
 
-  override def queryString: util.Map[String, Array[String]] = header.queryString.mapValues(_.toArray).toMap.asJava
+  override def queryString: util.Map[String, Array[String]] = header.queryString.view.mapValues(_.toArray).toMap.asJava
 
   override def acceptedTypes: util.List[MediaRange] = header.acceptedTypes.asJava
 

--- a/core/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -25,7 +25,7 @@ object JavaParsers {
   ): play.mvc.Http.MultipartFormData[JTemporaryFile] = {
     new play.mvc.Http.MultipartFormData[JTemporaryFile] {
       lazy val asFormUrlEncoded = {
-        multipart.asFormUrlEncoded.mapValues(_.toArray).toMap.asJava
+        multipart.asFormUrlEncoded.view.mapValues(_.toArray).toMap.asJava
       }
       lazy val getFiles = {
         multipart.files.map { file =>

--- a/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -18,7 +18,7 @@ object FormUrlEncodedParser {
    */
   def parseNotPreservingOrder(data: String, encoding: String = "utf-8"): Map[String, Seq[String]] = {
     // Generate the pairs of values from the string.
-    parseToPairs(data, encoding).groupBy(_._1).mapValues(_.map(_._2)).toMap
+    parseToPairs(data, encoding).groupBy(_._1).view.mapValues(_.map(_._2)).toMap
   }
 
   /**

--- a/core/play/src/main/scala/play/core/routing/PathPattern.scala
+++ b/core/play/src/main/scala/play/core/routing/PathPattern.scala
@@ -74,7 +74,7 @@ case class PathPattern(parts: Seq[PathPart]) {
   def apply(path: String): Option[Map[String, Either[Throwable, String]]] = {
     val matcher = regex.matcher(path)
     if (matcher.matches) {
-      Some(groups.mapValues(_(matcher)).toMap)
+      Some(groups.view.mapValues(_(matcher)).toMap)
     } else {
       None
     }

--- a/core/play/src/main/scala/views/helper/checkbox.scala.html
+++ b/core/play/src/main/scala/views/helper/checkbox.scala.html
@@ -15,6 +15,6 @@
 
 @boxValue = @{ args.toMap.get(Symbol("value")).getOrElse("true") }
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
-    <input type="checkbox" id="@id" name="@name" value="@boxValue" @if(value == Some(boxValue)){checked="checked"} @toHtmlArgs(htmlArgs.filterKeys(_ != Symbol("value")).toMap)/>
+    <input type="checkbox" id="@id" name="@name" value="@boxValue" @if(value == Some(boxValue)){checked="checked"} @toHtmlArgs(htmlArgs.view.filterKeys(_ != Symbol("value")).toMap)/>
     <span>@translate(args.toMap.get(Symbol("_text")))</span>
 }

--- a/core/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -436,7 +436,7 @@ object ConfigurationSpec {
 
   /** Allows loading in-memory resources. */
   final class InMemoryResourceClassLoader(entries: (String, String)*) extends ClassLoader {
-    val bytes = entries.toMap.mapValues(_.getBytes(StandardCharsets.UTF_8)).toMap
+    val bytes = entries.toMap.view.mapValues(_.getBytes(StandardCharsets.UTF_8)).toMap
 
     override def findResource(name: String) = {
       Objects.requireNonNull(name)

--- a/core/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
+++ b/core/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
@@ -118,7 +118,7 @@ class UrlContextSpec extends Specification {
 
   "query string interpolation" should {
     def qs(params: (String, String)*): Map[String, Seq[String]] = {
-      params.groupBy(_._1).mapValues(_.map(_._2)).toMap
+      params.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
     }
 
     "allow required parameter extraction" in {

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -685,6 +685,7 @@ abstract class ResourceEvolutionsReader extends EvolutionsReader {
             .reverse
             .drop(1)
             .groupBy(i => i._1)
+            .view
             .mapValues { _.map(_._2).mkString("\n").trim }
 
           Evolution(revision, parsed.getOrElse(UPS, ""), parsed.getOrElse(DOWNS, ""))

--- a/persistence/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -83,7 +83,7 @@ class DBApiProvider(
       )
       .getOrElse(ConnectionPool.fromConfig(config.getString("play.db.pool"), environment, defaultConnectionPool))
     val configs = if (config.hasPath(dbKey)) {
-      Configuration(config).getPrototypedMap(dbKey, "play.db.prototype").mapValues(_.underlying).toMap
+      Configuration(config).getPrototypedMap(dbKey, "play.db.prototype").view.mapValues(_.underlying).toMap
     } else Map.empty[String, Config]
     val db = new DefaultDBApi(configs, pool, environment, maybeInjector.getOrElse(NewInstanceInjector))
     lifecycle.addStopHook { () =>

--- a/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -415,7 +415,7 @@ trait ResultExtractors {
       of.map { result =>
         val cookies = result.newCookies
         new Cookies {
-          lazy val cookiesByName: Map[String, Cookie]    = cookies.groupBy(_.name).mapValues(_.head).toMap
+          lazy val cookiesByName: Map[String, Cookie]    = cookies.groupBy(_.name).view.mapValues(_.head).toMap
           override def get(name: String): Option[Cookie] = cookiesByName.get(name)
           override def foreach[U](f: Cookie => U): Unit  = cookies.foreach(f)
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -102,7 +102,7 @@ private[server] class NettyModelConversion(
       override lazy val queryMap: Map[String, Seq[String]] = {
         val decoder = new QueryStringDecoder(parsedQueryString)
         try {
-          decoder.parameters().asScala.mapValues(_.asScala.toList).toMap
+          decoder.parameters().asScala.view.mapValues(_.asScala.toList).toMap
         } catch {
           case NonFatal(e) =>
             logger.warn("Failed to parse query string; returning empty map.", e)

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -73,7 +73,7 @@ class CompileTimeDependencyInjectionFormSpec extends FormSpec {
     override def httpFilters(): java.util.List[EssentialFilter] = java.util.Collections.emptyList()
 
     override def config(): Config = {
-      val javaExtraConfig = extraConfig
+      val javaExtraConfig = extraConfig.view
         .mapValues {
           case v: Seq[Any] => v.asJava
           case v           => v

--- a/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -146,7 +146,7 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
    */
   def verifiedId(queryString: java.util.Map[String, Array[String]]): Future[UserInfo] = {
     import scala.jdk.CollectionConverters._
-    verifiedId(queryString.asScala.toMap.mapValues(_.toSeq).toMap)
+    verifiedId(queryString.asScala.toMap.view.mapValues(_.toSeq).toMap)
   }
 
   private def verifiedId(queryString: Map[String, Seq[String]]): Future[UserInfo] = {

--- a/web/play-openid/src/test/scala/play/api/libs/openid/package.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/package.scala
@@ -30,7 +30,7 @@ package object openid {
     catching(classOf[MalformedURLException])
       .opt(new URL(url))
       .map { url =>
-        new QueryStringDecoder(url.toURI.getRawQuery, false).parameters().asScala.mapValues(_.asScala.toSeq).toMap
+        new QueryStringDecoder(url.toURI.getRawQuery, false).parameters().asScala.view.mapValues(_.asScala.toSeq).toMap
       }
       .getOrElse(Map())
   }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes

Fix warnings

## Purpose

`.mapValues` => `.view.mapValues`

## Background Context

- https://github.com/scala/scala/blob/v2.13.8/src/library/scala/collection/Map.scala#L261-L262
- https://app.travis-ci.com/github/playframework/playframework/jobs/557562682#L1116


```
[warn] /home/travis/build/playframework/playframework/core/play/src/main/scala/play/api/Configuration.scala:130:41: method mapValues in trait MapOps is deprecated (since 2.13.0): Use .view.mapValues(f). A future version will include a strict version of this method (for now, .view.mapValues(f).toMap).
[warn]       case map: Map[_, _]        => map.mapValues(toJava).toMap.asJava
[warn]                                         ^
[warn] /home/travis/build/playframework/playframework/core/play/src/main/scala/play/api/data/Form.scala:259:8: method mapValues in trait MapOps is deprecated (since 2.13.0): Use .view.mapValues(f). A future version will include a strict version of this method (for now, .view.mapValues(f).toMap).
[warn]       .mapValues(_.map(e => messages(e.message, e.args.map(translate): _*)))
[warn]        ^
```

## References

