### PR TITLE
use slash syntax instead deprecated `in`

### DIFF
--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -150,18 +150,18 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
     javaManualSourceDirectories := Nil,
     scalaManualSourceDirectories := Nil,
     commonManualSourceDirectories := Nil,
-    unmanagedSourceDirectories in Test ++= javaManualSourceDirectories.value ++ scalaManualSourceDirectories.value ++
+    Test / unmanagedSourceDirectories ++= javaManualSourceDirectories.value ++ scalaManualSourceDirectories.value ++
       commonManualSourceDirectories.value ++ migrationManualSources.value,
-    unmanagedResourceDirectories in Test ++= javaManualSourceDirectories.value ++ scalaManualSourceDirectories.value ++
+    Test / unmanagedResourceDirectories ++= javaManualSourceDirectories.value ++ scalaManualSourceDirectories.value ++
       commonManualSourceDirectories.value ++ migrationManualSources.value,
     javaTwirlSourceManaged := target.value / "twirl" / "java",
     scalaTwirlSourceManaged := target.value / "twirl" / "scala",
-    managedSourceDirectories in Test ++= Seq(
+    Test / managedSourceDirectories ++= Seq(
       javaTwirlSourceManaged.value,
       scalaTwirlSourceManaged.value
     ),
     // Need to ensure that templates in the Java docs get Java imports, and in the Scala docs get Scala imports
-    sourceGenerators in Test += Def.task {
+    Test / sourceGenerators += Def.task {
       compileTemplates(
         javaManualSourceDirectories.value,
         javaTwirlSourceManaged.value,
@@ -169,7 +169,7 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
         streams.value.log
       )
     }.taskValue,
-    sourceGenerators in Test += Def.task {
+    Test / sourceGenerators += Def.task {
       compileTemplates(
         scalaManualSourceDirectories.value,
         scalaTwirlSourceManaged.value,
@@ -177,7 +177,7 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
         streams.value.log
       )
     }.taskValue,
-    routesCompilerTasks in Test := {
+    Test / routesCompilerTasks := {
       val javaRoutes   = (javaManualSourceDirectories.value * "*.routes").get
       val scalaRoutes  = (scalaManualSourceDirectories.value * "*.routes").get
       val commonRoutes = (commonManualSourceDirectories.value * "*.routes").get
@@ -189,7 +189,7 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
     evaluateSbtFiles := {
       val unit              = loadedBuild.value.units(thisProjectRef.value.build)
       val (eval, structure) = defaultLoad(state.value, unit.localBase)
-      val sbtFiles          = ((unmanagedSourceDirectories in Test).value * "*.sbt").get
+      val sbtFiles          = ((Test / unmanagedSourceDirectories).value * "*.sbt").get
       val log               = state.value.log
       if (sbtFiles.nonEmpty) {
         log.info("Testing .sbt files...")
@@ -212,11 +212,11 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
         throw new TestsFailedException
       }
     },
-    parallelExecution in Test := false,
-    javacOptions in Test ++= Seq("-g", "-Xlint:deprecation"),
-    testOptions in Test += Tests
+    Test / parallelExecution := false,
+    Test / javacOptions ++= Seq("-g", "-Xlint:deprecation"),
+    Test / testOptions += Tests
       .Argument(TestFrameworks.Specs2, "sequential", "true", "junitxml", "console", "showtimes"),
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "--ignore-runners=org.specs2.runner.JUnitRunner")
+    Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "--ignore-runners=org.specs2.runner.JUnitRunner")
   )
 
   val docsJarFileSetting: Def.Initialize[Task[Option[File]]] = Def.task {
@@ -238,7 +238,7 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
     val args = Def.spaceDelimited().parsed
     val port = args.headOption.map(_.toInt).getOrElse(9000)
 
-    val classpath: Seq[Attributed[File]] = (dependencyClasspath in Test).value
+    val classpath: Seq[Attributed[File]] = (Test / dependencyClasspath).value
 
     // Get classloader
     val sbtLoader = this.getClass.getClassLoader

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -135,7 +135,7 @@ object ScriptedTools extends AutoPlugin {
   }
 
   val assertProcessIsStopped: Command = Command.args("assertProcessIsStopped", "") { (state, args) =>
-    val pidFile = Project.extract(state).get(stagingDirectory in Universal) / "RUNNING_PID"
+    val pidFile = Project.extract(state).get(Universal / stagingDirectory) / "RUNNING_PID"
     if (!pidFile.exists())
       sys.error("RUNNING_PID file not found. Can't assert the process is stopped without knowing the process ID.")
     val pid = Files.readAllLines(pidFile.getAbsoluteFile.toPath).get(0)
@@ -171,7 +171,7 @@ object ScriptedTools extends AutoPlugin {
           case Value(v) => v
           case Inc(inc) =>
             // If there was a compilation error, dump generated routes files so we can read them
-            ((target in routes in Compile).value ** AllPassFilter).filter(_.isFile).get.foreach { file =>
+            ((Compile / routes / target).value ** AllPassFilter).filter(_.isFile).get.foreach { file =>
               println(s"Dumping $file:")
               IO.readLines(file).zipWithIndex.foreach {
                 case (line, index) => println(f"${index + 1}%4d: $line")

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -31,7 +31,7 @@ lazy val main = Project("Play-Documentation", file("."))
     ivyConfigurations += DocsApplication,
     // We need to publishLocal playDocs since its jar file is
     // a dependency of `docsJarFile` setting.
-    test in Test := ((test in Test).dependsOn(publishLocal in playDocs)).value,
+    Test / test := ((Test / test).dependsOn(playDocs / publishLocal)).value,
     resolvers += Resolver
       .sonatypeRepo("releases"), // TODO: Delete this eventually, just needed for lag between deploying to sonatype and getting on maven central
     version := PlayVersion.current,
@@ -42,7 +42,7 @@ lazy val main = Project("Play-Documentation", file("."))
       // https://github.com/logstash/logstash-logback-encoder/tree/logstash-logback-encoder-4.9#including
       "net.logstash.logback" % "logstash-logback-encoder" % "5.1" % "test"
     ),
-    PlayDocsKeys.docsJarFile := Some((packageBin in (playDocs, Compile)).value),
+    PlayDocsKeys.docsJarFile := Some((playDocs / Compile / packageBin).value),
     PlayDocsKeys.playDocsValidationConfig := PlayDocsValidation.ValidationConfig(
       downstreamWikiPages = Set(
         "JavaEbean",
@@ -71,23 +71,23 @@ lazy val main = Project("Play-Documentation", file("."))
     PlayDocsKeys.commonManualSourceDirectories :=
       (baseDirectory.value / "manual" / "working" / "commonGuide" ** "code").get ++
         (baseDirectory.value / "manual" / "gettingStarted" ** "code").get,
-    unmanagedSourceDirectories in Test ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
-    unmanagedResourceDirectories in Test ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
+    Test / unmanagedSourceDirectories ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
+    Test / unmanagedResourceDirectories ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
     // Don't include sbt files in the resources
-    excludeFilter in (Test, unmanagedResources) := (excludeFilter in (Test, unmanagedResources)).value || "*.sbt",
+    Test / unmanagedResources / excludeFilter := (Test / unmanagedResources / excludeFilter).value || "*.sbt",
     crossScalaVersions := Seq("2.13.7"),
     scalaVersion := "2.13.7",
-    fork in Test := true,
-    javaOptions in Test ++= Seq("-Xmx512m", "-Xms128m"),
+    Test / fork := true,
+    Test / javaOptions ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) Lightbend Inc. <https://www.lightbend.com>")),
     headerMappings ++= Map(
       FileType.xml  -> CommentStyle.xmlStyleBlockComment,
       FileType.conf -> CommentStyle.hashLineComment
     ),
-    sourceDirectories in javafmt in Test ++= (unmanagedSourceDirectories in Test).value,
-    sourceDirectories in javafmt in Test ++= (unmanagedResourceDirectories in Test).value,
+    Test / javafmt / sourceDirectories ++= (Test / unmanagedSourceDirectories).value,
+    Test / javafmt / sourceDirectories ++= (Test / unmanagedResourceDirectories).value,
     // No need to show eviction warnings for Play documentation.
-    evictionWarningOptions in update := EvictionWarningOptions.default
+    update / evictionWarningOptions := EvictionWarningOptions.default
       .withWarnTransitiveEvictions(false)
       .withWarnDirectEvictions(false)
   )

--- a/documentation/manual/gettingStarted/code/ide.sbt
+++ b/documentation/manual/gettingStarted/code/ide.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 // Compile the project before generating Eclipse files, so
 // that generated .scala or .class files for views and routes are present
 
-EclipseKeys.preTasks := Seq(compile in Compile, compile in Test)
+EclipseKeys.preTasks := Seq(Compile / compile, Test / compile)
 // #sbt-eclipse-plugin-preTasks
 
 // #sbt-eclipse-plugin-projectFlavor
@@ -18,5 +18,5 @@ EclipseKeys.createSrc := EclipseCreateSrc.ValueSet(EclipseCreateSrc.ManagedClass
 // #sbt-eclipse-plugin-projectFlavor
 
 // #sbt-eclipse-plugin-skipParents
-EclipseKeys.skipParents in ThisBuild := false
+ThisBuild / EclipseKeys.skipParents := false
 // #sbt-eclipse-plugin-skipParents

--- a/documentation/manual/working/commonGuide/build/code/cookbook.sbt
+++ b/documentation/manual/working/commonGuide/build/code/cookbook.sbt
@@ -7,12 +7,12 @@ scalacOptions += "-feature"
 //#compiler-options
 
 //#add-assets
-unmanagedResourceDirectories in Assets += baseDirectory.value / "pictures"
+Assets / unmanagedResourceDirectories += baseDirectory.value / "pictures"
 //#add-assets
 
 //#disable-scaladoc
-sources in (Compile, doc) := Seq.empty
-publishArtifact in (Compile, packageDoc) := false
+Compile / doc / sources := Seq.empty
+Compile / packageDoc / publishArtifact := false
 //#disable-scaladoc
 
 //#ivy-logging
@@ -20,6 +20,6 @@ ivyLoggingLevel := UpdateLogging.Quiet
 //#ivy-logging
 
 //#fork-parallel-test
-parallelExecution in Test := true
-fork in Test := false
+Test / parallelExecution := true
+Test / fork := false
 //#fork-parallel-test

--- a/documentation/manual/working/commonGuide/build/sbtCookbook.md
+++ b/documentation/manual/working/commonGuide/build/sbtCookbook.md
@@ -84,6 +84,6 @@ For example if you want to only display errors:
 
 ## Fork and parallel execution in test
 
-By default parallel execution is disabled and fork is enabled. You can change this behavior by setting `parallelExecution in Test` and/or `fork in Test`:
+By default parallel execution is disabled and fork is enabled. You can change this behavior by setting `Test / parallelExecution` and/or `Test / fork`:
 
 @[fork-parallel-test](code/cookbook.sbt)

--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -448,4 +448,4 @@ For powers of two, exactly these strings are supported:
 
 Java system properties override settings found in the `application.conf` and `reference.conf` files. This supports specifying config options on the command line, for example `sbt -Dkey=value run`.
 
-> **Note**: Play forks the JVM for tests - and so to use command line overrides in tests you must add `Keys.fork in Test := false` in `build.sbt` before you can use them for a test.
+> **Note**: Play forks the JVM for tests - and so to use command line overrides in tests you must add `Test / Keys.fork := false` in `build.sbt` before you can use them for a test.

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -165,7 +165,7 @@ http://obscure-sierra-7788.herokuapp.com/ | git@heroku.com:obscure-sierra-7788.g
 Now add something like this to your `build.sbt`, but replace “obscure-sierra-7788” with the name of the application you created (or you can skip this if you are using Git locally).
 
 ```scala
-herokuAppName in Compile := "obscure-sierra-7788"
+Compile / herokuAppName := "obscure-sierra-7788"
 ```
 
 The sbt-heroku project's documentation contains details on [configuring the execution of the plugin](https://github.com/heroku/sbt-heroku#configuring-the-plugin).

--- a/documentation/manual/working/commonGuide/production/code/assembly.sbt
+++ b/documentation/manual/working/commonGuide/production/code/assembly.sbt
@@ -3,10 +3,10 @@
 //
 
 //#assembly
-mainClass in assembly := Some("play.core.server.ProdServerStart")
-fullClasspath in assembly += Attributed.blank(PlayKeys.playPackageAssets.value)
+assembly / mainClass := Some("play.core.server.ProdServerStart")
+assembly / fullClasspath += Attributed.blank(PlayKeys.playPackageAssets.value)
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case manifest if manifest.contains("MANIFEST.MF") =>
     // We don't need manifest files since sbt-assembly will create
     // one with the given settings
@@ -16,7 +16,7 @@ assemblyMergeStrategy in assembly := {
     MergeStrategy.concat
   case x =>
     // For all the other files, use the default sbt-assembly merge strategy
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
 //#assembly

--- a/documentation/manual/working/commonGuide/production/code/debian.sbt
+++ b/documentation/manual/working/commonGuide/production/code/debian.sbt
@@ -6,9 +6,9 @@
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, DebianPlugin)
 
-maintainer in Linux := "First Lastname <first.last@example.com>"
+Linux / maintainer := "First Lastname <first.last@example.com>"
 
-packageSummary in Linux := "My custom package summary"
+Linux / packageSummary := "My custom package summary"
 
 packageDescription := "My longer package description"
 //#debian

--- a/documentation/manual/working/commonGuide/production/code/production.sbt
+++ b/documentation/manual/working/commonGuide/production/code/production.sbt
@@ -3,9 +3,9 @@
 //
 
 //#no-scaladoc
-sources in (Compile, doc) := Seq.empty
+Compile / doc / sources := Seq.empty
 
-publishArtifact in (Compile, packageDoc) := false
+Compile / packageDoc / publishArtifact := false
 //#no-scaladoc
 
 //#publish-repo

--- a/documentation/manual/working/commonGuide/production/code/rpm.sbt
+++ b/documentation/manual/working/commonGuide/production/code/rpm.sbt
@@ -6,9 +6,9 @@
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, RpmPlugin)
 
-maintainer in Linux := "First Lastname <first.last@example.com>"
+Linux / maintainer := "First Lastname <first.last@example.com>"
 
-packageSummary in Linux := "My custom package summary"
+Linux / packageSummary := "My custom package summary"
 
 packageDescription := "My longer package description"
 

--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -26,7 +26,7 @@ The default way to test a Play application is with [JUnit](https://junit.org/jun
 > **Note:** A new process is forked each time `test` or `test-only` is run.  The new process uses default JVM settings.  Custom settings can be added to `build.sbt`.  For example:
 
 > ```scala
-> javaOptions in Test ++= Seq(
+> Test / javaOptions ++= Seq(
 >   "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9998",
 >   "-Xms512M",
 >   "-Xmx1536M",


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix warnings

## Purpose

## Background Context


## References

- https://github.com/sbt/sbt/commit/e6fec6b1db5f212a74bf5e3766b9b70f2d983f24
- https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
