### PR TITLE
scala-steward can now provide Java 11+ only dependencies

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -35,23 +35,10 @@ updates.ignore = [
 updates.pin = [
   { groupId = "com.typesafe.akka", artifactId = "akka-actor", version = "2.6." },
   { groupId = "com.typesafe.akka", artifactId = "akka-http-core", version = "10.1." },
-  // HikariCP 5+ requires Java 11. See https://github.com/brettwooldridge/HikariCP/issues/1816#issuecomment-890255579
-  { groupId = "com.zaxxer", artifactId = "HikariCP", version = "4." },
-  // caffeine 3+ requires Java 11. See https://github.com/ben-manes/caffeine/releases/tag/v3.0.0
-  { groupId = "com.github.ben-manes.caffeine", version = "2." },
-  // FluentLenium 4+ requires Java 11.
-  // See https://github.com/FluentLenium/FluentLenium/releases/tag/v4.0.0 and https://fluentlenium.com/quickstart/#choose-the-right-version
-  { groupId = "org.fluentlenium", version = "3." },
-  // FluentLenium 3 only works with Selenium 3
-  { groupId = "org.seleniumhq.selenium", artifactId = "selenium-api", version = "3." },
-  // Selenium 3 is only compatible with htmlunit-driver 2, see https://github.com/SeleniumHQ/htmlunit-driver/releases/tag/2.56.0
-  { groupId = "org.seleniumhq.selenium", artifactId = "htmlunit-driver", version = "2." },
   // Hibernate Validator 7.0 is jakarta.validation based, 6.2 is javax.validation based
   // and the Spring libraries we use still depends on Hibernate Validator 6.x
   // See https://github.com/playframework/playframework/pull/10616#issuecomment-758273638
   { groupId = "org.hibernate.validator", artifactId = "hibernate-validator", version = "6." },
-  // Apache Derby above 10.14 requires Java 9+. See https://db.apache.org/derby/derby_downloads.html
-  { groupId = "org.apache.derby", artifactId = "derby", version = "10.14." }
 ]
 
 updatePullRequests = never


### PR DESCRIPTION
Thanks to #11435 we are building Play with Java 11, so no need to hold back those deps anymore.