### PR TITLE
fix TypedMap.scala. prepare Scala 3

### DIFF
--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -174,9 +174,9 @@ private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Ma
   override def updated[A](key: TypedKey[A], value: A): TypedMap = new DefaultTypedMap(m.updated(key, value))
   override def +(e1: TypedEntry[_]): TypedMap                   = new DefaultTypedMap(m.updated(e1.key, e1.value))
   override def +(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap =
-    new DefaultTypedMap(m + (e1.key -> e1.value) + (e2.key -> e2.value))
+    new DefaultTypedMap(m.updated(e1.key, e1.value).updated(e2.key, e2.value))
   override def +(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap =
-    new DefaultTypedMap(m + (e1.key -> e1.value) + (e2.key -> e2.value) + (e3.key -> e3.value))
+    new DefaultTypedMap(m.updated(e1.key, e1.value).updated(e2.key, e2.value).updated(e3.key, e3.value))
   override def +(entries: TypedEntry[_]*): TypedMap = {
     val m2 = entries.foldLeft(m) {
       case (m1, e) => m1.updated(e.key, e.value)


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose

use `updated` instead of `->`

## Background Context

Scala 2 return `Tuple2 `but Scala 3 return `TypedEntry`.

https://github.com/playframework/playframework/blob/6e614d11cca8070e6c3aa4940f682f8cc1183e73/core/play/src/main/scala/play/api/libs/typedmap/TypedKey.scala#L33

```
Welcome to Scala 3.1.2 (11.0.15, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> class TypedKey[A] {
     |   def ->(value: A) = println("TypedKey.->")
     | }
// defined class TypedKey

scala> case class TypedEntry[A](key: TypedKey[A], value: A)
// defined case class TypedEntry

scala> def foo(e: TypedEntry[_]) = e.key -> e.value
def foo(e: TypedEntry[?]): Unit

scala> foo(TypedEntry(new TypedKey[Int], 3))
TypedKey.->
```

```
Welcome to Scala 2.13.8 (OpenJDK 64-Bit Server VM, Java 11.0.15).
Type in expressions for evaluation. Or try :help.

scala> class TypedKey[A] {
     |   def ->(value: A) = println("TypedKey.->")
     | }
class TypedKey

scala> case class TypedEntry[A](key: TypedKey[A], value: A)
class TypedEntry

scala> def foo(e: TypedEntry[_]) = e.key -> e.value
                                         ^
       warning: inferred existential type (TypedKey[_$1], Any) forSome { type _$1 }, which cannot be expressed by wildcards, should be enabled
       by making the implicit value scala.language.existentials visible.
       This can be achieved by adding the import clause 'import scala.language.existentials'
       or by setting the compiler option -language:existentials.
       See the Scaladoc for value scala.language.existentials for a discussion
       why the feature should be explicitly enabled.
def foo(e: TypedEntry[_]): (TypedKey[_$1], Any) forSome { type _$1 }

scala> foo(TypedEntry(new TypedKey[Int], 3))
          ^
       warning: inferred existential type (TypedKey[_$1], Any) forSome { type _$1 }, which cannot be expressed by wildcards, should be enabled
       by making the implicit value scala.language.existentials visible.
val res0: (TypedKey[_$1], Any) forSome { type _$1 } = (TypedKey@23c7cb18,3)
```


## References

- https://github.com/playframework/playframework/issues/11260