### PR TITLE
fix Seq implicit conversions warnings

### DIFF
--- a/core/play/src/main/scala/play/api/http/AcceptEncoding.scala
+++ b/core/play/src/main/scala/play/api/http/AcceptEncoding.scala
@@ -183,9 +183,9 @@ object AcceptEncoding {
     private val logger = Logger(this.getClass())
 
     val separatorChars  = "()<>@,;:\\\"/[]?={} \t"
-    val separatorBitSet = BitSet(separatorChars.toCharArray.map(_.toInt): _*)
+    val separatorBitSet = separatorChars.toCharArray.map(_.toInt).to(BitSet)
     val qChars          = "Qq"
-    val qBitSet         = BitSet(qChars.toCharArray.map(_.toInt): _*)
+    val qBitSet         = qChars.toCharArray.map(_.toInt).to(BitSet)
 
     type Elem = Char
 

--- a/core/play/src/main/scala/play/api/http/MediaRange.scala
+++ b/core/play/src/main/scala/play/api/http/MediaRange.scala
@@ -179,7 +179,7 @@ object MediaRange {
     private val logger = Logger(this.getClass())
 
     val separatorChars  = "()<>@,;:\\\"/[]?={} \t"
-    val separatorBitSet = BitSet(separatorChars.toCharArray.map(_.toInt): _*)
+    val separatorBitSet = separatorChars.toCharArray.map(_.toInt).to(BitSet)
 
     type Elem = Char
 

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -29,6 +29,7 @@ import play.mvc.Http.{ Request => JRequest }
 import play.mvc.Http.{ RequestImpl => JRequestImpl }
 
 import scala.jdk.CollectionConverters._
+import scala.collection.immutable.ArraySeq
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -59,7 +60,7 @@ class JavaActionAnnotations(
     .flatten
 
   val actionMixins: Seq[(Annotation, Class[_ <: JAction[_]], AnnotatedElement)] = {
-    val methodAnnotations = method.getDeclaredAnnotations.map((_, method))
+    val methodAnnotations = ArraySeq.unsafeWrapArray(method.getDeclaredAnnotations.map((_, method)))
     val allDeclaredAnnotations: Seq[(java.lang.annotation.Annotation, AnnotatedElement)] =
       if (config.controllerAnnotationsFirst) {
         controllerAnnotations ++ methodAnnotations

--- a/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -5,6 +5,7 @@
 package play.core.parsers
 
 import java.net.URLDecoder
+import scala.collection.immutable.ArraySeq
 
 /** An object for parsing application/x-www-form-urlencoded data */
 object FormUrlEncodedParser {
@@ -78,12 +79,12 @@ object FormUrlEncodedParser {
     if (split.length == 1 && split(0).isEmpty) {
       Seq.empty
     } else {
-      split.map { param =>
+      ArraySeq.unsafeWrapArray(split.map { param =>
         val parts = param.split("=", -1)
         val key   = URLDecoder.decode(parts(0), encoding)
         val value = URLDecoder.decode(parts.lift(1).getOrElse(""), encoding)
         key -> value
-      }
+      })
     }
   }
 }

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -19,6 +19,7 @@ import play.api.Logger
 import play.api.Mode
 import play.core.DefaultWebCommands
 import play.utils.PlayIO
+import scala.collection.immutable.ArraySeq
 
 /**
  * An SQL evolution - database changes associated with a software version.
@@ -60,7 +61,7 @@ trait Script {
    */
   def statements: Seq[String] = {
     // Regex matches on semicolons that neither precede nor follow other semicolons
-    sql.split("(?<!;);(?!;)").map(_.trim.replace(";;", ";")).filter(_ != "")
+    ArraySeq.unsafeWrapArray(sql.split("(?<!;);(?!;)")).map(_.trim.replace(";;", ";")).filter(_ != "")
   }
 }
 

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -81,7 +81,8 @@ private[server] class AkkaModelConversion(
           override def clientCertificateChain: Option[Seq[X509Certificate]] = {
             try {
               request.header[`Tls-Session-Info`].map { tlsSessionInfo =>
-                tlsSessionInfo.getSession.getPeerCertificates
+                immutable.ArraySeq
+                  .unsafeWrapArray(tlsSessionInfo.getSession.getPeerCertificates)
                   .collect { case x509: X509Certificate => x509 }
               }
             } catch {

--- a/transport/server/play-server/src/main/scala/play/core/server/ProdServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ProdServerStart.scala
@@ -26,7 +26,7 @@ object ProdServerStart {
   /**
    * Start a prod mode server from the command line.
    */
-  def main(args: Array[String]): Unit = start(new RealServerProcess(args))
+  def main(args: Array[String]): Unit = start(new RealServerProcess(args.toIndexedSeq))
 
   /**
    * Starts a Play server and application for the given process. The settings

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -18,6 +18,7 @@ import play.core.utils.AsciiRange
 import play.core.utils.AsciiSet
 
 import scala.annotation.tailrec
+import scala.collection.immutable.ArraySeq
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
@@ -334,5 +335,5 @@ private[play] final class ServerResultUtils(
   }
 
   def splitSetCookieHeaderValue(value: String): Seq[String] =
-    cookieHeaderEncoding.SetCookieHeaderSeparatorRegex.split(value)
+    ArraySeq.unsafeWrapArray(cookieHeaderEncoding.SetCookieHeaderSeparatorRegex.split(value))
 }

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -12,6 +12,7 @@ import play.core.j.JavaContextComponents
 import play.core.j.JavaHttpErrorHandlerAdapter
 
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
 import play.api.Logger
 import play.api.libs.streams.Accumulator
 import play.api.libs.typedmap.TypedKey
@@ -56,7 +57,7 @@ class CORSFilter(
     this(
       corsConfig,
       new JavaHttpErrorHandlerAdapter(errorHandler),
-      Seq(pathPrefixes.toArray.asInstanceOf[Array[String]]: _*)
+      pathPrefixes.asScala.toSeq
     )
   }
 
@@ -70,7 +71,7 @@ class CORSFilter(
     this(
       corsConfig,
       new JavaHttpErrorHandlerAdapter(errorHandler),
-      Seq(pathPrefixes.toArray.asInstanceOf[Array[String]]: _*)
+      pathPrefixes.asScala.toSeq
     )
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes

Fix warnings

## Purpose

use `ArraySeq.unsafeWrapArray`, `toSeq` or something

## Background Context

https://app.travis-ci.com/github/playframework/playframework/jobs/557628971#L1164

```
[warn] /home/travis/build/playframework/playframework/transport/server/play-server/src/main/scala/play/core/server/ProdServerStart.scala:29:69: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
[warn]   def main(args: Array[String]): Unit = start(new RealServerProcess(args))
[warn]                                                                     ^
[warn] /home/travis/build/playframework/playframework/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala:337:61: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
[warn]     cookieHeaderEncoding.SetCookieHeaderSeparatorRegex.split(value)
[warn]                                                             ^
```

```
[warn] /home/travis/build/playframework/playframework/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala:63:68: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
[warn]     sql.split("(?<!;);(?!;)").map(_.trim.replace(";;", ";")).filter(_ != "")
[warn]                                                                    ^
```

## References
