### PR TITLE
10622 - java validation should use the same regex as scala validation

### DIFF
--- a/web/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -552,7 +552,7 @@ public class Constraints {
     public static final String message = "error.email";
     static final java.util.regex.Pattern regex =
         java.util.regex.Pattern.compile(
-            "\\b[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\\b");
+            "^[a-zA-Z0-9\\.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$");
 
     public EmailValidator() {}
 

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -934,6 +934,10 @@ trait FormSpec extends CommonFormSpec {
         .errors()
         .asScala must beEmpty
       userEmail
+        .bind(Lang.defaultLang(), TypedMap.empty(), Map("email" -> "-test@test.com").asJava)
+        .errors()
+        .asScala must beEmpty
+      userEmail
         .bind(Lang.defaultLang(), TypedMap.empty(), Map("email" -> "john@ex'ample.com").asJava)
         .errors()
         .asScala must not(beEmpty)


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/10622 by changing the java email regex to be the same as the scala one.