### PR TITLE
Don't cache elements for 1 second, makes no sense

### DIFF
--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -188,6 +188,7 @@ class SyncCaffeineCacheApi @Inject() (val cache: NamedCaffeineCache[Any, Any]) e
 
   override def set(key: String, value: Any, expiration: Duration): Unit = {
     if (!expiration.isFinite || !expiration.lteq(0.seconds)) {
+      // Cache only if expiration is greater than 0 (0 and below won't cache)
       syncCache.put(key, ExpirableCacheValue(value, Some(expiration)))
     }
     Done

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.Executor
 import javax.cache.CacheException
 
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.FutureConverters._
@@ -186,7 +187,9 @@ class SyncCaffeineCacheApi @Inject() (val cache: NamedCaffeineCache[Any, Any]) e
   private val syncCache: Cache[Any, Any] = cache.synchronous()
 
   override def set(key: String, value: Any, expiration: Duration): Unit = {
-    syncCache.put(key, ExpirableCacheValue(value, Some(expiration)))
+    if (!expiration.isFinite || !expiration.lteq(0.seconds)) {
+      syncCache.put(key, ExpirableCacheValue(value, Some(expiration)))
+    }
     Done
   }
 

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
@@ -31,7 +31,7 @@ private[caffeine] class DefaultCaffeineExpiry extends Expiry[String, ExpirableCa
 
   private def calculateExpirationTime(durationMaybe: Option[Duration]): Long = {
     durationMaybe match {
-      case Some(duration) if duration.isFinite && duration.lteq(0.second) => 1.second.toNanos
+      case Some(duration) if duration.isFinite && duration.lteq(0.second) => 0.seconds.toNanos
       case Some(duration) if duration.isFinite                            => duration.toNanos
       case _                                                              => Long.MaxValue
     }

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
@@ -31,9 +31,10 @@ private[caffeine] class DefaultCaffeineExpiry extends Expiry[String, ExpirableCa
 
   private def calculateExpirationTime(durationMaybe: Option[Duration]): Long = {
     durationMaybe match {
-      case Some(duration) if duration.isFinite && duration.lteq(0.second) => 0.seconds.toNanos
-      case Some(duration) if duration.isFinite                            => duration.toNanos
-      case _                                                              => Long.MaxValue
+      case Some(duration) if duration.isFinite && duration.lteq(0.second) =>
+        0.seconds.toNanos // Will always end up in a cache miss, so this equals to not caching at all: https://github.com/ben-manes/caffeine/discussions/803
+      case Some(duration) if duration.isFinite => duration.toNanos
+      case _                                   => Long.MaxValue
     }
   }
 }


### PR DESCRIPTION
While looking at #11506 and working on #11515 I was wondering why we put elements in the cache for 1 seconds if the expiration is set to 0 (which btw for us in Play means do not cache it - some libraries may treat that as indefinitely, just a note)

This was started in #5923 where ehcache, which was our first cache implementation long before caffeine, set the time to live to 1 second.

This behaviour is now causing problems for #11515. I can not see the sense of this behaviour.