### PR TITLE
logback-classic 1.3.x (from 1.2.x)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
 
   val playJsonVersion = "2.8.2"
 
-  val logback = "ch.qos.logback" % "logback-classic" % "1.2.11"
+  val logback = "ch.qos.logback" % "logback-classic" % "1.3.5"
 
   val specs2Version = "4.8.3"
   val specs2Deps = Seq(


### PR DESCRIPTION
Not sure yet (because of compatibility), see https://logback.qos.ch/news.html#1.3.0

Would fix cases where another library upgrades slf4j to 2.x which currently breaks Play, see: #11499