### PR TITLE
Add warning `serverTerminateTimeout` is longer than `service-unbind` timeout

### DIFF
--- a/transport/server/play-akka-http-server/src/main/resources/reference.conf
+++ b/transport/server/play-akka-http-server/src/main/resources/reference.conf
@@ -17,7 +17,9 @@ play {
       # Timeout after which all requests and connections shall be forcefully terminated
       # when shutting down the server. It will default to Coordinated Shutdown service-unbind
       # phase timeout. Value must be a duration, for example:
-      # play.server.akka.terminationTimeout = 10 seconds
+      #   play.server.akka.terminationTimeout = 5 seconds
+      # This should be less than or equal to the value for `akka.coordinated-shutdown.phases.service-unbind.timeout`
+      # to prevent early server terminations by the underlying Akka Coordinated Shutdown system.
       terminationTimeout = null
 
       # Enables/disables automatic handling of HEAD requests.

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -465,7 +465,14 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
 
     // The termination hard-deadline is either what was configured by the user
     // or defaults to `service-unbind` phase timeout.
-    val serverTerminateTimeout = terminationTimeout.getOrElse(cs.timeout(CoordinatedShutdown.PhaseServiceUnbind))
+    val serviceUnboundTimeout  = cs.timeout(CoordinatedShutdown.PhaseServiceUnbind)
+    val serverTerminateTimeout = terminationTimeout.getOrElse(serviceUnboundTimeout)
+    if (serverTerminateTimeout > serviceUnboundTimeout)
+      logger.warn(
+        s"""The value for `play.server.akka.terminationTimeout` [$serverTerminateTimeout] is higher than the total `service-unbind.timeout` duration [$serviceUnboundTimeout].
+           |Set `akka.coordinated-shutdown.phases.service-unbind.timeout` to an equal (or greater) value to prevent unexpected server termination.""".stripMargin
+      )
+
     cs.addTask(CoordinatedShutdown.PhaseServiceUnbind, "akka-http-server-unbind") { () =>
       def terminate(binding: Option[Http.ServerBinding]): Future[Done] = {
         binding


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
    - No new files
* [x] Have you checked that both Scala and Java APIs are updated?
    - I think `AkkaHttpServer` is implemented only Scala
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?
    - No functionality changes

# Helpful things

## Fixes

N/A

## Purpose

Add warning for `serverTerminateTimeout` is longer than `service-unbind` phase timeout.

## Background Context

- Default `service-unbind` phase timeout is 5000 milliseconds
- If we set `serverTerminateTimeout = 10 seconds` in the example, it maybe don't work well:
    ```
    --- (Running the application, auto-reloading is enabled) ---

    [info] p.c.s.AkkaHttpServer - Listening for HTTP on /0:0:0:0:0:0:0:0:9000

    (Server started, use Enter to stop and go back to the console...)

    [info] p.a.h.EnabledFilters - Enabled Filters (see <https://www.playframework.com/documentation/latest/Filters>):

        play.filters.csrf.CSRFFilter
        play.filters.headers.SecurityHeadersFilter
        play.filters.hosts.AllowedHostsFilter
    [info] play.api.Play - Application started (Dev) (no global state)
    [info] p.c.s.AkkaHttpServer - Stopping Akka HTTP server...
    [info] p.c.s.AkkaHttpServer - Terminating server binding for /0:0:0:0:0:0:0:0:9000
    [warn] a.a.CoordinatedShutdown - Coordinated shutdown phase [service-unbind] timed out after 5000 milliseconds
    [info] p.c.s.AkkaHttpServer - Running provided shutdown stop hooks
    ```

## References

N/A
