### PR TITLE
[2.8.x] Netty: Websockets should respect play.server.http.idleTimeout

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketClient.scala
@@ -31,6 +31,7 @@ import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.codec.http._
 import io.netty.handler.codec.http.websocketx._
 import io.netty.util.ReferenceCountUtil
+import play.api.Logger
 import play.api.http.websocket._
 import play.it.http.websocket.WebSocketClient.ExtendedMessage
 
@@ -62,6 +63,7 @@ trait WebSocketClient {
 }
 
 object WebSocketClient {
+  private val logger = Logger(getClass)
   trait ExtendedMessage {
     def finalFragment: Boolean
   }
@@ -207,6 +209,11 @@ object WebSocketClient {
             }
 
             def onPull(): Unit = pull(in)
+
+            override def onUpstreamFailure(ex: Throwable): Unit = {
+              logger.error("Communication problem using WebSocketClient", ex);
+              super.onUpstreamFailure(ex)
+            }
 
             setHandlers(in, out, this)
           }

--- a/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -12,11 +12,13 @@ import akka.actor.Props
 import akka.actor.Status
 import akka.stream.scaladsl._
 import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
 import org.specs2.execute.AsResult
 import org.specs2.execute.EventuallyResults
 import org.specs2.matcher.Matcher
 import org.specs2.specification.AroundEach
 import play.api.Application
+import play.api.Configuration
 import play.api.http.websocket._
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.streams.ActorFlow
@@ -220,7 +222,7 @@ trait WebSocketSpec
           import app.materializer
           val (_, headers) = runWebSocket({ flow =>
             sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
-          }, Some("my_crazy_subprotocol"))
+          }, Some("my_crazy_subprotocol"), c => c)
           (headers
             .map { case (key, value) => (key.toLowerCase, value) }
             .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
@@ -344,7 +346,7 @@ trait WebSocketSpec
       import play.core.routing.HandlerInvokerFactory
       import play.core.routing.HandlerInvokerFactory._
 
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
 
       implicit def toHandler[J <: AnyRef](
           javaHandler: => J
@@ -378,35 +380,53 @@ trait WebSocketSpec
 }
 
 trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
+
+  import scala.jdk.CollectionConverters._
+
   // Extend the default spec timeout for CI.
   implicit override def defaultAwaitTimeout = 10.seconds
 
-  def withServer[A](webSocket: Application => Handler)(block: Application => A): A = {
+  def withServer[A](webSocket: Application => Handler, extraConfig: Map[String, Any] = Map.empty)(
+      block: Application => A
+  ): A = {
     val currentApp = new AtomicReference[Application]
+    val config     = Configuration(ConfigFactory.parseMap(extraConfig.asJava))
     val app = GuiceApplicationBuilder()
+      .configure(config)
       .routes {
         case _ => webSocket(currentApp.get())
       }
       .build()
     currentApp.set(app)
-    running(TestServer(testServerPort, app))(block(app))
+    val testServer = TestServer(testServerPort, app)
+    val configuredTestServer =
+      testServer.copy(config = testServer.config.copy(configuration = testServer.config.configuration ++ config))
+    running(configuredTestServer)(block(app))
   }
-
-  def runWebSocket[A](handler: Flow[ExtendedMessage, ExtendedMessage, _] => Future[A]): A =
-    runWebSocket(handler, subprotocol = None) match { case (result, _) => result }
 
   def runWebSocket[A](
       handler: Flow[ExtendedMessage, ExtendedMessage, _] => Future[A],
-      subprotocol: Option[String]
+      handleConnect: Future[_] => Future[_] = c => c
+  ): A =
+    runWebSocket(handler, subprotocol = None, handleConnect) match { case (result, _) => result }
+
+  def runWebSocket[A](
+      handler: Flow[ExtendedMessage, ExtendedMessage, _] => Future[A],
+      subprotocol: Option[String],
+      handleConnect: Future[_] => Future[_]
   ): (A, immutable.Seq[(String, String)]) = {
     WebSocketClient { client =>
       val innerResult     = Promise[A]()
       val responseHeaders = Promise[immutable.Seq[(String, String)]]()
-      await(client.connect(URI.create("ws://localhost:" + testServerPort + "/stream"), subprotocol = subprotocol) {
-        (headers, flow) =>
-          innerResult.completeWith(handler(flow))
-          responseHeaders.success(headers)
-      })
+      await(
+        handleConnect(
+          client.connect(URI.create("ws://localhost:" + testServerPort + "/stream"), subprotocol = subprotocol) {
+            (headers, flow) =>
+              innerResult.completeWith(handler(flow))
+              responseHeaders.success(headers)
+          }
+        )
+      )
       (await(innerResult.future), await(responseHeaders.future))
     }
   }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -229,6 +229,7 @@ class NettyServer(
           logger.trace(s"using idle timeout of $timeout $timeUnit on port $port")
           // only timeout if both reader and writer have been idle for the specified time
           pipeline.addLast("idle-handler", new IdleStateHandler(0, 0, timeout, timeUnit))
+          pipeline.addLast("idle-handler-play", new NettyIdleHandler())
       }
 
       val requestHandler = newRequestHandler()

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyIdleHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyIdleHandler.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.netty
+
+import io.netty.channel._
+import io.netty.handler.timeout.IdleStateEvent
+import play.api.Logger
+
+private object NettyIdleHandler {
+  private val logger: Logger = Logger(classOf[NettyIdleHandler])
+}
+
+private[play] class NettyIdleHandler extends ChannelInboundHandlerAdapter {
+  import NettyIdleHandler._
+
+  /**
+   * Originally, this method lived within [[PlayRequestHandler]]. However, the [[PlayRequestHandler]]
+   * gets removed from the Netty pipeline when a http connection gets upgraded to a websocket connection.
+   * Therefore, for websockets, a user events would not be handled anymore, not calling this method and leaving
+   * the connection open forever.
+   */
+  override def userEventTriggered(ctx: ChannelHandlerContext, evt: scala.Any): Unit = {
+    evt match {
+      case idle: IdleStateEvent if ctx.channel().isOpen =>
+        logger.trace(s"Closing connection due to idle timeout")
+        ctx.close()
+      case _ => super.userEventTriggered(ctx, evt)
+    }
+  }
+}

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -8,13 +8,11 @@ import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 
 import akka.stream.Materializer
-import com.typesafe.config.ConfigMemorySize
 import com.typesafe.netty.http.DefaultWebSocketHttpResponse
 import io.netty.channel._
 import io.netty.handler.codec.TooLongFrameException
 import io.netty.handler.codec.http._
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory
-import io.netty.handler.timeout.IdleStateEvent
 import play.api.http._
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
@@ -268,15 +266,6 @@ private[play] class PlayRequestHandler(
     // this method is called when the channel is registered with the event loop,
     // so ctx.read is automatically safe here w/o needing an isRegistered().
     ctx.read()
-  }
-
-  override def userEventTriggered(ctx: ChannelHandlerContext, evt: scala.Any): Unit = {
-    evt match {
-      case idle: IdleStateEvent if ctx.channel().isOpen =>
-        logger.trace(s"Closing connection due to idle timeout")
-        ctx.close()
-      case _ => super.userEventTriggered(ctx, evt)
-    }
   }
 
   //----------------------------------------------------------------


### PR DESCRIPTION
So a premium sponsor reached out to me regarding problems with Websockets.
Turns out the Netty server does not care about the `play.server.http.idleTimeout` config when upgrading a connection to a websocket. akka-http however works correctly (did extensive manually testing using https://github.com/vi/websocat and even wireshark to watch those frames).

The problem step-by-step:
1. The netty backend [sets up request handler](https://github.com/playframework/playframework/blob/919b5bda99b03a8ebeca956a6f6c0c6361ce9df5/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala#L234-L237) which gets added to the netty pipeline via a `HttpStreamsServerHandler`.
2. Our `PlayRequestHandler` [reacts to `IdleStateEvents` to close connections if they are idle](https://github.com/playframework/playframework/blob/919b5bda99b03a8ebeca956a6f6c0c6361ce9df5/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala#L274-L276).
3. When upgrading a connection to a websocket, the handler of the connection (which is a `HttpStreamsServerHandler` which wraps our `PlayRequestHandler`) [_removes itself_ from the pipeline](https://github.com/playframework/netty-reactive-streams/blob/9eecca96c07fdefadf13865f1a16a9b5946dea12/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/HttpStreamsServerHandler.java#L198-L199). Problem here is when our request handler is not on the pipeline anymore, then also our `userEventTriggered` handler to close connections isn't there anymore as well!

To fix that I split out the `userEventTriggered` method into its own handler, which always stays in the pipeline.

This is working great, I did manual testing.
However... actually I am trying to add a test to https://github.com/playframework/playframework/blob/main/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala since hours, however I just can't get akka-http to work correctly, the connection always stays open, even when passing the serverconfig a idle timeout of 1 second and stopping a thread within a websockt for like 3 seconds. Netty correctly closes the connection. I am not sure what I do wrong in the test, maybe akka-http is configured different.... I need to find out.