### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/release-drafter-main.yml
+++ b/.github/release-drafter-main.yml
@@ -1,7 +1,7 @@
 name-template: 'Play $NEXT_MINOR_VERSION'
 tag-template: '$NEXT_MINOR_VERSION'
 filter-by-commitish: true
-commitish: master
+commitish: main
 
 change-template: '- $TITLE #$NUMBER by @$AUTHOR'
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5
         with:
-          config-name: release-drafter-master.yml # located in .github/ in default branch
+          config-name: release-drafter-main.yml # located in .github/ in default branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 # Only build non-pushes (so PRs, API requests & cron jobs) OR tags OR forks OR main branch builds
 # https://docs.travis-ci.com/user/conditional-builds-stages-jobs/
-if: type != push OR tag IS present OR repo != playframework/playframework OR branch IN (master, 2.8.x, 2.7.x, 2.6.x)
+if: type != push OR tag IS present OR repo != playframework/playframework OR branch IN (main, 2.8.x, 2.7.x, 2.6.x)
 
 git:
   depth: false # Avoid sbt-dynver not seeing the tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,6 @@ Before making a contribution, it is important to make sure that the change you w
 3. Ensure that your commits are squashed.  See [working with git](https://playframework.com/documentation/latest/WorkingWithGit) for more information.
 4. Submit a pull request.
 
-If the pull request does not meet the above requirements then the code should **not** be merged into master, or even reviewed - regardless of how good or important it is. No exceptions.
+If the pull request does not meet the above requirements then the code should **not** be merged into main, or even reviewed - regardless of how good or important it is. No exceptions.
 
 The pull request will be reviewed according to the [implementation decision process](https://playframework.com/community-process#Implementation-decisions).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Play Framework - The High Velocity Web Framework
 
 [![Discord](https://img.shields.io/discord/931647755942776882)](https://discord.com/channels/931647755942776882)
-[![Build Status](https://app.travis-ci.com/playframework/playframework.svg?branch=master)](https://app.travis-ci.com/playframework/playframework)
+[![Build Status](https://app.travis-ci.com/playframework/playframework.svg?branch=main)](https://app.travis-ci.com/playframework/playframework)
 [![Maven](https://img.shields.io/maven-central/v/com.typesafe.play/play_2.13.svg)](https://mvnrepository.com/artifact/com.typesafe.play/play_2.13)
 [![OpenCollective](https://opencollective.com/playframework/tiers/badge.svg)](https://opencollective.com/playframework)
 

--- a/core/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/core/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -483,7 +483,7 @@ object RangeResult {
     }
   }
 
-  // See https://github.com/akka/akka-http/blob/master/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala#L76
+  // See https://github.com/akka/akka-http/blob/main/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala#L76
   private def sliceBytesTransformer(start: Long, length: Option[Long]): Flow[ByteString, ByteString, NotUsed] = {
     val transformer: GraphStage[FlowShape[ByteString, ByteString]] = new GraphStage[FlowShape[ByteString, ByteString]] {
       val in: Inlet[ByteString]   = Inlet("Slicer.in")

--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -15,7 +15,7 @@ From the shell, first checkout the Play source:
 $ git clone git://github.com/playframework/playframework.git
 ```
 
-Checkout the branch you want, `master` is the current development branch, while stable branches for major releases are named with a `.x`, for example, `2.8.x`.
+Checkout the branch you want, `main` is the current development branch, while stable branches for major releases are named with a `.x`, for example, `2.8.x`.
 
 Now run `sbt`:
 

--- a/documentation/manual/hacking/ThirdPartyTools.md
+++ b/documentation/manual/hacking/ThirdPartyTools.md
@@ -7,7 +7,7 @@ A big THANK YOU! to these sponsors for their support of open source projects.
 
 [[images/TravisCI-Full-Color.png]]
 
-Our continuous integration runs on [Travis CI](https://travis-ci.org/playframework/playframework). We not only run CI on major release and master branches, but we also perform github pull request validation using Travis functionality.
+Our continuous integration runs on [Travis CI](https://travis-ci.org/playframework/playframework). We not only run CI on major release and main branches, but we also perform github pull request validation using Travis functionality.
 
 ## Profiling
 

--- a/documentation/manual/hacking/Translations.md
+++ b/documentation/manual/hacking/Translations.md
@@ -115,7 +115,7 @@ To view the translation report, run the documentation server (like normal), and 
 
 [playframework.com](https://playframework.com) serves documentation out of git repositories.  If you want your translation to be served from playframework.com, you'll need to put your documentation into a GitHub repository, and contact the Play team to have them add it to playframework.com.
 
-The git repository needs to be in a very particular format.  The current master branch is for the documentation of the latest development version of Play.  Documentation for stable versions of Play must be in branches such as 2.3.x.  Documentation specific to a particular release of Play will be served from a tag of the repository with that name, for example, 2.3.1.
+The git repository needs to be in a very particular format.  The current main branch is for the documentation of the latest development version of Play.  Documentation for stable versions of Play must be in branches such as 2.3.x.  Documentation specific to a particular release of Play will be served from a tag of the repository with that name, for example, 2.3.1.
 
 Once the Play team has configured playframework.com to serve your translation, any changes pushed to your GitHub repository will be picked up within about 10 minutes, as playframework.com does a `git fetch` on all repos it uses once every 10 minutes.
 

--- a/documentation/manual/hacking/WorkingWithGit.md
+++ b/documentation/manual/hacking/WorkingWithGit.md
@@ -9,7 +9,7 @@ We recommend the convention of calling the remote for the official Play reposito
 
 ## Branches
 
-Typically, all work should be done in branches.  If you do work directly on master, then you can only submit one pull request at a time, since if you try to submit a second from master, the second will contain commits from both your first and your second.  Working in branches allows you to isolate pull requests from each other.
+Typically, all work should be done in branches.  If you do work directly on main, then you can only submit one pull request at a time, since if you try to submit a second from main, the second will contain commits from both your first and your second.  Working in branches allows you to isolate pull requests from each other.
 
 It's up to you what you call your branches, some people like to include issue numbers in their branch name, others like to use a hierarchical structure.
 
@@ -18,7 +18,7 @@ It's up to you what you call your branches, some people like to include issue nu
 We prefer that all pull requests be a single commit.  There are a few reasons for this:
 
 * It's much easier and less error prone to backport single commits to stable branches than backport groups of commits.  If the change is just in one commit, then there is no opportunity for error, either the whole change is cherry picked, or it isn't.
-* We aim to have our master branch to always be releasable, not just now, but also for all points in history.  If we need to back something out, we want to be confident that the commit before that is stable.
+* We aim to have our main branch to always be releasable, not just now, but also for all points in history.  If we need to back something out, we want to be confident that the commit before that is stable.
 * It's much easier to get a complete picture of what happened in history when changes are self-contained in one commit.
 
 Of course, there are some situations where it's not appropriate to squash commits, this will be decided on a case by case basis, but examples of when we won't require commits to be squashed include:
@@ -29,17 +29,17 @@ Of course, there are some situations where it's not appropriate to squash commit
 
 However, for the general case, if your pull request contains more than one commit, then you will need to squash it.  To do this, or if you already have submitted a pull request and we ask you to squash it, then you should follow these steps:
 
-1. Ensure that you have all the changes from the core master branch in your repo:
+1. Ensure that you have all the changes from the core main branch in your repo:
 
         git fetch origin
 
 2. Start an interactive rebase
 
-        git rebase -i origin/master
+        git rebase -i origin/main
 
 3. This will open up a screen in your editor, allowing you to say what should be done with each commit.  If the commit message for the first commit is suitable for describing all of the commits, then leave it as is, otherwise, change the command for it from `pick` to `reword`.
 4. For each remaining commit, change the command from `pick` to `fixup`.  This tells git to merge that commit into the previous commit, using the commit message from the previous commit.
-5. Save the file and exit your editor.  Git will now start the rebase.  If you told it to reword the first commit, it will prompt you in a new editor for the wording for that commit.  If all goes well, then you're done, but it may be the case that there were conflicts when applying your changes to the most recent master branch.  If that's the case, fix the conflicts, stage the fixes, and then run:
+5. Save the file and exit your editor.  Git will now start the rebase.  If you told it to reword the first commit, it will prompt you in a new editor for the wording for that commit.  If all goes well, then you're done, but it may be the case that there were conflicts when applying your changes to the most recent main branch.  If that's the case, fix the conflicts, stage the fixes, and then run:
 
         git rebase --continue
 
@@ -65,7 +65,7 @@ Sometimes people find that they get their pull request completely wrong and want
 To start over, make sure you've got the latest changes from Play core, and create a new branch from that point:
 
     git fetch origin
-    git checkout -b mynewbranch origin/master
+    git checkout -b mynewbranch origin/main
 
 Now make your changes, and then when you're ready to submit a pull request, assuming your old branch was called `myoldbranch`, push your new branch into that old branch in your repository:
 
@@ -79,6 +79,6 @@ You may have heard it said that you shouldn't change git history once you publis
 
 There are definitely times when git history shouldn't be changed after being published.  The main times are when it's likely that other people have forked your repository, or pulled changes from your repository.  Changing history in those cases will make it impossible for them to safely merge changes from your repo into their repository.  For this reason, we never change history in the official Play Framework repository.
 
-However, when it comes to your personal fork, for branches that are just intended to be pull requests, then it's a different matter - the intent of the workflow is that your changes get "published" once they get merged into the master branch.  Before that, the history can be considered a work in progress.
+However, when it comes to your personal fork, for branches that are just intended to be pull requests, then it's a different matter - the intent of the workflow is that your changes get "published" once they get merged into the main branch.  Before that, the history can be considered a work in progress.
 
 If however your branch is a collaboration of many people, and you believe that other people have pull from your branch for good reasons, please let us know, we won't force squashing commits where it doesn't make sense.

--- a/documentation/manual/releases/release24/migration24/Migration24.md
+++ b/documentation/manual/releases/release24/migration24/Migration24.md
@@ -220,7 +220,7 @@ Both Java `play.Plugin` and Scala `play.api.Plugin` types have been deprecated. 
 
 ## Configuration changes
 
-Play 2.4 now uses `reference.conf` to document and specify defaults for all properties.  You can easily find these by going [here](https://github.com/playframework/playframework/find/master) and searching for files called `reference.conf`.
+Play 2.4 now uses `reference.conf` to document and specify defaults for all properties.  You can easily find these by going [here](https://github.com/playframework/playframework/find/main) and searching for files called `reference.conf`.
 
 Additionally, Play has now better namespaced a large number of its configuration properties.  The old configuration paths will generally still work, but a deprecation warning will be output at runtime if you use them.  Here is a summary of the changed keys:
 

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -822,7 +822,7 @@ The mapping of file extensions to MIME types has been moved to `reference.conf` 
 
 Note that `play.http.fileMimeTypes` configuration setting is defined using triple quotes as a single string -- this is because several file extensions have syntax that breaks HOCON, such as `c++`.
 
-To append a custom MIME type, use [HOCON string value concatenation](https://github.com/typesafehub/config/blob/master/HOCON.md#string-value-concatenation):
+To append a custom MIME type, use [HOCON string value concatenation](https://github.com/typesafehub/config/blob/main/HOCON.md#string-value-concatenation):
 
 ```
 play.http.fileMimeTypes = ${play.http.fileMimeTypes} """
@@ -1233,7 +1233,7 @@ And if you are, for some reason, directly using Netty classes, you should [adapt
 
 ### FluentLenium and Selenium
 
-The FluentLenium library was updated to version 3.2.0 and Selenium was updated to version [3.3.1](https://seleniumhq.wordpress.com/2016/10/13/selenium-3-0-out-now/) (you may want to see the [changelog here](https://raw.githubusercontent.com/SeleniumHQ/selenium/master/java/CHANGELOG)). If you were using Selenium's WebDriver API before, there should not be anything to do. Please check [this](https://seleniumhq.wordpress.com/2016/10/04/selenium-3-is-coming/) announcement for further information.
+The FluentLenium library was updated to version 3.2.0 and Selenium was updated to version [3.3.1](https://seleniumhq.wordpress.com/2016/10/13/selenium-3-0-out-now/) (you may want to see the [changelog here](https://raw.githubusercontent.com/SeleniumHQ/selenium/trunk/java/CHANGELOG)). If you were using Selenium's WebDriver API before, there should not be anything to do. Please check [this](https://seleniumhq.wordpress.com/2016/10/04/selenium-3-is-coming/) announcement for further information.
 If you were using the FluentLenium library you might have to change some syntax to get your tests working again. Please see FluentLenium's [Migration Guide](https://fluentlenium.com/migration/from-0.13.2-to-1.0-or-3.0/) for more details about how to adapt your code.
 
 ### HikariCP

--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -3,7 +3,7 @@
 
 > The configuration file used by Play is based on the [Typesafe config library](https://github.com/typesafehub/config).
 
-The configuration file of a Play application must be defined in `conf/application.conf`. It uses the [HOCON format](https://github.com/typesafehub/config/blob/master/HOCON.md).
+The configuration file of a Play application must be defined in `conf/application.conf`. It uses the [HOCON format](https://github.com/typesafehub/config/blob/main/HOCON.md).
 
 As well as the `application.conf` file, configuration comes from a couple of other places.
 

--- a/documentation/manual/working/commonGuide/filters/CspFilter.md
+++ b/documentation/manual/working/commonGuide/filters/CspFilter.md
@@ -221,7 +221,7 @@ Using `CSPNonce.attrMap` is appropriate in cases where existing helpers take a m
 
 For ease of use, there are [`style`](api/scala/views/html/helper/style$.html), and [`script`](api/scala/views/html/helper/script$.html) helpers that will wrap existing inline blocks.  These are useful for adding simple bits of inline Javascript and CSS.
 
-Because these helpers are generated from Twirl templates, Scaladoc does not provide the correct source reference for these helpers. The source code for these helpers can be seen on [Github](https://github.com/playframework/playframework/blob/master/core/play/src/main/scala/views/helper/) for a more complete view.
+Because these helpers are generated from Twirl templates, Scaladoc does not provide the correct source reference for these helpers. The source code for these helpers can be seen on [Github](https://github.com/playframework/playframework/blob/main/core/play/src/main/scala/views/helper/) for a more complete view.
 
 ##### Style Helper
 

--- a/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
+++ b/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
@@ -13,7 +13,7 @@ Each of these types have different methods to configure them.
 
 Play has a number of configurable settings. You can configure database connection URLs, the application secret, the HTTP port, SSL configuration, and so on.
 
-Most of Play's configuration is defined in various `.conf` files, which use the [HOCON format](https://github.com/typesafehub/config/blob/master/HOCON.md). The main configuration file that you'll use is the `application.conf` file. You can find this file at `conf/application.conf` within your project. The `application.conf` file is loaded from the classpath at runtime (or you can override where it is loaded from). There can only be one `application.conf` per project.
+Most of Play's configuration is defined in various `.conf` files, which use the [HOCON format](https://github.com/typesafehub/config/blob/main/HOCON.md). The main configuration file that you'll use is the `application.conf` file. You can find this file at `conf/application.conf` within your project. The `application.conf` file is loaded from the classpath at runtime (or you can override where it is loaded from). There can only be one `application.conf` per project.
 
 Other `.conf` files are loaded too. Libraries define default settings in `reference.conf` files. These files are stored in the libraries' JARs—one `reference.conf` per JAR—and aggregated together at runtime. The `reference.conf` files provide defaults; they are overridden by any settings defined in the `application.conf` file.
 

--- a/documentation/manual/working/commonGuide/production/cloud/Deploying-CleverCloud.md
+++ b/documentation/manual/working/commonGuide/production/cloud/Deploying-CleverCloud.md
@@ -15,16 +15,16 @@ To deploy your application on Clever Cloud, just use git to push your code to th
 
 ```bash
 $ git remote add <your-remote-name> <your-git-deployment-url>
-$ git push <your-remote-name> master
+$ git push <your-remote-name> main
 ```
 
-**Important tip: do not forget to push to the remote master branch.**
+**Important tip: do not forget to push to the remote main branch.**
 
 If you work in a different branch, just use: 
 
 ```bash
 $ git remote add <your-remote-name> <your-git-deployment-url>
-$ git push <your-remote-name> <your-branch-name>:master
+$ git push <your-remote-name> <your-branch-name>:main
 ```
 
 <br/>

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -39,7 +39,7 @@ This provisions a new application with an HTTP (and HTTPS) endpoint and Git endp
 To deploy your application on Heroku, use Git to push it into the `heroku` remote repository:
 
 ```bash
-$ git push heroku master
+$ git push heroku main
 Counting objects: 93, done.
 Delta compression using up to 4 threads.
 Compressing objects: 100% (84/84), done.
@@ -65,7 +65,7 @@ remote:        https://warm-frost-1289.herokuapp.com/ deployed to Heroku
 remote:
 remote: Verifying deploy... done.
 To https://git.heroku.com/warm-frost-1289.git
-* [new branch]      master -> master
+* [new branch]      main -> main
 ```
 
 Heroku will run `sbt stage` to prepare your application. On the first deployment, all dependencies will be downloaded, which takes a while to complete (but they will be cached for future deployments).

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -151,7 +151,7 @@ There are several input helpers, but the most helpful are:
 * [`checkbox`](api/scala/views/html/helper/checkbox$.html): renders a [checkbox](https://www.w3.org/TR/html/sec-forms.html#element-statedef-input-checkbox) element.
 * [`input`](api/scala/views/html/helper/input$.html): renders a generic input element (which requires explicit arguments).
 
-> **Note:** The source code for each of these templates is defined as Twirl templates under `views/helper` package, and so the packaged version corresponds to the generated Scala source code.  For reference, it can be useful to see the [`views/helper`](https://github.com/playframework/playframework/tree/master/core/play/src/main/scala/views/helper) package on Github.
+> **Note:** The source code for each of these templates is defined as Twirl templates under `views/helper` package, and so the packaged version corresponds to the generated Scala source code.  For reference, it can be useful to see the [`views/helper`](https://github.com/playframework/playframework/tree/main/core/play/src/main/scala/views/helper) package on Github.
 
 As with the `form` helper, you can specify an extra set of parameters that will be added to the generated Html:
 


### PR DESCRIPTION
@SethTisue and @ihostage already renamed the `master` branch in some play repos:
* https://github.com/playframework/cachecontrol/pull/163
* https://github.com/playframework/play-file-watch/pull/136
* https://github.com/playframework/play-json/pull/598
* https://github.com/playframework/play-soap/pull/282
* https://github.com/playframework/play-ws/pull/597
* https://github.com/playframework/twirl/pull/416

Now that we are centralising configs in the [`.github`](https://github.com/playframework/.github) repo it's a good idea that all repos have the same default branch name.

To change to `main` locally (if the remote to this repo is called `upstream`):
```sh
git branch -m master main # rename master to main (actually "move")
git fetch upstream
git branch -u upstream/main main # set upstream
git remote set-head upstream -a # make sure HEAD is set correctly for this remote (autodetect)
```