### PR TITLE
Fix duplicate `<dependencyManagement />` tag in BOM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,8 +57,6 @@ lazy val billOfMaterials = PlayCrossBuiltProject("bill-of-materials", "dev-mode/
   .settings(
     name := "play-bom",
     bomIncludeProjects := userProjects,
-    pomExtra := pomExtra.value :+ bomDependenciesListing.value,
-    publishTo := sonatypePublishToBundle.value,
     mimaPreviousArtifacts := Set.empty
   )
 


### PR DESCRIPTION
Publishing a first experimental milestone for the next Play major version [didn't work](https://github.com/playframework/playframework/actions/runs/3173494244/jobs/5169171990#step:5:2479). 

So, the `BillOfMaterialsPlugin` plugin [appends the dependency listings to `pomExtra`](https://github.com/lightbend/sbt-bill-of-materials/blob/86664c142cdc855c2e739a40f1b63d7f6b992db6/src/main/scala/com/lightbend/sbt/billofmaterials/BillOfMaterialsPlugin.scala#L89). Unfortunaly, until now, [we did the same as well.](https://github.com/playframework/playframework/blob/cdffc62844b395aa2ffb4f67e16a1625fe3bd1b0/build.sbt#L60), so the entries were duplicated.
Until now however this didn't cause any problems, because interplay "hard reseted" `pomExtra`, so it kind of overrode one of those settings. Since last interplay release however it [does not set `pomExtra` anymore,](https://github.com/playframework/interplay/commit/86320cf8580c9bfb04aea0c6b6533d4fbd978b7c) so now both settings kick in, creating the duplicates.
(This problem did not materialize in Play 2.8.x because it uses an old version of interplay).

I also think `publishTo` shouldn't be set here because the sbt-ci-release plugin already handles that.
