### PR TITLE
[2.8.x] Reverts #11109 (downgrade ssl-config back to 0.4.x)

### DIFF
--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -38,7 +38,6 @@ object ScriptedTools extends AutoPlugin with ScriptedTools0 {
     // using this variant due to sbt#5405
     resolvers += "sonatype-service-local-releases"
       .at("https://oss.sonatype.org/service/local/repositories/releases/content/"), // sync ScriptedTools.scala
-    resolvers += Resolver.sonatypeRepo("snapshots"),
     // This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
     // the snapshot resolvers in `cron` builds.
     // If this is a cron job in Travis:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.15")
 
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.0"
+  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.2"
 
   val playJsonVersion = "2.8.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18+31-9d0684d8-SNAPSHOT")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.15")
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -288,7 +288,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.1.7+3-cb4c8cfb-SNAPSHOT"
+  val playWsStandaloneVersion = "2.1.7"
   val playWsDeps = Seq(
     "com.typesafe.play"                        %% "play-ws-standalone" % playWsStandaloneVersion,
     "com.typesafe.play"                        %% "play-ws-standalone-xml" % playWsStandaloneVersion,


### PR DESCRIPTION
Reverts #11109, kind of the same like I just did with play-ws: https://github.com/playframework/play-ws/pull/662

akka did _not_ upgrade to ssl-config 0.6.x because it has binary compatibility issues with 0.4.x. Actually it got upgraded first, see https://github.com/akka/akka/pull/31046, then it got partially reverted, see https://github.com/akka/akka/pull/31252.
Partially reverted means that only the dependency was downgraded again, however akka itself removed methods and classes not available anymore in ssl-config 0.6.x, so akka 2.6.19 itself works nicely with ssl-config 0.6.x. However they didn't want to upgrade to latest ssl-config to not break libraries depending on akka and which also use removed methods and/or classes from ssl-config 0.4.3.

For Play stable branch 2.8.x that means we don't need to upgrade to ssl-config 0.6.0 (and therefore also not play-ws snapshot).