### PR TITLE
use `CollectionConverters` instead of deprecated `JavaConverters`

### DIFF
--- a/core/play/src/main/java/play/i18n/MessagesApi.java
+++ b/core/play/src/main/java/play/i18n/MessagesApi.java
@@ -46,9 +46,7 @@ public class MessagesApi {
    * @return scala type for message processing
    */
   private static Seq<Object> convertArgsToScalaBuffer(final Object... args) {
-    return scala.collection.JavaConverters.asScalaBufferConverter(wrapArgsToListIfNeeded(args))
-        .asScala()
-        .toList();
+    return scala.jdk.javaapi.CollectionConverters.asScala(wrapArgsToListIfNeeded(args)).toList();
   }
 
   /**
@@ -99,7 +97,7 @@ public class MessagesApi {
    * @return the formatted message or a default rendering if the key wasn't defined
    */
   public String get(play.api.i18n.Lang lang, List<String> keys, Object... args) {
-    Buffer<String> keyArgs = scala.collection.JavaConverters.asScalaBufferConverter(keys).asScala();
+    Buffer<String> keyArgs = scala.jdk.javaapi.CollectionConverters.asScala(keys);
     Seq<Object> scalaArgs = convertArgsToScalaBuffer(args);
     return messages.apply(keyArgs.toSeq(), scalaArgs, lang);
   }

--- a/core/play/src/main/java/play/inject/Module.java
+++ b/core/play/src/main/java/play/inject/Module.java
@@ -6,7 +6,7 @@ package play.inject;
 
 import com.typesafe.config.Config;
 import play.Environment;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 import scala.collection.immutable.Seq;
 
 import java.util.List;
@@ -54,7 +54,7 @@ public abstract class Module extends play.api.inject.Module {
         bindings(environment.asJava(), configuration.underlying()).stream()
             .map(Binding::asScala)
             .collect(Collectors.toList());
-    return JavaConverters.collectionAsScalaIterableConverter(list).asScala().toList();
+    return CollectionConverters.asScala(list).toList();
   }
 
   /** Create a binding key for the given class. */

--- a/core/play/src/main/java/play/libs/Scala.java
+++ b/core/play/src/main/java/play/libs/Scala.java
@@ -26,7 +26,7 @@ public class Scala {
    * @param <T> the element type.
    */
   public static <T> scala.collection.immutable.Seq<T> toSeq(java.util.List<T> list) {
-    return scala.collection.JavaConverters.asScalaBufferConverter(list).asScala().toList();
+    return scala.jdk.javaapi.CollectionConverters.asScala(list).toList();
   }
 
   /**
@@ -90,7 +90,7 @@ public class Scala {
    * @return the java map.
    */
   public static <K, V> java.util.Map<K, V> asJava(scala.collection.Map<K, V> scalaMap) {
-    return scala.collection.JavaConverters.mapAsJavaMapConverter(scalaMap).asJava();
+    return scala.jdk.javaapi.CollectionConverters.asJava(scalaMap);
   }
 
   /**
@@ -103,7 +103,7 @@ public class Scala {
    */
   public static <K, V> scala.collection.immutable.Map<K, V> asScala(Map<K, V> javaMap) {
     return play.utils.Conversions.newMap(
-        scala.collection.JavaConverters.mapAsScalaMapConverter(javaMap).asScala().toSeq());
+        scala.jdk.javaapi.CollectionConverters.asScala(javaMap).toSeq());
   }
 
   /**
@@ -117,9 +117,7 @@ public class Scala {
   public static <A extends B, B> scala.collection.immutable.Seq<B> asScala(
       Collection<A> javaCollection) {
     final scala.collection.immutable.List<A> as =
-        scala.collection.JavaConverters.collectionAsScalaIterableConverter(javaCollection)
-            .asScala()
-            .toList();
+        scala.jdk.javaapi.CollectionConverters.asScala(javaCollection).toList();
     @SuppressWarnings("unchecked")
     // covariance: List<A> <: List<B> iff A <: B, given List<A> is covariant in A
     final scala.collection.immutable.List<B> bs = (scala.collection.immutable.List<B>) as;
@@ -179,7 +177,7 @@ public class Scala {
    * @param <T> the return type.
    */
   public static <T> java.util.List<T> asJava(scala.collection.Seq<T> scalaList) {
-    return scala.collection.JavaConverters.seqAsJavaListConverter(scalaList).asJava();
+    return scala.jdk.javaapi.CollectionConverters.asJava(scalaList);
   }
 
   /**

--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -30,7 +30,7 @@ import play.libs.XML;
 import play.libs.streams.Accumulator;
 import play.mvc.Http.Status;
 import scala.Option;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 import scala.compat.java8.FutureConverters;
 import scala.compat.java8.OptionConverters;
 import scala.concurrent.Future;
@@ -54,7 +54,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.*;
-import static scala.collection.JavaConverters.seqAsJavaListConverter;
 
 /** A body parser parses the HTTP request body content. */
 public interface BodyParser<A> {
@@ -826,7 +825,7 @@ public interface BodyParser<A> {
       @Override
       public Map<String, String[]> asFormUrlEncoded() {
         // TODO have this transformations in Scala is easier.
-        return JavaConverters.mapAsJavaMap(scalaFormData.asFormUrlEncoded()).entrySet().stream()
+        return CollectionConverters.asJava(scalaFormData.asFormUrlEncoded()).entrySet().stream()
             .collect(
                 Collectors.toMap(
                     Map.Entry::getKey, entry -> Scala.asArray(String.class, entry.getValue())));
@@ -834,7 +833,7 @@ public interface BodyParser<A> {
 
       @Override
       public List<FilePart<A>> getFiles() {
-        return seqAsJavaListConverter(scalaFormData.files()).asJava().stream()
+        return CollectionConverters.asJava(scalaFormData.files()).stream()
             .map(DelegatingMultipartFormDataBodyParser.this::toJava)
             .collect(Collectors.toList());
       }

--- a/core/play/src/main/java/play/mvc/Results.java
+++ b/core/play/src/main/java/play/mvc/Results.java
@@ -19,7 +19,7 @@ import play.api.mvc.Results$;
 import play.core.j.JavaHelpers;
 import play.http.HttpEntity;
 import play.twirl.api.Content;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 import scala.compat.java8.OptionConverters;
 
 import static play.mvc.Http.HeaderNames.LOCATION;
@@ -47,7 +47,7 @@ public class Results {
    */
   public static Map<String, String> contentDispositionHeader(
       boolean inline, Optional<String> name) {
-    return JavaConverters.mapAsJavaMap(
+    return CollectionConverters.asJava(
         play.api.mvc.Results.contentDispositionHeader(inline, OptionConverters.toScala(name)));
   }
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/app/controllers/Application.scala
@@ -6,7 +6,6 @@ package controllers
 
 import play.api._
 import play.api.mvc._
-import scala.collection.JavaConverters._
 
 import javax.inject.Inject
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
@@ -6,7 +6,6 @@ package controllers
 
 import play.api._
 import play.api.mvc._
-import scala.collection.JavaConverters._
 
 import javax.inject.Inject
 

--- a/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/csp/MyDynamicCSPAction.java
+++ b/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/csp/MyDynamicCSPAction.java
@@ -10,7 +10,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 
 // #java-csp-dynamic-action
 public class MyDynamicCSPAction extends AbstractCSPAction {
@@ -29,8 +29,7 @@ public class MyDynamicCSPAction extends AbstractCSPAction {
   }
 
   private List<CSPDirective> generateDirectives() {
-    // import scala.collection.JavaConverters;
-    List<CSPDirective> baseDirectives = JavaConverters.seqAsJavaList(cspConfig.directives());
+    List<CSPDirective> baseDirectives = CollectionConverters.asJava(cspConfig.directives());
     return baseDirectives.stream()
         .map(
             directive -> {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix warnings

## Purpose

## Background Context

- https://github.com/playframework/playframework/pull/10956 play dropped Scala 2.12 support

## References

