### PR TITLE
[2.8.x] Partial support for Java17

### DIFF
--- a/core/play/src/main/java/play/package-info.java
+++ b/core/play/src/main/java/play/package-info.java
@@ -5,7 +5,7 @@
 /**
  * Provides the Play framework's publicly accessible Java API.
  *
- * <h3>Play</h3>
+ * <h2>Play</h2>
  *
  * <a href="http://www.playframework.com">http://www.playframework.com</a>
  */

--- a/core/play/src/main/scala/play/utils/Resources.scala
+++ b/core/play/src/main/scala/play/utils/Resources.scala
@@ -11,8 +11,6 @@ import java.net.URL
 import java.io.File
 import java.util.zip.ZipFile
 
-import sun.net.www.protocol.file.FileURLConnection
-
 /**
  * Provide resources helpers
  */
@@ -33,7 +31,7 @@ object Resources {
    * this returns false.
    */
   def isUrlConnectionADirectory(urlConnection: URLConnection) = urlConnection match {
-    case file: FileURLConnection => new File(file.getURL.toURI).isDirectory
+    case file if file.getURL.getProtocol == "file" => new File(file.getURL.toURI).isDirectory
     case jar: JarURLConnection =>
       if (jar.getJarEntry.isDirectory) {
         true

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -210,6 +210,9 @@ object BuildSettings {
         "play.api.mvc.BaseControllerHelpers.play$api$mvc$BaseControllerHelpers$_setter_$defaultFormBinding_="
       ),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.BaseControllerHelpers.defaultFormBinding"),
+      // Fix compile error on JDK15: Use direct AlgorithmId.get() (is private[play] anyway)
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("play.core.server.ssl.CertificateGenerator.generateCertificate"),
     ),
     unmanagedSourceDirectories in Compile += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.18")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.1.15")
 
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.2"
+  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.4.3"
 
   val playJsonVersion = "2.8.2"
 

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
@@ -9,7 +9,6 @@ import java.security.cert._
 import java.security._
 import java.math.BigInteger
 import java.util.Date
-import sun.security.util.ObjectIdentifier
 import java.time.Duration
 import java.time.Instant
 
@@ -40,7 +39,7 @@ object CertificateGenerator {
       Date.from(from),
       Date.from(to),
       "SHA256withRSA",
-      AlgorithmId.sha256WithRSAEncryption_oid
+      AlgorithmId.get("SHA256WithRSA")
     )
   }
 
@@ -61,7 +60,7 @@ object CertificateGenerator {
       Date.from(from),
       Date.from(to),
       "SHA1withRSA",
-      AlgorithmId.sha256WithRSAEncryption_oid
+      AlgorithmId.get("SHA256WithRSA")
     )
   }
 
@@ -87,7 +86,7 @@ object CertificateGenerator {
     val keyGen = KeyPairGenerator.getInstance("RSA")
     keyGen.initialize(keySize, new SecureRandom())
     val pair = keyGen.generateKeyPair()
-    generateCertificate(dn, pair, Date.from(from), Date.from(to), "MD5WithRSA", AlgorithmId.md5WithRSAEncryption_oid)
+    generateCertificate(dn, pair, Date.from(from), Date.from(to), "MD5WithRSA", AlgorithmId.get("MD5WithRSA"))
   }
 
   private[play] def generateCertificate(
@@ -96,7 +95,7 @@ object CertificateGenerator {
       from: Date,
       to: Date,
       algorithm: String,
-      oid: ObjectIdentifier
+      algoId: AlgorithmId
   ): X509Certificate = {
     val info: X509CertInfo            = new X509CertInfo
     val interval: CertificateValidity = new CertificateValidity(from, to)
@@ -111,13 +110,11 @@ object CertificateGenerator {
     info.set(X509CertInfo.KEY, new CertificateX509Key(pair.getPublic))
     info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3))
 
-    var algo: AlgorithmId = new AlgorithmId(oid)
-
-    info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algo))
+    info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algoId))
     var cert: X509CertImpl  = new X509CertImpl(info)
     val privkey: PrivateKey = pair.getPrivate
     cert.sign(privkey, algorithm)
-    algo = cert.get(X509CertImpl.SIG_ALG).asInstanceOf[AlgorithmId]
+    val algo = cert.get(X509CertImpl.SIG_ALG).asInstanceOf[AlgorithmId]
     info.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, algo)
     cert = new X509CertImpl(info)
     cert.sign(privkey, algorithm)


### PR DESCRIPTION
See https://github.com/playframework/playframework/pull/10819#issuecomment-1074831204

This might not enable full Java 17 support for Play 2.8.x out of the box yet, however it unlocks it partially.
People very likely still need to upgrade deps on their own, like:
- Guice to latest version 5.x: https://github.com/google/guice/releases/
- If using Java routing DSL to 0.6.3: `"net.jodah" % "typetools" % "0.6.3"`, see #10055 and #10814

Also avoid using `jnotify` for the `FileWatchService`, see https://github.com/playframework/playframework/pull/10731/files#diff-200727c8deef149abd2e23743e98a3478c2d2662fc0f78529fe46ffd3f675938

There might be other stuff that breaks, which I am not aware of right now.