### PR TITLE
Add `application/typescript` to MIME types

### DIFF
--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -300,6 +300,7 @@ play {
         csp=application/csp-report
         css=text/css
         csv=text/csv
+        cts=application/typescript
         cxx=text/plain
         dar=application/x-dar
         dcr=application/x-director
@@ -480,6 +481,7 @@ play {
         mpx=application/x-project
         mrc=application/marc
         ms=application/x-troff-ms
+        mts=application/typescript
         mv=video/x-sgi-movie
         my=audio/make
         mzz=application/x-vndaudioexplosionmzz
@@ -652,6 +654,7 @@ play {
         tif=image/tiff
         tiff=image/tiff
         tr=application/x-troff
+        ts=application/typescript
         tsi=audio/tsp-audio
         tsp=application/dsptype
         tsv=text/tab-separated-values


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [X] Have you checked that both Scala and Java APIs are updated?
* [X] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

I have a problem for providing assets as `global.d.ts`, Play thinks that it is `application/octet-stream`, so RequireJS cannot load definitions

## Background Context

Why did you take this approach?

## References

https://www.digipres.org/formats/sources/githublinguist/formats/#378