### PR TITLE
Scalafmt3

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,5 @@
 e7923768a51fd30e549572c57506f2387b5337d4
 # Upgrade Scalafmt to 2.7.x
 20e0e98f709e90116a29b671d675b03c39db832d
+# Upgrade Scalafmt to 3.x
+87bcdac6fd18ec4a0de058fd3da1458334e1d209

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,12 +2,15 @@
 # Keep this in sync with documentation/.scalafmt.conf
 runner.dialect = scala212
 align.preset = true
+align.allowOverflow = true
 assumeStandardLibraryStripMargin = true
 danglingParentheses.preset = true
 newlines.alwaysBeforeMultilineDef = false
 newlines.implicitParamListModifierPrefer = before
 newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
-docstrings = JavaDoc
+newlines.inInterpolation = "avoid"
+docstrings.style = Asterisk
+docstrings.wrap = no
 maxColumn = 120
 project.excludeFilters += core/play/src/main/scala/play/core/hidden/ObjectMappings.scala
 project.git = true
@@ -15,4 +18,4 @@ rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifi
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
-version = 2.7.5
+version = 3.7.1

--- a/build.sbt
+++ b/build.sbt
@@ -65,8 +65,8 @@ lazy val PlayExceptionsProject = PlayNonCrossBuiltProject("Play-Exceptions", "co
 lazy val billOfMaterials = PlayCrossBuiltProject("bill-of-materials", "dev-mode/bill-of-materials")
   .enablePlugins(BillOfMaterialsPlugin)
   .settings(
-    name := "play-bom",
-    bomIncludeProjects := userProjects,
+    name                  := "play-bom",
+    bomIncludeProjects    := userProjects,
     mimaPreviousArtifacts := Set.empty
   )
 
@@ -266,7 +266,7 @@ lazy val PlayConfiguration = PlayCrossBuiltProject("Play-Configuration", "core/p
   .settings(
     libraryDependencies ++= Seq(typesafeConfig, slf4jApi) ++ specs2Deps.map(_ % Test),
     (Test / parallelExecution) := false,
-    mimaPreviousArtifacts := Set.empty,
+    mimaPreviousArtifacts      := Set.empty,
     // quieten deprecation warnings in tests
     (Test / scalacOptions) := (Test / scalacOptions).value.diff(Seq("-deprecation"))
   )
@@ -326,10 +326,10 @@ lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Te
     inConfig(IntegrationTest)(ScalafmtPlugin.scalafmtConfigSettings),
     headerSettings(IntegrationTest),
     inConfig(IntegrationTest)(JavaFormatterPlugin.toBeScopedSettings),
-    libraryDependencies += okHttp % IntegrationTest,
+    libraryDependencies += okHttp          % IntegrationTest,
     (IntegrationTest / parallelExecution) := false,
-    mimaPreviousArtifacts := Set.empty,
-    (IntegrationTest / fork) := true,
+    mimaPreviousArtifacts                 := Set.empty,
+    (IntegrationTest / fork)              := true,
     (IntegrationTest / javaOptions) += "-Dfile.encoding=UTF8",
   )
   .dependsOn(
@@ -359,12 +359,12 @@ lazy val PlayMicrobenchmarkProject = PlayCrossBuiltProject("Play-Microbenchmark"
     // we need to put our JMH sources into src/test so they can pick
     // up the integration test files.
     // See: https://github.com/ktoso/sbt-jmh/pull/73#issue-163891528
-    (Jmh / classDirectory) := (Test / classDirectory).value,
-    (Jmh / dependencyClasspath) := (Test / dependencyClasspath).value,
-    (Jmh / generateJmhSourcesAndResources) := (Jmh / generateJmhSourcesAndResources).dependsOn((Test / compile)).value,
-    (Jmh / run / mainClass) := Some("org.openjdk.jmh.Main"),
-    (Test / parallelExecution) := false,
-    mimaPreviousArtifacts := Set.empty
+    (Jmh / classDirectory)                 := (Test / classDirectory).value,
+    (Jmh / dependencyClasspath)            := (Test / dependencyClasspath).value,
+    (Jmh / generateJmhSourcesAndResources) := (Jmh / generateJmhSourcesAndResources).dependsOn(Test / compile).value,
+    (Jmh / run / mainClass)                := Some("org.openjdk.jmh.Main"),
+    (Test / parallelExecution)             := false,
+    mimaPreviousArtifacts                  := Set.empty
   )
   .dependsOn(
     PlayProject                % "test->test",
@@ -484,14 +484,14 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
   .enablePlugins(PlayRootProject)
   .settings(
     playCommonSettings,
-    scalaVersion := (PlayProject / scalaVersion).value,
-    crossScalaVersions := Nil,
+    scalaVersion                    := (PlayProject / scalaVersion).value,
+    crossScalaVersions              := Nil,
     (ThisBuild / playBuildRepoName) := "playframework",
     (Global / concurrentRestrictions) += Tags.limit(Tags.Test, 1),
     libraryDependencies ++= (runtime(scalaVersion.value) ++ jdbcDeps),
-    Docs.apiDocsInclude := false,
+    Docs.apiDocsInclude        := false,
     Docs.apiDocsIncludeManaged := false,
-    mimaReportBinaryIssues := (()),
+    mimaReportBinaryIssues     := (()),
     commands += Commands.quickPublish,
     publish / skip := true,
     (Compile / headerSources) ++=

--- a/cache/play-cache/src/main/scala/play/api/cache/Cached.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/Cached.scala
@@ -262,7 +262,7 @@ final class CachedBuilder(
    * The returned cache will store all responses whatever they may contain
    * @param duration how long we should store responses
    */
-  def default(duration: Duration): CachedBuilder = compose({ case _: ResponseHeader => duration })
+  def default(duration: Duration): CachedBuilder = compose { case _: ResponseHeader => duration }
 
   /**
    * The returned cache will store all responses whatever they may contain

--- a/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -100,7 +100,7 @@ class CachedSpec extends PlaySpecification {
     "cache values using Application's Cached" in new WithApplication() {
       val invoked = new AtomicInteger()
       val action = cached(app)(_ => "foo") {
-        (Action(Results.Ok("" + invoked.incrementAndGet())))
+        Action(Results.Ok("" + invoked.incrementAndGet()))
       }
       val result1 = action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
@@ -122,7 +122,7 @@ class CachedSpec extends PlaySpecification {
       status(result1) must_== 200
       invoked.get() must_== 1
       val etag = header(ETAG, result1)
-      etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) //"""
+      etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) // """
       val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run()
       status(result2) must_== NOT_MODIFIED
       invoked.get() must_== 1
@@ -146,7 +146,7 @@ class CachedSpec extends PlaySpecification {
       status(result1) must_== 200
       invoked.get() must_== 1
       val etag = header(ETAG, result1).map("W/" + _)
-      etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) //"""
+      etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) // """
       val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run()
       status(result2) must_== NOT_MODIFIED
       invoked.get() must_== 1
@@ -243,8 +243,8 @@ class CachedSpec extends PlaySpecification {
         Duration(target - now, MILLISECONDS)
       }
 
-      res0.map(toDuration) must beSome(beBetween((duration - 10.seconds), duration))
-      res1.map(toDuration) must beSome(beBetween((duration - 10.seconds), duration))
+      res0.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
+      res1.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
     }
 
     "cache 200 OK results for a given duration" in new WithApplication {
@@ -263,7 +263,7 @@ class CachedSpec extends PlaySpecification {
         Duration(target - now, MILLISECONDS)
       }
 
-      res0.map(toDuration) must beSome(beBetween((duration - 10.seconds), duration))
+      res0.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
       res1.map(toDuration) must beNone
     }
   }

--- a/core/play-integration-test/src/it/scala/play/it/http/AkkaRequestTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/AkkaRequestTimeoutSpec.scala
@@ -40,9 +40,9 @@ class AkkaRequestTimeoutSpec extends PlaySpecification with AkkaHttpIntegrationS
         play.api.test.TestServer(
           config = serverConfig,
           application = new GuiceApplicationBuilder()
-            .routes({
+            .routes {
               case _ => action
-            })
+            }
             .build(),
           serverProvider = Some(integrationServerProvider)
         )

--- a/core/play-integration-test/src/it/scala/play/it/http/HttpErrorHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/HttpErrorHandlingSpec.scala
@@ -103,8 +103,8 @@ class HttpErrorHandlingSpec
         override def reload(): AnyRef                                            = null
         override def findSource(className: String, line: Integer): Array[AnyRef] = null
         override def projectPath(): File                                         = new File("").getAbsoluteFile
-        override def forceReload(): Unit = { /* do nothing */ }
-        override def settings(): util.Map[String, String] = util.Collections.emptyMap()
+        override def forceReload(): Unit                                         = { /* do nothing */ }
+        override def settings(): util.Map[String, String]                        = util.Collections.emptyMap()
       }
 
       val devSourceMapper = new SourceMapper {

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
@@ -66,7 +66,7 @@ class JavaHttpErrorHandlingSpec
 
         //  Config config, Environment environment, OptionalSourceMapper sourceMapper, Provider<Router> routes
         override def httpErrorHandler(): HttpErrorHandler = {
-          val mapper = (applicationContext.devContext()).map(_.sourceMapper).toScala
+          val mapper = applicationContext.devContext().map(_.sourceMapper).toScala
 
           val routesProvider: Provider[play.api.routing.Router] = new Provider[play.api.routing.Router] {
             override def get(): play.api.routing.Router = router().asScala()
@@ -150,8 +150,8 @@ class JavaHttpErrorHandlingSpec
         override def reload(): AnyRef                                            = null
         override def findSource(className: String, line: Integer): Array[AnyRef] = null
         override def projectPath(): File                                         = new File("").getAbsoluteFile
-        override def forceReload(): Unit = { /* do nothing */ }
-        override def settings(): util.Map[String, String] = util.Collections.emptyMap()
+        override def forceReload(): Unit                                         = { /* do nothing */ }
+        override def settings(): util.Map[String, String]                        = util.Collections.emptyMap()
       }
 
       val devSourceMapper = new SourceMapper {

--- a/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -129,12 +129,14 @@ trait ScalaResultsHandlingSpec
       implicit val fileMimeTypes = new FileMimeTypes {
         override def forFileName(name: String): Option[String] = Some("text/plain")
       }
-      try makeRequest(
-        Results.Ok.sendPath(emptyPath)
-      ) { response =>
-        response.status must_== 200
-        response.header(CONTENT_LENGTH) must beSome("0")
-      } finally JFiles.delete(emptyPath)
+      try
+        makeRequest(
+          Results.Ok.sendPath(emptyPath)
+        ) { response =>
+          response.status must_== 200
+          response.header(CONTENT_LENGTH) must beSome("0")
+        }
+      finally JFiles.delete(emptyPath)
     }
 
     "not add a content length header when none is supplied" in makeRequest(

--- a/core/play-integration-test/src/it/scala/play/it/http/assets/AssetsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/assets/AssetsSpec.scala
@@ -275,7 +275,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
       )
 
       result.header(VARY) must beSome(ACCEPT_ENCODING)
-      //result.header(CONTENT_ENCODING) must beSome("gzip")
+      // result.header(CONTENT_ENCODING) must beSome("gzip")
       val ahcResult: play.shaded.ahc.org.asynchttpclient.Response =
         result.underlying.asInstanceOf[play.shaded.ahc.org.asynchttpclient.Response]
       val is = new ByteArrayInputStream(ahcResult.getResponseBodyAsBytes)

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -176,44 +176,44 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
         }
         parts.badParts must haveLength(5)
         parts.badParts must contain(
-          (BadPart(
+          BadPart(
             Map(
               "content-disposition" -> """form-data; name="file4"; filename=""""",
               "content-type"        -> "application/octet-stream"
             )
-          ))
+          )
         )
         parts.badParts must contain(
-          (BadPart(
+          BadPart(
             Map(
               "content-disposition" -> """form-data; name="file5"; filename=""",
               "content-type"        -> "application/octet-stream"
             )
-          ))
+          )
         )
         parts.badParts must contain(
-          (BadPart(
+          BadPart(
             Map(
               "content-disposition" -> """form-data; name="empty_file_middle"; filename="empty_file_followed_by_other_part.txt"""",
               "content-type"        -> "text/plain"
             )
-          ))
+          )
         )
         parts.badParts must contain(
-          (BadPart(
+          BadPart(
             Map(
               "content-disposition" -> """form-data; name="empty_file_empty_filename"; filename=""""",
               "content-type"        -> "application/octet-stream"
             )
-          ))
+          )
         )
         parts.badParts must contain(
-          (BadPart(
+          BadPart(
             Map(
               "content-disposition" -> """form-data; name="empty_file_bottom"; filename="empty_file_not_followed_by_any_other_part.txt"""",
               "content-type"        -> "text/plain"
             )
-          ))
+          )
         )
     }
   }

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -148,7 +148,7 @@ class XmlBodyParserSpec extends PlaySpecification {
 
     "gracefully fail when there are too many nested entities" in new WithApplication() {
       val nested = for (x <- 1 to 30) yield "<!ENTITY laugh" + x + " \"&laugh" + (x - 1) + ";&laugh" + (x - 1) + ";\">"
-      val xml    = s"""<?xml version="1.0"?>
+      val xml = s"""<?xml version="1.0"?>
                    | <!DOCTYPE billion [
                    | <!ELEMENT billion (#PCDATA)>
                    | <!ENTITY laugh0 "ha">
@@ -162,7 +162,7 @@ class XmlBodyParserSpec extends PlaySpecification {
     "gracefully fail when an entity expands to be very large" in new WithApplication() {
       val as       = "a" * 50000
       val entities = "&a;" * 50000
-      val xml      = s"""<?xml version="1.0"?>
+      val xml = s"""<?xml version="1.0"?>
                    | <!DOCTYPE kaboom [
                    | <!ENTITY a "$as">
                    | ]>

--- a/core/play-integration-test/src/it/scala/play/it/libs/json/JavaJsonSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/json/JavaJsonSpec.scala
@@ -280,8 +280,8 @@ class Address(var city: String, var street: String) {
   override def equals(other: Any): Boolean = other match {
     case that: Address =>
       (that.canEqual(this)) &&
-        city == that.city &&
-        street == that.street
+      city == that.city &&
+      street == that.street
     case _ => false
   }
   override def hashCode(): Int = {
@@ -297,8 +297,8 @@ class Customer(var code: String) {
   override def equals(other: Any): Boolean = other match {
     case that: Customer =>
       (that.canEqual(this)) &&
-        code == that.code &&
-        address == that.address
+      code == that.code &&
+      address == that.address
     case _ => false
   }
   override def hashCode(): Int = {
@@ -315,8 +315,8 @@ class ShoppingCart(var id: String, @JsonRawValue var contents: String) {
   override def equals(other: Any): Boolean = other match {
     case that: ShoppingCart =>
       (that.canEqual(this)) &&
-        id == that.id &&
-        contents == that.contents
+      id == that.id &&
+      contents == that.contents
     case _ => false
   }
   override def hashCode(): Int = {

--- a/core/play-java/src/test/scala/play/libs/XPathSpec.scala
+++ b/core/play-java/src/test/scala/play/libs/XPathSpec.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable.Specification
 import scala.jdk.CollectionConverters._
 
 class XPathSpec extends Specification {
-  //XPathFactory.newInstance() used internally by XPath is not thread safe so forcing sequential execution
+  // XPathFactory.newInstance() used internally by XPath is not thread safe so forcing sequential execution
   sequential
 
   val xmlWithNamespace =

--- a/core/play/src/main/scala/play/api/Play.scala
+++ b/core/play/src/main/scala/play/api/Play.scala
@@ -97,10 +97,12 @@ object Play {
     // Set the current app if the global application is enabled
     // Also set it if the current app is null, in order to display more useful errors if we try to use the app
     if (globalApp) {
-      logger.warn(s"""
-                     |You are using the deprecated global state to set and access the current running application. If you
-                     |need an instance of Application, set $GlobalAppConfigKey = false and use Dependency Injection instead.
-        """.stripMargin)
+      logger.warn(
+        s"""
+           |You are using the deprecated global state to set and access the current running application. If you
+           |need an instance of Application, set $GlobalAppConfigKey = false and use Dependency Injection instead.
+        """.stripMargin
+      )
       _currentApp.set(app)
 
       // It's possible to stop the Application using Coordinated Shutdown, when that happens the Application

--- a/core/play/src/main/scala/play/api/data/format/Format.scala
+++ b/core/play/src/main/scala/play/api/data/format/Format.scala
@@ -154,13 +154,13 @@ object Formats {
           .either {
             val bd = BigDecimal(s)
             precision
-              .map({
+              .map {
                 case (p, s) =>
                   if (bd.precision - bd.scale > p - s) {
                     throw new java.lang.ArithmeticException("Invalid precision")
                   }
                   bd.setScale(s)
-              })
+              }
               .getOrElse(bd)
           }
           .left

--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -162,7 +162,7 @@ trait DefaultWriteables extends LowPriorityWriteables {
           case (name, values) =>
             values.map { value =>
               s"""--$resolvedBoundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name="${Multipart
-                .escapeParamWithHTML5Strategy(name)}"\r\n\r\n$value\r\n"""
+                  .escapeParamWithHTML5Strategy(name)}"\r\n\r\n$value\r\n"""
             }
         }
         .mkString("")

--- a/core/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/core/play/src/main/scala/play/api/i18n/Messages.scala
@@ -118,7 +118,7 @@ object Messages extends MessagesImplicits {
   private[i18n] class MessagesParser(messageSource: MessageSource, messageSourceName: String) extends RegexParsers {
     override val whiteSpace = """^[ \t]+""".r
     val end                 = """^\s*""".r
-    val newLine             = namedError((("\r".?) ~> "\n"), "End of line expected")
+    val newLine             = namedError(("\r".?) ~> "\n", "End of line expected")
     val ignoreWhiteSpace    = opt(whiteSpace)
     val blankLine           = ignoreWhiteSpace <~ newLine ^^ (_ => Comment(""))
     val comment             = """^#.*""".r ^^ (s => Comment(s))

--- a/core/play/src/main/scala/play/api/inject/Binding.scala
+++ b/core/play/src/main/scala/play/api/inject/Binding.scala
@@ -262,8 +262,8 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
       throw new PlayException(
         "Cannot bind abstract target",
         s"""You have attempted to bind $target as a construction target for $this, however, $target is abstract. If you wish to bind this as an alias, bind it to a ${classOf[
-          BindingKey[_]
-        ]} instead."""
+            BindingKey[_]
+          ]} instead."""
       )
     }
     target

--- a/core/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/core/play/src/main/scala/play/api/libs/EventSource.scala
@@ -56,9 +56,9 @@ object EventSource {
     Flow[E].map(Event(_))
   }
 
-  //------------------
+  // ------------------
   // Event
-  //------------------
+  // ------------------
 
   /**
    * An event encoded with the SSE protocol..
@@ -106,9 +106,9 @@ object EventSource {
     }
   }
 
-  //------------------
+  // ------------------
   // Event Data Extractor
-  //------------------
+  // ------------------
 
   case class EventDataExtractor[A](eventData: A => String)
 
@@ -120,9 +120,9 @@ object EventSource {
 
   object EventDataExtractor extends LowPriorityEventEncoder
 
-  //------------------
+  // ------------------
   // Event ID Extractor
-  //------------------
+  // ------------------
 
   case class EventIdExtractor[E](eventId: E => Option[String])
 
@@ -132,9 +132,9 @@ object EventSource {
 
   object EventIdExtractor extends LowPriorityEventIdExtractor
 
-  //------------------
+  // ------------------
   // Event Name Extractor
-  //------------------
+  // ------------------
 
   case class EventNameExtractor[E](eventName: E => Option[String])
 

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -102,9 +102,10 @@ object Files {
      */
     def copyTo(to: Path, replace: Boolean): Path = {
       val destination =
-        try if (replace) JFiles.copy(path, to, StandardCopyOption.REPLACE_EXISTING)
-        else if (!to.toFile.exists()) JFiles.copy(path, to)
-        else to
+        try
+          if (replace) JFiles.copy(path, to, StandardCopyOption.REPLACE_EXISTING)
+          else if (!to.toFile.exists()) JFiles.copy(path, to)
+          else to
         catch {
           case _: FileAlreadyExistsException => to
         }

--- a/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
@@ -41,8 +41,8 @@ trait RemoteConnection {
   override def equals(obj: scala.Any): Boolean = obj match {
     case that: RemoteConnection =>
       (this.remoteAddress == that.remoteAddress) &&
-        (this.secure == that.secure) &&
-        (this.clientCertificateChain == that.clientCertificateChain)
+      (this.secure == that.secure) &&
+      (this.clientCertificateChain == that.clientCertificateChain)
     case _ => false
   }
 }

--- a/core/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
+++ b/core/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
@@ -59,8 +59,8 @@ object JavaScriptReverseRouter {
          |var _qS = function(items){var qs = ''; for(var i=0;i<items.length;i++) {if(items[i]) qs += (qs ? '&' : '') + items[i]}; return qs ? ('?' + qs) : ''}
          |var _s = function(p,s){return p+((s===true||(s&&s.secure))?'s':'')+'://'}
          |var _wA = function(r){return {$ajaxField method:r.method,type:r.method,url:r.url,absoluteURL: function(s){return _s('http',s)+'${esc(
-        host
-      )}'+r.url},webSocketURL: function(s){return _s('ws',s)+'${esc(host)}'+r.url}}}
+          host
+        )}'+r.url},webSocketURL: function(s){return _s('ws',s)+'${esc(host)}'+r.url}}}
          |$routesStr
          |})($name)
     """.stripMargin.trim

--- a/core/play/src/main/scala/play/api/templates/Templates.scala
+++ b/core/play/src/main/scala/play/api/templates/Templates.scala
@@ -25,10 +25,10 @@ object PlayMagic {
   def toHtmlArgs(args: Map[Symbol, Any]) =
     Html(
       args
-        .map({
+        .map {
           case (s, None) => s.name
           case (s, v)    => s.name + "=\"" + play.twirl.api.HtmlFormat.escape(v.toString).body + "\""
-        })
+        }
         .mkString(" ")
     )
 

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -161,7 +161,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
       logger.debug("### Start of action order")
       actionChain
         .zip(LazyList.from(1))
-        .foreach({
+        .foreach {
           case (action, index) =>
             logger.debug(
               s"${index}. ${action.getClass.getName}" +
@@ -169,7 +169,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
                    s" defined on ${action.annotatedElement}"
                  })
             )
-        })
+        }
       logger.debug("### End of action order")
     }
     val actionFuture: Future[Future[JResult]] = Future {

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -242,9 +242,9 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def hasBody: Boolean = header.hasBody
 
-  override def contentType(): Optional[String] = (header.contentType).toJava
+  override def contentType(): Optional[String] = header.contentType.toJava
 
-  override def charset(): Optional[String] = (header.charset).toJava
+  override def charset(): Optional[String] = header.charset.toJava
 
   override def withTransientLang(lang: play.i18n.Lang): JRequestHeader = addAttr(i18n.Messages.Attrs.CurrentLang, lang)
 

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -109,7 +109,7 @@ abstract class GeneratedRouter extends Router {
     pa.value.fold(badRequest, generator)
   }
 
-  //Keep the old versions for avoiding compiler failures while building for Scala 2.10,
+  // Keep the old versions for avoiding compiler failures while building for Scala 2.10,
   // and for avoiding warnings when building for newer Scala versions
   // format: off
   def call[A1, A2](pa1: Param[A1], pa2: Param[A2])(generator: Function2[A1, A2, Handler]): Handler = {

--- a/core/play/src/main/scala/play/core/utils/AsciiSet.scala
+++ b/core/play/src/main/scala/play/core/utils/AsciiSet.scala
@@ -51,7 +51,7 @@ trait AsciiSet {
   /** Convert into an [[AsciiBitSet]] for fast querying. */
   def toBitSet: AsciiBitSet = {
     val bitSet = new JBitSet(256)
-    for (i <- (0 until 256)) {
+    for (i <- 0 until 256) {
       if (this.getInternal(i)) {
         bitSet.set(i)
       }

--- a/core/play/src/main/scala/play/core/utils/HttpHeaderEncoding.scala
+++ b/core/play/src/main/scala/play/core/utils/HttpHeaderEncoding.scala
@@ -132,7 +132,7 @@ private[play] object HttpHeaderParameterEncoding {
     // - https://tools.ietf.org/html/rfc6266#section-4.3 (for Content-Disposition filename parameter)
 
     if (hasExtendedChars) {
-      def hexDigit(x: Int): Char = (if (x < 10) (x + '0') else (x - 10 + 'a')).toChar
+      def hexDigit(x: Int): Char = (if (x < 10) x + '0' else x - 10 + 'a').toChar
 
       // From https://tools.ietf.org/html/rfc5987#section-3.2.1:
       //

--- a/core/play/src/main/scala/play/utils/Colors.scala
+++ b/core/play/src/main/scala/play/utils/Colors.scala
@@ -21,12 +21,12 @@ object Colors {
       .getOrElse(true)
   }
 
-  def red(str: String): String     = if (isANSISupported) (RED + str + RESET) else str
-  def blue(str: String): String    = if (isANSISupported) (BLUE + str + RESET) else str
-  def cyan(str: String): String    = if (isANSISupported) (CYAN + str + RESET) else str
-  def green(str: String): String   = if (isANSISupported) (GREEN + str + RESET) else str
-  def magenta(str: String): String = if (isANSISupported) (MAGENTA + str + RESET) else str
-  def white(str: String): String   = if (isANSISupported) (WHITE + str + RESET) else str
-  def black(str: String): String   = if (isANSISupported) (BLACK + str + RESET) else str
-  def yellow(str: String): String  = if (isANSISupported) (YELLOW + str + RESET) else str
+  def red(str: String): String     = if (isANSISupported) RED + str + RESET else str
+  def blue(str: String): String    = if (isANSISupported) BLUE + str + RESET else str
+  def cyan(str: String): String    = if (isANSISupported) CYAN + str + RESET else str
+  def green(str: String): String   = if (isANSISupported) GREEN + str + RESET else str
+  def magenta(str: String): String = if (isANSISupported) MAGENTA + str + RESET else str
+  def white(str: String): String   = if (isANSISupported) WHITE + str + RESET else str
+  def black(str: String): String   = if (isANSISupported) BLACK + str + RESET else str
+  def yellow(str: String): String  = if (isANSISupported) YELLOW + str + RESET else str
 }

--- a/core/play/src/main/scala/play/utils/JsonNodeDeserializer.scala
+++ b/core/play/src/main/scala/play/utils/JsonNodeDeserializer.scala
@@ -54,7 +54,7 @@ private class JsonNodeDeserializer extends JsonDeserializer[JsonNode] {
   override def deserialize(jp: JsonParser, ctxt: DeserializationContext): JsonNode =
     deserialize(jp, ctxt, Nil)
 
-  //====================================================================================
+  // ====================================================================================
   // NOTE: the following two methods are re-encoding part of
   // com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer
   private val F_MASK_INT_COERCIONS: Int =
@@ -107,7 +107,7 @@ private class JsonNodeDeserializer extends JsonDeserializer[JsonNode] {
 
   }
 
-  //====================================================================================
+  // ====================================================================================
 
   /* re-encoding of part of JsonNodeDeserializer (jackson-databind 2.10.5)
    * https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.10.5/src/main/java/com/fasterxml/jackson/databind/deser/std/JsonNodeDeserializer.java#L602-L623
@@ -138,7 +138,7 @@ private class JsonNodeDeserializer extends JsonDeserializer[JsonNode] {
     }
   }
 
-  //====================================================================================
+  // ====================================================================================
 
   @tailrec
   final def deserialize(

--- a/core/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/core/play/src/main/scala/play/utils/UriEncoding.scala
@@ -216,7 +216,7 @@ object UriEncoding {
    */
   private def upperHex(x: Int): Int = {
     // Assume 0 <= x < 16
-    if (x < 10) (x + '0') else (x - 10 + 'A')
+    if (x < 10) x + '0' else x - 10 + 'A'
   }
 
   /**

--- a/core/play/src/main/scala/views/helper/Helpers.scala
+++ b/core/play/src/main/scala/views/helper/Helpers.scala
@@ -19,15 +19,15 @@ package views.html.helper {
   ) {
     def infos: Seq[Any] = {
       args.get(Symbol("_help")).map(m => Seq(translate(m)(p))).getOrElse {
-        (if (
-           args.get(Symbol("_showConstraints")) match {
-             case Some(false) => false
-             case _           => true
-           }
-         ) {
-           field.constraints.map(c => p.messages(c._1, c._2.map(a => translate(a)(p)): _*)) ++
-             field.format.map(f => p.messages(f._1, f._2.map(a => translate(a)(p)): _*))
-         } else Nil)
+        if (
+          args.get(Symbol("_showConstraints")) match {
+            case Some(false) => false
+            case _           => true
+          }
+        ) {
+          field.constraints.map(c => p.messages(c._1, c._2.map(a => translate(a)(p)): _*)) ++
+            field.format.map(f => p.messages(f._1, f._2.map(a => translate(a)(p)): _*))
+        } else Nil
       }
     }
 
@@ -41,14 +41,14 @@ package views.html.helper {
         case Some(value) => Some(translate(value)(p))
         case _           => None
       }).map(Seq(_)).getOrElse {
-        (if (
-           args.get(Symbol("_showErrors")) match {
-             case Some(false) => false
-             case _           => true
-           }
-         ) {
-           field.errors.map(e => p.messages(e.message, e.args.map(a => translate(a)(p)): _*))
-         } else Nil)
+        if (
+          args.get(Symbol("_showErrors")) match {
+            case Some(false) => false
+            case _           => true
+          }
+        ) {
+          field.errors.map(e => p.messages(e.message, e.args.map(a => translate(a)(p)): _*))
+        } else Nil
       }
     }
 

--- a/core/play/src/test/scala/play/api/libs/CometSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/CometSpec.scala
@@ -25,21 +25,21 @@ class CometSpec extends Specification {
       extends ControllerHelpers {
     val Action = action
 
-    //#comet-string
+    // #comet-string
     def cometString = action {
       implicit val m                      = materializer
       def stringSource: Source[String, _] = Source(List("kiki", "foo", "bar"))
       Ok.chunked(stringSource.via(Comet.string("parent.cometMessage"))).as(ContentTypes.HTML)
     }
-    //#comet-string
+    // #comet-string
 
-    //#comet-json
+    // #comet-json
     def cometJson = action {
       implicit val m                       = materializer
       def stringSource: Source[JsValue, _] = Source(List(JsString("jsonString")))
       Ok.chunked(stringSource.via(Comet.json("parent.cometMessage"))).as(ContentTypes.HTML)
     }
-    //#comet-json
+    // #comet-json
   }
 
   def newTestApplication(): play.api.Application = new PlayCoreTestApplication() {
@@ -75,7 +75,7 @@ class CometSpec extends Specification {
     }
   }
 
-  //---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
   // Can't use play.api.test.ResultsExtractor here as it is not imported
   // So, copy the methods necessary to extract string.
 

--- a/core/play/src/test/scala/play/libs/FTupleSpec.scala
+++ b/core/play/src/test/scala/play/libs/FTupleSpec.scala
@@ -39,7 +39,7 @@ class FTupleSpec extends Specification with ScalaCheck {
 
       "obey hashCode contract" in prop { (a1: A, a2: A) =>
         // (a1 equals a2) ==> (a1.hashCode == a2.hashCode)
-        if (a1.equals(a2)) (a1.hashCode == a2.hashCode) else true
+        if (a1.equals(a2)) a1.hashCode == a2.hashCode else true
       }
     }
   }

--- a/core/play/src/test/scala/play/libs/XMLSpec.scala
+++ b/core/play/src/test/scala/play/libs/XMLSpec.scala
@@ -69,7 +69,7 @@ class XMLSpec extends Specification {
 
     "gracefully fail when there are too many nested entities" in {
       val nested = for (x <- 1 to 30) yield "<!ENTITY laugh" + x + " \"&laugh" + (x - 1) + ";&laugh" + (x - 1) + ";\">"
-      val xml    = s"""<?xml version="1.0"?>
+      val xml = s"""<?xml version="1.0"?>
                    | <!DOCTYPE billion [
                    | <!ELEMENT billion (#PCDATA)>
                    | <!ENTITY laugh0 "ha">
@@ -85,7 +85,7 @@ class XMLSpec extends Specification {
     "gracefully fail when an entity expands to be very large" in {
       val as       = "a" * 50000
       val entities = "&a;" * 50000
-      val xml      = s"""<?xml version="1.0"?>
+      val xml = s"""<?xml version="1.0"?>
                    | <!DOCTYPE kaboom [
                    | <!ENTITY a "$as">
                    | ]>

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -118,15 +118,15 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
   override def projectSettings = docsRunSettings ++ docsReportSettings ++ docsTestSettings
 
   def docsRunSettings = Seq(
-    playDocsValidationConfig := ValidationConfig(),
-    manualPath := baseDirectory.value,
-    run := docsRunSetting.evaluated,
+    playDocsValidationConfig  := ValidationConfig(),
+    manualPath                := baseDirectory.value,
+    run                       := docsRunSetting.evaluated,
     generateMarkdownRefReport := PlayDocsValidation.generateMarkdownRefReportTask.value,
-    validateDocs := PlayDocsValidation.validateDocsTask.value,
-    validateExternalLinks := PlayDocsValidation.validateExternalLinksTask.value,
-    docsVersion := PlayVersion.current,
-    docsName := "play-docs",
-    docsJarFile := docsJarFileSetting.value,
+    validateDocs              := PlayDocsValidation.validateDocsTask.value,
+    validateExternalLinks     := PlayDocsValidation.validateExternalLinksTask.value,
+    docsVersion               := PlayVersion.current,
+    docsName                  := "play-docs",
+    docsJarFile               := docsJarFileSetting.value,
     PlayDocsKeys.resources := Seq(PlayDocsDirectoryResource(manualPath.value)) ++
       docsJarFile.value.map(jar => PlayDocsJarFileResource(jar, Some("play/docs/content"))).toSeq,
     docsJarScalaBinaryVersion := scalaBinaryVersion.value,
@@ -138,23 +138,23 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
   )
 
   def docsReportSettings = Seq(
-    generateMarkdownCodeSamplesReport := PlayDocsValidation.generateMarkdownCodeSamplesTask.value,
-    generateUpstreamCodeSamplesReport := PlayDocsValidation.generateUpstreamCodeSamplesTask.value,
-    translationCodeSamplesReportFile := target.value / "report.html",
-    translationCodeSamplesReport := PlayDocsValidation.translationCodeSamplesReportTask.value,
+    generateMarkdownCodeSamplesReport  := PlayDocsValidation.generateMarkdownCodeSamplesTask.value,
+    generateUpstreamCodeSamplesReport  := PlayDocsValidation.generateUpstreamCodeSamplesTask.value,
+    translationCodeSamplesReportFile   := target.value / "report.html",
+    translationCodeSamplesReport       := PlayDocsValidation.translationCodeSamplesReportTask.value,
     cachedTranslationCodeSamplesReport := PlayDocsValidation.cachedTranslationCodeSamplesReportTask.value
   )
 
   def docsTestSettings = Seq(
-    migrationManualSources := Nil,
-    javaManualSourceDirectories := Nil,
-    scalaManualSourceDirectories := Nil,
+    migrationManualSources        := Nil,
+    javaManualSourceDirectories   := Nil,
+    scalaManualSourceDirectories  := Nil,
     commonManualSourceDirectories := Nil,
     Test / unmanagedSourceDirectories ++= javaManualSourceDirectories.value ++ scalaManualSourceDirectories.value ++
       commonManualSourceDirectories.value ++ migrationManualSources.value,
     Test / unmanagedResourceDirectories ++= javaManualSourceDirectories.value ++ scalaManualSourceDirectories.value ++
       commonManualSourceDirectories.value ++ migrationManualSources.value,
-    javaTwirlSourceManaged := target.value / "twirl" / "java",
+    javaTwirlSourceManaged  := target.value / "twirl" / "java",
     scalaTwirlSourceManaged := target.value / "twirl" / "scala",
     Test / managedSourceDirectories ++= Seq(
       javaTwirlSourceManaged.value,

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -196,25 +196,25 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
   def blankLine: Parser[Unit] = ignoreWhiteSpace ~> newLine ^^ { case _ => () }
 
   def parentheses: Parser[String] = {
-    "(" ~ (several((parentheses | not(")") ~> """.""".r))) ~ commit(")") ^^ {
+    "(" ~ (several(parentheses | not(")") ~> """.""".r)) ~ commit(")") ^^ {
       case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
     }
   }
 
   def brackets: Parser[String] = {
-    "[" ~ (several((parentheses | not("]") ~> """.""".r))) ~ commit("]") ^^ {
+    "[" ~ (several(parentheses | not("]") ~> """.""".r)) ~ commit("]") ^^ {
       case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
     }
   }
 
   def string: Parser[String] = {
-    "\"" ~ (several((parentheses | not("\"") ~> """.""".r))) ~ commit("\"") ^^ {
+    "\"" ~ (several(parentheses | not("\"") ~> """.""".r)) ~ commit("\"") ^^ {
       case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
     }
   }
 
   def multiString: Parser[String] = {
-    "\"\"\"" ~ (several((parentheses | not("\"\"\"") ~> """.""".r))) ~ commit("\"\"\"") ^^ {
+    "\"\"\"" ~ (several(parentheses | not("\"\"\"") ~> """.""".r)) ~ commit("\"\"\"") ^^ {
       case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
     }
   }

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
@@ -126,7 +126,7 @@ trait PathPart
  * @param encode Whether this part should be encoded or not.
  */
 case class DynamicPart(name: String, constraint: String, encode: Boolean) extends PathPart with Positional {
-  override def toString = """DynamicPart("""" + name + "\", \"\"\"" + constraint + "\"\"\"," + encode + ")" //"
+  override def toString = """DynamicPart("""" + name + "\", \"\"\"" + constraint + "\"\"\"," + encode + ")" // "
 }
 
 /**

--- a/dev-mode/run-support/src/main/scala/play/runsupport/Colors.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Colors.scala
@@ -21,13 +21,13 @@ object Colors {
       .getOrElse(true)
   }
 
-  def red(str: String): String     = if (isANSISupported) (RED + str + RESET) else str
-  def blue(str: String): String    = if (isANSISupported) (BLUE + str + RESET) else str
-  def cyan(str: String): String    = if (isANSISupported) (CYAN + str + RESET) else str
-  def green(str: String): String   = if (isANSISupported) (GREEN + str + RESET) else str
-  def magenta(str: String): String = if (isANSISupported) (MAGENTA + str + RESET) else str
-  def white(str: String): String   = if (isANSISupported) (WHITE + str + RESET) else str
-  def black(str: String): String   = if (isANSISupported) (BLACK + str + RESET) else str
-  def yellow(str: String): String  = if (isANSISupported) (YELLOW + str + RESET) else str
-  def bold(str: String): String    = if (isANSISupported) (BOLD + str + RESET) else str
+  def red(str: String): String     = if (isANSISupported) RED + str + RESET else str
+  def blue(str: String): String    = if (isANSISupported) BLUE + str + RESET else str
+  def cyan(str: String): String    = if (isANSISupported) CYAN + str + RESET else str
+  def green(str: String): String   = if (isANSISupported) GREEN + str + RESET else str
+  def magenta(str: String): String = if (isANSISupported) MAGENTA + str + RESET else str
+  def white(str: String): String   = if (isANSISupported) WHITE + str + RESET else str
+  def black(str: String): String   = if (isANSISupported) BLACK + str + RESET else str
+  def yellow(str: String): String  = if (isANSISupported) YELLOW + str + RESET else str
+  def bold(str: String): String    = if (isANSISupported) BOLD + str + RESET else str
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayLayoutPlugin.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayLayoutPlugin.scala
@@ -21,20 +21,20 @@ object PlayLayoutPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override def projectSettings = Seq(
-    target := baseDirectory.value / "target",
-    Compile / sourceDirectory := baseDirectory.value / "app",
-    Test / sourceDirectory := baseDirectory.value / "test",
-    Compile / resourceDirectory := baseDirectory.value / "conf",
-    Compile / scalaSource := baseDirectory.value / "app",
-    Test / scalaSource := baseDirectory.value / "test",
-    Compile / javaSource := baseDirectory.value / "app",
-    Test / javaSource := baseDirectory.value / "test",
+    target                                                   := baseDirectory.value / "target",
+    Compile / sourceDirectory                                := baseDirectory.value / "app",
+    Test / sourceDirectory                                   := baseDirectory.value / "test",
+    Compile / resourceDirectory                              := baseDirectory.value / "conf",
+    Compile / scalaSource                                    := baseDirectory.value / "app",
+    Test / scalaSource                                       := baseDirectory.value / "test",
+    Compile / javaSource                                     := baseDirectory.value / "app",
+    Test / javaSource                                        := baseDirectory.value / "test",
     Compile / TwirlKeys.compileTemplates / sourceDirectories := Seq((Compile / sourceDirectory).value),
-    Test / TwirlKeys.compileTemplates / sourceDirectories := Seq((Test / sourceDirectory).value),
+    Test / TwirlKeys.compileTemplates / sourceDirectories    := Seq((Test / sourceDirectory).value),
     // sbt-web
-    Assets / sourceDirectory := (Compile / sourceDirectory).value / "assets",
+    Assets / sourceDirectory     := (Compile / sourceDirectory).value / "assets",
     TestAssets / sourceDirectory := (Test / sourceDirectory).value / "assets",
-    Assets / resourceDirectory := baseDirectory.value / "public",
+    Assets / resourceDirectory   := baseDirectory.value / "public",
     // Native packager
     Universal / sourceDirectory := baseDirectory.value / "dist"
   )

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -78,8 +78,8 @@ object PlaySettings {
             |Version ${play.core.PlayVersion.current} running Java ${System.getProperty("java.version")}
             |
             |${Colors.bold(
-          "Play is run entirely by the community. Please consider contributing and/or donating:"
-        )}
+             "Play is run entirely by the community. Please consider contributing and/or donating:"
+           )}
             |https://www.playframework.com/sponsors
             |
             |""".stripMargin +
@@ -93,9 +93,9 @@ object PlaySettings {
     },
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-encoding", "utf8"),
     Compile / javacOptions ++= Seq("-encoding", "utf8", "-g"),
-    playPlugin := false,
-    generateAssetsJar := true,
-    externalizeResources := true,
+    playPlugin                   := false,
+    generateAssetsJar            := true,
+    externalizeResources         := true,
     externalizeResourcesExcludes := Nil,
     includeDocumentationInBinary := true,
     Compile / doc / javacOptions := List("-encoding", "utf8"),
@@ -106,8 +106,8 @@ object PlaySettings {
         "com.typesafe.play" %% "play-server" % PlayVersion.current
     },
     libraryDependencies += "com.typesafe.play" %% "play-test" % PlayVersion.current % "test",
-    Test / parallelExecution := false,
-    Test / fork := true,
+    Test / parallelExecution                   := false,
+    Test / fork                                := true,
     Test / testOptions += Tests.Argument(TestFrameworks.Specs2, "sequential", "true", "junitxml", "console"),
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "--ignore-runners=org.specs2.runner.JUnitRunner"),
     // Adds app directory's source files to continuous hot reloading
@@ -123,7 +123,7 @@ object PlaySettings {
     PlayInternalKeys.playAllAssets := Seq.empty,
     PlayRun.playAssetsClassLoaderSetting,
     // THE `in Compile` IS IMPORTANT!
-    Compile / Keys.run := PlayRun.playDefaultRunTask.evaluated,
+    Compile / Keys.run             := PlayRun.playDefaultRunTask.evaluated,
     Compile / Keys.run / mainClass := Some("play.core.server.DevServerStart"),
     PlayInternalKeys.playStop := {
       playInteractionMode.value match {
@@ -142,16 +142,16 @@ object PlaySettings {
     playReloaderClasspath ~= { _.filter(_.get(WebKeys.webModulesLib.key).isEmpty) },
     playCommonClassloader := PlayCommands.playCommonClassloaderTask.value,
     playCompileEverything := PlayCommands.playCompileEverythingTask.value.asInstanceOf[Seq[Analysis]],
-    playReload := PlayCommands.playReloadTask.value,
-    ivyLoggingLevel := UpdateLogging.DownloadOnly,
-    playMonitoredFiles := PlayCommands.playMonitoredFilesTask.value,
+    playReload            := PlayCommands.playReloadTask.value,
+    ivyLoggingLevel       := UpdateLogging.DownloadOnly,
+    playMonitoredFiles    := PlayCommands.playMonitoredFilesTask.value,
     fileWatchService := {
       FileWatchService.defaultWatchService(target.value, pollInterval.value.toMillis.toInt, sLog.value)
     },
-    playDefaultPort := 9000,
+    playDefaultPort    := 9000,
     playDefaultAddress := "0.0.0.0",
     // Default hooks
-    playRunHooks := Nil,
+    playRunHooks        := Nil,
     playInteractionMode := PlayConsoleInteractionMode,
     // Settings
     devSettings := Nil,
@@ -218,7 +218,7 @@ object PlaySettings {
     // Adds the Play application directory to the command line args passed to Play
     bashScriptExtraDefines += "addJava \"-Duser.dir=$(realpath \"$(cd \"${app_home}/..\"; pwd -P)\"  $(is_cygwin && echo \"fix\"))\"\n",
     generateSecret := ApplicationSecretGenerator.generateSecretTask.value,
-    updateSecret := ApplicationSecretGenerator.updateSecretTask.value,
+    updateSecret   := ApplicationSecretGenerator.updateSecretTask.value,
     // by default, compile any routes files in the root named "routes" or "*.routes"
     Compile / RoutesKeys.routes / sources ++= {
       val dirs = (Compile / unmanagedResourceDirectories).value
@@ -239,8 +239,8 @@ object PlaySettings {
     playMonitoredFiles ++= (Compile / compileTemplates / sourceDirectories).value,
     routesImport ++= Seq("controllers.Assets.Asset"),
     // sbt-web
-    Assets / jsFilter := new PatternFilter("""[^_].*\.js""".r.pattern),
-    WebKeys.stagingDirectory := WebKeys.stagingDirectory.value / "public",
+    Assets / jsFilter         := new PatternFilter("""[^_].*\.js""".r.pattern),
+    WebKeys.stagingDirectory  := WebKeys.stagingDirectory.value / "public",
     playAssetsWithCompilation := (Compile / compile).value.asInstanceOf[Analysis],
     playAssetsWithCompilation := playAssetsWithCompilation.dependsOn((Assets / assets).?).value,
     // Assets for run mode
@@ -249,7 +249,7 @@ object PlaySettings {
     assetsPrefix := "public/",
     // Assets for distribution
     Assets / WebKeys.packagePrefix := assetsPrefix.value,
-    playPackageAssets := (Assets / packageBin).value,
+    playPackageAssets              := (Assets / packageBin).value,
     scriptClasspathOrdering := Def.taskDyn {
       val oldValue = scriptClasspathOrdering.value
       // only create a assets-jar if the task is active

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -78,7 +78,7 @@ object RoutesCompiler extends AutoPlugin {
 
       // Aggregate all the routes file tasks that we want to compile the reverse routers for.
       aggregateReverseRoutes.value
-        .map { agg => (agg.project / configuration.value / routesCompilerTasks) }
+        .map { agg => agg.project / configuration.value / routesCompilerTasks }
         .join
         .map { (aggTasks: Seq[Seq[RoutesCompilerTask]]) =>
           // Aggregated tasks need to have forwards router compilation disabled and reverse router compilation enabled.
@@ -102,13 +102,13 @@ object RoutesCompiler extends AutoPlugin {
     }.value,
     Defaults.ConfigGlobal / watchSources ++= (routes / sources).value,
     routes / target := crossTarget.value / "routes" / Defaults.nameForSrc(configuration.value.name),
-    routes := compileRoutesFiles.value,
+    routes          := compileRoutesFiles.value,
     sourceGenerators += Def.task(routes.value).taskValue,
     managedSourceDirectories += (routes / target).value
   )
 
   def defaultSettings = Seq(
-    routesImport := Nil,
+    routesImport           := Nil,
     aggregateReverseRoutes := Nil,
     // Generate reverse router defaults to true if this project is not aggregated by any of the projects it depends on
     // aggregateReverseRoutes projects.  Otherwise, it will be false, since another project will be generating the
@@ -131,7 +131,7 @@ object RoutesCompiler extends AutoPlugin {
         }
     }.value,
     namespaceReverseRouter := false,
-    routesGenerator := InjectedRoutesGenerator,
+    routesGenerator        := InjectedRoutesGenerator,
     sourcePositionMappers += routesPositionMapper
   )
 

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -158,7 +158,7 @@ object PlayReload {
     def unapply(value: Option[Any]): Option[Any] =
       value.filter { vf =>
         val name = vf.getClass.getSimpleName
-        (name == "BasicVirtualFileRef" || name == "MappedVirtualFile")
+        name == "BasicVirtualFileRef" || name == "MappedVirtualFile"
       }
   }
 

--- a/documentation/.scalafmt.conf
+++ b/documentation/.scalafmt.conf
@@ -3,12 +3,15 @@
 # TODO remove when making documentation a subproject
 runner.dialect = scala212
 align.preset = true
+align.allowOverflow = true
 assumeStandardLibraryStripMargin = true
 danglingParentheses.preset = true
 newlines.alwaysBeforeMultilineDef = false
 newlines.implicitParamListModifierPrefer = before
 newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
-docstrings = JavaDoc
+newlines.inInterpolation = "avoid"
+docstrings.style = Asterisk
+docstrings.wrap = no
 maxColumn = 120
 project.excludeFilters += core/play/src/main/scala/play/core/hidden/ObjectMappings.scala
 project.git = true
@@ -16,4 +19,4 @@ rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifi
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
-version = 2.7.5
+version = 3.7.1

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -30,7 +30,7 @@ lazy val main = Project("Play-Documentation", file("."))
     ivyConfigurations += DocsApplication,
     // We need to publishLocal playDocs since its jar file is
     // a dependency of `docsJarFile` setting.
-    Test / test := ((Test / test).dependsOn(playDocs / publishLocal)).value,
+    Test / test := (Test / test).dependsOn(playDocs / publishLocal).value,
     resolvers += Resolver
       .sonatypeRepo(
         "releases"
@@ -76,9 +76,9 @@ lazy val main = Project("Play-Documentation", file("."))
     Test / unmanagedResourceDirectories ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
     // Don't include sbt files in the resources
     Test / unmanagedResources / excludeFilter := (Test / unmanagedResources / excludeFilter).value || "*.sbt",
-    crossScalaVersions := Seq("2.13.10"),
-    scalaVersion := "2.13.10",
-    Test / fork := true,
+    crossScalaVersions                        := Seq("2.13.10"),
+    scalaVersion                              := "2.13.10",
+    Test / fork                               := true,
     Test / javaOptions ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(
       HeaderLicense.Custom(

--- a/documentation/manual/gettingStarted/code/PlayConsole.scala
+++ b/documentation/manual/gettingStarted/code/PlayConsole.scala
@@ -10,14 +10,14 @@ import play.api._
 package consoleapp {
   class MyPlayConsole {
     def createApplication() = {
-      //#consoleapp
+      // #consoleapp
       import play.api._
       val env     = Environment(new java.io.File("."), this.getClass.getClassLoader, Mode.Dev)
       val context = ApplicationLoader.Context.create(env)
       val loader  = ApplicationLoader(context)
       val app     = loader.load(context)
       Play.start(app)
-      //#consoleapp
+      // #consoleapp
       app
     }
   }

--- a/documentation/manual/tutorial/code/scalaguide/hello/HelloController.scala
+++ b/documentation/manual/tutorial/code/scalaguide/hello/HelloController.scala
@@ -19,17 +19,17 @@ package scalaguide.hello {
 
   class HelloController @Inject() (cc: ControllerComponents)(implicit assetsFinder: AssetsFinder)
       extends AbstractController(cc) {
-    //#hello-world-index-action
+    // #hello-world-index-action
     def index = Action {
       Ok(views.html.index("Your new application is ready."))
     }
-    //#hello-world-index-action
+    // #hello-world-index-action
 
-    //#hello-world-hello-action
+    // #hello-world-hello-action
     def hello = Action {
       Ok(views.html.hello())
     }
-    //#hello-world-hello-action
+    // #hello-world-hello-action
 
     /*
     //#hello-world-hello-error-action
@@ -39,10 +39,10 @@ package scalaguide.hello {
     //#hello-world-hello-error-action
      */
 
-    //#hello-world-hello-correct-action
+    // #hello-world-hello-correct-action
     def hello(name: String) = Action {
       Ok(views.html.hello(name))
     }
-    //#hello-world-hello-correct-action
+    // #hello-world-hello-correct-action
   }
 }

--- a/documentation/manual/working/commonGuide/build/code/scalaguide/common/build/controllers/SubProjectsAssetsBuilder.scala
+++ b/documentation/manual/working/commonGuide/build/code/scalaguide/common/build/controllers/SubProjectsAssetsBuilder.scala
@@ -3,7 +3,7 @@
  */
 
 package common.build.controllers {
-  //#assets-builder
+  // #assets-builder
   import javax.inject._
 
   import play.api.http.HttpErrorHandler
@@ -12,11 +12,11 @@ package common.build.controllers {
       errorHandler: HttpErrorHandler,
       assetsMetadata: controllers.AssetsMetadata
   ) extends controllers.AssetsBuilder(errorHandler, assetsMetadata)
-  //#assets-builder
+  // #assets-builder
 
   package admin {
-    //#admin-home-controller
-    //###insert: package controllers.admin
+    // #admin-home-controller
+    // ###insert: package controllers.admin
 
     import play.api.mvc._
     import javax.inject.Inject
@@ -24,6 +24,6 @@ package common.build.controllers {
     class HomeController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
       def index = Action { implicit request => Ok("admin") }
     }
-    //#admin-home-controller
+    // #admin-home-controller
   }
 }

--- a/documentation/manual/working/commonGuide/configuration/code/Configuration.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/Configuration.scala
@@ -5,12 +5,12 @@
 // With Play Scala
 
 object DependencyInjection {
-  //#dependency-injection
+  // #dependency-injection
   import javax.inject._
   import play.api.Configuration
 
   class MyController @Inject() (config: Configuration) {
     // ...
   }
-  //#dependency-injection
+  // #dependency-injection
 }

--- a/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
@@ -36,34 +36,34 @@ class ThreadPoolsSpec extends PlaySpecification {
       #my-context-config """
     ) { implicit app =>
       val akkaSystem = app.actorSystem
-      //#my-context-usage
+      // #my-context-usage
       val myExecutionContext: ExecutionContext = akkaSystem.dispatchers.lookup("my-context")
-      //#my-context-usage
+      // #my-context-usage
       await(Future(Thread.currentThread().getName)(myExecutionContext)) must startWith("application-my-context")
 
-      //#my-context-explicit
+      // #my-context-explicit
       Future {
         // Some blocking or expensive code here
       }(myExecutionContext)
-      //#my-context-explicit
+      // #my-context-explicit
 
       {
-        //#my-context-implicit
+        // #my-context-implicit
         implicit val ec = myExecutionContext
 
         Future {
           // Some blocking or expensive code here
         }
-        //#my-context-implicit
+        // #my-context-implicit
       }
       success
     }
 
     "allow access to the application classloader" in new WithApplication() {
       val myClassName = "java.lang.String"
-      //#using-app-classloader
+      // #using-app-classloader
       val myClass = app.classloader.loadClass(myClassName)
-      //#using-app-classloader
+      // #using-app-classloader
     }
 
     "allow a synchronous thread pool" in {
@@ -120,7 +120,7 @@ class ThreadPoolsSpec extends PlaySpecification {
     #many-specific-config """
     ) { implicit app =>
       val akkaSystem = app.actorSystem
-      //#many-specific-contexts
+      // #many-specific-contexts
       object Contexts {
         implicit val simpleDbLookups: ExecutionContext = akkaSystem.dispatchers.lookup("contexts.simple-db-lookups")
         implicit val expensiveDbLookups: ExecutionContext =
@@ -129,7 +129,7 @@ class ThreadPoolsSpec extends PlaySpecification {
         implicit val expensiveCpuOperations: ExecutionContext =
           akkaSystem.dispatchers.lookup("contexts.expensive-cpu-operations")
       }
-      //#many-specific-contexts
+      // #many-specific-contexts
       def test(context: ExecutionContext, name: String) = {
         await(Future(Thread.currentThread().getName)(context)) must startWith("application-contexts." + name)
       }

--- a/documentation/manual/working/commonGuide/database/code/CompileTimeDIEvolutions.scala
+++ b/documentation/manual/working/commonGuide/database/code/CompileTimeDIEvolutions.scala
@@ -21,7 +21,7 @@ class AppComponents(cntx: Context)
   // this will actually run the database migrations on startup
   applicationEvolutions
 
-  //###skip: 1
+  // ###skip: 1
   val router = Router.empty
 }
 //#compile-time-di-evolutions

--- a/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
+++ b/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
@@ -21,11 +21,11 @@ class GzipEncoding extends PlaySpecification {
         def Action       = app.injector.instanceOf[DefaultActionBuilder]
 
         val filter =
-          //#should-gzip
+          // #should-gzip
           new GzipFilter(
             shouldGzip = (request, response) => response.body.contentType.exists(_.startsWith("text/html"))
           )
-        //#should-gzip
+        // #should-gzip
 
         header(CONTENT_ENCODING, filter(Action(Results.Ok("foo")))(gzipRequest).run()) must beNone
       }

--- a/documentation/manual/working/commonGuide/filters/code/SecurityHeaders.scala
+++ b/documentation/manual/working/commonGuide/filters/code/SecurityHeaders.scala
@@ -15,9 +15,9 @@ import play.api.mvc.ControllerComponents
 
 class SecurityHeaders @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
   def index = Action {
-    //#allowActionSpecificHeaders
+    // #allowActionSpecificHeaders
     Ok("Index").withHeaders(SecurityHeadersFilter.REFERRER_POLICY -> "my page-specific header")
-    //#allowActionSpecificHeaders
+    // #allowActionSpecificHeaders
   }
 }
 

--- a/documentation/manual/working/commonGuide/server/code/SomeScalaController.scala
+++ b/documentation/manual/working/commonGuide/server/code/SomeScalaController.scala
@@ -11,7 +11,7 @@ class SomeScalaController @Inject() (cc: ControllerComponents) extends AbstractC
   def index = Action { request =>
     assert(request.attrs.get(RequestAttrKey.Server) == Option("netty"))
     // ...
-    //###skip: 1
+    // ###skip: 1
     Ok("")
   }
 }

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration.Duration
 class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
   "Embedding play with akka" should {
     "be very simple" in {
-      //#simple-akka-http
+      // #simple-akka-http
       import play.api.mvc._
       import play.api.routing.sird._
       import play.core.server.AkkaHttpServer
@@ -27,19 +27,19 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
             }
         }
       }
-      //#simple-akka-http
+      // #simple-akka-http
 
       try {
         testRequest(9000)
       } finally {
-        //#stop-akka-http
+        // #stop-akka-http
         server.stop()
-        //#stop-akka-http
+        // #stop-akka-http
       }
     }
 
     "be configurable with akka" in {
-      //#config-akka-http
+      // #config-akka-http
       import play.api.mvc._
       import play.api.routing.sird._
       import play.core.server.AkkaHttpServer
@@ -60,7 +60,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
             }
         }
       }
-      //#config-akka-http
+      // #config-akka-http
 
       try {
         testRequest(19000)
@@ -70,7 +70,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
     }
 
     "allow overriding components" in {
-      //#components-akka-http
+      // #components-akka-http
       import play.api.http.DefaultHttpErrorHandler
       import play.api.mvc._
       import play.api.routing.Router
@@ -99,7 +99,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
         }
       }
       val server = components.server
-      //#components-akka-http
+      // #components-akka-http
 
       try {
         testRequest(9000)
@@ -109,7 +109,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
     }
 
     "allow usage from a running application" in {
-      //#application-akka-http
+      // #application-akka-http
       import play.api.mvc._
       import play.api.routing.sird._
       import play.core.server.AkkaHttpServer
@@ -136,7 +136,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
           address = "127.0.0.1"
         )
       )
-      //#application-akka-http
+      // #application-akka-http
 
       try {
         testRequest(19000)
@@ -146,7 +146,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
     }
 
     "allow usage from with logger configurator" in {
-      //#logger-akka-http
+      // #logger-akka-http
       import play.api.mvc._
       import play.api.routing.sird._
       import play.filters.HttpFiltersComponents
@@ -179,7 +179,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
           address = "127.0.0.1"
         )
       )
-      //#logger-akka-http
+      // #logger-akka-http
 
       try {
         testRequest(19000)

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaNettyEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaNettyEmbeddingPlay.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration.Duration
 class ScalaNettyEmbeddingPlay extends Specification with WsTestClient {
   "Embedding play" should {
     "be very simple" in {
-      //#simple
+      // #simple
       import play.api.mvc._
       import play.api.routing.sird._
       import play.core.server._
@@ -27,19 +27,19 @@ class ScalaNettyEmbeddingPlay extends Specification with WsTestClient {
             }
         }
       }
-      //#simple
+      // #simple
 
       try {
         testRequest(9000)
       } finally {
-        //#stop
+        // #stop
         server.stop()
-        //#stop
+        // #stop
       }
     }
 
     "be configurable" in {
-      //#config
+      // #config
       import play.api.mvc._
       import play.api.routing.sird._
       import play.core.server._
@@ -58,7 +58,7 @@ class ScalaNettyEmbeddingPlay extends Specification with WsTestClient {
             }
         }
       }
-      //#config
+      // #config
 
       try {
         testRequest(19000)
@@ -68,7 +68,7 @@ class ScalaNettyEmbeddingPlay extends Specification with WsTestClient {
     }
 
     "allow overriding components" in {
-      //#components
+      // #components
       import play.api.http.DefaultHttpErrorHandler
       import play.api.mvc._
       import play.api.routing.Router
@@ -93,7 +93,7 @@ class ScalaNettyEmbeddingPlay extends Specification with WsTestClient {
           }
       }
       val server = components.server
-      //#components
+      // #components
 
       try {
         testRequest(9000)
@@ -103,7 +103,7 @@ class ScalaNettyEmbeddingPlay extends Specification with WsTestClient {
     }
 
     "work with logger configurator" in {
-      //#logger-configurator
+      // #logger-configurator
       import play.api.mvc._
       import play.api.routing.Router
       import play.api.routing.sird._
@@ -128,7 +128,7 @@ class ScalaNettyEmbeddingPlay extends Specification with WsTestClient {
       }
 
       val server = components.server
-      //#logger-configurator
+      // #logger-configurator
 
       try {
         testRequest(9000)

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
@@ -9,11 +9,11 @@ import play.api.test.FakeRequest
 import play.api.test.WithApplication
 
 class ScalaSirdRouter extends Specification {
-  //#imports
+  // #imports
   import play.api.mvc._
   import play.api.routing._
   import play.api.routing.sird._
-  //#imports
+  // #imports
 
   private def Action(block: => Result)(implicit app: play.api.Application) =
     app.injector.instanceOf[DefaultActionBuilder].apply(block)
@@ -21,14 +21,14 @@ class ScalaSirdRouter extends Specification {
   "sird router" should {
     "allow a simple match" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#simple
+      // #simple
       val router = Router.from {
         case GET(p"/hello/$to") =>
           Action {
             Results.Ok(s"Hello $to")
           }
       }
-      //#simple
+      // #simple
 
       router.routes.lift(FakeRequest("GET", "/hello/world")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/goodbye/world")) must beNone
@@ -36,12 +36,12 @@ class ScalaSirdRouter extends Specification {
 
     "allow a full path match" in new WithApplication {
       val Assets = app.injector.instanceOf[controllers.Assets]
-      //#full-path
+      // #full-path
       val router = Router.from {
         case GET(p"/assets/$file*") =>
           Assets.versioned(path = "/public", file = file)
       }
-      //#full-path
+      // #full-path
 
       router.routes.lift(FakeRequest("GET", "/assets/javascripts/main.js")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/foo/bar")) must beNone
@@ -49,14 +49,14 @@ class ScalaSirdRouter extends Specification {
 
     "allow a regex match" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#regexp
+      // #regexp
       val router = Router.from {
         case GET(p"/items/$id<[0-9]+>") =>
           Action {
             Results.Ok(s"Item $id")
           }
       }
-      //#regexp
+      // #regexp
 
       router.routes.lift(FakeRequest("GET", "/items/21")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/items/foo")) must beNone
@@ -64,14 +64,14 @@ class ScalaSirdRouter extends Specification {
 
     "allow extracting required query parameters" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#required
+      // #required
       val router = Router.from {
         case GET(p"/search" ? q"query=$query") =>
           Action {
             Results.Ok(s"Searching for $query")
           }
       }
-      //#required
+      // #required
 
       router.routes.lift(FakeRequest("GET", "/search?query=foo")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/search")) must beNone
@@ -79,7 +79,7 @@ class ScalaSirdRouter extends Specification {
 
     "allow extracting optional query parameters" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#optional
+      // #optional
       val router = Router.from {
         case GET(p"/items" ? q_o"page=$page") =>
           Action {
@@ -87,7 +87,7 @@ class ScalaSirdRouter extends Specification {
             Results.Ok(s"Showing page $thisPage")
           }
       }
-      //#optional
+      // #optional
 
       router.routes.lift(FakeRequest("GET", "/items?page=10")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
@@ -95,7 +95,7 @@ class ScalaSirdRouter extends Specification {
 
     "allow extracting multi value query parameters" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#many
+      // #many
       val router = Router.from {
         case GET(p"/items" ? q_s"tag=$tags") =>
           Action {
@@ -103,7 +103,7 @@ class ScalaSirdRouter extends Specification {
             Results.Ok(s"Showing items tagged: $allTags")
           }
       }
-      //#many
+      // #many
 
       router.routes.lift(FakeRequest("GET", "/items?tag=a&tag=b")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
@@ -111,7 +111,7 @@ class ScalaSirdRouter extends Specification {
 
     "allow extracting multiple query parameters" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#multiple
+      // #multiple
       val router = Router.from {
         case GET(
               p"/items" ? q_o"page=$page"
@@ -124,7 +124,7 @@ class ScalaSirdRouter extends Specification {
             Results.Ok(s"Showing page $thisPage of length $pageLength")
           }
       }
-      //#multiple
+      // #multiple
 
       router.routes.lift(FakeRequest("GET", "/items?page=10&per_page=20")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
@@ -132,14 +132,14 @@ class ScalaSirdRouter extends Specification {
 
     "allow sub extractor" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#int
+      // #int
       val router = Router.from {
         case GET(p"/items/${int(id)}") =>
           Action {
             Results.Ok(s"Item $id")
           }
       }
-      //#int
+      // #int
 
       router.routes.lift(FakeRequest("GET", "/items/21")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/items/foo")) must beNone
@@ -147,7 +147,7 @@ class ScalaSirdRouter extends Specification {
 
     "allow sub extractor on a query parameter" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#query-int
+      // #query-int
       val router = Router.from {
         case GET(p"/items" ? q_o"page=${int(page)}") =>
           Action {
@@ -155,7 +155,7 @@ class ScalaSirdRouter extends Specification {
             Results.Ok(s"Items page $thePage")
           }
       }
-      //#query-int
+      // #query-int
 
       router.routes.lift(FakeRequest("GET", "/items?page=21")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/items?page=foo")) must beNone
@@ -164,7 +164,7 @@ class ScalaSirdRouter extends Specification {
 
     "allow complex extractors" in new WithApplication {
       val Action = app.injector.instanceOf[DefaultActionBuilder]
-      //#complex
+      // #complex
       val router = Router.from {
         case rh @ GET(
               p"/items/${idString @ int(id)}" ?
@@ -174,7 +174,7 @@ class ScalaSirdRouter extends Specification {
             Results.Ok(s"Expensive item $id")
           }
       }
-      //#complex
+      // #complex
 
       router.routes.lift(FakeRequest("GET", "/items/21?price=400")) must beSome[Handler]
       router.routes.lift(FakeRequest("GET", "/items/21?price=foo")) must beNone

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/BinderApplication.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/BinderApplication.scala
@@ -11,15 +11,15 @@ import play.api.mvc._
 import scalaguide.binder.models._
 
 class BinderApplication @Inject() (components: ControllerComponents) extends AbstractController(components) {
-  //#path
+  // #path
   def user(user: User) = Action {
     Ok(user.name)
   }
-  //#path
+  // #path
 
-  //#query
+  // #query
   def age(age: AgeRange) = Action {
     Ok(age.from.toString)
   }
-  //#query
+  // #query
 }

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/Users.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/Users.scala
@@ -12,7 +12,7 @@ import play.api.routing._
 //#javascript-router-resource-imports
 
 class Application @Inject() (components: ControllerComponents) extends AbstractController(components) {
-  //#javascript-router-resource
+  // #javascript-router-resource
   def javascriptRoutes = Action { implicit request =>
     Ok(
       JavaScriptReverseRouter("jsRoutes")(
@@ -21,16 +21,16 @@ class Application @Inject() (components: ControllerComponents) extends AbstractC
       )
     ).as(MimeTypes.JAVASCRIPT)
   }
-  //#javascript-router-resource
+  // #javascript-router-resource
 
   def javascriptRoutes2 = Action { implicit request =>
     Ok(
-      //#javascript-router-resource-custom-method
+      // #javascript-router-resource-custom-method
       JavaScriptReverseRouter("jsRoutes", Some("myAjaxFunction"))(
         routes.javascript.Users.list,
         routes.javascript.Users.get
       )
-      //#javascript-router-resource-custom-method
+      // #javascript-router-resource-custom-method
     ).as(MimeTypes.JAVASCRIPT)
   }
 }

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/AgeRange.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/AgeRange.scala
@@ -14,7 +14,7 @@ import play.api.mvc.QueryStringBindable
 case class AgeRange(from: Int, to: Int) {}
 //#declaration
 object AgeRange {
-  //#bind
+  // #bind
   implicit def queryStringBindable(implicit intBinder: QueryStringBindable[Int]): QueryStringBindable[AgeRange] =
     new QueryStringBindable[AgeRange] {
       override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, AgeRange]] = {
@@ -32,5 +32,5 @@ object AgeRange {
         intBinder.unbind("from", ageRange.from) + "&" + intBinder.unbind("to", ageRange.to)
       }
     }
-  //#bind
+  // #bind
 }

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/CartItem.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/CartItem.scala
@@ -27,13 +27,13 @@ object CartItem {
           }
         }
       }
-      //#unbind
+      // #unbind
       override def unbind(key: String, cartItem: CartItem): String = {
         // If we don't use Play's QueryStringBindable[String].unbind() for some reason, we need to construct the result string manually.
         // The key is constant and does not contain any special character, but
         // value may contain special characters => need form URL encoding for cartItem.identifier:
         "identifier=" + URLEncoder.encode(cartItem.identifier, "utf-8")
       }
-      //#unbind
+      // #unbind
     }
 }

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/User.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/User.scala
@@ -22,7 +22,7 @@ object User extends Logging {
     Some(user)
   }
 
-  //#bind
+  // #bind
   implicit def pathBinder(implicit intBinder: PathBindable[Int]): PathBindable[User] = new PathBindable[User] {
     override def bind(key: String, value: String): Either[String, User] = {
       for {
@@ -34,5 +34,5 @@ object User extends Logging {
       user.id.toString
     }
   }
-  //#bind
+  // #bind
 }

--- a/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
+++ b/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
@@ -45,7 +45,7 @@ package scalaguide.akka {
         import actors.HelloActor.SayHello
 
         import scala.concurrent.ExecutionContext.Implicits.global
-        //#ask
+        // #ask
         import scala.concurrent.duration._
         import akka.pattern.ask
         implicit val timeout: Timeout = 5.seconds
@@ -53,7 +53,7 @@ package scalaguide.akka {
         def sayHello(name: String) = Action.async {
           (helloActor ? SayHello(name)).mapTo[String].map { message => Ok(message) }
         }
-        //#ask
+        // #ask
 
         contentAsString(sayHello("world")(FakeRequest())) must_== "Hello, world"
       }
@@ -101,7 +101,7 @@ package scalaguide.akka {
     class Application @Inject() (system: ActorSystem, cc: ControllerComponents) extends AbstractController(cc) {
       val helloActor = system.actorOf(HelloActor.props, "hello-actor")
 
-      //...
+      // ...
     }
 //#controller
   }

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -63,32 +63,32 @@ class ScalaAsyncSamples @Inject() (val controllerComponents: ControllerComponent
 ) extends BaseController {
   def futureResult = {
     def computePIAsynchronously() = Future.successful(3.14)
-    //#future-result
+    // #future-result
 
     val futurePIValue: Future[Double] = computePIAsynchronously()
     val futureResult: Future[Result]  = futurePIValue.map { pi => Ok("PI value computed: " + pi) }
-    //#future-result
+    // #future-result
     futureResult
   }
 
   def intensiveComputation() = 10
 
   def intensiveComp = {
-    //#intensive-computation
+    // #intensive-computation
     val futureInt: Future[Int] = scala.concurrent.Future {
       intensiveComputation()
     }
-    //#intensive-computation
+    // #intensive-computation
     futureInt
   }
 
   def asyncResult = {
-    //#async-result
+    // #async-result
     def index = Action.async {
       val futureInt = scala.concurrent.Future { intensiveComputation() }
       futureInt.map(i => Ok("Got result: " + i))
     }
-    //#async-result
+    // #async-result
 
     index
   }
@@ -99,7 +99,7 @@ class ScalaAsyncSamples @Inject() (val controllerComponents: ControllerComponent
       10
     }
 
-    //#timeout
+    // #timeout
     import scala.concurrent.duration._
     import play.api.libs.concurrent.Futures._
 
@@ -114,7 +114,7 @@ class ScalaAsyncSamples @Inject() (val controllerComponents: ControllerComponent
             InternalServerError("timeout")
         }
     }
-    //#timeout
+    // #timeout
     index
   }
 }

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
@@ -17,21 +17,21 @@ import play.api.test._
 
 class MockController(val controllerComponents: ControllerComponents)(implicit materializer: Materializer)
     extends BaseController {
-  //#comet-string
+  // #comet-string
   def cometString = Action {
     implicit val m                      = materializer
     def stringSource: Source[String, _] = Source(List("kiki", "foo", "bar"))
     Ok.chunked(stringSource.via(Comet.string("parent.cometMessage"))).as(ContentTypes.HTML)
   }
-  //#comet-string
+  // #comet-string
 
-  //#comet-json
+  // #comet-json
   def cometJson = Action {
     implicit val m                     = materializer
     def jsonSource: Source[JsValue, _] = Source(List(JsString("jsonString")))
     Ok.chunked(jsonSource.via(Comet.json("parent.cometMessage"))).as(ContentTypes.HTML)
   }
-  //#comet-json
+  // #comet-json
 }
 
 class ScalaCometSpec extends PlaySpecification {

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -61,11 +61,11 @@ class ScalaWebSockets extends PlaySpecification {
         class MyActor extends Actor {
           def receive = PartialFunction.empty
 
-          //#actor-post-stop
+          // #actor-post-stop
           override def postStop() = {
             someResource.close()
           }
-          //#actor-post-stop
+          // #actor-post-stop
         }
 
         implicit def actorSystem = app.injector.instanceOf[ActorSystem]
@@ -82,11 +82,11 @@ class ScalaWebSockets extends PlaySpecification {
         class MyActor extends Actor {
           def receive = PartialFunction.empty
 
-          //#actor-stop
+          // #actor-stop
           import akka.actor.PoisonPill
 
           self ! PoisonPill
-          //#actor-stop
+          // #actor-stop
         }
 
         implicit def actorSystem = app.injector.instanceOf[ActorSystem]
@@ -159,7 +159,7 @@ class ScalaWebSockets extends PlaySpecification {
 object Controller1 {
   import Actor1.MyWebSocketActor
 
-  //#actor-accept
+  // #actor-accept
   import play.api.mvc._
   import play.api.libs.streams.ActorFlow
   import javax.inject.Inject
@@ -172,11 +172,11 @@ object Controller1 {
       ActorFlow.actorRef { out => MyWebSocketActor.props(out) }
     }
   }
-  //#actor-accept
+  // #actor-accept
 }
 
 object Actor1 {
-  //#example-actor
+  // #example-actor
   import akka.actor._
 
   object MyWebSocketActor {
@@ -189,13 +189,13 @@ object Actor1 {
         out ! ("I received your message: " + msg)
     }
   }
-  //#example-actor
+  // #example-actor
 }
 
 object Controller2 {
   import Actor1.MyWebSocketActor
 
-  //#actor-try-accept
+  // #actor-try-accept
   import play.api.mvc._
   import play.api.libs.streams.ActorFlow
   import javax.inject.Inject
@@ -230,7 +230,7 @@ object Controller4 {
     def props(out: ActorRef) = Props(new MyWebSocketActor(out))
   }
 
-  //#actor-json
+  // #actor-json
   import play.api.libs.json._
   import play.api.mvc._
   import play.api.libs.streams.ActorFlow
@@ -244,19 +244,19 @@ object Controller4 {
       ActorFlow.actorRef { out => MyWebSocketActor.props(out) }
     }
   }
-  //#actor-json
+  // #actor-json
 }
 
 object Controller5 {
   case class InEvent(foo: String)
   case class OutEvent(bar: String)
 
-  //#actor-json-formats
+  // #actor-json-formats
   import play.api.libs.json._
 
   implicit val inEventFormat: Format[InEvent]   = Json.format[InEvent]
   implicit val outEventFormat: Format[OutEvent] = Json.format[OutEvent]
-  //#actor-json-formats
+  // #actor-json-formats
 
   import akka.actor._
 
@@ -271,14 +271,14 @@ object Controller5 {
     def props(out: ActorRef) = Props(new MyWebSocketActor(out))
   }
 
-  //#actor-json-frames
+  // #actor-json-frames
   import play.api.mvc.WebSocket.MessageFlowTransformer
 
   implicit val messageFlowTransformer: MessageFlowTransformer[InEvent, OutEvent] =
     MessageFlowTransformer.jsonMessageFlowTransformer[InEvent, OutEvent]
-  //#actor-json-frames
+  // #actor-json-frames
 
-  //#actor-json-in-out
+  // #actor-json-in-out
   import play.api.mvc._
 
   import play.api.libs.streams.ActorFlow
@@ -292,11 +292,11 @@ object Controller5 {
       ActorFlow.actorRef { out => MyWebSocketActor.props(out) }
     }
   }
-  //#actor-json-in-out
+  // #actor-json-in-out
 }
 
 class Controller6 {
-  //#streams1
+  // #streams1
   import play.api.mvc._
   import akka.stream.scaladsl._
 
@@ -309,11 +309,11 @@ class Controller6 {
 
     Flow.fromSinkAndSource(in, out)
   }
-  //#streams1
+  // #streams1
 }
 
 class Controller7 {
-  //#streams2
+  // #streams2
   import play.api.mvc._
   import akka.stream.scaladsl._
 
@@ -326,11 +326,11 @@ class Controller7 {
 
     Flow.fromSinkAndSource(in, out)
   }
-  //#streams2
+  // #streams2
 }
 
 class Controller8 {
-  //#streams3
+  // #streams3
   import play.api.mvc._
   import akka.stream.scaladsl._
 
@@ -341,5 +341,5 @@ class Controller8 {
       "I received your message: " + msg
     }
   }
-  //#streams3
+  // #streams3
 }

--- a/documentation/manual/working/scalaGuide/main/async/code/scalaguide/async/scalastream/ScalaStream.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/scalaguide/async/scalastream/ScalaStream.scala
@@ -24,30 +24,30 @@ import scala.concurrent.ExecutionContext
 class ScalaStreamController @Inject() (val controllerComponents: ControllerComponents)(
     implicit executionContext: ExecutionContext
 ) extends BaseController {
-  //#by-default
+  // #by-default
   def index = Action {
     Ok("Hello World")
   }
-  //#by-default
+  // #by-default
 
-  //#by-default-http-entity
+  // #by-default-http-entity
   def action = Action {
     Result(
       header = ResponseHeader(200, Map.empty),
       body = HttpEntity.Strict(ByteString("Hello world"), Some("text/plain"))
     )
   }
-  //#by-default-http-entity
+  // #by-default-http-entity
 
   private def createSourceFromFile = {
-    //#create-source-from-file
+    // #create-source-from-file
     val file                          = new java.io.File("/tmp/fileToServe.pdf")
     val path: java.nio.file.Path      = file.toPath
     val source: Source[ByteString, _] = FileIO.fromPath(path)
-    //#create-source-from-file
+    // #create-source-from-file
   }
 
-  //#streaming-http-entity
+  // #streaming-http-entity
   def streamed = Action {
     val file                          = new java.io.File("/tmp/fileToServe.pdf")
     val path: java.nio.file.Path      = file.toPath
@@ -58,9 +58,9 @@ class ScalaStreamController @Inject() (val controllerComponents: ControllerCompo
       body = HttpEntity.Streamed(source, None, Some("application/pdf"))
     )
   }
-  //#streaming-http-entity
+  // #streaming-http-entity
 
-  //#streaming-http-entity-with-content-length
+  // #streaming-http-entity-with-content-length
   def streamedWithContentLength = Action {
     val file                          = new java.io.File("/tmp/fileToServe.pdf")
     val path: java.nio.file.Path      = file.toPath
@@ -73,53 +73,53 @@ class ScalaStreamController @Inject() (val controllerComponents: ControllerCompo
       body = HttpEntity.Streamed(source, contentLength, Some("application/pdf"))
     )
   }
-  //#streaming-http-entity-with-content-length
+  // #streaming-http-entity-with-content-length
 
-  //#serve-file
+  // #serve-file
   def file = Action {
     Ok.sendFile(new java.io.File("/tmp/fileToServe.pdf"))
   }
-  //#serve-file
+  // #serve-file
 
-  //#serve-file-with-name
+  // #serve-file-with-name
   def fileWithName = Action {
     Ok.sendFile(
       content = new java.io.File("/tmp/fileToServe.pdf"),
       fileName = _ => Some("termsOfService.pdf")
     )
   }
-  //#serve-file-with-name
+  // #serve-file-with-name
 
-  //#serve-file-attachment
+  // #serve-file-attachment
   def fileAttachment = Action {
     Ok.sendFile(
       content = new java.io.File("/tmp/fileToServe.pdf"),
       inline = false
     )
   }
-  //#serve-file-attachment
+  // #serve-file-attachment
 
   private def getDataStream: InputStream = new ByteArrayInputStream("hello".getBytes())
 
   private def sourceFromInputStream = {
-    //#create-source-from-input-stream
+    // #create-source-from-input-stream
     val data                               = getDataStream
     val dataContent: Source[ByteString, _] = StreamConverters.fromInputStream(() => data)
-    //#create-source-from-input-stream
+    // #create-source-from-input-stream
   }
 
-  //#chunked-from-input-stream
+  // #chunked-from-input-stream
   def chunked = Action {
     val data                               = getDataStream
     val dataContent: Source[ByteString, _] = StreamConverters.fromInputStream(() => data)
     Ok.chunked(dataContent)
   }
-  //#chunked-from-input-stream
+  // #chunked-from-input-stream
 
-  //#chunked-from-source
+  // #chunked-from-source
   def chunkedFromSource = Action {
     val source = Source.apply(List("kiki", "foo", "bar"))
     Ok.chunked(source)
   }
-  //#chunked-from-source
+  // #chunked-from-source
 }

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -35,25 +35,25 @@ package scalaguide.cache {
 
       "a cache" in withCache { cache =>
         val connectedUser = User("xf")
-        //#set-value
+        // #set-value
         val result: Future[Done] = cache.set("item.key", connectedUser)
-        //#set-value
+        // #set-value
         Await.result(result, 1.second)
 
-        //#get-value
+        // #get-value
         val futureMaybeUser: Future[Option[User]] = cache.get[User]("item.key")
-        //#get-value
+        // #get-value
 
         val maybeUser = Await.result(futureMaybeUser, 1.second)
         maybeUser must beSome(connectedUser)
 
-        //#remove-value
+        // #remove-value
         val removeResult: Future[Done] = cache.remove("item.key")
-        //#remove-value
+        // #remove-value
 
-        //#removeAll-values
+        // #removeAll-values
         val removeAllResult: Future[Done] = cache.removeAll()
-        //#removeAll-values
+        // #removeAll-values
 
         Await.result(removeResult, 1.second)
 
@@ -62,22 +62,22 @@ package scalaguide.cache {
 
       "a cache or get user" in withCache { cache =>
         val connectedUser = "xf"
-        //#retrieve-missing
+        // #retrieve-missing
         val futureUser: Future[User] = cache.getOrElseUpdate[User]("item.key") {
           User.findById(connectedUser)
         }
-        //#retrieve-missing
+        // #retrieve-missing
         val user = Await.result(futureUser, 1.second)
         user must beEqualTo(User(connectedUser))
       }
 
       "cache with expiry" in withCache { cache =>
         val connectedUser = "xf"
-        //#set-value-expiration
+        // #set-value-expiration
         import scala.concurrent.duration._
 
         val result: Future[Done] = cache.set("item.key", connectedUser, 5.minutes)
-        //#set-value-expiration
+        // #set-value-expiration
         Await.result(result, 1.second)
         ok
       }
@@ -187,17 +187,17 @@ package scalaguide.cache {
 
     class Application1 @Inject() (cached: Cached, cc: ControllerComponents)(implicit ec: ExecutionContext)
         extends AbstractController(cc) {
-      //#cached-action
+      // #cached-action
       def index = cached("homePage") {
         Action {
           Ok("Hello world")
         }
       }
-      //#cached-action
+      // #cached-action
 
       import play.api.mvc.Security._
 
-      //#composition-cached-action
+      // #composition-cached-action
       def userProfile = WithAuthentication(_.session.get("username")) { userId =>
         cached(req => "profile." + userId) {
           Action.async {
@@ -205,8 +205,8 @@ package scalaguide.cache {
           }
         }
       }
-      //#composition-cached-action
-      //#cached-action-control
+      // #composition-cached-action
+      // #cached-action-control
       def get(index: Int) = cached.status(_ => "/resource/" + index, 200) {
         Action {
           if (index > 0) {
@@ -216,10 +216,10 @@ package scalaguide.cache {
           }
         }
       }
-      //#cached-action-control
+      // #cached-action-control
     }
     class Application2 @Inject() (cached: Cached, cc: ControllerComponents) extends AbstractController(cc) {
-      //#cached-action-control-404
+      // #cached-action-control-404
       def get(index: Int) = {
         val caching = cached
           .status(_ => "/resource/" + index, 200)
@@ -235,7 +235,7 @@ package scalaguide.cache {
           }
         }
       }
-      //#cached-action-control-404
+      // #cached-action-control-404
     }
   }
 

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaEhCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaEhCache.scala
@@ -35,25 +35,25 @@ package scalaguide.ehcache {
 
       "a cache" in withCache { cache =>
         val connectedUser = User("xf")
-        //#set-value
+        // #set-value
         val result: Future[Done] = cache.set("item.key", connectedUser)
-        //#set-value
+        // #set-value
         Await.result(result, 1.second)
 
-        //#get-value
+        // #get-value
         val futureMaybeUser: Future[Option[User]] = cache.get[User]("item.key")
-        //#get-value
+        // #get-value
 
         val maybeUser = Await.result(futureMaybeUser, 1.second)
         maybeUser must beSome(connectedUser)
 
-        //#remove-value
+        // #remove-value
         val removeResult: Future[Done] = cache.remove("item.key")
-        //#remove-value
+        // #remove-value
 
-        //#removeAll-values
+        // #removeAll-values
         val removeAllResult: Future[Done] = cache.removeAll()
-        //#removeAll-values
+        // #removeAll-values
 
         Await.result(removeResult, 1.second)
 
@@ -62,22 +62,22 @@ package scalaguide.ehcache {
 
       "a cache or get user" in withCache { cache =>
         val connectedUser = "xf"
-        //#retrieve-missing
+        // #retrieve-missing
         val futureUser: Future[User] = cache.getOrElseUpdate[User]("item.key") {
           User.findById(connectedUser)
         }
-        //#retrieve-missing
+        // #retrieve-missing
         val user = Await.result(futureUser, 1.second)
         user must beEqualTo(User(connectedUser))
       }
 
       "cache with expiry" in withCache { cache =>
         val connectedUser = "xf"
-        //#set-value-expiration
+        // #set-value-expiration
         import scala.concurrent.duration._
 
         val result: Future[Done] = cache.set("item.key", connectedUser, 5.minutes)
-        //#set-value-expiration
+        // #set-value-expiration
         Await.result(result, 1.second)
         ok
       }
@@ -187,17 +187,17 @@ package scalaguide.ehcache {
 
     class Application1 @Inject() (cached: Cached, cc: ControllerComponents)(implicit ec: ExecutionContext)
         extends AbstractController(cc) {
-      //#cached-action
+      // #cached-action
       def index = cached("homePage") {
         Action {
           Ok("Hello world")
         }
       }
-      //#cached-action
+      // #cached-action
 
       import play.api.mvc.Security._
 
-      //#composition-cached-action
+      // #composition-cached-action
       def userProfile = WithAuthentication(_.session.get("username")) { userId =>
         cached(req => "profile." + userId) {
           Action.async {
@@ -205,8 +205,8 @@ package scalaguide.ehcache {
           }
         }
       }
-      //#composition-cached-action
-      //#cached-action-control
+      // #composition-cached-action
+      // #cached-action-control
       def get(index: Int) = cached.status(_ => "/resource/" + index, 200) {
         Action {
           if (index > 0) {
@@ -216,10 +216,10 @@ package scalaguide.ehcache {
           }
         }
       }
-      //#cached-action-control
+      // #cached-action-control
     }
     class Application2 @Inject() (cached: Cached, cc: ControllerComponents) extends AbstractController(cc) {
-      //#cached-action-control-404
+      // #cached-action-control-404
       def get(index: Int) = {
         val caching = cached
           .status(_ => "/resource/" + index, 200)
@@ -235,7 +235,7 @@ package scalaguide.ehcache {
           }
         }
       }
-      //#cached-action-control-404
+      // #cached-action-control-404
     }
   }
 

--- a/documentation/manual/working/scalaGuide/main/config/code/ScalaConfig.scala
+++ b/documentation/manual/working/scalaGuide/main/config/code/ScalaConfig.scala
@@ -42,7 +42,7 @@ class ScalaConfigSpec extends AbstractController(Helpers.stubControllerComponent
     }
 
     "get different types of keys" in {
-      //#config-get
+      // #config-get
 
       // foo = bar
       config.get[String]("foo")
@@ -56,11 +56,11 @@ class ScalaConfigSpec extends AbstractController(Helpers.stubControllerComponent
       // listOfFoos = ["bar", "baz"]
       config.get[Seq[String]]("listOfFoos")
 
-      //#config-get
+      // #config-get
 
-      //#config-validate
+      // #config-validate
       config.getAndValidate[String]("foo", Set("bar", "baz"))
-      //#config-validate
+      // #config-validate
 
       // check that a bad key doesn't work
       config.get[String]("bogus") must throwAn[Exception]
@@ -69,13 +69,13 @@ class ScalaConfigSpec extends AbstractController(Helpers.stubControllerComponent
     }
 
     "allow defining custom config loaders" in {
-      //#config-loader-get
+      // #config-loader-get
       // app.config = {
       //   title = "My App
       //   baseUri = "https://example.com/"
       // }
       config.get[AppConfig]("app.config")
-      //#config-loader-get
+      // #config-loader-get
 
       ok
     }

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -68,7 +68,7 @@ package cleanup {
     val connection = connectToMessageQueue()
     lifecycle.addStopHook { () => Future.successful(connection.stop()) }
 
-    //...
+    // ...
   }
 //#cleanup
 }
@@ -183,7 +183,7 @@ package eagerguicestartup {
   class ApplicationStart @Inject() (lifecycle: ApplicationLifecycle) {
     // Shut-down hook
     lifecycle.addStopHook { () => Future.successful(()) }
-    //...
+    // ...
   }
 //#eager-guice-startup
 }

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
@@ -40,13 +40,13 @@ class ScalaCsrf extends PlaySpecification {
 
   "Play's CSRF protection" should {
     "allow global configuration" in new WithApplication() {
-      //#http-filters
+      // #http-filters
       import play.api.http.DefaultHttpFilters
       import play.filters.csrf.CSRFFilter
       import javax.inject.Inject
 
       class Filters @Inject() (csrfFilter: CSRFFilter) extends DefaultHttpFilters(csrfFilter)
-      //#http-filters
+      // #http-filters
       ok
     }
 
@@ -54,9 +54,9 @@ class ScalaCsrf extends PlaySpecification {
       val csrfTokenSigner = app.injector.instanceOf[CSRFTokenSigner]
       val originalToken   = csrfTokenSigner.generateSignedToken
       val addAndGetToken = addToken(Action { implicit request =>
-        //#get-token
+        // #get-token
         val token: Option[CSRF.Token] = CSRF.getToken
-        //#get-token
+        // #get-token
         Ok(token.map(_.value).getOrElse(""))
       })
       val result = addAndGetToken(FakeRequest().withSession("csrfToken" -> originalToken))
@@ -90,8 +90,8 @@ class ScalaCsrf extends PlaySpecification {
 
     "allow per action checking" in new WithApplication {
       import play.api.mvc.Results.Ok
-      //#csrf-check
-      //###insert: import play.api.mvc._
+      // #csrf-check
+      // ###insert: import play.api.mvc._
       import play.filters.csrf._
 
       def save = checkToken {
@@ -100,7 +100,7 @@ class ScalaCsrf extends PlaySpecification {
           Ok
         }
       }
-      //#csrf-check
+      // #csrf-check
 
       await(
         save(
@@ -114,14 +114,14 @@ class ScalaCsrf extends PlaySpecification {
     "allow per action token handling" in new WithApplication() {
       import play.api.mvc.Results.Ok
       val csrfTokenSigner = app.injector.instanceOf[CSRFTokenSigner]
-      //#csrf-add-token
-      //###insert: import play.api.mvc._
+      // #csrf-add-token
+      // ###insert: import play.api.mvc._
       import play.filters.csrf._
 
       def form = addToken {
         Action { implicit req => Ok(views.html.itemsForm) }
       }
-      //#csrf-add-token
+      // #csrf-add-token
 
       val body = await(form(FakeRequest("GET", "/")).flatMap(_.body.consumeData))
       csrfTokenSigner.extractSignedToken(body.utf8String) must beSome
@@ -130,7 +130,7 @@ class ScalaCsrf extends PlaySpecification {
     "be easy to use with an action builder" in new WithApplication() {
       import play.api.mvc.Results.Ok
       val csrfTokenSigner = app.injector.instanceOf[CSRFTokenSigner]
-      //#csrf-action-builder
+      // #csrf-action-builder
       import play.api.mvc._
       import play.filters.csrf._
 
@@ -149,19 +149,19 @@ class ScalaCsrf extends PlaySpecification {
         }
         override def composeAction[A](action: Action[A]) = addToken(action)
       }
-      //#csrf-action-builder
+      // #csrf-action-builder
 
       val getAction  = new GetAction(app.injector.instanceOf[BodyParsers.Default])
       val postAction = new PostAction(app.injector.instanceOf[BodyParsers.Default])
 
-      //#csrf-actions
+      // #csrf-actions
       def save = postAction {
         // handle body
         Ok
       }
 
       def form = getAction { implicit req => Ok(views.html.itemsForm) }
-      //#csrf-actions
+      // #csrf-actions
 
       await(
         save(

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -42,10 +42,10 @@ package scalaguide.forms.scalaforms {
         val controller = app.injector.instanceOf[controllers.Application]
         val userForm   = controller.userForm
 
-        //#userForm-generate-map
+        // #userForm-generate-map
         val anyData  = Map("name" -> "bob", "age" -> "21")
         val userData = userForm.bind(anyData).get
-        //#userForm-generate-map
+        // #userForm-generate-map
 
         userData.name === "bob"
       }
@@ -59,9 +59,9 @@ package scalaguide.forms.scalaforms {
 
         val anyData          = Json.parse("""{"name":"bob","age":"21"}""")
         implicit val request = FakeRequest().withBody(anyData)
-        //#userForm-generate-request
+        // #userForm-generate-request
         val userData = userForm.bindFromRequest().get
-        //#userForm-generate-request
+        // #userForm-generate-request
 
         userData.name === "bob"
       }
@@ -86,10 +86,10 @@ package scalaguide.forms.scalaforms {
 
         implicit val request = FakeRequest().withFormUrlEncodedBody("name" -> "", "age" -> "25")
 
-        //#userForm-constraints-2-with-errors
+        // #userForm-constraints-2-with-errors
         val boundForm = userFormConstraints2.bind(Map("bob" -> "", "age" -> "25"))
         boundForm.hasErrors must beTrue
-        //#userForm-constraints-2-with-errors
+        // #userForm-constraints-2-with-errors
       }
 
       "handling binding failure" in new WithApplication {
@@ -118,7 +118,7 @@ package scalaguide.forms.scalaforms {
       }
 
       "map single values" in new WithApplication {
-        //#form-single-value
+        // #form-single-value
         val singleForm = Form(
           single(
             "email" -> email
@@ -126,7 +126,7 @@ package scalaguide.forms.scalaforms {
         )
 
         val emailValue = singleForm.bind(Map("email" -> "bob@example.com")).get
-        //#form-single-value
+        // #form-single-value
         emailValue must beEqualTo("bob@example.com")
       }
 
@@ -199,14 +199,14 @@ package scalaguide.forms.scalaforms {
     class Application @Inject() (components: ControllerComponents)
         extends AbstractController(components)
         with I18nSupport {
-      //#userForm-define
+      // #userForm-define
       val userForm = Form(
         mapping(
           "name" -> text,
           "age"  -> number
         )(UserData.apply)(UserData.unapply)
       )
-      //#userForm-define
+      // #userForm-define
 
       def home(id: Int = 0) = Action {
         Ok("Welcome!")
@@ -219,7 +219,7 @@ package scalaguide.forms.scalaforms {
       def userPostHandlingFailure() = Action { implicit request =>
         val userForm = userFormConstraints
 
-        //#userForm-handling-failure
+        // #userForm-handling-failure
         userForm
           .bindFromRequest()
           .fold(
@@ -234,7 +234,7 @@ package scalaguide.forms.scalaforms {
               Redirect(routes.Application.home(id))
             }
           )
-      //#userForm-handling-failure
+      // #userForm-handling-failure
       }
 
       // #form-bodyparser
@@ -266,36 +266,36 @@ package scalaguide.forms.scalaforms {
       def submit = Action { implicit request => BadRequest("Not used") }
 
       val userFormName = {
-        //#userForm-get
+        // #userForm-get
         val anyData        = Map("name" -> "bob", "age" -> "18")
         val user: UserData = userForm.bind(anyData).get
-        //#userForm-get
+        // #userForm-get
 
-        //#userForm-filled
+        // #userForm-filled
         val filledForm = userForm.fill(UserData("Bob", 18))
-        //#userForm-filled
+        // #userForm-filled
 
         user.name
       }
 
-      //#addressSelectForm-constraint
+      // #addressSelectForm-constraint
       val addressSelectForm: Form[HomeAddressData] = Form(
         mapping(
           "street" -> text,
           "city"   -> text
         )(HomeAddressData.apply)(HomeAddressData.unapply)
       )
-      //#addressSelectForm-constraint
+      // #addressSelectForm-constraint
 
       val filledAddressSelectForm = {
-        //#addressSelectForm-filled
+        // #addressSelectForm-filled
         val selectedFormValues = HomeAddressData(street = "Main St", city = "London")
         val filledForm         = addressSelectForm.fill(selectedFormValues)
-        //#addressSelectForm-filled
+        // #addressSelectForm-filled
         filledForm
       }
 
-      //#userForm-verify
+      // #userForm-verify
       val userFormVerify = Form(
         mapping(
           "name"   -> text,
@@ -303,7 +303,7 @@ package scalaguide.forms.scalaforms {
           "accept" -> checked("Please accept the terms and conditions")
         )((name, age, _) => UserData(name, age))((user: UserData) => Some(user.name, user.age, false))
       )
-      //#userForm-verify
+      // #userForm-verify
 
       val userFormVerifyName = {
         val anyData        = Map("name" -> "bob", "age" -> "18", "accept" -> "true")
@@ -311,14 +311,14 @@ package scalaguide.forms.scalaforms {
         user.name
       }
 
-      //#userForm-constraints
+      // #userForm-constraints
       val userFormConstraints = Form(
         mapping(
           "name" -> text.verifying(nonEmpty),
           "age"  -> number.verifying(min(0), max(100))
         )(UserData.apply)(UserData.unapply)
       )
-      //#userForm-constraints
+      // #userForm-constraints
 
       val userFormConstraintsName = {
         val anyData        = Map("name" -> "bob", "age" -> "18", "accept" -> "true")
@@ -326,14 +326,14 @@ package scalaguide.forms.scalaforms {
         user.name
       }
 
-      //#userForm-constraints-2
+      // #userForm-constraints-2
       val userFormConstraints2 = Form(
         mapping(
           "name" -> nonEmptyText,
           "age"  -> number(min = 0, max = 100)
         )(UserData.apply)(UserData.unapply)
       )
-      //#userForm-constraints-2
+      // #userForm-constraints-2
 
       val userFormConstraints2Name = {
         val anyData        = Map("name" -> "bob", "age" -> "18", "accept" -> "true")
@@ -341,7 +341,7 @@ package scalaguide.forms.scalaforms {
         user.name
       }
 
-      //#userForm-constraints-ad-hoc
+      // #userForm-constraints-ad-hoc
       def validate(name: String, age: Int) = {
         name match {
           case "bob" if age >= 18 =>
@@ -365,7 +365,7 @@ package scalaguide.forms.scalaforms {
             }
         )
       )
-      //#userForm-constraints-ad-hoc
+      // #userForm-constraints-ad-hoc
 
       val userFormConstraintsAdhocName = {
         val anyData  = Map("name" -> "bob", "age" -> "18")
@@ -373,7 +373,7 @@ package scalaguide.forms.scalaforms {
         formData.name
       }
 
-      //#userForm-nested
+      // #userForm-nested
       val userFormNested: Form[UserAddressData] = Form(
         mapping(
           "name" -> text,
@@ -387,7 +387,7 @@ package scalaguide.forms.scalaforms {
           )(WorkAddressData.apply)(WorkAddressData.unapply)
         )(UserAddressData.apply)(UserAddressData.unapply)
       )
-      //#userForm-nested
+      // #userForm-nested
 
       val userFormNestedWorkCity = {
         val anyData = Map(
@@ -401,14 +401,14 @@ package scalaguide.forms.scalaforms {
         user.workAddress.city
       }
 
-      //#userForm-repeated
+      // #userForm-repeated
       val userFormRepeated = Form(
         mapping(
           "name"   -> text,
           "emails" -> list(email)
         )(UserListData.apply)(UserListData.unapply)
       )
-      //#userForm-repeated
+      // #userForm-repeated
 
       val userFormRepeatedEmails = {
         val anyData = Map("name" -> "bob", "emails[0]" -> "benewu@gmail.com", "emails[1]" -> "bob@gmail.com")
@@ -417,14 +417,14 @@ package scalaguide.forms.scalaforms {
         user.emails
       }
 
-      //#userForm-optional
+      // #userForm-optional
       val userFormOptional = Form(
         mapping(
           "name"  -> text,
           "email" -> optional(email)
         )(UserOptionalData.apply)(UserOptionalData.unapply)
       )
-      //#userForm-optional
+      // #userForm-optional
 
       val userFormOptionalEmail = {
         val anyData = Map("name" -> "bob")
@@ -433,18 +433,18 @@ package scalaguide.forms.scalaforms {
         user.email
       }
 
-      //#userForm-default
+      // #userForm-default
       Form(
         mapping(
           "name" -> default(text, "Bob"),
           "age"  -> default(number, 18)
         )(UserData.apply)(UserData.unapply)
       )
-      //#userForm-default
+      // #userForm-default
 
       case class UserStaticData(id: Long, name: String, email: Option[String])
 
-      //#userForm-static-value
+      // #userForm-static-value
       val userFormStatic = Form(
         mapping(
           "id"    -> ignored(23L),
@@ -452,18 +452,18 @@ package scalaguide.forms.scalaforms {
           "email" -> optional(email)
         )(UserStaticData.apply)(UserStaticData.unapply)
       )
-      //#userForm-static-value
+      // #userForm-static-value
 
-      //#userForm-custom-datatype
+      // #userForm-custom-datatype
       val userFormCustom = Form(
         mapping(
           "name"    -> text,
           "website" -> of[URL]
         )(UserCustomData.apply)(UserCustomData.unapply)
       )
-      //#userForm-custom-datatype
+      // #userForm-custom-datatype
 
-      //#userForm-custom-formatter
+      // #userForm-custom-formatter
       import play.api.data.format.Formatter
       import play.api.data.format.Formats._
       implicit object UrlFormatter extends Formatter[URL] {
@@ -471,7 +471,7 @@ package scalaguide.forms.scalaforms {
         override def bind(key: String, data: Map[String, String]) = parsing(new URL(_), "error.url", Nil)(key, data)
         override def unbind(key: String, value: URL)              = Map(key -> value.toString)
       }
-      //#userForm-custom-formatter
+      // #userForm-custom-formatter
 
       val userFormStaticId = {
         val anyData = Map("id" -> "1", "name" -> "bob")
@@ -605,7 +605,7 @@ package scalaguide.forms.scalaforms {
     }
 //#messages-request-controller
 
-    //#messages-abstract-controller
+    // #messages-abstract-controller
     // Form with Action extending MessagesAbstractController
     class MessagesFormController @Inject() (components: MessagesControllerComponents)
         extends MessagesAbstractController(components) {
@@ -623,6 +623,6 @@ package scalaguide.forms.scalaforms {
 
       def post() = TODO
     }
-    //#messages-abstract-controller
+    // #messages-abstract-controller
   }
 }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
@@ -17,40 +17,40 @@ package scalaguide.http.scalaactions {
   class ScalaActionsSpec extends AbstractController(Helpers.stubControllerComponents()) with SpecificationLike {
     "A scala action" should {
       "allow writing a simple echo action" in {
-        //#echo-action
+        // #echo-action
         def echo = Action { request => Ok("Got request [" + request + "]") }
-        //#echo-action
+        // #echo-action
         testAction(echo)
       }
 
       "support zero arg actions" in {
         testAction(
-          //#zero-arg-action
+          // #zero-arg-action
           Action {
             Ok("Hello world")
           }
-          //#zero-arg-action
+          // #zero-arg-action
         )
       }
 
       "pass the request to the action" in {
         testAction(
-          //#request-action
+          // #request-action
           Action { request => Ok("Got request [" + request + "]") }
-          //#request-action
+          // #request-action
         )
       }
 
       "pass the request implicitly to the action" in {
         testAction(
-          //#implicit-request-action
+          // #implicit-request-action
           Action { implicit request => Ok("Got request [" + request + "]") }
-          //#implicit-request-action
+          // #implicit-request-action
         )
       }
 
       "pass the request implicitly to the action with more methods" in {
-        //#implicit-request-action-with-more-methods
+        // #implicit-request-action-with-more-methods
         def action = Action { implicit request =>
           anotherMethod("Some para value")
           Ok("Got request [" + request + "]")
@@ -59,15 +59,15 @@ package scalaguide.http.scalaactions {
         def anotherMethod(p: String)(implicit request: Request[_]) = {
           // do something that needs access to the request
         }
-        //#implicit-request-action-with-more-methods
+        // #implicit-request-action-with-more-methods
         testAction(action)
       }
 
       "allow specifying a parser" in {
         testAction(
-          action = //#json-parser-action
+          action = // #json-parser-action
             Action(parse.json) { implicit request => Ok("Got request [" + request + "]") }
-          //#json-parser-action
+          // #json-parser-action
           ,
           request = FakeRequest().withBody(Json.obj()).withHeaders(CONTENT_TYPE -> "application/json")
         )
@@ -78,17 +78,17 @@ package scalaguide.http.scalaactions {
       }
 
       "support an action with parameters" in {
-        //#parameter-action
+        // #parameter-action
         def hello(name: String) = Action {
           Ok("Hello " + name)
         }
-        //#parameter-action
+        // #parameter-action
 
         assertAction(hello("world")) { result => contentAsString(result) must_== "Hello world" }
       }
 
       "support returning a simple result" in {
-        //#simple-result-action
+        // #simple-result-action
         import play.api.http.HttpEntity
 
         def index = Action {
@@ -97,60 +97,60 @@ package scalaguide.http.scalaactions {
             body = HttpEntity.Strict(ByteString("Hello world!"), Some("text/plain"))
           )
         }
-        //#simple-result-action
+        // #simple-result-action
         assertAction(index) { result => contentAsString(result) must_== "Hello world!" }
       }
 
       "support ok helper" in {
-        //#ok-result-action
+        // #ok-result-action
         def index = Action {
           Ok("Hello world!")
         }
-        //#ok-result-action
+        // #ok-result-action
         testAction(index)
       }
 
       "support other result types" in {
         val formWithErrors = ""
 
-        //#other-results
+        // #other-results
         val ok           = Ok("Hello world!")
         val notFound     = NotFound
         val pageNotFound = NotFound(<h1>Page not found</h1>)
         val badRequest   = BadRequest(views.html.form(formWithErrors))
         val oops         = InternalServerError("Oops")
         val anyStatus    = Status(488)("Strange response type")
-        //#other-results
+        // #other-results
 
         anyStatus.header.status must_== 488
       }
 
       "support redirects" in {
-        //#redirect-action
+        // #redirect-action
         def index = Action {
           Redirect("/user/home")
         }
-        //#redirect-action
+        // #redirect-action
         assertAction(index, expectedResponse = SEE_OTHER) { result =>
           (header(LOCATION, result) must be).some("/user/home")
         }
       }
 
       "support other redirects" in {
-        //#moved-permanently-action
+        // #moved-permanently-action
         def index = Action {
           Redirect("/user/home", MOVED_PERMANENTLY)
         }
-        //#moved-permanently-action
+        // #moved-permanently-action
         assertAction(index, expectedResponse = MOVED_PERMANENTLY) { result =>
           (header(LOCATION, result) must be).some("/user/home")
         }
       }
 
       "support todo actions" in {
-        //#todo-action
+        // #todo-action
         def index(name: String) = TODO
-        //#todo-action
+        // #todo-action
         testAction(index("foo"), expectedResponse = NOT_IMPLEMENTED)
       }
     }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -35,7 +35,7 @@ package scalaguide.http.scalaactionscomposition {
       val actionBuilder                 = new DefaultActionBuilderImpl(new BodyParsers.Default(parse))
 
       "Basic action composition" in {
-        //#basic-logging
+        // #basic-logging
         import play.api.mvc._
 
         class LoggingAction @Inject() (parser: BodyParsers.Default)(implicit ec: ExecutionContext)
@@ -46,31 +46,31 @@ package scalaguide.http.scalaactionscomposition {
             block(request)
           }
         }
-        //#basic-logging
+        // #basic-logging
 
         val loggingAction = new LoggingAction(defaultParser)
 
-        //#basic-logging-index
+        // #basic-logging-index
         class MyController @Inject() (loggingAction: LoggingAction, cc: ControllerComponents)
             extends AbstractController(cc) {
           def index = loggingAction {
             Ok("Hello World")
           }
         }
-        //#basic-logging-index
+        // #basic-logging-index
 
         testAction(new MyController(loggingAction, Helpers.stubControllerComponents()).index)
 
-        //#basic-logging-parse
+        // #basic-logging-parse
         def submit = loggingAction(parse.text) { request => Ok("Got a body " + request.body.length + " bytes long") }
-        //#basic-logging-parse
+        // #basic-logging-parse
 
         val request = FakeRequest().withTextBody("hello with the parse")
         testAction(new MyController(loggingAction, Helpers.stubControllerComponents()).index, request)
       }
 
       "Wrapping existing actions" in {
-        //#actions-class-wrapping
+        // #actions-class-wrapping
         import play.api.mvc._
 
         case class Logging[A](action: Action[A]) extends Action[A] with play.api.Logging {
@@ -82,9 +82,9 @@ package scalaguide.http.scalaactionscomposition {
           override def parser           = action.parser
           override def executionContext = action.executionContext
         }
-        //#actions-class-wrapping
+        // #actions-class-wrapping
 
-        //#actions-wrapping-builder
+        // #actions-wrapping-builder
         class LoggingAction @Inject() (parser: BodyParsers.Default)(implicit ec: ExecutionContext)
             extends ActionBuilderImpl(parser) {
           override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
@@ -92,46 +92,46 @@ package scalaguide.http.scalaactionscomposition {
           }
           override def composeAction[A](action: Action[A]) = new Logging(action)
         }
-        //#actions-wrapping-builder
+        // #actions-wrapping-builder
 
         val loggingAction = new LoggingAction(defaultParser)
 
         {
-          //#actions-wrapping-index
+          // #actions-wrapping-index
           def index = loggingAction {
             Ok("Hello World")
           }
-          //#actions-wrapping-index
+          // #actions-wrapping-index
 
           testAction(index)
         }
 
         {
           val Action = actionBuilder
-          //#actions-wrapping-direct
+          // #actions-wrapping-direct
           def index = Logging {
             Action {
               Ok("Hello World")
             }
           }
-          //#actions-wrapping-direct
+          // #actions-wrapping-direct
 
           testAction(index)
         }
       }
 
       "Wrapping existing actions without defining the Logging class" in {
-        //#actions-def-wrapping
+        // #actions-def-wrapping
         import play.api.mvc._
 
-        //###skip:2
+        // ###skip:2
         val logger = Logger(getClass)
         val Action = actionBuilder
         def logging[A](action: Action[A]) = Action.async(action.parser) { request =>
           logger.info("Calling action")
           action(request)
         }
-        //#actions-def-wrapping
+        // #actions-def-wrapping
 
         val request = FakeRequest().withTextBody("hello with the parse")
         testAction(
@@ -145,11 +145,11 @@ package scalaguide.http.scalaactionscomposition {
       }
 
       "allow modifying the request object" in {
-        //#modify-request
+        // #modify-request
         import play.api.mvc._
         import play.api.mvc.request.RemoteConnection
 
-        //###skip:1
+        // ###skip:1
         val Action = actionBuilder
         def xForwardedFor[A](action: Action[A]) = Action.async(action.parser) { request =>
           val newRequest = request.headers.get("X-Forwarded-For") match {
@@ -160,17 +160,17 @@ package scalaguide.http.scalaactionscomposition {
           }
           action(newRequest)
         }
-        //#modify-request
+        // #modify-request
 
         testAction(xForwardedFor(Action(Ok)))
       }
 
       "allow blocking the request" in {
-        //#block-request
+        // #block-request
         import play.api.mvc._
-        //###insert: import play.api.mvc.Results._
+        // ###insert: import play.api.mvc.Results._
 
-        //###skip:1
+        // ###skip:1
         val Action = actionBuilder
         def onlyHttps[A](action: Action[A]) = Action.async(action.parser) { request =>
           request.headers
@@ -182,27 +182,27 @@ package scalaguide.http.scalaactionscomposition {
               Future.successful(Forbidden("Only HTTPS requests allowed"))
             }
         }
-        //#block-request
+        // #block-request
 
         testAction(action = onlyHttps(Action(Ok)), expectedResponse = FORBIDDEN)
       }
 
       "allow modifying the result" in {
-        //#modify-result
+        // #modify-result
         import play.api.mvc._
 
-        //###skip:1
+        // ###skip:1
         val Action = actionBuilder
         def addUaHeader[A](action: Action[A]) = Action.async(action.parser) { request =>
           action(request).map(_.withHeaders("X-UA-Compatible" -> "Chrome=1"))
         }
-        //#modify-result
+        // #modify-result
 
         assertAction(addUaHeader(Action(Ok))) { result => header("X-UA-Compatible", result) must beSome("Chrome=1") }
       }
 
       "allow action builders with different request types" in {
-        //#authenticated-action-builder
+        // #authenticated-action-builder
         import play.api.mvc._
 
         class UserRequest[A](val username: Option[String], request: Request[A]) extends WrappedRequest[A](request)
@@ -214,7 +214,7 @@ package scalaguide.http.scalaactionscomposition {
             new UserRequest(request.session.get("username"), request)
           }
         }
-        //#authenticated-action-builder
+        // #authenticated-action-builder
         val userAction = new UserAction(defaultParser)
 
         def currentUser = userAction { request => Ok("The current user is " + request.username.getOrElse("anonymous")) }
@@ -229,15 +229,15 @@ package scalaguide.http.scalaactionscomposition {
           def findById(id: String) = Some(Item(id))
         }
 
-        //#request-with-item
+        // #request-with-item
         import play.api.mvc._
 
         class ItemRequest[A](val item: Item, request: UserRequest[A]) extends WrappedRequest[A](request) {
           def username = request.username
         }
-        //#request-with-item
+        // #request-with-item
 
-        //#item-action-builder
+        // #item-action-builder
         def ItemAction(itemId: String)(implicit ec: ExecutionContext) = new ActionRefiner[UserRequest, ItemRequest] {
           def executionContext = ec
           def refine[A](input: UserRequest[A]) = Future.successful {
@@ -247,9 +247,9 @@ package scalaguide.http.scalaactionscomposition {
               .toRight(NotFound)
           }
         }
-        //#item-action-builder
+        // #item-action-builder
 
-        //#permission-check-action
+        // #permission-check-action
         def PermissionCheckAction(implicit ec: ExecutionContext) = new ActionFilter[ItemRequest] {
           def executionContext = ec
           def filter[A](input: ItemRequest[A]) = Future.successful {
@@ -259,15 +259,15 @@ package scalaguide.http.scalaactionscomposition {
               None
           }
         }
-        //#permission-check-action
+        // #permission-check-action
 
-        //#item-action-use
+        // #item-action-use
         def tagItem(itemId: String, tag: String)(implicit ec: ExecutionContext) =
           userAction.andThen(ItemAction(itemId)).andThen(PermissionCheckAction) { request =>
             request.item.addTag(tag)
             Ok("User " + request.username + " tagged " + request.item.id)
           }
-        //#item-action-use
+        // #item-action-use
 
         testAction(tagItem("foo", "bar"), expectedResponse = FORBIDDEN)
       }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -45,7 +45,7 @@ package scalaguide.http.scalabodyparsers {
 
     "A scala body parser" should {
       "parse request as json" in new WithController() {
-        //#access-json-body
+        // #access-json-body
         def save = Action { (request: Request[AnyContent]) =>
           val body: AnyContent          = request.body
           val jsonBody: Option[JsValue] = body.asJson
@@ -57,34 +57,34 @@ package scalaguide.http.scalabodyparsers {
               BadRequest("Expecting application/json request body")
             }
         }
-        //#access-json-body
+        // #access-json-body
         testAction(save, helloRequest)
       }
 
       "body parser json" in new WithController() {
-        //#body-parser-json
+        // #body-parser-json
         def save = Action(parse.json) { (request: Request[JsValue]) =>
           Ok("Got: " + (request.body \ "name").as[String])
         }
-        //#body-parser-json
+        // #body-parser-json
         testAction(save, helloRequest)
       }
 
       "body parser tolerantJson" in new WithController() {
-        //#body-parser-tolerantJson
+        // #body-parser-tolerantJson
         def save = Action(parse.tolerantJson) { (request: Request[JsValue]) =>
           Ok("Got: " + (request.body \ "name").as[String])
         }
-        //#body-parser-tolerantJson
+        // #body-parser-tolerantJson
         testAction(save, helloRequest)
       }
 
       "body parser file" in new WithController() {
-        //#body-parser-file
+        // #body-parser-file
         def save = Action(parse.file(to = new File("/tmp/upload"))) { (request: Request[File]) =>
           Ok("Saved the request content to " + request.body)
         }
-        //#body-parser-file
+        // #body-parser-file
         testAction(save, helloRequest.withSession("username" -> "player"))
       }
 
@@ -97,10 +97,10 @@ package scalaguide.http.scalabodyparsers {
 
       "body parser limit text" in new WithController() {
         val text = "hello"
-        //#body-parser-limit-text
+        // #body-parser-limit-text
         // Accept only 10KB of data.
         def save = Action(parse.text(maxLength = 1024 * 10)) { (request: Request[String]) => Ok("Got: " + text) }
-        //#body-parser-limit-text
+        // #body-parser-limit-text
         testAction(save, FakeRequest("POST", "/").withTextBody("foo"))
       }
 
@@ -108,18 +108,18 @@ package scalaguide.http.scalabodyparsers {
         implicit val mat = app.materializer
         val storeInUserFile =
           new scalaguide.http.scalabodyparsers.full.Application(controllerComponents).storeInUserFile
-        //#body-parser-limit-file
+        // #body-parser-limit-file
         // Accept only 10KB of data.
         def save = Action(parse.maxLength(1024 * 10, storeInUserFile)) { request =>
           Ok("Saved the request content to " + request.body)
         }
-        //#body-parser-limit-file
+        // #body-parser-limit-file
         val result = call(save, helloRequest.withSession("username" -> "player"))
         status(result) must_== OK
       }
 
       "forward the body" in new WithApplication() {
-        //#forward-body
+        // #forward-body
         import javax.inject._
         import play.api.mvc._
         import play.api.libs.streams._
@@ -141,14 +141,14 @@ package scalaguide.http.scalabodyparsers {
 
           def myAction = Action(forward(ws.url("https://example.com"))) { req => Ok("Uploaded") }
         }
-        //#forward-body
+        // #forward-body
 
         ok
       }
 
       "parse the body as csv" in new WithApplication() with Injecting {
         import scala.concurrent.ExecutionContext.Implicits.global
-        //#csv
+        // #csv
         import play.api.mvc.BodyParser
         import play.api.libs.streams._
         import akka.util.ByteString
@@ -169,7 +169,7 @@ package scalaguide.http.scalabodyparsers {
           // Convert the body to a Right either
           Accumulator(sink).map(Right.apply)
         }
-        //#csv
+        // #csv
 
         testAction(Action(csv)(req => Ok(req.body(1)(2))), FakeRequest("POST", "/").withTextBody("1,2\n3,4,foo\n5,6"))
       }
@@ -201,7 +201,7 @@ package scalaguide.http.scalabodyparsers {
     import play.api.mvc._
 
     class Application @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
-      //#body-parser-combining
+      // #body-parser-combining
       val storeInUserFile = parse.using { request =>
         request.session
           .get("username")
@@ -213,25 +213,25 @@ package scalaguide.http.scalabodyparsers {
 
       def save = Action(storeInUserFile) { request => Ok("Saved the request content to " + request.body) }
 
-      //#body-parser-combining
+      // #body-parser-combining
     }
 
     object CodeShow {
-      //#action
+      // #action
       trait Action[A] extends (Request[A] => Result) {
         def parser: BodyParser[A]
       }
-      //#action
+      // #action
 
-      //#request
+      // #request
       trait Request[+A] extends RequestHeader {
         def body: A
       }
-      //#request
+      // #request
 
-      //#body-parser
+      // #body-parser
       trait BodyParser[+A] extends (RequestHeader => Accumulator[ByteString, Either[Result, A]])
-      //#body-parser
+      // #body-parser
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaContentNegotiation.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaContentNegotiation.scala
@@ -18,7 +18,7 @@ package scalaguide.http.scalacontentnegotiation {
   class ScalaContentNegotiation extends AbstractController(Helpers.stubControllerComponents()) with SpecificationLike {
     "A Scala Content Negotiation" should {
       "negotiate accept type" in {
-        //#negotiate_accept_type
+        // #negotiate_accept_type
         val list = Action { implicit request =>
           val items = Item.findAll
           render {
@@ -26,7 +26,7 @@ package scalaguide.http.scalacontentnegotiation {
             case Accepts.Json() => Ok(Json.toJson(items))
           }
         }
-        //#negotiate_accept_type
+        // #negotiate_accept_type
 
         val requestHtml = FakeRequest().withHeaders(ACCEPT -> "text/html")
         assertAction(list, OK, requestHtml)(r => contentAsString(r) === "<html>1,2,3</html>")
@@ -38,13 +38,13 @@ package scalaguide.http.scalacontentnegotiation {
       "negotiate accept type" in {
         val list = Action { implicit request =>
           def ??? = Ok("ok")
-          //#extract_custom_accept_type
+          // #extract_custom_accept_type
           val AcceptsMp3 = Accepting("audio/mp3")
           render {
             case AcceptsMp3() => ???
           }
         }
-        //#extract_custom_accept_type
+        // #extract_custom_accept_type
 
         val requestHtml = FakeRequest().withHeaders(ACCEPT -> "audio/mp3")
         assertAction(list, OK, requestHtml)(r => contentAsString(r) === "ok")

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
@@ -22,53 +22,53 @@ package scalaguide.http.scalaresults {
   class ScalaResultsSpec extends AbstractController(Helpers.stubControllerComponents()) with PlaySpecification {
     "A scala result" should {
       "default result Content-Type" in {
-        //#content-type_text
+        // #content-type_text
         val textResult = Ok("Hello World!")
-        //#content-type_text
+        // #content-type_text
         testContentType(textResult, "text/plain")
       }
 
       "default xml result Content-Type" in {
-        //#content-type_xml
+        // #content-type_xml
         val xmlResult = Ok(<message>Hello World!</message>)
-        //#content-type_xml
+        // #content-type_xml
         testContentType(xmlResult, "application/xml")
       }
 
       "set result Content-Type as html" in {
-        //#content-type_html
+        // #content-type_html
         val htmlResult = Ok(<h1>Hello World!</h1>).as("text/html")
-        //#content-type_html
+        // #content-type_html
         testContentType(htmlResult, "text/html")
 
-        //#content-type_defined_html
+        // #content-type_defined_html
         val htmlResult2 = Ok(<h1>Hello World!</h1>).as(HTML)
-        //#content-type_defined_html
+        // #content-type_defined_html
         testContentType(htmlResult2, "text/html")
       }
 
       "Manipulating HTTP headers" in {
-        //#set-headers
+        // #set-headers
         val result = Ok("Hello World!").withHeaders(CACHE_CONTROL -> "max-age=3600", ETAG -> "xx")
-        //#set-headers
+        // #set-headers
         testHeader(result, CACHE_CONTROL, "max-age=3600")
         testHeader(result, ETAG, "xx")
       }
 
       "Setting and discarding cookies" in {
-        //#set-cookies
+        // #set-cookies
         val result = Ok("Hello world")
           .withCookies(Cookie("theme", "blue"))
           .bakeCookies()
-        //#set-cookies
+        // #set-cookies
         testHeader(result, SET_COOKIE, "theme=blue")
-        //#discarding-cookies
+        // #discarding-cookies
         val result2 = result.discardingCookies(DiscardingCookie("theme"))
-        //#discarding-cookies
+        // #discarding-cookies
         testHeader(result2, SET_COOKIE, "theme=;")
-        //#setting-discarding-cookies
+        // #setting-discarding-cookies
         val result3 = result.withCookies(Cookie("theme", "blue")).discardingCookies(DiscardingCookie("skin"))
-        //#setting-discarding-cookies
+        // #setting-discarding-cookies
         testHeader(result3, SET_COOKIE, "skin=;")
         testHeader(result3, SET_COOKIE, "theme=blue;")
       }
@@ -87,7 +87,7 @@ package scalaguide.http.scalaresults {
         "for Sources" in {
           val request = FakeRequest().withHeaders("Range" -> "bytes=0-5")
 
-          //#range-result-source
+          // #range-result-source
           val header  = request.headers.get(RANGE)
           val content = "This is the full body!"
           val source  = Source.single(ByteString(content))
@@ -99,7 +99,7 @@ package scalaguide.http.scalaresults {
             fileName = Some("file.txt"),
             contentType = Some(TEXT)
           )
-          //#range-result-source
+          // #range-result-source
 
           testContentType(partialContent, "text/plain")
           partialContent.header.status must beEqualTo(PARTIAL_CONTENT)
@@ -108,10 +108,10 @@ package scalaguide.http.scalaresults {
         "for InputStream" in {
           val request = FakeRequest().withHeaders("Range" -> "bytes=0-5")
 
-          //#range-result-input-stream
+          // #range-result-input-stream
           val input          = getInputStream()
           val partialContent = RangeResult.ofStream(input, request.headers.get(RANGE), "video.mp4", Some("video/mp4"))
-          //#range-result-input-stream
+          // #range-result-input-stream
 
           testContentType(partialContent, "video/mp4")
           partialContent.header.status must beEqualTo(PARTIAL_CONTENT)
@@ -123,7 +123,7 @@ package scalaguide.http.scalaresults {
               Source(content.getBytes.iterator.map(ByteString(_)).toIndexedSeq)
 
             def index = Action { request =>
-              //#range-result-source-with-offset
+              // #range-result-source-with-offset
               val header  = request.headers.get(RANGE)
               val content = "This is the full body!"
               val source  = sourceFrom(content)
@@ -135,7 +135,7 @@ package scalaguide.http.scalaresults {
                 fileName = Some("file.txt"),
                 contentType = Some(TEXT)
               )
-              //#range-result-source-with-offset
+              // #range-result-source-with-offset
 
               partialContent
             }
@@ -190,7 +190,7 @@ package scalaguide.http.scalaresults {
   package scalaguide.http.scalaresults.full {
     import javax.inject.Inject
 
-    //#full-application-set-myCustomCharset
+    // #full-application-set-myCustomCharset
     class Application @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
       implicit val myCustomCharset = Codec.javaSupported("iso-8859-1")
 
@@ -198,14 +198,14 @@ package scalaguide.http.scalaresults {
         Ok(<h1>Hello World!</h1>).as(HTML)
       }
     }
-    //#full-application-set-myCustomCharset
+    // #full-application-set-myCustomCharset
 
     object CodeShow {
-      //#Source-Code-HTML
+      // #Source-Code-HTML
       def HTML(implicit codec: Codec) = {
         "text/html; charset=" + codec.charset
       }
-      //#Source-Code-HTML
+      // #Source-Code-HTML
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -18,7 +18,7 @@ package scalaguide.http.scalasessionflash {
   class ScalaSessionFlashSpec extends AbstractController(Helpers.stubControllerComponents()) with SpecificationLike {
     "A scala SessionFlash" should {
       "Reading a Session value" in {
-        //#index-retrieve-incoming-session
+        // #index-retrieve-incoming-session
         def index = Action { request =>
           request.session
             .get("connected")
@@ -27,7 +27,7 @@ package scalaguide.http.scalasessionflash {
               Unauthorized("Oops, you are not connected")
             }
         }
-        //#index-retrieve-incoming-session
+        // #index-retrieve-incoming-session
 
         assertAction(index, OK, FakeRequest().withSession("connected" -> "player"))(res =>
           contentAsString(res) must contain("player")
@@ -36,9 +36,9 @@ package scalaguide.http.scalasessionflash {
 
       "Storing data in the Session" in {
         def storeSession = Action { implicit request =>
-          //#store-session
+          // #store-session
           Redirect("/home").withSession("connected" -> "user@gmail.com")
-          //#store-session
+          // #store-session
         }
 
         assertAction(storeSession, SEE_OTHER, FakeRequest())(res =>
@@ -48,9 +48,9 @@ package scalaguide.http.scalasessionflash {
 
       "add data in the Session" in {
         def addSession = Action { implicit request =>
-          //#add-session
+          // #add-session
           Redirect("/home").withSession(request.session + ("saidHello" -> "yes"))
-          //#add-session
+          // #add-session
         }
 
         assertAction(addSession, SEE_OTHER, FakeRequest())(res => testSession(res, "saidHello", Some("yes")))
@@ -58,9 +58,9 @@ package scalaguide.http.scalasessionflash {
 
       "remove data in the Session" in {
         def removeSession = Action { implicit request =>
-          //#remove-session
+          // #remove-session
           Redirect("/home").withSession(request.session - "theme")
-          //#remove-session
+          // #remove-session
         }
 
         assertAction(removeSession, SEE_OTHER, FakeRequest().withSession("theme" -> "blue"))(res =>
@@ -70,9 +70,9 @@ package scalaguide.http.scalasessionflash {
 
       "Discarding the whole session" in {
         def discardingSession = Action { implicit request =>
-          //#discarding-session
+          // #discarding-session
           Redirect("/home").withNewSession
-          //#discarding-session
+          // #discarding-session
         }
         assertAction(discardingSession, SEE_OTHER, FakeRequest().withSession("theme" -> "blue"))(res =>
           testSession(res, "theme", None)
@@ -80,7 +80,7 @@ package scalaguide.http.scalasessionflash {
       }
 
       "get from flash" in {
-        //#using-flash
+        // #using-flash
         def index = Action { implicit request =>
           Ok {
             request.flash.get("success").getOrElse("Welcome!")
@@ -90,7 +90,7 @@ package scalaguide.http.scalasessionflash {
         def save = Action {
           Redirect("/home").flashing("success" -> "The item has been created")
         }
-        //#using-flash
+        // #using-flash
         assertAction(index, OK, FakeRequest().withFlash("success" -> "success!"))(res =>
           contentAsString(res) must contain("success!")
         )
@@ -100,9 +100,9 @@ package scalaguide.http.scalasessionflash {
       }
 
       "access flash in template" in {
-        //#flash-implicit-request
+        // #flash-implicit-request
         def index = Action { implicit request => Ok(views.html.index()) }
-        //#flash-implicit-request
+        // #flash-implicit-request
 
         assertAction(index, OK, FakeRequest())(result => contentAsString(result) must contain("Welcome!"))
         assertAction(index, OK, FakeRequest().withFlash("success" -> "Flashed!"))(result =>

--- a/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
@@ -19,7 +19,7 @@ package scalaguide.i18n.scalai18n {
     }
   }
 
-  //#i18n-messagescontroller
+  // #i18n-messagescontroller
   import javax.inject.Inject
   import play.api.i18n._
 
@@ -41,9 +41,9 @@ package scalaguide.i18n.scalai18n {
       Ok(views.html.formpage())
     }
   }
-  //#i18n-messagescontroller
+  // #i18n-messagescontroller
 
-  //#i18n-support
+  // #i18n-support
   import javax.inject.Inject
   import play.api.i18n._
 
@@ -78,7 +78,7 @@ package scalaguide.i18n.scalai18n {
       Ok(views.html.formpage())
     }
   }
-  //#i18n-support
+  // #i18n-support
 
   @RunWith(classOf[JUnitRunner])
   class ScalaI18nSpec extends AbstractController(Helpers.stubControllerComponents()) with PlaySpecification {
@@ -111,15 +111,15 @@ package scalaguide.i18n.scalai18n {
       implicit val lang = Lang("en")
 
       "escape single quotes" in {
-        //#apostrophe-messages
+        // #apostrophe-messages
         messagesApi("info.error") == "You aren't logged in!"
-        //#apostrophe-messages
+        // #apostrophe-messages
       }
 
       "escape parameter substitution" in {
-        //#parameter-escaping
+        // #parameter-escaping
         messagesApi("example.formatting") == "When using MessageFormat, '{0}' is replaced with the first parameter."
-        //#parameter-escaping
+        // #parameter-escaping
       }
     }
   }

--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
@@ -18,26 +18,26 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
     "allow serving JSON" in new WithApplication() with Injecting {
       val Action = inject[DefaultActionBuilder]
 
-      //#serve-json-imports
-      //###insert: import play.api.mvc._
+      // #serve-json-imports
+      // ###insert: import play.api.mvc._
       import play.api.libs.functional.syntax._
       import play.api.libs.json._
-      //#serve-json-imports
+      // #serve-json-imports
 
-      //#serve-json-implicits
+      // #serve-json-implicits
       implicit val locationWrites: Writes[Location] =
         (JsPath \ "lat").write[Double].and((JsPath \ "long").write[Double])(unlift(Location.unapply))
 
       implicit val placeWrites: Writes[Place] =
         (JsPath \ "name").write[String].and((JsPath \ "location").write[Location])(unlift(Place.unapply))
-      //#serve-json-implicits
+      // #serve-json-implicits
 
-      //#serve-json
+      // #serve-json
       def listPlaces = Action {
         val json = Json.toJson(Place.list)
         Ok(json)
       }
-      //#serve-json
+      // #serve-json
 
       val result: Future[Result] = listPlaces().apply(FakeRequest())
       status(result) === OK
@@ -50,20 +50,20 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
     "allow handling JSON" in new WithApplication() with Injecting {
       val Action = inject[DefaultActionBuilder]
 
-      //#handle-json-imports
+      // #handle-json-imports
       import play.api.libs.functional.syntax._
       import play.api.libs.json._
-      //#handle-json-imports
+      // #handle-json-imports
 
-      //#handle-json-implicits
+      // #handle-json-implicits
       implicit val locationReads: Reads[Location] =
         (JsPath \ "lat").read[Double].and((JsPath \ "long").read[Double])(Location.apply _)
 
       implicit val placeReads: Reads[Place] =
         (JsPath \ "name").read[String].and((JsPath \ "location").read[Location])(Place.apply _)
-      //#handle-json-implicits
+      // #handle-json-implicits
 
-      //#handle-json
+      // #handle-json
       def savePlace = Action { request =>
         request.body.asJson
           .map { json =>
@@ -82,9 +82,9 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
             BadRequest(Json.obj("message" -> "Expecting JSON data."))
           }
       }
-      //#handle-json
+      // #handle-json
 
-      val body                   = Json.parse("""
+      val body = Json.parse("""
       {
         "name" : "Nuthanger Farm",
         "location" : {
@@ -114,7 +114,7 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
       val parse  = inject[PlayBodyParsers]
       val Action = inject[DefaultActionBuilder]
 
-      //#handle-json-bodyparser
+      // #handle-json-bodyparser
       def savePlace = Action(parse.json) { request =>
         val placeResult = request.body.validate[Place]
         placeResult.fold(
@@ -127,9 +127,9 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
           }
         )
       }
-      //#handle-json-bodyparser
+      // #handle-json-bodyparser
 
-      val body: JsValue          = Json.parse("""
+      val body: JsValue = Json.parse("""
       {
         "name" : "Nuthanger Farm",
         "location" : {
@@ -152,16 +152,15 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
       val parse  = inject[PlayBodyParsers]
       val Action = inject[DefaultActionBuilder]
 
-      //#handle-json-bodyparser-concise
+      // #handle-json-bodyparser-concise
       import play.api.libs.functional.syntax._
       import play.api.libs.json.Reads._
       import play.api.libs.json._
 
-      implicit val locationReads: Reads[Location] = (
+      implicit val locationReads: Reads[Location] =
         (JsPath \ "lat")
           .read[Double](min(-90.0).keepAnd(max(90.0)))
-          .and((JsPath \ "long").read[Double](min(-180.0).keepAnd(max(180.0))))
-      )(Location.apply _)
+          .and((JsPath \ "long").read[Double](min(-180.0).keepAnd(max(180.0))))(Location.apply _)
 
       implicit val placeReads: Reads[Place] =
         (JsPath \ "name").read[String](minLength[String](2)).and((JsPath \ "location").read[Location])(Place.apply _)
@@ -181,7 +180,7 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
         Place.save(place)
         Ok(Json.obj("message" -> ("Place '" + place.name + "' saved.")))
       }
-      //#handle-json-bodyparser-concise
+      // #handle-json-bodyparser-concise
 
       val body: JsValue = Json.parse("""
       {

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -35,7 +35,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
         logger.isErrorEnabled().returns(true)
       }
 
-      //#logging-example
+      // #logging-example
       // Log some debug info
       logger.debug("Attempting risky calculation.")
 
@@ -50,7 +50,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
           logger.error("Exception with riskyCalculation", t)
         }
       }
-      //#logging-example
+      // #logging-example
 
       there.was(atLeastOne(logger.logger).isDebugEnabled())
       there.was(atLeastOne(logger.logger).debug(anyString))
@@ -61,13 +61,13 @@ class ScalaLoggingSpec extends Specification with Mockito {
 
   "Creating a Logger" should {
     "return a new Logger with specified name" in {
-      //#logging-import
+      // #logging-import
       import play.api.Logger
-      //#logging-import
+      // #logging-import
 
-      //#logging-create-logger-name
+      // #logging-create-logger-name
       val accessLogger: Logger = Logger("access")
-      //#logging-create-logger-name
+      // #logging-create-logger-name
 
       accessLogger.underlyingLogger.getName must equalTo("access")
     }
@@ -75,21 +75,21 @@ class ScalaLoggingSpec extends Specification with Mockito {
     "return a new Logger with class name" in {
       import play.api.Logger
 
-      //#logging-create-logger-class
+      // #logging-create-logger-class
       val logger: Logger = Logger(this.getClass())
-      //#logging-create-logger-class
+      // #logging-create-logger-class
 
       logger.underlyingLogger.getName must equalTo("scalaguide.logging.ScalaLoggingSpec")
     }
 
     "use Logging trait" in {
-      //#logging-trait
+      // #logging-trait
       import play.api.Logging
 
       class MyClassWithLogging extends Logging {
         logger.info("Using the trait")
       }
-      //#logging-trait
+      // #logging-trait
 
       new MyClassWithLogging()
       success
@@ -104,7 +104,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
 //        def apply[T](name: String): play.api.Logger = new play.api.Logger(mock[org.slf4j.Logger].smart)
 //      }
 
-      //#logging-pattern-mix
+      // #logging-pattern-mix
       import scala.concurrent.Future
       import play.api.Logger
       import play.api.mvc._
@@ -135,7 +135,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
           }
         }
       }
-      //#logging-pattern-mix
+      // #logging-pattern-mix
 
       import akka.actor._
       import akka.stream.Materializer
@@ -150,7 +150,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
     }
 
     "allow for use in filters" in {
-      //#logging-pattern-filter
+      // #logging-pattern-filter
       import javax.inject.Inject
       import akka.stream.Materializer
       import scala.concurrent.ExecutionContext.Implicits.global
@@ -174,7 +174,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
           resultFuture
         }
       }
-      //#logging-pattern-filter
+      // #logging-pattern-filter
 
       ok
     }
@@ -186,29 +186,29 @@ class ScalaLoggingSpec extends Specification with Mockito {
 
       val logger: Logger = Logger("access")
 
-      //#logging-underlying
+      // #logging-underlying
       val underlyingLogger: org.slf4j.Logger = logger.underlyingLogger
       val loggerName                         = underlyingLogger.getName()
-      //#logging-underlying
+      // #logging-underlying
 
       loggerName must equalTo("access")
     }
   }
 
-  //#logging-default-marker-context
+  // #logging-default-marker-context
   val someMarker: org.slf4j.Marker = MarkerFactory.getMarker("SOMEMARKER")
   case object SomeMarkerContext extends play.api.DefaultMarkerContext(someMarker)
-  //#logging-default-marker-context
+  // #logging-default-marker-context
 
   "MarkerContext" should {
     "return some marker" in {
       import play.api.Logger
       val logger: Logger = Logger("access")
 
-      //#logging-marker-context
+      // #logging-marker-context
       val marker: org.slf4j.Marker = MarkerFactory.getMarker("SOMEMARKER")
       val mc: MarkerContext        = MarkerContext(marker)
-      //#logging-marker-context
+      // #logging-marker-context
       mc.marker must beSome.which(_ must be_==(marker))
     }
 
@@ -216,7 +216,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
       import play.api.Logger
       val logger: Logger = Logger("access")
 
-      //#logging-log-info-with-explicit-markercontext
+      // #logging-log-info-with-explicit-markercontext
       // use a typed marker as input
       logger.info("log message with explicit marker context with case object")(SomeMarkerContext)
 
@@ -224,7 +224,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
       val otherMarker: Marker               = MarkerFactory.getMarker("OTHER")
       val otherMarkerContext: MarkerContext = MarkerContext(otherMarker)
       logger.info("log message with explicit marker context")(otherMarkerContext)
-      //#logging-log-info-with-explicit-markercontext
+      // #logging-log-info-with-explicit-markercontext
 
       success
     }
@@ -233,13 +233,13 @@ class ScalaLoggingSpec extends Specification with Mockito {
       import play.api.Logger
       val logger: Logger = Logger("access")
 
-      //#logging-log-info-with-implicit-markercontext
+      // #logging-log-info-with-implicit-markercontext
       val marker: Marker             = MarkerFactory.getMarker("SOMEMARKER")
       implicit val mc: MarkerContext = MarkerContext(marker)
 
       // Use the implicit MarkerContext in logger.info...
       logger.info("log message with implicit marker context")
-      //#logging-log-info-with-implicit-markercontext
+      // #logging-log-info-with-implicit-markercontext
 
       mc.marker must beSome.which(_ must be_==(marker))
     }
@@ -248,12 +248,12 @@ class ScalaLoggingSpec extends Specification with Mockito {
       import play.api.Logger
       val logger: Logger = Logger("access")
 
-      //#logging-log-info-with-implicit-conversion
+      // #logging-log-info-with-implicit-conversion
       val mc: MarkerContext = MarkerFactory.getMarker("SOMEMARKER")
 
       // Use the marker that has been implicitly converted to MarkerContext
       logger.info("log message with implicit marker context")(mc)
-      //#logging-log-info-with-implicit-conversion
+      // #logging-log-info-with-implicit-conversion
 
       success
     }
@@ -288,7 +288,7 @@ class ImplicitRequestController @Inject() (cc: ControllerComponents)(implicit ot
     with RequestMarkerContext {
   private val logger = play.api.Logger(getClass)
 
-  //#logging-log-info-with-request-context
+  // #logging-log-info-with-request-context
   def asyncIndex = Action.async { implicit request =>
     Future {
       methodInOtherExecutionContext() // implicit conversion here
@@ -299,7 +299,7 @@ class ImplicitRequestController @Inject() (cc: ControllerComponents)(implicit ot
     logger.debug("index: ") // same as above
     Ok("testing")
   }
-  //#logging-log-info-with-request-context
+  // #logging-log-info-with-request-context
 }
 
 //#logging-log-trace-with-tracer-controller

--- a/documentation/manual/working/scalaGuide/main/tests/code/database/ScalaTestingWithDatabases.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/database/ScalaTestingWithDatabases.scala
@@ -12,18 +12,18 @@ class ScalaTestingWithDatabases extends Specification {
   // We don't test this code because otherwise it would try to connect to MySQL
   class NotTested {
     {
-      //#database
+      // #database
       import play.api.db.Databases
 
       val database = Databases(
         driver = "com.mysql.jdbc.Driver",
         url = "jdbc:mysql://localhost/test"
       )
-      //#database
+      // #database
     }
 
     {
-      //#full-config
+      // #full-config
       import play.api.db.Databases
 
       val database = Databases(
@@ -35,15 +35,15 @@ class ScalaTestingWithDatabases extends Specification {
           "password" -> "secret"
         )
       )
-      //#full-config
+      // #full-config
 
-      //#shutdown
+      // #shutdown
       database.shutdown()
-      //#shutdown
+      // #shutdown
     }
 
     {
-      //#with-database
+      // #with-database
       import play.api.db.Databases
 
       Databases.withDatabase(
@@ -53,11 +53,11 @@ class ScalaTestingWithDatabases extends Specification {
         val connection = database.getConnection()
       // ...
       }
-      //#with-database
+      // #with-database
     }
 
     {
-      //#custom-with-database
+      // #custom-with-database
       import play.api.db.Database
       import play.api.db.Databases
 
@@ -72,24 +72,24 @@ class ScalaTestingWithDatabases extends Specification {
           )
         )(block)
       }
-      //#custom-with-database
+      // #custom-with-database
 
-      //#custom-with-database-use
+      // #custom-with-database-use
       withMyDatabase { database =>
         val connection = database.getConnection()
       // ...
       }
-      //#custom-with-database-use
+      // #custom-with-database-use
     }
   }
 
   "database helpers" should {
     "allow connecting to an in memory database" in {
-      //#in-memory
+      // #in-memory
       import play.api.db.Databases
 
       val database = Databases.inMemory()
-      //#in-memory
+      // #in-memory
 
       try {
         database.getConnection().getMetaData.getDatabaseProductName must_== "H2"
@@ -99,7 +99,7 @@ class ScalaTestingWithDatabases extends Specification {
     }
 
     "allow connecting to an in memory database with more options" in {
-      //#in-memory-full-config
+      // #in-memory-full-config
       import play.api.db.Databases
 
       val database = Databases.inMemory(
@@ -111,19 +111,19 @@ class ScalaTestingWithDatabases extends Specification {
           "logStatements" -> true
         )
       )
-      //#in-memory-full-config
+      // #in-memory-full-config
 
       try {
         database.getConnection().getMetaData.getDatabaseProductName must_== "H2"
       } finally {
-        //#in-memory-shutdown
+        // #in-memory-shutdown
         database.shutdown()
-        //#in-memory-shutdown
+        // #in-memory-shutdown
       }
     }
 
     "manage an in memory database for the user" in {
-      //#with-in-memory
+      // #with-in-memory
       import play.api.db.Databases
 
       Databases.withInMemory() { database =>
@@ -131,12 +131,12 @@ class ScalaTestingWithDatabases extends Specification {
 
       // ...
       }
-      //#with-in-memory
+      // #with-in-memory
       ok
     }
 
     "manage an in memory database for the user with custom config" in {
-      //#with-in-memory-custom
+      // #with-in-memory-custom
       import play.api.db.Database
       import play.api.db.Databases
 
@@ -151,26 +151,26 @@ class ScalaTestingWithDatabases extends Specification {
           )
         )(block)
       }
-      //#with-in-memory-custom
+      // #with-in-memory-custom
 
       withMyDatabase(_.getConnection().getMetaData.getDatabaseProductName must_== "H2")
     }
 
     "allow running evolutions" in play.api.db.Databases.withInMemory() { database =>
-      //#apply-evolutions
+      // #apply-evolutions
       import play.api.db.evolutions._
 
       Evolutions.applyEvolutions(database)
-      //#apply-evolutions
+      // #apply-evolutions
 
-      //#cleanup-evolutions
+      // #cleanup-evolutions
       Evolutions.cleanupEvolutions(database)
-      //#cleanup-evolutions
+      // #cleanup-evolutions
       ok
     }
 
     "allow running static evolutions" in play.api.db.Databases.withInMemory() { database =>
-      //#apply-evolutions-simple
+      // #apply-evolutions-simple
       import play.api.db.evolutions._
 
       Evolutions.applyEvolutions(
@@ -183,29 +183,29 @@ class ScalaTestingWithDatabases extends Specification {
           )
         )
       )
-      //#apply-evolutions-simple
+      // #apply-evolutions-simple
 
       val connection = database.getConnection()
       connection.prepareStatement("insert into test values (10, 'testing')").execute()
 
-      //#cleanup-evolutions-simple
+      // #cleanup-evolutions-simple
       Evolutions.cleanupEvolutions(database)
-      //#cleanup-evolutions-simple
+      // #cleanup-evolutions-simple
 
       connection.prepareStatement("select * from test").executeQuery() must throwAn[SQLException]
     }
 
     "allow running evolutions from a custom path" in play.api.db.Databases.withInMemory() { database =>
-      //#apply-evolutions-custom-path
+      // #apply-evolutions-custom-path
       import play.api.db.evolutions._
 
       Evolutions.applyEvolutions(database, ClassLoaderEvolutionsReader.forPrefix("testdatabase/"))
-      //#apply-evolutions-custom-path
+      // #apply-evolutions-custom-path
       ok
     }
 
     "allow play to manage evolutions for you" in play.api.db.Databases.withInMemory() { database =>
-      //#with-evolutions
+      // #with-evolutions
       import play.api.db.evolutions._
 
       Evolutions.withEvolutions(database) {
@@ -213,12 +213,12 @@ class ScalaTestingWithDatabases extends Specification {
 
         // ...
       }
-      //#with-evolutions
+      // #with-evolutions
       ok
     }
 
     "allow simple composition of with database and with evolutions" in {
-      //#with-evolutions-custom
+      // #with-evolutions-custom
       import play.api.db.Database
       import play.api.db.Databases
       import play.api.db.evolutions._
@@ -246,9 +246,9 @@ class ScalaTestingWithDatabases extends Specification {
           }
         }
       }
-      //#with-evolutions-custom
+      // #with-evolutions-custom
 
-      //#with-evolutions-custom-use
+      // #with-evolutions-custom-use
       withMyDatabase { database =>
         val connection = database.getConnection()
         connection.prepareStatement("insert into test values (10, 'testing')").execute()
@@ -258,7 +258,7 @@ class ScalaTestingWithDatabases extends Specification {
           .executeQuery()
           .next() must_== true
       }
-      //#with-evolutions-custom-use
+      // #with-evolutions-custom-use
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -78,7 +78,7 @@ class ScalaTestingWebServiceClients extends Specification {
 
   "webservice testing" should {
     "allow mocking a service" in {
-      //#mock-service
+      // #mock-service
       import play.api.libs.json._
       import play.api.mvc._
       import play.api.routing.sird._
@@ -94,13 +94,13 @@ class ScalaTestingWebServiceClients extends Specification {
             }
         }
       } { implicit port =>
-        //#mock-service
+        // #mock-service
         ok
       }
     }
 
     "allow sending a resource" in {
-      //#send-resource
+      // #send-resource
       import play.api.mvc._
       import play.api.routing.sird._
       import play.api.test._
@@ -114,7 +114,7 @@ class ScalaTestingWebServiceClients extends Specification {
           }
         }.application
       } { implicit port =>
-        //#send-resource
+        // #send-resource
         WsTestClient.withClient { client =>
           Await.result(new GitHubClient(client, "").repositories(), 10.seconds) must_== Seq("octocat/Hello-World")
         }
@@ -122,7 +122,7 @@ class ScalaTestingWebServiceClients extends Specification {
     }
 
     "allow being dry" in {
-      //#with-github-client
+      // #with-github-client
       import play.api.mvc._
       import play.api.routing.sird._
       import play.core.server.Server
@@ -138,14 +138,14 @@ class ScalaTestingWebServiceClients extends Specification {
           }.application
         } { implicit port => WsTestClient.withClient { client => block(new GitHubClient(client, "")) } }
       }
-      //#with-github-client
+      // #with-github-client
 
-      //#with-github-test
+      // #with-github-test
       withGitHubClient { client =>
         val result = Await.result(client.repositories(), 10.seconds)
         result must_== Seq("octocat/Hello-World")
       }
-      //#with-github-test
+      // #with-github-test
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -43,7 +43,7 @@ package scalaguide.upload.fileupload {
         val parse  = app.injector.instanceOf[PlayBodyParsers]
         val Action = app.injector.instanceOf[DefaultActionBuilder]
 
-        //#upload-file-action
+        // #upload-file-action
         def upload = Action(parse.multipartFormData) { request =>
           request.body
             .file("picture")
@@ -62,7 +62,7 @@ package scalaguide.upload.fileupload {
             }
         }
 
-        //#upload-file-action
+        // #upload-file-action
         val temporaryFileCreator = SingletonTemporaryFileCreator
         val tf                   = temporaryFileCreator.create(tmpFile)
         val request = FakeRequest().withBody(
@@ -116,16 +116,16 @@ package scalaguide.upload.fileupload {
   package democontrollers {
     class HomeController(controllerComponents: ControllerComponents)(implicit ec: ExecutionContext)
         extends AbstractController(controllerComponents) {
-      //#upload-file-directly-action
+      // #upload-file-directly-action
       def upload = Action(parse.temporaryFile) { request =>
         request.body.moveTo(Paths.get("/tmp/picture/uploaded"), replace = true)
         Ok("File uploaded")
       }
-      //#upload-file-directly-action
+      // #upload-file-directly-action
 
       def index = Action { request => Ok("Upload failed") }
 
-      //#upload-file-customparser
+      // #upload-file-customparser
       type FilePartHandler[A] = FileInfo => Accumulator[ByteString, FilePart[A]]
 
       def handleFilePartAsFile: FilePartHandler[File] = {
@@ -150,7 +150,7 @@ package scalaguide.upload.fileupload {
 
         Ok(s"File uploaded: $fileOption")
       }
-      //#upload-file-customparser
+      // #upload-file-customparser
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
@@ -31,7 +31,7 @@ class ScalaOAuthSpec extends PlaySpecification {
   "Scala OAuth" should {
     "be injectable" in new WithApplication() with Injecting {
       val controller = new HomeController(inject[WSClient], inject[ControllerComponents])(inject[ExecutionContext]) {
-        //#flow
+        // #flow
         val KEY = ConsumerKey("xxxxx", "xxxxx")
 
         val oauth = OAuth(
@@ -75,9 +75,9 @@ class ScalaOAuthSpec extends PlaySpecification {
               case Left(e) => throw e
             })
         }
-        //#flow
+        // #flow
 
-        //#extended
+        // #extended
         def timeline = Action.async { implicit request: Request[AnyContent] =>
           sessionTokenPair match {
             case Some(credentials) => {
@@ -90,7 +90,7 @@ class ScalaOAuthSpec extends PlaySpecification {
             case _ => Future.successful(Redirect(routes.Application.authenticate))
           }
         }
-        //#extended
+        // #extended
       }
       controller must beAnInstanceOf[HomeController]
     }

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -28,7 +28,7 @@ class ScalaOpenIdSpec extends PlaySpecification {
     "be injectable" in new WithApplication() with Injecting {
       val controller =
         new IdController(inject[OpenIdClient], inject[ControllerComponents])(inject[ExecutionContext]) with Logging {
-          //#flow
+          // #flow
           def login = Action {
             Ok(views.html.login())
           }
@@ -63,16 +63,16 @@ class ScalaOpenIdSpec extends PlaySpecification {
                   Redirect(routes.Application.login)
               }
           }
-          //#flow
+          // #flow
 
           def extended(openId: String)(implicit request: RequestHeader) = {
-            //#extended
+            // #extended
             openIdClient.redirectURL(
               openId,
               routes.Application.openIdCallback.absoluteURL(),
               Seq("email" -> "http://schema.openid.net/contact/email")
             )
-            //#extended
+            // #extended
           }
         }
       controller must beAnInstanceOf[IdController]

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -92,26 +92,26 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
    */
   val largeSource: Source[ByteString, _] = {
     val source = Source.single(ByteString("abcdefghij" * 100))
-    (1 to 9).foldLeft(source) { (acc, _) => (acc ++ source) }
+    (1 to 9).foldLeft(source) { (acc, _) => acc ++ source }
   }
 
   "WSClient" should {
     "allow making a request" in withSimpleServer { ws =>
-      //#simple-holder
+      // #simple-holder
       val request: WSRequest = ws.url(url)
-      //#simple-holder
+      // #simple-holder
 
-      //#complex-holder
+      // #complex-holder
       val complexRequest: WSRequest =
         request
           .addHttpHeaders("Accept" -> "application/json")
           .addQueryStringParameters("search" -> "play")
           .withRequestTimeout(10000.millis)
-      //#complex-holder
+      // #complex-holder
 
-      //#holder-get
+      // #holder-get
       val futureResponse: Future[WSResponse] = complexRequest.get()
-      //#holder-get
+      // #holder-get
 
       await(futureResponse).status must_== 200
     }
@@ -121,75 +121,75 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       val password = "password"
 
       val response =
-        //#auth-request
+        // #auth-request
         ws.url(url).withAuth(user, password, WSAuthScheme.BASIC).get()
-      //#auth-request
+      // #auth-request
 
       await(response).status must_== 200
     }
 
     "allow following redirects" in withSimpleServer { ws =>
       val response =
-        //#redirects
+        // #redirects
         ws.url(url).withFollowRedirects(true).get()
-      //#redirects
+      // #redirects
 
       await(response).status must_== 200
     }
 
     "allow setting a query string" in withSimpleServer { ws =>
       val response =
-        //#query-string
+        // #query-string
         ws.url(url).addQueryStringParameters("paramKey" -> "paramValue").get()
-      //#query-string
+      // #query-string
 
       await(response).status must_== 200
     }
 
     "allow setting headers" in withSimpleServer { ws =>
       val response =
-        //#headers
+        // #headers
         ws.url(url).addHttpHeaders("headerKey" -> "headerValue").get()
-      //#headers
+      // #headers
 
       await(response).status must_== 200
     }
 
     "allow setting the content type" in withSimpleServer { ws =>
       val xmlString = "<foo></foo>"
-      val response  =
-        //#content-type
+      val response =
+        // #content-type
         ws.url(url)
           .addHttpHeaders("Content-Type" -> "application/xml")
           .post(xmlString)
-      //#content-type
+      // #content-type
 
       await(response).status must_== 200
     }
 
     "allow setting the cookie" in withSimpleServer { ws =>
       val response =
-        //#cookie
+        // #cookie
         ws.url(url).addCookies(DefaultWSCookie("cookieName", "cookieValue")).get()
-      //#cookie
+      // #cookie
 
       await(response).status must_== 200
     }
 
     "allow setting the virtual host" in withSimpleServer { ws =>
       val response =
-        //#virtual-host
+        // #virtual-host
         ws.url(url).withVirtualHost("192.168.1.1").get()
-      //#virtual-host
+      // #virtual-host
 
       await(response).status must_== 200
     }
 
     "allow setting the request timeout" in withSimpleServer { ws =>
       val response =
-        //#request-timeout
+        // #request-timeout
         ws.url(url).withRequestTimeout(5000.millis).get()
-      //#request-timeout
+      // #request-timeout
 
       await(response).status must_== 200
     }
@@ -200,9 +200,9 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case other         => Action { NotFound }
       } { ws =>
         val response =
-          //#url-encoded
+          // #url-encoded
           ws.url(url).post(Map("key" -> Seq("value")))
-        //#url-encoded
+        // #url-encoded
 
         await(response).body must_== "value"
       }
@@ -213,9 +213,9 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       } { ws =>
         import play.api.mvc.MultipartFormData._
         val response =
-          //#multipart-encoded
+          // #multipart-encoded
           ws.url(url).post(Source.single(DataPart("key", "value")))
-        //#multipart-encoded
+        // #multipart-encoded
 
         await(response).body must_== "value"
       }
@@ -233,7 +233,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
 
         import play.api.mvc.MultipartFormData._
         val response =
-          //#multipart-encoded2
+          // #multipart-encoded2
           ws.url(url)
             .post(
               Source(
@@ -243,7 +243,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
                 ) :: List()
               )
             )
-        //#multipart-encoded2
+        // #multipart-encoded2
 
         await(response).body must_== "world"
       }
@@ -269,7 +269,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case other         => Action { NotFound }
       } { ws =>
         // #scalaws-post-xml
-        val data                               = <person>
+        val data = <person>
           <name>Steve</name>
           <age>23</age>
         </person>
@@ -342,7 +342,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case ("GET", "/") => Action(Ok.chunked(largeSource))
         case other        => Action { NotFound }
       } { ws =>
-        //#stream-count-bytes
+        // #stream-count-bytes
         // Make the request
         val futureResponse: Future[WSResponse] =
           ws.url(url).withMethod("GET").stream()
@@ -351,7 +351,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
           // Count the number of bytes returned
           res.bodyAsSource.runWith(Sink.fold[Long, ByteString](0L) { (total, bytes) => total + bytes.length })
         }
-        //#stream-count-bytes
+        // #stream-count-bytes
         await(bytesReturned) must_== 10000L
       }
 
@@ -361,7 +361,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       } { ws =>
         val file = File.createTempFile("stream-to-file-", ".txt")
         try {
-          //#stream-to-file
+          // #stream-to-file
           // Make the request
           val futureResponse: Future[WSResponse] =
             ws.url(url).withMethod("GET").stream()
@@ -384,7 +384,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
               }
               .map(_ => file)
           }
-          //#stream-to-file
+          // #stream-to-file
           await(downloadedFile) must_== file
         } finally {
           file.delete()
@@ -395,7 +395,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case ("GET", "/") => Action(Ok.chunked(largeSource))
         case other        => Action { NotFound }
       } { ws =>
-        //#stream-to-result
+        // #stream-to-result
         def downloadFile = Action.async {
           // Make the request
           ws.url(url).withMethod("GET").stream().map { response =>
@@ -419,7 +419,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
             }
           }
         }
-        //#stream-to-result
+        // #stream-to-result
         val file = File.createTempFile("stream-to-file-", ".txt")
         await(
           downloadFile(FakeRequest())
@@ -432,15 +432,15 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case ("PUT", "/") => Action(Ok.chunked(largeSource))
         case other        => Action { NotFound }
       } { ws =>
-        //#stream-put
+        // #stream-put
         val futureResponse: Future[WSResponse] =
           ws.url(url).withMethod("PUT").withBody("some body").stream()
-        //#stream-put
+        // #stream-put
 
         val bytesReturned: Future[Long] = futureResponse.flatMap { res =>
           res.bodyAsSource.runWith(Sink.fold[Long, ByteString](0L) { (total, bytes) => total + bytes.length })
         }
-        //#stream-count-bytes
+        // #stream-count-bytes
         await(bytesReturned) must_== 10000L
       }
 
@@ -449,12 +449,12 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case other        => Action { NotFound }
       } { ws =>
         def largeImageFromDB: Source[ByteString, _] = largeSource
-        //#scalaws-stream-request
+        // #scalaws-stream-request
         val wsResponse: Future[WSResponse] = ws
           .url(url)
           .withBody(largeImageFromDB)
           .execute("PUT")
-        //#scalaws-stream-request
+        // #scalaws-stream-request
         await(wsResponse).status must_== 200
       }
     }
@@ -497,19 +497,19 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
     }
 
     "map to async result" in withSimpleServer { ws =>
-      //#async-result
+      // #async-result
       def wsAction = Action.async {
         ws.url(url).get().map { response => Ok(response.body) }
       }
       status(wsAction(FakeRequest())) must_== OK
-      //#async-result
+      // #async-result
     }
 
     "allow timeout across futures" in new WithServer() with Injecting {
       val url2             = url
       implicit val futures = inject[Futures]
       val ws               = inject[WSClient]
-      //#ws-futures-timeout
+      // #ws-futures-timeout
       // Adds withTimeout as type enrichment on Future[WSResponse]
       import play.api.libs.concurrent.Futures._
 
@@ -525,18 +525,18 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
             case e: scala.concurrent.TimeoutException =>
               GatewayTimeout
           }
-      //#ws-futures-timeout
+      // #ws-futures-timeout
       status(result) must_== OK
     }
 
     "allow simple programmatic configuration" in new WithApplication() {
-      //#simple-ws-custom-client
+      // #simple-ws-custom-client
       import play.api.libs.ws.ahc._
 
       // usually injected through @Inject()(implicit mat: Materializer)
       implicit val materializer = app.materializer
       val wsClient              = AhcWSClient()
-      //#simple-ws-custom-client
+      // #simple-ws-custom-client
 
       wsClient.close()
 
@@ -544,7 +544,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
     }
 
     "allow programmatic configuration" in new WithApplication() {
-      //#ws-custom-client
+      // #ws-custom-client
       import play.api._
       import play.api.libs.ws._
       import play.api.libs.ws.ahc._
@@ -556,21 +556,21 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       val wsConfig           = AhcWSClientConfigFactory.forConfig(configuration.underlying, environment.classLoader)
       val mat                = app.materializer
       val wsClient: WSClient = AhcWSClient(wsConfig)(mat)
-      //#ws-custom-client
+      // #ws-custom-client
 
-      //#close-client
+      // #close-client
       wsClient.close()
-      //#close-client
+      // #close-client
 
       ok
     }
 
     "grant access to the underlying client" in withSimpleServer { ws =>
-      //#underlying
+      // #underlying
       import play.shaded.ahc.org.asynchttpclient.AsyncHttpClient
 
       val client: AsyncHttpClient = ws.underlying
-      //#underlying
+      // #underlying
 
       ok
     }

--- a/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala
+++ b/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala
@@ -22,7 +22,7 @@ package scalaguide.xml.scalaxmlrequests {
 
     "A scala XML request" should {
       "request body as xml" in new WithApplication {
-        //#xml-request-body-asXml
+        // #xml-request-body-asXml
         def sayHello = Action { request =>
           request.body.asXml
             .map { xml =>
@@ -38,14 +38,14 @@ package scalaguide.xml.scalaxmlrequests {
             }
         }
 
-        //#xml-request-body-asXml
+        // #xml-request-body-asXml
 
         private val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
         status(call(sayHello, request)) must beEqualTo(Helpers.OK)
       }
 
       "request body as xml body parser" in new WithApplication {
-        //#xml-request-body-parser
+        // #xml-request-body-parser
         def sayHello = Action(parse.xml) { request =>
           (request.body \\ "name" headOption)
           .map(_.text)
@@ -55,14 +55,14 @@ package scalaguide.xml.scalaxmlrequests {
           }
         }
 
-        //#xml-request-body-parser
+        // #xml-request-body-parser
 
         private val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
         status(call(sayHello, request)) must beEqualTo(Helpers.OK)
       }
 
       "request body as xml body parser and xml response" in new WithApplication {
-        //#xml-request-body-parser-xml-response
+        // #xml-request-body-parser-xml-response
         def sayHello = Action(parse.xml) { request =>
           (request.body \\ "name" headOption)
           .map(_.text)
@@ -76,7 +76,7 @@ package scalaguide.xml.scalaxmlrequests {
           }
         }
 
-        //#xml-request-body-parser-xml-response
+        // #xml-request-body-parser-xml-response
 
         private val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
         status(call(sayHello, request)) must beEqualTo(Helpers.OK)

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -844,7 +844,9 @@ case class InconsistentDatabase(db: String, script: String, error: String, rev: 
   private val buttonLabel = if (autocommit) """Mark it resolved""" else """Try again"""
 
   def htmlDescription: String = {
-    <span>An evolution has not been applied properly. Please check the problem and resolve it manually{sentenceEnd} -</span>
+    <span>An evolution has not been applied properly. Please check the problem and resolve it manually{
+      sentenceEnd
+    } -</span>
     <input name="evolution-button" type="button" value={buttonLabel} onclick={redirectJavascript}/>
   }.mkString
 }

--- a/persistence/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -154,6 +154,6 @@ class DatabasesSpec extends Specification {
 
   trait WithDatabase extends After {
     def db: Database
-    def after = () //db.shutdown()
+    def after = () // db.shutdown()
   }
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -92,7 +92,7 @@ object BuildSettings {
     // overwrite Interplay settings to new Sonatype profile
     sonatypeProfileName := "com.typesafe.play",
     fileHeaderSettings,
-    homepage := Some(url("https://playframework.com")),
+    homepage        := Some(url("https://playframework.com")),
     ivyLoggingLevel := UpdateLogging.DownloadOnly,
     resolvers ++= Resolver.sonatypeOssRepos("releases"), // sync ScriptedTools.scala
     resolvers ++= Seq(
@@ -110,8 +110,8 @@ object BuildSettings {
         case _                       => Seq()
       }
     },
-    (Test / fork) := true,
-    (Test / parallelExecution) := false,
+    (Test / fork)                 := true,
+    (Test / parallelExecution)    := false,
     (Test / test / testListeners) := Nil,
     (Test / javaOptions) ++= Seq("-XX:MaxMetaspaceSize=384m", "-Xmx512m", "-Xms128m"),
     testOptions ++= Seq(
@@ -197,7 +197,7 @@ object BuildSettings {
             None
         }
         url <- urlOption
-      } yield (fullyFile -> url))(collection.breakOut(Map.canBuildFrom))
+      } yield fullyFile -> url)(collection.breakOut(Map.canBuildFrom))
     }
   )
 
@@ -220,7 +220,7 @@ object BuildSettings {
       // Refactor constructor to use StandaloneAhcWSClient
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.AhcWSClientProvider.this"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.libs.ws.ahc.AhcWSModule#AhcWSClientProvider.this"),
-      //Remove deprecated methods from Http
+      // Remove deprecated methods from Http
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.mvc.Http#RequestImpl.this"),
       // Remove deprecated methods from HttpRequestHandler
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.DefaultHttpRequestHandler.filterHandler"),
@@ -393,8 +393,8 @@ object BuildSettings {
       .settings(playRuntimeSettings: _*)
       .settings(omnidocSettings: _*)
       .settings(
-        autoScalaLibrary := false,
-        crossPaths := false,
+        autoScalaLibrary   := false,
+        crossPaths         := false,
         crossScalaVersions := Seq("2.13.10")
       )
   }
@@ -423,7 +423,7 @@ object BuildSettings {
   def omnidocSettings: Seq[Setting[_]] = Def.settings(
     Omnidoc.projectSettings,
     omnidocSnapshotBranch := snapshotBranch,
-    omnidocPathPrefix := ""
+    omnidocPathPrefix     := ""
   )
 
   def playScriptedSettings: Seq[Setting[_]] = Seq(
@@ -433,7 +433,7 @@ object BuildSettings {
     // * run a publishLocal in the root project to get everything
     // * run a publishLocal in the changes projects for fast feedback loops
     scriptedDependencies := (()), // drop Test/compile & publishLocal
-    scriptedBufferLog := false,
+    scriptedBufferLog    := false,
     scriptedLaunchOpts ++= Seq(
       s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
       "-Xmx512m",
@@ -446,7 +446,7 @@ object BuildSettings {
 
   def disablePublishing = Def.settings(
     (publish / skip) := true,
-    publishLocal := {},
+    publishLocal     := {},
   )
 
   /** A project that runs in the sbt runtime. */
@@ -466,7 +466,7 @@ object BuildSettings {
       .settings(
         playCommonSettings,
         playScriptedSettings,
-        (Test / fork) := false,
+        (Test / fork)         := false,
         mimaPreviousArtifacts := Set.empty,
       )
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,7 +90,7 @@ object Dependencies {
     acolyte              % Test,
     logback              % Test,
     "tyrex"              % "tyrex"     % "1.0.1"
-  ) ++ specs2Deps.map(_  % Test)
+  ) ++ specs2Deps.map(_ % Test)
 
   val jpaDeps = Seq(
     "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.2.Final",
@@ -110,7 +110,7 @@ object Dependencies {
 
   val javaDeps = Seq(
     // Used by the Java routing DSL
-    "net.jodah"         % "typetools" % "0.6.3"
+    "net.jodah" % "typetools" % "0.6.3"
   ) ++ specs2Deps.map(_ % Test)
 
   val joda = Seq(
@@ -174,7 +174,7 @@ object Dependencies {
   val netty = Seq(
     "com.typesafe.netty" % "netty-reactive-streams-http"  % "2.0.8",
     ("io.netty"          % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
-  ) ++ specs2Deps.map(_  % Test)
+  ) ++ specs2Deps.map(_ % Test)
 
   val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
 
@@ -220,7 +220,7 @@ object Dependencies {
       sbtDep("com.github.sbt"    % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
       sbtDep("com.typesafe.sbt"  % "sbt-web"             % "1.4.4"),
       sbtDep("com.typesafe.sbt"  % "sbt-js-engine"       % "1.2.3"),
-      logback             % Test
+      logback % Test
     ) ++ specs2Deps.map(_ % Test)
   }
 
@@ -235,8 +235,8 @@ object Dependencies {
   ) ++ playdocWebjarDependencies
 
   val streamsDependencies = Seq(
-    "org.reactivestreams"   % "reactive-streams" % "1.0.4",
-    "com.typesafe.akka"    %% "akka-stream"      % akkaVersion,
+    "org.reactivestreams" % "reactive-streams" % "1.0.4",
+    "com.typesafe.akka"  %% "akka-stream"      % akkaVersion,
   ) ++ specs2CoreDeps.map(_ % Test) ++ javaTestDeps
 
   val playServerDependencies = specs2Deps.map(_ % Test) ++ Seq(
@@ -292,7 +292,7 @@ object Dependencies {
     "com.typesafe.play" %% "play-ws-standalone-xml"  % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-json" % playWsStandaloneVersion,
     // Update transitive Akka version as needed:
-    "com.typesafe.akka"                       %% "akka-stream" % akkaVersion
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion
   ) ++ (specs2Deps :+ specsMatcherExtra).map(_ % Test) :+ mockitoAll % Test
 
   // Must use a version of ehcache that supports jcache 1.0.0

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -33,7 +33,7 @@ object Docs {
   val allConfs            = taskKey[Seq[(String, File)]]("Gather all configuration files")
 
   lazy val settings = Seq(
-    apiDocsInclude := false,
+    apiDocsInclude        := false,
     apiDocsIncludeManaged := false,
     apiDocsScalaSources := Def.taskDyn {
       val pr = thisProjectRef.value

--- a/project/Tasks.scala
+++ b/project/Tasks.scala
@@ -65,7 +65,7 @@ object Commands {
       filtered ++ Seq(
         GlobalScope / packageDoc / publishArtifact := toggle,
         GlobalScope / packageSrc / publishArtifact := toggle,
-        GlobalScope / publishArtifact := true
+        GlobalScope / publishArtifact              := true
       ),
       state.put(quickPublishToggle, toggle)
     )

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
@@ -155,9 +155,9 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
 
   override def withUrl(url: String): WSRequest = toWSRequest(underlying.withUrl(url))
 
-  //-------------------------------------------------
+  // -------------------------------------------------
   // PATCH
-  //-------------------------------------------------
+  // -------------------------------------------------
 
   /**
    * Perform a PATCH on the request asynchronously.
@@ -185,9 +185,9 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
     patch[Source[MultipartFormData.Part[Source[ByteString, _]], _]](body)
   }
 
-  //-------------------------------------------------
+  // -------------------------------------------------
   // POST
-  //-------------------------------------------------
+  // -------------------------------------------------
 
   /**
    * Perform a POST on the request asynchronously.
@@ -214,9 +214,9 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
     post[Source[MultipartFormData.Part[Source[ByteString, _]], _]](body)
   }
 
-  //-------------------------------------------------
+  // -------------------------------------------------
   // PUT
-  //-------------------------------------------------
+  // -------------------------------------------------
 
   /**
    * Perform a PUT on the request asynchronously.

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
@@ -195,18 +195,18 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
    */
   override def withMethod(method: String): Self
 
-  //------------------------------------------------
+  // ------------------------------------------------
   // GET
-  //------------------------------------------------
+  // ------------------------------------------------
 
   /**
    * performs a get
    */
   override def get(): Future[Response]
 
-  //------------------------------------------------
+  // ------------------------------------------------
   // POST
-  //------------------------------------------------
+  // ------------------------------------------------
 
   /**
    * Performs a POST request.
@@ -227,9 +227,9 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
    */
   def post(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[Response]
 
-  //------------------------------------------------
+  // ------------------------------------------------
   // PATCH
-  //------------------------------------------------
+  // ------------------------------------------------
 
   /**
    * Performs a PATCH request.
@@ -250,9 +250,9 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
    */
   def patch(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[Response]
 
-  //------------------------------------------------
+  // ------------------------------------------------
   // PUT
-  //------------------------------------------------
+  // ------------------------------------------------
 
   /**
    * Performs a PUT request.
@@ -273,9 +273,9 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
    */
   def put(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[Response]
 
-  //------------------------------------------------
+  // ------------------------------------------------
   // DELETE, HEAD, OPTIONS
-  //------------------------------------------------
+  // ------------------------------------------------
 
   /**
    * Perform a DELETE on the request asynchronously.
@@ -292,9 +292,9 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
    */
   override def options(): Future[Response]
 
-  //------------------------------------------------
+  // ------------------------------------------------
   // Generic execution
-  //------------------------------------------------
+  // ------------------------------------------------
 
   /**
    * Executes the given HTTP method.

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -363,7 +363,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     }
 
     (handler, upgradeToWebSocket) match {
-      //execute normal action
+      // execute normal action
       case (action: EssentialAction, _) =>
         runAction(tryApp, request, taggedRequestHeader, requestBodySource, action, errorHandler)
       case (websocket: WebSocket, Some(upgrade)) =>

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -135,10 +135,10 @@ class NettyServer(
       val cleanKey = option.getKey.stripPrefix("\"").stripSuffix("\"")
       if (ChannelOption.exists(cleanKey)) {
         logger.debug(s"Setting Netty channel option ${cleanKey} to ${unwrap(option.getValue)}${if (bootstrapping) {
-          " at bootstrapping"
-        } else {
-          ""
-        }}")
+            " at bootstrapping"
+          } else {
+            ""
+          }}")
         setOption(ChannelOption.valueOf(cleanKey), unwrap(option.getValue))
       } else {
         logger.warn("Ignoring unknown Netty channel option: " + cleanKey)

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -134,7 +134,7 @@ private[play] class PlayRequestHandler(
     }
 
     handler match {
-      //execute normal action
+      // execute normal action
       case action: EssentialAction =>
         handleAction(action, requestHeader, request, tryApp)
 
@@ -172,7 +172,7 @@ private[play] class PlayRequestHandler(
               }
           }
 
-      //handle bad websocket request
+      // handle bad websocket request
       case ws: WebSocket =>
         logger.trace(s"Bad websocket request: $request")
         val action = EssentialAction(_ =>
@@ -195,7 +195,7 @@ private[play] class PlayRequestHandler(
     }
   }
 
-  //----------------------------------------------------------------
+  // ----------------------------------------------------------------
   // Netty overrides
 
   override def channelRead(ctx: ChannelHandlerContext, msg: Object): Unit = {
@@ -274,7 +274,7 @@ private[play] class PlayRequestHandler(
     ctx.read()
   }
 
-  //----------------------------------------------------------------
+  // ----------------------------------------------------------------
   // Private methods
 
   /**

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -169,7 +169,7 @@ private[server] object ForwardedHeaderHandler {
         val params = for {
           fhs <- headers.getAll("Forwarded")
           fh  <- fhs.split(",\\s*")
-        } yield (fh
+        } yield fh
           .split(";")
           .iterator
           .flatMap {
@@ -185,7 +185,7 @@ private[server] object ForwardedHeaderHandler {
               }
             }
           }
-          .toMap)
+          .toMap
 
         params.map { (paramMap: Map[String, String]) => ForwardedEntry(paramMap.get("for"), paramMap.get("proto")) }
       }

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
@@ -94,5 +94,5 @@ object noCATrustManager extends X509TrustManager {
 
   override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String): Unit = {}
   override def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String): Unit = {}
-  override def getAcceptedIssuers(): Array[X509Certificate] = nullArray
+  override def getAcceptedIssuers(): Array[X509Certificate]                                  = nullArray
 }

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -291,8 +291,8 @@ private[cors] trait AbstractCORSPolicy {
 
   private def handleInvalidCORSRequest(request: RequestHeader): Accumulator[ByteString, Result] = {
     logger.warn(s"""Invalid CORS request;Origin=${request.headers
-      .get(HeaderNames.ORIGIN)};Method=${request.method};${HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS}=${request.headers
-      .get(HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS)}""")(SecurityMarkerContext)
+        .get(HeaderNames.ORIGIN)};Method=${request.method};${HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS}=${request.headers
+        .get(HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS)}""")(SecurityMarkerContext)
     Accumulator.done(Future.successful(Results.Forbidden))
   }
 

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -221,7 +221,7 @@ object ScalaCSPReport {
       )
   }
 
-  implicit val reads: Reads[ScalaCSPReport] = (
+  implicit val reads: Reads[ScalaCSPReport] =
     (__ \ "document-uri")
       .read[String]
       .and((__ \ "violated-directive").read[String])
@@ -234,8 +234,7 @@ object ScalaCSPReport {
       .and((__ \ "status-code").readNullable[Int])
       .and((__ \ "source-file").readNullable[String])
       .and((__ \ "line-number").readNullable[Long](longOrStringToLongRead))
-      .and((__ \ "column-number").readNullable[Long](longOrStringToLongRead))
-  )(ScalaCSPReport.apply _)
+      .and((__ \ "column-number").readNullable[Long](longOrStringToLongRead))(ScalaCSPReport.apply _)
 }
 
 import java.util.Optional

--- a/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -151,12 +151,12 @@ class SecurityHeadersFilter @Inject() (config: SecurityHeadersConfig) extends Es
    */
   protected def headers(request: RequestHeader, result: Result): Seq[(String, String)] = {
     val headers = Seq(
-      config.frameOptions.map(X_FRAME_OPTIONS_HEADER                                   -> _),
-      config.xssProtection.map(X_XSS_PROTECTION_HEADER                                 -> _),
-      config.contentTypeOptions.map(X_CONTENT_TYPE_OPTIONS_HEADER                      -> _),
+      config.frameOptions.map(X_FRAME_OPTIONS_HEADER -> _),
+      config.xssProtection.map(X_XSS_PROTECTION_HEADER -> _),
+      config.contentTypeOptions.map(X_CONTENT_TYPE_OPTIONS_HEADER -> _),
       config.permittedCrossDomainPolicies.map(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER -> _),
-      config.contentSecurityPolicy.map(CONTENT_SECURITY_POLICY_HEADER                  -> _),
-      config.referrerPolicy.map(REFERRER_POLICY                                        -> _)
+      config.contentSecurityPolicy.map(CONTENT_SECURITY_POLICY_HEADER -> _),
+      config.referrerPolicy.map(REFERRER_POLICY -> _)
     ).flatten
 
     if (config.allowActionSpecificHeaders) {

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -64,7 +64,7 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       val (plain, gzipped) = (None, Some("gzip"))
 
       "Accept-Encoding of request" || "Response" |
-        //------------------------------------++------------+
+        // ------------------------------------++------------+
         "gzip" !! gzipped |
         "compress,gzip" !! gzipped |
         "compress, gzip" !! gzipped |

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -649,11 +649,11 @@ trait FormSpec extends CommonFormSpec {
             Map(
               "entry.name"                 -> Array("Bill"),
               "entry.value"                -> Array("3"),
-              "entries[].name"             -> Array("Calvin", "John", "Edward"), //   -> entries[0|1|2].name
-              "entries[].value"            -> Array("14", "26", "76"), //             -> entries[0|1|2].value
-              "entries[].entries[].name"   -> Array("Robin Hood", "Donald Duck"), //  -> entries[0].entries[0|1].name
+              "entries[].name"             -> Array("Calvin", "John", "Edward"),   // -> entries[0|1|2].name
+              "entries[].value"            -> Array("14", "26", "76"),             // -> entries[0|1|2].value
+              "entries[].entries[].name"   -> Array("Robin Hood", "Donald Duck"),  // -> entries[0].entries[0|1].name
               "entries[].entries[].street" -> Array("Wall Street", "Main Street"), // -> entries[0].entries[0|1].street
-              "entries[].entries[].value"  -> Array("143", "196"), //                 -> entries[0].entries[0|1].value
+              "entries[].entries[].value"  -> Array("143", "196"),                 // -> entries[0].entries[0|1].value
               "entries[].entries[].notes[]" -> Array(
                 "Note 1",
                 "Note 2",
@@ -673,7 +673,7 @@ trait FormSpec extends CommonFormSpec {
                 "Third Street"
               ), // -> entries[1].entries[0|1|2].street
               "entries[1].entries[].value"   -> Array("372", "641", "961"), // -> entries[1].entries[0|1|2].value
-              "entries[1].entries[].notes[]" -> Array("Note 6", "Note 7"), // -> entries[1].entries[0].notes[0|1]
+              "entries[1].entries[].notes[]" -> Array("Note 6", "Note 7"),  // -> entries[1].entries[0].notes[0|1]
               "entries[1].entries[1].notes[]" -> Array(
                 "Note 8",
                 "Note 9",
@@ -1505,11 +1505,11 @@ trait FormSpec extends CommonFormSpec {
             TypedMap.empty(),
             Map(
               "entry.name" -> "Bill",
-              //"entry.value" -> "...",  -> Missing but required by validate method of sub form
-              //"entries[0].name"  -> "...", -> Missing but required by @Constraints.Required
+              // "entry.value" -> "...",  -> Missing but required by validate method of sub form
+              // "entries[0].name"  -> "...", -> Missing but required by @Constraints.Required
               "entries[0].value" -> "14",
               "entries[1].name"  -> "John",
-              //"entries[1].value" -> "...",  -> Missing but required by validate method of sub form
+              // "entries[1].value" -> "...",  -> Missing but required by validate method of sub form
               "entries[0].entries[0].name"   -> "Robin Hood",
               "entries[0].entries[1].street" -> "Wall Street",
             ).asJava

--- a/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -124,10 +124,10 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
         ) ++ axParameters(axRequired, axOptional) ++ realm.map("openid.realm" -> _).toList
         val separator = if (server.url.contains("?")) "&" else "?"
         server.url + separator + parameters
-          .map({
+          .map {
             case (k, v) =>
               URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(v, "UTF-8")
-          })
+          }
           .mkString("&")
       }
   }
@@ -191,7 +191,7 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
         if (axOptional.isEmpty) Nil
         else Seq("openid.ax.if_available" -> axOptional.map(_._1).mkString(","))
 
-      val definitions = (axRequired ++ axOptional).map(attribute => ("openid.ax.type." + attribute._1 -> attribute._2))
+      val definitions = (axRequired ++ axOptional).map(attribute => "openid.ax.type." + attribute._1 -> attribute._2)
 
       Seq(
         "openid.ns.ax"   -> "http://openid.net/srv/ax/1.0",


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->


## Fixes

Fixes #11510

## Purpose

Upgrades scalafmt version to keep it current. This will unblock sorting of imports 

## Background Context

This change aims to make as minimal a change-set as possible. There does seem to be some fundamental changes in scalafmt reformats that were unavoidable

#### Notable Format Changes

See new scalafmt config [here](https://github.com/playframework/playframework/pull/11512/files#diff-88adef9b969d41ed5848ebca29ae7b61f25ed76010b0ed18079a8e2f06e195d8)

- [functions and anonymous objects in param list seem to trigger more line breaks, particularly if a function is multiline](https://github.com/playframework/playframework/pull/11512/files#diff-adb0fd54ad522f91d0d352c8ae49833978051510019e7d0ff00b6ba588f07ca3L124)
- [previous scalafmt version did not remove line breaks before params in lambdas. Now does](https://github.com/playframework/playframework/pull/11512/files#diff-f5e7ed844ac5a5f09e21aadf567a7b68f6b6e3a152b1be8cf953766b36f64640L223)
- [spaces added after single line comment slashes`//`](https://github.com/playframework/playframework/pull/11512/files#diff-30bd55944dc03e2fd1923ed8ee11cf79d72f674ccc1f407a61d7986496cbbbb7L280)
- [hexadecimal casing changed](https://github.com/playframework/playframework/pull/11512/files#diff-e6579288a2bc6529850d896a6ade14a1ba5d41a384004c298556d16c937b8d12L160)
- [location of `implicit` keyword was inconsistent](https://github.com/playframework/playframework/pull/11512/files#diff-5e31632f0b42bfb9fe27b2b37391f130aa04c7f23002572585da4c0cc8de202dL54) 
- [like param lists, if an `if` clause is multiline, they are more aggressively line broken](https://github.com/playframework/playframework/pull/11512/files#diff-5ac63ebda6fca975e476c2b010447258cb030e0cc090d17ae9c334e88d6f91beL42)
- [various changes to alignment, sometimes more, sometimes less](https://github.com/playframework/playframework/pull/11512/files#diff-6c8907861b56419107983b7e5507ae89376881cf87021259f0d435cdd06079c0L221) - (there's lots of new ways to tune the alignment in scalafmt 3 )
- string interpolation now doing a little bit of reformatting, and some improvements to multiline strings

#### Caveats
- disabled `RedundantParens` rule, since its become a lot more aggressive, and I was trying to keep changes down. I do miss this rule though
- potential other rules that may be nice to be turned on later

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

