### PR TITLE
Test against all Java versions, but only nightly

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -97,7 +97,7 @@ jobs:
       - "check-code-style-docs"
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
-      java: 11
+      java: 11, 8
       scala: 2.13.8
       add-dimensions: >-
         {
@@ -105,6 +105,7 @@ jobs:
         }
       exclude: >-
         [
+          { "java": "${{ github.event_name == 'schedule' || '11' }}" },
           { "sbt_test_task": "${{ github.event_name == 'schedule' || 'Play-Microbenchmark/jmh:run -i 1 -wi 0 -f 1 -t 1 -foe=true' }}" }
         ]
       cmd: sbt "${{needs.extra-vars.outputs.akka_version_opts}}" "${{needs.extra-vars.outputs.akka_http_version_opts}}" ++$MATRIX_SCALA "$MATRIX_SBT_TEST_TASK"
@@ -118,8 +119,12 @@ jobs:
       - "check-code-style-docs"
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
-      java: 11
+      java: 11, 8
       scala: 2.13.8
+      exclude: >-
+        [
+          { "java": "${{ github.event_name == 'schedule' || '11' }}" }
+        ]
       cmd: cd documentation && sbt "${{needs.extra-vars.outputs.akka_version_opts}}" "${{needs.extra-vars.outputs.akka_http_version_opts}}" ++$MATRIX_SCALA test
 
   scripted-tests:
@@ -129,13 +134,17 @@ jobs:
       - "publish-local"
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
-      java: 8
+      java: 11, 8
       scala: 2.13.8
       add-dimensions: >-
         {
           "sbt": [ "1.6.2" ],
           "sbt_steps": [ "*1of3", "*2of3", "*3of3" ]
         }
+      exclude: >-
+        [
+          { "java": "${{ github.event_name == 'schedule' || '11' }}" }
+        ]
       cmd: >-
         sbt "${{needs.extra-vars.outputs.akka_version_opts}}" "${{needs.extra-vars.outputs.akka_http_version_opts}}" "
           project Sbt-Plugin;


### PR DESCRIPTION
Make sure to test against all support Java version. When using travis we did not do that for the main branch because in travis only had 5 workers and everything was blocked when a cron build started. This is not a problem anymore with GHA.

Also the `build-test.yml` from the main branch is now almost identical with the `build-test.yml` fromt the 2.8.x branch - only in 2.8.x we still support Scala 2.12.x

(Of course we Java 8 will soon be replaced with Java 17 here)