### PR TITLE
Jackson 2.13

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -33,8 +33,6 @@ updates.ignore = [
 updates.pin = [
   { groupId = "com.typesafe.akka", artifactId = "akka-actor", version = "2.6." },
   { groupId = "com.typesafe.akka", artifactId = "akka-http-core", version = "10.1." },
-  // To be updated in tandem with upstream Akka
-  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.11." },
   // HikariCP 5+ requires Java 11. See https://github.com/brettwooldridge/HikariCP/issues/1816#issuecomment-890255579
   { groupId = "com.zaxxer", artifactId = "HikariCP", version = "4." },
   // caffeine 3+ requires Java 11. See https://github.com/ben-manes/caffeine/releases/tag/v3.0.0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,8 +30,8 @@ object Dependencies {
     "org.scalacheck" %% "scalacheck"        % "1.15.4"      % Test
   )
 
-  val jacksonVersion         = "2.11.4"
-  val jacksonDatabindVersion = jacksonVersion
+  val jacksonVersion         = "2.13.2"
+  val jacksonDatabindVersion = "2.13.2.2"
   val jacksonDatabind        = Seq("com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion)
   val jacksons = Seq(
     "com.fasterxml.jackson.core"     % "jackson-core",


### PR DESCRIPTION
See explanations in
* #11217
* https://github.com/playframework/play-json/pull/740
* https://github.com/playframework/play-json/issues/632#issuecomment-1088585039
* https://github.com/playframework/play-json/pull/633#issuecomment-1081181201

Also I am pretty sure this pr will fail because we also need to upgrade some jackson deps that `akka-serialization-jackson` pulls in:
```
...
[info]   |   +-com.typesafe.akka:akka-serialization-jackson_2.13:2.6.19 [S]
...
[info]   |   | +-com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4
...
[info]   |   | +-com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.4
...
[info]   |   | +-com.fasterxml.jackson.module:jackson-module-scala_2.13:2.11.4 [S]
...
```
Let's see what CI says...