### PR TITLE
Make the "please donate" message more friendly

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -78,7 +78,7 @@ object PlaySettings {
             |Version ${play.core.PlayVersion.current} running Java ${System.getProperty("java.version")}
             |
             |${Colors.bold(
-             "Play is run entirely by the community. If you want to keep using it please consider donating:"
+             "Play is run entirely by the community. Please consider contributing and/or donating:"
            )}
             |https://www.playframework.com/sponsors
             |


### PR DESCRIPTION
The current message sounds a little aggressive/alarmist - people can certainly keep using the framework regardless of whether they contribute or donate. 

That said, we do of course very much want to encourage people to contribute & donate.