### PR TITLE
Fix docs: Passing request to WebSocket action not supported

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -68,7 +68,8 @@ public class JavaWebSockets {
       return WebSocket.Text.acceptOrResult(
           request ->
               CompletableFuture.completedFuture(
-                  request.session()
+                  request
+                      .session()
                       .get("user")
                       .map(
                           user ->

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -64,7 +64,7 @@ public class JavaWebSockets {
     private Materializer materializer;
 
     // #actor-reject
-    public WebSocket socket(Http.Request req) {
+    public WebSocket socket() {
       return WebSocket.Text.acceptOrResult(
           request ->
               CompletableFuture.completedFuture(

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -68,7 +68,7 @@ public class JavaWebSockets {
       return WebSocket.Text.acceptOrResult(
           request ->
               CompletableFuture.completedFuture(
-                  req.session()
+                  request.session()
                       .get("user")
                       .map(
                           user ->


### PR DESCRIPTION
See #11029

I don't think this is even needed since you have access to the request later in `...acceptOrResult(request -> ...`
Should have been in #8639, but probably was forgotten.
I think this is just a doc problem.

In case someone really needs the request directly in the controller method we may can make this work, however let's see if there is really need for that.