### PR TITLE
Remove `-XX:MaxPermSize`, breaks on Java 17

### DIFF
--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -30,8 +30,7 @@ The default way to test a Play application is with [JUnit](https://junit.org/jun
 >   "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9998",
 >   "-Xms512M",
 >   "-Xmx1536M",
->   "-Xss1M",
->   "-XX:MaxPermSize=384M"
+>   "-Xss1M"
 > )
 > ```
 


### PR DESCRIPTION
Deprecated in Java 8 already, removed in (at least) Java 17.
Replaced by `MaxMetaspaceSize` which is "unlimited" however: https://stackoverflow.com/questions/62127596/why-is-the-default-maxmetaspacesize-on-java-very-large

@Mergifyio backport main