### PR TITLE
Add maximum-size to Caffeine config.

### DIFF
--- a/cache/play-caffeine-cache/src/main/resources/reference.conf
+++ b/cache/play-caffeine-cache/src/main/resources/reference.conf
@@ -11,6 +11,7 @@ play {
     caffeine {
       defaults {
         initial-capacity = null
+        maximum-size = 10000
         weak-keys = null
         weak-keys = false
         soft-values = false

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -132,6 +132,10 @@ Because of these reasons, starting from Play 2.9 the `akka.*` prefix is dedicate
 
 Some default values used by Play had changed and that can have an impact on your application. This section details the default changes.
 
+### Caffeine has a new default value defined by `play.cache.caffeine.defaults.maximum-size`.
+
+Application keeps on adding many items to the cache over time, then, with the Caffeine-based cache, the JVM will sooner or later crash because of `Out of Memory` error. We're defining a maximum size to `Caffeine` configuration to use 10000 as project default value.
+
 ### TBA
 
 TBA


### PR DESCRIPTION
Signed-off-by: Felipe Bonezi <felipebonezi@gmail.com>

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10955 

## Purpose

Add maximum size to Caffeine Cache config using 10000 elements as a default value.

## Background Context

It's already implemented to read from Config file - i.e. `play.cache.caffeine.CaffeineParser` - but it wasn't using any default value.

## References

Ref from #11181 
