### PR TITLE
Handle java multipart form data on requests in test Helpers

### DIFF
--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -50,7 +50,6 @@ import play.mvc.Http.Status;
 import scala.concurrent.Future;
 import scala.jdk.javaapi.CollectionConverters;
 import scala.jdk.javaapi.FutureConverters;
-import scala.jdk.javaapi.OptionConverters;
 import scala.runtime.AbstractFunction1;
 
 /** A body parser parses the HTTP request body content. */
@@ -832,20 +831,9 @@ public interface BodyParser<A> {
       @Override
       public List<FilePart<A>> getFiles() {
         return CollectionConverters.asJava(scalaFormData.files()).stream()
-            .map(DelegatingMultipartFormDataBodyParser.this::toJava)
+            .map(play.api.mvc.MultipartFormData.FilePart::asJava)
             .collect(Collectors.toList());
       }
-    }
-
-    private Http.MultipartFormData.FilePart<A> toJava(
-        play.api.mvc.MultipartFormData.FilePart<A> filePart) {
-      return new Http.MultipartFormData.FilePart<>(
-          filePart.key(),
-          filePart.filename(),
-          OptionConverters.toJava(filePart.contentType()).orElse(null),
-          filePart.ref(),
-          filePart.fileSize(),
-          filePart.dispositionType());
     }
   }
 

--- a/core/play/src/main/java/play/mvc/BodyParser.java
+++ b/core/play/src/main/java/play/mvc/BodyParser.java
@@ -47,7 +47,6 @@ import play.libs.Scala;
 import play.libs.XML;
 import play.libs.streams.Accumulator;
 import play.mvc.Http.Status;
-import scala.Option;
 import scala.concurrent.Future;
 import scala.jdk.javaapi.CollectionConverters;
 import scala.jdk.javaapi.FutureConverters;
@@ -784,7 +783,7 @@ public interface BodyParser<A> {
       @Override
       public play.api.mvc.MultipartFormData.FilePart<A> apply(
           Http.MultipartFormData.FilePart<A> filePart) {
-        return toScala(filePart);
+        return filePart.asScala();
       }
     }
 
@@ -847,17 +846,6 @@ public interface BodyParser<A> {
           filePart.ref(),
           filePart.fileSize(),
           filePart.dispositionType());
-    }
-
-    private play.api.mvc.MultipartFormData.FilePart<A> toScala(
-        Http.MultipartFormData.FilePart<A> filePart) {
-      return new play.api.mvc.MultipartFormData.FilePart<>(
-          filePart.getKey(),
-          filePart.getFilename(),
-          Option.apply(filePart.getContentType()),
-          filePart.getRef(),
-          filePart.getFileSize(),
-          filePart.getDispositionType());
     }
   }
 

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -10,6 +10,7 @@ import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -21,6 +22,7 @@ import java.time.Duration;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
@@ -1424,13 +1426,33 @@ public class Http {
       final A ref;
       final String dispositionType;
       final long fileSize;
+      final Function<A, Optional<ByteString>> refToBytes;
 
       public FilePart(String key, String filename, String contentType, A ref) {
-        this(key, filename, contentType, ref, -1);
+        this(key, filename, contentType, ref, a -> Optional.empty());
+      }
+
+      public FilePart(
+          String key,
+          String filename,
+          String contentType,
+          A ref,
+          Function<A, Optional<ByteString>> refToBytes) {
+        this(key, filename, contentType, ref, -1, refToBytes);
       }
 
       public FilePart(String key, String filename, String contentType, A ref, long fileSize) {
-        this(key, filename, contentType, ref, fileSize, "form-data");
+        this(key, filename, contentType, ref, fileSize, a -> Optional.empty());
+      }
+
+      public FilePart(
+          String key,
+          String filename,
+          String contentType,
+          A ref,
+          long fileSize,
+          Function<A, Optional<ByteString>> refToBytes) {
+        this(key, filename, contentType, ref, fileSize, "form-data", refToBytes);
       }
 
       public FilePart(
@@ -1440,12 +1462,24 @@ public class Http {
           A ref,
           long fileSize,
           String dispositionType) {
+        this(key, filename, contentType, ref, fileSize, dispositionType, a -> Optional.empty());
+      }
+
+      public FilePart(
+          String key,
+          String filename,
+          String contentType,
+          A ref,
+          long fileSize,
+          String dispositionType,
+          Function<A, Optional<ByteString>> refToBytes) {
         this.key = key;
         this.filename = filename;
         this.contentType = contentType;
         this.ref = ref;
         this.dispositionType = dispositionType;
         this.fileSize = fileSize;
+        this.refToBytes = refToBytes;
       }
 
       /** @return the part name */
@@ -1482,6 +1516,46 @@ public class Http {
         return fileSize;
       }
 
+      public ByteString transformRefToBytes() {
+        return refToBytes
+            .apply(ref)
+            .or(
+                () -> {
+                  // Out of the box Play can help transforming objects to bytes it knows about
+                  // to make life easier for users
+                  try {
+                    if (ref instanceof play.api.libs.Files.TemporaryFile) {
+                      return Optional.of(
+                          ByteString.fromArray(
+                              java.nio.file.Files.readAllBytes(
+                                  ((play.api.libs.Files.TemporaryFile) ref).path())));
+                    } else if (ref instanceof play.libs.Files.TemporaryFile) {
+                      return Optional.of(
+                          ByteString.fromArray(
+                              java.nio.file.Files.readAllBytes(
+                                  ((play.libs.Files.TemporaryFile) ref).path())));
+                    } else if (ref instanceof java.io.File) {
+                      return Optional.of(
+                          ByteString.fromArray(
+                              java.nio.file.Files.readAllBytes(((java.io.File) ref).toPath())));
+                    } else if (ref instanceof java.nio.file.Path) {
+                      return Optional.of(
+                          ByteString.fromArray(
+                              java.nio.file.Files.readAllBytes((java.nio.file.Path) ref)));
+                    }
+                  } catch (IOException e) {
+                    throw new RuntimeException("Can not transform the FilePart ref to bytes", e);
+                  }
+                  return Optional.empty();
+                })
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "To be able to convert this FilePart's ref to bytes you need to define refToBytes of FilePart["
+                            + ref.getClass().getName()
+                            + "]"));
+      }
+
       public play.api.mvc.MultipartFormData.FilePart<A> asScala() {
         return new play.api.mvc.MultipartFormData.FilePart<>(
             getKey(),
@@ -1489,7 +1563,8 @@ public class Http {
             Option.apply(getContentType()),
             getRef(),
             getFileSize(),
-            getDispositionType());
+            getDispositionType(),
+            ref -> OptionConverters.toScala(refToBytes.apply(ref)));
       }
     }
 

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -41,6 +41,7 @@ import play.libs.typedmap.TypedEntry;
 import play.libs.typedmap.TypedKey;
 import play.libs.typedmap.TypedMap;
 import play.mvc.Http.Cookie.SameSite;
+import scala.Option;
 import scala.collection.immutable.Map$;
 import scala.jdk.javaapi.OptionConverters;
 
@@ -1479,6 +1480,16 @@ public class Http {
       /** @return the size of the file in bytes */
       public long getFileSize() {
         return fileSize;
+      }
+
+      public play.api.mvc.MultipartFormData.FilePart<A> asScala() {
+        return new play.api.mvc.MultipartFormData.FilePart<>(
+            getKey(),
+            getFilename(),
+            Option.apply(getContentType()),
+            getRef(),
+            getFileSize(),
+            getDispositionType());
       }
     }
 

--- a/core/play/src/main/java/play/mvc/MultipartFormatter.java
+++ b/core/play/src/main/java/play/mvc/MultipartFormatter.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import play.api.mvc.MultipartFormData;
 import play.core.formatters.Multipart;
 import scala.Option;
+import scala.jdk.javaapi.OptionConverters;
 
 public class MultipartFormatter {
 
@@ -45,7 +46,9 @@ public class MultipartFormatter {
                       ct,
                       fp.ref.asScala(),
                       fp.getFileSize(),
-                      fp.getDispositionType());
+                      fp.getDispositionType(),
+                      byteSource ->
+                          OptionConverters.toScala(fp.refToBytes.apply(byteSource.asJava())));
                 }
               }
               throw new UnsupportedOperationException("Unsupported Part Class");

--- a/core/play/src/main/java/play/mvc/MultipartFormatter.java
+++ b/core/play/src/main/java/play/mvc/MultipartFormatter.java
@@ -34,16 +34,16 @@ public class MultipartFormatter {
                 return (MultipartFormData.Part)
                     new MultipartFormData.DataPart(dp.getKey(), dp.getValue());
               } else if (part instanceof Http.MultipartFormData.FilePart) {
-                Http.MultipartFormData.FilePart<?> fp = (Http.MultipartFormData.FilePart<?>) part;
-                if (fp.ref instanceof Source) {
+                if (((Http.MultipartFormData.FilePart) part).ref instanceof Source) {
                   @SuppressWarnings("unchecked")
-                  Source<ByteString, ?> ref = (Source<ByteString, ?>) fp.ref;
+                  Http.MultipartFormData.FilePart<Source<ByteString, ?>> fp =
+                      (Http.MultipartFormData.FilePart<Source<ByteString, ?>>) part;
                   Option<String> ct = Option.apply(fp.getContentType());
                   return new MultipartFormData.FilePart<akka.stream.scaladsl.Source<ByteString, ?>>(
                       fp.getKey(),
                       fp.getFilename(),
                       ct,
-                      ref.asScala(),
+                      fp.ref.asScala(),
                       fp.getFileSize(),
                       fp.getDispositionType());
                 }

--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -162,7 +162,7 @@ trait DefaultWriteables extends LowPriorityWriteables {
         .flatMap {
           case (name, values) =>
             values.map { value =>
-              s"--$boundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name=$name\r\n\r\n$value\r\n"
+              s"""--$boundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name="$name"\r\n\r\n$value\r\n"""
             }
         }
         .mkString("")

--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -9,6 +9,7 @@ import play.api.libs.Files.TemporaryFile
 import play.api.mvc._
 import play.api.libs.json._
 import play.api.mvc.MultipartFormData.FilePart
+import play.libs.Files.{ TemporaryFile => JTemporaryFile }
 
 import scala.annotation._
 
@@ -126,6 +127,22 @@ trait DefaultWriteables extends LowPriorityWriteables {
       codec,
       Writeable[FilePart[TemporaryFile]](
         (f: FilePart[TemporaryFile]) => ByteString.fromArray(JFiles.readAllBytes(f.ref.path)),
+        contentType
+      )
+    )
+  }
+
+  /**
+   * `Writeable` for `MultipartFormData` when using Play's Java [[JTemporaryFile]]s.
+   */
+  def writeableOf_MultipartFormDataJavaTemporaryFile(
+      codec: Codec,
+      contentType: Option[String]
+  ): Writeable[MultipartFormData[JTemporaryFile]] = {
+    writeableOf_MultipartFormData(
+      codec,
+      Writeable[FilePart[JTemporaryFile]](
+        (f: FilePart[JTemporaryFile]) => ByteString.fromArray(JFiles.readAllBytes(f.ref.path)),
         contentType
       )
     )

--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -115,8 +115,11 @@ trait DefaultWriteables extends LowPriorityWriteables {
 
   /**
    * `Writeable` for `MultipartFormData`.
+   *
+   * If the passed writeable contains a contentType with a boundary, this boundary will be used to separate the data/file parts of the multipart/form-data body.
+   * If you don't pass a contentType with the writeable, or it does not contain a boundary, a random one will be generated.
    */
-  @deprecated("Pass contentType instead of Writeable", "2.9.0")
+  @deprecated("Use method that takes boundary and implicit codec", "2.9.0")
   def writeableOf_MultipartFormData[A](
       codec: Codec,
       aWriteable: Writeable[FilePart[A]]
@@ -124,25 +127,41 @@ trait DefaultWriteables extends LowPriorityWriteables {
 
   /**
    * `Writeable` for `MultipartFormData`.
+   *
+   * If you pass a contentType which contains a boundary, this boundary will be used to separate the data/file parts of the multipart/form-data body.
+   * If you don't pass a contentType, or it does not contain a boundary, a random one will be generated.
    */
+  @deprecated("Use method that takes boundary and implicit codec", "2.9.0")
   def writeableOf_MultipartFormData[A](
       codec: Codec,
       contentType: Option[String]
   ): Writeable[MultipartFormData[A]] = {
-    // If a the passed contentType already provides a boundary we use it, if not we generate a new one
+    // If the passed contentType already provides a boundary, we (re)use it for the Content-Disposition header
     val maybeBoundary = for {
       mt         <- contentType.flatMap(MediaType.parse(_))
       (_, value) <- mt.parameters.find(_._1.equalsIgnoreCase("boundary"))
       boundary   <- value
     } yield boundary
-    val boundary = maybeBoundary.getOrElse(Multipart.randomBoundary())
+    writeableOf_MultipartFormData(maybeBoundary)(codec)
+  }
+
+  /**
+   * `Writeable` for `MultipartFormData`.
+   *
+   * If you pass a boundary, it will be used to separate the data/file parts of the multipart/form-data body.
+   * If you don't pass a boundary a random one will be generated.
+   */
+  def writeableOf_MultipartFormData[A](
+      boundary: Option[String]
+  )(implicit codec: Codec): Writeable[MultipartFormData[A]] = {
+    val resolvedBoundary = boundary.getOrElse(Multipart.randomBoundary())
 
     def formatDataParts(data: Map[String, Seq[String]]) = {
       val dataParts = data
         .flatMap {
           case (name, values) =>
             values.map { value =>
-              s"""--$boundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name="$name"\r\n\r\n$value\r\n"""
+              s"""--$resolvedBoundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name="$name"\r\n\r\n$value\r\n"""
             }
         }
         .mkString("")
@@ -156,7 +175,7 @@ trait DefaultWriteables extends LowPriorityWriteables {
         .map { ct => s"${HeaderNames.CONTENT_TYPE}: $ct\r\n" }
         .getOrElse("")
       codec.encode(
-        s"--$boundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name=$name; filename=$filename\r\n$contentType\r\n"
+        s"--$resolvedBoundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name=$name; filename=$filename\r\n$contentType\r\n"
       )
     }
 
@@ -164,9 +183,9 @@ trait DefaultWriteables extends LowPriorityWriteables {
       transform = { (form: MultipartFormData[A]) =>
         formatDataParts(form.dataParts) ++ ByteString(form.files.flatMap { file =>
           filePartHeader(file) ++ file.transformRefToBytes() ++ codec.encode("\r\n")
-        }: _*) ++ codec.encode(s"--$boundary--")
+        }: _*) ++ codec.encode(s"--$resolvedBoundary--")
       },
-      contentType = Some(s"multipart/form-data; boundary=$boundary")
+      contentType = Some(s"multipart/form-data; boundary=$resolvedBoundary")
     )
   }
 

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -36,6 +36,7 @@ import play.utils.PlayIO
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.jdk.OptionConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -187,8 +188,25 @@ object MultipartFormData {
       contentType: Option[String],
       ref: A,
       fileSize: Long = -1,
-      dispositionType: String = "form-data"
+      dispositionType: String = "form-data",
+      refToBytes: A => Option[ByteString] = (a: A) => None
   ) extends Part[A] {
+    def transformRefToBytes(): ByteString =
+      refToBytes(ref)
+        .orElse(ref match {
+          // Out of the box Play can help transforming objects to bytes it knows about to make life easier for users
+          case stf: play.api.libs.Files.TemporaryFile => Some(ByteString.fromArray(Files.readAllBytes(stf.path)))
+          case jtf: play.libs.Files.TemporaryFile     => Some(ByteString.fromArray(Files.readAllBytes(jtf.path)))
+          case file: java.io.File                     => Some(ByteString.fromArray(Files.readAllBytes(file.toPath)))
+          case path: java.nio.file.Path               => Some(ByteString.fromArray(Files.readAllBytes(path)))
+          case _                                      => None
+        })
+        .getOrElse(
+          throw new RuntimeException(
+            s"To be able to convert this FilePart's ref to bytes you need to define refToBytes of FilePart[${ref.getClass.getName}]"
+          )
+        )
+
     def asJava(): play.mvc.Http.MultipartFormData.FilePart[A] = new play.mvc.Http.MultipartFormData.FilePart[A](
       key,
       filename,
@@ -196,6 +214,7 @@ object MultipartFormData {
       ref,
       fileSize,
       dispositionType,
+      refToBytes(_).toJava
     )
   }
 

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -11,7 +11,6 @@ import java.nio.file.Files
 import java.util.Locale
 
 import javax.inject.Inject
-import akka.actor.ActorSystem
 import akka.stream._
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
@@ -189,7 +188,16 @@ object MultipartFormData {
       ref: A,
       fileSize: Long = -1,
       dispositionType: String = "form-data"
-  ) extends Part[A]
+  ) extends Part[A] {
+    def asJava(): play.mvc.Http.MultipartFormData.FilePart[A] = new play.mvc.Http.MultipartFormData.FilePart[A](
+      key,
+      filename,
+      contentType.getOrElse(null),
+      ref,
+      fileSize,
+      dispositionType,
+    )
+  }
 
   /**
    * A part that has not been properly parsed.

--- a/core/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/core/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -148,9 +148,9 @@ object Multipart {
             }
 
             def completePartFormatting(): Source[ByteString, Any] = bodyPart match {
-              case MultipartFormData.DataPart(_, data)            => Source.single((f ~~ ByteString(data)).get)
-              case MultipartFormData.FilePart(_, _, _, ref, _, _) => bodyPartChunks(ref)
-              case _                                              => throw new UnsupportedOperationException()
+              case MultipartFormData.DataPart(_, data)               => Source.single((f ~~ ByteString(data)).get)
+              case MultipartFormData.FilePart(_, _, _, ref, _, _, _) => bodyPartChunks(ref)
+              case _                                                 => throw new UnsupportedOperationException()
             }
 
             renderBoundary(f, boundary, suppressInitialCrLf = !firstBoundaryRendered)
@@ -158,7 +158,15 @@ object Multipart {
 
             val (key, filename, contentType, dispositionType) = bodyPart match {
               case MultipartFormData.DataPart(innerKey, _) => (innerKey, None, Option("text/plain"), "form-data")
-              case MultipartFormData.FilePart(innerKey, innerFilename, innerContentType, _, _, innerDispositionType) =>
+              case MultipartFormData.FilePart(
+                  innerKey,
+                  innerFilename,
+                  innerContentType,
+                  _,
+                  _,
+                  innerDispositionType,
+                  _
+                  ) =>
                 (innerKey, Option(innerFilename), innerContentType, innerDispositionType)
               case _ => throw new UnsupportedOperationException()
             }

--- a/core/play/src/test/scala/play/api/http/WriteableSpec.scala
+++ b/core/play/src/test/scala/play/api/http/WriteableSpec.scala
@@ -24,7 +24,7 @@ class WriteableSpec extends Specification {
         )
         val codec = Codec.utf_8
 
-        val writeable               = Writeable.writeableOf_MultipartFormData[TemporaryFile](codec, None)
+        val writeable               = Writeable.writeableOf_MultipartFormData[TemporaryFile](None)(codec)
         val transformed: ByteString = writeable.transform(multipartFormData)
 
         transformed.utf8String must contain("""Content-Disposition: form-data; name="name"""")
@@ -40,7 +40,7 @@ class WriteableSpec extends Specification {
           createMultipartFormData[String]("file part value", data => Some(ByteString.fromString(data)))
         val codec = Codec.utf_8
 
-        val writeable               = Writeable.writeableOf_MultipartFormData[String](codec, None)
+        val writeable               = Writeable.writeableOf_MultipartFormData[String](None)(codec)
         val transformed: ByteString = writeable.transform(multipartFormData)
 
         transformed.utf8String must contain("""Content-Disposition: form-data; name="name"""")
@@ -52,11 +52,8 @@ class WriteableSpec extends Specification {
       }
 
       "use multipart/form-data content-type" in {
-        val codec = Codec.utf_8
-        val writeable = Writeable.writeableOf_MultipartFormData(
-          codec,
-          None
-        )
+        val codec     = Codec.utf_8
+        val writeable = Writeable.writeableOf_MultipartFormData(None)(codec)
 
         writeable.contentType must beSome(startWith("multipart/form-data; boundary="))
       }

--- a/core/play/src/test/scala/play/api/http/WriteableSpec.scala
+++ b/core/play/src/test/scala/play/api/http/WriteableSpec.scala
@@ -28,7 +28,7 @@ class WriteableSpec extends Specification {
         val writeable               = Writeable.writeableOf_MultipartFormData(codec, contentType)
         val transformed: ByteString = writeable.transform(multipartFormData)
 
-        transformed.utf8String must contain("Content-Disposition: form-data; name=name")
+        transformed.utf8String must contain("""Content-Disposition: form-data; name="name"""")
         transformed.utf8String must contain(
           """Content-Disposition: form-data; name="thefile"; filename="something.text""""
         )
@@ -47,7 +47,7 @@ class WriteableSpec extends Specification {
         )
         val transformed: ByteString = writeable.transform(multipartFormData)
 
-        transformed.utf8String must contain("Content-Disposition: form-data; name=name")
+        transformed.utf8String must contain("""Content-Disposition: form-data; name="name"""")
         transformed.utf8String must contain(
           """Content-Disposition: form-data; name="thefile"; filename="something.text""""
         )

--- a/core/play/src/test/scala/play/api/http/WriteableSpec.scala
+++ b/core/play/src/test/scala/play/api/http/WriteableSpec.scala
@@ -22,10 +22,9 @@ class WriteableSpec extends Specification {
         val multipartFormData = createMultipartFormData[TemporaryFile](
           create(new File("src/test/resources/multipart-form-data-file.txt").toPath)
         )
-        val contentType = Some("text/plain")
-        val codec       = Codec.utf_8
+        val codec = Codec.utf_8
 
-        val writeable               = Writeable.writeableOf_MultipartFormData(codec, contentType)
+        val writeable               = Writeable.writeableOf_MultipartFormData[TemporaryFile](codec, None)
         val transformed: ByteString = writeable.transform(multipartFormData)
 
         transformed.utf8String must contain("""Content-Disposition: form-data; name="name"""")
@@ -37,14 +36,11 @@ class WriteableSpec extends Specification {
       }
 
       "work composing with another writeable" in {
-        val multipartFormData = createMultipartFormData[String]("file part value")
-        val contentType       = Some("text/plain")
-        val codec             = Codec.utf_8
+        val multipartFormData =
+          createMultipartFormData[String]("file part value", data => Some(ByteString.fromString(data)))
+        val codec = Codec.utf_8
 
-        val writeable = Writeable.writeableOf_MultipartFormData(
-          codec,
-          Writeable[FilePart[String]]((f: FilePart[String]) => codec.encode(f.ref), contentType)
-        )
+        val writeable               = Writeable.writeableOf_MultipartFormData[String](codec, None)
         val transformed: ByteString = writeable.transform(multipartFormData)
 
         transformed.utf8String must contain("""Content-Disposition: form-data; name="name"""")
@@ -56,11 +52,10 @@ class WriteableSpec extends Specification {
       }
 
       "use multipart/form-data content-type" in {
-        val contentType = Some("text/plain")
-        val codec       = Codec.utf_8
+        val codec = Codec.utf_8
         val writeable = Writeable.writeableOf_MultipartFormData(
           codec,
-          Writeable[FilePart[String]]((f: FilePart[String]) => codec.encode(f.ref), contentType)
+          None
         )
 
         writeable.contentType must beSome(startWith("multipart/form-data; boundary="))
@@ -78,7 +73,7 @@ class WriteableSpec extends Specification {
     }
   }
 
-  def createMultipartFormData[A](ref: A): MultipartFormData[A] = {
+  def createMultipartFormData[A](ref: A, refToBytes: A => Option[ByteString] = (a: A) => None): MultipartFormData[A] = {
     MultipartFormData[A](
       dataParts = Map(
         "name" -> Seq("value")
@@ -88,7 +83,8 @@ class WriteableSpec extends Specification {
           key = "thefile",
           filename = "something.text",
           contentType = Some("text/plain"),
-          ref = ref
+          ref = ref,
+          refToBytes = refToBytes
         )
       ),
       badParts = Seq.empty

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/build.sbt
@@ -1,0 +1,17 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+name := """java-test-helpers"""
+organization := "com.example"
+
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayJava)
+  // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
+  .disablePlugins(PlayLayoutPlugin)
+
+scalaVersion := ScriptedTools.scalaVersionFromJavaProperties()
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false))
+
+libraryDependencies += guice

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/project/plugins.sbt
@@ -1,0 +1,6 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-scripted-tools" % sys.props("project.version"))
+lazy val plugins = (project in file(".")).settings(scalaVersion := "2.12.17")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/java/controller/HomeController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/java/controller/HomeController.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers;
+
+import play.libs.Files;
+import play.mvc.Controller;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.io.IOException;
+
+public class HomeController extends Controller {
+
+    public Result multipartFormUploadNoFiles(Http.Request request) {
+        Http.MultipartFormData<Files.TemporaryFile> body = request.body().asMultipartFormData();
+        return ok("Files: " + body.getFiles().size() + ", Data: " + body.asFormUrlEncoded().size() + " [" + body.asFormUrlEncoded().get("key1")[0]  +  "]");
+    }
+
+    public Result multipartFormUpload(Http.Request request) throws IOException {
+        Http.MultipartFormData<Object> data =
+                request.body().asMultipartFormData();
+        Files.TemporaryFile ref =
+                (Files.TemporaryFile) data.getFile("document").getRef();
+        String contents = java.nio.file.Files.readString(ref.path());
+        return ok(
+                "author: "
+                        + data.asFormUrlEncoded().get("author")[0]
+                        + "\n"
+                        + "filename: "
+                        + data.getFile("document").getFilename()
+                        + "\n"
+                        + "contentType: "
+                        + data.getFile("document").getContentType()
+                        + "\n"
+                        + "contents: "
+                        + contents
+                        + "\n");
+    }
+
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/resources/logback.xml
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>
+        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <logger name="controllers.HomeController" level="DEBUG" />
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/resources/routes
@@ -1,0 +1,4 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+POST     /multipart-form-data-no-files             controllers.HomeController.multipartFormUploadNoFiles(request: Request)
+POST     /multipart-form-data                      controllers.HomeController.multipartFormUpload(request: Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/test/java/controllers/HomeControllerTest.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/test/java/controllers/HomeControllerTest.java
@@ -10,18 +10,25 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import akka.util.ByteString;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import play.libs.Files;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.test.WithApplication;
 
+import static java.nio.file.Files.write;
 import static org.junit.Assert.assertEquals;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.POST;
 import static play.test.Helpers.route;
 
 public class HomeControllerTest extends WithApplication {
+
+    @Rule
+    public ExpectedException exceptionGrabber = ExpectedException.none();
 
     @Test
     public void testOnlyFormDataNoFiles() throws ExecutionException, InterruptedException, TimeoutException {
@@ -39,20 +46,49 @@ public class HomeControllerTest extends WithApplication {
     }
 
     @Test
+    public void testStringFilePart() throws ExecutionException, InterruptedException, TimeoutException {
+        String content = "Twas brillig and the slithy Toves...";
+        testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", content,
+                data -> Optional.of(ByteString.fromString(data)))));
+    }
+
+    @Test
+    public void testStringFilePartToRefToBytesDefined() throws ExecutionException, InterruptedException, TimeoutException {
+        exceptionGrabber.expect(RuntimeException.class);
+        exceptionGrabber.expectMessage("To be able to convert this FilePart's ref to bytes you need to define refToBytes of FilePart[java.lang.String]");
+        String content = "Twas brillig and the slithy Toves...";
+        testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", content)));
+    }
+
+    @Test
     public void testJavaTemporaryFile() throws IOException, ExecutionException, InterruptedException, TimeoutException {
         Files.TemporaryFile tempFile = Files.singletonTemporaryFileCreator().create("temp", "txt");
-        java.nio.file.Files.write(tempFile.path(), "Twas brillig and the slithy Toves...".getBytes());
+        write(tempFile.path(), "Twas brillig and the slithy Toves...".getBytes());
         testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", tempFile)));
     }
 
     @Test
     public void testScalaTemporaryFile() throws IOException, ExecutionException, InterruptedException, TimeoutException {
         play.api.libs.Files.TemporaryFile tempFile = play.api.libs.Files.SingletonTemporaryFileCreator$.MODULE$.create("temp", "txt");
-        java.nio.file.Files.write(tempFile.path(), "Twas brillig and the slithy Toves...".getBytes());
+        write(tempFile.path(), "Twas brillig and the slithy Toves...".getBytes());
         testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", tempFile)));
     }
 
-    private void testTemporaryFile(final List<Http.MultipartFormData.FilePart> files) throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    @Test
+    public void testFile() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        play.api.libs.Files.TemporaryFile tempFile = play.api.libs.Files.SingletonTemporaryFileCreator$.MODULE$.create("temp", "txt");
+        write(tempFile.path(), "Twas brillig and the slithy Toves...".getBytes());
+        testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", tempFile.file())));
+    }
+
+    @Test
+    public void testPath() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        play.api.libs.Files.TemporaryFile tempFile = play.api.libs.Files.SingletonTemporaryFileCreator$.MODULE$.create("temp", "txt");
+        write(tempFile.path(), "Twas brillig and the slithy Toves...".getBytes());
+        testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", tempFile.path())));
+    }
+
+    private void testTemporaryFile(final List<Http.MultipartFormData.FilePart> files) throws ExecutionException, InterruptedException, TimeoutException {
         final Map<String, String[]> data = new HashMap<>();
         data.put("author", new String[]{"Lewis Carrol"});
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/test/java/controllers/HomeControllerTest.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/test/java/controllers/HomeControllerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+import play.libs.Files;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.test.WithApplication;
+
+import static org.junit.Assert.assertEquals;
+import static play.mvc.Http.Status.OK;
+import static play.test.Helpers.POST;
+import static play.test.Helpers.route;
+
+public class HomeControllerTest extends WithApplication {
+
+    @Test
+    public void testOnlyFormDataNoFiles() throws ExecutionException, InterruptedException, TimeoutException {
+        final Map<String, String[]> postParams = new HashMap<>();
+        postParams.put("key1", new String[]{"value1"});
+        Http.RequestBuilder request = new Http.RequestBuilder()
+                .method(POST)
+                .bodyMultipart(postParams, Collections.emptyList())
+                .uri("/multipart-form-data-no-files");
+
+        Result result = route(app, request);
+        String content = result.body().consumeData(mat).thenApply(bs -> bs.utf8String()).toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertEquals(OK, result.status());
+        assertEquals("Files: 0, Data: 1 [value1]", content);
+    }
+
+    @Test
+    public void testJavaTemporaryFile() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        Files.TemporaryFile tempFile = Files.singletonTemporaryFileCreator().create("temp", "txt");
+        java.nio.file.Files.write(tempFile.path(), "Twas brillig and the slithy Toves...".getBytes());
+        testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", tempFile)));
+    }
+
+    @Test
+    public void testScalaTemporaryFile() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        play.api.libs.Files.TemporaryFile tempFile = play.api.libs.Files.SingletonTemporaryFileCreator$.MODULE$.create("temp", "txt");
+        java.nio.file.Files.write(tempFile.path(), "Twas brillig and the slithy Toves...".getBytes());
+        testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", tempFile)));
+    }
+
+    private void testTemporaryFile(final List<Http.MultipartFormData.FilePart> files) throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        final Map<String, String[]> data = new HashMap<>();
+        data.put("author", new String[]{"Lewis Carrol"});
+
+        Http.RequestBuilder request = new Http.RequestBuilder()
+                .method(POST)
+                .bodyMultipart(data, files)
+                .uri("/multipart-form-data");
+
+        Result result = route(app, request);
+        String content = result.body().consumeData(mat).thenApply(bs -> bs.utf8String()).toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertEquals(OK, result.status());
+        assertEquals("author: Lewis Carrol\n"
+                        + "filename: jabberwocky.txt\n"
+                        + "contentType: text/plain\n"
+                        + "contents: Twas brillig and the slithy Toves...\n",
+                content);
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/test
@@ -1,0 +1,3 @@
+# Run tests
+
+> test

--- a/documentation/manual/working/javaGuide/main/upload/JavaFileUpload.md
+++ b/documentation/manual/working/javaGuide/main/upload/JavaFileUpload.md
@@ -38,7 +38,7 @@ Another way to send files to the server is to use Ajax to upload files asynchron
 
 @[asyncUpload](code/JavaFileUpload.java)
 
-### Writing a custom multipart file part body parser
+## Writing a custom multipart file part body parser
 
 The multipart upload specified by [`MultipartFormData`](api/java/play/mvc/BodyParser.MultipartFormData.html) takes uploaded data from the request and puts into a TemporaryFile object.  It is possible to override this behavior so that `Multipart.FileInfo` information is streamed to another class, using the `DelegatingMultipartFormDataBodyParser` class:
 

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -144,7 +144,7 @@ package scalaguide.upload.fileupload {
 
       def uploadCustom = Action(parse.multipartFormData(handleFilePartAsFile)) { request =>
         val fileOption = request.body.file("name").map {
-          case FilePart(key, filename, contentType, file, fileSize, dispositionType) =>
+          case FilePart(key, filename, contentType, file, fileSize, dispositionType, _) =>
             file.toPath
         }
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -353,6 +353,10 @@ object BuildSettings {
       ProblemFilters.exclude[MissingTypesProblem]("play.core.server.common.WebSocketFlowHandler$RawMessage$"),
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("play.core.server.common.WebSocketFlowHandler#RawMessage.apply"),
+      // Add FilePart.transformRefToBytes() method
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MultipartFormData#FilePart.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MultipartFormData#FilePart.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.MultipartFormData#FilePart.copy"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -283,7 +283,7 @@ trait RouteInvokers extends EssentialActionCaller {
         mpfd.getFiles.asScala.headOption.map(_.getRef) match { // Check first file for type
           case Some(_: JFiles.TemporaryFile) =>
             implicit val write: Writeable[MultipartFormData[JFiles.TemporaryFile]] =
-              Writeable.writeableOf_MultipartFormDataJavaTemporaryFile(implicitly[Codec], r.contentType)
+              Writeable.writeableOf_MultipartFormDataJavaTemporaryFile(implicitly[Codec], r.mediaType.map(_.toString))
             route(
               app,
               r,
@@ -293,7 +293,7 @@ trait RouteInvokers extends EssentialActionCaller {
             )
           case _ => // Matches None and Play Scala's play.api.libs.Files.TemporaryFile
             implicit val write: Writeable[MultipartFormData[Files.TemporaryFile]] =
-              Writeable.writeableOf_MultipartFormData(implicitly[Codec], r.contentType)
+              Writeable.writeableOf_MultipartFormData(implicitly[Codec], r.mediaType.map(_.toString))
             route(
               app,
               r,

--- a/testkit/play-test/src/test/java/play/test/HelpersTest.java
+++ b/testkit/play-test/src/test/java/play/test/HelpersTest.java
@@ -6,11 +6,13 @@ package play.test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static play.test.Helpers.POST;
 
 import akka.actor.ActorSystem;
 import akka.actor.Terminated;
 import akka.stream.Materializer;
 import akka.util.ByteString;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.hamcrest.CoreMatchers;
@@ -140,6 +142,17 @@ public class HelpersTest {
     Http.RequestBuilder request = Helpers.fakeRequest("POST", "/uri");
     Application app = Helpers.fakeApplication();
 
+    Result result = Helpers.route(app, request);
+    assertThat(result.status(), equalTo(404));
+  }
+
+  @Test
+  public void shouldSuccessfullyExecutePostRequestWithMultipartFormData() {
+    Application app = Helpers.fakeApplication();
+    Map<String, String[]> postParams = new java.util.HashMap();
+    postParams.put("key", new String[] {"value"});
+    Http.RequestBuilder request =
+        new Http.RequestBuilder().method(POST).bodyMultipart(postParams, Collections.emptyList());
     Result result = Helpers.route(app, request);
     assertThat(result.status(), equalTo(404));
   }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

## Fixes

Fixes #11496 

## Purpose

Handles the case of multipart form data in the java `Helpers` api so that java based routes and tests that accept multipart form data files can be properly tested.

This is my first contribution here, so interested in feedback on implementation:

- I extracted a `FilePart.asScala()` method to keep the codebase DRY. However this method is now in the public API. Is this acceptable? It seemed somewhat appropriate as there are a bunch of similar methods in the same file for similar classes to convert to scala.
- The different types of generic "files" are still not terribly well handled for multipart form data. Only `MultipartFormData[TemporaryFile]` is handled. The types are cooerced somewhat awkwardly, but seems like there's likely diminishing returns with how many cases should be handled here, and I'm somewhat unclear on whether other types of form data files are even supported? Currently if you send, e.g. a `FilePart[String]` through, there will be another blow up in parsing internals from type casting. I could just ignore cases where the `FilePart` is not matching, and perhaps throw a more descriptive exception at least?
- I added a fairly monstrous test to the Play-Integration-Tests, because I had some general concerns about whether things were actually being serialized correctly. This test creates a temp file, so it may also be somewhat slow. I was basing this behavior off of some of the form tests that do the same. Is this test too much?

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?
