### PR TITLE
fix warning in `project/Docs.scala`

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -8,6 +8,8 @@ import sbt.File
 import sbt.util.CacheStoreFactory
 import sbt.internal.inc.AnalyzingCompiler
 import sbt.internal.inc.LoggedReporter
+import sbt.internal.inc.PlainVirtualFile
+import sbt.internal.inc.PlainVirtualFileConverter
 import java.net.URLClassLoader
 import java.util.Optional
 import org.webjars.WebJarExtractor
@@ -187,7 +189,16 @@ object Docs {
     val log        = streams.value.log
     val reporter   = new LoggedReporter(10, log)
 
-    javadoc.run(sources, classpath, outputDir, options, incToolOpt, log, reporter)
+    javadoc.run(
+      sources = sources.map(s => PlainVirtualFile(s.toPath)),
+      classpath = classpath.map(s => PlainVirtualFile(s.toPath)),
+      converter = PlainVirtualFileConverter.converter,
+      outputDirectory = outputDir.toPath,
+      options = options,
+      incToolOptions = incToolOpt,
+      log = log,
+      reporter = reporter
+    )
   }
 
   def fixJavadocLinks(apiTarget: File) = {


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose

fix warnings

## Background Context



> [warn] /home/runner/work/playframework/playframework/project/Docs.scala:190:13: method run in trait JavaDoc is deprecated (since 1.4.0): Use variant that takes VirtualFiles
> [warn]     javadoc.run(sources, classpath, outputDir, options, incToolOpt, log, reporter)
> [warn]             ^
> [warn] one warning found


https://github.com/sbt/zinc/blob/57d03412abe3810be5762a8c8e8c55cbf622ed03/zinc-compile/src/main/scala/sbt/inc/Doc.scala#L108

## References
