### PR TITLE
To refactor `BodyPartParser` of `Multipart` in order to avoid StackOverflowError easily

### DIFF
--- a/core/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/core/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -321,8 +321,15 @@ object Multipart {
       "'boundary' parameter of multipart Content-Type must not end with a space char"
     )
 
-    // phantom type for ensuring soundness of our parsing method setup
     sealed trait StateResult
+    sealed trait Done extends StateResult
+    case object Done  extends Done
+    class ContinueParsing(parse: => StateResult) extends StateResult {
+      def apply(): StateResult = parse
+    }
+    object ContinueParsing {
+      def apply(parse: => StateResult): ContinueParsing = new ContinueParsing(parse)
+    }
 
     private[this] val needle: Array[Byte] = {
       val array = new Array[Byte](boundary.length + 4)
@@ -345,9 +352,9 @@ object Multipart {
 
     override def createLogic(attributes: Attributes): GraphStageLogic =
       new GraphStageLogic(shape) with InHandler with OutHandler {
-        private var output                           = collection.immutable.Queue.empty[RawPart]
-        private var state: ByteString => StateResult = tryParseInitialBoundary
-        private var terminated                       = false
+        private var output                    = collection.immutable.Queue.empty[RawPart]
+        private var state: ByteString => Done = tryParseInitialBoundary
+        private var terminated                = false
 
         override def onPush(): Unit = {
           if (!terminated) {
@@ -373,13 +380,23 @@ object Multipart {
 
         setHandlers(in, out, this)
 
-        def tryParseInitialBoundary(input: ByteString): StateResult = {
+        @tailrec
+        def handleParsingState(parse: ContinueParsing): Done = {
+          parse() match {
+            case Done               => Done
+            case c: ContinueParsing => handleParsingState(c)
+          }
+        }
+
+        def handleParsingState(exec: => StateResult): Done = handleParsingState(ContinueParsing(exec))
+
+        def tryParseInitialBoundary(input: ByteString): Done = {
           // we don't use boyerMoore here because we are testing for the boundary *without* a
           // preceding CRLF and at a known location (the very beginning of the entity)
           try {
             if (boundary(input, 0)) {
               val ix = boundaryLength
-              if (crlf(input, ix)) parseHeader(input, ix + 2, 0)
+              if (crlf(input, ix)) handleParsingState(parseHeader(input, ix + 2, 0))
               else if (doubleDash(input, ix)) terminate()
               else parsePreamble(input, 0)
             } else parsePreamble(input, 0)
@@ -388,11 +405,11 @@ object Multipart {
           }
         }
 
-        def parsePreamble(input: ByteString, offset: Int): StateResult = {
+        def parsePreamble(input: ByteString, offset: Int): Done = {
           try {
-            @tailrec def rec(index: Int): StateResult = {
+            @tailrec def rec(index: Int): Done = {
               val needleEnd = boyerMoore.nextIndex(input, index) + needle.length
-              if (crlf(input, needleEnd)) parseHeader(input, needleEnd + 2, 0)
+              if (crlf(input, needleEnd)) handleParsingState(parseHeader(input, needleEnd + 2, 0))
               else if (doubleDash(input, needleEnd)) terminate()
               else rec(needleEnd)
             }
@@ -483,7 +500,8 @@ object Multipart {
               } else {
                 // There was not even enough space in the input to contain the needle. Only after we have enough data
                 // of at least the size of the needle we can decide if the body is empty or not.
-                state = more => checkEmptyBody(input ++ more, partStart, memoryBufferSize)(nonEmpty)(empty)
+                state = more =>
+                  handleParsingState(checkEmptyBody(input ++ more, partStart, memoryBufferSize)(nonEmpty)(empty))
                 done()
               }
           }
@@ -512,7 +530,7 @@ object Multipart {
             val needleEnd      = currentPartEnd + needle.length
             if (crlf(input, needleEnd)) {
               emit(input.slice(offset, currentPartEnd))
-              parseHeader(input, needleEnd + 2, memoryBufferSize)
+              ContinueParsing(parseHeader(input, needleEnd + 2, memoryBufferSize))
             } else if (doubleDash(input, needleEnd)) {
               emit(input.slice(offset, currentPartEnd))
               terminate()
@@ -541,7 +559,7 @@ object Multipart {
               bufferExceeded("Memory buffer full on part " + partName)
             } else if (crlf(input, needleEnd)) {
               emit(DataPart(partName, input.slice(partStart, currentPartEnd).utf8String))
-              parseHeader(input, needleEnd + 2, newMemoryBufferSize)
+              ContinueParsing(parseHeader(input, needleEnd + 2, newMemoryBufferSize))
             } else if (doubleDash(input, needleEnd)) {
               emit(DataPart(partName, input.slice(partStart, currentPartEnd).utf8String))
               terminate()
@@ -568,7 +586,7 @@ object Multipart {
             val needleEnd      = currentPartEnd + needle.length
             if (crlf(input, needleEnd)) {
               emit(BadPart(headers))
-              parseHeader(input, needleEnd + 2, memoryBufferSize)
+              ContinueParsing(parseHeader(input, needleEnd + 2, memoryBufferSize))
             } else if (doubleDash(input, needleEnd)) {
               emit(BadPart(headers))
               terminate()
@@ -595,36 +613,31 @@ object Multipart {
           head
         }
 
-        def continue(input: ByteString, offset: Int)(next: (ByteString, Int) => StateResult): StateResult = {
+        def continue(input: ByteString, offset: Int)(next: (ByteString, Int) => StateResult): Done = {
           state = math.signum(offset - input.length) match {
-            case -1 => more => next(input ++ more, offset)
-            case 0  => next(_, 0)
+            case -1 => more => handleParsingState(next(input ++ more, offset))
+            case 0  => more => handleParsingState(next(more, 0))
             case 1  => throw new IllegalStateException
           }
           done()
         }
 
-        def continue(next: (ByteString, Int) => StateResult): StateResult = {
-          state = next(_, 0)
-          done()
-        }
-
-        def bufferExceeded(message: String): StateResult = {
+        def bufferExceeded(message: String): Done = {
           emit(MaxMemoryBufferExceeded(message))
           terminate()
         }
 
-        def fail(message: String): StateResult = {
+        def fail(message: String): Done = {
           emit(ParseError(message))
           terminate()
         }
 
-        def terminate(): StateResult = {
+        def terminate(): Done = {
           terminated = true
           done()
         }
 
-        def done(): StateResult = null // StateResult is a phantom type
+        def done(): Done = Done
 
         // the length of the needle without the preceding CRLF
         def boundaryLength: Int = needle.length - 2


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
  * No new files in this pull request.
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
  * It looks there aren't documentations that we need to update  for this pull request. 
* [x] Have you added tests for any changed functionality?
  * StackOverflowError depends on an environment so it is difficult to check in unit tests, I think.

# Helpful things

## Fixes

Fixes #10590 

## Purpose
Refactoring to avoid StackOverflowError easily when parsing multipart/form-data on `BodyPartParser` of `Multipart`

## Background Context
The current code uses recursive call so StackOverflowError is occurred. We need to estimate `maxMemoryBuffer` size in order to avoid the error.
https://github.com/playframework/playframework/issues/10590

I guess refactoring the code to use @tailrec or loop would avoid the error without estimating the size of `maxMemoryBuffer`.



## References
https://github.com/playframework/playframework/discussions/11347