### PR TITLE
Add to RouteInvokers test helper

### DIFF
--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -154,6 +154,40 @@ class HelpersSpec extends Specification {
 
         result.get.map(result => result.header.status mustEqual 404)
       }
+
+      "successfully execute a GET request in an Application" in {
+        val request = FakeRequest(GET, "/abc")
+        val fakeApplication = Helpers.baseApplicationBuilder
+          .routes {
+            case (GET, "/abc") => ctrl.abcAction
+          }
+          .build()
+        val Some(result) = Helpers.route(fakeApplication, request)
+
+        Helpers.status(result) mustEqual OK
+      }
+
+      "successfully execute a GET request in a Router" in {
+        val request = FakeRequest(GET, "/abc")
+        val router = {
+          import play.api.routing.Router
+          import play.api.routing.sird._
+          Router.from {
+            case GET(p"/abc") => ctrl.abcAction
+          }
+        }
+
+        val Some(result) = {
+          implicit val system = ActorSystem()
+          try {
+            Helpers.route(router, request)
+          } finally {
+            system.terminate()
+          }
+        }
+
+        Helpers.status(result) mustEqual OK
+      }
     }
   }
 }


### PR DESCRIPTION
## Background

The test helper mixin [play.api.test.RouteInvokers](https://www.playframework.com/documentation/latest/api/scala/play/api/test/RouteInvokers.html) contains helper methods for executing the route and action of an Application instance.

## Purpose 

To aid in testing routers built with [String Interpolating Routing DSL](https://www.playframework.com/documentation/latest/ScalaSirdRouter), this PR adds test helper methods to execute a Router instance directly.

These methods are for convenience, so that the test does not need to build a fake application to invoke the router.