### PR TITLE
avoid `postfixOps`. prepare Scala 3

### DIFF
--- a/core/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/core/play/src/main/scala/play/api/i18n/Messages.scala
@@ -118,7 +118,7 @@ object Messages extends MessagesImplicits {
   private[i18n] class MessagesParser(messageSource: MessageSource, messageSourceName: String) extends RegexParsers {
     override val whiteSpace = """^[ \t]+""".r
     val end                 = """^\s*""".r
-    val newLine             = namedError((("\r" ?) ~> "\n"), "End of line expected")
+    val newLine             = namedError((("\r".?) ~> "\n"), "End of line expected")
     val ignoreWhiteSpace    = opt(whiteSpace)
     val blankLine           = ignoreWhiteSpace <~ newLine ^^ (_ => Comment(""))
     val comment             = """^#.*""".r ^^ (s => Comment(s))
@@ -128,7 +128,7 @@ object Messages extends MessagesImplicits {
     val messagePattern = namedError(
       rep(
         ("""\""" ^^ (_ => "")) ~> (// Ignore the leading \
-        ("\r" ?) ~> "\n" ^^ (_ => "") | // Ignore escaped end of lines \
+        ("\r".?) ~> "\n" ^^ (_ => "") | // Ignore escaped end of lines \
           "n" ^^ (_ => "\n") |          // Translate literal \n to real newline
           """\""" |                     // Handle escaped \\
           "^.".r ^^ ("""\""" + _)) |


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes



## Purpose


## Background Context

postfixOps disabled with Scala 3 by default.

## References


