### PR TITLE
Update Evolutions.scala

### DIFF
--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -91,6 +91,7 @@ private[evolutions] object DatabaseUrlPatterns {
   lazy val OracleJdbcUrl    = "^jdbc:oracle:.*".r
   lazy val MysqlJdbcUrl     = "^(jdbc:)?mysql:.*".r
   lazy val DerbyJdbcUrl     = "^jdbc:derby:.*".r
+  lazy val HsqlJdbcUrl      = "^jdbc:hsqldb:.*".r
 }
 
 /**

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -126,16 +126,16 @@ trait EvolutionsApi {
    *     final sql instead of replacing it with its substitution.
    */
   def evolve(
-              db: String,
-              scripts: Seq[Script],
-              autocommit: Boolean,
-              schema: String,
-              metaTable: String,
-              substitutionsMappings: Map[String, String],
-              substitutionsPrefix: String,
-              substitutionsSuffix: String,
-              substitutionsEscape: Boolean
-            ): Unit
+      db: String,
+      scripts: Seq[Script],
+      autocommit: Boolean,
+      schema: String,
+      metaTable: String,
+      substitutionsMappings: Map[String, String],
+      substitutionsPrefix: String,
+      substitutionsSuffix: String,
+      substitutionsEscape: Boolean
+  ): Unit
 
   /**
    * Resolve evolution conflicts.
@@ -160,16 +160,16 @@ trait EvolutionsApi {
    * Apply pending evolutions for the given database.
    */
   def applyFor(
-                dbName: String,
-                path: File = new File("."),
-                autocommit: Boolean = true,
-                schema: String = "",
-                metaTable: String = "play_evolutions",
-                substitutionsMappings: Map[String, String] = Map.empty,
-                substitutionsPrefix: String = "$evolutions{{{",
-                substitutionsSuffix: String = "}}}",
-                substitutionsEscape: Boolean = true
-              ): Unit = {
+      dbName: String,
+      path: File = new File("."),
+      autocommit: Boolean = true,
+      schema: String = "",
+      metaTable: String = "play_evolutions",
+      substitutionsMappings: Map[String, String] = Map.empty,
+      substitutionsPrefix: String = "$evolutions{{{",
+      substitutionsSuffix: String = "}}}",
+      substitutionsEscape: Boolean = true
+  ): Unit = {
     val scripts =
       this.scripts(dbName, new EnvironmentEvolutionsReader(Environment.simple(path = path)), schema, metaTable)
     this.evolve(
@@ -192,14 +192,14 @@ trait EvolutionsApi {
 @Singleton
 class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
   private def databaseEvolutions(
-                                  name: String,
-                                  schema: String,
-                                  metaTable: String = "play_evolutions",
-                                  substitutionsMappings: Map[String, String] = Map.empty,
-                                  substitutionsPrefix: String = "$evolutions{{{",
-                                  substitutionsSuffix: String = "}}}",
-                                  substitutionsEscape: Boolean = true
-                                ) =
+      name: String,
+      schema: String,
+      metaTable: String = "play_evolutions",
+      substitutionsMappings: Map[String, String] = Map.empty,
+      substitutionsPrefix: String = "$evolutions{{{",
+      substitutionsSuffix: String = "}}}",
+      substitutionsEscape: Boolean = true
+  ) =
     new DatabaseEvolutions(
       dbApi.database(name),
       schema,
@@ -233,16 +233,16 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
     databaseEvolutions(db, schema, metaTable).evolve(scripts, autocommit)
 
   def evolve(
-              db: String,
-              scripts: Seq[Script],
-              autocommit: Boolean,
-              schema: String,
-              metaTable: String,
-              substitutionsMappings: Map[String, String],
-              substitutionsPrefix: String,
-              substitutionsSuffix: String,
-              substitutionsEscape: Boolean
-            ): Unit =
+      db: String,
+      scripts: Seq[Script],
+      autocommit: Boolean,
+      schema: String,
+      metaTable: String,
+      substitutionsMappings: Map[String, String],
+      substitutionsPrefix: String,
+      substitutionsSuffix: String,
+      substitutionsEscape: Boolean
+  ): Unit =
     databaseEvolutions(
       db,
       schema,
@@ -263,14 +263,14 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
  * Evolutions for a particular database.
  */
 class DatabaseEvolutions(
-                          database: Database,
-                          schema: String = "",
-                          metaTable: String = "play_evolutions",
-                          substitutionsMappings: Map[String, String] = Map.empty,
-                          substitutionsPrefix: String = "$evolutions{{{",
-                          substitutionsSuffix: String = "}}}",
-                          substitutionsEscape: Boolean = true
-                        ) {
+    database: Database,
+    schema: String = "",
+    metaTable: String = "play_evolutions",
+    substitutionsMappings: Map[String, String] = Map.empty,
+    substitutionsPrefix: String = "$evolutions{{{",
+    substitutionsSuffix: String = "}}}",
+    substitutionsEscape: Boolean = true
+) {
   def this(database: Database, schema: String, metaTable: String) = {
     this(database, schema, metaTable, Map.empty, "$evolutions{{{", "}}}", true)
   }
@@ -416,13 +416,13 @@ class DatabaseEvolutions(
           connection.rollback()
 
           val humanScript = "-- Rev:" + lastScript.evolution.revision + "," + (if (lastScript.isInstanceOf[UpScript])
-            "Ups"
-          else
-            "Downs") + " - " + lastScript.evolution.hash + "\n\n" + (if (lastScript
-            .isInstanceOf[UpScript])
-            lastScript.evolution.sql_up
-          else
-            lastScript.evolution.sql_down)
+                                                                                 "Ups"
+                                                                               else
+                                                                                 "Downs") + " - " + lastScript.evolution.hash + "\n\n" + (if (lastScript
+                                                                                                                                                .isInstanceOf[UpScript])
+                                                                                                                                            lastScript.evolution.sql_up
+                                                                                                                                          else
+                                                                                                                                            lastScript.evolution.sql_down)
 
           throw InconsistentDatabase(database.name, humanScript, message, lastScript.evolution.revision, autocommit)
         } else {
@@ -758,9 +758,9 @@ class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends R
  *               evolutions in different environments to work with different databases.
  */
 class ClassLoaderEvolutionsReader(
-                                   classLoader: ClassLoader = classOf[ClassLoaderEvolutionsReader].getClassLoader,
-                                   prefix: String = ""
-                                 ) extends ResourceEvolutionsReader {
+    classLoader: ClassLoader = classOf[ClassLoaderEvolutionsReader].getClassLoader,
+    prefix: String = ""
+) extends ResourceEvolutionsReader {
   def loadResource(db: String, revision: Int) = {
     Option(classLoader.getResourceAsStream(prefix + Evolutions.resourceName(db, revision)))
   }
@@ -782,7 +782,7 @@ object ClassLoaderEvolutionsReader {
  * environments.
  */
 object ThisClassLoaderEvolutionsReader
-  extends ClassLoaderEvolutionsReader(classOf[ClassLoaderEvolutionsReader].getClassLoader)
+    extends ClassLoaderEvolutionsReader(classOf[ClassLoaderEvolutionsReader].getClassLoader)
 
 /**
  * Simple map based implementation of the evolutions reader.
@@ -820,15 +820,14 @@ object SimpleEvolutionsReader {
  * @param rev the revision
  */
 case class InconsistentDatabase(db: String, script: String, error: String, rev: Int, autocommit: Boolean)
-  extends PlayException.RichDescription(
-    "Database '" + db + "' is in an inconsistent state!",
-    "An evolution has not been applied properly. Please check the problem and resolve it manually" + (if (autocommit)
-      " before marking it as resolved."
-    else ".")
-  ) {
+    extends PlayException.RichDescription(
+      "Database '" + db + "' is in an inconsistent state!",
+      "An evolution has not been applied properly. Please check the problem and resolve it manually" + (if (autocommit)
+                                                                                                          " before marking it as resolved."
+                                                                                                        else ".")
+    ) {
   def subTitle = "We got the following error: " + error + ", while trying to run this SQL script:"
-
-  def content = script
+  def content  = script
 
   private val resolvePathJavascript =
     if (autocommit) s"'/@evolutions/resolve/$db/$rev?redirect=' + encodeURIComponent(window.location)"
@@ -841,9 +840,7 @@ case class InconsistentDatabase(db: String, script: String, error: String, rev: 
   private val buttonLabel = if (autocommit) """Mark it resolved""" else """Try again"""
 
   def htmlDescription: String = {
-    <span>An evolution has not been applied properly. Please check the problem and resolve it manually
-      {sentenceEnd}
-      -</span>
-        <input name="evolution-button" type="button" value={buttonLabel} onclick={redirectJavascript}/>
+    <span>An evolution has not been applied properly. Please check the problem and resolve it manually{sentenceEnd} -</span>
+    <input name="evolution-button" type="button" value={buttonLabel} onclick={redirectJavascript}/>
   }.mkString
 }

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -452,6 +452,7 @@ class DatabaseEvolutions(
           case OracleJdbcUrl()    => CreatePlayEvolutionsOracleSql
           case MysqlJdbcUrl(_)    => CreatePlayEvolutionsMySql
           case DerbyJdbcUrl()     => CreatePlayEvolutionsDerby
+          case HsqlJdbcUrl()      => CreatePlayEvolutionsHsql
           case _                  => CreatePlayEvolutionsSql
         }
 
@@ -611,6 +612,19 @@ private object DefaultEvolutionsApi {
   val CreatePlayEvolutionsDerby =
     """
       create table ${schema}${evolutions_table} (
+          id int not null primary key,
+          hash varchar(255) not null,
+          applied_at timestamp not null,
+          apply_script clob,
+          revert_script clob,
+          state varchar(255),
+          last_problem clob
+      )
+    """
+  
+  val CreatePlayEvolutionsHsql = 
+    """
+    create table ${schema}${evolutions_table} (
           id int not null primary key,
           hash varchar(255) not null,
           applied_at timestamp not null,

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -624,7 +624,7 @@ private object DefaultEvolutionsApi {
   
   val CreatePlayEvolutionsHsql = 
     """
-    create table ${schema}${evolutions_table} (
+      create table ${schema}${evolutions_table} (
           id int not null primary key,
           hash varchar(255) not null,
           applied_at timestamp not null,

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -126,16 +126,16 @@ trait EvolutionsApi {
    *     final sql instead of replacing it with its substitution.
    */
   def evolve(
-      db: String,
-      scripts: Seq[Script],
-      autocommit: Boolean,
-      schema: String,
-      metaTable: String,
-      substitutionsMappings: Map[String, String],
-      substitutionsPrefix: String,
-      substitutionsSuffix: String,
-      substitutionsEscape: Boolean
-  ): Unit
+              db: String,
+              scripts: Seq[Script],
+              autocommit: Boolean,
+              schema: String,
+              metaTable: String,
+              substitutionsMappings: Map[String, String],
+              substitutionsPrefix: String,
+              substitutionsSuffix: String,
+              substitutionsEscape: Boolean
+            ): Unit
 
   /**
    * Resolve evolution conflicts.
@@ -160,16 +160,16 @@ trait EvolutionsApi {
    * Apply pending evolutions for the given database.
    */
   def applyFor(
-      dbName: String,
-      path: File = new File("."),
-      autocommit: Boolean = true,
-      schema: String = "",
-      metaTable: String = "play_evolutions",
-      substitutionsMappings: Map[String, String] = Map.empty,
-      substitutionsPrefix: String = "$evolutions{{{",
-      substitutionsSuffix: String = "}}}",
-      substitutionsEscape: Boolean = true
-  ): Unit = {
+                dbName: String,
+                path: File = new File("."),
+                autocommit: Boolean = true,
+                schema: String = "",
+                metaTable: String = "play_evolutions",
+                substitutionsMappings: Map[String, String] = Map.empty,
+                substitutionsPrefix: String = "$evolutions{{{",
+                substitutionsSuffix: String = "}}}",
+                substitutionsEscape: Boolean = true
+              ): Unit = {
     val scripts =
       this.scripts(dbName, new EnvironmentEvolutionsReader(Environment.simple(path = path)), schema, metaTable)
     this.evolve(
@@ -192,14 +192,14 @@ trait EvolutionsApi {
 @Singleton
 class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
   private def databaseEvolutions(
-      name: String,
-      schema: String,
-      metaTable: String = "play_evolutions",
-      substitutionsMappings: Map[String, String] = Map.empty,
-      substitutionsPrefix: String = "$evolutions{{{",
-      substitutionsSuffix: String = "}}}",
-      substitutionsEscape: Boolean = true
-  ) =
+                                  name: String,
+                                  schema: String,
+                                  metaTable: String = "play_evolutions",
+                                  substitutionsMappings: Map[String, String] = Map.empty,
+                                  substitutionsPrefix: String = "$evolutions{{{",
+                                  substitutionsSuffix: String = "}}}",
+                                  substitutionsEscape: Boolean = true
+                                ) =
     new DatabaseEvolutions(
       dbApi.database(name),
       schema,
@@ -233,16 +233,16 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
     databaseEvolutions(db, schema, metaTable).evolve(scripts, autocommit)
 
   def evolve(
-      db: String,
-      scripts: Seq[Script],
-      autocommit: Boolean,
-      schema: String,
-      metaTable: String,
-      substitutionsMappings: Map[String, String],
-      substitutionsPrefix: String,
-      substitutionsSuffix: String,
-      substitutionsEscape: Boolean
-  ): Unit =
+              db: String,
+              scripts: Seq[Script],
+              autocommit: Boolean,
+              schema: String,
+              metaTable: String,
+              substitutionsMappings: Map[String, String],
+              substitutionsPrefix: String,
+              substitutionsSuffix: String,
+              substitutionsEscape: Boolean
+            ): Unit =
     databaseEvolutions(
       db,
       schema,
@@ -263,14 +263,14 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
  * Evolutions for a particular database.
  */
 class DatabaseEvolutions(
-    database: Database,
-    schema: String = "",
-    metaTable: String = "play_evolutions",
-    substitutionsMappings: Map[String, String] = Map.empty,
-    substitutionsPrefix: String = "$evolutions{{{",
-    substitutionsSuffix: String = "}}}",
-    substitutionsEscape: Boolean = true
-) {
+                          database: Database,
+                          schema: String = "",
+                          metaTable: String = "play_evolutions",
+                          substitutionsMappings: Map[String, String] = Map.empty,
+                          substitutionsPrefix: String = "$evolutions{{{",
+                          substitutionsSuffix: String = "}}}",
+                          substitutionsEscape: Boolean = true
+                        ) {
   def this(database: Database, schema: String, metaTable: String) = {
     this(database, schema, metaTable, Map.empty, "$evolutions{{{", "}}}", true)
   }
@@ -416,13 +416,13 @@ class DatabaseEvolutions(
           connection.rollback()
 
           val humanScript = "-- Rev:" + lastScript.evolution.revision + "," + (if (lastScript.isInstanceOf[UpScript])
-                                                                                 "Ups"
-                                                                               else
-                                                                                 "Downs") + " - " + lastScript.evolution.hash + "\n\n" + (if (lastScript
-                                                                                                                                                .isInstanceOf[UpScript])
-                                                                                                                                            lastScript.evolution.sql_up
-                                                                                                                                          else
-                                                                                                                                            lastScript.evolution.sql_down)
+            "Ups"
+          else
+            "Downs") + " - " + lastScript.evolution.hash + "\n\n" + (if (lastScript
+            .isInstanceOf[UpScript])
+            lastScript.evolution.sql_up
+          else
+            lastScript.evolution.sql_down)
 
           throw InconsistentDatabase(database.name, humanScript, message, lastScript.evolution.revision, autocommit)
         } else {
@@ -621,8 +621,8 @@ private object DefaultEvolutionsApi {
           last_problem clob
       )
     """
-  
-  val CreatePlayEvolutionsHsql = 
+
+  val CreatePlayEvolutionsHsql =
     """
       create table ${schema}${evolutions_table} (
           id int not null primary key,
@@ -758,9 +758,9 @@ class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends R
  *               evolutions in different environments to work with different databases.
  */
 class ClassLoaderEvolutionsReader(
-    classLoader: ClassLoader = classOf[ClassLoaderEvolutionsReader].getClassLoader,
-    prefix: String = ""
-) extends ResourceEvolutionsReader {
+                                   classLoader: ClassLoader = classOf[ClassLoaderEvolutionsReader].getClassLoader,
+                                   prefix: String = ""
+                                 ) extends ResourceEvolutionsReader {
   def loadResource(db: String, revision: Int) = {
     Option(classLoader.getResourceAsStream(prefix + Evolutions.resourceName(db, revision)))
   }
@@ -782,7 +782,7 @@ object ClassLoaderEvolutionsReader {
  * environments.
  */
 object ThisClassLoaderEvolutionsReader
-    extends ClassLoaderEvolutionsReader(classOf[ClassLoaderEvolutionsReader].getClassLoader)
+  extends ClassLoaderEvolutionsReader(classOf[ClassLoaderEvolutionsReader].getClassLoader)
 
 /**
  * Simple map based implementation of the evolutions reader.
@@ -820,14 +820,15 @@ object SimpleEvolutionsReader {
  * @param rev the revision
  */
 case class InconsistentDatabase(db: String, script: String, error: String, rev: Int, autocommit: Boolean)
-    extends PlayException.RichDescription(
-      "Database '" + db + "' is in an inconsistent state!",
-      "An evolution has not been applied properly. Please check the problem and resolve it manually" + (if (autocommit)
-                                                                                                          " before marking it as resolved."
-                                                                                                        else ".")
-    ) {
+  extends PlayException.RichDescription(
+    "Database '" + db + "' is in an inconsistent state!",
+    "An evolution has not been applied properly. Please check the problem and resolve it manually" + (if (autocommit)
+      " before marking it as resolved."
+    else ".")
+  ) {
   def subTitle = "We got the following error: " + error + ", while trying to run this SQL script:"
-  def content  = script
+
+  def content = script
 
   private val resolvePathJavascript =
     if (autocommit) s"'/@evolutions/resolve/$db/$rev?redirect=' + encodeURIComponent(window.location)"
@@ -840,7 +841,9 @@ case class InconsistentDatabase(db: String, script: String, error: String, rev: 
   private val buttonLabel = if (autocommit) """Mark it resolved""" else """Try again"""
 
   def htmlDescription: String = {
-    <span>An evolution has not been applied properly. Please check the problem and resolve it manually{sentenceEnd} -</span>
-    <input name="evolution-button" type="button" value={buttonLabel} onclick={redirectJavascript}/>
+    <span>An evolution has not been applied properly. Please check the problem and resolve it manually
+      {sentenceEnd}
+      -</span>
+        <input name="evolution-button" type="button" value={buttonLabel} onclick={redirectJavascript}/>
   }.mkString
 }


### PR DESCRIPTION
HSQL does not support the data type "text". Therefore it needs an additional statement, to create the initial play_evolutions table.
Steps:
1. Create an additional pattern 'HsqlJdbcUrl' für HSQL in Evolutions.scala
2. Provide a custom SQL script for 'play_evolutions' table creation in EvolutionsApi.scala

Affected files:
play.api.db.evolutions.Evolutions.scala
play.api.db.evolutions.EvolutionsApi.scala

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Scala Play Evolutions "play_evolutions" table creation.

## Purpose

I allows the use of Play Evolutions with a HSQL Database for Scala Play.

## Background Context

I used Play Evolutions with HSQL local database server

## References

Are there any relevant issues / PRs / mailing lists discussions?
