### PR TITLE
Override getOrElseUpdate to set expiration based on value

### DIFF
--- a/cache/play-cache/src/main/java/play/cache/AsyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/AsyncCacheApi.java
@@ -7,6 +7,7 @@ package play.cache;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.Done;
 
 /** The Cache API. */
@@ -52,6 +53,18 @@ public interface AsyncCacheApi {
    */
   <T> CompletionStage<T> getOrElseUpdate(
       String key, Callable<CompletionStage<T>> block, int expiration);
+
+  /**
+   * Retrieve a value from the cache, or set it from a default Callable function.
+   *
+   * @param <T> the type of the value
+   * @param key Item key.
+   * @param block block returning value to set if key does not exist
+   * @param expiration function that returns expiration period in seconds.
+   * @return a CompletionStage containing the value
+   */
+  <T> CompletionStage<T> getOrElseUpdate(
+      String key, Callable<CompletionStage<T>> block, Function<T, Integer> expiration);
 
   /**
    * Retrieve a value from the cache, or set it from a default Callable function.

--- a/cache/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/DefaultAsyncCacheApi.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.apache.pekko.Done;
 import play.libs.Scala;
 import scala.concurrent.duration.Duration;
@@ -47,6 +48,17 @@ public class DefaultAsyncCacheApi implements AsyncCacheApi {
     return asJava(
         asyncCacheApi.getOrElseUpdate(
             key, intToDuration(expiration), Scala.asScalaWithFuture(block), Scala.<T>classTag()));
+  }
+
+  @Override
+  public <T> CompletionStage<T> getOrElseUpdate(
+      String key, Callable<CompletionStage<T>> block, Function<T, Integer> expiration) {
+    return asJava(
+        asyncCacheApi.getOrElseUpdate(
+            key,
+            value -> intToDuration(expiration.apply(value)),
+            Scala.asScalaWithFuture(block),
+            Scala.<T>classTag()));
   }
 
   @Override

--- a/cache/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 /**
  * An implementation of SyncCacheApi that wraps AsyncCacheApi
@@ -39,6 +40,13 @@ public class DefaultSyncCacheApi implements SyncCacheApi {
 
   @Override
   public <T> T getOrElseUpdate(String key, Callable<T> block, int expiration) {
+    return blocking(
+        cacheApi.getOrElseUpdate(
+            key, () -> CompletableFuture.completedFuture(block.call()), expiration));
+  }
+
+  @Override
+  public <T> T getOrElseUpdate(String key, Callable<T> block, Function<T, Integer> expiration) {
     return blocking(
         cacheApi.getOrElseUpdate(
             key, () -> CompletableFuture.completedFuture(block.call()), expiration));

--- a/cache/play-cache/src/main/java/play/cache/SyncCacheApi.java
+++ b/cache/play-cache/src/main/java/play/cache/SyncCacheApi.java
@@ -6,6 +6,7 @@ package play.cache;
 
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 
 /** A synchronous API to access a Cache. */
 public interface SyncCacheApi {
@@ -41,6 +42,17 @@ public interface SyncCacheApi {
    * @return the value
    */
   <T> T getOrElseUpdate(String key, Callable<T> block, int expiration);
+
+  /**
+   * Retrieve a value from the cache, or set it from a default Callable function.
+   *
+   * @param <T> the type of the value
+   * @param key Item key.
+   * @param block block returning value to set if key does not exist
+   * @param expiration function that returns expiration period in seconds.
+   * @return the value
+   */
+  <T> T getOrElseUpdate(String key, Callable<T> block, Function<T, Integer> expiration);
 
   /**
    * Retrieve a value from the cache, or set it from a default Callable function.

--- a/cache/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
+++ b/cache/play-cache/src/main/java/play/cache/SyncCacheApiAdapter.java
@@ -9,6 +9,7 @@ import static scala.jdk.javaapi.OptionConverters.toJava;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import play.libs.Scala;
 import scala.concurrent.duration.Duration;
 
@@ -30,6 +31,15 @@ public class SyncCacheApiAdapter implements SyncCacheApi {
   public <T> T getOrElseUpdate(String key, Callable<T> block, int expiration) {
     return scalaApi.getOrElseUpdate(
         key, intToDuration(expiration), Scala.asScala(block), Scala.classTag());
+  }
+
+  @Override
+  public <T> T getOrElseUpdate(String key, Callable<T> block, Function<T, Integer> expiration) {
+    return scalaApi.getOrElseUpdate(
+        key,
+        value -> intToDuration(expiration.apply(value)),
+        Scala.asScala(block),
+        Scala.classTag());
   }
 
   @Override

--- a/cache/play-cache/src/main/scala/play/api/cache/AsyncCacheApi.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/AsyncCacheApi.scala
@@ -44,6 +44,15 @@ trait AsyncCacheApi {
   def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration = Duration.Inf)(orElse: => Future[A]): Future[A]
 
   /**
+   * Retrieve a value from the cache, or set it from a default function.
+   *
+   * @param key        Item key.
+   * @param expiration Function that returns the expiration period in seconds.
+   * @param orElse     The default function to invoke if the value was not found in cache.
+   */
+  def getOrElseUpdate[A: ClassTag](key: String, expiration: A => Duration)(orElse: => Future[A]): Future[A]
+
+  /**
    * Retrieve a value from the cache for the given type
    *
    * @param key Item key.

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -188,6 +188,7 @@ class SyncCaffeineCacheApi @Inject() (val cache: NamedCaffeineCache[Any, Any]) e
 
   override def set(key: String, value: Any, expiration: Duration): Unit = {
     if (!expiration.isFinite || !expiration.lteq(0.seconds)) {
+      // Cache only if expiration is greater than 0 (0 and below won't cache)
       syncCache.put(key, ExpirableCacheValue(value, Some(expiration)))
     }
     Done

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.Executor
 import javax.cache.CacheException
 
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.FutureConverters._
@@ -186,7 +187,9 @@ class SyncCaffeineCacheApi @Inject() (val cache: NamedCaffeineCache[Any, Any]) e
   private val syncCache: Cache[Any, Any] = cache.synchronous()
 
   override def set(key: String, value: Any, expiration: Duration): Unit = {
-    syncCache.put(key, ExpirableCacheValue(value, Some(expiration)))
+    if (!expiration.isFinite || !expiration.lteq(0.seconds)) {
+      syncCache.put(key, ExpirableCacheValue(value, Some(expiration)))
+    }
     Done
   }
 

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -200,6 +200,13 @@ class SyncCaffeineCacheApi @Inject() (val cache: NamedCaffeineCache[Any, Any]) e
     syncCache.get(key, _ => ExpirableCacheValue(orElse, Some(expiration))).asInstanceOf[ExpirableCacheValue[A]].value
   }
 
+  override def getOrElseUpdate[A: ClassTag](key: String, expiration: A => Duration)(orElse: => A): A = {
+    syncCache
+      .get(key, xx => ExpirableCacheValue(orElse, Some(expiration(orElse))))
+      .asInstanceOf[ExpirableCacheValue[A]]
+      .value
+  }
+
   override def get[T](key: String)(implicit ct: ClassTag[T]): Option[T] = {
     Option(syncCache.getIfPresent(key).asInstanceOf[ExpirableCacheValue[T]])
       .filter { v =>
@@ -234,10 +241,13 @@ class CaffeineCacheApi @Inject() (val cache: NamedCaffeineCache[Any, Any]) exten
     Future.successful(Done)
   }
 
-  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] = {
+  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] =
+    getOrElseUpdate[A](key, (_: A) => expiration)(orElse)
+
+  def getOrElseUpdate[A: ClassTag](key: String, expiration: A => Duration)(orElse: => Future[A]): Future[A] = {
     lazy val orElseAsJavaFuture =
       orElse
-        .map(ExpirableCacheValue(_, Some(expiration)).asInstanceOf[Any])(using trampoline)
+        .map(value => ExpirableCacheValue(value, Some(expiration(value))).asInstanceOf[Any])(using trampoline)
         .asJava
         .toCompletableFuture
 

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
@@ -31,7 +31,7 @@ private[caffeine] class DefaultCaffeineExpiry extends Expiry[String, ExpirableCa
 
   private def calculateExpirationTime(durationMaybe: Option[Duration]): Long = {
     durationMaybe match {
-      case Some(duration) if duration.isFinite && duration.lteq(0.second) => 1.second.toNanos
+      case Some(duration) if duration.isFinite && duration.lteq(0.second) => 0.seconds.toNanos
       case Some(duration) if duration.isFinite                            => duration.toNanos
       case _                                                              => Long.MaxValue
     }

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
@@ -31,9 +31,10 @@ private[caffeine] class DefaultCaffeineExpiry extends Expiry[String, ExpirableCa
 
   private def calculateExpirationTime(durationMaybe: Option[Duration]): Long = {
     durationMaybe match {
-      case Some(duration) if duration.isFinite && duration.lteq(0.second) => 0.seconds.toNanos
-      case Some(duration) if duration.isFinite                            => duration.toNanos
-      case _                                                              => Long.MaxValue
+      case Some(duration) if duration.isFinite && duration.lteq(0.second) =>
+        0.seconds.toNanos // Will always end up in a cache miss, so this equals to not caching at all: https://github.com/ben-manes/caffeine/discussions/803
+      case Some(duration) if duration.isFinite => duration.toNanos
+      case _                                   => Long.MaxValue
     }
   }
 }

--- a/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -220,6 +220,16 @@ class SyncEhCacheApi @Inject() (private[ehcache] val cache: Ehcache) extends Syn
     }
   }
 
+  override def getOrElseUpdate[A: ClassTag](key: String, expiration: A => Duration)(orElse: => A): A = {
+    get[A](key) match {
+      case Some(value) => value
+      case None =>
+        val value = orElse
+        set(key, value, expiration(value))
+        value
+    }
+  }
+
   override def get[T](key: String)(implicit ct: ClassTag[T]): Option[T] = {
     Option(cache.get(key))
       .map(_.getObjectValue)
@@ -252,10 +262,13 @@ class EhCacheApi @Inject() (private[ehcache] val cache: Ehcache)(implicit contex
     Done
   }
 
-  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] = {
+  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] =
+    getOrElseUpdate[A](key, (_: A) => expiration)(orElse)
+
+  override def getOrElseUpdate[A: ClassTag](key: String, expiration: A => Duration)(orElse: => Future[A]): Future[A] = {
     get[A](key).flatMap {
       case Some(value) => Future.successful(value)
-      case None        => orElse.flatMap(value => set(key, value, expiration).map(_ => value))
+      case None        => orElse.flatMap(value => set(key, value, expiration(value)).map(_ => value))
     }
   }
 

--- a/core/play-integration-test/src/test/scala/play/it/http/JavaCachedActionSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/JavaCachedActionSpec.scala
@@ -151,10 +151,13 @@ class TestAsyncCacheApi(cache: Cache[String, Object])(implicit context: Executio
     Done
   }
 
-  override def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] = {
+  override def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] =
+    getOrElseUpdate[A](key, (_: A) => expiration)(orElse)
+
+  override def getOrElseUpdate[A: ClassTag](key: String, expiration: A => Duration)(orElse: => Future[A]): Future[A] = {
     get[A](key).flatMap {
       case Some(value) => Future.successful(value)
-      case None        => orElse.flatMap(value => set(key, value, expiration).map(_ => value))
+      case None        => orElse.flatMap(value => set(key, value, expiration(value)).map(_ => value))
     }
   }
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -553,6 +553,27 @@ object BuildSettings {
       // Make Java's Formatters.print(TypeDescriptor desc, ...) package private to hide spring implementation
       // (It leaks the now internal play.data.internal.binding.core.convert.TypeDescriptor)
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.data.format.Formatters.print"),
+      // Variable substitution in evolutions scripts
+      ProblemFilters
+        .exclude[ReversedMissingMethodProblem]("play.api.db.evolutions.EvolutionsDatasourceConfig.substitutionsSuffix"),
+      ProblemFilters
+        .exclude[ReversedMissingMethodProblem]("play.api.db.evolutions.EvolutionsDatasourceConfig.substitutionsPrefix"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "play.api.db.evolutions.EvolutionsDatasourceConfig.substitutionsMappings"
+      ),
+      ProblemFilters
+        .exclude[ReversedMissingMethodProblem]("play.api.db.evolutions.EvolutionsDatasourceConfig.substitutionsEscape"),
+      // Remove routeAndCall(...) methods that depended on StaticRoutesGenerator
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.test.Helpers.routeAndCall"),
+      // Remove CrossScala (parent class of play.libs.Scala)
+      ProblemFilters.exclude[MissingTypesProblem]("play.libs.Scala"),
+      // Renaming clearLang to withoutLang
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.i18n.MessagesApi.withoutLang"),
+      // Override getOrElseUpdate to set expiration based on value
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.cache.AsyncCacheApi.getOrElseUpdate"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.cache.SyncCacheApi.getOrElseUpdate"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.AsyncCacheApi.getOrElseUpdate"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.cache.SyncCacheApi.getOrElseUpdate"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
WIP, don't review yet.

Allows more flexibility. IMHO there are cases when it makes sense to set the expiration date based on the "new" value that was just calculated. Makes it possible to fix #11506 (I am not saying there are no other ways to fix that problem, even if so this pull request on it's on does make some sense IMHO)
