### PR TITLE
[2.8.x] Adjust welcome message for experimental Java 17 support

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -90,10 +90,16 @@ object PlaySettings extends PlaySettingsCompat {
             |https://www.playframework.com/sponsors
             |
             |""".stripMargin +
-        (if (javaVersion != "1.8" && javaVersion != "11")
-           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-              |  Java version is ${sys.props("java.specification.version")}. Play supports only 8 and 11.
-              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        (if (javaVersion == "17")
+           s"""Running Play on Java ${sys.props("java.specification.version")} is experimental. Tweaks are necessary:
+              |https://github.com/playframework/playframework/releases/2.8.15
+              |
+              |""".stripMargin
+         else if (javaVersion != "1.8" && javaVersion != "11")
+           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+              |  Java version is ${sys
+                .props("java.specification.version")}. Play supports only 8, 11 and, experimentally, 17.
+              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
               |
               |""".stripMargin
          else "")


### PR DESCRIPTION
Running future Play 2.8.x on Java 17:
![image](https://user-images.githubusercontent.com/644927/161053651-403b03c9-efca-4527-8850-aded86b60ee9.png)

Running future Play on a not supported Java version:
![image](https://user-images.githubusercontent.com/644927/161053720-c0b7f55e-1620-4093-b5e5-042fd9f72629.png)
