### PR TITLE
avoid `compat.java8.OptionConverters`

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
@@ -44,7 +44,7 @@ class JavaHttpErrorHandlingSpec
     override def create(): ScalaApplication = {
       val components = new BuiltInComponentsFromContext(applicationContext) with RoutingDslComponents {
         import scala.jdk.CollectionConverters._
-        import scala.compat.java8.OptionConverters
+        import scala.jdk.OptionConverters._
 
         // Add the web command handler if it is available
         webCommandHandler.foreach(webCommands().addHandler)
@@ -66,7 +66,7 @@ class JavaHttpErrorHandlingSpec
 
         //  Config config, Environment environment, OptionalSourceMapper sourceMapper, Provider<Router> routes
         override def httpErrorHandler(): HttpErrorHandler = {
-          val mapper = OptionConverters.toScala(applicationContext.devContext()).map(_.sourceMapper)
+          val mapper = (applicationContext.devContext()).map(_.sourceMapper).toScala
 
           val routesProvider: Provider[play.api.routing.Router] = new Provider[play.api.routing.Router] {
             override def get(): play.api.routing.Router = router().asScala()

--- a/core/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/core/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -14,11 +14,11 @@ import scala.collection.convert.ToScalaImplicits
 
 /** Defines a magic helper for Play templates in a Java context. */
 object PlayMagicForJava extends ToScalaImplicits with ToJavaImplicits {
-  import scala.compat.java8.OptionConverters._
+  import scala.jdk.OptionConverters._
   import scala.language.implicitConversions
 
   /** Transforms a Play Java `Optional` to a proper Scala `Option`. */
-  implicit def javaOptionToScala[T](x: Optional[T]): Option[T] = x.asScala
+  implicit def javaOptionToScala[T](x: Optional[T]): Option[T] = x.toScala
 
   @implicitNotFound(
     """An implicit play.mvc.Http.RequestHeader (or play.mvc.Http.Request) is necessary so that it can be converted to a play.api.mvc.RequestHeader.

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -20,7 +20,7 @@ import scala.compat.java8.FutureConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 /**
  * An accumulator of elements into a future of a result.
@@ -201,7 +201,7 @@ private class StrictAccumulator[-E, +A](handler: Option[E] => Future[A], val toS
 
   override def asJava: play.libs.streams.Accumulator[E @uV, A @uV] =
     play.libs.streams.Accumulator.strict(
-      (t: Optional[E]) => handler(t.asScala).toJava,
+      (t: Optional[E]) => handler(t.toScala).toJava,
       toSink.mapMaterializedValue(FutureConverters.toJava).asJava
     )
 }

--- a/core/play/src/main/scala/play/api/http/HttpEntity.scala
+++ b/core/play/src/main/scala/play/api/http/HttpEntity.scala
@@ -10,7 +10,7 @@ import akka.util.ByteString
 import play.api.mvc.Headers
 import play.http.{ HttpEntity => JHttpEntity }
 
-import scala.compat.java8.OptionConverters
+import scala.jdk.OptionConverters._
 import scala.concurrent.Future
 
 /**
@@ -80,7 +80,7 @@ object HttpEntity {
     def contentLength                                    = Some(data.size)
     def dataStream                                       = if (data.isEmpty) Source.empty[ByteString] else Source.single(data)
     override def consumeData(implicit mat: Materializer) = Future.successful(data)
-    def asJava                                           = new JHttpEntity.Strict(data, OptionConverters.toJava(contentType))
+    def asJava                                           = new JHttpEntity.Strict(data, contentType.toJava)
     def as(contentType: String)                          = copy(contentType = Option(contentType))
   }
 
@@ -99,8 +99,8 @@ object HttpEntity {
     def asJava =
       new JHttpEntity.Streamed(
         data.asJava,
-        OptionConverters.toJava(contentLength.asInstanceOf[Option[java.lang.Long]]),
-        OptionConverters.toJava(contentType)
+        contentLength.asInstanceOf[Option[java.lang.Long]].toJava,
+        contentType.toJava
       )
     def as(contentType: String) = copy(contentType = Option(contentType))
   }
@@ -120,7 +120,7 @@ object HttpEntity {
     def dataStream = chunks.collect {
       case HttpChunk.Chunk(data) => data
     }
-    def asJava                  = new JHttpEntity.Chunked(chunks.asJava, OptionConverters.toJava(contentType))
+    def asJava                  = new JHttpEntity.Chunked(chunks.asJava, contentType.toJava)
     def as(contentType: String) = copy(contentType = Option(contentType))
   }
 }

--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -15,7 +15,7 @@ import java.util.UUID
 import scala.annotation._
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import reflect.ClassTag
 
@@ -262,25 +262,25 @@ object JavascriptLiteral {
    * Convert a Java Optional to Javascript literal (use "null" for an empty Optional)
    */
   implicit def literalJavaOption[T](implicit jsl: JavascriptLiteral[T]): JavascriptLiteral[Optional[T]] =
-    (value: Optional[T]) => value.asScala.map(jsl.to(_)).getOrElse("null")
+    (value: Optional[T]) => value.toScala.map(jsl.to(_)).getOrElse("null")
 
   /**
    * Convert a Java OptionalInt to Javascript literal (use "null" for an empty OptionalInt)
    */
   implicit def literalJavaOptionalInt: JavascriptLiteral[OptionalInt] =
-    (value: OptionalInt) => value.asScala.map(_.toString).getOrElse("null")
+    (value: OptionalInt) => value.toScala.map(_.toString).getOrElse("null")
 
   /**
    * Convert a Java OptionalLong to Javascript literal (use "null" for an empty OptionalLong)
    */
   implicit def literalJavaOptionalLong: JavascriptLiteral[OptionalLong] =
-    (value: OptionalLong) => value.asScala.map(_.toString).getOrElse("null")
+    (value: OptionalLong) => value.toScala.map(_.toString).getOrElse("null")
 
   /**
    * Convert a Java OptionalDouble to Javascript literal (use "null" for an empty OptionalDouble)
    */
   implicit def literalJavaOptionalDouble: JavascriptLiteral[OptionalDouble] =
-    (value: OptionalDouble) => value.asScala.map(_.toString).getOrElse("null")
+    (value: OptionalDouble) => value.toScala.map(_.toString).getOrElse("null")
 
   /**
    * Convert a Play Asset to Javascript String
@@ -490,7 +490,7 @@ object QueryStringBindable {
         )
       }
       def unbind(key: String, value: Optional[T]) = {
-        value.asScala.map(implicitly[QueryStringBindable[T]].unbind(key, _)).getOrElse("")
+        value.toScala.map(implicitly[QueryStringBindable[T]].unbind(key, _)).getOrElse("")
       }
       override def javascriptUnbind = javascriptUnbindOption(implicitly[QueryStringBindable[T]].javascriptUnbind)
     }
@@ -507,7 +507,7 @@ object QueryStringBindable {
           .getOrElse(Right(OptionalInt.empty))
       )
     }
-    def unbind(key: String, value: OptionalInt) = value.asScala.getOrElse(0).toString
+    def unbind(key: String, value: OptionalInt) = value.toScala.getOrElse(0).toString
     override def javascriptUnbind               = javascriptUnbindOption(super.javascriptUnbind)
   }
 
@@ -523,7 +523,7 @@ object QueryStringBindable {
           .getOrElse(Right(OptionalLong.empty))
       )
     }
-    def unbind(key: String, value: OptionalLong) = value.asScala.getOrElse(0L).toString
+    def unbind(key: String, value: OptionalLong) = value.toScala.getOrElse(0L).toString
     override def javascriptUnbind                = javascriptUnbindOption(super.javascriptUnbind)
   }
 
@@ -540,7 +540,7 @@ object QueryStringBindable {
             .getOrElse(Right(OptionalDouble.empty))
         )
       }
-      def unbind(key: String, value: OptionalDouble) = value.asScala.getOrElse(0.0).toString
+      def unbind(key: String, value: OptionalDouble) = value.toScala.getOrElse(0.0).toString
       override def javascriptUnbind                  = javascriptUnbindOption(super.javascriptUnbind)
     }
 

--- a/core/play/src/main/scala/play/api/templates/Templates.scala
+++ b/core/play/src/main/scala/play/api/templates/Templates.scala
@@ -9,7 +9,7 @@ import java.util.Optional
 import play.twirl.api.Html
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 /** Defines a magic helper for Play templates. */
 object PlayMagic {
@@ -44,9 +44,9 @@ object PlayMagic {
     case Some(key: String) => Some(p.messages(key))
     case Some(key: Html)   => Some(Html(p.messages(key.toString)))
     case key: Optional[_] =>
-      key.asScala match {
-        case Some(key: String) => Some(p.messages(key)).asJava
-        case Some(key: Html)   => Some(Html(p.messages(key.toString))).asJava
+      key.toScala match {
+        case Some(key: String) => Some(p.messages(key)).toJava
+        case Some(key: Html)   => Some(Html(p.messages(key.toString))).toJava
         case _                 => arg
       }
     case keys: Seq[_]            => keys.map(key => translate(key))

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -37,7 +37,7 @@ import play.mvc.Http.{ RequestImpl => JRequestImpl }
 import play.mvc.Http
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters
+import scala.jdk.OptionConverters._
 
 /**
  * Provides helper methods that manage Java to Scala Result and Scala to Java Context
@@ -227,14 +227,14 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def cookies = JavaHelpers.cookiesToJavaCookies(header.cookies)
 
-  override def clientCertificateChain() = OptionConverters.toJava(header.clientCertificateChain.map(_.asJava))
+  override def clientCertificateChain() = header.clientCertificateChain.map(_.asJava).toJava
 
   @deprecated
   override def getQueryString(key: String): String = {
     if (queryString().containsKey(key) && queryString().get(key).length > 0) queryString().get(key)(0) else null
   }
 
-  override def queryString(key: String): Optional[String] = OptionConverters.toJava(header.getQueryString(key))
+  override def queryString(key: String): Optional[String] = header.getQueryString(key).toJava
 
   @deprecated override def cookie(name: String): JCookie = cookies().get(name).orElse(null)
 
@@ -242,9 +242,9 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def hasBody: Boolean = header.hasBody
 
-  override def contentType(): Optional[String] = OptionConverters.toJava(header.contentType)
+  override def contentType(): Optional[String] = (header.contentType).toJava
 
-  override def charset(): Optional[String] = OptionConverters.toJava(header.charset)
+  override def charset(): Optional[String] = (header.charset).toJava
 
   override def withTransientLang(lang: play.i18n.Lang): JRequestHeader = addAttr(i18n.Messages.Attrs.CurrentLang, lang)
 

--- a/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
@@ -13,7 +13,7 @@ import akka.annotation.ApiMayChange
 import play.mvc.RangeResults
 import play.mvc.Result
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 import akka.stream.javadsl.Source
 import akka.util.ByteString
 import play.api.mvc.RangeResult
@@ -26,7 +26,7 @@ object JavaRangeResult {
   private type ScalaSource = akka.stream.scaladsl.Source[ByteString, _]
 
   def ofStream(stream: InputStream, rangeHeader: OptString, fileName: String, contentType: OptString): Result = {
-    RangeResult.ofStream(stream, rangeHeader.asScala, fileName, contentType.asScala).asJava
+    RangeResult.ofStream(stream, rangeHeader.toScala, fileName, contentType.toScala).asJava
   }
 
   def ofStream(
@@ -36,23 +36,23 @@ object JavaRangeResult {
       fileName: String,
       contentType: OptString
   ): Result = {
-    RangeResult.ofStream(entityLength, stream, rangeHeader.asScala, fileName, contentType.asScala).asJava
+    RangeResult.ofStream(entityLength, stream, rangeHeader.toScala, fileName, contentType.toScala).asJava
   }
 
   def ofPath(path: Path, rangeHeader: OptString, contentType: OptString): Result = {
-    RangeResult.ofPath(path, rangeHeader.asScala, contentType.asScala).asJava
+    RangeResult.ofPath(path, rangeHeader.toScala, contentType.toScala).asJava
   }
 
   def ofPath(path: Path, rangeHeader: OptString, fileName: String, contentType: OptString): Result = {
-    RangeResult.ofPath(path, rangeHeader.asScala, fileName, contentType.asScala).asJava
+    RangeResult.ofPath(path, rangeHeader.toScala, fileName, contentType.toScala).asJava
   }
 
   def ofFile(file: File, rangeHeader: OptString, contentType: OptString): Result = {
-    RangeResult.ofFile(file, rangeHeader.asScala, contentType.asScala).asJava
+    RangeResult.ofFile(file, rangeHeader.toScala, contentType.toScala).asJava
   }
 
   def ofFile(file: File, rangeHeader: OptString, fileName: String, contentType: OptString): Result = {
-    RangeResult.ofFile(file, rangeHeader.asScala, fileName, contentType.asScala).asJava
+    RangeResult.ofFile(file, rangeHeader.toScala, fileName, contentType.toScala).asJava
   }
 
   def ofSource(
@@ -63,7 +63,7 @@ object JavaRangeResult {
       contentType: OptString
   ): Result = {
     RangeResult
-      .ofSource(entityLength, source.asScala, rangeHeader.asScala, fileName.asScala, contentType.asScala)
+      .ofSource(entityLength, source.asScala, rangeHeader.toScala, fileName.toScala, contentType.toScala)
       .asJava
   }
 
@@ -75,7 +75,7 @@ object JavaRangeResult {
       contentType: OptString
   ): Result = {
     RangeResult
-      .ofSource(entityLength.asScala, source.asScala, rangeHeader.asScala, fileName.asScala, contentType.asScala)
+      .ofSource(entityLength.toScala, source.asScala, rangeHeader.toScala, fileName.toScala, contentType.toScala)
       .asJava
   }
 
@@ -92,7 +92,7 @@ object JavaRangeResult {
       (result.getOffset, result.getSource.asScala)
     }
     RangeResult
-      .ofSource(entityLength.asScala, getSourceAsScala, rangeHeader.asScala, fileName.asScala, contentType.asScala)
+      .ofSource(entityLength.toScala, getSourceAsScala, rangeHeader.toScala, fileName.toScala, contentType.toScala)
       .asJava
   }
 }

--- a/core/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
@@ -10,13 +10,13 @@ import play.mvc.Http.RequestHeader
 import play.routing.Router.RouteDocumentation
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 /**
  * Adapts the Scala router to the Java Router API
  */
 class JavaRouterAdapter @Inject() (underlying: play.api.routing.Router) extends play.routing.Router {
-  def route(requestHeader: RequestHeader) = underlying.handlerFor(requestHeader.asScala()).asJava
+  def route(requestHeader: RequestHeader) = underlying.handlerFor(requestHeader.asScala()).toJava
   def withPrefix(prefix: String)          = new JavaRouterAdapter(asScala.withPrefix(prefix))
   def documentation() =
     asScala.documentation.map {

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -17,7 +17,7 @@ import play.libs.reflect.MethodUtils
 import play.mvc.Http.RequestBody
 
 import scala.compat.java8.FutureConverters
-import scala.compat.java8.OptionConverters
+import scala.jdk.OptionConverters._
 import scala.util.control.NonFatal
 
 /**
@@ -185,7 +185,7 @@ object HandlerInvokerFactory {
                       case PingMessage(data)   => new JMessage.Ping(data)
                       case PongMessage(data)   => new JMessage.Pong(data)
                       case CloseMessage(code, reason) =>
-                        new JMessage.Close(OptionConverters.toJava(code).asInstanceOf[Optional[Integer]], reason)
+                        new JMessage.Close(code.toJava.asInstanceOf[Optional[Integer]], reason)
                     }
                     .via(resultOrFlow.right.get.asScala)
                     .map {
@@ -194,7 +194,7 @@ object HandlerInvokerFactory {
                       case ping: JMessage.Ping     => PingMessage(ping.data)
                       case pong: JMessage.Pong     => PongMessage(pong.data)
                       case close: JMessage.Close =>
-                        CloseMessage(OptionConverters.toScala(close.code).asInstanceOf[Option[Int]], close.reason)
+                        CloseMessage(close.code.toScala.asInstanceOf[Option[Int]], close.reason)
                     }
                 )
               }

--- a/core/play/src/test/scala/play/mvc/DefaultBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/DefaultBodyParserSpec.scala
@@ -21,7 +21,7 @@ import play.http.HttpErrorHandler
 import play.libs.F
 import play.mvc.Http.RequestBody
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 class DefaultBodyParserSpec extends Specification with AfterAll with MustMatchers {
   "Java DefaultBodyParserSpec" title
@@ -62,7 +62,7 @@ class DefaultBodyParserSpec extends Specification with AfterAll with MustMatcher
         new Http.RequestBuilder().method("POST").body(new RequestBody(body.utf8String), "text/plain").req
       postRequest.hasBody must beFalse
       parse(req(postRequest), body) must beRight[Object].like {
-        case empty: Optional[_] => empty.asScala must beNone
+        case empty: Optional[_] => empty.toScala must beNone
       }
     }
     "handle 'Content-Length: 1' header as non-empty body" in {
@@ -80,7 +80,7 @@ class DefaultBodyParserSpec extends Specification with AfterAll with MustMatcher
         new Http.RequestBuilder().method("POST").body(new RequestBody(null), "text/plain").req
       postRequest.hasBody must beFalse
       parse(req(postRequest), body) must beRight[Object].like {
-        case empty: Optional[_] => empty.asScala must beNone
+        case empty: Optional[_] => empty.toScala must beNone
       }
     }
     "handle missing Content-Length and Transfer-Encoding headers as empty body (containing Optional.empty)" in {
@@ -89,7 +89,7 @@ class DefaultBodyParserSpec extends Specification with AfterAll with MustMatcher
         new Http.RequestBuilder().method("POST").req
       postRequest.hasBody must beFalse
       parse(req(postRequest), body) must beRight[Object].like {
-        case empty: Optional[_] => empty.asScala must beNone
+        case empty: Optional[_] => empty.toScala must beNone
       }
     }
   }

--- a/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
@@ -26,7 +26,7 @@ import play.http.DefaultHttpErrorHandler
 import play.libs.F
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.language.existentials
 
 class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatchers {
@@ -64,8 +64,8 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatch
   }
 
   def maxLengthEnforced(result: F.Either[Result, _]) = {
-    result.left.asScala.map(_.status) must beSome(Status.REQUEST_ENTITY_TOO_LARGE)
-    result.right.asScala must beNone
+    result.left.toScala.map(_.status) must beSome(Status.REQUEST_ENTITY_TOO_LARGE)
+    result.right.toScala must beNone
   }
 
   val bodyParsers: Seq[(BodyParser[_], Option[String], ByteString)] = Seq(
@@ -153,8 +153,8 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatch
             food = data,
             ai = ai
           )
-          result.left.asScala must beNone
-          result.right.asScala must beSome // successfully parsed
+          result.left.toScala must beNone
+          result.right.toScala must beSome // successfully parsed
           ai.get must_== 1                 // also makes sure parsing took place
         }
       }
@@ -173,8 +173,8 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatch
             food = data,
             ai = ai
           )
-          result.left.asScala must beNone
-          result.right.asScala must beSome // successfully parsed
+          result.left.toScala must beNone
+          result.right.toScala must beSome // successfully parsed
           ai.get must_== 1                 // also makes sure parsing took place
         }
       }

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -14,7 +14,7 @@ import play.api.mvc.request.RemoteConnection
 import play.api.mvc.request.RequestTarget
 import play.mvc.Http.HeaderNames
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.jdk.CollectionConverters._
 
 class RequestHeaderSpec extends Specification {
@@ -42,8 +42,8 @@ class RequestHeaderSpec extends Specification {
       }
 
       "get a single header value" in {
-        toScala(headers().get("a")) must beSome("b1")
-        toScala(headers().get("c")) must beSome("d1")
+        headers().get("a").toScala must beSome("b1")
+        headers().get("c").toScala must beSome("d1")
       }
 
       "get all header values" in {
@@ -53,11 +53,11 @@ class RequestHeaderSpec extends Specification {
 
       "handle header names case insensitively" in {
         "when getting the header" in {
-          toScala(headers().get("a")) must beSome("b1")
-          toScala(headers().get("c")) must beSome("d1")
+          headers().get("a").toScala must beSome("b1")
+          headers().get("c").toScala must beSome("d1")
 
-          toScala(headers().get("A")) must beSome("b1")
-          toScala(headers().get("C")) must beSome("d1")
+          headers().get("A").toScala must beSome("b1")
+          headers().get("C").toScala must beSome("d1")
         }
 
         "when checking if the header exists" in {
@@ -72,8 +72,8 @@ class RequestHeaderSpec extends Specification {
         hs mustNotEqual h
         h.contains("new") must beTrue
         hs.contains("new") must beFalse
-        toScala(h.get("new")) must beSome("value")
-        toScala(hs.get("new")) must beNone
+        h.get("new").toScala must beSome("value")
+        hs.get("new").toScala must beNone
       }
 
       "can add new headers with a list of values" in {

--- a/core/play/src/test/scala/play/mvc/ResponseHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/ResponseHeaderSpec.scala
@@ -6,7 +6,7 @@ package play.mvc
 
 import org.specs2.mutable.Specification
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 class ResponseHeaderSpec extends Specification {
   "ResponseHeader" should {
@@ -14,15 +14,15 @@ class ResponseHeaderSpec extends Specification {
       val headers        = Map("a" -> "b").asJava
       val responseHeader = new ResponseHeader(Http.Status.OK, headers)
       responseHeader.status() must beEqualTo(Http.Status.OK)
-      responseHeader.getHeader("a").asScala must beSome("b")
+      responseHeader.getHeader("a").toScala must beSome("b")
     }
 
     "create with status, headers and a reason phrase" in {
       val headers        = Map("a" -> "b").asJava
       val responseHeader = new ResponseHeader(Http.Status.OK, headers, "Custom")
       responseHeader.status() must beEqualTo(Http.Status.OK)
-      responseHeader.getHeader("a").asScala must beSome("b")
-      responseHeader.reasonPhrase().asScala must beSome("Custom")
+      responseHeader.getHeader("a").toScala must beSome("b")
+      responseHeader.reasonPhrase().toScala must beSome("Custom")
     }
 
     "get all headers" in {
@@ -35,8 +35,8 @@ class ResponseHeaderSpec extends Specification {
     "get a single header" in {
       val headers        = Map("a" -> "b").asJava
       val responseHeader = new ResponseHeader(Http.Status.OK, headers)
-      responseHeader.getHeader("a").asScala must beSome("b")
-      responseHeader.getHeader("c").asScala must beNone
+      responseHeader.getHeader("a").toScala must beSome("b")
+      responseHeader.getHeader("c").toScala must beNone
     }
 
     "add a single new header" in {
@@ -86,7 +86,7 @@ class ResponseHeaderSpec extends Specification {
       "when getting the header" in {
         val headers        = Map("Name" -> "Value").asJava
         val responseHeader = new ResponseHeader(Http.Status.OK, headers)
-        responseHeader.getHeader("NAME").asScala must beSome("Value")
+        responseHeader.getHeader("NAME").toScala must beSome("Value")
       }
     }
   }

--- a/core/play/src/test/scala/play/mvc/ResultSpec.scala
+++ b/core/play/src/test/scala/play/mvc/ResultSpec.scala
@@ -15,7 +15,7 @@ import play.api.mvc.Cookie
 import play.api.mvc.{ Results => ScalaResults }
 import play.mvc.Http.HeaderNames
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 class ResultSpec extends Specification {
   "Result" should {
@@ -48,7 +48,7 @@ class ResultSpec extends Specification {
 
     "get the location header" in {
       val javaResult = ScalaResults.Ok("Hello world").withHeaders(HeaderNames.LOCATION -> "/new-location").asJava
-      javaResult.redirectLocation().asScala must beSome("/new-location")
+      javaResult.redirectLocation().toScala must beSome("/new-location")
     }
   }
 }

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -175,20 +175,20 @@ case class ScalaCSPReport(
     columnNumber: Option[Long] = None
 ) {
   def asJava: JavaCSPReport = {
-    import scala.compat.java8.OptionConverters._
+    import scala.jdk.OptionConverters._
     new JavaCSPReport(
       documentUri,
       violatedDirective,
-      blockedUri.asJava,
-      originalPolicy.asJava,
-      effectiveDirective.asJava,
-      referrer.asJava,
-      disposition.asJava,
-      scriptSample.asJava,
-      statusCode.asJava,
-      sourceFile.asJava,
-      lineNumber.asJava,
-      columnNumber.asJava
+      blockedUri.toJava,
+      originalPolicy.toJava,
+      effectiveDirective.toJava,
+      referrer.toJava,
+      disposition.toJava,
+      scriptSample.toJava,
+      statusCode.toJava,
+      sourceFile.toJava,
+      lineNumber.toJava,
+      columnNumber.toJava
     )
   }
 }
@@ -255,20 +255,20 @@ class JavaCSPReport(
     val columnNumber: Optional[Long]
 ) {
   def asScala: ScalaCSPReport = {
-    import scala.compat.java8.OptionConverters._
+    import scala.jdk.OptionConverters._
     ScalaCSPReport(
       documentUri,
       violatedDirective,
-      blockedUri.asScala,
-      originalPolicy.asScala,
-      effectiveDirective.asScala,
-      referrer.asScala,
-      disposition.asScala,
-      scriptSample.asScala,
-      statusCode.asScala,
-      sourceFile.asScala,
-      lineNumber.asScala,
-      columnNumber.asScala
+      blockedUri.toScala,
+      originalPolicy.toScala,
+      effectiveDirective.toScala,
+      referrer.toScala,
+      disposition.toScala,
+      scriptSample.toScala,
+      statusCode.toScala,
+      sourceFile.toScala,
+      lineNumber.toScala,
+      columnNumber.toScala
     )
   }
 }

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -71,11 +71,11 @@ case class CSRFConfig(
   import play.mvc.Http.{ RequestHeader => JRequestHeader }
 
   import scala.compat.java8.FunctionConverters._
-  import scala.compat.java8.OptionConverters._
+  import scala.jdk.OptionConverters._
 
   def withTokenName(tokenName: String)                = copy(tokenName = tokenName)
   def withHeaderName(headerName: String)              = copy(headerName = headerName)
-  def withCookieName(cookieName: ju.Optional[String]) = copy(cookieName = cookieName.asScala)
+  def withCookieName(cookieName: ju.Optional[String]) = copy(cookieName = cookieName.toScala)
   def withSecureCookie(isSecure: Boolean)             = copy(secureCookie = isSecure)
   def withHttpOnlyCookie(isHttpOnly: Boolean)         = copy(httpOnlyCookie = isHttpOnly)
   def withSameSiteCookie(sameSite: Option[SameSite])  = copy(sameSiteCookie = sameSite)
@@ -85,7 +85,7 @@ case class CSRFConfig(
   def withSignTokens(signTokens: Boolean)                     = copy(signTokens = signTokens)
   def withMethods(checkMethod: ju.function.Predicate[String]) = copy(checkMethod = checkMethod.asScala)
   def withContentTypes(checkContentType: ju.function.Predicate[Optional[String]]) =
-    copy(checkContentType = checkContentType.asScala.compose(_.asJava))
+    copy(checkContentType = checkContentType.asScala.compose(_.toJava))
   def withShouldProtect(shouldProtect: ju.function.Predicate[JRequestHeader]) =
     copy(shouldProtect = shouldProtect.asScala.compose(_.asJava))
   def withBypassCorsTrustedOrigins(bypass: Boolean) = copy(bypassCorsTrustedOrigins = bypass)

--- a/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -90,22 +90,22 @@ case class SecurityHeadersConfig(
 
   import java.{ util => ju }
 
-  import scala.compat.java8.OptionConverters._
+  import scala.jdk.OptionConverters._
 
   def withFrameOptions(frameOptions: ju.Optional[String]): SecurityHeadersConfig =
-    copy(frameOptions = frameOptions.asScala)
+    copy(frameOptions = frameOptions.toScala)
   def withXssProtection(xssProtection: ju.Optional[String]): SecurityHeadersConfig =
-    copy(xssProtection = xssProtection.asScala)
+    copy(xssProtection = xssProtection.toScala)
   def withContentTypeOptions(contentTypeOptions: ju.Optional[String]): SecurityHeadersConfig =
-    copy(contentTypeOptions = contentTypeOptions.asScala)
+    copy(contentTypeOptions = contentTypeOptions.toScala)
   def withPermittedCrossDomainPolicies(permittedCrossDomainPolicies: ju.Optional[String]): SecurityHeadersConfig =
-    copy(permittedCrossDomainPolicies = permittedCrossDomainPolicies.asScala)
+    copy(permittedCrossDomainPolicies = permittedCrossDomainPolicies.toScala)
 
   @deprecated("Please use play.filters.csp.CSPFilter", "2.7.0")
   def withContentSecurityPolicy(contentSecurityPolicy: ju.Optional[String]): SecurityHeadersConfig =
-    copy(contentSecurityPolicy = contentSecurityPolicy.asScala)
+    copy(contentSecurityPolicy = contentSecurityPolicy.toScala)
   def withReferrerPolicy(referrerPolicy: ju.Optional[String]): SecurityHeadersConfig =
-    copy(referrerPolicy = referrerPolicy.asScala)
+    copy(referrerPolicy = referrerPolicy.toScala)
 }
 
 /**

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -27,7 +27,7 @@ import play.api.Environment
 import play.api.Mode
 import play.mvc.Http
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.concurrent.Future
 import scala.util.Random
 
@@ -414,7 +414,7 @@ class JavaErrorHandler extends CSRFErrorHandler {
       play.mvc.Results.unauthorized(
         "Origin: " + req.attrs
           .getOptional(play.http.HttpErrorHandler.Attrs.HTTP_ERROR_INFO)
-          .asScala
+          .toScala
           .map(_.origin)
           .getOrElse("<not set>") + " / " + msg
       )

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -19,7 +19,7 @@ import play.mvc.Controller
 import play.mvc.Result
 import play.mvc.Results
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
@@ -152,7 +152,7 @@ object JavaCSRFActionSpec {
           "Origin: " + req
             .attrs()
             .getOptional(HttpErrorHandler.Attrs.HTTP_ERROR_INFO)
-            .asScala
+            .toScala
             .map(_.origin)
             .getOrElse("<not set>") + " / " + msg
         )

--- a/web/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
+++ b/web/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
@@ -7,7 +7,7 @@ package play.core.j
 /** Defines a magic helper for Play templates in a Java Forms context. */
 object PlayFormsMagicForJava {
   import scala.jdk.CollectionConverters._
-  import scala.compat.java8.OptionConverters
+  import scala.jdk.OptionConverters._
   import scala.language.implicitConversions
 
   /**
@@ -32,7 +32,7 @@ object PlayFormsMagicForJava {
           }
         )
         .getOrElse(Nil),
-      OptionConverters.toScala(jField.value)
+      jField.value.toScala
     ) {
       override def apply(key: String) = {
         javaFieldtoScalaField(jField.sub(key))

--- a/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -29,7 +29,7 @@ import views.html.helper.FieldConstructor.defaultField
 import views.html.helper.inputText
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 /**
  * Specs for Java dynamic forms
@@ -67,20 +67,20 @@ class DynamicFormSpec extends CommonFormSpec {
         myForm.files().size() must beEqualTo(10)
 
         myForm.get("title") must beEqualTo("How Scala works")
-        myForm.field("title").value().asScala must beSome("How Scala works")
-        myForm.field("title").file().asScala must beNone
+        myForm.field("title").value().toScala must beSome("How Scala works")
+        myForm.field("title").file().toScala must beNone
         myForm.field("title").indexes() must beEqualTo(List.empty.asJava)
 
         myForm.field("letters").indexes() must beEqualTo(List(0, 1).asJava)
-        myForm.field("letters").value().asScala must beNone
-        myForm.field("letters").file().asScala must beNone
+        myForm.field("letters").value().toScala must beNone
+        myForm.field("letters").file().toScala must beNone
 
         myForm.field("letters[0].address").indexes() must beEqualTo(List.empty.asJava)
-        myForm.field("letters[0].address").value().asScala must beSome("Vienna")
-        myForm.field("letters[0].address").file().asScala must beNone
+        myForm.field("letters[0].address").value().toScala must beSome("Vienna")
+        myForm.field("letters[0].address").file().toScala must beNone
         myForm.field("letters[0].address").indexes() must beEqualTo(List.empty.asJava)
-        myForm.field("letters[1].address").value().asScala must beSome("Berlin")
-        myForm.field("letters[1].address").file().asScala must beNone
+        myForm.field("letters[1].address").value().toScala must beSome("Berlin")
+        myForm.field("letters[1].address").file().toScala must beNone
 
         checkFileParts(
           Seq(myForm.file("letters[0].coverPage"), myForm.field("letters[0].coverPage").file().get()),
@@ -89,7 +89,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "first-letter-cover_page.txt",
           "First Letter Cover Page"
         )
-        myForm.field("letters[0].coverPage").value().asScala must beNone
+        myForm.field("letters[0].coverPage").value().toScala must beNone
 
         checkFileParts(
           Seq(myForm.file("letters[1].coverPage"), myForm.field("letters[1].coverPage").file().get()),
@@ -98,7 +98,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "second-letter-cover_page.odt",
           "Second Letter Cover Page"
         )
-        myForm.field("letters[1].coverPage").value().asScala must beNone
+        myForm.field("letters[1].coverPage").value().toScala must beNone
 
         myForm.field("letters[0].letterPages").indexes() must beEqualTo(List(0, 1).asJava)
         checkFileParts(
@@ -111,7 +111,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "first-letter-page_1.doc",
           "First Letter Page One"
         )
-        myForm.field("letters[0].letterPages[0]").value().asScala must beNone
+        myForm.field("letters[0].letterPages[0]").value().toScala must beNone
 
         checkFileParts(
           Seq(
@@ -123,7 +123,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "first-letter-page_2.docx",
           "First Letter Page Two"
         )
-        myForm.field("letters[0].letterPages[1]").value().asScala must beNone
+        myForm.field("letters[0].letterPages[1]").value().toScala must beNone
 
         myForm.field("letters[1].letterPages").indexes() must beEqualTo(List(0).asJava)
         checkFileParts(
@@ -136,7 +136,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "second-letter-page_1.rtf",
           "Second Letter Page One"
         )
-        myForm.field("letters[1].letterPages[0]").value().asScala must beNone
+        myForm.field("letters[1].letterPages[0]").value().toScala must beNone
 
         checkFileParts(
           Seq(myForm.file("document"), myForm.field("document").file().get()),
@@ -145,7 +145,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "best_thesis.pdf",
           "by Lightbend founder Martin Odersky"
         )
-        myForm.field("document").value().asScala must beNone
+        myForm.field("document").value().toScala must beNone
         myForm.field("document").indexes() must beEqualTo(List.empty.asJava)
 
         checkFileParts(
@@ -155,7 +155,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "final_draft.tex",
           "the final draft"
         )
-        myForm.field("attachments[0]").value().asScala must beNone
+        myForm.field("attachments[0]").value().toScala must beNone
         checkFileParts(
           Seq(myForm.file("attachments[1]"), myForm.field("attachments[1]").file().get()),
           "attachments[]",
@@ -163,7 +163,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "examples.scala",
           "some code snippets"
         )
-        myForm.field("attachments[1]").value().asScala must beNone
+        myForm.field("attachments[1]").value().toScala must beNone
         myForm.field("attachments").indexes() must beEqualTo(List(0, 1).asJava)
 
         checkFileParts(
@@ -173,7 +173,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "Java_Concurrency_in_Practice.epub",
           "Java Concurrency in Practice"
         )
-        myForm.field("bibliography[0]").value().asScala must beNone
+        myForm.field("bibliography[0]").value().toScala must beNone
         checkFileParts(
           Seq(myForm.file("bibliography[1]"), myForm.field("bibliography[1]").file().get()),
           "bibliography[1]",
@@ -181,7 +181,7 @@ class DynamicFormSpec extends CommonFormSpec {
           "The-Java-Programming-Language.mobi",
           "The Java Programming Language"
         )
-        myForm.field("bibliography[1]").value().asScala must beNone
+        myForm.field("bibliography[1]").value().toScala must beNone
         myForm.field("bibliography").indexes() must beEqualTo(List(0, 1).asJava)
       } finally {
         files.values.foreach(temporaryFileCreator.delete(_))

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -46,7 +46,7 @@ import play.twirl.api.Html
 import javax.validation.constraints.Size
 import scala.beans.BeanProperty
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 class RuntimeDependencyInjectionFormSpec extends FormSpec {
   private var app: Option[Application] = None
@@ -257,7 +257,7 @@ trait FormSpec extends CommonFormSpec {
         val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest(req)
 
         myForm.hasErrors() must beEqualTo(true)
-        myForm.field("task.name").value.asScala must beSome("peter")
+        myForm.field("task.name").value.toScala must beSome("peter")
       }
       "have an error due to missing required value" in new WithApplication(application()) {
         val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891x"), "task.name" -> Array("peter")))
@@ -310,7 +310,7 @@ trait FormSpec extends CommonFormSpec {
       st.dueDate = createDate()
       val myForm = formFactory.form(classOf[play.data.Subtask]).withDirectFieldAccess(true).fill(st)
       myForm.get().dueDate must beEqualTo(createDate())
-      myForm("dueDate").value().asScala must beSome("01/01/1970")
+      myForm("dueDate").value().toScala must beSome("01/01/1970")
       myForm("dueDate").format() must beEqualTo(F.Tuple("format.date", List("dd/MM/yyyy").asJava))
       myForm("dueDate").constraints() must beEqualTo(List(F.Tuple("constraint.required", List().asJava)).asJava)
     }
@@ -319,7 +319,7 @@ trait FormSpec extends CommonFormSpec {
       st.emails = List("one@example.com", "two@example.com").asJava
       val myForm = formFactory.form(classOf[play.data.Subtask]).withDirectFieldAccess(true).fill(st)
       myForm.get().emails must beEqualTo(List("one@example.com", "two@example.com").asJava)
-      myForm("emails").value().asScala must beSome("[one@example.com, two@example.com]")
+      myForm("emails").value().toScala must beSome("[one@example.com, two@example.com]")
       myForm("emails").indexes() must beEqualTo(List(0, 1).asJava)
     }
     "be valid with all fields with direct field access switched on in config" in new WithApplication(
@@ -786,18 +786,18 @@ trait FormSpec extends CommonFormSpec {
           val thesis = myForm.get
 
           thesis.getTitle must beEqualTo("How Scala works")
-          myForm.field("title").value().asScala must beSome("How Scala works")
-          myForm.field("title").file().asScala must beNone
+          myForm.field("title").value().toScala must beSome("How Scala works")
+          myForm.field("title").file().toScala must beNone
 
           thesis.getLetters().size() must beEqualTo(2)
           myForm.field("letters").indexes() must beEqualTo(List(0, 1).asJava)
 
           thesis.getLetters().get(0).getAddress must beEqualTo("Vienna")
-          myForm.field("letters[0].address").value().asScala must beSome("Vienna")
-          myForm.field("letters[0].address").file().asScala must beNone
+          myForm.field("letters[0].address").value().toScala must beSome("Vienna")
+          myForm.field("letters[0].address").file().toScala must beNone
           thesis.getLetters().get(1).getAddress must beEqualTo("Berlin")
-          myForm.field("letters[1].address").value().asScala must beSome("Berlin")
-          myForm.field("letters[1].address").file().asScala must beNone
+          myForm.field("letters[1].address").value().toScala must beSome("Berlin")
+          myForm.field("letters[1].address").file().toScala must beNone
 
           checkFileParts(
             Seq(thesis.getLetters().get(0).getCoverPage, myForm.field("letters[0].coverPage").file().get()),
@@ -806,7 +806,7 @@ trait FormSpec extends CommonFormSpec {
             "first-letter-cover_page.txt",
             "First Letter Cover Page"
           )
-          myForm.field("letters[0].coverPage").value().asScala must beNone
+          myForm.field("letters[0].coverPage").value().toScala must beNone
 
           checkFileParts(
             Seq(thesis.getLetters().get(1).getCoverPage, myForm.field("letters[1].coverPage").file().get()),
@@ -815,7 +815,7 @@ trait FormSpec extends CommonFormSpec {
             "second-letter-cover_page.odt",
             "Second Letter Cover Page"
           )
-          myForm.field("letters[1].coverPage").value().asScala must beNone
+          myForm.field("letters[1].coverPage").value().toScala must beNone
 
           thesis.getLetters().get(0).getLetterPages().size() must beEqualTo(2)
           myForm.field("letters[0].letterPages").indexes() must beEqualTo(List(0, 1).asJava)
@@ -829,7 +829,7 @@ trait FormSpec extends CommonFormSpec {
             "first-letter-page_1.doc",
             "First Letter Page One"
           )
-          myForm.field("letters[0].letterPages[0]").value().asScala must beNone
+          myForm.field("letters[0].letterPages[0]").value().toScala must beNone
 
           checkFileParts(
             Seq(
@@ -841,7 +841,7 @@ trait FormSpec extends CommonFormSpec {
             "first-letter-page_2.docx",
             "First Letter Page Two"
           )
-          myForm.field("letters[0].letterPages[1]").value().asScala must beNone
+          myForm.field("letters[0].letterPages[1]").value().toScala must beNone
 
           thesis.getLetters().get(1).getLetterPages().size() must beEqualTo(1)
           myForm.field("letters[1].letterPages").indexes() must beEqualTo(List(0).asJava)
@@ -855,7 +855,7 @@ trait FormSpec extends CommonFormSpec {
             "second-letter-page_1.rtf",
             "Second Letter Page One"
           )
-          myForm.field("letters[1].letterPages[0]").value().asScala must beNone
+          myForm.field("letters[1].letterPages[0]").value().toScala must beNone
 
           checkFileParts(
             Seq(thesis.getDocument, myForm.field("document").file().get()),
@@ -864,7 +864,7 @@ trait FormSpec extends CommonFormSpec {
             "best_thesis.pdf",
             "by Lightbend founder Martin Odersky"
           )
-          myForm.field("document").value().asScala must beNone
+          myForm.field("document").value().toScala must beNone
 
           thesis.getAttachments().size() must beEqualTo(2)
           myForm.field("attachments").indexes() must beEqualTo(List(0, 1).asJava)
@@ -875,7 +875,7 @@ trait FormSpec extends CommonFormSpec {
             "final_draft.tex",
             "the final draft"
           )
-          myForm.field("attachments[0]").value().asScala must beNone
+          myForm.field("attachments[0]").value().toScala must beNone
           checkFileParts(
             Seq(thesis.getAttachments().get(1), myForm.field("attachments[1]").file().get()),
             "attachments[]",
@@ -883,7 +883,7 @@ trait FormSpec extends CommonFormSpec {
             "examples.scala",
             "some code snippets"
           )
-          myForm.field("attachments[1]").value().asScala must beNone
+          myForm.field("attachments[1]").value().toScala must beNone
 
           thesis.getBibliography().size() must beEqualTo(2)
           myForm.field("bibliography").indexes() must beEqualTo(List(0, 1).asJava)
@@ -894,7 +894,7 @@ trait FormSpec extends CommonFormSpec {
             "Java_Concurrency_in_Practice.epub",
             "Java Concurrency in Practice"
           )
-          myForm.field("bibliography[0]").value().asScala must beNone
+          myForm.field("bibliography[0]").value().toScala must beNone
           checkFileParts(
             Seq(thesis.getBibliography().get(1), myForm.field("bibliography[1]").file().get()),
             "bibliography[1]",
@@ -902,7 +902,7 @@ trait FormSpec extends CommonFormSpec {
             "The-Java-Programming-Language.mobi",
             "The Java Programming Language"
           )
-          myForm.field("bibliography[1]").value().asScala must beNone
+          myForm.field("bibliography[1]").value().toScala must beNone
         } finally {
           files.values.foreach(temporaryFileCreator.delete(_))
         }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes



## Purpose

use std `scala.jdk.OptionConverters` instead of `scala.compat.java8.OptionConverters`

## Background Context

- playframework dropped Scala 2.12 https://github.com/playframework/playframework/pull/10956
- https://github.com/scala/scala/blob/2.13.x/src/library/scala/jdk/OptionConverters.scala scala std lib has OptionConverters since Scala 2.13
- https://github.com/scala/scala-java8-compat/blob/ff64b0109e9445e71f9d7c66fd230be5d12d053b/src/main/scala/scala/compat/java8/OptionConverters.scala

## References

