### PR TITLE
DefaultTestServerFactory should use HTTP server port from helpers

### DIFF
--- a/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
@@ -61,7 +61,7 @@ import scala.util.control.NonFatal
   }
 
   protected def serverConfig(app: Application) = {
-    val sc = ServerConfig(port = Some(0), sslPort = Some(0), mode = Mode.Test, rootDir = app.path)
+    val sc = ServerConfig(port = Some(Helpers.testServerPort), sslPort = Some(0), mode = Mode.Test, rootDir = app.path)
     sc.copy(configuration = overrideServerConfiguration(app).withFallback(sc.configuration))
   }
 


### PR DESCRIPTION
## Purpose

This PR defaults the test server to start on an HTTP endpoint that's defined by `play.api.test.Helpers.testServerPort`.

## Background Context

The documentation at https://www.playframework.com/documentation/2.8.x/ScalaFunctionalTestingWithScalaTest#Testing-with-a-server says

> The OneServerPerSuite and OneServerPerTest traits provide the port number on which the server is running as the port field. By default this is 19001, however you can change this either overriding port or by setting the system property testserver.port. This can be useful for integrating with continuous integration servers, so that ports can be dynamically reserved for each build.

But this isn't the case -- the port number is randomly assigned as 0.  So this is inconsistent with the docs and with prior behavior.

Ironically, the current behavior is a fix for https://github.com/playframework/playframework/issues/5473 but that bug remains open -- so either the documentation needs to be updated or the behavior reverted.
