### PR TITLE
sbt-header plugins should handle md files in docs project

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Build documentation
 
 This is the README for the Play documentation project.  The documentation project does not build with the rest of the Play projects, and uses its own sbt setup instead.  Please refer to the [main README file](../README.md) for how to build Play in general and how to [contribute](../CONTRIBUTING.md).

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -9,7 +9,9 @@ import playbuild.JavaVersion
 import playbuild.CrossJava
 
 import de.heikoseeberger.sbtheader.FileType
+import de.heikoseeberger.sbtheader.CommentCreator
 import de.heikoseeberger.sbtheader.CommentStyle
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern.commentBetween
 
 val DocsApplication = config("docs").hide
 
@@ -82,8 +84,14 @@ lazy val main = Project("Play-Documentation", file("."))
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) Lightbend Inc. <https://www.lightbend.com>")),
     headerMappings ++= Map(
       FileType.xml  -> CommentStyle.xmlStyleBlockComment,
-      FileType.conf -> CommentStyle.hashLineComment
+      FileType.conf -> CommentStyle.hashLineComment,
+      FileType("md") -> CommentStyle(new CommentCreator() {
+        override def apply(text: String, existingText: Option[String]): String = {
+          s"<!--- $text -->"
+        }
+      }, commentBetween("<!---", "*", "-->"))
     ),
+    Test / headerSources ++= (baseDirectory.value ** "*.md").get,
     Test / javafmt / sourceDirectories ++= (Test / unmanagedSourceDirectories).value,
     Test / javafmt / sourceDirectories ++= (Test / unmanagedResourceDirectories).value,
     // No need to show eviction warnings for Play documentation.

--- a/documentation/manual/Home.md
+++ b/documentation/manual/Home.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play %PLAY_VERSION% documentation
 
 > Play is a high-productivity Java and Scala web application framework that integrates the components and APIs you need for modern web application development. 

--- a/documentation/manual/LatestRelease.md
+++ b/documentation/manual/LatestRelease.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Latest release
 
 Learn more about the latest Play release. You can download Play releases [here](https://www.playframework.com/download).

--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play modules
 
 Play uses public modules to augment built-in functionality.  

--- a/documentation/manual/about/Philosophy.md
+++ b/documentation/manual/about/Philosophy.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Introducing Play 2
 
 Since 2007, we have been working on making Java web application development easier. Play started as an internal project at Zenexity (now [Zengularity](https://zengularity.com/en)) and was heavily influenced by our way of doing web projects: focusing on developer productivity, respecting web architecture, and using a fresh approach to packaging conventions from the start — breaking so-called JEE best practices where it made sense.

--- a/documentation/manual/gettingStarted/Anatomy.md
+++ b/documentation/manual/gettingStarted/Anatomy.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Anatomy of a Play application
 
 ## The Play application layout

--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Setting up your preferred IDE
 
 Working with Play is easy. You don’t even need a sophisticated IDE, because Play compiles and refreshes the modifications you make to your source files automatically, so you can easily work using a simple text editor.

--- a/documentation/manual/gettingStarted/Installing.md
+++ b/documentation/manual/gettingStarted/Installing.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Installing Play
 
 This page shows how to download, install and run a Play application.  There's a built in tutorial that shows you around, so running this Play application will show you how Play itself works!

--- a/documentation/manual/gettingStarted/LearningExamples.md
+++ b/documentation/manual/gettingStarted/LearningExamples.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Learning from Play Examples
 
 [Lightbend Tech Hub](https://developer.lightbend.com/start/?group=play) offers downloadable Play examples for Java and Scala. Play has many features, so rather than pack them all into one project, we've organized many examples that each showcase a Play feature or demonstrate a common use case. The zip files include everything you need to build and run the examples, including a distribution of the sbt and Gradle. Refer to the `README.md` file in the top-level project directory to learn more about the example.

--- a/documentation/manual/gettingStarted/NewApplication.md
+++ b/documentation/manual/gettingStarted/NewApplication.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Creating a New Application
 
 Play expects a specific project structure. If you already have [sbt installed](https://www.scala-sbt.org/1.x/docs/Setup.html), you can use a [giter8](http://www.foundweekends.org/giter8/) template, similar to a Maven archetype, to create a new Play project. This gives you the advantage of setting up your project folders, build structure, and development environment — all with one command.

--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Building Play from source
 
 If you want to use some unreleased changes for Play, or you want to contribute to the development of Play yourself, you'll need to compile Play from the source code. You’ll need a [Git client](https://git-scm.com/) to fetch the source.

--- a/documentation/manual/hacking/Documentation.md
+++ b/documentation/manual/hacking/Documentation.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Guidelines for writing Play documentation
 
 The Play documentation is written in Markdown format, with code samples extracted from compiled, run and tested source files.

--- a/documentation/manual/hacking/Issues.md
+++ b/documentation/manual/hacking/Issues.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Issues tracker
 
 We use GitHub as our issue tracker, at:

--- a/documentation/manual/hacking/Repositories.md
+++ b/documentation/manual/hacking/Repositories.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Artifact repositories
 
 ## Maven Central

--- a/documentation/manual/hacking/ThirdPartyTools.md
+++ b/documentation/manual/hacking/ThirdPartyTools.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # 3rd Party Tools
 
 A big THANK YOU! to these sponsors for their support of open source projects.

--- a/documentation/manual/hacking/Translations.md
+++ b/documentation/manual/hacking/Translations.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Translating the Play Documentation
 
 Play 2.3+ provides infrastructure to aid documentation translators in translating the Play documentation and keeping it up to date.

--- a/documentation/manual/hacking/WorkingWithGit.md
+++ b/documentation/manual/hacking/WorkingWithGit.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Working with Git
 
 This guide is designed to help new contributors get started with Play.  Some things mentioned here are conventions that we think are good and make contributing to Play easier, but they are certainly not prescriptive, you should use what works best for you.

--- a/documentation/manual/releases/Releases.md
+++ b/documentation/manual/releases/Releases.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # About Play releases
 
 Visit the [changelog page](https://www.playframework.com/changelog) to get started with the latest Play releases. This page lists all past Play releases starting from 2.x.

--- a/documentation/manual/releases/release21/Highlights21.md
+++ b/documentation/manual/releases/release21/Highlights21.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.1?
 
 ## Migration to Scala 2.10 

--- a/documentation/manual/releases/release21/Migration21.md
+++ b/documentation/manual/releases/release21/Migration21.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play 2.1 migration guide
 
 This is a guide for migrating from Play 2.0 to Play 2.1.

--- a/documentation/manual/releases/release22/Highlights22.md
+++ b/documentation/manual/releases/release22/Highlights22.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.2
 
 ## New results structure for Java and Scala

--- a/documentation/manual/releases/release22/Migration22.md
+++ b/documentation/manual/releases/release22/Migration22.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play 2.2 Migration Guide
 
 This is a guide for migrating from Play 2.1 to Play 2.2. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.1 Migration Guide|Migration21]].

--- a/documentation/manual/releases/release23/Highlights23.md
+++ b/documentation/manual/releases/release23/Highlights23.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.3
 
 This page highlights the new features of Play 2.3. If you want learn about the changes you need to make to migrate to Play 2.3, check out the [[Play 2.3 Migration Guide|Migration23]].

--- a/documentation/manual/releases/release23/Migration23.md
+++ b/documentation/manual/releases/release23/Migration23.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play 2.3 Migration Guide
 
 This is a guide for migrating from Play 2.2 to Play 2.3. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.2 Migration Guide|Migration22]].

--- a/documentation/manual/releases/release24/Highlights24.md
+++ b/documentation/manual/releases/release24/Highlights24.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.4
 
 This page highlights the new features of Play 2.4. If you want learn about the changes you need to make to migrate to Play 2.4, check out the [[Play 2.4 Migration Guide|Migration24]].

--- a/documentation/manual/releases/release24/ReactiveStreamsIntegration.md
+++ b/documentation/manual/releases/release24/ReactiveStreamsIntegration.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Reactive Streams integration (experimental)
 
 > **Play experimental libraries are not ready for production use**. APIs may change. Features may not work properly.

--- a/documentation/manual/releases/release24/migration24/Anorm.md
+++ b/documentation/manual/releases/release24/migration24/Anorm.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Anorm
 
 Anorm has been pulled out of the core of Play into a separately managed project that can have its own lifecycle.  To add a dependency on it, use:

--- a/documentation/manual/releases/release24/migration24/GlobalSettings.md
+++ b/documentation/manual/releases/release24/migration24/GlobalSettings.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Removing `GlobalSettings`
 
 If you are keen to use dependency injection, we are recommending that you move out of your `GlobalSettings` implementation class as much code as possible. Ideally, you should be able to refactor your code so that it is possible to eliminate your `GlobalSettings` class altogether.

--- a/documentation/manual/releases/release24/migration24/Migration24.md
+++ b/documentation/manual/releases/release24/migration24/Migration24.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play 2.4 Migration Guide
 
 This is a guide for migrating from Play 2.3 to Play 2.4. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.3 Migration Guide|Migration23]].

--- a/documentation/manual/releases/release24/migration24/PluginsToModules.md
+++ b/documentation/manual/releases/release24/migration24/PluginsToModules.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Migrating Plugin to Module
 
 > **Note:** The deprecated `play.Plugin` system is removed as of 2.5.x.

--- a/documentation/manual/releases/release25/Highlights25.md
+++ b/documentation/manual/releases/release25/Highlights25.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.5
 
 This page highlights the new features of Play 2.5. If you want to learn about the changes you need to make to migrate to Play 2.5, check out the [[Play 2.5 Migration Guide|Migration25]].

--- a/documentation/manual/releases/release25/migration25/CryptoMigration25.md
+++ b/documentation/manual/releases/release25/migration25/CryptoMigration25.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Crypto Migration Guide
 
 From Play 1.x, Play has come with a Crypto object that provides some cryptographic operations.  This used internally by Play.  The Crypto object is not mentioned in the documentation, but is mentioned as "cryptographic utilities" in the scaladoc:

--- a/documentation/manual/releases/release25/migration25/JavaMigration25.md
+++ b/documentation/manual/releases/release25/migration25/JavaMigration25.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Java Migration Guide
 
 In order to better fit in to the Java 8 ecosystem, and to allow Play Java users to make more idiomatic use of Java in their applications, Play has switched to using a number of Java 8 types such as `CompletionStage` and `Function`. Play also has new Java APIs for `EssentialAction`, `EssentialFilter`, `Router`, `BodyParser` and `HttpRequestHandler`.

--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play 2.5 Migration Guide
 
 This is a guide for migrating from Play 2.4 to Play 2.5. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.4 Migration Guide|Migration24]].

--- a/documentation/manual/releases/release25/migration25/StreamsMigration25.md
+++ b/documentation/manual/releases/release25/migration25/StreamsMigration25.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Streams Migration Guide
 
 Play 2.5 has made several major changes to how it streams data and response bodies.

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.6
 
 This page highlights the new features of Play 2.6. If you want to learn about the changes you need to make when you migrate to Play 2.6, check out the [[Play 2.6 Migration Guide|Migration26]].

--- a/documentation/manual/releases/release26/migration26/CacheMigration26.md
+++ b/documentation/manual/releases/release26/migration26/CacheMigration26.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Cache APIs Migration
 
 ## New packages

--- a/documentation/manual/releases/release26/migration26/JPAMigration26.md
+++ b/documentation/manual/releases/release26/migration26/JPAMigration26.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # JPA Migration
 
 ## Removed Deprecated Methods

--- a/documentation/manual/releases/release26/migration26/MessagesMigration26.md
+++ b/documentation/manual/releases/release26/migration26/MessagesMigration26.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # I18N API Migration
 
 There are a number of changes to the I18N API to make working with messages and languages easier to use, particularly with forms and templates.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play 2.6 Migration Guide
 
 This is a guide for migrating from Play 2.5 to Play 2.6. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.5 Migration Guide|Migration25]].

--- a/documentation/manual/releases/release26/migration26/WSMigration26.md
+++ b/documentation/manual/releases/release26/migration26/WSMigration26.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play WS Migration Guide
 
 Play WS now has a standalone version - [https://github.com/playframework/play-ws](https://github.com/playframework/play-ws) - that can be used outside a Play project. If you have a Play sbt project, you can still add WS by adding the following line to your `build.sbt`:

--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.7
 
 This page highlights the new features of Play 2.7. If you want to learn about the changes you need to make when you migrate to Play 2.7, check out the [[Play 2.7 Migration Guide|Migration27]].

--- a/documentation/manual/releases/release28/Highlights28.md
+++ b/documentation/manual/releases/release28/Highlights28.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.8
 
 This page highlights the new features of Play 2.8. If you want to learn about the changes you need to make when you migrate to Play 2.8, check out the [[Play 2.8 Migration Guide|Migration28]].

--- a/documentation/manual/releases/release29/Highlights29.md
+++ b/documentation/manual/releases/release29/Highlights29.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # What's new in Play 2.9
 
 This page highlights the new features of Play 2.9. If you want to learn about the changes you need to make when you migrate to Play 2.9, check out the [[Play 2.9 Migration Guide|Migration29]].

--- a/documentation/manual/tutorial/Tutorials.md
+++ b/documentation/manual/tutorial/Tutorials.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play Tutorials
 
 Play's documentation shows the available features and how to use them, but the documentation will not show how to create an application from start to finish.  This is where tutorials and examples come in.

--- a/documentation/manual/working/commonGuide/Modules.md
+++ b/documentation/manual/working/commonGuide/Modules.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Extending Play with modules
 
 At its core, Play is a very lightweight HTTP server, providing mechanisms for serving HTTP requests, but not much else. Additional functionality in Play is provided through the use of Play modules.

--- a/documentation/manual/working/commonGuide/akka/AkkaClusterSharding.md
+++ b/documentation/manual/working/commonGuide/akka/AkkaClusterSharding.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Cluster Sharding for Akka Typed (incubating)
 
 Play provides an [incubating](https://developer.lightbend.com/docs/lightbend-platform/introduction/getting-help/support-terminology.html) module for integration with [Akka Cluster Sharding Typed](https://doc.akka.io/docs/akka/2.6/typed/cluster-sharding.html). To enable this module, add the following dependency to your build:

--- a/documentation/manual/working/commonGuide/akka/AkkaIntegrations.md
+++ b/documentation/manual/working/commonGuide/akka/AkkaIntegrations.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Akka Advanced Integrations
 
 This section covers some topics related to working with advanced features in Akka.

--- a/documentation/manual/working/commonGuide/akka/AkkaTyped.md
+++ b/documentation/manual/working/commonGuide/akka/AkkaTyped.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Integrating with Akka Typed
 
 Akka 2.6 marked the new typed Actor API ("Akka Typed") as stable. The typed API is now officially the main API for Akka. In the typed API, each actor needs to declares which message type it is able to handle and the type system enforces that only messages of this type can be sent to the actor. Although Play does not fully adopt Akka Typed, we already provide some APIs to better integrate it in Play applications.

--- a/documentation/manual/working/commonGuide/assets/Assets.md
+++ b/documentation/manual/working/commonGuide/assets/Assets.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Static assets
 
 This section covers serving your application’s static resources such as JavaScript, CSS and images.

--- a/documentation/manual/working/commonGuide/assets/AssetsCoffeeScript.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsCoffeeScript.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Using CoffeeScript
 
 [CoffeeScript](https://coffeescript.org/) is a small and elegant language that compiles into JavaScript. It provides a nice syntax for writing JavaScript code.

--- a/documentation/manual/working/commonGuide/assets/AssetsJSHint.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsJSHint.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Using JSHint
 
 From its [website documentation](https://jshint.com/about/):

--- a/documentation/manual/working/commonGuide/assets/AssetsLess.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsLess.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Using LESS CSS
 
 [LESS CSS](http://lesscss.org/) is a dynamic stylesheet language. It allows considerable flexibility in the way you write CSS files including support for variables, mixins and more.

--- a/documentation/manual/working/commonGuide/assets/AssetsOverview.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsOverview.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Working with public assets
 
 Serving a public resource in Play is the same as serving any other HTTP request. It uses the same routing as regular resources using the controller/action path to distribute CSS, JavaScript or image files to the client.

--- a/documentation/manual/working/commonGuide/assets/AssetsSass.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsSass.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Using Sass
 
 [Sass](https://sass-lang.com/) is a dynamic stylesheet language. It allows considerable flexibility in the way you write CSS files including support for variables, mixins and more.

--- a/documentation/manual/working/commonGuide/assets/RequireJS-support.md
+++ b/documentation/manual/working/commonGuide/assets/RequireJS-support.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # RequireJS
 
 According to [RequireJS](https://requirejs.org/)' website 

--- a/documentation/manual/working/commonGuide/build/AggregatingReverseRouters.md
+++ b/documentation/manual/working/commonGuide/build/AggregatingReverseRouters.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Aggregating reverse routers
 
 In some situations you want to share reverse routers between sub projects that are not dependent on each other.

--- a/documentation/manual/working/commonGuide/build/Build.md
+++ b/documentation/manual/working/commonGuide/build/Build.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # The build system
 
 This section gives details about Play's build system.

--- a/documentation/manual/working/commonGuide/build/BuildOverview.md
+++ b/documentation/manual/working/commonGuide/build/BuildOverview.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Overview of the build system
 
 The Play build system uses [sbt](https://www.scala-sbt.org/), a high-performance integrated build for Scala and Java projects.  Using `sbt` as our build tool brings certain requirements to play which are explained on this page.

--- a/documentation/manual/working/commonGuide/build/CompilationSpeed.md
+++ b/documentation/manual/working/commonGuide/build/CompilationSpeed.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Improving Compilation Times
 
 Compilation speed can be improved by following some guidelines that are also good engineering practice:

--- a/documentation/manual/working/commonGuide/build/sbtCookbook.md
+++ b/documentation/manual/working/commonGuide/build/sbtCookbook.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # sbt Cookbook
 
 ## Hooking into Play's dev mode

--- a/documentation/manual/working/commonGuide/build/sbtDebugging.md
+++ b/documentation/manual/working/commonGuide/build/sbtDebugging.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Debugging your build
 
 If you are having difficulties getting sbt to do what you want it to do, you may need to use some of the built in utilities that sbt provides to help you debug your build.

--- a/documentation/manual/working/commonGuide/build/sbtDependencies.md
+++ b/documentation/manual/working/commonGuide/build/sbtDependencies.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Managing library dependencies
 
 > **Note:** Some sections of this page were copied from the sbt manual, specifically from the [Library Dependencies](https://www.scala-sbt.org/1.x/docs/Library-Dependencies.html) page. You can refer to that page for a more detailed and updated version of the information here.

--- a/documentation/manual/working/commonGuide/build/sbtSettings.md
+++ b/documentation/manual/working/commonGuide/build/sbtSettings.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # About sbt Settings
 
 ## About sbt settings

--- a/documentation/manual/working/commonGuide/build/sbtSubProjects.md
+++ b/documentation/manual/working/commonGuide/build/sbtSubProjects.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Working with sub-projects
 
 A complex project is not necessarily composed of a single Play application. You may want to split a large project into several smaller applications, or even extract some logic into a standard Java or Scala library that has nothing to do with a Play application.

--- a/documentation/manual/working/commonGuide/configuration/ApplicationSecret.md
+++ b/documentation/manual/working/commonGuide/configuration/ApplicationSecret.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # The Application Secret
 
 Play uses a secret key for a number of things, including:

--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuration file syntax and features
 
 > The configuration file used by Play is based on the [Typesafe config library](https://github.com/typesafehub/config).

--- a/documentation/manual/working/commonGuide/configuration/Configuration.md
+++ b/documentation/manual/working/commonGuide/configuration/Configuration.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuration
 
 This section explains how to configure your Play application.

--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring the Akka HTTP server backend
 
 By default, Play uses the [[Akka HTTP server backend|AkkaHttpServer]].

--- a/documentation/manual/working/commonGuide/configuration/SettingsJDBC.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsJDBC.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring the JDBC pool
 
 The Play JDBC datasource is managed by [HikariCP](https://github.com/brettwooldridge/HikariCP).

--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring logging
 
 Play uses SLF4J for logging, backed by [Logback](http://logback.qos.ch/) as its default logging engine.  See the [Logback documentation](http://logback.qos.ch/manual/configuration.html) for details on configuration.

--- a/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring Netty Server Backend
 
 The Netty server backend is built on top of [Netty](https://netty.io/).

--- a/documentation/manual/working/commonGuide/configuration/SettingsSession.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsSession.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring the session cookie
 
 Play stores the session using a session cookie in the browser.  When you are programming, you will typically access the session through the [[Scala API|ScalaSessionFlash]] or [[Java API|JavaSessionFlash]], but there are useful configuration settings.

--- a/documentation/manual/working/commonGuide/configuration/ThreadPools.md
+++ b/documentation/manual/working/commonGuide/configuration/ThreadPools.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Understanding Play thread pools
 
 Play Framework is, from the bottom up, an asynchronous web framework. Thread pools in Play are tuned to use fewer threads than in traditional web frameworks, since IO in play-core never blocks.

--- a/documentation/manual/working/commonGuide/configuration/WsCache.md
+++ b/documentation/manual/working/commonGuide/configuration/WsCache.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring WS Cache
 
 [[Play WS|ScalaWS]] allows you to set up HTTP caching from configuration.

--- a/documentation/manual/working/commonGuide/configuration/WsSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/WsSSL.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring WS SSL
 
 [[Play WS|ScalaWS]] allows you to set up HTTPS completely from a configuration file, without the need to write code.  It does this by layering the Java Secure Socket Extension (JSSE) with a configuration layer and with reasonable defaults.

--- a/documentation/manual/working/commonGuide/database/AccessingAnSQLDatabase.md
+++ b/documentation/manual/working/commonGuide/database/AccessingAnSQLDatabase.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Accessing an SQL database
 
 > **NOTE**: JDBC is a blocking operation that will cause threads to wait.  You can negatively impact the performance of your Play application by running JDBC queries directly in your controller!  Please see the "Configuring a CustomExecutionContext" section.

--- a/documentation/manual/working/commonGuide/database/Databases.md
+++ b/documentation/manual/working/commonGuide/database/Databases.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Working with Databases
 
 This section covers some topics related to working with databases in Play.

--- a/documentation/manual/working/commonGuide/database/Developing-with-the-H2-Database.md
+++ b/documentation/manual/working/commonGuide/database/Developing-with-the-H2-Database.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # H2 database
 
 > **Note:** From Play 2.6.x onwards you actually need to include the H2 Dependency on your own. To do this you just need to add the following to your build.sbt:

--- a/documentation/manual/working/commonGuide/database/Evolutions.md
+++ b/documentation/manual/working/commonGuide/database/Evolutions.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Managing database evolutions
 
 When you use a relational database, you need a way to track and organize your database schema evolutions. Typically there are several situations where you need a more sophisticated way to track your database schema changes:

--- a/documentation/manual/working/commonGuide/filters/AllowedHostsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/AllowedHostsFilter.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Allowed hosts filter
 
 Play provides a filter that lets you configure which hosts can access your application. This is useful to prevent cache poisoning attacks. For a detailed description of how this attack works, see [this blog post](https://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html). The filter introduces a whitelist of allowed hosts and sends a 400 (Bad Request) response to all requests with a host that do not match the whitelist.

--- a/documentation/manual/working/commonGuide/filters/CorsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/CorsFilter.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Cross-Origin Resource Sharing
 
 Play provides a filter that implements Cross-Origin Resource Sharing (CORS).

--- a/documentation/manual/working/commonGuide/filters/CspFilter.md
+++ b/documentation/manual/working/commonGuide/filters/CspFilter.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring Content Security Policy Headers
 
 A good content security policy (CSP) is an essential part of securing a website.  Used properly, CSP can make XSS and injection much harder for attackers, although some attacks are [still possible](https://csp.withgoogle.com/docs/faq.html#caveats).

--- a/documentation/manual/working/commonGuide/filters/Filters.md
+++ b/documentation/manual/working/commonGuide/filters/Filters.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Built-in HTTP filters
 
 Play provides several standard filters that can modify the HTTP behavior of your application. You can also write your own filters in either [[Java|JavaHttpFilters]] or [[Scala|ScalaHttpFilters]].

--- a/documentation/manual/working/commonGuide/filters/GzipEncoding.md
+++ b/documentation/manual/working/commonGuide/filters/GzipEncoding.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring gzip encoding
 
 Play provides a gzip filter that can be used to gzip responses.

--- a/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Redirect HTTPS Filter
 
 Play provides a filter which will redirect all HTTP requests to HTTPS automatically.

--- a/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
+++ b/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring Security Headers
 
 Play provides a security headers filter that can be used to configure some default headers in the HTTP response to mitigate security issues and provide an extra level of defense for new applications.

--- a/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
+++ b/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Configuring HTTPS
 
 Play can be configured to serve HTTPS.  To enable this, simply tell Play which port to listen to using the `https.port` system property.  For example:

--- a/documentation/manual/working/commonGuide/production/Deploying.md
+++ b/documentation/manual/working/commonGuide/production/Deploying.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Deploying your application
 
 We have seen how to run a Play application in development mode, however the `run` command should not be used to run an application in production mode.  When using `run`, on each request, Play checks with sbt to see if any files have changed, and this may have significant performance impacts on your application.

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Setting up a front end HTTP server
 
 You can easily deploy your application as a stand-alone server by setting the application HTTP port to 80:

--- a/documentation/manual/working/commonGuide/production/Production.md
+++ b/documentation/manual/working/commonGuide/production/Production.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Using Play in production
 
 This section covers topics related to building, configuring and deploying your Play application for production.

--- a/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
+++ b/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Production Configuration
 
 There are a number of different types of configuration that you can configure in production.  The three mains types are:

--- a/documentation/manual/working/commonGuide/production/cloud/Deploying-CleverCloud.md
+++ b/documentation/manual/working/commonGuide/production/cloud/Deploying-CleverCloud.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Deploying to Clever Cloud
 [Clever Cloud](https://www.clever-cloud.com/en/) is a Platform as a Service solution. You can deploy on it Scala, Java, PHP, Python and Node.js applications. Its main particularity is that it supports **automatic vertical and horizontal scaling**.
 

--- a/documentation/manual/working/commonGuide/production/cloud/Deploying-CloudCaptain.md
+++ b/documentation/manual/working/commonGuide/production/cloud/Deploying-CloudCaptain.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Deploying to CloudCaptain and AWS
 
 CloudCaptain lets you deploy your Play applications on AWS. It is based on 3 core principles: Immutable Infrastructure, Minimal Images and Blue/Green deployments.

--- a/documentation/manual/working/commonGuide/production/cloud/Deploying-CloudFoundry.md
+++ b/documentation/manual/working/commonGuide/production/cloud/Deploying-CloudFoundry.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Deploying to CloudFoundry / AppFog
 
 ## Prerequisites

--- a/documentation/manual/working/commonGuide/production/cloud/DeployingCloud.md
+++ b/documentation/manual/working/commonGuide/production/cloud/DeployingCloud.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Deploying a Play application to a cloud service
 
 Many third party cloud services have built in support for deploying Play applications.

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Deploying to Heroku
 
 [Heroku](https://www.heroku.com/) is a cloud application platform – a way of building and deploying web apps.

--- a/documentation/manual/working/commonGuide/schedule/ScheduledTasks.md
+++ b/documentation/manual/working/commonGuide/schedule/ScheduledTasks.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Scheduling asynchronous tasks
 
 You can schedule sending messages to actors and executing tasks (functions or `Runnable` instances). You will get a `Cancellable` back that you can call `cancel` on to cancel the execution of the scheduled operation.

--- a/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
+++ b/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Akka HTTP Server Backend
 
 Play uses the [Akka HTTP](https://doc.akka.io/docs/akka-http/current/index.html) server backend to implement HTTP requests and responses using Akka Streams over the network.  Akka HTTP implements a full server stack for HTTP, including full HTTPS support, and has support for HTTP/2.

--- a/documentation/manual/working/commonGuide/server/NettyServer.md
+++ b/documentation/manual/working/commonGuide/server/NettyServer.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Netty Server Backend
 
 Prior to Play 2.6.x, Play used the Netty server backend as the default.  In 2.6.x, the default backend was changed to Akka HTTP, but you can still manually select the Netty backend server in your project.

--- a/documentation/manual/working/commonGuide/server/Server.md
+++ b/documentation/manual/working/commonGuide/server/Server.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Server Backends
 
 Play comes with two configurable server backends, which handle the low level work of processing HTTP requests and responses to and from TCP/IP packets.

--- a/documentation/manual/working/commonGuide/shutdown/Shutdown.md
+++ b/documentation/manual/working/commonGuide/shutdown/Shutdown.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Coordinated Shutdown
 
 Play incorporates the use of Akka's [Coordinated Shutdown](https://doc.akka.io/docs/akka/2.6/actors.html?language=scala#coordinated-shutdown) but still didn't rely on it completely. While Coordinated Shutdown is responsible for the complete shutdown of Play, there is still the `ApplicationLifecycle` API, and it is Play's responsibility to exit the JVM.

--- a/documentation/manual/working/javaGuide/advanced/JavaAdvanced.md
+++ b/documentation/manual/working/javaGuide/advanced/JavaAdvanced.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Advanced topics for Java
 
 This section describes advanced techniques for writing Play applications in Java.

--- a/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlay.md
+++ b/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlay.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Embedding a Play server in your application
 
 While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.

--- a/documentation/manual/working/javaGuide/advanced/extending/JavaPlayModules.md
+++ b/documentation/manual/working/javaGuide/advanced/extending/JavaPlayModules.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Writing Play Modules
 
 > **Note:** This page covers the new [[module system|JavaDependencyInjection#Play-libraries]] to add new functionality to Play.

--- a/documentation/manual/working/javaGuide/advanced/extending/JavaPlugins.md
+++ b/documentation/manual/working/javaGuide/advanced/extending/JavaPlugins.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Writing Plugins
 
 > **Note:**  The `play.Plugin` API was deprecated in 2.4.x and is removed as of 2.5.x.

--- a/documentation/manual/working/javaGuide/advanced/routing/JavaJavascriptRouter.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/JavaJavascriptRouter.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Javascript Routing
 
 The play router is able to generate Javascript code to handle routing from Javascript running client side back to your application. The Javascript router aids in refactoring your application. If you change the structure of your URLs or parameter names your Javascript gets automatically updated to use that new structure.

--- a/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Routing DSL
 
 Play provides a DSL for routers directly in code.  This DSL has many uses, including embedding a light weight Play server, providing custom or more advanced routing capabilities to a regular Play application, and mocking REST services for testing.

--- a/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Custom Routing
 
 Play provides a mechanism to bind types from path or query string parameters. 

--- a/documentation/manual/working/javaGuide/main/JavaHome.md
+++ b/documentation/manual/working/javaGuide/main/JavaHome.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Main concepts for Java
 
 This section introduces you to the most common aspects of writing a Play application in Java. You'll learn about handling HTTP requests, sending HTTP responses, working with different types of data, using databases and much more.

--- a/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
+++ b/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Integrating with Akka
 
 [Akka](https://akka.io/) uses the Actor Model to raise the abstraction level and provide a better platform to build correct concurrent and scalable applications. For fault-tolerance it adopts the ‘Let it crash’ model, which has been used with great success in the telecoms industry to build applications that self-heal - systems that never stop. Actors also provide the abstraction for transparent distribution and the basis for truly scalable and fault-tolerant applications.

--- a/documentation/manual/working/javaGuide/main/application/JavaApplication.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaApplication.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Application Settings
 
 A running instance of Play is built around the `Application` class, the starting point for most of the application state for Play.  The Application is loaded through an `ApplicationLoader` and is configured with a disposable classloader so that changing a setting in development mode will reload the Application.  Most of the `Application` settings are configurable, but more complex behavior can be hooked into Play by binding the various handlers to a specific instance through dependency injection.

--- a/documentation/manual/working/javaGuide/main/application/JavaErrorHandling.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaErrorHandling.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling errors
 
 There are two main types of errors that an HTTP application can return - client errors and server errors.  Client errors indicate that the connecting client has done something wrong, server errors indicate that there is something wrong with the server.

--- a/documentation/manual/working/javaGuide/main/application/JavaEssentialAction.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaEssentialAction.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Introduction to Play HTTP API
 
 ## What is EssentialAction?

--- a/documentation/manual/working/javaGuide/main/application/JavaHttpFilters.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaHttpFilters.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Filters
 
 Play provides a simple filter API for applying global filters to each request.

--- a/documentation/manual/working/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaAsync.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling asynchronous results
 
 ## Make controllers asynchronous

--- a/documentation/manual/working/javaGuide/main/async/JavaComet.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaComet.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Comet
 
 ## Using chunked responses with Comet

--- a/documentation/manual/working/javaGuide/main/async/JavaStream.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaStream.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Streaming HTTP responses
 
 ## Standard responses and Content-Length header

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # WebSockets
 
 [WebSockets](https://en.wikipedia.org/wiki/WebSocket) are sockets that can be used from a web browser based on a protocol that allows two way full duplex communication.  The client can send messages and the server can receive messages at any time, as long as there is an active WebSocket connection between the server and the client.

--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # The Play cache API
 
 Caching data is a typical optimization in modern applications, and so Play provides a global cache.

--- a/documentation/manual/working/javaGuide/main/config/JavaConfig.md
+++ b/documentation/manual/working/javaGuide/main/config/JavaConfig.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # The Typesafe Config API
 
 Play uses the [Typesafe config library](https://github.com/typesafehub/config) as the configuration library. If you're not familiar with Typesafe config, you may also want to read the documentation on [[configuration file syntax and features|ConfigFile]].

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaCompileTimeDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaCompileTimeDependencyInjection.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Compile Time Dependency Injection
 
 Out of the box, Play provides a mechanism for runtime dependency injection - that is, dependency injection where dependencies aren't wired until runtime.  This approach has both advantages and disadvantages, the main advantages being around minimization of boilerplate code, the main disadvantage being that the construction of the application is not validated at compile time.

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Dependency Injection
 
 Dependency injection is a widely used design pattern that helps to separate your components' behaviour from dependency resolution.  Components declare their dependencies, usually as constructor parameters, and a dependency injection framework helps you wire together those components so you don't have to do so manually.

--- a/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Protecting against Cross Site Request Forgery
 
 Cross Site Request Forgery (CSRF) is a security exploit where an attacker tricks a victim's browser into making a request using the victim's session.  Since the session token is sent with every request, if an attacker can coerce the victim's browser to make a request on their behalf, the attacker can make requests on the user's behalf.

--- a/documentation/manual/working/javaGuide/main/forms/JavaFormHelpers.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaFormHelpers.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Form template helpers
 
 Play provides several helpers to help you render form fields in HTML templates.

--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling form submission
 
 ## Enabling/Disabling the forms module

--- a/documentation/manual/working/javaGuide/main/http/JavaActionCreator.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionCreator.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Intercepting HTTP requests
 
 Play's Java APIs provide two ways of intercepting action calls. The first is called `ActionCreator`, which provides a `createAction` method that is used to create the initial action used in action composition. It handles calling the actual method for your action, which allows you to intercept requests.

--- a/documentation/manual/working/javaGuide/main/http/JavaActions.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActions.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Actions, Controllers and Results
 
 ## What is an Action?

--- a/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Action composition
 
 This chapter introduces several ways to define generic action functionality.

--- a/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Body parsers
 
 ## What is a body parser?

--- a/documentation/manual/working/javaGuide/main/http/JavaContentNegotiation.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaContentNegotiation.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Content negotiation
 
 [Content negotiation](https://en.wikipedia.org/wiki/Content_negotiation) is a mechanism that makes it possible to serve different representation of a same resource (URI). It is useful *e.g.* for writing Web Services supporting several output formats (XML, JSON, etc.). Server-driven negotiation is essentially performed using the `Accept*` requests headers. You can find more information on content negotiation in the [HTTP specification](http://www.w3.org/Protocols/rfc2616/rfc2616-sec12.html).

--- a/documentation/manual/working/javaGuide/main/http/JavaResponse.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaResponse.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Manipulating Results
 
 ## Changing the default `Content-Type`

--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # HTTP routing
 
 ## The built-in HTTP router

--- a/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Session and Flash scopes
 
 ## How it is different in Play

--- a/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
+++ b/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Internationalization with Messages
 
 ## Specifying languages supported by your application

--- a/documentation/manual/working/javaGuide/main/json/JavaJsonActions.md
+++ b/documentation/manual/working/javaGuide/main/json/JavaJsonActions.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling and serving JSON
 
 In Java, Play uses the [Jackson](https://github.com/FasterXML/jackson#documentation) JSON library to convert objects to and from JSON. Play's actions work with the `JsonNode` type and the framework provides utility methods for conversion in the `play.libs.Json` API.

--- a/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
+++ b/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # The Logging API
 
 Using logging in your application can be useful for monitoring, debugging, error tracking, and business intelligence. Play uses [`SLF4J`](http://www.slf4j.org) as a logging facade with [Logback](http://logback.qos.ch/) as the default logging engine.

--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Using JPA to access your database
 
 ## Adding dependencies to your project

--- a/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Writing functional tests
 
 Play provides a number of classes and convenience methods that assist with functional testing. Most of these can be found either in the [`play.test`](api/java/play/test/package-summary.html) package or in the [`Helpers`](api/java/play/test/Helpers.html) class.

--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing your application
 
 Writing tests for your application can be an involved process. Play supports [JUnit](https://junit.org/junit4/) and provides helpers and application stubs to make testing your application as easy as possible.

--- a/documentation/manual/working/javaGuide/main/tests/JavaTestingWebServiceClients.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTestingWebServiceClients.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing web service clients
 
 A lot of code can go into writing a web service client - preparing the request, serializing and deserializing the bodies, setting the correct headers.  Since a lot of this code works with strings and weakly typed maps, testing it is very important.  However testing it also presents some challenges.  Some common approaches include:

--- a/documentation/manual/working/javaGuide/main/tests/JavaTestingWithDatabases.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTestingWithDatabases.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing with databases
 
 While it is possible to write [[functional tests|JavaFunctionalTest]] that test database access code by starting up a full application including the database, starting up a full application is not often desirable, due to the complexity of having many more components started and running just to test one small part of your application.

--- a/documentation/manual/working/javaGuide/main/tests/JavaTestingWithGuice.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTestingWithGuice.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing with Guice
 
 If you're using Guice for [[dependency injection|JavaDependencyInjection]] then you can directly configure how components and applications are created for tests. This includes adding extra bindings or overriding existing bindings.

--- a/documentation/manual/working/javaGuide/main/upload/JavaFileUpload.md
+++ b/documentation/manual/working/javaGuide/main/upload/JavaFileUpload.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling file upload
 
 ## Uploading files in a form using `multipart/form-data`

--- a/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # OAuth
 
 [OAuth](https://oauth.net/) is a simple way to publish and interact with protected data. It's also a safer and more secure way for people to give you access. For example, it can be used to access your users' data on [Twitter](https://dev.twitter.com/oauth/overview/introduction).

--- a/documentation/manual/working/javaGuide/main/ws/JavaOpenID.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOpenID.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # OpenID Support in Play
 
 [OpenID](https://openid.net/get-an-openid/what-is-openid/) is a protocol for users to access several services with a single account. As a web developer, you can use OpenID to offer users a way to log in using an account they already have, such as their [Google account](https://developers.google.com/accounts/docs/OpenID). In the enterprise, you may be able to use OpenID to connect to a company’s SSO server.

--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Calling REST APIs with Play WS
 
 Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its [WS ("WebService") library](api/java/play/libs/ws/package-summary.html), which provides a way to make asynchronous HTTP calls.

--- a/documentation/manual/working/javaGuide/main/xml/JavaXmlRequests.md
+++ b/documentation/manual/working/javaGuide/main/xml/JavaXmlRequests.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling and serving XML requests
 
 ## Handling an XML request

--- a/documentation/manual/working/scalaGuide/advanced/ScalaAdvanced.md
+++ b/documentation/manual/working/scalaGuide/advanced/ScalaAdvanced.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Advanced topics for Scala
 
 This section describes advanced techniques for writing Play applications in Scala.

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayAkkaHttp.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayAkkaHttp.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 #  Embedding an Akka Http server in your application
 
 While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application. This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary. A common use case is an application with only a few simple routes. To use Akka HTTP Server embedded, you will need the following dependency:

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Embedding a Netty server in your application
 
 While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application. This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary. A common use case is an application with only a few simple routes. To use Netty Server embedded, you will need the following dependency:

--- a/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlayModules.md
+++ b/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlayModules.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Writing Play Modules
 
 > **Note:** This page covers the new [[module system|ScalaDependencyInjection#Play-libraries]] to add functionality to Play.

--- a/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlugins.md
+++ b/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlugins.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Writing Plugins
 
 > **Note:**  The `play.api.Plugin` API was deprecated in 2.4.x and is removed as of 2.5.x.

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaJavascriptRouting.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaJavascriptRouting.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Javascript Routing
 
 The play router is able to generate Javascript code to handle routing from Javascript running client side back to your application. The Javascript router aids in refactoring your application. If you change the structure of your URLs or parameter names your Javascript gets automatically updated to use that new structure.

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Custom Routing
 
 Play provides a mechanism to bind types from path or query string parameters. 

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # String Interpolating Routing DSL
 
 Play provides a DSL for defining embedded routers called the *String Interpolating Routing DSL*, or sird for short.  This DSL has many uses, including embedding a light weight Play server, providing custom or more advanced routing capabilities to a regular Play application, and mocking REST services for testing.

--- a/documentation/manual/working/scalaGuide/main/ScalaHome.md
+++ b/documentation/manual/working/scalaGuide/main/ScalaHome.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Main concepts for Scala
 
 This section introduces you to the most common aspects of writing a Play application in Scala. You'll learn about handling HTTP requests, sending HTTP responses, working with different types of data, using databases and much more.

--- a/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Integrating with Akka
 
 [Akka](https://akka.io/) uses the Actor Model to raise the abstraction level and provide a better platform to build correct concurrent and scalable applications. For fault-tolerance it adopts the ‘Let it crash’ model, which has been used with great success in the telecoms industry to build applications that self-heal - systems that never stop. Actors also provide the abstraction for transparent distribution and the basis for truly scalable and fault-tolerant applications.

--- a/documentation/manual/working/scalaGuide/main/application/ScalaApplication.md
+++ b/documentation/manual/working/scalaGuide/main/application/ScalaApplication.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Application Settings
 
 A running instance of Play is built around the `Application` class, the starting point for most of the application state for Play.  The Application is loaded through an `ApplicationLoader` and is configured with a disposable classloader so that changing a setting in development mode will reload the Application.  Most of the `Application` settings are configurable, but more complex behavior can be hooked into Play by binding the various handlers to a specific instance through dependency injection.

--- a/documentation/manual/working/scalaGuide/main/application/ScalaEssentialAction.md
+++ b/documentation/manual/working/scalaGuide/main/application/ScalaEssentialAction.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Essential Action
 
 ## What is EssentialAction?

--- a/documentation/manual/working/scalaGuide/main/application/ScalaHttpFilters.md
+++ b/documentation/manual/working/scalaGuide/main/application/ScalaHttpFilters.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Filters
 
 Play provides a simple filter API for applying global filters to each request.

--- a/documentation/manual/working/scalaGuide/main/application/ScalaHttpRequestHandlers.md
+++ b/documentation/manual/working/scalaGuide/main/application/ScalaHttpRequestHandlers.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # HTTP Request Handlers
 
 Play provides a range of abstractions for routing requests to actions, providing routers and filters to allow most common needs.  Sometimes however an application will have more advanced needs that aren't met by Play's abstractions.  When this is the case, applications can provide custom implementations of Play's lowest level HTTP pipeline API, the [`HttpRequestHandler`](api/scala/play/api/http/HttpRequestHandler.html).

--- a/documentation/manual/working/scalaGuide/main/async/ScalaAsync.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaAsync.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling asynchronous results
 
 ## Make controllers asynchronous

--- a/documentation/manual/working/scalaGuide/main/async/ScalaComet.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaComet.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Comet
 
 ## Using chunked responses with Comet

--- a/documentation/manual/working/scalaGuide/main/async/ScalaStream.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaStream.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Streaming HTTP responses
 
 ## Standard responses and `Content-Length` header

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # WebSockets
 
 [WebSockets](https://en.wikipedia.org/wiki/WebSocket) are sockets that can be used from a web browser based on a protocol that allows two way full duplex communication.  The client can send messages and the server can receive messages at any time, as long as there is an active WebSocket connection between the server and the client.

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # The Play cache API
 
 Caching data is a typical optimization in modern applications, and so Play provides a global cache.

--- a/documentation/manual/working/scalaGuide/main/config/ScalaConfig.md
+++ b/documentation/manual/working/scalaGuide/main/config/ScalaConfig.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # The Scala Configuration API
 
 Play uses the [Typesafe config library](https://github.com/typesafehub/config), but Play also provides a nice Scala wrapper called [`Configuration`](api/scala/play/api/Configuration.html) with more advanced Scala features. If you're not familiar with Typesafe config, you may also want to read the documentation on [[configuration file syntax and features|ConfigFile]].

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaCompileTimeDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaCompileTimeDependencyInjection.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Compile Time Dependency Injection
 
 Out of the box, Play provides a mechanism for runtime dependency injection - that is, dependency injection where dependencies aren't wired until runtime.  This approach has both advantages and disadvantages, the main advantages being around minimization of boilerplate code, the main disadvantage being that the construction of the application is not validated at compile time.

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Dependency Injection
 
 Dependency injection is a widely used design pattern that helps separate your components' behaviour from dependency resolution.  Play supports both runtime dependency injection based on [JSR 330](https://jcp.org/en/jsr/detail?id=330) (described in this page) and [[compile time dependency injection|ScalaCompileTimeDependencyInjection]] in Scala.

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Protecting against Cross Site Request Forgery
 
 Cross Site Request Forgery (CSRF) is a security exploit where an attacker tricks a victim's browser into making a request using the victim's session.  Since the session token is sent with every request, if an attacker can coerce the victim's browser to make a request on their behalf, the attacker can make requests on the user's behalf.

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCustomFieldConstructors.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCustomFieldConstructors.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Custom Field Constructors
 
 A field rendering is not only composed of the `<input>` tag, but it also needs a `<label>` and possibly other tags used by your CSS framework to decorate the field.

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCustomValidations.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCustomValidations.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Using Custom Validations
 
 The [validation package](api/scala/play/api/data/validation/index.html) allows you to create ad-hoc constraints using the `verifying` method.  However, Play gives you the option of creating your own custom constraints, using the [`Constraint`](api/scala/play/api/data/validation/Constraint.html) case class.

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling form submission
 
 ## Overview

--- a/documentation/manual/working/scalaGuide/main/http/ScalaActions.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaActions.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Actions, Controllers and Results
 
 ## What is an Action?

--- a/documentation/manual/working/scalaGuide/main/http/ScalaActionsComposition.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaActionsComposition.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Action composition
 
 This chapter introduces several ways of defining generic action functionality.

--- a/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Body parsers
 
 ## What is a body parser?

--- a/documentation/manual/working/scalaGuide/main/http/ScalaContentNegotiation.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaContentNegotiation.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Content negotiation
 
 Content negotiation is a mechanism that makes it possible to serve different representation of a same resource (URI). It is useful *e.g.* for writing Web Services supporting several output formats (XML, JSON, etc.). Server-driven negotiation is essentially performed using the `Accept*` requests headers. You can find more information on content negotiation in the [HTTP specification](http://www.w3.org/Protocols/rfc2616/rfc2616-sec12.html).

--- a/documentation/manual/working/scalaGuide/main/http/ScalaErrorHandling.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaErrorHandling.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling errors
 
 There are two main types of errors that an HTTP application can return - client errors and server errors.  Client errors indicate that the connecting client has done something wrong, server errors indicate that there is something wrong with the server.

--- a/documentation/manual/working/scalaGuide/main/http/ScalaResults.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaResults.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Manipulating Results
 
 ## Changing the default `Content-Type`

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # HTTP routing
 
 ## The built-in HTTP router

--- a/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Session and Flash scopes
 
 ## How it is different in Play

--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Internationalization with Messages
 
 ## Specifying languages supported by your application

--- a/documentation/manual/working/scalaGuide/main/json/ScalaJsonHttp.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJsonHttp.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # JSON with HTTP
 
 Play supports HTTP requests and responses with a content type of JSON by using the HTTP API in combination with the JSON library.

--- a/documentation/manual/working/scalaGuide/main/logging/ScalaLogging.md
+++ b/documentation/manual/working/scalaGuide/main/logging/ScalaLogging.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # The Logging API
 
 Using logging in your application can be useful for monitoring, debugging, error tracking, and business intelligence. Play provides an API for logging which is accessed through the [`Logger`](api/scala/play/api/Logger$.html) object and uses [Logback](http://logback.qos.ch/) as the default logging engine.

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Writing functional tests with specs2
 
 Play provides a number of classes and convenience methods that assist with functional testing.  Most of these can be found either in the [`play.api.test`](api/scala/play/api/test/index.html) package or in the [`Helpers`](api/scala/play/api/test/Helpers$.html) object.

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWebServiceClients.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWebServiceClients.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing web service clients
 
 A lot of code can go into writing a web service client - preparing the request, serializing and deserializing the bodies, setting the correct headers.  Since a lot of this code works with strings and weakly typed maps, testing it is very important.  However testing it also presents some challenges.  Some common approaches include:

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithDatabases.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithDatabases.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing with databases
 
 While it is possible to write functional tests using [[ScalaTest|ScalaFunctionalTestingWithScalaTest]] or [[specs2|ScalaFunctionalTestingWithSpecs2]] that test database access code by starting up a full application including the database, starting up a full application is not often desirable, due to the complexity of having many more components started and running just to test one small part of your application.

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithGuice.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithGuice.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing with Guice
 
 If you're using Guice for [[dependency injection|ScalaDependencyInjection]] then you can directly configure how components and applications are created for tests. This includes adding extra bindings or overriding existing bindings.

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing your application with specs2
 
 Writing tests for your application can be an involved process.  Play provides a default test framework for you, and provides helpers and application stubs to make testing your application as easy as possible.

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingYourApplication.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingYourApplication.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Testing your application
 
 Writing tests for your application can be an involved process. Play offers integration with both [ScalaTest](http://www.scalatest.org) and [specs2](https://etorreborre.github.io/specs2/) and provides helpers and application stubs to make testing your application as easy as possible. For the details of using your preferred test framework with Play, see the pages on [[ScalaTest|ScalaTestingWithScalaTest]] or [[specs2|ScalaTestingWithSpecs2]].

--- a/documentation/manual/working/scalaGuide/main/upload/ScalaFileUpload.md
+++ b/documentation/manual/working/scalaGuide/main/upload/ScalaFileUpload.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling file upload
 
 ## Uploading files in a form using `multipart/form-data`

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaOAuth.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaOAuth.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # OAuth
 
 [OAuth](https://oauth.net/) is a simple way to publish and interact with protected data. It's also a safer and more secure way for people to give you access. For example, it can be used to access your users' data on [Twitter](https://dev.twitter.com/oauth/overview/introduction).

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaOpenID.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaOpenID.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # OpenID Support in Play
 
 OpenID is a protocol for users to access several services with a single account. As a web developer, you can use OpenID to offer users a way to log in using an account they already have, such as their [Google account](https://developers.google.com/accounts/docs/OpenID). In the enterprise, you may be able to use OpenID to connect to a company’s SSO server.

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Calling REST APIs with Play WS
 
 Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its [WS ("WebService") library](api/scala/play/api/libs/ws/index.html), which provides a way to make asynchronous HTTP calls through a WSClient instance.

--- a/documentation/manual/working/scalaGuide/main/xml/ScalaXmlRequests.md
+++ b/documentation/manual/working/scalaGuide/main/xml/ScalaXmlRequests.md
@@ -1,4 +1,5 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+
 # Handling and serving XML requests
 
 ## Handling an XML request


### PR DESCRIPTION
Makes the ancient [`addMarkdownCopyright`](https://github.com/playframework/playframework/blob/2.8.15/documentation/addMarkdownCopyright) script obsolete so we can remove it in #11142, since we have the sbt-header plugin now.
The empty line gets added by default when running `headerCreateAll`. We could set `headerEmptyLine := false`, however that does not really help, since there are many java and scala files which do have the empty line, meaning now these would be modified, this time automatically removing the empty line by the sbt-header plugin. 