### PR TITLE
 Fixing SLF4J 2.0.0 issue for #11419 and #11400

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,8 @@ object Dependencies {
 
   val playJsonVersion = "2.10.0-RC6"
 
-  val logback = "ch.qos.logback" % "logback-classic" % "1.2.11"
+  // 1.3.1 is for Java 8, can upgrade to 1.4.1 if Java 11 (see https://logback.qos.ch/download.html)
+  val logback = "ch.qos.logback" % "logback-classic" % "1.3.1"
 
   val specs2Version = "4.15.0"
   val specs2CoreDeps = Seq(
@@ -52,7 +53,7 @@ object Dependencies {
 
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
 
-  val slf4jVersion = "1.7.36"
+  val slf4jVersion = "2.0.0"
   val slf4j        = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % slf4jVersion)
   val slf4jSimple  = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
@@ -75,8 +76,7 @@ object Dependencies {
   )
 
   val jdbcDeps = Seq(
-    ("com.zaxxer" % "HikariCP" % "4.0.3")
-      .exclude("org.slf4j", "slf4j-api"), // fetches slf4j 2.0.0-alpha1, but Play (still) uses 1.7, see https://github.com/brettwooldridge/HikariCP/pull/1669
+    "com.zaxxer"         % "HikariCP" % "4.0.3",
     "com.googlecode.usc" % "jdbcdslog" % "1.0.6.2",
     h2database           % Test,
     acolyte              % Test,


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Resolves #11419 and resolves #11400

## Purpose

Upgrading SLF4J to v2.0.0 forces us to upgrade Logback too, as explained on the [Logback documentation](https://logback.qos.ch/download.html).
We can't upgrade Logback to 1.4.1 as it needs at least Java 11, and we must keep the Java 8 compatibility for now.

Also removing an exluded dependency for HikariCP as it depends also on SLF4J 2.0.0.

Has been tested on Java 8 and Java 11.

## References

Should fix PR #11417 
