### PR TITLE
remove scala-java8-compat dependency

### DIFF
--- a/cache/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
@@ -16,8 +16,8 @@ import akka.Done;
 import play.libs.Scala;
 import scala.concurrent.duration.Duration;
 
-import scala.compat.java8.OptionConverters;
-import static scala.compat.java8.FutureConverters.toJava;
+import scala.jdk.javaapi.OptionConverters;
+import static scala.jdk.javaapi.FutureConverters.asJava;
 
 /**
  * Adapts a Scala AsyncCacheApi to a Java AsyncCacheApi. This is Play's default Java AsyncCacheApi
@@ -40,42 +40,42 @@ public class DefaultAsyncCacheApi implements AsyncCacheApi {
 
   @Override
   public <T> CompletionStage<Optional<T>> get(String key) {
-    return toJava(asyncCacheApi.get(key, Scala.<T>classTag())).thenApply(OptionConverters::toJava);
+    return asJava(asyncCacheApi.get(key, Scala.<T>classTag())).thenApply(OptionConverters::toJava);
   }
 
   @Override
   public <T> CompletionStage<T> getOrElseUpdate(
       String key, Callable<CompletionStage<T>> block, int expiration) {
-    return toJava(
+    return asJava(
         asyncCacheApi.getOrElseUpdate(
             key, intToDuration(expiration), Scala.asScalaWithFuture(block), Scala.<T>classTag()));
   }
 
   @Override
   public <T> CompletionStage<T> getOrElseUpdate(String key, Callable<CompletionStage<T>> block) {
-    return toJava(
+    return asJava(
         asyncCacheApi.getOrElseUpdate(
             key, Duration.Inf(), Scala.asScalaWithFuture(block), Scala.<T>classTag()));
   }
 
   @Override
   public CompletionStage<Done> set(String key, Object value, int expiration) {
-    return toJava(asyncCacheApi.set(key, value, intToDuration(expiration)));
+    return asJava(asyncCacheApi.set(key, value, intToDuration(expiration)));
   }
 
   @Override
   public CompletionStage<Done> set(String key, Object value) {
-    return toJava(asyncCacheApi.set(key, value, Duration.Inf()));
+    return asJava(asyncCacheApi.set(key, value, Duration.Inf()));
   }
 
   @Override
   public CompletionStage<Done> remove(String key) {
-    return toJava(asyncCacheApi.remove(key));
+    return asJava(asyncCacheApi.remove(key));
   }
 
   @Override
   public CompletionStage<Done> removeAll() {
-    return toJava(asyncCacheApi.removeAll());
+    return asJava(asyncCacheApi.removeAll());
   }
 
   private Duration intToDuration(int seconds) {

--- a/cache/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
+++ b/cache/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
@@ -12,7 +12,7 @@ import scala.concurrent.duration.Duration;
 
 import play.libs.Scala;
 
-import static scala.compat.java8.OptionConverters.toJava;
+import static scala.jdk.javaapi.OptionConverters.toJava;
 
 /** Adapts a Scala SyncCacheApi to a Java SyncCacheApi */
 public class SyncCacheApiAdapter implements SyncCacheApi {

--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -15,7 +15,7 @@ import play.api.test.WithApplication
 import play.cache.{ AsyncCacheApi => JavaAsyncCacheApi }
 import play.cache.{ SyncCacheApi => JavaSyncCacheApi }
 
-import scala.compat.java8.FutureConverters._
+import scala.jdk.FutureConverters._
 import scala.concurrent.duration._
 
 class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
@@ -29,63 +29,63 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
   "Java AsyncCacheApi" should {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      await(cacheApi.set("foo", "bar").asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar", oneSecondExpiration).toScala)
+      await(cacheApi.set("foo", "bar", oneSecondExpiration).asScala)
 
-      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await }
+      after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await }
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar", tenSecondsExpiration).toScala)
+      await(cacheApi.set("foo", "bar", tenSecondsExpiration).asScala)
 
-      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await }
+      after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-        await(cacheApi.set("foo", "bar").toScala)
-        cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+        await(cacheApi.set("foo", "bar").asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         val future = cacheApi
           .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"))
-          .toScala
+          .asScala
 
         future must beEqualTo("bar").await
-        cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         val future = cacheApi
           .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"), oneSecondExpiration)
-          .toScala
+          .asScala
 
         future must beEqualTo("bar").await
 
-        after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await }
+        after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      await(cacheApi.set("foo", "bar").asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
 
-      await(cacheApi.remove("foo").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await
+      await(cacheApi.remove("foo").asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
     }
 
     "remove all values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      await(cacheApi.set("foo", "bar").asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
 
-      await(cacheApi.removeAll().toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await
+      await(cacheApi.removeAll().asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
     }
   }
 

--- a/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -15,7 +15,7 @@ import play.api.test.WithApplication
 import play.cache.{ AsyncCacheApi => JavaAsyncCacheApi }
 import play.cache.{ SyncCacheApi => JavaSyncCacheApi }
 
-import scala.compat.java8.FutureConverters._
+import scala.jdk.FutureConverters._
 import scala.concurrent.duration._
 
 class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
@@ -29,63 +29,63 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
   "Java AsyncCacheApi" should {
     "set cache values" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      await(cacheApi.set("foo", "bar").asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar", oneSecondExpiration).toScala)
+      await(cacheApi.set("foo", "bar", oneSecondExpiration).asScala)
 
-      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await }
+      after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await }
     }
     "set cache values with an expiration time" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar", tenSecondsExpiration).toScala)
+      await(cacheApi.set("foo", "bar", tenSecondsExpiration).asScala)
 
-      after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await }
+      after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await }
     }
     "get or update" should {
       "get value when it exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-        await(cacheApi.set("foo", "bar").toScala)
-        cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+        await(cacheApi.set("foo", "bar").asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         val future = cacheApi
           .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"))
-          .toScala
+          .asScala
 
         future must beEqualTo("bar").await
-        cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         val future = cacheApi
           .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"), oneSecondExpiration)
-          .toScala
+          .asScala
 
         future must beEqualTo("bar").await
 
-        after2sec { cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await }
+        after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await }
       }
     }
     "remove values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      await(cacheApi.set("foo", "bar").asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
 
-      await(cacheApi.remove("foo").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await
+      await(cacheApi.remove("foo").asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
     }
 
     "remove all values from cache" in new WithApplication {
       val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.of("bar")).await
+      await(cacheApi.set("foo", "bar").asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
 
-      await(cacheApi.removeAll().toScala)
-      cacheApi.get[String]("foo").toScala must beEqualTo(Optional.empty()).await
+      await(cacheApi.removeAll().asScala)
+      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
     }
   }
 

--- a/core/play-integration-test/src/it/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/it/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -10,7 +10,7 @@ import akka.stream.javadsl.Source;
 import play.libs.F;
 import play.mvc.Results;
 import play.mvc.WebSocket;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 import scala.concurrent.Promise;
 
 import java.util.ArrayList;
@@ -32,7 +32,7 @@ public class WebSocketSpecJavaActions {
   }
 
   private static <A> Source<A, ?> emptySource() {
-    return Source.fromFuture(FutureConverters.toScala(new CompletableFuture<>()));
+    return Source.fromFuture(FutureConverters.asScala(new CompletableFuture<>()));
   }
 
   public static WebSocket allowConsumingMessages(Promise<List<String>> messages) {

--- a/core/play-integration-test/src/it/scala/play/it/routing/ServerSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/routing/ServerSpec.scala
@@ -15,7 +15,6 @@ import play.mvc.Results
 import play.routing.RoutingDsl
 import play.server.Server
 import play.{ Mode => JavaMode }
-import scala.compat.java8.FunctionConverters._
 
 class AkkaHTTPServerSpec extends ServerSpec {
   override def serverProvider: String = "play.core.server.AkkaHttpServerProvider"
@@ -40,7 +39,7 @@ trait ServerSpec extends Specification with BeforeAll {
     "start server" in {
       "with default mode and free port" in {
         withServer(
-          Server.forRouter(asJavaFunction((_: JBuiltInComponents) => Router.empty.asJava))
+          Server.forRouter((_: JBuiltInComponents) => Router.empty.asJava)
         ) { server =>
           server.httpPort() must beGreaterThan(0)
           server.underlying().mode must beEqualTo(Mode.Test)
@@ -48,7 +47,7 @@ trait ServerSpec extends Specification with BeforeAll {
       }
       "with given port and default mode" in {
         withServer(
-          Server.forRouter(9999, asJavaFunction((_: JBuiltInComponents) => Router.empty.asJava))
+          Server.forRouter(9999, (_: JBuiltInComponents) => Router.empty.asJava)
         ) { server =>
           server.httpPort() must beEqualTo(9999)
           server.underlying().mode must beEqualTo(Mode.Test)
@@ -56,7 +55,7 @@ trait ServerSpec extends Specification with BeforeAll {
       }
       "with the given mode and free port" in {
         withServer(
-          Server.forRouter(JavaMode.DEV, asJavaFunction((_: JBuiltInComponents) => Router.empty.asJava))
+          Server.forRouter(JavaMode.DEV, (_: JBuiltInComponents) => Router.empty.asJava)
         ) { server =>
           server.httpPort() must beGreaterThan(0)
           server.underlying().mode must beEqualTo(Mode.Dev)
@@ -64,7 +63,7 @@ trait ServerSpec extends Specification with BeforeAll {
       }
       "with the given mode and port" in {
         withServer(
-          Server.forRouter(JavaMode.DEV, 9999, asJavaFunction((_: JBuiltInComponents) => Router.empty.asJava))
+          Server.forRouter(JavaMode.DEV, 9999, (_: JBuiltInComponents) => Router.empty.asJava)
         ) { server =>
           server.httpPort() must beEqualTo(9999)
           server.underlying().mode must beEqualTo(Mode.Dev)
@@ -73,8 +72,7 @@ trait ServerSpec extends Specification with BeforeAll {
       "with the given router" in {
         withServer(
           Server.forRouter(
-            JavaMode.DEV,
-            asJavaFunction { (components: JBuiltInComponents) =>
+            JavaMode.DEV, { (components: JBuiltInComponents) =>
               RoutingDsl
                 .fromComponents(components)
                 .GET("/something")
@@ -94,7 +92,7 @@ trait ServerSpec extends Specification with BeforeAll {
 
     "get the address the server is running" in {
       withServer(
-        Server.forRouter(9999, asJavaFunction((_: JBuiltInComponents) => Router.empty.asJava))
+        Server.forRouter(9999, (_: JBuiltInComponents) => Router.empty.asJava)
       ) { server =>
         server.mainAddress().getPort must beEqualTo(9999)
       }

--- a/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -12,7 +12,7 @@ import play.mvc.Result
 import play.utils.UriEncoding
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -35,7 +35,7 @@ private[routing] class RouterBuilderHelper(
               case result: Result => Future.successful(result)
               case promise: CompletionStage[_] =>
                 val p = promise.asInstanceOf[CompletionStage[Result]]
-                FutureConverters.toScala(p)
+                p.asScala
             }
             javaResultFuture.map(_.asScala())
           }

--- a/core/play-streams/src/main/java/play/libs/streams/Accumulator.java
+++ b/core/play-streams/src/main/java/play/libs/streams/Accumulator.java
@@ -12,8 +12,8 @@ import akka.stream.Materializer;
 import akka.stream.javadsl.*;
 import play.api.libs.streams.Accumulator$;
 import scala.Option;
-import scala.compat.java8.FutureConverters;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.FutureConverters;
+import scala.jdk.javaapi.OptionConverters;
 import scala.concurrent.Future;
 import scala.runtime.AbstractFunction1;
 
@@ -363,7 +363,7 @@ public abstract class Accumulator<E, A> {
 
     public play.api.libs.streams.Accumulator<E, A> asScala() {
       return Accumulator$.MODULE$.apply(
-          sink.mapMaterializedValue(FutureConverters::toScala).asScala());
+          sink.mapMaterializedValue(FutureConverters::asScala).asScala());
     }
   }
 
@@ -428,10 +428,10 @@ public abstract class Accumulator<E, A> {
           new AbstractFunction1<Option<E>, Future<A>>() {
             @Override
             public Future<A> apply(Option<E> v1) {
-              return FutureConverters.toScala(strictHandler.apply(OptionConverters.toJava(v1)));
+              return FutureConverters.asScala(strictHandler.apply(OptionConverters.toJava(v1)));
             }
           },
-          toSink.mapMaterializedValue(FutureConverters::toScala).asScala());
+          toSink.mapMaterializedValue(FutureConverters::asScala).asScala());
     }
   }
 

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -13,10 +13,9 @@ import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
-import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.compat.java8.FutureConverters._
+import scala.jdk.FutureConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -143,7 +142,7 @@ private class SinkAccumulator[-E, +A](wrappedSink: => Sink[E, Future[A]]) extend
   def toSink: Sink[E, Future[A]] = sink
 
   def asJava: play.libs.streams.Accumulator[E @uV, A @uV] = {
-    play.libs.streams.Accumulator.fromSink(sink.mapMaterializedValue(FutureConverters.toJava).asJava)
+    play.libs.streams.Accumulator.fromSink(sink.mapMaterializedValue(_.asJava).asJava)
   }
 }
 
@@ -201,8 +200,8 @@ private class StrictAccumulator[-E, +A](handler: Option[E] => Future[A], val toS
 
   override def asJava: play.libs.streams.Accumulator[E @uV, A @uV] =
     play.libs.streams.Accumulator.strict(
-      (t: Optional[E]) => handler(t.toScala).toJava,
-      toSink.mapMaterializedValue(FutureConverters.toJava).asJava
+      (t: Optional[E]) => handler(t.toScala).asJava,
+      toSink.mapMaterializedValue(_.asJava).asJava
     )
 }
 

--- a/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -14,7 +14,7 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import org.specs2.mutable.Specification
 
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -126,14 +126,14 @@ class AccumulatorSpec extends Specification {
       "Java asScala" in withMaterializer { implicit m =>
         await(
           play.libs.streams.Accumulator
-            .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int])
+            .fromSink(sum.toSink.mapMaterializedValue(_.asJava).asJava[Int])
             .asScala()
             .run(source)
         ) must_== 6
       }
 
       "Scala asJava" in withMaterializer { implicit m =>
-        await(FutureConverters.toScala(sum.asJava.run(source.asJava, m))) must_== 6
+        await(sum.asJava.run(source.asJava, m).asScala) must_== 6
       }
     }
   }
@@ -224,14 +224,14 @@ class AccumulatorSpec extends Specification {
         "Java asScala" in withMaterializer { implicit m =>
           await(
             play.libs.streams.Accumulator
-              .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int])
+              .fromSink(sum.toSink.mapMaterializedValue(_.asJava).asJava[Int])
               .asScala()
               .run(source)
           ) must_== 6
         }
 
         "Scala asJava" in withMaterializer { implicit m =>
-          await(FutureConverters.toScala(sum.asJava.run(source.asJava, m))) must_== 6
+          await(sum.asJava.run(source.asJava, m).asScala) must_== 6
         }
       }
     }
@@ -285,14 +285,14 @@ class AccumulatorSpec extends Specification {
         "Java asScala" in withMaterializer { implicit m =>
           await(
             play.libs.streams.Accumulator
-              .fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava[Int])
+              .fromSink(sum.toSink.mapMaterializedValue(_.asJava).asJava[Int])
               .asScala()
               .run(6)
           ) must_== 6
         }
 
         "Scala asJava" in withMaterializer { implicit m =>
-          await(FutureConverters.toScala(sum.asJava.run(6, m))) must_== 6
+          await(sum.asJava.run(6, m).asScala) must_== 6
         }
       }
     }

--- a/core/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -14,7 +14,7 @@ import akka.NotUsed
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 import akka.actor.ActorSystem
 import akka.stream.javadsl.Source
 import akka.stream.javadsl.Sink
@@ -92,7 +92,7 @@ class AccumulatorSpec extends org.specs2.mutable.Specification {
       "Java asScala" in withMaterializer { implicit m =>
         val sink = sum.toSink.mapMaterializedValue(new JFn[CompletionStage[Int], Future[Int]] {
           def apply(f: CompletionStage[Int]): Future[Int] =
-            FutureConverters.toScala(f)
+            f.asScala
         })
 
         await(play.api.libs.streams.Accumulator(sink.asScala).run(source.asScala)) must_== 6

--- a/core/play/src/main/java/play/ApplicationLoader.java
+++ b/core/play/src/main/java/play/ApplicationLoader.java
@@ -14,7 +14,7 @@ import play.api.inject.DefaultApplicationLifecycle;
 import play.core.SourceMapper;
 import play.inject.ApplicationLifecycle;
 import play.libs.Scala;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 /**
  * Loads an application. This is responsible for instantiating an application given a context.

--- a/core/play/src/main/java/play/ContextBasedBuiltInComponents.java
+++ b/core/play/src/main/java/play/ContextBasedBuiltInComponents.java
@@ -38,7 +38,7 @@ import play.libs.crypto.DefaultCookieSigner;
 import play.mvc.BodyParser;
 import play.mvc.FileMimeTypes;
 import scala.collection.immutable.Map$;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.util.Optional;
 import java.util.function.Supplier;

--- a/core/play/src/main/java/play/DelegateLoggerConfigurator.java
+++ b/core/play/src/main/java/play/DelegateLoggerConfigurator.java
@@ -7,7 +7,7 @@ package play;
 import com.typesafe.config.Config;
 import org.slf4j.ILoggerFactory;
 import play.libs.Scala;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import javax.inject.Inject;
 import java.io.File;

--- a/core/play/src/main/java/play/Environment.java
+++ b/core/play/src/main/java/play/Environment.java
@@ -13,7 +13,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Optional;
 
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 /**
  * The environment for the application.

--- a/core/play/src/main/java/play/LoggerConfigurator.java
+++ b/core/play/src/main/java/play/LoggerConfigurator.java
@@ -10,7 +10,7 @@ import play.api.Configuration;
 import play.api.LoggerConfigurator$;
 import play.libs.Scala;
 import scala.Option;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.io.File;
 import java.net.URL;

--- a/core/play/src/main/java/play/http/HttpEntity.java
+++ b/core/play/src/main/java/play/http/HttpEntity.java
@@ -11,7 +11,7 @@ import akka.util.ByteString;
 import play.api.http.HttpChunk;
 import play.twirl.api.Content;
 import play.twirl.api.Xml;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;

--- a/core/play/src/main/java/play/i18n/MessagesApi.java
+++ b/core/play/src/main/java/play/i18n/MessagesApi.java
@@ -10,7 +10,7 @@ import play.mvc.Http;
 import play.mvc.Result;
 import scala.collection.immutable.Seq;
 import scala.collection.mutable.Buffer;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 import scala.Option;
 
 import javax.inject.Inject;

--- a/core/play/src/main/java/play/inject/Binding.java
+++ b/core/play/src/main/java/play/inject/Binding.java
@@ -4,7 +4,7 @@
 
 package play.inject;
 
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;

--- a/core/play/src/main/java/play/inject/BindingKey.java
+++ b/core/play/src/main/java/play/inject/BindingKey.java
@@ -4,8 +4,8 @@
 
 package play.inject;
 
-import scala.compat.java8.functionConverterImpls.FromJavaSupplier;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.FunctionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import javax.inject.Provider;
 import java.lang.annotation.Annotation;
@@ -138,7 +138,7 @@ public final class BindingKey<T> {
 
   /** Bind this binding key to the given instance. */
   public <A extends T> Binding<T> to(final Supplier<A> instance) {
-    return underlying.to(new FromJavaSupplier<>(instance)).asJava();
+    return underlying.to(FunctionConverters.asScalaFromSupplier(instance)).asJava();
   }
 
   /** Bind this binding key to another binding key. */

--- a/core/play/src/main/java/play/libs/Scala.java
+++ b/core/play/src/main/java/play/libs/Scala.java
@@ -5,7 +5,7 @@
 package play.libs;
 
 import akka.japi.JavaPartialFunction;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 import scala.runtime.AbstractFunction0;
 
 import java.lang.reflect.Array;
@@ -159,7 +159,7 @@ public class Scala {
       @Override
       public scala.concurrent.Future<A> apply() {
         try {
-          return FutureConverters.toScala(callable.call());
+          return FutureConverters.asScala(callable.call());
         } catch (RuntimeException | Error e) {
           throw e;
         } catch (Throwable t) {

--- a/core/play/src/main/java/play/libs/concurrent/DefaultFutures.java
+++ b/core/play/src/main/java/play/libs/concurrent/DefaultFutures.java
@@ -15,7 +15,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
-import static scala.compat.java8.FutureConverters.toJava;
+import static scala.jdk.javaapi.FutureConverters.asJava;
 
 /**
  * The default implementation of the Futures trait. This provides an implementation that uses the
@@ -49,7 +49,7 @@ public class DefaultFutures implements Futures {
     requireNonNull(unit, "Null unit");
 
     FiniteDuration duration = FiniteDuration.apply(amount, unit);
-    return toJava(delegate.timeout(duration, Scala.asScalaWithFuture(() -> stage)));
+    return asJava(delegate.timeout(duration, Scala.asScalaWithFuture(() -> stage)));
   }
 
   /**
@@ -67,7 +67,7 @@ public class DefaultFutures implements Futures {
 
     FiniteDuration finiteDuration =
         FiniteDuration.apply(duration.toMillis(), TimeUnit.MILLISECONDS);
-    return toJava(delegate.timeout(finiteDuration, Scala.asScalaWithFuture(() -> stage)));
+    return asJava(delegate.timeout(finiteDuration, Scala.asScalaWithFuture(() -> stage)));
   }
 
   /**
@@ -88,20 +88,20 @@ public class DefaultFutures implements Futures {
     requireNonNull(unit, "Null unit");
 
     FiniteDuration duration = FiniteDuration.apply(amount, unit);
-    return toJava(delegate.delayed(duration, Scala.asScalaWithFuture(callable)));
+    return asJava(delegate.delayed(duration, Scala.asScalaWithFuture(callable)));
   }
 
   @Override
   public CompletionStage<Done> delay(Duration duration) {
     FiniteDuration finiteDuration =
         FiniteDuration.apply(duration.toMillis(), TimeUnit.MILLISECONDS);
-    return toJava(delegate.delay(finiteDuration));
+    return asJava(delegate.delay(finiteDuration));
   }
 
   @Override
   public CompletionStage<Done> delay(long amount, TimeUnit unit) {
     FiniteDuration finiteDuration = FiniteDuration.apply(amount, unit);
-    return toJava(delegate.delay(finiteDuration));
+    return asJava(delegate.delay(finiteDuration));
   }
 
   /**
@@ -121,6 +121,6 @@ public class DefaultFutures implements Futures {
 
     FiniteDuration finiteDuration =
         FiniteDuration.apply(duration.toMillis(), TimeUnit.MILLISECONDS);
-    return toJava(delegate.delayed(finiteDuration, Scala.asScalaWithFuture(callable)));
+    return asJava(delegate.delayed(finiteDuration, Scala.asScalaWithFuture(callable)));
   }
 }

--- a/core/play/src/main/java/play/libs/typedmap/TypedMap.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedMap.java
@@ -5,7 +5,7 @@
 package play.libs.typedmap;
 
 import play.api.libs.typedmap.TypedMap$;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.util.Arrays;
 import java.util.List;

--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -31,8 +31,8 @@ import play.libs.streams.Accumulator;
 import play.mvc.Http.Status;
 import scala.Option;
 import scala.jdk.javaapi.CollectionConverters;
-import scala.compat.java8.FutureConverters;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.FutureConverters;
+import scala.jdk.javaapi.OptionConverters;
 import scala.concurrent.Future;
 import scala.runtime.AbstractFunction1;
 
@@ -574,7 +574,7 @@ public interface BodyParser<A> {
             takeUpToFlow.toMat(
                 result,
                 (statusFuture, resultFuture) ->
-                    FutureConverters.toJava(statusFuture)
+                    FutureConverters.asJava(statusFuture)
                         .thenCompose(
                             status -> {
                               if (status instanceof MaxSizeNotExceeded$) {

--- a/core/play/src/main/java/play/mvc/FileMimeTypes.java
+++ b/core/play/src/main/java/play/mvc/FileMimeTypes.java
@@ -4,7 +4,7 @@
 
 package play.mvc;
 
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;

--- a/core/play/src/main/java/play/mvc/Filter.java
+++ b/core/play/src/main/java/play/mvc/Filter.java
@@ -7,7 +7,7 @@ package play.mvc;
 import akka.stream.Materializer;
 import play.mvc.Http.RequestHeader;
 import scala.Function1;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 import scala.concurrent.Future;
 
 import java.util.concurrent.CompletionStage;
@@ -36,11 +36,11 @@ public abstract class Filter extends EssentialFilter {
       public Future<play.api.mvc.Result> apply(
           Function1<play.api.mvc.RequestHeader, Future<play.api.mvc.Result>> next,
           play.api.mvc.RequestHeader requestHeader) {
-        return FutureConverters.toScala(
+        return FutureConverters.asScala(
             Filter.this
                 .apply(
                     (rh) ->
-                        FutureConverters.toJava(next.apply(rh.asScala()))
+                        FutureConverters.asJava(next.apply(rh.asScala()))
                             .thenApply(play.api.mvc.Result::asJava),
                     requestHeader.asJava())
                 .thenApply(Result::asScala));

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -29,7 +29,7 @@ import play.libs.typedmap.TypedKey;
 import play.libs.typedmap.TypedMap;
 import play.mvc.Http.Cookie.SameSite;
 import scala.collection.immutable.Map$;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
@@ -1976,7 +1976,7 @@ public class Http {
       return new play.api.mvc.Cookie(
           name(),
           value(),
-          OptionConverters.toScala(optMaxAge),
+          OptionConverters.toScala(optMaxAge).map(x -> x),
           path(),
           OptionConverters.toScala(optDomain),
           secure(),

--- a/core/play/src/main/java/play/mvc/ResponseHeader.java
+++ b/core/play/src/main/java/play/mvc/ResponseHeader.java
@@ -4,7 +4,7 @@
 
 package play.mvc;
 
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.util.*;
 

--- a/core/play/src/main/java/play/mvc/Results.java
+++ b/core/play/src/main/java/play/mvc/Results.java
@@ -20,7 +20,7 @@ import play.core.j.JavaHelpers;
 import play.http.HttpEntity;
 import play.twirl.api.Content;
 import scala.jdk.javaapi.CollectionConverters;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import static play.mvc.Http.HeaderNames.LOCATION;
 import static play.mvc.Http.Status.*;

--- a/core/play/src/main/java/play/server/ApplicationProvider.java
+++ b/core/play/src/main/java/play/server/ApplicationProvider.java
@@ -7,7 +7,7 @@ package play.server;
 import play.Application;
 import play.mvc.Http;
 import play.mvc.Result;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.util.Optional;
 

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -23,7 +23,7 @@ import play.utils.PlayIO
 import play.utils.Reflect
 
 import scala.annotation.tailrec
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 import scala.concurrent._
 import scala.util.Failure
 import scala.util.Success
@@ -563,8 +563,8 @@ private[play] class JavaHttpErrorHandlerDelegate @Inject() (delegate: HttpErrorH
   import play.core.Execution.Implicits.trampoline
 
   def onClientError(request: Http.RequestHeader, statusCode: Int, message: String): CompletionStage[play.mvc.Result] =
-    FutureConverters.toJava(delegate.onClientError(request.asScala(), statusCode, message).map(_.asJava))
+    delegate.onClientError(request.asScala(), statusCode, message).map(_.asJava).asJava
 
   def onServerError(request: Http.RequestHeader, exception: Throwable): CompletionStage[play.mvc.Result] =
-    FutureConverters.toJava(delegate.onServerError(request.asScala(), exception).map(_.asJava))
+    delegate.onServerError(request.asScala(), exception).map(_.asJava).asJava
 }

--- a/core/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/core/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 import play.api.Logger
 
 import scala.annotation.tailrec
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Failure
@@ -74,7 +74,7 @@ trait ApplicationLifecycle {
    * immediately and return a successful future.
    */
   def addStopHook(hook: Callable[_ <: CompletionStage[_]]): Unit =
-    addStopHook(() => { val cs = hook.call(); FutureConverters.toScala(cs) })
+    addStopHook(() => { val cs = hook.call(); cs.asScala })
 
   /**
    * Call to shutdown the application and execute the registered hooks.

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -368,7 +368,7 @@ object Files {
       Future {
         playTempFolder
           .map { f =>
-            import scala.compat.java8.StreamConverters._
+            import scala.jdk.StreamConverters._
 
             val directoryStream: stream.Stream[Path] = JFiles.list(f)
 
@@ -378,7 +378,7 @@ object Files {
                   val lastModifiedTime = JFiles.getLastModifiedTime(p).toInstant
                   lastModifiedTime.isBefore(secondsAgo)
                 })
-                .toScala[List]
+                .toScala(List)
 
               reaped.foreach(delete)
               reaped

--- a/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala
+++ b/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala
@@ -7,7 +7,6 @@ package play.core.j
 import java.util.concurrent.Executor
 
 import play.utils.ExecCtxUtils
-import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 
@@ -35,7 +34,7 @@ object HttpExecutionContext {
   def fromThread(delegate: Executor): ExecutionContextExecutor =
     new HttpExecutionContext(
       Thread.currentThread().getContextClassLoader(),
-      FutureConverters.fromExecutor(delegate)
+      ExecutionContext.fromExecutor(delegate)
     )
 
   /**

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -14,7 +14,7 @@ import play.api.http.HttpConfiguration
 import play.api.inject.Injector
 import play.api.Logger
 
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 import scala.language.existentials
 import play.core.Execution.Implicits.trampoline
 import play.api.mvc._
@@ -173,7 +173,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
       logger.debug("### End of action order")
     }
     val actionFuture: Future[Future[JResult]] = Future {
-      FutureConverters.toScala(firstAction.call(javaRequest))
+      firstAction.call(javaRequest).asScala
     }(trampolineWithContext)
     val flattenedActionFuture: Future[JResult] = actionFuture.flatMap(identity)(trampoline)
     val resultFuture: Future[Result]           = flattenedActionFuture.map(_.asScala)(trampoline)

--- a/core/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
@@ -11,7 +11,7 @@ import play.api.mvc.RequestHeader
 import play.core.Execution
 import play.http.{ HttpErrorHandler => JHttpErrorHandler }
 
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 
 /**
  * Adapter from a Java HttpErrorHandler to a Scala HttpErrorHandler
@@ -23,12 +23,13 @@ class JavaHttpErrorHandlerAdapter @Inject() (underlying: JHttpErrorHandler) exte
   }
 
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
-    FutureConverters
-      .toScala(underlying.onClientError(request.asJava, statusCode, message))
+    underlying
+      .onClientError(request.asJava, statusCode, message)
+      .asScala
       .map(_.asScala)(Execution.trampoline)
   }
 
   def onServerError(request: RequestHeader, exception: Throwable) = {
-    FutureConverters.toScala(underlying.onServerError(request.asJava, exception)).map(_.asScala)(Execution.trampoline)
+    underlying.onServerError(request.asJava, exception).asScala.map(_.asScala)(Execution.trampoline)
   }
 }

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -16,7 +16,7 @@ import play.core.j._
 import play.libs.reflect.MethodUtils
 import play.mvc.Http.RequestBody
 
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
 import scala.util.control.NonFatal
 
@@ -173,7 +173,7 @@ object HandlerInvokerFactory {
       def call(call: => JWebSocket) = new JavaHandler {
         def withComponents(handlerComponents: JavaHandlerComponents): WebSocket = {
           WebSocket.acceptOrResult[Message, Message] { request =>
-            FutureConverters.toScala(call(request.asJava)).map { resultOrFlow =>
+            call(request.asJava).asScala.map { resultOrFlow =>
               if (resultOrFlow.left.isPresent) {
                 Left(resultOrFlow.left.get.asScala())
               } else {

--- a/core/play/src/test/java/play/mvc/RangeResultsTest.java
+++ b/core/play/src/test/java/play/mvc/RangeResultsTest.java
@@ -17,7 +17,7 @@ import akka.stream.javadsl.FileIO;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import org.junit.*;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -422,7 +422,7 @@ public class RangeResultsTest {
     Materializer mat = Materializer.matFromSystem(actorSystem);
     ByteString bs =
         Await.result(
-            FutureConverters.toScala(result.body().consumeData(mat)), Duration.create("60s"));
+            FutureConverters.asScala(result.body().consumeData(mat)), Duration.create("60s"));
     return bs.utf8String();
   }
 }

--- a/core/play/src/test/java/play/mvc/ResultsTest.java
+++ b/core/play/src/test/java/play/mvc/ResultsTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import play.mvc.Http.HeaderNames;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -251,7 +251,7 @@ public class ResultsTest {
 
       // Actually we need to wait until the Stream completes
       Await.ready(
-          FutureConverters.toScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
+          FutureConverters.asScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
           Duration.create("60s"));
       // and then we need to wait until the onClose completes
       Thread.sleep(500);
@@ -273,7 +273,7 @@ public class ResultsTest {
 
       // Actually we need to wait until the Stream completes
       Await.ready(
-          FutureConverters.toScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
+          FutureConverters.asScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
           Duration.create("60s"));
       // and then we need to wait until the onClose completes
       Thread.sleep(500);
@@ -296,7 +296,7 @@ public class ResultsTest {
 
       // Actually we need to wait until the Stream completes
       Await.ready(
-          FutureConverters.toScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
+          FutureConverters.asScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
           Duration.create("60s"));
       // and then we need to wait until the onClose completes
       Thread.sleep(500);
@@ -324,7 +324,7 @@ public class ResultsTest {
 
       // Actually we need to wait until the Stream completes
       Await.ready(
-          FutureConverters.toScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
+          FutureConverters.asScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
           Duration.create("60s"));
       // and then we need to wait until the onClose completes
       Thread.sleep(500);
@@ -350,7 +350,7 @@ public class ResultsTest {
 
       // Actually we need to wait until the Stream completes
       Await.ready(
-          FutureConverters.toScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
+          FutureConverters.asScala(result.body().dataStream().runWith(Sink.ignore(), mat)),
           Duration.create("60s"));
       // and then we need to wait until the onClose completes
       Thread.sleep(500);

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/Application.scala
@@ -7,7 +7,7 @@ package controllers
 import play.api.mvc._
 import javax.inject.Inject
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 import models._
 
 class Application @Inject()(c: ControllerComponents) extends AbstractController(c) {
@@ -42,7 +42,7 @@ class Application @Inject()(c: ControllerComponents) extends AbstractController(
     Ok(x.getOrElse("emptyOption"))
   }
   def takeStringOptional(x: java.util.Optional[String]) = Action {
-    Ok(x.asScala.getOrElse("emptyOptional"))
+    Ok(x.toScala.getOrElse("emptyOptional"))
   }
   def takeChar(x: Char) = Action {
     Ok(x.toString)
@@ -60,16 +60,16 @@ class Application @Inject()(c: ControllerComponents) extends AbstractController(
     Ok(x.toString)
   }
   def takeIntegerOptional(x: java.util.Optional[Integer]) = Action {
-    Ok(x.asScala.map(_.toString).getOrElse("emptyOptional"))
+    Ok(x.toScala.map(_.toString).getOrElse("emptyOptional"))
   }
   def takeOptionalInt(x: java.util.OptionalInt) = Action {
-    Ok(x.asScala.map(_.toString).getOrElse("emptyOptionalInt"))
+    Ok(x.toScala.map(_.toString).getOrElse("emptyOptionalInt"))
   }
   def takeOptionalLong(x: java.util.OptionalLong) = Action {
-    Ok(x.asScala.map(_.toString).getOrElse("emptyOptionalLong"))
+    Ok(x.toScala.map(_.toString).getOrElse("emptyOptionalLong"))
   }
   def takeOptionalDouble(x: java.util.OptionalDouble) = Action {
-    Ok(x.asScala.map(_.toString).getOrElse("emptyOptionalDouble"))
+    Ok(x.toScala.map(_.toString).getOrElse("emptyOptionalDouble"))
   }
   def takeListString(x: List[String]) = Action {
     Ok(
@@ -121,7 +121,7 @@ class Application @Inject()(c: ControllerComponents) extends AbstractController(
   }
   def takeJavaListStringOptional(x: java.util.Optional[java.util.List[String]]) = Action {
     Ok(
-      x.asScala
+      x.toScala
         .map(
           _.asScala
             .map(
@@ -147,7 +147,7 @@ class Application @Inject()(c: ControllerComponents) extends AbstractController(
     Ok(x.asScala.mkString(","))
   }
   def takeJavaListIntegerOptional(x: java.util.Optional[java.util.List[Integer]]) = Action {
-    Ok(x.asScala.map(_.asScala.mkString(",")).getOrElse("emptyOptional"))
+    Ok(x.toScala.map(_.asScala.mkString(",")).getOrElse("emptyOptional"))
   }
   def takeStringWithDefault(x: String) = Action {
     Ok(x)
@@ -156,7 +156,7 @@ class Application @Inject()(c: ControllerComponents) extends AbstractController(
     Ok(x.getOrElse("emptyOption"))
   }
   def takeStringOptionalWithDefault(x: java.util.Optional[String]) = Action {
-    Ok(x.asScala.getOrElse("emptyOptional"))
+    Ok(x.toScala.getOrElse("emptyOptional"))
   }
   def takeCharWithDefault(x: Char) = Action {
     Ok(x.toString)
@@ -174,16 +174,16 @@ class Application @Inject()(c: ControllerComponents) extends AbstractController(
     Ok(x.toString)
   }
   def takeIntegerOptionalWithDefault(x: java.util.Optional[Integer]) = Action {
-    Ok(x.asScala.map(_.toString).getOrElse("emptyOptional"))
+    Ok(x.toScala.map(_.toString).getOrElse("emptyOptional"))
   }
   def takeOptionalIntWithDefault(x: java.util.OptionalInt) = Action {
-    Ok(x.asScala.map(_.toString).getOrElse("emptyOptionalInt"))
+    Ok(x.toScala.map(_.toString).getOrElse("emptyOptionalInt"))
   }
   def takeOptionalLongWithDefault(x: java.util.OptionalLong) = Action {
-    Ok(x.asScala.map(_.toString).getOrElse("emptyOptionalLong"))
+    Ok(x.toScala.map(_.toString).getOrElse("emptyOptionalLong"))
   }
   def takeOptionalDoubleWithDefault(x: java.util.OptionalDouble) = Action {
-    Ok(x.asScala.map(_.toString).getOrElse("emptyOptionalDouble"))
+    Ok(x.toScala.map(_.toString).getOrElse("emptyOptionalDouble"))
   }
   def takeListStringWithDefault(x: List[String]) = Action {
     Ok(
@@ -235,7 +235,7 @@ class Application @Inject()(c: ControllerComponents) extends AbstractController(
   }
   def takeJavaListStringOptionalWithDefault(x: java.util.Optional[java.util.List[String]]) = Action {
     Ok(
-      x.asScala
+      x.toScala
         .map(
           _.asScala
             .map(
@@ -261,7 +261,7 @@ class Application @Inject()(c: ControllerComponents) extends AbstractController(
     Ok(x.asScala.mkString(","))
   }
   def takeJavaListIntegerOptionalWithDefault(x: java.util.Optional[java.util.List[Integer]]) = Action {
-    Ok(x.asScala.map(_.asScala.mkString(",")).getOrElse("emptyOptional"))
+    Ok(x.toScala.map(_.asScala.mkString(",")).getOrElse("emptyOptional"))
   }
   def urlcoding(dynamic: String, static: String, query: String) = Action {
     Ok(s"dynamic=$dynamic static=$static query=$query")

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ask/Application.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ask/Application.java
@@ -10,7 +10,7 @@ import javaguide.akka.HelloActorProtocol.SayHello;
 // #ask
 import akka.actor.*;
 import play.mvc.*;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 import javax.inject.*;
 import java.util.concurrent.CompletionStage;
 
@@ -27,7 +27,7 @@ public class Application extends Controller {
   }
 
   public CompletionStage<Result> sayHello(String name) {
-    return FutureConverters.toJava(ask(helloActor, new SayHello(name), 1000))
+    return FutureConverters.asJava(ask(helloActor, new SayHello(name), 1000))
         .thenApply(response -> ok((String) response));
   }
 }

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/inject/Application.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/inject/Application.java
@@ -9,7 +9,7 @@ import javaguide.akka.ConfiguredActorProtocol;
 // #inject
 import akka.actor.ActorRef;
 import play.mvc.*;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -27,7 +27,7 @@ public class Application extends Controller {
   }
 
   public CompletionStage<Result> getConfig() {
-    return FutureConverters.toJava(
+    return FutureConverters.asJava(
             ask(configuredActor, new ConfiguredActorProtocol.GetConfig(), 1000))
         .thenApply(response -> ok((String) response));
   }

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
@@ -48,7 +48,7 @@ public class CompileTimeDependencyInjection {
   // #basic-my-components
 
   // #basic-logger-configurator
-  // ###insert: import scala.compat.java8.OptionConverters;
+  // ###insert: import scala.jdk.javaapi.OptionConverters;
   public class MyAppLoaderWithLoggerConfiguration implements ApplicationLoader {
     @Override
     public Application load(Context context) {

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/MyController.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/MyController.java
@@ -14,7 +14,7 @@ import akka.util.ByteString;
 import play.mvc.*;
 import play.libs.ws.*;
 
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 
 public class MyController extends Controller {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,8 +90,7 @@ object Dependencies {
     "org.hibernate"                   % "hibernate-core"        % "5.4.32.Final" % "test"
   )
 
-  def scalaReflect(scalaVersion: String) = "org.scala-lang"         % "scala-reflect"       % scalaVersion % "provided"
-  val scalaJava8Compat                   = "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
+  def scalaReflect(scalaVersion: String) = "org.scala-lang" % "scala-reflect" % scalaVersion % "provided"
   def scalaParserCombinators(scalaVersion: String) =
     Seq("org.scala-lang.modules" %% "scala-parser-combinators" % {
       CrossVersion.partialVersion(scalaVersion) match {
@@ -103,7 +102,6 @@ object Dependencies {
   val springFrameworkVersion = "5.3.19"
 
   val javaDeps = Seq(
-    scalaJava8Compat,
     // Used by the Java routing DSL
     "net.jodah"         % "typetools" % "0.6.3"
   ) ++ specs2Deps.map(_ % Test)
@@ -161,7 +159,6 @@ object Dependencies {
         "jakarta.transaction" % "jakarta.transaction-api" % "2.0.1",
         "javax.inject"        % "javax.inject"            % "1",
         scalaReflect(scalaVersion),
-        scalaJava8Compat,
         sslConfig
       ) ++ scalaParserCombinators(scalaVersion) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
 
@@ -229,9 +226,8 @@ object Dependencies {
   ) ++ playdocWebjarDependencies
 
   val streamsDependencies = Seq(
-    "org.reactivestreams" % "reactive-streams" % "1.0.3",
-    "com.typesafe.akka"   %% "akka-stream"     % akkaVersion,
-    scalaJava8Compat
+    "org.reactivestreams"   % "reactive-streams" % "1.0.3",
+    "com.typesafe.akka"     %% "akka-stream" % akkaVersion,
   ) ++ specs2CoreDeps.map(_ % Test) ++ javaTestDeps
 
   val playServerDependencies = specs2Deps.map(_ % Test) ++ Seq(

--- a/testkit/play-test/src/main/java/play/test/Helpers.java
+++ b/testkit/play-test/src/main/java/play/test/Helpers.java
@@ -32,8 +32,8 @@ import play.mvc.Call;
 import play.mvc.Result;
 import play.routing.Router;
 import play.twirl.api.Content;
-import scala.compat.java8.FutureConverters;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.FutureConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import static play.libs.Scala.asScala;
 import static play.mvc.Http.Request;
@@ -87,7 +87,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     } else {
       try {
         final play.api.mvc.Result scalaResult =
-            FutureConverters.toJava(result)
+            FutureConverters.asJava(result)
                 .toCompletableFuture()
                 .get(timeout, TimeUnit.MILLISECONDS);
         return scalaResult.asJava();

--- a/testkit/play-test/src/main/java/play/test/TestServer.java
+++ b/testkit/play-test/src/main/java/play/test/TestServer.java
@@ -8,7 +8,7 @@ import play.Application;
 import play.Mode;
 import play.core.server.ServerConfig;
 import scala.Option;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.io.File;
 import java.util.Optional;
@@ -61,13 +61,13 @@ public class TestServer extends play.api.test.TestServer {
   @SuppressWarnings("unchecked")
   public OptionalInt getRunningHttpPort() {
     Option scalaPortOption = runningHttpPort();
-    return OptionConverters.specializer_OptionalInt().fromScala(scalaPortOption);
+    return OptionConverters.toJavaOptionalInt(scalaPortOption);
   }
 
   /** The HTTPS port that the server is running on. */
   @SuppressWarnings("unchecked")
   public OptionalInt getRunningHttpsPort() {
     Option scalaPortOption = runningHttpsPort();
-    return OptionConverters.specializer_OptionalInt().fromScala(scalaPortOption);
+    return OptionConverters.toJavaOptionalInt(scalaPortOption);
   }
 }

--- a/testkit/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -14,7 +14,7 @@ import org.openqa.selenium.firefox._
 import org.openqa.selenium.htmlunit._
 import org.openqa.selenium.support.ui.FluentWait
 
-import scala.compat.java8.FunctionConverters._
+import scala.jdk.FunctionConverters._
 
 /**
  * A test browser (Using Selenium WebDriver) with the FluentLenium API (https://github.com/Fluentlenium/FluentLenium).

--- a/transport/server/play-server/src/main/java/play/server/Server.java
+++ b/transport/server/play-server/src/main/java/play/server/Server.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 /** A Play server. */
 public class Server {

--- a/web/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
@@ -12,7 +12,7 @@ import scala.Option;
 
 import java.util.concurrent.CompletionStage;
 
-import static scala.compat.java8.OptionConverters.*;
+import static scala.jdk.javaapi.OptionConverters.*;
 
 /** Processes a request and adds content security policy header. */
 public abstract class AbstractCSPAction extends Action<CSP> {

--- a/web/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -16,7 +16,7 @@ import play.mvc.Http;
 import play.mvc.Http.RequestBody;
 import play.mvc.Http.RequestImpl;
 import play.mvc.Result;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 

--- a/web/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
@@ -7,7 +7,7 @@ package play.filters.csrf;
 import play.mvc.Http;
 import play.mvc.Results;
 import play.mvc.Result;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 
 import javax.inject.Inject;
 import java.util.concurrent.CompletionStage;
@@ -35,7 +35,7 @@ public interface CSRFErrorHandler {
 
     @Override
     public CompletionStage<Result> handle(Http.RequestHeader requestHeader, String msg) {
-      return FutureConverters.toJava(errorHandler.handle(requestHeader.asScala(), msg))
+      return FutureConverters.asJava(errorHandler.handle(requestHeader.asScala(), msg))
           .thenApply(play.api.mvc.Result::asJava);
     }
   }

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -82,7 +82,7 @@ case class CORSConfig(
     copy(serveForbiddenOrigins = serveForbiddenOrigins)
 
   import scala.jdk.CollectionConverters._
-  import scala.compat.java8.FunctionConverters._
+  import scala.jdk.FunctionConverters._
   import java.util.{ function => juf }
 
   def withOriginsAllowed(origins: juf.Function[String, Boolean]): CORSConfig = withOriginsAllowed(origins.asScala)

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
@@ -29,7 +29,7 @@ case class CSPConfig(
 
   import play.mvc.Http.{ RequestHeader => JRequestHeader }
 
-  import scala.compat.java8.FunctionConverters._
+  import scala.jdk.FunctionConverters._
 
   /** Java Constructor */
   def this() = this(reportOnly = true)

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -29,7 +29,7 @@ import play.filters.csrf.CSRF._
 import play.mvc.Http
 import play.utils.Reflect
 
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 import scala.concurrent.Future
 
 /**
@@ -70,7 +70,7 @@ case class CSRFConfig(
 
   import play.mvc.Http.{ RequestHeader => JRequestHeader }
 
-  import scala.compat.java8.FunctionConverters._
+  import scala.jdk.FunctionConverters._
   import scala.jdk.OptionConverters._
 
   def withTokenName(tokenName: String)                = copy(tokenName = tokenName)
@@ -296,14 +296,14 @@ object CSRF {
       this(underlying)
     }
     def handle(request: RequestHeader, msg: String) =
-      FutureConverters.toScala(underlying.handle(request.asJava, msg)).map(_.asScala)(Execution.trampoline)
+      underlying.handle(request.asJava, msg).asScala.map(_.asScala)(Execution.trampoline)
   }
 
   class JavaCSRFErrorHandlerDelegate @Inject() (delegate: ErrorHandler) extends CSRFErrorHandler {
     import play.core.Execution.Implicits.trampoline
 
     def handle(requestHeader: Http.RequestHeader, msg: String) =
-      FutureConverters.toJava(delegate.handle(requestHeader.asScala(), msg).map(_.asJava))
+      delegate.handle(requestHeader.asScala(), msg).map(_.asJava).asJava
   }
 
   object ErrorHandler {

--- a/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -24,7 +24,7 @@ import play.api.libs.streams.GzipFlow
 import play.api.mvc.RequestHeader.acceptHeader
 import play.api.mvc._
 
-import scala.compat.java8.FunctionConverters._
+import scala.jdk.FunctionConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 

--- a/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -93,7 +93,7 @@ private[hosts] case class HostMatcher(pattern: String) {
 case class AllowedHostsConfig(allowed: Seq[String], shouldProtect: RequestHeader => Boolean = _ => true) {
   import scala.jdk.CollectionConverters._
   import play.mvc.Http.{ RequestHeader => JRequestHeader }
-  import scala.compat.java8.FunctionConverters._
+  import scala.jdk.FunctionConverters._
 
   def withHostPatterns(hosts: java.util.List[String]): AllowedHostsConfig = copy(allowed = hosts.asScala.toSeq)
   def withShouldProtect(shouldProtect: java.util.function.Predicate[JRequestHeader]): AllowedHostsConfig =

--- a/web/play-openid/src/main/java/play/libs/openid/DefaultOpenIdClient.java
+++ b/web/play-openid/src/main/java/play/libs/openid/DefaultOpenIdClient.java
@@ -6,7 +6,7 @@ package play.libs.openid;
 
 import play.libs.Scala;
 import play.mvc.Http;
-import scala.compat.java8.FutureConverters;
+import scala.jdk.javaapi.FutureConverters;
 import scala.concurrent.ExecutionContext;
 import scala.runtime.AbstractFunction1;
 
@@ -56,7 +56,7 @@ public class DefaultOpenIdClient implements OpenIdClient {
       String realm) {
     if (axRequired == null) axRequired = new HashMap<>();
     if (axOptional == null) axOptional = new HashMap<>();
-    return FutureConverters.toJava(
+    return FutureConverters.asJava(
         client.redirectURL(
             openID,
             callbackURL,
@@ -79,6 +79,6 @@ public class DefaultOpenIdClient implements OpenIdClient {
                   }
                 },
                 executionContext);
-    return FutureConverters.toJava(scalaPromise);
+    return FutureConverters.asJava(scalaPromise);
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose


use std `scala.jdk.` classes instead of `scala-java8-compat` library.

## Background Context

- playframework dropped Scala 2.12 https://github.com/playframework/playframework/pull/10956
- https://github.com/scala/scala/blob/2.13.x/src/library/scala/jdk/ scala std lib has some converters since Scala 2.13

## References
