### PR TITLE
Use environment file instead `set-output`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,11 +31,11 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
             AKKA_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-actor_2.13/ | grep -oEi '2\.6\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
             AKKA_HTTP_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-http-core_2.13/ | grep -oEi '10\.1\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
-            echo "::set-output name=akka_opts::-Dakka.version=$AKKA_VERSION"
-            echo "::set-output name=akka_http_opts::-Dakka.http.version=$AKKA_HTTP_VERSION"
+            echo "akka_opts=-Dakka.version=$AKKA_VERSION" >> $GITHUB_OUTPUT
+            echo "akka_http_opts=-Dakka.http.version=$AKKA_HTTP_VERSION" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=akka_opts::"
-            echo "::set-output name=akka_http_opts::"
+            echo "akka_opts=" >> $GITHUB_OUTPUT
+            echo "akka_http_opts=" >> $GITHUB_OUTPUT
           fi
 
   prefetch-for-caching:


### PR DESCRIPTION
## References

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
