### PR TITLE
Prepare build for Scala3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,6 +148,21 @@ jobs:
       cache-path: ~/.ivy2/local/com.typesafe.play
       cache-key: play-published-local-jdk{0}-${{ github.sha }}-${{ github.event_name != 'schedule' || github.run_id }}
 
+  scala3-compilation:
+    name: Build with Scala3
+    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    with:
+      java: 11
+      scala: 3.1.2
+      # doing nothing for now, but as we progress we should add here the modules that are ready for compilation
+      # with Scala 3
+      # sbt "-Dscala.version=$SCALA_VERSION
+      #  Play / compile
+      #  Play / Test / compile
+      #  "
+      cmd: >-
+        sbt "-Dscala.version=$MATRIX_SCALA"
+
   finish:
     name: Finish
     if: github.event_name == 'pull_request'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -161,9 +161,7 @@ jobs:
       #  Play / Test / compile
       #  "
       cmd: >-
-        sbt "-Dscala.version=$MATRIX_SCALA
-        scalaVersion
-        "
+        sbt "-Dscala.version=$MATRIX_SCALA scalaVersion"
 
   finish:
     name: Finish

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -161,7 +161,7 @@ jobs:
       #  Play / Test / compile
       #  "
       cmd: >-
-        sbt "-Dscala.version=$MATRIX_SCALA scalaVersion"
+        sbt -Dscala.version=$MATRIX_SCALA scalaVersion
 
   finish:
     name: Finish

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -161,7 +161,9 @@ jobs:
       #  Play / Test / compile
       #  "
       cmd: >-
-        sbt "-Dscala.version=$MATRIX_SCALA"
+        sbt "-Dscala.version=$MATRIX_SCALA
+        scalaVersion
+        "
 
   finish:
     name: Finish


### PR DESCRIPTION
This is a initial setup to gradually start to compile with Scala3. 

The next step is to upgrade all the dependencies to their Scala3 releases. That can be challenging. I already run into an issue, for example spec2-mock was not published for Scala3.