### PR TITLE
[2.8.x] Revert "Upgrade to Scala 2.12.17 and 2.13.9"

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -95,7 +95,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
       java: 11, 8
-      scala: 2.12.17, 2.13.9
+      scala: 2.12.15, 2.13.8
       add-dimensions: >-
         {
           "sbt_test_task": [ "test", "Play-Integration-Test/It/test", "Play-Microbenchmark/jmh:run -i 1 -wi 0 -f 1 -t 1 -foe=true" ]
@@ -103,7 +103,7 @@ jobs:
       exclude: >-
         [
           { "java": "${{ github.event_name == 'schedule' || '11' }}" },
-          { "scala": "${{ github.event_name == 'schedule' || '2.12.17' }}" },
+          { "scala": "${{ github.event_name == 'schedule' || '2.12.15' }}" },
           { "sbt_test_task": "${{ github.event_name == 'schedule' || 'Play-Microbenchmark/jmh:run -i 1 -wi 0 -f 1 -t 1 -foe=true' }}" }
         ]
       cmd: sbt "${{needs.extra-vars.outputs.akka_version_opts}}" "${{needs.extra-vars.outputs.akka_http_version_opts}}" ++$MATRIX_SCALA "$MATRIX_SBT_TEST_TASK"
@@ -118,11 +118,11 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
       java: 11, 8
-      scala: 2.12.17, 2.13.9
+      scala: 2.12.15, 2.13.8
       exclude: >-
         [
           { "java": "${{ github.event_name == 'schedule' || '11' }}" },
-          { "scala": "${{ github.event_name == 'schedule' || '2.12.17' }}" }
+          { "scala": "${{ github.event_name == 'schedule' || '2.12.15' }}" }
         ]
       cmd: cd documentation && sbt "${{needs.extra-vars.outputs.akka_version_opts}}" "${{needs.extra-vars.outputs.akka_http_version_opts}}" ++$MATRIX_SCALA test
 
@@ -134,7 +134,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
       java: 11, 8
-      scala: 2.12.17, 2.13.9
+      scala: 2.12.15, 2.13.8
       add-dimensions: >-
         {
           "sbt": [ "1.3.13", "1.6.2" ],
@@ -143,7 +143,7 @@ jobs:
       exclude: >-
         [
           { "java": "${{ github.event_name == 'schedule' || '11' }}" },
-          { "scala": "${{ github.event_name == 'schedule' || '2.12.17' }}" },
+          { "scala": "${{ github.event_name == 'schedule' || '2.12.15' }}" },
           { "sbt": "${{ github.event_name == 'schedule' || '1.3.13' }}" }
         ]
       cmd: >-

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -77,8 +77,8 @@ lazy val main = Project("Play-Documentation", file("."))
     unmanagedResourceDirectories in Test ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
     // Don't include sbt files in the resources
     excludeFilter in (Test, unmanagedResources) := (excludeFilter in (Test, unmanagedResources)).value || "*.sbt",
-    crossScalaVersions := Seq("2.13.9", "2.12.17"),
-    scalaVersion := "2.13.9",
+    crossScalaVersions := Seq("2.13.8", "2.12.15"),
+    scalaVersion := "2.13.8",
     fork in Test := true,
     javaOptions in Test ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(HeaderLicense.Custom("Copyright (C) Lightbend Inc. <https://www.lightbend.com>")),

--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -38,7 +38,7 @@ This will build and publish Play for the default Scala version. If you want to p
 Or to publish for a specific Scala version:
 
 ```bash
-> ++ 2.13.9 publishLocal
+> ++ 2.13.8 publishLocal
 ```
 
 ## Build the documentation

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -12,7 +12,7 @@ You can select which version of Scala you would like to use by setting the `scal
 For Scala 2.12:
 
 ```scala
-scalaVersion := "2.12.17"
+scalaVersion := "2.12.15"
 ```
 
 For Scala 2.11:
@@ -30,7 +30,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayService)
   .enablePlugins(RoutesCompiler) // place routes in src/main/resources, or remove if using SIRD/RoutingDsl
   .settings(
-    scalaVersion := "2.12.17",
+    scalaVersion := "2.12.15",
     libraryDependencies ++= Seq(
       guice, // remove if not using Play's Guice loader
       akkaHttpServer, // or use nettyServer for Netty

--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -12,7 +12,7 @@ You can select which version of Scala you would like to use by setting the `scal
 For Scala 2.12:
 
 ```scala
-scalaVersion := "2.12.17"
+scalaVersion := "2.12.15"
 ```
 
 For Scala 2.11:
@@ -24,7 +24,7 @@ scalaVersion := "2.11.12"
 For Scala 2.13:
 
 ```scala
-scalaVersion := "2.13.9"
+scalaVersion := "2.13.8"
 ```
 
 ## Lifecycle managed by Akka's Coordinated Shutdown

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -47,14 +47,14 @@ Play 2.8 support Scala 2.12 and 2.13, but not 2.11, which has reached its end of
 To set the Scala version in sbt, simply set the `scalaVersion` key, for example:
 
 ```scala
-scalaVersion := "2.13.9"
+scalaVersion := "2.13.8"
 ```
 
 If you have a single project build, then this setting can just be placed on its own line in `build.sbt`.  However, if you have a multi-project build, then the scala version setting must be set on each project.  Typically, in a multi-project build, you will have some common settings shared by every project, this is the best place to put the setting, for example:
 
 ```scala
 def commonSettings = Seq(
-  scalaVersion := "2.13.9"
+  scalaVersion := "2.13.8"
 )
 
 val projectA = (project in file("projectA"))

--- a/documentation/manual/working/commonGuide/build/sbtDependencies.md
+++ b/documentation/manual/working/commonGuide/build/sbtDependencies.md
@@ -37,7 +37,7 @@ If you use `groupID %% artifactID % revision` rather than `groupID % artifactID 
 
 @[explicit-scala-version-dep](code/dependencies.sbt)
 
-Assuming the `scalaVersion` for your build is `2.13.9`, the following is identical (note the double `%%` after `"org.scala-tools"`):
+Assuming the `scalaVersion` for your build is `2.13.8`, the following is identical (note the double `%%` after `"org.scala-tools"`):
 
 @[auto-scala-version-dep](code/dependencies.sbt)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -319,8 +319,8 @@ object Dependencies {
  * How to use this:
  *    $ sbt -J-XX:+UnlockCommercialFeatures -J-XX:+FlightRecorder -Dakka-http.sources=$HOME/code/akka-http '; project Play-Akka-Http-Server; test:run'
  *
- * Make sure Akka-HTTP has 2.12 as the FIRST version (or that scalaVersion := "2.12.17", otherwise it won't find the artifact
- *    crossScalaVersions := Seq("2.12.17", "2.11.12"),
+ * Make sure Akka-HTTP has 2.12 as the FIRST version (or that scalaVersion := "2.12.15", otherwise it won't find the artifact
+ *    crossScalaVersions := Seq("2.12.15", "2.11.12"),
  */
 object AkkaDependency {
   // Needs to be a URI like git://github.com/akka/akka.git#main or file:///xyz/akka


### PR DESCRIPTION
I want to cut a new release, however it seems Scala 2.13.9 is a bit buggy (like https://github.com/scala/bug/issues/12650) and 2.13.10 will be released soon.
Reverting to the same versions we used to cut 2.8.16