### PR TITLE
SLF4J 2 compatibility: avoid direct usage of StaticLoggerBinder

### DIFF
--- a/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -12,13 +12,13 @@ import ch.qos.logback.classic.jul.LevelChangePropagator
 import ch.qos.logback.classic.util.ContextInitializer
 import ch.qos.logback.core.util._
 import org.slf4j.ILoggerFactory
+import org.slf4j.LoggerFactory
 import org.slf4j.bridge._
-import org.slf4j.impl.StaticLoggerBinder
 import play.api._
 
 class LogbackLoggerConfigurator extends LoggerConfigurator {
   def loggerFactory: ILoggerFactory = {
-    StaticLoggerBinder.getSingleton.getLoggerFactory
+    LoggerFactory.getILoggerFactory
   }
 
   /**

--- a/documentation/manual/working/commonGuide/configuration/code/JavaLog4JLoggerConfigurator.java
+++ b/documentation/manual/working/commonGuide/configuration/code/JavaLog4JLoggerConfigurator.java
@@ -6,6 +6,7 @@
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
 import play.Environment;
 import play.LoggerConfigurator;
 import play.Mode;
@@ -65,7 +66,7 @@ public class JavaLog4JLoggerConfigurator implements LoggerConfigurator {
       LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
       loggerContext.setConfigLocation(config.get().toURI());
 
-      factory = org.slf4j.impl.StaticLoggerBinder.getSingleton().getLoggerFactory();
+      factory = LoggerFactory.getILoggerFactory();
     } catch (URISyntaxException ex) {
       throw new PlayException(
           "log4j2.xml resource was not found",

--- a/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
@@ -24,6 +24,7 @@ import play.api.Configuration
 import play.api.Environment
 import play.api.LoggerConfigurator
 import org.slf4j.ILoggerFactory
+import org.slf4j.LoggerFactory
 
 class Log4J2LoggerConfigurator extends LoggerConfigurator {
   private var factory: ILoggerFactory = _
@@ -61,7 +62,7 @@ class Log4J2LoggerConfigurator extends LoggerConfigurator {
     val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
     context.setConfigLocation(config.get.toURI)
 
-    factory = org.slf4j.impl.StaticLoggerBinder.getSingleton.getLoggerFactory
+    factory = LoggerFactory.getILoggerFactory
   }
 
   override def loggerFactory: ILoggerFactory = factory


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Partially addresses #11400 by using a method for finding a logger factory that should be compatible with SLF4J 2.0.0. The upgrade itself can be done separately and not backported to `2.8.x`.

## Purpose

Allows consumers to use SLF4J 2.0.0 in their projects without breaking Play 2.8 compatibility.

Makes `LogbackLoggerConfigurator` compatible with SLF4J 2.0.0, which has removed binding via finding a `StaticLoggerBinder` on the classpath, in favour of `ServiceLoader`. In practice, we don't need to implement any `ServiceLoader` logic because SLF4J provides `LoggerFactory.getILoggerFactory` (which is backwards/forwards compatible.)

Updates documentation references to `StaticLoggerBinder` as well.

## Background Context

`getILoggerFactory` has always provided the functionality we require, so it seems like the natural method to use. However it was used originally and changed in https://github.com/playframework/playframework/pull/6025, so perhaps there was a reason for that.

## References

https://github.com/orgs/playframework/discussions/11399
