### PR TITLE
Add workflow to trigger cache invalidation

### DIFF
--- a/.github/workflows/trigger-cache-invalidation.yml
+++ b/.github/workflows/trigger-cache-invalidation.yml
@@ -1,0 +1,8 @@
+name: Trigger cache invalidation
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-cache-invalidation:
+    uses: playframework/.github/.github/workflows/trigger-cache-invalidation.yml@clean-cache


### PR DESCRIPTION
Right now there is no possibility to clean the GH actions cache. Neither by UI, nor by REST api:
* https://github.com/actions/cache/issues/2
* https://github.community/t/how-to-clear-cache-in-github-actions/129038

However, there is one workaround (inspired by https://github.com/actions/cache/issues/2#issuecomment-1098723830):
[As stated in the docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy), given that...

> ...the total size of all caches in a repository is limited to 10 GB. If you exceed this limit, GitHub will save your cache but will begin evicting caches until the total size is less than 10 GB.

...we can fill up the cache with one big fat 10GB file, which will then cause older entries in the cache to be evicted (within a couple of hours).
The exact maximium amount of bytes for the cache is `10737418240`, as you can see in https://github.com/actions/toolkit/blob/91f9153ca87feb260480640429822005380ea9de/packages/cache/src/cache.ts#L174:
```ts
const fileSizeLimit = 10 * 1024 * 1024 * 1024 // 10GB per repo limit
```
So I created [this workflow](https://github.com/playframework/.github/blob/clean-cache/.github/workflows/trigger-cache-invalidation.yml), which generates a large file, which when compressed by GH actions will be just one byte below the maximum (`10737418239`, I was not able to generate the exact bytes, since of the compression algorithm)

I did test this in a demo repo of mine: https://github.com/mkurz/release-drafter-test/runs/6131011813?check_suite_focus=true#step:3:1 and it worked.
Running
```
curl https://api.github.com/repos/mkurz/release-drafter-test/actions/cache/usage
```
to check the cache size of that repo (see [api docs](https://docs.github.com/en/rest/actions/cache)), it dropped to 0.

As you can see in the output of the `Post Setup cache` step (`Cache Size: ~10240 MB (10737418239 B)`), like said there is just one byte missing. That's why I use `10737170860` bytes in the workflow (they will be compressed + some overhead of the tar file format)

Sure this is a bit of a dirty workound, but to test if we correctly set up our caching strategy for GH actions, it's good enough. (The idea is I want to have a workflow that caches all deps for each scala/sbt version we use, also caches all JVMs we want to run the tests with and then always reuse that cache. The problem is the the cache can not be updated once it was created, so what does not get cached at the beginning will never be cached)