### PR TITLE
Add `resource` scheme for #11253

### DIFF
--- a/core/play/src/main/java/play/controllers/AssetsComponents.java
+++ b/core/play/src/main/java/play/controllers/AssetsComponents.java
@@ -38,6 +38,6 @@ public interface AssetsComponents
   }
 
   default Assets assets() {
-    return new Assets(scalaHttpErrorHandler(), assetsMetadata());
+    return new Assets(scalaHttpErrorHandler(), assetsMetadata(), environment().asScala());
   }
 }

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -832,7 +832,7 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: E
       case Some((assetInfo, acceptEncoding)) =>
         val connection = assetInfo.url(acceptEncoding).openConnection()
         // Make sure it's not a directory
-        if (env != null && Resources.isUrlConnectionADirectory(env.classLoader, connection)) {
+        if (Resources.isUrlConnectionADirectory(if (env != null) env.classLoader else null, connection)) {
           Resources.closeUrlConnection(connection)
           notFound
         } else {

--- a/core/play/src/main/scala/play/utils/Resources.scala
+++ b/core/play/src/main/scala/play/utils/Resources.scala
@@ -20,8 +20,14 @@ object Resources {
     case "jar"                       => isZipResourceDirectory(url)
     case "zip"                       => isZipResourceDirectory(url)
     case "bundle" | "bundleresource" => isBundleResourceDirectory(classLoader, url)
+    case "resource"                  => isGraalVMResourceDirectory(classLoader, url)
     case _ =>
       throw new IllegalArgumentException(s"Cannot check isDirectory for a URL with protocol='${url.getProtocol}'")
+  }
+
+  @deprecated("Use isUrlConnectionADirectory(classLoader,urlConnection) instead.", "2.9")
+  def isUrlConnectionADirectory(urlConnection: URLConnection): Boolean = {
+    isUrlConnectionADirectory(null, urlConnection)
   }
 
   /**
@@ -30,22 +36,21 @@ object Resources {
    * Depends on the URL connection type whether it's accurate.  If it's unable to determine whether it's a directory,
    * this returns false.
    */
-  def isUrlConnectionADirectory(urlConnection: URLConnection) = urlConnection match {
-    case file if file.getURL.getProtocol == "file" => new File(file.getURL.toURI).isDirectory
-    case jar: JarURLConnection =>
-      if (jar.getJarEntry.isDirectory) {
-        true
-      } else {
-        // JarEntry.isDirectory is rubbish....
-        val is = jar.getJarFile.getInputStream(jar.getJarEntry)
-        if (is == null) {
-          true
-        } else {
-          is.close()
-          false
-        }
-      }
-    case other => false
+  def isUrlConnectionADirectory(classLoader: ClassLoader, urlConnection: URLConnection): Boolean = {
+    (urlConnection, urlConnection.getURL.getProtocol) match {
+      case (file, "file") =>
+        new File(file.getURL.toURI).isDirectory
+      case (jar: JarURLConnection, _) =>
+        isJarURLConnectionDirectory(jar)
+      case (bundle, "bundle") =>
+        isBundleResourceDirectory(classLoader, bundle)
+      case (bundleResource, "bundleresource") =>
+        isBundleResourceDirectory(classLoader, bundleResource)
+      case (resource, "resource") =>
+        isGraalVMResourceDirectory(classLoader, resource)
+      case _ =>
+        false
+    }
   }
 
   /**
@@ -63,19 +68,6 @@ object Resources {
       case other =>
         other.getInputStream.close()
     }
-  }
-
-  private def isBundleResourceDirectory(classLoader: ClassLoader, url: URL): Boolean = {
-    /* ClassLoader within an OSGi container behave differently than the standard classloader.
-     * One difference is how getResource returns when the resource's name end with a slash.
-     * In a standard JVM, getResource doesn't care of ending slashes, and return the URL of
-     * any existing resources. In an OSGi container (tested with Apache Felix), ending slashes
-     * refers to a directory (return null otherwise). */
-
-    val path      = url.getPath
-    val pathSlash = if (path.last == '/') path else path + '/'
-
-    classLoader.getResource(path) != null && classLoader.getResource(pathSlash) != null
   }
 
   private def isZipResourceDirectory(url: URL): Boolean = {
@@ -103,5 +95,50 @@ object Resources {
     } finally {
       zip.close()
     }
+  }
+
+  private def isJarURLConnectionDirectory(jar: JarURLConnection): Boolean = {
+    if (jar.getJarEntry.isDirectory) {
+      true
+    } else {
+      // JarEntry.isDirectory is rubbish....
+      val is = jar.getJarFile.getInputStream(jar.getJarEntry)
+      if (is == null) {
+        true
+      } else {
+        is.close()
+        false
+      }
+    }
+  }
+
+  private def isBundleResourceDirectory(classLoader: ClassLoader, urlConnection: URLConnection): Boolean = {
+    isBundleResourceDirectory(classLoader, urlConnection.getURL)
+  }
+
+  private def isBundleResourceDirectory(classLoader: ClassLoader, url: URL): Boolean = {
+    if (classLoader != null) {
+      /* ClassLoader within an OSGi container behave differently than the standard classloader.
+       * One difference is how getResource returns when the resource's name end with a slash.
+       * In a standard JVM, getResource doesn't care of ending slashes, and return the URL of
+       * any existing resources. In an OSGi container (tested with Apache Felix), ending slashes
+       * refers to a directory (return null otherwise). */
+
+      val path      = url.getPath
+      val pathSlash = if (path.last == '/') path else path + '/'
+
+      classLoader.getResource(path) != null && classLoader.getResource(pathSlash) != null
+    } else {
+      false
+    }
+  }
+
+  private def isGraalVMResourceDirectory(classLoader: ClassLoader, urlConnection: URLConnection): Boolean = {
+    isGraalVMResourceDirectory(classLoader, urlConnection.getURL)
+  }
+
+  private def isGraalVMResourceDirectory(classLoader: ClassLoader, url: URL): Boolean = {
+    /* Resource access in GraalVM can be considered the same as OSGi bundle resources. */
+    isBundleResourceDirectory(classLoader, url)
   }
 }

--- a/core/play/src/test/scala/play/api/controllers/AssetsSpec.scala
+++ b/core/play/src/test/scala/play/api/controllers/AssetsSpec.scala
@@ -12,10 +12,11 @@ import play.api.http.DefaultHttpErrorHandler
 import play.api.http.FileMimeTypes
 import play.api.http.FileMimeTypesConfiguration
 import play.api.mvc.ResponseHeader
+import play.api.Environment
 import play.utils.InvalidUriEncodingException
 
 class AssetsSpec extends Specification {
-  val Assets = new AssetsBuilder(new DefaultHttpErrorHandler(), StaticAssetsMetadata)
+  val Assets = new AssetsBuilder(new DefaultHttpErrorHandler(), StaticAssetsMetadata, Environment.simple())
 
   "Assets controller" should {
     "look up assets with the correct resource name" in {

--- a/core/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/core/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -127,6 +127,27 @@ class ResourcesSpec extends Specification {
         .and(isDirectory(osgiClassloader, urlBundleresource) must beFalse)
     }
 
+    "return true for a directory resource URL with the 'resource' protocol" in {
+      val relativeIndex = dirBundle.getAbsolutePath.indexOf("test-bundle-")
+      val dir           = dirBundle.getAbsolutePath.substring(relativeIndex)
+      val urlResource   = new URL("resource", "325.0", 25, dir, new BundleStreamHandler)
+      isDirectory(osgiClassloader, urlResource) must beTrue
+    }
+
+    "return true for a directory resource URL that contains space with the 'resource' protocol" in {
+      val relativeIndex = spacesDirBundle.getAbsolutePath.indexOf("test-bundle-")
+      val dir           = spacesDirBundle.getAbsolutePath.substring(relativeIndex)
+      val urlResource   = new URL("resource", "325.0", 25, dir, new BundleStreamHandler)
+      isDirectory(osgiClassloader, urlResource) must beTrue
+    }
+
+    "return false for a file resource URL with the 'resource' protocol" in {
+      val relativeIndex = fileBundle.getAbsolutePath.indexOf("test-bundle-")
+      val file          = fileBundle.getAbsolutePath.substring(relativeIndex)
+      val urlResource   = new URL("resource", "325.0", 25, file, new BundleStreamHandler)
+      isDirectory(osgiClassloader, urlResource) must beFalse
+    }
+
     "return true for a directory resource URL with the 'zip' protocol" in {
       val url = new URL("zip", "", 0, createZipUrl(jar, dirRes), EmptyURLStreamHandler)
       isDirectory(classloader, url) must beTrue

--- a/documentation/manual/working/commonGuide/build/code/javaguide/common/build/controllers/Assets.java
+++ b/documentation/manual/working/commonGuide/build/code/javaguide/common/build/controllers/Assets.java
@@ -8,14 +8,15 @@ package javaguide.common.build.controllers;
 
 import controllers.AssetsMetadata;
 import javax.inject.Inject;
+import play.api.Environment;
 import play.api.http.HttpErrorHandler;
 import play.api.mvc.*;
 
 public class Assets extends controllers.Assets {
 
   @Inject
-  public Assets(HttpErrorHandler errorHandler, AssetsMetadata meta) {
-    super(errorHandler, meta);
+  public Assets(HttpErrorHandler errorHandler, AssetsMetadata meta, Environment env) {
+    super(errorHandler, meta, env);
   }
 
   public Action<AnyContent> at(String path, String file) {

--- a/documentation/manual/working/commonGuide/build/code/scalaguide/common/build/controllers/SubProjectsAssetsBuilder.scala
+++ b/documentation/manual/working/commonGuide/build/code/scalaguide/common/build/controllers/SubProjectsAssetsBuilder.scala
@@ -7,11 +7,13 @@ package common.build.controllers {
   import javax.inject._
 
   import play.api.http.HttpErrorHandler
+  import play.api.Environment
 
   class Assets @Inject() (
       errorHandler: HttpErrorHandler,
-      assetsMetadata: controllers.AssetsMetadata
-  ) extends controllers.AssetsBuilder(errorHandler, assetsMetadata)
+      assetsMetadata: controllers.AssetsMetadata,
+      environment: Environment
+  ) extends controllers.AssetsBuilder(errorHandler, assetsMetadata, environment)
   // #assets-builder
 
   package admin {

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/dependencyinjection/controllers/Assets.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/dependencyinjection/controllers/Assets.java
@@ -5,10 +5,11 @@
 package javaguide.dependencyinjection.controllers;
 
 import controllers.AssetsMetadata;
+import play.api.Environment;
 import play.api.http.HttpErrorHandler;
 
 public class Assets extends controllers.Assets {
-  public Assets(HttpErrorHandler errorHandler, AssetsMetadata meta) {
-    super(errorHandler, meta);
+  public Assets(HttpErrorHandler errorHandler, AssetsMetadata meta, Environment env) {
+    super(errorHandler, meta, env);
   }
 }

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
@@ -116,7 +116,8 @@ public class CompileTimeDependencyInjection {
     @Override
     public Router router() {
       HomeController homeController = new HomeController();
-      Assets assets = new Assets(scalaHttpErrorHandler(), assetsMetadata());
+      Assets assets =
+          new Assets(scalaHttpErrorHandler(), assetsMetadata(), environment().asScala());
       // ###replace: return new router.Routes(scalaHttpErrorHandler(), homeController,
       // assets).asJava();
       return new javaguide.dependencyinjection.Routes(

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -131,6 +131,7 @@ package controllers {
 
   import play.api.http.HttpErrorHandler
   import play.api.mvc._
+  import play.api.Environment
 
   class Application @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
     def index = Action(Ok)
@@ -138,9 +139,10 @@ package controllers {
   }
 
   trait AssetsComponents extends _root_.controllers.AssetsComponents {
-    override lazy val assets = new scalaguide.dependencyinjection.controllers.Assets(httpErrorHandler, assetsMetadata)
+    override lazy val assets =
+      new scalaguide.dependencyinjection.controllers.Assets(httpErrorHandler, assetsMetadata, environment)
   }
 
-  class Assets(errorHandler: HttpErrorHandler, assetsMetadata: AssetsMetadata)
-      extends _root_.controllers.Assets(errorHandler, assetsMetadata)
+  class Assets(errorHandler: HttpErrorHandler, assetsMetadata: AssetsMetadata, environment: Environment)
+      extends _root_.controllers.Assets(errorHandler, assetsMetadata, environment)
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

This pull request only supports the `resource` scheme. I will not add support for other graalvm features.

## Purpose

graalvm requires resources to be accessed with a scheme called `resource`. So Play needs to handle the `resource` scheme properly.

## Background Context

- The implementation has been copied over from the existing `bundleresource` scheme as it is functionally equivalent.
- Accessing the directory results in an invalid file download. This is because the `resource` scheme cannot tell if the file is a directory.

## References

Discussion for #11253
