### PR TITLE
deprecate `Collections.unfoldLeft`

### DIFF
--- a/core/play/src/main/scala/play/api/libs/Collections.scala
+++ b/core/play/src/main/scala/play/api/libs/Collections.scala
@@ -26,6 +26,7 @@ object Collections {
    * @param seed Initial value.
    * @param f Function producing the List elements.
    */
+  @deprecated(message = "use Seq.unfold", since = "2.9.0")
   def unfoldLeft[A, B](seed: B)(f: B => Option[(B, A)]): Seq[A] = {
     def loop(seed: B)(ls: List[A]): List[A] = f(seed) match {
       case Some((b, a)) => loop(b)(a :: ls)


### PR DESCRIPTION
# Pull Request Checklist


* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose

deprecate `unfoldLeft`. use `scala.Seq.unfold`

## Background Context

- Scala std lib add `Seq.unfold` since 2.13. https://github.com/scala/scala/blob/7952071b88a85e2502e9ecd4e8bd57040d9448f5/src/library/scala/collection/Factory.scala#L114-L124
- playframework dropped Scala 2.12 https://github.com/playframework/playframework/pull/10956

## References
