### PR TITLE
fix TypedAkka.scala. prepare Scala 3

### DIFF
--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/TypedAkka.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/TypedAkka.scala
@@ -35,7 +35,7 @@ private[play] object TypedAkka {
     tpe.getActualTypeArguments()(0).asInstanceOf[Class[T]]
   }
 
-  private def typeLiteral[C[_], T](cls: Class[_])(implicit C: ClassTag[C[_]]) = {
+  private def typeLiteral[C[_], T](cls: Class[_])(implicit C: ClassTag[C[Any]]) = {
     val parameterizedType = Types.newParameterizedType(C.runtimeClass, cls)
     TypeLiteral.get(parameterizedType).asInstanceOf[TypeLiteral[C[T]]]
   }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes

Fixes compile error in Scala 3.

## Purpose

use `Any` instead of `_`

## Background Context

```scala
Welcome to Scala 3.1.2 (11.0.15, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                                                                                             
scala> import scala.reflect.ClassTag
                                                                                                                                                                                                                                             
scala> def typeLiteral[C[_], T](cls: Class[_])(implicit C: ClassTag[C[_]]) = null
-- [E043] Type Error: ----------------------------------------------------------
1 |def typeLiteral[C[_], T](cls: Class[_])(implicit C: ClassTag[C[_]]) = null
  |                                                             ^^^^
  |     unreducible application of higher-kinded type C to wildcard arguments

longer explanation available when compiling with `-explain`
1 error found
                                                                                                     
scala> def typeLiteral[C[_], T](cls: Class[_])(implicit C: ClassTag[C[?]]) = null
-- [E043] Type Error: ----------------------------------------------------------
1 |def typeLiteral[C[_], T](cls: Class[_])(implicit C: ClassTag[C[?]]) = null
  |                                                             ^^^^
  |     unreducible application of higher-kinded type C to wildcard arguments

longer explanation available when compiling with `-explain`
1 error found
                                                                                                                                                                                          
scala> def typeLiteral[C[_], T](cls: Class[_])(implicit C: ClassTag[C[Any]]) = null
def typeLiteral
  [C[_$1], T](cls: Class[?])(implicit C: reflect.ClassTag[C[Any]]): Null
```

## References



- https://github.com/playframework/playframework/issues/11260