### PR TITLE
chore(#11143): set next minor version when being on main branch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ import sbt.Keys.parallelExecution
 import sbt._
 import sbt.io.Path._
 import org.scalafmt.sbt.ScalafmtPlugin
+import VersionHelper._
 
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed
 (ThisBuild / dynverVTagPrefix) := false
@@ -20,11 +21,11 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
   s
 }
 
-// Correctly set version
-ThisBuild / version := dynverGitDescribeOutput.value.mkVersion(VersionHelper.versionFmt, VersionHelper.fallbackVersion(dynverCurrentDate.value))
+// Makes sure to increase the version and remove the distance
+ThisBuild / version := dynverGitDescribeOutput.value.mkVersion(out => versionFmt(out, dynverSonatypeSnapshots.value), fallbackVersion(dynverCurrentDate.value))
 ThisBuild / dynver := {
   val d = new java.util.Date
-  sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(VersionHelper.versionFmt, VersionHelper.fallbackVersion(d))
+  sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(out => versionFmt(out, dynverSonatypeSnapshots.value), fallbackVersion(d))
 }
 
 lazy val BuildLinkProject = PlayNonCrossBuiltProject("Build-Link", "dev-mode/build-link")

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,13 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
   s
 }
 
+// Correctly set version
+ThisBuild / version := dynverGitDescribeOutput.value.mkVersion(VersionHelper.versionFmt, VersionHelper.fallbackVersion(dynverCurrentDate.value))
+ThisBuild / dynver := {
+  val d = new java.util.Date
+  sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(VersionHelper.versionFmt, VersionHelper.fallbackVersion(d))
+}
+
 lazy val BuildLinkProject = PlayNonCrossBuiltProject("Build-Link", "dev-mode/build-link")
   .dependsOn(PlayExceptionsProject)
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,13 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 }
 
 // Makes sure to increase the version and remove the distance
-ThisBuild / version := dynverGitDescribeOutput.value.mkVersion(out => versionFmt(out, dynverSonatypeSnapshots.value), fallbackVersion(dynverCurrentDate.value))
+ThisBuild / version := dynverGitDescribeOutput.value
+  .mkVersion(out => versionFmt(out, dynverSonatypeSnapshots.value), fallbackVersion(dynverCurrentDate.value))
 ThisBuild / dynver := {
   val d = new java.util.Date
-  sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(out => versionFmt(out, dynverSonatypeSnapshots.value), fallbackVersion(d))
+  sbtdynver.DynVer
+    .getGitDescribeOutput(d)
+    .mkVersion(out => versionFmt(out, dynverSonatypeSnapshots.value), fallbackVersion(d))
 }
 
 lazy val BuildLinkProject = PlayNonCrossBuiltProject("Build-Link", "dev-mode/build-link")

--- a/project/VersionHelper.scala
+++ b/project/VersionHelper.scala
@@ -2,9 +2,13 @@
  * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
+import scala.sys.process.Process
+import scala.sys.process.ProcessLogger
+
 object VersionHelper {
 
-  private val SemVer = """(\d*)\.(\d*)\.(\d*).*""".r
+  private val SemVer           = """(\d*)\.(\d*)\.(\d*).*""".r
+  private val SemVerPreVersion = """(\d*)\.(\d*)\.(\d*)-(M|RC)(\d*)""".r
 
   // For main branch
   private def increaseMinorVersion(tag: String): String = {
@@ -26,13 +30,38 @@ object VersionHelper {
     }
   }
 
+  // For release candiates (-RC) and milestones (-M), no matter which branch
+  private def increasePreVersion(tag: String): String = {
+    tag match {
+      case SemVerPreVersion(major, minor, patch, preVersionType, preVersion) =>
+        s"$major.$minor.$patch-$preVersionType${preVersion.toInt + 1}"
+      case _ =>
+        tag
+    }
+  }
+
   def versionFmt(out: sbtdynver.GitDescribeOutput, dynverSonatypeSnapshots: Boolean): String = {
     if (out.isCleanAfterTag) {
       out.ref.dropPrefix
     } else {
       val dirtyPart    = if (out.isDirty()) out.dirtySuffix.value else ""
       val snapshotPart = if (dynverSonatypeSnapshots && out.isSnapshot()) "-SNAPSHOT" else ""
-      VersionHelper.increaseMinorVersion(out.ref.dropPrefix) + "-" + out.commitSuffix.sha + dirtyPart + snapshotPart
+      (if (out.ref.dropPrefix.matches(""".*-(M|RC)\d+$""")) {
+         // tag is a milestone or release candidate, therefore we increase the version after the -RC or -M (e.g. -RC1 becomes -RC2)
+         // it does not matter on which branch we are on
+         VersionHelper.increasePreVersion(out.ref.dropPrefix)
+       } else {
+         val mainBranchIsAncestor =
+           Process("git merge-base --is-ancestor main HEAD").run(ProcessLogger(_ => ())).exitValue() == 0
+         if (mainBranchIsAncestor) {
+           // We are on the main branch, or a branch that is forked off from the main branch
+           VersionHelper.increaseMinorVersion(out.ref.dropPrefix)
+         } else {
+           // We are not on the main branch or one off its children.
+           // Therefore we are e.g. on 2.8.x or a branch that is forked off from 2.8.x or 2.9.x or ... you get it ;)
+           VersionHelper.increasePatchVersion(out.ref.dropPrefix)
+         }
+       }) + "-" + out.commitSuffix.sha + dirtyPart + snapshotPart
     }
   }
 

--- a/project/VersionHelper.scala
+++ b/project/VersionHelper.scala
@@ -22,12 +22,13 @@ object VersionHelper {
     }
   }
 
-  def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+  def versionFmt(out: sbtdynver.GitDescribeOutput, dynverSonatypeSnapshots: Boolean): String = {
     if (out.isCleanAfterTag) {
       out.ref.dropPrefix
     } else {
-      // Change to increasePatchVersion when not on "main" branch
-      VersionHelper.increaseMinorVersion(out.ref.dropPrefix) + "-" + out.commitSuffix.sha + "-SNAPSHOT"
+      val dirtyPart = if (out.isDirty()) out.dirtySuffix.value else ""
+      val snapshotPart = if (dynverSonatypeSnapshots && out.isSnapshot()) "-SNAPSHOT" else ""
+      VersionHelper.increaseMinorVersion(out.ref.dropPrefix) + "-" + out.commitSuffix.sha + dirtyPart + snapshotPart
     }
   }
 

--- a/project/VersionHelper.scala
+++ b/project/VersionHelper.scala
@@ -63,7 +63,7 @@ object VersionHelper {
            // Therefore we are e.g. on 2.8.x or a branch that is forked off from 2.8.x or 2.9.x or ... you get it ;)
            VersionHelper.increasePatchVersion(out.ref.dropPrefix)
          }
-       }) + "-" + out.commitSuffix.sha + dirtyPart + snapshotPart
+       }) + Option(out.commitSuffix.sha).filter(_.nonEmpty).map("-" + _).getOrElse("") + dirtyPart + snapshotPart
     }
   }
 

--- a/project/VersionHelper.scala
+++ b/project/VersionHelper.scala
@@ -26,7 +26,7 @@ object VersionHelper {
     if (out.isCleanAfterTag) {
       out.ref.dropPrefix
     } else {
-      val dirtyPart = if (out.isDirty()) out.dirtySuffix.value else ""
+      val dirtyPart    = if (out.isDirty()) out.dirtySuffix.value else ""
       val snapshotPart = if (dynverSonatypeSnapshots && out.isSnapshot()) "-SNAPSHOT" else ""
       VersionHelper.increaseMinorVersion(out.ref.dropPrefix) + "-" + out.commitSuffix.sha + dirtyPart + snapshotPart
     }

--- a/project/VersionHelper.scala
+++ b/project/VersionHelper.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 object VersionHelper {
 
   private val SemVer = """(\d*)\.(\d*)\.(\d*).*""".r

--- a/project/VersionHelper.scala
+++ b/project/VersionHelper.scala
@@ -1,0 +1,36 @@
+object VersionHelper {
+
+  private val SemVer = """(\d*)\.(\d*)\.(\d*).*""".r
+
+  // For main branch
+  private def increaseMinorVersion(tag: String): String = {
+    tag match {
+      case SemVer(major, minor, patch) =>
+        s"$major.${minor.toInt + 1}.0"
+      case _ =>
+        tag
+    }
+  }
+
+  // For version branches
+  private def increasePatchVersion(tag: String): String = {
+    tag match {
+      case SemVer(major, minor, patch) =>
+        s"$major.$minor.${patch.toInt + 1}"
+      case _ =>
+        tag
+    }
+  }
+
+  def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+    if (out.isCleanAfterTag) {
+      out.ref.dropPrefix
+    } else {
+      // Change to increasePatchVersion when not on "main" branch
+      VersionHelper.increaseMinorVersion(out.ref.dropPrefix) + "-" + out.commitSuffix.sha + "-SNAPSHOT"
+    }
+  }
+
+  def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer.timestamp(d)}"
+
+}

--- a/project/VersionHelper.scala
+++ b/project/VersionHelper.scala
@@ -53,11 +53,13 @@ object VersionHelper {
        } else {
          val mainBranchIsAncestor =
            Process("git merge-base --is-ancestor main HEAD").run(ProcessLogger(_ => ())).exitValue() == 0
-         if (mainBranchIsAncestor) {
-           // We are on the main branch, or a branch that is forked off from the main branch
+         lazy val masterBranchIsAncestor =
+           Process("git merge-base --is-ancestor master HEAD").run(ProcessLogger(_ => ())).exitValue() == 0
+         if (mainBranchIsAncestor || masterBranchIsAncestor) {
+           // We are on the main (or master) branch, or a branch that is forked off from the main branch
            VersionHelper.increaseMinorVersion(out.ref.dropPrefix)
          } else {
-           // We are not on the main branch or one off its children.
+           // We are not on the main (or master) branch or one off its children.
            // Therefore we are e.g. on 2.8.x or a branch that is forked off from 2.8.x or 2.9.x or ... you get it ;)
            VersionHelper.increasePatchVersion(out.ref.dropPrefix)
          }


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #11143 

## Purpose

Add a custom method for sbt-dynver to compute the version by:
- not including the distance
- incrementing minor version (or patch version later)
