### PR TITLE
Change copyright

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
+
 <!--
 
 If you are reporting a bug, please be informative. This template can guide you to provide basic information, but you are not limited to that.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,5 @@
+<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
+
 ---
 name: Bug report
 about: Create a report to help us improve

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
+
 # Pull Request Checklist
 
 * [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
-<!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
+<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play contributor guidelines
 
 The canonical version of this document can be found on the [Play contributor guidelines](https://playframework.com/contributing) page of the Play website.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can also individually sponsor the project by <a href="https://www.playframew
 
 ## License
 
-Copyright (C) Lightbend Inc. (https://www.lightbend.com).
+Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play Framework - The High Velocity Web Framework
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/playframework?label=follow&style=flat&logo=twitter&color=brightgreen)](https://twitter.com/playframework)

--- a/build.sbt
+++ b/build.sbt
@@ -234,7 +234,7 @@ lazy val SbtPluginProject = PlaySbtPluginProject("Sbt-Plugin", "dev-mode/sbt-plu
         (Compile / sourceManaged).value
       )
     }.taskValue,
-    (Compile / headerSources) ++= (sbtTestDirectory.value ** ("*.scala" || "*.java")).get,
+    (Compile / headerSources) ++= (sbtTestDirectory.value ** ("*.scala" || "*.java" || "*.sbt")).get,
   )
   .dependsOn(SbtRoutesCompilerProject, RunSupportProject)
 
@@ -473,6 +473,12 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
     mimaReportBinaryIssues := (()),
     commands += Commands.quickPublish,
     publish / skip := true,
+    (Compile / headerSources) ++=
+      ((baseDirectory.value ** ("*.default" || "*.properties" || "*.md" || "*.sbt" || "*.routes" || "routes" || "*.js" || "*.less"))
+        --- (baseDirectory.value ** ("jquery*js"))
+        --- (baseDirectory.value / "documentation" ** "*")).get ++
+        (baseDirectory.value / "web" / "play-openid" ** "*.html").get ++
+        (baseDirectory.value / "project" ** "*.scala").get
   )
   .aggregate((userProjects ++ nonUserProjects): _*)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
 import BuildSettings._
 import Dependencies._
 import Generators._

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 import BuildSettings._
 import Dependencies._

--- a/cache/play-cache/src/main/java/play/cache/AsyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/AsyncCacheApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/Cached.java
+++ b/cache/play-cache/src/main/java/play/cache/Cached.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/CachedAction.java
+++ b/cache/play-cache/src/main/java/play/cache/CachedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/NamedCache.java
+++ b/cache/play-cache/src/main/java/play/cache/NamedCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/NamedCacheImpl.java
+++ b/cache/play-cache/src/main/java/play/cache/NamedCacheImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/SyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/SyncCacheApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
+++ b/cache/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache;

--- a/cache/play-cache/src/main/java/play/cache/package-info.java
+++ b/cache/play-cache/src/main/java/play/cache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides the Cache API. */

--- a/cache/play-cache/src/main/scala/play/api/cache/AsyncCacheApi.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/AsyncCacheApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-cache/src/main/scala/play/api/cache/Cached.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/Cached.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-cache/src/main/scala/play/api/cache/package.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/cache/play-cache/src/test/resources/logback-test.xml
+++ b/cache/play-cache/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineCacheComponents.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineCacheComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache.caffeine;

--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineDefaultExpiry.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineDefaultExpiry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache.caffeine;

--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineExecutionContext.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache.caffeine;

--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineParser.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache.caffeine;

--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/NamedCaffeineCache.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/NamedCaffeineCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache.caffeine;

--- a/cache/play-caffeine-cache/src/main/resources/reference.conf
+++ b/cache/play-caffeine-cache/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
 

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache.caffeine

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheManager.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache.caffeine

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache.caffeine

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/ExpirableCacheValue.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/ExpirableCacheValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache.caffeine

--- a/cache/play-caffeine-cache/src/test/java/play/cache/caffeine/NamedCaffeineCacheSpec.java
+++ b/cache/play-caffeine-cache/src/test/java/play/cache/caffeine/NamedCaffeineCacheSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache.caffeine;

--- a/cache/play-caffeine-cache/src/test/resources/logback-test.xml
+++ b/cache/play-caffeine-cache/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/SerializableResultSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/SerializableResultSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/caffeine/CaffeineCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/caffeine/CaffeineCacheApiSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache.caffeine

--- a/cache/play-ehcache/src/main/java/play/cache/ehcache/EhCacheComponents.java
+++ b/cache/play-ehcache/src/main/java/play/cache/ehcache/EhCacheComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cache.ehcache;

--- a/cache/play-ehcache/src/main/resources/ehcache-default.xml
+++ b/cache/play-ehcache/src/main/resources/ehcache-default.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../config/ehcache.xsd" updateCheck="false">

--- a/cache/play-ehcache/src/main/resources/reference.conf
+++ b/cache/play-ehcache/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
 

--- a/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache.ehcache

--- a/cache/play-ehcache/src/test/resources/ehcache-alternate.xml
+++ b/cache/play-ehcache/src/test/resources/ehcache-alternate.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../config/ehcache.xsd" updateCheck="false">

--- a/cache/play-ehcache/src/test/resources/logback-test.xml
+++ b/cache/play-ehcache/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-ehcache/src/test/scala/play/api/cache/SerializableResultSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/SerializableResultSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache

--- a/cache/play-ehcache/src/test/scala/play/api/cache/ehcache/EhCacheApiSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/ehcache/EhCacheApiSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cache.ehcache

--- a/cache/play-jcache/src/main/java/play/libs/jcache/JCacheComponents.java
+++ b/cache/play-jcache/src/main/java/play/libs/jcache/JCacheComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.jcache;

--- a/cache/play-jcache/src/main/resources/reference.conf
+++ b/cache/play-jcache/src/main/resources/reference.conf
@@ -1,3 +1,3 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.modules.enabled+=play.api.libs.jcache.JCacheModule

--- a/cache/play-jcache/src/main/scala/play/api/libs/jcache/JCacheComponents.scala
+++ b/cache/play-jcache/src/main/scala/play/api/libs/jcache/JCacheComponents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.jcache

--- a/cache/play-jcache/src/main/scala/play/api/libs/jcache/JCacheModule.scala
+++ b/cache/play-jcache/src/main/scala/play/api/libs/jcache/JCacheModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.jcache

--- a/cache/play-jcache/src/test/scala/play/api/libs/jcache/JCacheSpec.scala
+++ b/cache/play-jcache/src/test/scala/play/api/libs/jcache/JCacheSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.jcache

--- a/cluster/play-cluster-sharding/src/main/resources/play/reference-overrides.conf
+++ b/cluster/play-cluster-sharding/src/main/resources/play/reference-overrides.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # we need provider to be 'cluster' when using this module
 akka.actor.provider = cluster

--- a/cluster/play-cluster-sharding/src/main/resources/reference.conf
+++ b/cluster/play-cluster-sharding/src/main/resources/reference.conf
@@ -1,3 +1,3 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.modules.enabled += "play.api.cluster.sharding.typed.ClusterShardingModule"

--- a/cluster/play-cluster-sharding/src/main/scala/play/api/cluster/sharding/typed/ClusterShardingComponents.scala
+++ b/cluster/play-cluster-sharding/src/main/scala/play/api/cluster/sharding/typed/ClusterShardingComponents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cluster.sharding.typed

--- a/cluster/play-cluster-sharding/src/main/scala/play/api/cluster/sharding/typed/ClusterShardingModule.scala
+++ b/cluster/play-cluster-sharding/src/main/scala/play/api/cluster/sharding/typed/ClusterShardingModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.cluster.sharding.typed

--- a/cluster/play-java-cluster-sharding/src/main/java/play/cluster/sharding/typed/ClusterShardingComponents.java
+++ b/cluster/play-java-cluster-sharding/src/main/java/play/cluster/sharding/typed/ClusterShardingComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cluster.sharding.typed;

--- a/cluster/play-java-cluster-sharding/src/main/resources/play/reference-overrides.conf
+++ b/cluster/play-java-cluster-sharding/src/main/resources/play/reference-overrides.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # we need provider to be 'cluster' when using this module
 akka.actor.provider = cluster

--- a/cluster/play-java-cluster-sharding/src/main/resources/reference.conf
+++ b/cluster/play-java-cluster-sharding/src/main/resources/reference.conf
@@ -1,3 +1,3 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.modules.enabled += "play.cluster.sharding.typed.ClusterShardingModule"

--- a/cluster/play-java-cluster-sharding/src/main/scala/play/cluster/sharding/typed/ClusterShardingModule.scala
+++ b/cluster/play-java-cluster-sharding/src/main/scala/play/cluster/sharding/typed/ClusterShardingModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.cluster.sharding.typed

--- a/core/play-exceptions/src/main/java/play/api/PlayException.java
+++ b/core/play-exceptions/src/main/java/play/api/PlayException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api;

--- a/core/play-exceptions/src/main/java/play/api/UsefulException.java
+++ b/core/play-exceptions/src/main/java/play/api/UsefulException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api;

--- a/core/play-guice/src/main/java/play/inject/guice/GuiceApplicationBuilder.java
+++ b/core/play-guice/src/main/java/play/inject/guice/GuiceApplicationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject.guice;

--- a/core/play-guice/src/main/java/play/inject/guice/GuiceApplicationLoader.java
+++ b/core/play-guice/src/main/java/play/inject/guice/GuiceApplicationLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject.guice;

--- a/core/play-guice/src/main/java/play/inject/guice/GuiceBuilder.java
+++ b/core/play-guice/src/main/java/play/inject/guice/GuiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject.guice;

--- a/core/play-guice/src/main/java/play/inject/guice/GuiceInjectorBuilder.java
+++ b/core/play-guice/src/main/java/play/inject/guice/GuiceInjectorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject.guice;

--- a/core/play-guice/src/main/java/play/inject/guice/Guiceable.java
+++ b/core/play-guice/src/main/java/play/inject/guice/Guiceable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject.guice;

--- a/core/play-guice/src/main/java/play/libs/akka/AkkaGuiceSupport.java
+++ b/core/play-guice/src/main/java/play/libs/akka/AkkaGuiceSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.akka;

--- a/core/play-guice/src/main/java/play/libs/akka/BinderAccessor.java
+++ b/core/play-guice/src/main/java/play/libs/akka/BinderAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.akka;

--- a/core/play-guice/src/main/java/play/libs/akka/package-info.java
+++ b/core/play-guice/src/main/java/play/libs/akka/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Utility methods for working with Akka. */

--- a/core/play-guice/src/main/resources/reference.conf
+++ b/core/play-guice/src/main/resources/reference.conf
@@ -1,3 +1,3 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.application.loader = "play.api.inject.guice.GuiceApplicationLoader"

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject.guice

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject.guice

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/ActorModule.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/ActorModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/AkkaGuiceSupport.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/AkkaGuiceSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/TypedActorRefProvider.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/TypedActorRefProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/TypedAkka.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/TypedAkka.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject.guice;

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject.guice;

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject.guice;

--- a/core/play-guice/src/test/resources/logback-test.xml
+++ b/core/play-guice/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play-guice/src/test/scala/play/api/inject/ModulesSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/inject/ModulesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject.guice

--- a/core/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play-guice/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play-guice/src/test/scala/play/core/test/Fakes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.test

--- a/core/play-guice/src/test/scala/play/utils/ReflectSpec.scala
+++ b/core/play-guice/src/test/scala/play/utils/ReflectSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play-integration-test/src/it/java/play/BuiltInComponentsFromContextTest.java
+++ b/core/play-integration-test/src/it/java/play/BuiltInComponentsFromContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play-integration-test/src/it/java/play/it/JavaServerIntegrationTest.java
+++ b/core/play-integration-test/src/it/java/play/it/JavaServerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it;

--- a/core/play-integration-test/src/it/java/play/it/http/ActionCompositionActionCreator.java
+++ b/core/play-integration-test/src/it/java/play/it/http/ActionCompositionActionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/ActionCompositionOrderTest.java
+++ b/core/play-integration-test/src/it/java/play/it/http/ActionCompositionOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/MultipleRepeatableOnActionController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/MultipleRepeatableOnActionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/MultipleRepeatableOnTypeAndActionController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/MultipleRepeatableOnTypeAndActionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/MultipleRepeatableOnTypeController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/MultipleRepeatableOnTypeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/RepeatableBackwardCompatibilityController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/RepeatableBackwardCompatibilityController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/SingleRepeatableOnActionController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/SingleRepeatableOnActionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/SingleRepeatableOnTypeAndActionController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/SingleRepeatableOnTypeAndActionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/SingleRepeatableOnTypeController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/SingleRepeatableOnTypeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/WithOnActionController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/WithOnActionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/WithOnTypeAndActionController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/WithOnTypeAndActionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/WithOnTypeController.java
+++ b/core/play-integration-test/src/it/java/play/it/http/WithOnTypeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http;

--- a/core/play-integration-test/src/it/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/it/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.websocket;

--- a/core/play-integration-test/src/it/java/play/routing/AbstractRoutingDslTest.java
+++ b/core/play-integration-test/src/it/java/play/routing/AbstractRoutingDslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play-integration-test/src/it/java/play/routing/CompileTimeInjectionRoutingDslTest.java
+++ b/core/play-integration-test/src/it/java/play/routing/CompileTimeInjectionRoutingDslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play-integration-test/src/it/java/play/routing/DependencyInjectedRoutingDslTest.java
+++ b/core/play-integration-test/src/it/java/play/routing/DependencyInjectedRoutingDslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play-integration-test/src/it/resources/application.conf
+++ b/core/play-integration-test/src/it/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Play sometimes gets grumpy if this file doesn't exist.
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b

--- a/core/play-integration-test/src/it/resources/logback.xml
+++ b/core/play-integration-test/src/it/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/core/play-integration-test/src/it/resources/testassets/encoding.js
+++ b/core/play-integration-test/src/it/resources/testassets/encoding.js
@@ -1,1 +1,5 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 this is a file where we test the different encodings of the assets controller. this is the plain version

--- a/core/play-integration-test/src/it/scala/play/it/LogTester.scala
+++ b/core/play-integration-test/src/it/scala/play/it/LogTester.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it

--- a/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it

--- a/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it

--- a/core/play-integration-test/src/it/scala/play/it/action/ContentNegotiationSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/ContentNegotiationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.action

--- a/core/play-integration-test/src/it/scala/play/it/action/EssentialActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/EssentialActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.action

--- a/core/play-integration-test/src/it/scala/play/it/action/FormActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/FormActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.action

--- a/core/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.action

--- a/core/play-integration-test/src/it/scala/play/it/api/SecretConfigurationParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/api/SecretConfigurationParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.api

--- a/core/play-integration-test/src/it/scala/play/it/auth/SecuritySpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/auth/SecuritySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.auth

--- a/core/play-integration-test/src/it/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/AkkaHttpCustomServerProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/AkkaRequestTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/AkkaRequestTimeoutSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/AkkaResponseHeaderHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/AkkaResponseHeaderHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/BadClientHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/BasicHttpClient.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/BasicHttpClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/Expect100ContinueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/FlashCookieSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/FlashCookieSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/FormFieldOrderSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/FormFieldOrderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/HttpErrorHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/HttpErrorHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/HttpFiltersSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/HttpFiltersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/HttpHeaderSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/HttpHeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/HttpHeadersCommonSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/HttpHeadersCommonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/HttpPipeliningSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/JAction.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaCachedActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaCachedActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaHttpHandlerSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaHttpHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/RequestHeadersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/SecureFlagSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/SecureFlagSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/SessionCookieSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/SessionCookieSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/UriHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/UriHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http

--- a/core/play-integration-test/src/it/scala/play/it/http/assets/AssetsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/assets/AssetsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.assets

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/BodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/BodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/ByteStringBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/ByteStringBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/FormBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/FormBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/JacksonJsonBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/JacksonJsonBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/JsonBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/JsonBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/TextBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/TextBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.parsing

--- a/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /**

--- a/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.http.websocket

--- a/core/play-integration-test/src/it/scala/play/it/i18n/LangSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/i18n/LangSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.i18n

--- a/core/play-integration-test/src/it/scala/play/it/i18n/MessagesSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/i18n/MessagesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.i18n

--- a/core/play-integration-test/src/it/scala/play/it/libs/JavaFormSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/JavaFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.libs

--- a/core/play-integration-test/src/it/scala/play/it/libs/JavaWSSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/JavaWSSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.libs

--- a/core/play-integration-test/src/it/scala/play/it/libs/ScalaWSSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/ScalaWSSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.libs

--- a/core/play-integration-test/src/it/scala/play/it/libs/json/JavaJsonSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/json/JavaJsonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.libs.json

--- a/core/play-integration-test/src/it/scala/play/it/libs/json/JavaPOJO.java
+++ b/core/play-integration-test/src/it/scala/play/it/libs/json/JavaPOJO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.libs.json;

--- a/core/play-integration-test/src/it/scala/play/it/mvc/FiltersSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/mvc/FiltersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.mvc

--- a/core/play-integration-test/src/it/scala/play/it/mvc/HttpSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/mvc/HttpSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play-integration-test/src/it/scala/play/it/routing/ServerSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/routing/ServerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.routing

--- a/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/server/ServerReloadingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.server

--- a/core/play-integration-test/src/it/scala/play/it/test/AkkaHttpServerEndpointRecipes.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/AkkaHttpServerEndpointRecipes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.test

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.test

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.test

--- a/core/play-integration-test/src/it/scala/play/it/test/NettyServerEndpointRecipes.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/NettyServerEndpointRecipes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.test

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.test

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.test

--- a/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.test

--- a/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.test

--- a/core/play-integration-test/src/it/scala/play/it/tools/HttpBin.scala
+++ b/core/play-integration-test/src/it/scala/play/it/tools/HttpBin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.tools

--- a/core/play-integration-test/src/it/scala/play/it/views/DevErrorPageSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/views/DevErrorPageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.it.views

--- a/core/play-java/src/main/java/play/inject/BuiltInModule.java
+++ b/core/play-java/src/main/java/play/inject/BuiltInModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play-java/src/main/java/play/libs/Comet.java
+++ b/core/play-java/src/main/java/play/libs/Comet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play-java/src/main/java/play/libs/EventSource.java
+++ b/core/play-java/src/main/java/play/libs/EventSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play-java/src/main/java/play/libs/Jsonp.java
+++ b/core/play-java/src/main/java/play/libs/Jsonp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play-java/src/main/java/play/libs/Resources.java
+++ b/core/play-java/src/main/java/play/libs/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play-java/src/main/java/play/libs/Time.java
+++ b/core/play-java/src/main/java/play/libs/Time.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play-java/src/main/java/play/libs/XPath.java
+++ b/core/play-java/src/main/java/play/libs/XPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play-java/src/main/java/play/libs/package-info.java
+++ b/core/play-java/src/main/java/play/libs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides various APIs that are useful for developing web applications. */

--- a/core/play-java/src/main/java/play/routing/RequestFunctions.java
+++ b/core/play-java/src/main/java/play/routing/RequestFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/core/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play-java/src/main/java/play/routing/RoutingDslComponents.java
+++ b/core/play-java/src/main/java/play/routing/RoutingDslComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play-java/src/main/java/play/routing/RoutingDslComponentsFromContext.java
+++ b/core/play-java/src/main/java/play/routing/RoutingDslComponentsFromContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play-java/src/main/resources/reference.conf
+++ b/core/play-java/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
   modules {

--- a/core/play-java/src/main/scala/play/core/FileMimeTypesModule.scala
+++ b/core/play-java/src/main/scala/play/core/FileMimeTypesModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core

--- a/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
+++ b/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core

--- a/core/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/core/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing

--- a/core/play-java/src/main/scala/play/routing/RoutingDslModule.scala
+++ b/core/play-java/src/main/scala/play/routing/RoutingDslModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing

--- a/core/play-java/src/test/java/play/libs/ResourcesTest.java
+++ b/core/play-java/src/test/java/play/libs/ResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play-java/src/test/java/play/libs/TimeTest.java
+++ b/core/play-java/src/test/java/play/libs/TimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play-java/src/test/java/play/libs/testmodel/AC1.java
+++ b/core/play-java/src/test/java/play/libs/testmodel/AC1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.testmodel;

--- a/core/play-java/src/test/java/play/libs/testmodel/C1.java
+++ b/core/play-java/src/test/java/play/libs/testmodel/C1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.testmodel;

--- a/core/play-java/src/test/java/play/mvc/AttributesTest.java
+++ b/core/play-java/src/test/java/play/mvc/AttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/core/play-java/src/test/java/play/mvc/HttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play-java/src/test/java/play/mvc/ResultAttributesTest.java
+++ b/core/play-java/src/test/java/play/mvc/ResultAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play-java/src/test/resources/logback-test.xml
+++ b/core/play-java/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/core/play-java/src/test/scala/play/libs/XPathSpec.scala
+++ b/core/play-java/src/test/scala/play/libs/XPathSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs

--- a/core/play-logback/src/main/resources/logback-play-default.xml
+++ b/core/play-logback/src/main/resources/logback-play-default.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <!-- The default logback configuration that Play uses if no other configuration is provided -->

--- a/core/play-logback/src/main/resources/logback-play-dev.xml
+++ b/core/play-logback/src/main/resources/logback-play-dev.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <!-- The default logback configuration that Play uses in dev mode if no other configuration is provided -->

--- a/core/play-logback/src/main/resources/logger-configurator.properties
+++ b/core/play-logback/src/main/resources/logger-configurator.properties
@@ -1,4 +1,5 @@
 #
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 #
+
 play.logger.configurator=play.api.libs.logback.LogbackLoggerConfigurator

--- a/core/play-logback/src/main/resources/logger-configurator.properties
+++ b/core/play-logback/src/main/resources/logger-configurator.properties
@@ -1,5 +1,3 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.logger.configurator=play.api.libs.logback.LogbackLoggerConfigurator

--- a/core/play-logback/src/main/scala/play/api/libs/logback/ColoredLevel.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/ColoredLevel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.logback

--- a/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.logback

--- a/core/play-logback/src/test/scala/play/api/ModeSpecificLoggerSpec.scala
+++ b/core/play-logback/src/test/scala/play/api/ModeSpecificLoggerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play-logback/src/test/scala/play/api/libs/logback/LogbackCapturingAppender.scala
+++ b/core/play-logback/src/test/scala/play/api/libs/logback/LogbackCapturingAppender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.logback

--- a/core/play-microbenchmark/src/test/scala/play/api/mvc/Cookies_01_ReadCookieFromHeader.scala
+++ b/core/play-microbenchmark/src/test/scala/play/api/mvc/Cookies_01_ReadCookieFromHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play-microbenchmark/src/test/scala/play/api/mvc/MvcHelpers.scala
+++ b/core/play-microbenchmark/src/test/scala/play/api/mvc/MvcHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play-microbenchmark/src/test/scala/play/api/mvc/RequestHeader_01_ReadHeaderValue.scala
+++ b/core/play-microbenchmark/src/test/scala/play/api/mvc/RequestHeader_01_ReadHeaderValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play-microbenchmark/src/test/scala/play/core/server/netty/NettyHelpers.scala
+++ b/core/play-microbenchmark/src/test/scala/play/core/server/netty/NettyHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/core/play-microbenchmark/src/test/scala/play/core/server/netty/NettyModelConversion_01_ConvertMinimalRequest.scala
+++ b/core/play-microbenchmark/src/test/scala/play/core/server/netty/NettyModelConversion_01_ConvertMinimalRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/core/play-microbenchmark/src/test/scala/play/core/server/netty/NettyModelConversion_02_ConvertNormalRequest.scala
+++ b/core/play-microbenchmark/src/test/scala/play/core/server/netty/NettyModelConversion_02_ConvertNormalRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
+++ b/core/play-microbenchmark/src/test/scala/play/microbenchmark/it/HelloWorldBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.microbenchmark.it

--- a/core/play-streams/src/main/java/play/libs/streams/Accumulator.java
+++ b/core/play-streams/src/main/java/play/libs/streams/Accumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.streams;

--- a/core/play-streams/src/main/java/play/libs/streams/ActorFlow.java
+++ b/core/play-streams/src/main/java/play/libs/streams/ActorFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.streams;

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.streams

--- a/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.streams

--- a/core/play-streams/src/main/scala/play/api/libs/streams/AkkaStreams.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/AkkaStreams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.streams

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Execution.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Execution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.streams

--- a/core/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.streams

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Probes.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Probes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.streams

--- a/core/play-streams/src/test/java/play/libs/streams/AccumulatorTest.java
+++ b/core/play-streams/src/test/java/play/libs/streams/AccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.streams;

--- a/core/play-streams/src/test/resources/logback-test.xml
+++ b/core/play-streams/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.streams

--- a/core/play-streams/src/test/scala/play/api/libs/streams/ExecutionSpec.scala
+++ b/core/play-streams/src/test/scala/play/api/libs/streams/ExecutionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.streams

--- a/core/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.streams

--- a/core/play/src/main/java/play/Application.java
+++ b/core/play/src/main/java/play/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/ApplicationLoader.java
+++ b/core/play/src/main/java/play/ApplicationLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/BuiltInComponents.java
+++ b/core/play/src/main/java/play/BuiltInComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/BuiltInComponentsFromContext.java
+++ b/core/play/src/main/java/play/BuiltInComponentsFromContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/ContextBasedBuiltInComponents.java
+++ b/core/play/src/main/java/play/ContextBasedBuiltInComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/DefaultApplication.java
+++ b/core/play/src/main/java/play/DefaultApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/DelegateLoggerConfigurator.java
+++ b/core/play/src/main/java/play/DelegateLoggerConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/Environment.java
+++ b/core/play/src/main/java/play/Environment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/Logger.java
+++ b/core/play/src/main/java/play/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/LoggerConfigurator.java
+++ b/core/play/src/main/java/play/LoggerConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/Mode.java
+++ b/core/play/src/main/java/play/Mode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/core/play/src/main/java/play/components/AkkaComponents.java
+++ b/core/play/src/main/java/play/components/AkkaComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/AkkaTypedComponents.java
+++ b/core/play/src/main/java/play/components/AkkaTypedComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/ApplicationComponents.java
+++ b/core/play/src/main/java/play/components/ApplicationComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/BaseComponents.java
+++ b/core/play/src/main/java/play/components/BaseComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/BodyParserComponents.java
+++ b/core/play/src/main/java/play/components/BodyParserComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/ConfigurationComponents.java
+++ b/core/play/src/main/java/play/components/ConfigurationComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/CryptoComponents.java
+++ b/core/play/src/main/java/play/components/CryptoComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/FileMimeTypesComponents.java
+++ b/core/play/src/main/java/play/components/FileMimeTypesComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/HttpComponents.java
+++ b/core/play/src/main/java/play/components/HttpComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/HttpConfigurationComponents.java
+++ b/core/play/src/main/java/play/components/HttpConfigurationComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/HttpErrorHandlerComponents.java
+++ b/core/play/src/main/java/play/components/HttpErrorHandlerComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/components/TemporaryFileComponents.java
+++ b/core/play/src/main/java/play/components/TemporaryFileComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.components;

--- a/core/play/src/main/java/play/controllers/AssetsComponents.java
+++ b/core/play/src/main/java/play/controllers/AssetsComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.controllers;

--- a/core/play/src/main/java/play/core/Paths.java
+++ b/core/play/src/main/java/play/core/Paths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core;

--- a/core/play/src/main/java/play/core/j/MappedJavaHandlerComponents.java
+++ b/core/play/src/main/java/play/core/j/MappedJavaHandlerComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j;

--- a/core/play/src/main/java/play/http/ActionCreator.java
+++ b/core/play/src/main/java/play/http/ActionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/DefaultActionCreator.java
+++ b/core/play/src/main/java/play/http/DefaultActionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/DefaultHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/DefaultHttpErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/DefaultHttpFilters.java
+++ b/core/play/src/main/java/play/http/DefaultHttpFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/DefaultHttpRequestHandler.java
+++ b/core/play/src/main/java/play/http/DefaultHttpRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/HandlerForRequest.java
+++ b/core/play/src/main/java/play/http/HandlerForRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/HtmlOrJsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/HtmlOrJsonHttpErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/HttpEntity.java
+++ b/core/play/src/main/java/play/http/HttpEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/HttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/HttpErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/HttpErrorInfo.java
+++ b/core/play/src/main/java/play/http/HttpErrorInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/HttpFilters.java
+++ b/core/play/src/main/java/play/http/HttpFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/HttpRequestHandler.java
+++ b/core/play/src/main/java/play/http/HttpRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/JsonHttpErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/PreferredMediaTypeHttpErrorHandler.java
+++ b/core/play/src/main/java/play/http/PreferredMediaTypeHttpErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http;

--- a/core/play/src/main/java/play/http/package-info.java
+++ b/core/play/src/main/java/play/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Core Java HTTP API. */

--- a/core/play/src/main/java/play/http/websocket/Message.java
+++ b/core/play/src/main/java/play/http/websocket/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.http.websocket;

--- a/core/play/src/main/java/play/i18n/I18nComponents.java
+++ b/core/play/src/main/java/play/i18n/I18nComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.i18n;

--- a/core/play/src/main/java/play/i18n/Lang.java
+++ b/core/play/src/main/java/play/i18n/Lang.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.i18n;

--- a/core/play/src/main/java/play/i18n/Langs.java
+++ b/core/play/src/main/java/play/i18n/Langs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.i18n;

--- a/core/play/src/main/java/play/i18n/Messages.java
+++ b/core/play/src/main/java/play/i18n/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.i18n;

--- a/core/play/src/main/java/play/i18n/MessagesApi.java
+++ b/core/play/src/main/java/play/i18n/MessagesApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.i18n;

--- a/core/play/src/main/java/play/i18n/MessagesImpl.java
+++ b/core/play/src/main/java/play/i18n/MessagesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.i18n;

--- a/core/play/src/main/java/play/i18n/package-info.java
+++ b/core/play/src/main/java/play/i18n/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides the i18n API. */

--- a/core/play/src/main/java/play/inject/ApplicationLifecycle.java
+++ b/core/play/src/main/java/play/inject/ApplicationLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/Binding.java
+++ b/core/play/src/main/java/play/inject/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/BindingKey.java
+++ b/core/play/src/main/java/play/inject/BindingKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/BindingKeyTarget.java
+++ b/core/play/src/main/java/play/inject/BindingKeyTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/BindingTarget.java
+++ b/core/play/src/main/java/play/inject/BindingTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/Bindings.java
+++ b/core/play/src/main/java/play/inject/Bindings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/ConstructionTarget.java
+++ b/core/play/src/main/java/play/inject/ConstructionTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/DelegateApplicationLifecycle.java
+++ b/core/play/src/main/java/play/inject/DelegateApplicationLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/DelegateInjector.java
+++ b/core/play/src/main/java/play/inject/DelegateInjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/Injector.java
+++ b/core/play/src/main/java/play/inject/Injector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/Module.java
+++ b/core/play/src/main/java/play/inject/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/NamedImpl.java
+++ b/core/play/src/main/java/play/inject/NamedImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/ProviderConstructionTarget.java
+++ b/core/play/src/main/java/play/inject/ProviderConstructionTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/ProviderTarget.java
+++ b/core/play/src/main/java/play/inject/ProviderTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/QualifierAnnotation.java
+++ b/core/play/src/main/java/play/inject/QualifierAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/QualifierClass.java
+++ b/core/play/src/main/java/play/inject/QualifierClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/QualifierInstance.java
+++ b/core/play/src/main/java/play/inject/QualifierInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.inject;

--- a/core/play/src/main/java/play/inject/package-info.java
+++ b/core/play/src/main/java/play/inject/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides dependency injection utilities for Play lifecycle. */

--- a/core/play/src/main/java/play/libs/Akka.java
+++ b/core/play/src/main/java/play/libs/Akka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play/src/main/java/play/libs/AnnotationUtils.java
+++ b/core/play/src/main/java/play/libs/AnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play/src/main/java/play/libs/F.java
+++ b/core/play/src/main/java/play/libs/F.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play/src/main/java/play/libs/Files.java
+++ b/core/play/src/main/java/play/libs/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play/src/main/java/play/libs/Json.java
+++ b/core/play/src/main/java/play/libs/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play/src/main/java/play/libs/Scala.java
+++ b/core/play/src/main/java/play/libs/Scala.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play/src/main/java/play/libs/XML.java
+++ b/core/play/src/main/java/play/libs/XML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs;

--- a/core/play/src/main/java/play/libs/akka/InjectedActorSupport.java
+++ b/core/play/src/main/java/play/libs/akka/InjectedActorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.akka;

--- a/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
+++ b/core/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.concurrent;

--- a/core/play/src/main/java/play/libs/concurrent/DefaultFutures.java
+++ b/core/play/src/main/java/play/libs/concurrent/DefaultFutures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.concurrent;

--- a/core/play/src/main/java/play/libs/concurrent/Futures.java
+++ b/core/play/src/main/java/play/libs/concurrent/Futures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.concurrent;

--- a/core/play/src/main/java/play/libs/concurrent/HttpExecution.java
+++ b/core/play/src/main/java/play/libs/concurrent/HttpExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.concurrent;

--- a/core/play/src/main/java/play/libs/concurrent/HttpExecutionContext.java
+++ b/core/play/src/main/java/play/libs/concurrent/HttpExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.concurrent;

--- a/core/play/src/main/java/play/libs/concurrent/package-info.java
+++ b/core/play/src/main/java/play/libs/concurrent/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Concurrency utilities for handling CompletionStage and ExecutionContexts. */

--- a/core/play/src/main/java/play/libs/crypto/CSRFTokenSigner.java
+++ b/core/play/src/main/java/play/libs/crypto/CSRFTokenSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.crypto;

--- a/core/play/src/main/java/play/libs/crypto/CookieSigner.java
+++ b/core/play/src/main/java/play/libs/crypto/CookieSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.crypto;

--- a/core/play/src/main/java/play/libs/crypto/DefaultCSRFTokenSigner.java
+++ b/core/play/src/main/java/play/libs/crypto/DefaultCSRFTokenSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.crypto;

--- a/core/play/src/main/java/play/libs/crypto/DefaultCookieSigner.java
+++ b/core/play/src/main/java/play/libs/crypto/DefaultCookieSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.crypto;

--- a/core/play/src/main/java/play/libs/exception/ExceptionUtils.java
+++ b/core/play/src/main/java/play/libs/exception/ExceptionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.exception;

--- a/core/play/src/main/java/play/libs/streams/AkkaStreams.java
+++ b/core/play/src/main/java/play/libs/streams/AkkaStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.streams;

--- a/core/play/src/main/java/play/libs/streams/package-info.java
+++ b/core/play/src/main/java/play/libs/streams/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Utility methods for working with Akka Streams. */

--- a/core/play/src/main/java/play/libs/typedmap/TypedEntry.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.typedmap;

--- a/core/play/src/main/java/play/libs/typedmap/TypedKey.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.typedmap;

--- a/core/play/src/main/java/play/libs/typedmap/TypedMap.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.typedmap;

--- a/core/play/src/main/java/play/mvc/Action.java
+++ b/core/play/src/main/java/play/mvc/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/BodyParsers.java
+++ b/core/play/src/main/java/play/mvc/BodyParsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/Call.java
+++ b/core/play/src/main/java/play/mvc/Call.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/Controller.java
+++ b/core/play/src/main/java/play/mvc/Controller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/EssentialAction.java
+++ b/core/play/src/main/java/play/mvc/EssentialAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/EssentialFilter.java
+++ b/core/play/src/main/java/play/mvc/EssentialFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/FileMimeTypes.java
+++ b/core/play/src/main/java/play/mvc/FileMimeTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/Filter.java
+++ b/core/play/src/main/java/play/mvc/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/MultipartFormatter.java
+++ b/core/play/src/main/java/play/mvc/MultipartFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/PathBindable.java
+++ b/core/play/src/main/java/play/mvc/PathBindable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/QueryStringBindable.java
+++ b/core/play/src/main/java/play/mvc/QueryStringBindable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/RangeResults.java
+++ b/core/play/src/main/java/play/mvc/RangeResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/ResponseHeader.java
+++ b/core/play/src/main/java/play/mvc/ResponseHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/Result.java
+++ b/core/play/src/main/java/play/mvc/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/Results.java
+++ b/core/play/src/main/java/play/mvc/Results.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/Security.java
+++ b/core/play/src/main/java/play/mvc/Security.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/StaticFileMimeTypes.java
+++ b/core/play/src/main/java/play/mvc/StaticFileMimeTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/StatusHeader.java
+++ b/core/play/src/main/java/play/mvc/StatusHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/With.java
+++ b/core/play/src/main/java/play/mvc/With.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/main/java/play/mvc/package-info.java
+++ b/core/play/src/main/java/play/mvc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides the Controller/Action/Result API for handling HTTP requests. */

--- a/core/play/src/main/java/play/package-info.java
+++ b/core/play/src/main/java/play/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /**

--- a/core/play/src/main/java/play/routing/HandlerDef.java
+++ b/core/play/src/main/java/play/routing/HandlerDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play/src/main/java/play/routing/JavaScriptReverseRouter.java
+++ b/core/play/src/main/java/play/routing/JavaScriptReverseRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play/src/main/java/play/routing/Router.java
+++ b/core/play/src/main/java/play/routing/Router.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routing;

--- a/core/play/src/main/java/play/server/ApplicationProvider.java
+++ b/core/play/src/main/java/play/server/ApplicationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.server;

--- a/core/play/src/main/java/play/server/SSLEngineProvider.java
+++ b/core/play/src/main/java/play/server/SSLEngineProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.server;

--- a/core/play/src/main/resources/messages.default
+++ b/core/play/src/main/resources/messages.default
@@ -1,6 +1,4 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Default messages
 

--- a/core/play/src/main/resources/play/reference-overrides.conf
+++ b/core/play/src/main/resources/play/reference-overrides.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Hack to override some of Akka's defaults in Play
 

--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Reference configuration for Play
 

--- a/core/play/src/main/scala/controllers/Execution.scala
+++ b/core/play/src/main/scala/controllers/Execution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.controllers {

--- a/core/play/src/main/scala/models/DummyPlaceHolder.scala
+++ b/core/play/src/main/scala/models/DummyPlaceHolder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models

--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/core/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/Configuration.scala
+++ b/core/play/src/main/scala/play/api/Configuration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/Environment.scala
+++ b/core/play/src/main/scala/play/api/Environment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/Exceptions.scala
+++ b/core/play/src/main/scala/play/api/Exceptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/Logger.scala
+++ b/core/play/src/main/scala/play/api/Logger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/core/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/Mode.scala
+++ b/core/play/src/main/scala/play/api/Mode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/Play.scala
+++ b/core/play/src/main/scala/play/api/Play.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/core/play/src/main/scala/play/api/controllers/Default.scala
+++ b/core/play/src/main/scala/play/api/controllers/Default.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/core/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/core/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/core/play/src/main/scala/play/api/data/Form.scala
+++ b/core/play/src/main/scala/play/api/data/Form.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data

--- a/core/play/src/main/scala/play/api/data/Forms.scala
+++ b/core/play/src/main/scala/play/api/data/Forms.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data

--- a/core/play/src/main/scala/play/api/data/format/Format.scala
+++ b/core/play/src/main/scala/play/api/data/format/Format.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data.format

--- a/core/play/src/main/scala/play/api/data/format/PlayDate.scala
+++ b/core/play/src/main/scala/play/api/data/format/PlayDate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data.format

--- a/core/play/src/main/scala/play/api/data/format/package.scala
+++ b/core/play/src/main/scala/play/api/data/format/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data

--- a/core/play/src/main/scala/play/api/data/package.scala
+++ b/core/play/src/main/scala/play/api/data/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/data/validation/Validation.scala
+++ b/core/play/src/main/scala/play/api/data/validation/Validation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data.validation

--- a/core/play/src/main/scala/play/api/data/validation/package.scala
+++ b/core/play/src/main/scala/play/api/data/validation/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data

--- a/core/play/src/main/scala/play/api/http/AcceptEncoding.scala
+++ b/core/play/src/main/scala/play/api/http/AcceptEncoding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/ContentTypeOf.scala
+++ b/core/play/src/main/scala/play/api/http/ContentTypeOf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/FileMimeTypes.scala
+++ b/core/play/src/main/scala/play/api/http/FileMimeTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/HttpEntity.scala
+++ b/core/play/src/main/scala/play/api/http/HttpEntity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/HttpErrorInfo.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/core/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/MediaRange.scala
+++ b/core/play/src/main/scala/play/api/http/MediaRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/Port.scala
+++ b/core/play/src/main/scala/play/api/http/Port.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/core/play/src/main/scala/play/api/http/StandardValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/main/scala/play/api/http/package.scala
+++ b/core/play/src/main/scala/play/api/http/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/http/websocket/CloseCodes.scala
+++ b/core/play/src/main/scala/play/api/http/websocket/CloseCodes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http.websocket

--- a/core/play/src/main/scala/play/api/http/websocket/Message.scala
+++ b/core/play/src/main/scala/play/api/http/websocket/Message.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http.websocket

--- a/core/play/src/main/scala/play/api/i18n/I18nModule.scala
+++ b/core/play/src/main/scala/play/api/i18n/I18nModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.i18n

--- a/core/play/src/main/scala/play/api/i18n/I18nSupport.scala
+++ b/core/play/src/main/scala/play/api/i18n/I18nSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.i18n

--- a/core/play/src/main/scala/play/api/i18n/Langs.scala
+++ b/core/play/src/main/scala/play/api/i18n/Langs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.i18n

--- a/core/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/core/play/src/main/scala/play/api/i18n/Messages.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.i18n

--- a/core/play/src/main/scala/play/api/i18n/package.scala
+++ b/core/play/src/main/scala/play/api/i18n/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/core/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play/src/main/scala/play/api/inject/Binding.scala
+++ b/core/play/src/main/scala/play/api/inject/Binding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play/src/main/scala/play/api/inject/Injector.scala
+++ b/core/play/src/main/scala/play/api/inject/Injector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play/src/main/scala/play/api/inject/Module.scala
+++ b/core/play/src/main/scala/play/api/inject/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play/src/main/scala/play/api/inject/package.scala
+++ b/core/play/src/main/scala/play/api/inject/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/internal/libs/concurrent/CoordinatedShutdownSupport.scala
+++ b/core/play/src/main/scala/play/api/internal/libs/concurrent/CoordinatedShutdownSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.internal.libs.concurrent

--- a/core/play/src/main/scala/play/api/libs/Codecs.scala
+++ b/core/play/src/main/scala/play/api/libs/Codecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/main/scala/play/api/libs/Collections.scala
+++ b/core/play/src/main/scala/play/api/libs/Collections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/main/scala/play/api/libs/Comet.scala
+++ b/core/play/src/main/scala/play/api/libs/Comet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/core/play/src/main/scala/play/api/libs/EventSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/main/scala/play/api/libs/JNDI.scala
+++ b/core/play/src/main/scala/play/api/libs/JNDI.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/main/scala/play/api/libs/Jsonp.scala
+++ b/core/play/src/main/scala/play/api/libs/Jsonp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play/src/main/scala/play/api/libs/concurrent/CustomExecutionContext.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/CustomExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play/src/main/scala/play/api/libs/concurrent/Futures.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Futures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
+++ b/core/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.crypto

--- a/core/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
+++ b/core/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.crypto

--- a/core/play/src/main/scala/play/api/libs/package.scala
+++ b/core/play/src/main/scala/play/api/libs/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedEntry.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedEntry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.typedmap

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedKey.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedKey.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.typedmap

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.typedmap

--- a/core/play/src/main/scala/play/api/mvc/Action.scala
+++ b/core/play/src/main/scala/play/api/mvc/Action.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Call.scala
+++ b/core/play/src/main/scala/play/api/mvc/Call.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/core/play/src/main/scala/play/api/mvc/Controller.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/core/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/core/play/src/main/scala/play/api/mvc/Filters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/core/play/src/main/scala/play/api/mvc/Flash.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Handler.scala
+++ b/core/play/src/main/scala/play/api/mvc/Handler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/core/play/src/main/scala/play/api/mvc/Headers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/MessagesRequest.scala
+++ b/core/play/src/main/scala/play/api/mvc/MessagesRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/core/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Render.scala
+++ b/core/play/src/main/scala/play/api/mvc/Render.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/RequestExtractors.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestExtractors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Security.scala
+++ b/core/play/src/main/scala/play/api/mvc/Security.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/Session.scala
+++ b/core/play/src/main/scala/play/api/mvc/Session.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/WrappedRequest.scala
+++ b/core/play/src/main/scala/play/api/mvc/WrappedRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/main/scala/play/api/mvc/macros/BinderMacros.scala
+++ b/core/play/src/main/scala/play/api/mvc/macros/BinderMacros.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc.macros

--- a/core/play/src/main/scala/play/api/mvc/package.scala
+++ b/core/play/src/main/scala/play/api/mvc/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/main/scala/play/api/mvc/request/Cell.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/Cell.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc.request

--- a/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc.request

--- a/core/play/src/main/scala/play/api/mvc/request/RequestAttrKey.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RequestAttrKey.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc.request

--- a/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc.request

--- a/core/play/src/main/scala/play/api/mvc/request/RequestTarget.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RequestTarget.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc.request

--- a/core/play/src/main/scala/play/api/package.scala
+++ b/core/play/src/main/scala/play/api/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /**

--- a/core/play/src/main/scala/play/api/routing/HandlerDef.scala
+++ b/core/play/src/main/scala/play/api/routing/HandlerDef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing

--- a/core/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
+++ b/core/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing

--- a/core/play/src/main/scala/play/api/routing/Router.scala
+++ b/core/play/src/main/scala/play/api/routing/Router.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing

--- a/core/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing.sird

--- a/core/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing.sird

--- a/core/play/src/main/scala/play/api/routing/sird/QueryStringExtractors.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/QueryStringExtractors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing.sird

--- a/core/play/src/main/scala/play/api/routing/sird/RequestMethodExtractor.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/RequestMethodExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing.sird

--- a/core/play/src/main/scala/play/api/routing/sird/macroimpl/QueryStringParameterMacros.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/macroimpl/QueryStringParameterMacros.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 // This is in its own package so that the UrlContext.q interpolator in the sird package doesn't make the

--- a/core/play/src/main/scala/play/api/routing/sird/package.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing

--- a/core/play/src/main/scala/play/api/templates/Templates.scala
+++ b/core/play/src/main/scala/play/api/templates/Templates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.templates

--- a/core/play/src/main/scala/play/core/ApplicationProvider.scala
+++ b/core/play/src/main/scala/play/core/ApplicationProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core

--- a/core/play/src/main/scala/play/core/Execution.scala
+++ b/core/play/src/main/scala/play/core/Execution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core

--- a/core/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/core/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.formatters

--- a/core/play/src/main/scala/play/core/hidden/ObjectMappings.scala
+++ b/core/play/src/main/scala/play/core/hidden/ObjectMappings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data

--- a/core/play/src/main/scala/play/core/hidden/ObjectMappings.scala
+++ b/core/play/src/main/scala/play/core/hidden/ObjectMappings.scala
@@ -71,7 +71,7 @@ class ObjectMapping$times[R, $aParams](apply: Function$times[$aParams, R], unapp
 val scriptSource = scala.io.Source.fromFile(args(0)).getLines.mkString("\n")
 
 println(s"""/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 package play.api.data
 

--- a/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala
+++ b/core/play/src/main/scala/play/core/j/HttpExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaHttpRequestHandlerAdapter.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHttpRequestHandlerAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaModeConverter.scala
+++ b/core/play/src/main/scala/play/core/j/JavaModeConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/core/play/src/main/scala/play/core/j/JavaResults.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.parsers

--- a/core/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/core/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.parsers

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.routing

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.routing

--- a/core/play/src/main/scala/play/core/routing/PathPattern.scala
+++ b/core/play/src/main/scala/play/core/routing/PathPattern.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.routing

--- a/core/play/src/main/scala/play/core/routing/ReverseRouteContext.scala
+++ b/core/play/src/main/scala/play/core/routing/ReverseRouteContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.routing

--- a/core/play/src/main/scala/play/core/routing/package.scala
+++ b/core/play/src/main/scala/play/core/routing/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core

--- a/core/play/src/main/scala/play/core/system/NamedThreadFactory.scala
+++ b/core/play/src/main/scala/play/core/system/NamedThreadFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core

--- a/core/play/src/main/scala/play/core/system/RequestIdProvider.scala
+++ b/core/play/src/main/scala/play/core/system/RequestIdProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.system

--- a/core/play/src/main/scala/play/core/system/WebCommands.scala
+++ b/core/play/src/main/scala/play/core/system/WebCommands.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core

--- a/core/play/src/main/scala/play/core/utils/AsciiSet.scala
+++ b/core/play/src/main/scala/play/core/utils/AsciiSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.utils

--- a/core/play/src/main/scala/play/core/utils/CaseInsensitiveOrdered.scala
+++ b/core/play/src/main/scala/play/core/utils/CaseInsensitiveOrdered.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.utils

--- a/core/play/src/main/scala/play/core/utils/HttpHeaderEncoding.scala
+++ b/core/play/src/main/scala/play/core/utils/HttpHeaderEncoding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.utils

--- a/core/play/src/main/scala/play/server/api/SSLEngineProvider.scala
+++ b/core/play/src/main/scala/play/server/api/SSLEngineProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.server.api

--- a/core/play/src/main/scala/play/utils/Colors.scala
+++ b/core/play/src/main/scala/play/utils/Colors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/Conversions.scala
+++ b/core/play/src/main/scala/play/utils/Conversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/ExecCtxUtils.scala
+++ b/core/play/src/main/scala/play/utils/ExecCtxUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/InlineCache.scala
+++ b/core/play/src/main/scala/play/utils/InlineCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/JsonNodeDeserializer.scala
+++ b/core/play/src/main/scala/play/utils/JsonNodeDeserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/OrderPreserving.scala
+++ b/core/play/src/main/scala/play/utils/OrderPreserving.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/PlayIO.scala
+++ b/core/play/src/main/scala/play/utils/PlayIO.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/ProxyDriver.scala
+++ b/core/play/src/main/scala/play/utils/ProxyDriver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/Reflect.scala
+++ b/core/play/src/main/scala/play/utils/Reflect.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/Resources.scala
+++ b/core/play/src/main/scala/play/utils/Resources.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/Threads.scala
+++ b/core/play/src/main/scala/play/utils/Threads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/core/play/src/main/scala/play/utils/UriEncoding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/main/scala/views/defaultpages/package.scala
+++ b/core/play/src/main/scala/views/defaultpages/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package views.html

--- a/core/play/src/main/scala/views/helper/Helpers.scala
+++ b/core/play/src/main/scala/views/helper/Helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import play.api.data.FormError

--- a/core/play/src/main/scala/views/html/helper/CSPNonce.scala
+++ b/core/play/src/main/scala/views/html/helper/CSPNonce.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package views.html.helper

--- a/core/play/src/main/scala/views/html/helper/package.scala
+++ b/core/play/src/main/scala/views/html/helper/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package views.html

--- a/core/play/src/main/scala/views/js/helper/package.scala
+++ b/core/play/src/main/scala/views/js/helper/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package views.js

--- a/core/play/src/main/scala/views/package.scala
+++ b/core/play/src/main/scala/views/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /**

--- a/core/play/src/test/java/play/core/PathsTest.java
+++ b/core/play/src/test/java/play/core/PathsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core;

--- a/core/play/src/test/java/play/i18n/MessagesTest.java
+++ b/core/play/src/test/java/play/i18n/MessagesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.i18n;

--- a/core/play/src/test/java/play/libs/concurrent/FuturesTest.java
+++ b/core/play/src/test/java/play/libs/concurrent/FuturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.concurrent;

--- a/core/play/src/test/java/play/mvc/CallTest.java
+++ b/core/play/src/test/java/play/mvc/CallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/test/java/play/mvc/CookieBuilderTest.java
+++ b/core/play/src/test/java/play/mvc/CookieBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/test/java/play/mvc/RangeResultsTest.java
+++ b/core/play/src/test/java/play/mvc/RangeResultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/test/java/play/mvc/ResultsTest.java
+++ b/core/play/src/test/java/play/mvc/ResultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/test/java/play/mvc/SecurityTest.java
+++ b/core/play/src/test/java/play/mvc/SecurityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/test/java/play/utils/BigNumericJavaPojo.java
+++ b/core/play/src/test/java/play/utils/BigNumericJavaPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils;

--- a/core/play/src/test/java/play/utils/Child.java
+++ b/core/play/src/test/java/play/utils/Child.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils;

--- a/core/play/src/test/java/play/utils/ChildDeserializer.java
+++ b/core/play/src/test/java/play/utils/ChildDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils;

--- a/core/play/src/test/java/play/utils/Parent.java
+++ b/core/play/src/test/java/play/utils/Parent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils;

--- a/core/play/src/test/java/play/utils/PrimitiveNumericJavaPojo.java
+++ b/core/play/src/test/java/play/utils/PrimitiveNumericJavaPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils;

--- a/core/play/src/test/resources/logback-test.xml
+++ b/core/play/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/core/play/src/test/resources/reference.conf
+++ b/core/play/src/test/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
   http {

--- a/core/play/src/test/scala/play/api/ApplicationSpec.scala
+++ b/core/play/src/test/scala/play/api/ApplicationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/test/scala/play/api/BuiltInComponentsSpec.scala
+++ b/core/play/src/test/scala/play/api/BuiltInComponentsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/test/scala/play/api/LoggerConfiguratorSpec.scala
+++ b/core/play/src/test/scala/play/api/LoggerConfiguratorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/test/scala/play/api/LoggerSpec.scala
+++ b/core/play/src/test/scala/play/api/LoggerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/test/scala/play/api/ModeSpec.scala
+++ b/core/play/src/test/scala/play/api/ModeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/test/scala/play/api/PlayCoreTestApplication.scala
+++ b/core/play/src/test/scala/play/api/PlayCoreTestApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
+++ b/core/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/core/play/src/test/scala/play/api/controllers/AssetsDateParsingSpec.scala
+++ b/core/play/src/test/scala/play/api/controllers/AssetsDateParsingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/core/play/src/test/scala/play/api/controllers/AssetsSpec.scala
+++ b/core/play/src/test/scala/play/api/controllers/AssetsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/core/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data

--- a/core/play/src/test/scala/play/api/data/FormUtilsSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data

--- a/core/play/src/test/scala/play/api/data/format/FormatSpec.scala
+++ b/core/play/src/test/scala/play/api/data/format/FormatSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data.format

--- a/core/play/src/test/scala/play/api/data/format/PlayDateSpec.scala
+++ b/core/play/src/test/scala/play/api/data/format/PlayDateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data.format

--- a/core/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
+++ b/core/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data.validation

--- a/core/play/src/test/scala/play/api/http/AcceptEncodingSpec.scala
+++ b/core/play/src/test/scala/play/api/http/AcceptEncodingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/test/scala/play/api/http/EnabledFiltersSpec.scala
+++ b/core/play/src/test/scala/play/api/http/EnabledFiltersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/test/scala/play/api/http/MediaRangeSpec.scala
+++ b/core/play/src/test/scala/play/api/http/MediaRangeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
+++ b/core/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/test/scala/play/api/http/WriteableSpec.scala
+++ b/core/play/src/test/scala/play/api/http/WriteableSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.http

--- a/core/play/src/test/scala/play/api/i18n/LangSpec.scala
+++ b/core/play/src/test/scala/play/api/i18n/LangSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.i18n

--- a/core/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/core/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.i18n

--- a/core/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
+++ b/core/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.inject

--- a/core/play/src/test/scala/play/api/libs/CometSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/CometSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/test/scala/play/api/libs/EventSourceSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/EventSourceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/test/scala/play/api/libs/FileMimeTypesSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/FileMimeTypesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileReaperSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileReaperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/core/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play/src/test/scala/play/api/libs/concurrent/FuturesSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/concurrent/FuturesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.concurrent

--- a/core/play/src/test/scala/play/api/libs/crypto/CSRFTokenSignerSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/crypto/CSRFTokenSignerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.crypto

--- a/core/play/src/test/scala/play/api/libs/crypto/CookieSignerSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/crypto/CookieSignerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.crypto

--- a/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/DefaultBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/DefaultBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/InMemoryTemporaryFileCreator.scala
+++ b/core/play/src/test/scala/play/api/mvc/InMemoryTemporaryFileCreator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/MultipartBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/RawBufferSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RawBufferSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/RequestSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/mvc/TextBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/TextBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc

--- a/core/play/src/test/scala/play/api/routing/JavaScriptReverseRouterSpec.scala
+++ b/core/play/src/test/scala/play/api/routing/JavaScriptReverseRouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing

--- a/core/play/src/test/scala/play/api/routing/RouterSpec.scala
+++ b/core/play/src/test/scala/play/api/routing/RouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing

--- a/core/play/src/test/scala/play/api/routing/sird/DslSpec.scala
+++ b/core/play/src/test/scala/play/api/routing/sird/DslSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing.sird

--- a/core/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
+++ b/core/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.routing.sird

--- a/core/play/src/test/scala/play/api/templates/TemplatesSpec.scala
+++ b/core/play/src/test/scala/play/api/templates/TemplatesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.templates

--- a/core/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
+++ b/core/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.parsers

--- a/core/play/src/test/scala/play/core/routing/GeneratedRouterSpec.scala
+++ b/core/play/src/test/scala/play/core/routing/GeneratedRouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.routing

--- a/core/play/src/test/scala/play/core/routing/RouterSpec.scala
+++ b/core/play/src/test/scala/play/core/routing/RouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.routing

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.test

--- a/core/play/src/test/scala/play/core/test/package.scala
+++ b/core/play/src/test/scala/play/core/test/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core

--- a/core/play/src/test/scala/play/core/utils/HttpHeaderParameterEncodingSpec.scala
+++ b/core/play/src/test/scala/play/core/utils/HttpHeaderParameterEncodingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.utils

--- a/core/play/src/test/scala/play/core/utils/ThreadsSpec.scala
+++ b/core/play/src/test/scala/play/core/utils/ThreadsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.utils

--- a/core/play/src/test/scala/play/data/AnotherUser.java
+++ b/core/play/src/test/scala/play/data/AnotherUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/core/play/src/test/scala/play/data/MyUser.java
+++ b/core/play/src/test/scala/play/data/MyUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/core/play/src/test/scala/play/libs/FTupleSpec.scala
+++ b/core/play/src/test/scala/play/libs/FTupleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs

--- a/core/play/src/test/scala/play/libs/XMLSpec.scala
+++ b/core/play/src/test/scala/play/libs/XMLSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs

--- a/core/play/src/test/scala/play/mvc/DefaultBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/DefaultBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc

--- a/core/play/src/test/scala/play/mvc/DummyDelegatingMultipartFormDataBodyParser.java
+++ b/core/play/src/test/scala/play/mvc/DummyDelegatingMultipartFormDataBodyParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc

--- a/core/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc

--- a/core/play/src/test/scala/play/mvc/ResponseHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/ResponseHeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc

--- a/core/play/src/test/scala/play/mvc/ResultSpec.scala
+++ b/core/play/src/test/scala/play/mvc/ResultSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc

--- a/core/play/src/test/scala/play/mvc/StatusHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/StatusHeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc

--- a/core/play/src/test/scala/play/mvc/TextBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/TextBodyParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc

--- a/core/play/src/test/scala/play/utils/JsonNodeDeserializerSpec.scala
+++ b/core/play/src/test/scala/play/utils/JsonNodeDeserializerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/test/scala/play/utils/PlayIOSpec.scala
+++ b/core/play/src/test/scala/play/utils/PlayIOSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/core/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/test/scala/play/utils/UriEncodingSpec.scala
+++ b/core/play/src/test/scala/play/utils/UriEncodingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.utils

--- a/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package views.html.helper

--- a/core/play/src/test/scala/views/js/helper/HelpersSpec.scala
+++ b/core/play/src/test/scala/views/js/helper/HelpersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package views.js.helper

--- a/dev-mode/build-link/src/main/java/play/TemplateImports.java
+++ b/dev-mode/build-link/src/main/java/play/TemplateImports.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play;

--- a/dev-mode/build-link/src/main/java/play/core/Build.java
+++ b/dev-mode/build-link/src/main/java/play/core/Build.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core;

--- a/dev-mode/build-link/src/main/java/play/core/BuildDocHandler.java
+++ b/dev-mode/build-link/src/main/java/play/core/BuildDocHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core;

--- a/dev-mode/build-link/src/main/java/play/core/BuildLink.java
+++ b/dev-mode/build-link/src/main/java/play/core/BuildLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core;

--- a/dev-mode/build-link/src/main/java/play/core/server/ReloadableServer.java
+++ b/dev-mode/build-link/src/main/java/play/core/server/ReloadableServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server;

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package com.typesafe.play.docs.sbtplugin

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package com.typesafe.play.docs.sbtplugin

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/Version.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/Version.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package com.typesafe.play.docs.sbtplugin

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/sbt/internal/PlayDocsPluginCompat.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/sbt/internal/PlayDocsPluginCompat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package sbt.internal

--- a/dev-mode/play-docs/src/main/java/play/docs/BuildDocHandlerFactory.java
+++ b/dev-mode/play-docs/src/main/java/play/docs/BuildDocHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.docs;

--- a/dev-mode/play-docs/src/main/scala/play/docs/AggregateFileRepository.scala
+++ b/dev-mode/play-docs/src/main/scala/play/docs/AggregateFileRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.docs

--- a/dev-mode/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/dev-mode/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.docs

--- a/dev-mode/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
+++ b/dev-mode/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.docs

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/ScalaFormat.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/ScalaFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler

--- a/dev-mode/routes-compiler/src/test/resources/complexNames.routes
+++ b/dev-mode/routes-compiler/src/test/resources/complexNames.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET    /foo     controllers.FooController.foo(`bar[]`: List[String])

--- a/dev-mode/routes-compiler/src/test/resources/complexTypes.routes
+++ b/dev-mode/routes-compiler/src/test/resources/complexTypes.routes
@@ -1,3 +1,5 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET    /foo     controllers.FooController.foo(bar: Option[Option[String]])
 GET    /foo     controllers.FooController.foo(bar: (Int,Int,(Int,Int)))
 GET    /foo     controllers.FooController.foo(bar: A#B)

--- a/dev-mode/routes-compiler/src/test/resources/duplicateHandlers.routes
+++ b/dev-mode/routes-compiler/src/test/resources/duplicateHandlers.routes
@@ -1,3 +1,5 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET    /foo     controllers.FooController.foo(bar: Boolean = false)
 GET    /foo2    controllers.FooController.foo(bar: Boolean = false, baz: Boolean = true)
 GET    /bar     controllers.BarController.bar(baz)

--- a/dev-mode/routes-compiler/src/test/resources/generating.routes
+++ b/dev-mode/routes-compiler/src/test/resources/generating.routes
@@ -1,2 +1,4 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET    /foo     controllers.FooController.foo(bar: Boolean = false)
 GET /foo/lotsOfParams controller.FooController.lotsOfParams(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int, i: Int, j: Int, k: String, l: String, m: String, n: String, o: String, p: String, q: Option[Int], r: Option[Int], s: Option[Int], t: Option[Int], u: Option[String], v: Float, w: Float, x: Int)

--- a/dev-mode/routes-compiler/src/test/resources/logback-test.xml
+++ b/dev-mode/routes-compiler/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/dev-mode/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
+++ b/dev-mode/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler

--- a/dev-mode/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
+++ b/dev-mode/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler

--- a/dev-mode/routes-compiler/src/test/scala/play/routes/compiler/templates/TemplatesSpec.scala
+++ b/dev-mode/routes-compiler/src/test/scala/play/routes/compiler/templates/TemplatesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.routes.compiler.templates

--- a/dev-mode/run-support/src/main/java/play/runsupport/classloader/ApplicationClassLoaderProvider.java
+++ b/dev-mode/run-support/src/main/java/play/runsupport/classloader/ApplicationClassLoaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport.classloader;

--- a/dev-mode/run-support/src/main/java/play/runsupport/classloader/DelegatingClassLoader.java
+++ b/dev-mode/run-support/src/main/java/play/runsupport/classloader/DelegatingClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport.classloader;

--- a/dev-mode/run-support/src/main/scala/play/runsupport/AssetsClassLoader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/AssetsClassLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport

--- a/dev-mode/run-support/src/main/scala/play/runsupport/Colors.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Colors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport

--- a/dev-mode/run-support/src/main/scala/play/runsupport/DelegatedResourcesClassLoader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/DelegatedResourcesClassLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport

--- a/dev-mode/run-support/src/main/scala/play/runsupport/NamedURLClassLoader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/NamedURLClassLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport

--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport

--- a/dev-mode/run-support/src/main/scala/play/runsupport/RunHook.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/RunHook.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport

--- a/dev-mode/run-support/src/main/scala/play/runsupport/ServerStartException.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/ServerStartException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport

--- a/dev-mode/run-support/src/test/resources/logback-test.xml
+++ b/dev-mode/run-support/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/dev-mode/run-support/src/test/scala/play/runsupport/FilterArgsSpec.scala
+++ b/dev-mode/run-support/src/test/scala/play/runsupport/FilterArgsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.runsupport

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Colors.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Colors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayExceptions.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayExceptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayFilters.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayFilters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInternalKeys.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInternalKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayLayoutPlugin.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayLayoutPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayLogback.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayLogback.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayRunHook.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayRunHook.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt.routes

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt.run

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt.run

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/package.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/main/scala/sbt/internal/io/PlaySource.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/sbt/internal/io/PlaySource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package sbt

--- a/dev-mode/sbt-plugin/src/sbt-test/README.md
+++ b/dev-mode/sbt-plugin/src/sbt-test/README.md
@@ -1,3 +1,5 @@
+<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
+
 # Play's scripted tests
 
 This is a collection of sbt scripted tests for Play's sbt plugin.

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/app/controllers/HomeController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/app/controllers/HomeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 name := """akka-fork-join-pool"""
 organization := "com.lightbend.play"
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := """akka-fork-join-pool"""
 organization := "com.lightbend.play"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/conf/routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /                controllers.HomeController.index()

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/akka-fork-join-pool/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayService)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/resources/routes
@@ -1,3 +1,3 @@
-## Routes file
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET /   controllers.HomeController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayService)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/scala/router/Routes.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/src/main/scala/router/Routes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package router

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/Bar.java.bad
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/Bar.java.bad
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package outside;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/Foo.java.bad
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/Foo.java.bad
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package inside;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/HomeController.java.bad
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/HomeController.java.bad
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/app/controllers/HomeController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/app/controllers/HomeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/app/modules/SomeComponent.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/app/modules/SomeComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package modules;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/build.sbt.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/build.sbt.1
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/conf/routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET     /                     controllers.HomeController.index()

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/dev-mode-compile-and-config-error-source-sub-project-outside/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/dev-mode-compile-and-config-error-source-sub-project-outside/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val `sub-project-outside` = (project in file("."))
   .settings(commonSettings: _*)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/dev-mode-compile-and-config-error-source-sub-project-outside/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/dev-mode-compile-and-config-error-source-sub-project-outside/project/plugins.sbt
@@ -1,1 +1,3 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 addSbtPlugin("com.typesafe.play" % "sbt-scripted-tools" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/dev-mode-compile-and-config-error-source-sub-project-outside/src/main/scala/Bar.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/dev-mode-compile-and-config-error-source-sub-project-outside/src/main/scala/Bar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package outside;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/modules/sub-project-inside/src/main/scala/Foo.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/modules/sub-project-inside/src/main/scala/Foo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package inside;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/app/controllers/HomeController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/app/controllers/HomeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt.1
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/conf/routes
@@ -1,3 +1,5 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET     /controller-fail                     controllers.HomeController.controllerFail
 GET     /sub-project-inside-fail             controllers.HomeController.subProjectInsideFail
 GET     /sub-project-outside-fail            controllers.HomeController.subProjectOutsideFail

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val `sub-project-outside` = (project in file("."))
   .settings(commonSettings: _*)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/project/plugins.sbt
@@ -1,1 +1,3 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 addSbtPlugin("com.typesafe.play" % "sbt-scripted-tools" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/src/main/scala/Bar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package outside;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/modules/sub-project-inside/src/main/scala/Foo.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/modules/sub-project-inside/src/main/scala/Foo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package inside;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/Module.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import java.io.FileWriter

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/assets/main.less
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 .original {
   color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/assets/main.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 .original {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/controllers/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.1
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.1
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 package controllers
 
 import play.api.mvc._

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.2
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.2
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.2
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.2
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 package controllers
 
 import play.api.mvc._

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.3
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.3
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.3
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.3
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 package controllers
 
 import play.api.mvc._

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/main.less.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/main.less.1
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 .first {
   color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/main.less.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/main.less.1
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 .first {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 .original {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css
@@ -1,7 +1,3 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
-
 .original {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css.1
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 .first {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css.1
@@ -1,7 +1,3 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
-
 .first {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.0
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.0
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 .original {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.0
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.0
@@ -1,7 +1,3 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
-
 .original {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.1
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 .first {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.1
@@ -1,7 +1,3 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
-
 .first {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/conf/routes
@@ -1,2 +1,4 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /                    controllers.Application.index
 GET        /assets/*file        controllers.Assets.versioned(path = "/public", file: Asset)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/public/css/some.css
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/public/css/some.css
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 .original {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/public/css/some.css
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/public/css/some.css
@@ -1,7 +1,3 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
-
 .original {
     color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/app/assets/main.less
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 h2 {
   color: red;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/app/assets/main.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 h2 {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 import java.net.URLClassLoader
 import com.typesafe.sbt.packager.Keys.executableScriptName

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/app/controllers/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/conf/routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /                    controllers.Application.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/assets/main.less
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 @base: #f938ab;
 
 .box-shadow(@style, @c) when (iscolor(@c)) {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/routes
@@ -1,6 +1,4 @@
-# Routes
-# This file defines all application routes (Higher priority routes first)
-# ~~~~
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Home page
 GET        /                    controllers.Application.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/public/stylesheets/main.css
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/public/stylesheets/main.css
@@ -1,3 +1,0 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/controllers/UsersController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/controllers/UsersController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/models/User.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/models/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/startup/Startup.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/startup/Startup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package startup;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/startup/StartupModule.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/app/startup/StartupModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package startup;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := """auto-apply-false"""
 organization := "com.lightbend.play"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 name := """auto-apply-false"""
 organization := "com.lightbend.play"
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/conf/routes
@@ -1,6 +1,4 @@
-# Routes
-# This file defines all application routes (Higher priority routes first)
-# ~~~~
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # An example controller showing a sample home page
 GET     /                           controllers.UsersController.list

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/controllers/UsersController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/controllers/UsersController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/models/User.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/models/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/startup/Startup.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/startup/Startup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package startup;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/startup/StartupModule.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/app/startup/StartupModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package startup;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 name := """auto-apply-true"""
 organization := "com.lightbend.play"
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := """auto-apply-true"""
 organization := "com.lightbend.play"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/conf/routes
@@ -1,6 +1,4 @@
-# Routes
-# This file defines all application routes (Higher priority routes first)
-# ~~~~
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # An example controller showing a sample home page
 GET     /                           controllers.UsersController.list

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/app/controllers/GroupsController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/app/controllers/GroupsController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/app/controllers/UsersController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/app/controllers/UsersController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/app/models/Group.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/app/models/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/app/models/User.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/app/models/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 name := """multiple-databases"""
 organization := "com.lightbend.play"
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := """multiple-databases"""
 organization := "com.lightbend.play"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/conf/routes
@@ -1,6 +1,4 @@
-# Routes
-# This file defines all application routes (Higher priority routes first)
-# ~~~~
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # An example controller showing a sample home page
 GET     /users                      controllers.UsersController.list

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-multiple-databases/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayService)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/scala/router/Routes.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/src/main/scala/router/Routes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package router

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := """play-scala-seed"""
 organization := "com.example"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/build.sbt
@@ -1,11 +1,11 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
 name := """play-scala-seed"""
 organization := "com.example"
 
 version := "1.0-SNAPSHOT"
-
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, PlayAkkaHttp2Support)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/main/resources/routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET     /                           controllers.HomeController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http-http2/src/test/scala/controllers/IntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
@@ -1,11 +1,11 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
 name := """play-scala-seed"""
 organization := "com.example"
 
 version := "1.0-SNAPSHOT"
-
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := """play-scala-seed"""
 organization := "com.example"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/resources/routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET     /                           controllers.HomeController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/app/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/app/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := """netty-channel-options"""
 organization := "com.lightbend.play"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 name := """netty-channel-options"""
 organization := "com.lightbend.play"
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/conf/routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /                controllers.HomeController.index()

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
@@ -1,11 +1,11 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
 name := """play-scala-seed"""
 organization := "com.example"
 
 version := "1.0-SNAPSHOT"
-
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, PlayNettyServer)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := """play-scala-seed"""
 organization := "com.example"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/resources/routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET     /                           controllers.HomeController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/app/controllers/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/conf/routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /                    controllers.Application.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/tests/ServerSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/tests/ServerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import play.api.Application

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/build.sbt
@@ -1,3 +1,5 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 name := """twirl-reload"""
 organization := "com.example"
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/src/main/resources/routes
@@ -1,2 +1,4 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 # An example controller showing a sample home page
 GET     /                           controllers.HomeController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/app/assets/main.less
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 h2 {
   color: red;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/app/assets/main.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 h2 {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 import java.net.URLClassLoader
 import com.typesafe.sbt.packager.Keys.executableScriptName

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/app/assets/module.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/app/assets/module.less
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 h1 {
   color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/app/assets/module.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/app/assets/module.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 h1 {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 name := "assets-module-sample"
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/app/Root.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/app/Root.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 object Root

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/app/assets/main.less
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 h2 {
   color: red;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/app/assets/main.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/app/assets/main.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 h2 {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/nonplaymodule/src/main/scala/NonPlayModule.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/nonplaymodule/src/main/scala/NonPlayModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 object NonPlayModule

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/playmodule/app/PlayModule.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/playmodule/app/PlayModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 object PlayModule

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/playmodule/app/assets/module.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/playmodule/app/assets/module.less
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 h1 {
   color: blue;
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/playmodule/app/assets/module.less
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/playmodule/app/assets/module.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 h1 {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/Helpers.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/Helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 object JFile {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/transitive/app/Transitive.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/transitive/app/Transitive.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 object Transitive

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/build.sbt
@@ -1,6 +1,6 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/build.sbt
@@ -1,6 +1,6 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/conf/routes
@@ -1,4 +1,4 @@
-# Here is the first line
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET / controllers.Foo.index
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/BufferLogger.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/BufferLogger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import org.apache.logging.log4j.Level

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/a/app/controllers/a/A.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/a/app/controllers/a/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.a;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/a/conf/a.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/a/conf/a.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET /index controllers.a.A.index(req: Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/b/app/controllers/b/B.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/b/app/controllers/b/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.b;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/b/conf/b.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/b/conf/b.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET /index controllers.b.B.index(req: Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/c/app/controllers/c/C.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/c/app/controllers/c/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.c;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/c/conf/c.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/c/conf/c.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET /index controllers.c.C.index(req: Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/conf/routes
@@ -1,3 +1,5 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 ->        /a        a.Routes
 ->        /b        b.Routes
 ->        /c        c.Routes

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/nonplay/src/main/scala/nonplay.NonPlay.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/nonplay/src/main/scala/nonplay.NonPlay.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 object NonPlay

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/a/app/controllers/a/A.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/a/app/controllers/a/A.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.a

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/a/conf/a.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/a/conf/a.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET /index controllers.a.A.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/b/app/controllers/b/B.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/b/app/controllers/b/B.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.b

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/b/conf/b.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/b/conf/b.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET /index controllers.b.B.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/c/app/controllers/c/C.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/c/app/controllers/c/C.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.c

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/c/conf/c.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/c/conf/c.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET /index controllers.c.C.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/conf/routes
@@ -1,3 +1,5 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 ->        /a        a.Routes
 ->        /b        b.Routes
 ->        /c        c.Routes

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/nonplay/src/main/scala/nonplay.NonPlay.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/nonplay/src/main/scala/nonplay.NonPlay.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 object NonPlay

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/a.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/a.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /index        controllers.a.Application.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/b.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/b.routes
@@ -1,1 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /index        controllers.b.Application.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(RoutesCompiler)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 lazy val root = (project in file("."))
   .enablePlugins(RoutesCompiler)
   .settings(

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-incremental-compilation/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/Application.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/InstanceController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/InstanceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/module/ModuleController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/module/ModuleController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.module;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/πø$7ß.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/controllers/πø$7ß.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/models/UserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/models/UserId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/app/utils/JavaScriptRouterGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package utils

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/conf/module.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/conf/module.routes
@@ -1,5 +1,3 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET     /index          controllers.module.ModuleController.index(req: Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/conf/module.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/conf/module.routes
@@ -1,4 +1,5 @@
 #
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 #
+
 GET     /index          controllers.module.ModuleController.index(req: Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/conf/routes
@@ -1,6 +1,4 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET         /                       controllers.Application.index(r: Request)
 POST        /post                   controllers.Application.post(req: play.mvc.Http.Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/RouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/assets/JavaScriptRouterSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 var assert = require("assert");

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/assets/JavaScriptRouterSpec.js
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 var assert = require("assert");
 var jsRoutes = require("./jsRoutes");
 var jsRoutesBadHost = require("./jsRoutesBadHost");

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/InstanceController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/InstanceController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/module/ModuleController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/module/ModuleController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.module

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/πø$7ß.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/πø$7ß.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/models/UserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/models/UserId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package utils

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/conf/module.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/conf/module.routes
@@ -1,5 +1,3 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET     /index          controllers.module.ModuleController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/conf/module.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/conf/module.routes
@@ -1,4 +1,5 @@
 #
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 #
+
 GET     /index          controllers.module.ModuleController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/conf/routes
@@ -1,6 +1,4 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET         /                       controllers.Application.index
 POST        /post                   controllers.Application.post

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/assets/JavaScriptRouterSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 var assert = require("assert");

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/assets/JavaScriptRouterSpec.js
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 var assert = require("assert");
 var jsRoutes = require("./jsRoutes");
 var jsRoutesBadHost = require("./jsRoutesBadHost");

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/app/utils/JavaScriptRouterGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package utils

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/conf/routes
@@ -1,5 +1,3 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET         /public/*file           _root_.controllers.Assets.versioned(path="/public", file: _root_.controllers.Assets.Asset)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/tests/RouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/tests/assets/JavaScriptRouterSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 var assert = require("assert");

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/tests/assets/JavaScriptRouterSpec.js
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 var assert = require("assert");
 var jsRoutes = require("./jsRoutes");
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/models/UserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/models/UserId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/router/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/router/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package router

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/router/InstanceController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/router/InstanceController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package router

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/router/module/ModuleController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/router/module/ModuleController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package router.module

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/router/πø$7ß.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/router/πø$7ß.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package router

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/app/utils/JavaScriptRouterGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package utils

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/conf/router.module.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/conf/router.module.routes
@@ -1,4 +1,5 @@
 #
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 #
+
 GET     /index          ModuleController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/conf/router.module.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/conf/router.module.routes
@@ -1,5 +1,3 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET     /index          ModuleController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/conf/routes
@@ -1,6 +1,4 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET         /                       Application.index
 POST        /post                   Application.post

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/RouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/assets/JavaScriptRouterSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 var assert = require("assert");

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/assets/JavaScriptRouterSpec.js
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 var assert = require("assert");
 var jsRoutes = require("./jsRoutes");
 var jsRoutesBadHost = require("./jsRoutesBadHost");

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/InstanceController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/InstanceController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/module/ModuleController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/module/ModuleController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers.module

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/πø$7ß.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/πø$7ß.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/models/UserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/models/UserId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package models

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package utils

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/build.sbt
@@ -1,6 +1,7 @@
 //
 // Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 //
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/module.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/module.routes
@@ -1,5 +1,3 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET     /index          controllers.module.ModuleController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/module.routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/module.routes
@@ -1,4 +1,5 @@
 #
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 #
+
 GET     /index          controllers.module.ModuleController.index

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/routes
@@ -1,6 +1,4 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET         /                       controllers.Application.index
 POST        /post                   controllers.Application.post

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/assets/JavaScriptRouterSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 var assert = require("assert");

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/assets/JavaScriptRouterSpec.js
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
+
 var assert = require("assert");
 var jsRoutes = require("./jsRoutes");
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/build.sbt
@@ -1,6 +1,6 @@
-/*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
- */
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/show-versions/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/show-versions/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val root = (project in file("."))
   .settings(

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/show-versions/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/show-versions/project/plugins.sbt
@@ -1,2 +1,4 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 addSbtPlugin("com.typesafe.play" % "sbt-scripted-tools" % sys.props("project.version"))
 lazy val plugins = (project in file(".")).settings(scalaVersion := "2.12.17")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 import java.util.concurrent.TimeUnit
 import sbt._

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
@@ -1,11 +1,11 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
 import java.util.concurrent.TimeUnit
 import sbt._
 
 import sbt.Keys.libraryDependencies
-
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/resources/routes
@@ -1,3 +1,5 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /                    controllers.HomeController.index
 GET        /verbose             controllers.HomeController.indexVerbose
 GET        /simulate-downing    controllers.HomeController.downing

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/scala/Module.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/scala/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import java.io.FileWriter

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/test/scala/controllers/HomeControllerSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/test/scala/controllers/HomeControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 import java.util.concurrent.TimeUnit
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
@@ -1,3 +1,7 @@
+//
+// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+//
+
 import java.util.concurrent.TimeUnit
 
 import sbt._
@@ -5,10 +9,6 @@ import sbt.Keys.libraryDependencies
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/changes/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/changes/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/project/plugins.sbt
@@ -1,6 +1,4 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/resources/routes
@@ -1,2 +1,4 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
 GET        /                    controllers.HomeController.index
 GET        /slow                controllers.HomeController.slow

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/scala/Module.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/scala/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import java.io.FileWriter

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/scala/controllers/HomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/test/scala/controllers/HomeControllerSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/test/scala/controllers/HomeControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package controllers

--- a/dev-mode/sbt-plugin/src/test/resources/logback-test.xml
+++ b/dev-mode/sbt-plugin/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/dev-mode/sbt-plugin/src/test/scala/play/sbt/ApplicationSecretGeneratorSpec.scala
+++ b/dev-mode/sbt-plugin/src/test/scala/play/sbt/ApplicationSecretGeneratorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-plugin/src/test/scala/play/sbt/PlayRunHookSpec.scala
+++ b/dev-mode/sbt-plugin/src/test/scala/play/sbt/PlayRunHookSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.sbt.scriptedtools

--- a/persistence/play-java-jdbc/src/main/java/play/db/ConnectionPool.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/ConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/ConnectionPoolComponents.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/ConnectionPoolComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/DBComponents.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/DBComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/DBModule.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/DBModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/Databases.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/Databases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/DefaultConnectionPool.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/DefaultConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/DefaultDBApi.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/DefaultDBApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/HikariCPComponents.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/HikariCPComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/main/java/play/db/package-info.java
+++ b/persistence/play-java-jdbc/src/main/java/play/db/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides the JDBC database access API. */

--- a/persistence/play-java-jdbc/src/main/resources/reference.conf
+++ b/persistence/play-java-jdbc/src/main/resources/reference.conf
@@ -1,3 +1,3 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.modules.enabled += "play.db.DBModule"

--- a/persistence/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/persistence/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/test/java/play/db/NamedDatabaseTest.java
+++ b/persistence/play-java-jdbc/src/test/java/play/db/NamedDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-java-jdbc/src/test/resources/logback-test.xml
+++ b/persistence/play-java-jdbc/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.jpa;

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.jpa;

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.jpa;

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAComponents.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.jpa;

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAConfig.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.jpa;

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAModule.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/JPAModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.jpa;

--- a/persistence/play-java-jpa/src/main/java/play/db/jpa/package-info.java
+++ b/persistence/play-java-jpa/src/main/java/play/db/jpa/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides JPA ORM integration. */

--- a/persistence/play-java-jpa/src/main/resources/reference.conf
+++ b/persistence/play-java-jpa/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
   modules {

--- a/persistence/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
+++ b/persistence/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.jpa;

--- a/persistence/play-java-jpa/src/test/java/play/db/jpa/TestEntity.java
+++ b/persistence/play-java-jpa/src/test/java/play/db/jpa/TestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.jpa;

--- a/persistence/play-java-jpa/src/test/resources/META-INF/persistence.xml
+++ b/persistence/play-java-jpa/src/test/resources/META-INF/persistence.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"

--- a/persistence/play-java-jpa/src/test/resources/logback-test.xml
+++ b/persistence/play-java-jpa/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/persistence/play-jdbc-api/src/main/java/play/db/ConnectionCallable.java
+++ b/persistence/play-jdbc-api/src/main/java/play/db/ConnectionCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-jdbc-api/src/main/java/play/db/ConnectionRunnable.java
+++ b/persistence/play-jdbc-api/src/main/java/play/db/ConnectionRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-jdbc-api/src/main/java/play/db/DBApi.java
+++ b/persistence/play-jdbc-api/src/main/java/play/db/DBApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-jdbc-api/src/main/java/play/db/Database.java
+++ b/persistence/play-jdbc-api/src/main/java/play/db/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-jdbc-api/src/main/java/play/db/NamedDatabase.java
+++ b/persistence/play-jdbc-api/src/main/java/play/db/NamedDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-jdbc-api/src/main/java/play/db/NamedDatabaseImpl.java
+++ b/persistence/play-jdbc-api/src/main/java/play/db/NamedDatabaseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-jdbc-api/src/main/java/play/db/TransactionIsolationLevel.java
+++ b/persistence/play-jdbc-api/src/main/java/play/db/TransactionIsolationLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db;

--- a/persistence/play-jdbc-api/src/main/scala/play/api/db/DBApi.scala
+++ b/persistence/play-jdbc-api/src/main/scala/play/api/db/DBApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc-api/src/main/scala/play/api/db/Database.scala
+++ b/persistence/play-jdbc-api/src/main/scala/play/api/db/Database.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc-api/src/main/scala/play/api/db/TransactionIsolationLevel.scala
+++ b/persistence/play-jdbc-api/src/main/scala/play/api/db/TransactionIsolationLevel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolution.java
+++ b/persistence/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.evolutions;

--- a/persistence/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolutions.java
+++ b/persistence/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolutions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.evolutions;

--- a/persistence/play-jdbc-evolutions/src/main/java/play/db/evolutions/EvolutionsReader.java
+++ b/persistence/play-jdbc-evolutions/src/main/java/play/db/evolutions/EvolutionsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.evolutions;

--- a/persistence/play-jdbc-evolutions/src/main/java/play/db/evolutions/SimpleEvolutionsReader.java
+++ b/persistence/play-jdbc-evolutions/src/main/java/play/db/evolutions/SimpleEvolutionsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.evolutions;

--- a/persistence/play-jdbc-evolutions/src/main/resources/reference.conf
+++ b/persistence/play-jdbc-evolutions/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
 

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsHelper.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/test/java/play/db/evolutions/EvolutionsTest.java
+++ b/persistence/play-jdbc-evolutions/src/test/java/play/db/evolutions/EvolutionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.db.evolutions;

--- a/persistence/play-jdbc-evolutions/src/test/resources/logback-test.xml
+++ b/persistence/play-jdbc-evolutions/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsHelperSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsHelperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/LogbackCapturingAppender.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/LogbackCapturingAppender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/ScriptSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/ScriptSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db.evolutions

--- a/persistence/play-jdbc/src/main/java/org/jdbcdslog/AccessConnectionPoolDataSourceProxy.java
+++ b/persistence/play-jdbc/src/main/java/org/jdbcdslog/AccessConnectionPoolDataSourceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package org.jdbcdslog;

--- a/persistence/play-jdbc/src/main/resources/reference.conf
+++ b/persistence/play-jdbc/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
 

--- a/persistence/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/main/scala/play/api/db/DatabaseConfig.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/DatabaseConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/main/scala/play/api/db/package.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/persistence/play-jdbc/src/test/resources/application.conf
+++ b/persistence/play-jdbc/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Necessary when running tests using DEV or PROD mode.
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b

--- a/persistence/play-jdbc/src/test/resources/logback-test.xml
+++ b/persistence/play-jdbc/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/persistence/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/persistence/play-jdbc/src/test/scala/play/api/db/NamedDatabaseSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/NamedDatabaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.db

--- a/project/AkkaSnapshotRepositories.scala
+++ b/project/AkkaSnapshotRepositories.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 import sbt.Keys._
 import sbt._
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -51,9 +51,11 @@ object BuildSettings {
     (Compile / headerSources / excludeFilter) := HiddenFileFilter ||
       fileUriRegexFilter(".*/cookie/encoding/.*") || fileUriRegexFilter(".*/inject/SourceProvider.java$") ||
       fileUriRegexFilter(".*/libs/reflect/.*"),
-    headerLicense := Some(HeaderLicense.Custom(
-      """Copyright from 2022 (C) Contributors to the Play Framework project <https://github.com/playframework>
-        |Copyright 2011-2021 (C) Lightbend Inc. <https://www.lightbend.com>""".stripMargin)),
+    headerLicense := Some(
+      HeaderLicense.Custom(
+        """Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>""".stripMargin
+      )
+    ),
     headerMappings ++= Map(
       FileType.xml           -> CommentStyle.xmlStyleBlockComment,
       FileType.conf          -> CommentStyle.hashLineComment,

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
+
 import java.util.regex.Pattern
 import com.typesafe.tools.mima.core.ProblemFilters
 import com.typesafe.tools.mima.core._

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -2,15 +2,17 @@
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
 import java.util.regex.Pattern
-import com.jsuereth.sbtpgp.PgpKeys
 import com.typesafe.tools.mima.core.ProblemFilters
 import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
-import de.heikoseeberger.sbtheader.FileType
+import de.heikoseeberger.sbtheader.CommentBlockCreator
 import de.heikoseeberger.sbtheader.CommentStyle
+import de.heikoseeberger.sbtheader.FileType
+import de.heikoseeberger.sbtheader.LineCommentCreator
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern.commentBetween
 import interplay._
 import interplay.Omnidoc.autoImport._
 import interplay.PlayBuildBase.autoImport._
@@ -49,11 +51,24 @@ object BuildSettings {
     (Compile / headerSources / excludeFilter) := HiddenFileFilter ||
       fileUriRegexFilter(".*/cookie/encoding/.*") || fileUriRegexFilter(".*/inject/SourceProvider.java$") ||
       fileUriRegexFilter(".*/libs/reflect/.*"),
-    headerLicense := Some(HeaderLicense.Custom("Copyright (C) Lightbend Inc. <https://www.lightbend.com>")),
+    headerLicense := Some(HeaderLicense.Custom(
+      """Copyright from 2022 (C) Contributors to the Play Framework project <https://github.com/playframework>
+        |Copyright 2011-2021 (C) Lightbend Inc. <https://www.lightbend.com>""".stripMargin)),
     headerMappings ++= Map(
-      FileType.xml  -> CommentStyle.xmlStyleBlockComment,
-      FileType.conf -> CommentStyle.hashLineComment
-    )
+      FileType.xml           -> CommentStyle.xmlStyleBlockComment,
+      FileType.conf          -> CommentStyle.hashLineComment,
+      FileType("sbt")        -> HeaderCommentStyle.cppStyleLineComment,
+      FileType("routes")     -> HeaderCommentStyle.hashLineComment,
+      FileType("default")    -> HeaderCommentStyle.hashLineComment,
+      FileType("properties") -> HeaderCommentStyle.hashLineComment,
+      FileType("js")         -> HeaderCommentStyle.cStyleBlockComment,
+      FileType("less")       -> HeaderCommentStyle.cStyleBlockComment,
+      FileType("md")         -> CommentStyle(new LineCommentCreator("<!---", "-->"), commentBetween("<!---", "*", "-->")),
+      FileType("html") -> CommentStyle(
+        new CommentBlockCreator("<!--", "  ~", "  -->"),
+        commentBetween("<!--", "*", " -->")
+      ),
+    ),
   )
 
   private val VersionPattern = """^(\d+).(\d+).(\d+)(-.*)?""".r

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
+
 import sbt._
 import Keys._
 

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
+
 import sbt._
 import sbt.internal.BuildStructure
 import sbt.Keys._

--- a/project/Tasks.scala
+++ b/project/Tasks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import sbt.Keys._

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,6 +1,4 @@
-#
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-#
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # sync with documentation/project/build.properties
 sbt.version=1.7.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Lightbend Inc. <https://www.lightbend.com>
 #
+
 # sync with documentation/project/build.properties
 sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val plugins = (project in file(".")).settings(
   scalaVersion := "2.12.17", // TODO: remove when upgraded to sbt 1.8.0 (maybe even 1.7.2), see https://github.com/sbt/sbt/pull/7021

--- a/project/project/buildinfo.sbt
+++ b/project/project/buildinfo.sbt
@@ -1,5 +1,3 @@
-//
-// Copyright (C) Lightbend Inc. <https://www.lightbend.com>
-//
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")

--- a/testkit/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
+++ b/testkit/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/testkit/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-specs2/src/test/resources/logback-test.xml
+++ b/testkit/play-specs2/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
+++ b/testkit/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/java/play/test/Helpers.java
+++ b/testkit/play-test/src/main/java/play/test/Helpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/main/java/play/test/TestBrowser.java
+++ b/testkit/play-test/src/main/java/play/test/TestBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/main/java/play/test/TestServer.java
+++ b/testkit/play-test/src/main/java/play/test/TestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/main/java/play/test/WithApplication.java
+++ b/testkit/play-test/src/main/java/play/test/WithApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/main/java/play/test/WithBrowser.java
+++ b/testkit/play-test/src/main/java/play/test/WithBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/main/java/play/test/WithServer.java
+++ b/testkit/play-test/src/main/java/play/test/WithServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/main/java/play/test/package-info.java
+++ b/testkit/play-test/src/main/java/play/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Contains test helpers. */

--- a/testkit/play-test/src/main/scala/play/api/test/ApplicationFactory.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ApplicationFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/scala/play/api/test/NoMaterializer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/NoMaterializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 // Using an `akka` package to make it possible to extend Materializer

--- a/testkit/play-test/src/main/scala/play/api/test/RunningServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/RunningServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/main/scala/play/api/test/package.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api

--- a/testkit/play-test/src/test/java/play/test/HelpersTest.java
+++ b/testkit/play-test/src/test/java/play/test/HelpersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/test/java/play/test/TestServerTest.java
+++ b/testkit/play-test/src/test/java/play/test/TestServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/test/java/play/test/WithApplicationOverrideTest.java
+++ b/testkit/play-test/src/test/java/play/test/WithApplicationOverrideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/test/java/play/test/WithApplicationTest.java
+++ b/testkit/play-test/src/test/java/play/test/WithApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/test/java/play/test/WithBrowserTest.java
+++ b/testkit/play-test/src/test/java/play/test/WithBrowserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/testkit/play-test/src/test/resources/logback-test.xml
+++ b/testkit/play-test/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/testkit/play-test/src/test/scala/play/api/test/InjectingSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/InjectingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSClient.java
+++ b/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws.ahc;

--- a/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSComponents.java
+++ b/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws.ahc;

--- a/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSModule.java
+++ b/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws.ahc;

--- a/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws.ahc;

--- a/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSResponse.java
+++ b/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws.ahc;

--- a/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/WSClientComponents.java
+++ b/transport/client/play-ahc-ws/src/main/java/play/libs/ws/ahc/WSClientComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws.ahc;

--- a/transport/client/play-ahc-ws/src/main/java/play/test/WSTestClient.java
+++ b/transport/client/play-ahc-ws/src/main/java/play/test/WSTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.test;

--- a/transport/client/play-ahc-ws/src/main/resources/reference.conf
+++ b/transport/client/play-ahc-ws/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
   modules {

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClient.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws.ahc

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSComponents.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSComponents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws.ahc

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSModule.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws.ahc

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws.ahc

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSResponse.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws.ahc

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/transport/client/play-ahc-ws/src/test/resources/caffeine.conf
+++ b/transport/client/play-ahc-ws/src/test/resources/caffeine.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 caffeine.jcache {
   play-ws-cache {

--- a/transport/client/play-ahc-ws/src/test/resources/ehcache-play-ws-cache.xml
+++ b/transport/client/play-ahc-ws/src/test/resources/ehcache-play-ws-cache.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <ehcache

--- a/transport/client/play-ahc-ws/src/test/resources/logback-test.xml
+++ b/transport/client/play-ahc-ws/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws.ahc

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws.ahc

--- a/transport/client/play-ahc-ws/src/test/scala/play/libs/ws/WSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/libs/ws/WSSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws

--- a/transport/client/play-ws/src/main/java/play/libs/ws/WSBodyReadables.java
+++ b/transport/client/play-ws/src/main/java/play/libs/ws/WSBodyReadables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws;

--- a/transport/client/play-ws/src/main/java/play/libs/ws/WSBodyWritables.java
+++ b/transport/client/play-ws/src/main/java/play/libs/ws/WSBodyWritables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws;

--- a/transport/client/play-ws/src/main/java/play/libs/ws/WSClient.java
+++ b/transport/client/play-ws/src/main/java/play/libs/ws/WSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws;

--- a/transport/client/play-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/transport/client/play-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws;

--- a/transport/client/play-ws/src/main/java/play/libs/ws/WSResponse.java
+++ b/transport/client/play-ws/src/main/java/play/libs/ws/WSResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.ws;

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSBodyReadables.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSBodyReadables.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSBodyWritables.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSBodyWritables.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSClient.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSResponse.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.ws

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/package.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs

--- a/transport/server/play-akka-http-server/src/main/resources/play/reference-overrides.conf
+++ b/transport/server/play-akka-http-server/src/main/resources/play/reference-overrides.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Hack to override some of Akka's defaults in Play
 

--- a/transport/server/play-akka-http-server/src/main/resources/reference.conf
+++ b/transport/server/play-akka-http-server/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Configuration for Play's AkkaHttpServer
 play {

--- a/transport/server/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.play

--- a/transport/server/play-akka-http-server/src/main/scala/play/api/mvc/akkahttp/AkkaHttpHandler.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/api/mvc/akkahttp/AkkaHttpHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.mvc.akkahttp

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.akkahttp

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaServerConfigReader.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaServerConfigReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.akkahttp

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/HttpRequestDecoder.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/HttpRequestDecoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.akkahttp

--- a/transport/server/play-akka-http-server/src/test/resources/application.conf
+++ b/transport/server/play-akka-http-server/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
   http.secret.key = rosebud

--- a/transport/server/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/transport/server/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play

--- a/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
+++ b/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHeadersWrapperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.akkahttp

--- a/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaServerConfigReaderTest.scala
+++ b/transport/server/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaServerConfigReaderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.akkahttp

--- a/transport/server/play-akka-http2-support/src/main/resources/reference.conf
+++ b/transport/server/play-akka-http2-support/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Determines whether HTTP2 is enabled.
 play.server.akka.http2 {

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.server {
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyHeadersWrapper.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyHeadersWrapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/SynchronousMappedStreams.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/SynchronousMappedStreams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/transport/server/play-netty-server/src/test/resources/application.conf
+++ b/transport/server/play-netty-server/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
   http.secret.key = rosebud

--- a/transport/server/play-netty-server/src/test/scala/play/NettyTestServer.scala
+++ b/transport/server/play-netty-server/src/test/scala/play/NettyTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play

--- a/transport/server/play-netty-server/src/test/scala/play/core/server/netty/NettyHeadersWrapperSpec.scala
+++ b/transport/server/play-netty-server/src/test/scala/play/core/server/netty/NettyHeadersWrapperSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.netty

--- a/transport/server/play-server/src/main/java/play/server/Server.java
+++ b/transport/server/play-server/src/main/java/play/server/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.server;

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
 

--- a/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/ProdServerStart.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ProdServerStart.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerConfig.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoints.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerListenException.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerListenException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerProcess.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerProcess.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerProvider.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerStartException.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerStartException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/InvalidHeaderCharacterException.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/InvalidHeaderCharacterException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/PathAndQueryParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerDebugInfo.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerDebugInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultException.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/Subnet.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/Subnet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.ssl

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.ssl

--- a/transport/server/play-server/src/test/resources/application.conf
+++ b/transport/server/play-server/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # Needed so play-server tests run
 play.http.secret.key = "MwWGiFxb0bkpy=TU`ON=O23;3TqKgHAJWqSE3XsSfE`ByOqZcLuwmvc;^/;wCxqR"

--- a/transport/server/play-server/src/test/resources/logback-test.xml
+++ b/transport/server/play-server/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/test/scala/play/core/server/ServerConfigSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ServerConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/test/scala/play/core/server/common/SubnetSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/SubnetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.common

--- a/transport/server/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.server.ssl

--- a/web/play-filters-helpers/src/main/java/play/filters/components/AllowedHostsComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/AllowedHostsComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/CORSComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/CORSComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/CSPComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/CSPComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/CSPReportComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/CSPReportComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/GzipFilterComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/GzipFilterComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/HttpFiltersComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/HttpFiltersComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/NoHttpFiltersComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/NoHttpFiltersComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/RedirectHttpsComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/RedirectHttpsComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/components/SecurityHeadersComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/SecurityHeadersComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.components;

--- a/web/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csp/AbstractCSPAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp;

--- a/web/play-filters-helpers/src/main/java/play/filters/csp/CSP.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csp/CSP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp;

--- a/web/play-filters-helpers/src/main/java/play/filters/csp/CSPAction.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csp/CSPAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp;

--- a/web/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFToken.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf;

--- a/web/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf;

--- a/web/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf;

--- a/web/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheck.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf;

--- a/web/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf;

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.modules {
   enabled += "play.filters.csrf.CSRFModule"

--- a/web/play-filters-helpers/src/main/scala/play/api/test/CSRFTokenHelper.scala
+++ b/web/play-filters-helpers/src/main/scala/play/api/test/CSRFTokenHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.test

--- a/web/play-filters-helpers/src/main/scala/play/filters/HttpFiltersComponents.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/HttpFiltersComponents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPActionBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPModule.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPProcessor.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf

--- a/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.gzip

--- a/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.headers

--- a/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.hosts

--- a/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.https

--- a/web/play-filters-helpers/src/main/scala/views/html/helper/CSRF.scala
+++ b/web/play-filters-helpers/src/main/scala/views/html/helper/CSRF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package views.html.helper

--- a/web/play-filters-helpers/src/test/resources/application.conf
+++ b/web/play-filters-helpers/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b
 

--- a/web/play-filters-helpers/src/test/resources/logback-test.xml
+++ b/web/play-filters-helpers/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSActionBuilderSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSActionBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.cors

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPProcessorSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPProcessorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/ScalaCSPReportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csp

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.csrf

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.gzip

--- a/web/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.headers

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.hosts

--- a/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.filters.https

--- a/web/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/web/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/main/java/play/data/FormFactory.java
+++ b/web/play-java-forms/src/main/java/play/data/FormFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/main/java/play/data/FormFactoryComponents.java
+++ b/web/play-java-forms/src/main/java/play/data/FormFactoryComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/main/java/play/data/FormFactoryModule.java
+++ b/web/play-java-forms/src/main/java/play/data/FormFactoryModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/main/java/play/data/format/Formats.java
+++ b/web/play-java-forms/src/main/java/play/data/format/Formats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.format;

--- a/web/play-java-forms/src/main/java/play/data/format/Formatters.java
+++ b/web/play-java-forms/src/main/java/play/data/format/Formatters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.format;

--- a/web/play-java-forms/src/main/java/play/data/format/FormattersModule.java
+++ b/web/play-java-forms/src/main/java/play/data/format/FormattersModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.format;

--- a/web/play-java-forms/src/main/java/play/data/format/package-info.java
+++ b/web/play-java-forms/src/main/java/play/data/format/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides the formatting API used by <code>Form</code> classes. */

--- a/web/play-java-forms/src/main/java/play/data/package-info.java
+++ b/web/play-java-forms/src/main/java/play/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides data manipulation helpers, mainly for HTTP form handling. */

--- a/web/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/main/java/play/data/validation/DefaultConstraintValidatorFactory.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/DefaultConstraintValidatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/main/java/play/data/validation/MappedConstraintValidatorFactory.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/MappedConstraintValidatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/main/java/play/data/validation/ValidationError.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/ValidationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/main/java/play/data/validation/ValidatorFactoryProvider.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/ValidatorFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/main/java/play/data/validation/ValidatorProvider.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/ValidatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/main/java/play/data/validation/ValidatorsComponents.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/ValidatorsComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/main/java/play/data/validation/ValidatorsModule.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/ValidatorsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/main/java/play/data/validation/package-info.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides the JSR 303 validation constraints. */

--- a/web/play-java-forms/src/main/resources/reference.conf
+++ b/web/play-java-forms/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
   modules {

--- a/web/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
+++ b/web/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.core.j

--- a/web/play-java-forms/src/test/java/play/data/AnotherUser.java
+++ b/web/play-java-forms/src/test/java/play/data/AnotherUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/Birthday.java
+++ b/web/play-java-forms/src/test/java/play/data/Birthday.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/BlueValidator.java
+++ b/web/play-java-forms/src/test/java/play/data/BlueValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/DarkBlueValidator.java
+++ b/web/play-java-forms/src/test/java/play/data/DarkBlueValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/Formats.java
+++ b/web/play-java-forms/src/test/java/play/data/Formats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/GreenValidator.java
+++ b/web/play-java-forms/src/test/java/play/data/GreenValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/LegacyUser.java
+++ b/web/play-java-forms/src/test/java/play/data/LegacyUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/Letter.java
+++ b/web/play-java-forms/src/test/java/play/data/Letter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/LoginCheck.java
+++ b/web/play-java-forms/src/test/java/play/data/LoginCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/LoginUser.java
+++ b/web/play-java-forms/src/test/java/play/data/LoginUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/Money.java
+++ b/web/play-java-forms/src/test/java/play/data/Money.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/MyBlueUser.java
+++ b/web/play-java-forms/src/test/java/play/data/MyBlueUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/MyUser.java
+++ b/web/play-java-forms/src/test/java/play/data/MyUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/OrderedChecks.java
+++ b/web/play-java-forms/src/test/java/play/data/OrderedChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/PasswordCheck.java
+++ b/web/play-java-forms/src/test/java/play/data/PasswordCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/Red.java
+++ b/web/play-java-forms/src/test/java/play/data/Red.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/RedValidator.java
+++ b/web/play-java-forms/src/test/java/play/data/RedValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/RepeatableConstraintsForm.java
+++ b/web/play-java-forms/src/test/java/play/data/RepeatableConstraintsForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/SomeUser.java
+++ b/web/play-java-forms/src/test/java/play/data/SomeUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/Subtask.java
+++ b/web/play-java-forms/src/test/java/play/data/Subtask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/Task.java
+++ b/web/play-java-forms/src/test/java/play/data/Task.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/Thesis.java
+++ b/web/play-java-forms/src/test/java/play/data/Thesis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/TypeArgumentForm.java
+++ b/web/play-java-forms/src/test/java/play/data/TypeArgumentForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/UserBase.java
+++ b/web/play-java-forms/src/test/java/play/data/UserBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/UserEmail.java
+++ b/web/play-java-forms/src/test/java/play/data/UserEmail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/ValidateRed.java
+++ b/web/play-java-forms/src/test/java/play/data/ValidateRed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data;

--- a/web/play-java-forms/src/test/java/play/data/validation/TestConstraints.java
+++ b/web/play-java-forms/src/test/java/play/data/validation/TestConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.validation;

--- a/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;

--- a/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data

--- a/web/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data

--- a/web/play-java-forms/src/test/scala/play/data/format/FormattersTest.java
+++ b/web/play-java-forms/src/test/scala/play/data/format/FormattersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.data.format;

--- a/web/play-joda-forms/src/main/scala/play/api/data/JodaForms.scala
+++ b/web/play-joda-forms/src/main/scala/play/api/data/JodaForms.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data

--- a/web/play-joda-forms/src/main/scala/play/api/data/format/JodaFormats.scala
+++ b/web/play-joda-forms/src/main/scala/play/api/data/format/JodaFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.data.format

--- a/web/play-openid/src/main/java/play/libs/openid/DefaultOpenIdClient.java
+++ b/web/play-openid/src/main/java/play/libs/openid/DefaultOpenIdClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.openid;

--- a/web/play-openid/src/main/java/play/libs/openid/OpenIdClient.java
+++ b/web/play-openid/src/main/java/play/libs/openid/OpenIdClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.openid;

--- a/web/play-openid/src/main/java/play/libs/openid/OpenIdComponents.java
+++ b/web/play-openid/src/main/java/play/libs/openid/OpenIdComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.openid;

--- a/web/play-openid/src/main/java/play/libs/openid/OpenIdModule.java
+++ b/web/play-openid/src/main/java/play/libs/openid/OpenIdModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.openid;

--- a/web/play-openid/src/main/java/play/libs/openid/UserInfo.java
+++ b/web/play-openid/src/main/java/play/libs/openid/UserInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.libs.openid;

--- a/web/play-openid/src/main/java/play/libs/openid/package-info.java
+++ b/web/play-openid/src/main/java/play/libs/openid/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 /** Provides an OpenID client. */

--- a/web/play-openid/src/main/resources/reference.conf
+++ b/web/play-openid/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-# Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 play {
   modules {

--- a/web/play-openid/src/main/scala/play/api/libs/openid/OpenIDError.scala
+++ b/web/play-openid/src/main/scala/play/api/libs/openid/OpenIDError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.openid

--- a/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.openid

--- a/web/play-openid/src/test/resources/logback-test.xml
+++ b/web/play-openid/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <configuration>

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/opLocalIdentityPage.html
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/opLocalIdentityPage.html
@@ -1,6 +1,7 @@
 <!--
   ~ Copyright (C) Lightbend Inc. <https://www.lightbend.com>
   -->
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
 <head>

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/opLocalIdentityPage.html
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/opLocalIdentityPage.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+  ~ Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
   -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/openIDProvider-OpenID-1.1.html
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/openIDProvider-OpenID-1.1.html
@@ -1,6 +1,7 @@
 <!--
   ~ Copyright (C) Lightbend Inc. <https://www.lightbend.com>
   -->
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
 <head>

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/openIDProvider-OpenID-1.1.html
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/openIDProvider-OpenID-1.1.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+  ~ Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
   -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/openIDProvider.html
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/openIDProvider.html
@@ -1,6 +1,7 @@
 <!--
   ~ Copyright (C) Lightbend Inc. <https://www.lightbend.com>
   -->
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
 <head>

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/openIDProvider.html
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/html/openIDProvider.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+  ~ Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
   -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/google-account-response.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/google-account-response.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/invalid-op-identifier.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/invalid-op-identifier.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/multi-service-with-op-and-claimed-id-service.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/multi-service-with-op-and-claimed-id-service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/multi-service.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/multi-service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)"

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-op-non-unique.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-op-non-unique.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-op.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-op.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-openid-1-op.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-openid-1-op.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">

--- a/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-openid-1.1-op.xml
+++ b/web/play-openid/src/test/resources/play/api/libs/openid/discovery/xrds/simple-openid-1.1-op.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+   Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
 <xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">

--- a/web/play-openid/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.openid

--- a/web/play-openid/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.openid

--- a/web/play-openid/src/test/scala/play/api/libs/openid/RichUrl.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/RichUrl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.openid

--- a/web/play-openid/src/test/scala/play/api/libs/openid/UserInfoSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/UserInfoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.openid

--- a/web/play-openid/src/test/scala/play/api/libs/openid/WsMock.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/WsMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs.openid

--- a/web/play-openid/src/test/scala/play/api/libs/openid/package.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.api.libs


### PR DESCRIPTION
I spend almost too much time with this.
Turns out currently sbt-header did not check all the files currently so I needed to fix this. Plus before sbt-header could not apply its changes correctly, some files needed manually updating (like adding an empty line) otherwise we would end up with two headers in one file. Also it needed a fix to work properly: https://github.com/sbt/sbt-header/pull/297 (I was using a local build for now to generate the headers)

I ended up using
```
Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
```
because 
* it's one line. sbt-header did make problems e.g. for xml files where it uses `<!--- .. -->` on _each_ header line. So it would replace only the first one when re-running, always keeping the second existing one, so it will be a mess.
* Lightbend was exclusive copyright holder, so IMHO (and Sergey) I think we should still mention this, see https://github.com/playframework/play-meta/issues/211#issuecomment-1282556584

Inspired by https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects
Also see https://github.com/playframework/play-meta/issues/211

I know... I don't want to spend too much time with this but it needs to be done. Soon all those meta tasks are finished...