### PR TITLE
Latest akka/scala/ssl-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
   global:
     - secure: "NS2hMbBcmi6EF4QxtcNs4A2ZuNmIdLYQRJUWWejgnD4YtcsmoVjxrHRedqrnDdui4DyvaxWhg/3Uds23jEKTSbbh3ZphLO77BVgM2nUGUvVoa4i6qGF2eZFlIhq2G1gM700GPV7X4KmyjYi2HtH8CWBTkqP3g0An63mCZw/Gnlk="
     # These are the versions used for (scripted) tests. The versions Play is build with however are defined in interplay.
-    - SCRIPTED_SBT_1_6: "1.6.1"
-    - TEST_SCALA_2_13: "2.13.7"
+    - SCRIPTED_SBT_1_6: "1.6.2"
+    - TEST_SCALA_2_13: "2.13.8"
   jobs:
     - TRAVIS_JDK=11
 

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -30,7 +30,6 @@ object ScriptedTools extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[_]] = Def.settings(
     resolvers += Resolver.sonatypeRepo("releases"), // sync BuildSettings.scala
-    resolvers += Resolver.sonatypeRepo("snapshots"),
     // This is copy/pasted from AkkaSnapshotRepositories since scripted tests also need
     // the snapshot resolvers in `cron` builds.
     // If this is a cron job in Travis:

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -75,8 +75,8 @@ lazy val main = Project("Play-Documentation", file("."))
     Test / unmanagedResourceDirectories ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
     // Don't include sbt files in the resources
     Test / unmanagedResources / excludeFilter := (Test / unmanagedResources / excludeFilter).value || "*.sbt",
-    crossScalaVersions := Seq("2.13.7"),
-    scalaVersion := "2.13.7",
+    crossScalaVersions := Seq("2.13.8"),
+    scalaVersion := "2.13.8",
     Test / fork := true,
     Test / javaOptions ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) Lightbend Inc. <https://www.lightbend.com>")),

--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -38,7 +38,7 @@ This will build and publish Play for the default Scala version. If you want to p
 Or to publish for a specific Scala version:
 
 ```bash
-> ++ 2.13.7 publishLocal
+> ++ 2.13.8 publishLocal
 ```
 
 ## Build the documentation

--- a/documentation/manual/hacking/Translations.md
+++ b/documentation/manual/hacking/Translations.md
@@ -39,7 +39,7 @@ translation-project
 `build.properties` should contain the sbt version, ie:
 
 ```
-sbt.version=1.6.1
+sbt.version=1.6.2
 ```
 
 `plugins.sbt` should include the Play docs sbt plugin, ie:

--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -24,7 +24,7 @@ scalaVersion := "2.11.12"
 For Scala 2.13:
 
 ```scala
-scalaVersion := "2.13.7"
+scalaVersion := "2.13.8"
 ```
 
 ## Lifecycle managed by Akka's Coordinated Shutdown

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -47,14 +47,14 @@ Play 2.8 support Scala 2.12 and 2.13, but not 2.11, which has reached its end of
 To set the Scala version in sbt, simply set the `scalaVersion` key, for example:
 
 ```scala
-scalaVersion := "2.13.7"
+scalaVersion := "2.13.8"
 ```
 
 If you have a single project build, then this setting can just be placed on its own line in `build.sbt`.  However, if you have a multi-project build, then the scala version setting must be set on each project.  Typically, in a multi-project build, you will have some common settings shared by every project, this is the best place to put the setting, for example:
 
 ```scala
 def commonSettings = Seq(
-  scalaVersion := "2.13.7"
+  scalaVersion := "2.13.8"
 )
 
 val projectA = (project in file("projectA"))

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -23,10 +23,10 @@ Where the "x" in `2.9.x` is the minor version of Play you want to use, for insta
 Play 2.9 only supports sbt 1.6. To update, change your `project/build.properties` so that it reads:
 
 ```properties
-sbt.version=1.6.1
+sbt.version=1.6.2
 ```
 
-At the time of this writing `1.6.1` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version [releases](https://github.com/playframework/playframework/releases) and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
+At the time of this writing `1.6.2` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version [releases](https://github.com/playframework/playframework/releases) and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
 
 ### Minimum required Java version
 
@@ -48,14 +48,14 @@ Play 2.9 supports Scala 2.13, but not 2.12 anymore.
 To set the Scala version in sbt, simply set the `scalaVersion` key, for example:
 
 ```scala
-scalaVersion := "2.13.7"
+scalaVersion := "2.13.8"
 ```
 
 If you have a single project build, then this setting can just be placed on its own line in `build.sbt`.  However, if you have a multi-project build, then the scala version setting must be set on each project.  Typically, in a multi-project build, you will have some common settings shared by every project, this is the best place to put the setting, for example:
 
 ```scala
 def commonSettings = Seq(
-  scalaVersion := "2.13.7"
+  scalaVersion := "2.13.8"
 )
 
 val projectA = (project in file("projectA"))

--- a/documentation/manual/working/commonGuide/build/sbtDependencies.md
+++ b/documentation/manual/working/commonGuide/build/sbtDependencies.md
@@ -37,7 +37,7 @@ If you use `groupID %% artifactID % revision` rather than `groupID % artifactID 
 
 @[explicit-scala-version-dep](code/dependencies.sbt)
 
-Assuming the `scalaVersion` for your build is `2.13.7`, the following is identical (note the double `%%` after `"org.scala-tools"`):
+Assuming the `scalaVersion` for your build is `2.13.8`, the following is identical (note the double `%%` after `"org.scala-tools"`):
 
 @[auto-scala-version-dep](code/dependencies.sbt)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,10 +7,10 @@ import Keys._
 import buildinfo.BuildInfo
 
 object Dependencies {
-  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18+21-4fb7bd9b-SNAPSHOT")
+  val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.19")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.2.7")
 
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.0"
+  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.1"
 
   val playJsonVersion = "2.10.0-RC5"
 


### PR DESCRIPTION
Finally akka 2.6.19 is compatible with ssl-config 0.6.x, see https://github.com/akka/akka/pull/31046 and https://github.com/akka/akka/pull/31252.