### PR TITLE
avoid `scala.Symbol` literal

### DIFF
--- a/core/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormSpec.scala
@@ -433,7 +433,7 @@ class FormSpec extends Specification {
 
   "reject boolean binding from an invalid json" in {
     val f = ScalaForms.booleanForm.bind(Json.obj("accepted" -> "foo"))
-    f.errors must not be 'empty
+    f.errors must not be Symbol("empty")
   }
 
   "correctly lookup error messages when using errorsAsJson" in {

--- a/core/play/src/test/scala/play/api/templates/TemplatesSpec.scala
+++ b/core/play/src/test/scala/play/api/templates/TemplatesSpec.scala
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 class TemplatesSpec extends Specification {
   "toHtmlArgs" should {
     "escape attribute values" in {
-      PlayMagic.toHtmlArgs(Map('foo -> """bar <>&"'""")).body must_== """foo="bar &lt;&gt;&amp;&quot;&#x27;""""
+      PlayMagic.toHtmlArgs(Map(Symbol("foo") -> """bar <>&"'""")).body must_== """foo="bar &lt;&gt;&amp;&quot;&#x27;""""
     }
   }
 


### PR DESCRIPTION
# Pull Request Checklist



* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose


## Background Context

Symbol literal removed since Scala 3.

## References

