### PR TITLE
Fix the GitHub actions cron job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -85,7 +85,7 @@ jobs:
         rm -rf ~/.ivy2/local
         sbt "${{needs.extra-vars.outputs.akka_version_opts}}" "${{needs.extra-vars.outputs.akka_http_version_opts}}" crossScalaVersions crossSbtVersions +publishLocal
       cache-path: ~/.ivy2/local/com.typesafe.play
-      cache-key: play-published-local-jdk8-${{ github.sha }}
+      cache-key: play-published-local-jdk8-${{ github.sha }}-${{ github.event_name != 'schedule' || github.run_id }}
 
   publish-local-jdk11:
     name: Publish Local
@@ -178,7 +178,7 @@ jobs:
           scripted play-sbt-plugin/*1of3
         "
       cache-path: ~/.ivy2/local/com.typesafe.play
-      cache-key: play-published-local-jdk8-${{ github.sha }}
+      cache-key: play-published-local-jdk8-${{ github.sha }}-${{ github.event_name != 'schedule' || github.run_id }}
 
   scripted-tests-2:
     name: Scripted Tests (2 of 3)
@@ -199,7 +199,7 @@ jobs:
           scripted play-sbt-plugin/*2of3
         "
       cache-path: ~/.ivy2/local/com.typesafe.play
-      cache-key: play-published-local-jdk8-${{ github.sha }}
+      cache-key: play-published-local-jdk8-${{ github.sha }}-${{ github.event_name != 'schedule' || github.run_id }}
 
   scripted-tests-3:
     name: Scripted Tests (3 of 3)
@@ -220,7 +220,7 @@ jobs:
           scripted play-sbt-plugin/*3of3
         "
       cache-path: ~/.ivy2/local/com.typesafe.play
-      cache-key: play-published-local-jdk8-${{ github.sha }}
+      cache-key: play-published-local-jdk8-${{ github.sha }}-${{ github.event_name != 'schedule' || github.run_id }}
 
   finish:
     name: Finish


### PR DESCRIPTION
The problem:
1. Let's assume the cache is empty.
1. A scheduled job starts and will fetch [the current akka snapshot version](https://github.com/playframework/playframework/blob/55238a2b42c2480712b92dd9d7ca486d8ab9a935/.github/workflows/build-test.yml#L29-L30)
1. Afterwards `publishLocal`. Because we are using akka snapshots, the published Play version will be something like `2.8.1+1638-55238a2b-SNAPSHOT-akka-2.6.19+52-00c1da99-SNAPSHOT-akka-http-10.1.15+4-8e825ed4-SNAPSHOT`. Artifacts will be cached with `play-published-local-jdk8-${{ github.sha }}`. (`github.sha` is the commit from the Play repo)
1. scripted test reuse artifacts from cache `play-published-local-jdk8-${{ github.sha }}`
1. Everything works

The scheduled jobs finished, nothing changed (and nothing will be changing) in the Play repository. But, because the akka team isn't lazy, **new commits get pushed to akka (or akka-http)**! So the next nightly looks like this:

1. The cache still contains the key `play-published-local-jdk8-${{ github.sha }}`
1. A scheduled job starts and will fetch [the **new** current akka snapshot version](https://github.com/playframework/playframework/blob/55238a2b42c2480712b92dd9d7ca486d8ab9a935/.github/workflows/build-test.yml#L29-L30)
1. Afterwards `publishLocal`. Because of the new akka snapshot version the published Play version will change to `2.8.1+1638-55238a2b-SNAPSHOT-akka-2.6.19+58-af1e7560-SNAPSHOT-akka-http-10.1.15+4-8e825ed4-SNAPSHOT`. **These artifacts will not be cached anymore since there was a cache hit for `play-published-local-jdk8-${{ github.sha }}`** already, because the Play commit-sha did *not* change. Since the GHA cache is immutable, the cache will not be updated.
1. scripted test reuse artifacts from cache `play-published-local-jdk8-${{ github.sha }}`. Since the cache for the `github.sha` id was not updated, the artifacts build with the new akka snapshot version is missing.
1. Fail!