### PR TITLE
Fix #10927 - Add ability to configure a test address to bind

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -61,5 +61,21 @@ trait ServerIntegrationSpecificationSpec
         response.body[String] must_== expectedServerTag.toString
       }
     }
+
+    "run the server on the correct address" in {
+      val original = sys.props.get("testserver.address")
+      try {
+        sys.props += (("testserver.address", "127.0.0.1"))
+        val testServer = TestServer(testServerPort, GuiceApplicationBuilder().routes(httpServerTagRoutes).build())
+        running(testServer) {
+          testServer.runningAddress must_== "127.0.0.1"
+        }
+      } finally {
+        original match {
+          case None      => sys.props -= "testserver.address"
+          case Some(old) => sys.props += (("testserver.address", old))
+        }
+      }
+    }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -28,7 +28,7 @@ Sometimes you want to test the real HTTP stack from within your test, in which c
 
 @[scalafunctionaltest-testpaymentgateway](code/specs2/ScalaFunctionalTestSpec.scala)
 
-The `port` value contains the port number the server is running on.  By default a random port is assigned, however you can change this either by passing the port into [`WithServer`](api/scala/play/api/test/WithServer.html), or by setting the system property `testserver.port`.  This can be useful for integrating with continuous integration servers, so that ports can be dynamically reserved for each build.
+The `port` value contains the port number the server is running on.  By default a random port is assigned, however you can change this either by passing the port into [`WithServer`](api/scala/play/api/test/WithServer.html), or by setting the system property `testserver.port`.  This can be useful for integrating with continuous integration servers, so that ports can be dynamically reserved for each build. You can also configure the address the testserver binds to with the system property `testserver.address`. If unset it uses the play server default of `"0.0.0.0"`.
 
 An application can also be passed to the test server, which is useful for setting up custom routes and testing WS calls:
 

--- a/testkit/play-test/src/main/java/play/test/TestServer.java
+++ b/testkit/play-test/src/main/java/play/test/TestServer.java
@@ -51,7 +51,7 @@ public class TestServer extends play.api.test.TestServer {
         new File("."),
         (Option) OptionConverters.toScala(port),
         (Option) OptionConverters.toScala(sslPort),
-        "0.0.0.0",
+        play.api.test.Helpers.testServerAddress(),
         Mode.TEST.asScala(),
         System.getProperties());
   }

--- a/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -171,9 +171,12 @@ trait PlayRunners extends HttpVerbs {
    * The port to use for a test server. Defaults to a random port. May be configured using the system property
    * testserver.port
    */
-  lazy val testServerPort: Int = sys.props.get("testserver.port").map(_.toInt).getOrElse(0)
+  def testServerPort: Int = sys.props.get("testserver.port").map(_.toInt).getOrElse(0)
 
-  lazy val testServerHttpsPort: Option[Int] = sys.props.get("testserver.httpsport").map(_.toInt)
+  def testServerHttpsPort: Option[Int] = sys.props.get("testserver.httpsport").map(_.toInt)
+
+  def testServerAddress: String =
+    sys.props.get("testserver.address").orElse(sys.env.get("PLAY_TEST_SERVER_HTTP_ADDRESS")).getOrElse("0.0.0.0")
 
   /**
    * Constructs a in-memory (h2) database configuration to add to an Application.

--- a/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -69,6 +69,11 @@ case class TestServer(config: ServerConfig, application: Application, serverProv
   }
 
   /**
+   * The address that the server is running on.
+   */
+  def runningAddress: String = getTestServerIfRunning.mainAddress.getAddress.getHostAddress
+
+  /**
    * The HTTP port that the server is running on.
    */
   def runningHttpPort: Option[Int] = getTestServerIfRunning.httpPort
@@ -101,7 +106,13 @@ object TestServer {
       sslPort: Option[Int] = None,
       serverProvider: Option[ServerProvider] = None
   ) = new TestServer(
-    ServerConfig(port = Some(port), sslPort = sslPort, mode = Mode.Test, rootDir = application.path),
+    ServerConfig(
+      address = Helpers.testServerAddress,
+      port = Some(port),
+      sslPort = sslPort,
+      mode = Mode.Test,
+      rootDir = application.path
+    ),
     application,
     serverProvider
   )

--- a/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServerFactory.scala
@@ -63,6 +63,7 @@ import play.core.server._
 
   protected def serverConfig(app: Application) = {
     val sc = ServerConfig(
+      address = Helpers.testServerAddress,
       port = Some(Helpers.testServerPort),
       sslPort = Helpers.testServerHttpsPort,
       mode = Mode.Test,

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -134,6 +134,37 @@ class HelpersSpec extends Specification {
     }
   }
 
+  def restoringSysProp[T](propName: String)(block: => T): T = {
+    val original = sys.props.get(propName)
+    try {
+      block
+    } finally {
+      original match {
+        case None      => sys.props -= propName
+        case Some(old) => sys.props += ((propName, old))
+      }
+    }
+  }
+
+  "testServerAddress" should {
+
+    "set to 0.0.0.0 by default" in {
+      val addr = restoringSysProp("testserver.address") {
+        sys.props -= "testserver.address"
+        Helpers.testServerAddress
+      }
+      addr mustEqual "0.0.0.0"
+    }
+
+    "be configurable with sys props" in {
+      val addr = restoringSysProp("testserver.address") {
+        sys.props += (("testserver.address", "1.2.3.4"))
+        Helpers.testServerAddress
+      }
+      addr mustEqual "1.2.3.4"
+    }
+  }
+
   "Fakes" in {
     "FakeRequest" should {
       "parse query strings" in {
@@ -190,4 +221,5 @@ class HelpersSpec extends Specification {
       }
     }
   }
+
 }


### PR DESCRIPTION
## Fixes

Fixes #10927. Looks like this had a previous PR that stalled out: https://github.com/playframework/playframework/pull/11179. I cleaned up the remaining work and verified the changes

- rebased and targeted to main
- Fixed compilation issues
- FIxed format issues

Additional changes
-  I modified the values to be `def`s rather than `lazy vals` so that the system property values can more easily be tested and modified programmatically 
- added test coverage
- Updated documentation

## Purpose

Adds ability to specify hostname to bind server to so that test server. This is mainly to serve the use case of having the test server local only.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

