### PR TITLE
jackson.module.paranamer is not really needed

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,6 @@ object Dependencies {
   // Can be removed as soon as akka upgrades to same jackson version like Play uses
   val akkaSerializationJacksonOverrides = Seq(
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
-    "com.fasterxml.jackson.module"     % "jackson-module-parameter-names",
     "com.fasterxml.jackson.module"     %% "jackson-module-scala",
   ).map(_ % jacksonVersion)
 


### PR DESCRIPTION
scala module v2.13 doesn't use it

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
