### PR TITLE
[2.8.x] Use environment file instead `set-output`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # for checkout
+
 jobs:
   extra-vars:
     name: Extra variables
@@ -25,17 +28,18 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
             AKKA_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-actor_2.13/ | grep -oEi '2\.6\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
             AKKA_HTTP_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-http-core_2.13/ | grep -oEi '10\.1\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
-            echo "::set-output name=akka_opts::-Dakka.version=$AKKA_VERSION"
-            echo "::set-output name=akka_http_opts::-Dakka.http.version=$AKKA_HTTP_VERSION"
+            echo "akka_opts=-Dakka.version=$AKKA_VERSION" >> $GITHUB_OUTPUT
+            echo "akka_http_opts=-Dakka.http.version=$AKKA_HTTP_VERSION" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=akka_opts::"
-            echo "::set-output name=akka_http_opts::"
+            echo "akka_opts=" >> $GITHUB_OUTPUT
+            echo "akka_http_opts=" >> $GITHUB_OUTPUT
           fi
 
   prefetch-for-caching:
     name: Prefetch dependencies and JVMs for caching
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
+      java: 8
       cmd: |
         if [ "$CACHE_HIT_COURSIER" = "false" ]; then
           sbt +update                                             # Runs with adoptium:8 (default)
@@ -51,20 +55,24 @@ jobs:
     needs:
       - "extra-vars"
       - "prefetch-for-caching"
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
+      java: 8
       cmd: sbt "${{needs.extra-vars.outputs.akka_version_opts}}" "${{needs.extra-vars.outputs.akka_http_version_opts}}" validateCode
 
   check-binary-compatibility:
     name: Binary Compatibility
     needs: "prefetch-for-caching"
-    uses: playframework/.github/.github/workflows/binary-check.yml@v2
+    uses: playframework/.github/.github/workflows/binary-check.yml@v3
+    with:
+      java: 8
 
   check-code-style-docs:
     name: Code Style Docs
     needs: "prefetch-for-caching"
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
+      java: 8
       cmd: |
         cd documentation
         sbt validateCode
@@ -76,7 +84,7 @@ jobs:
       - "check-code-style"
       - "check-binary-compatibility"
       - "check-code-style-docs"
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 11, 8
       cmd: |
@@ -92,7 +100,7 @@ jobs:
       - "check-code-style"
       - "check-binary-compatibility"
       - "check-code-style-docs"
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 11, 8
       scala: 2.12.16, 2.13.10
@@ -115,7 +123,7 @@ jobs:
       - "check-code-style"
       - "check-binary-compatibility"
       - "check-code-style-docs"
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 11, 8
       scala: 2.12.16, 2.13.10
@@ -131,7 +139,7 @@ jobs:
     needs:
       - "extra-vars"
       - "publish-local"
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 11, 8
       scala: 2.12.16, 2.13.10
@@ -165,4 +173,4 @@ jobs:
       - "tests"
       - "docs-tests"
       - "scripted-tests"
-    uses: playframework/.github/.github/workflows/rtm.yml@v2
+    uses: playframework/.github/.github/workflows/rtm.yml@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,5 +11,7 @@ on:
 jobs:
   publish-artifacts:
     name: Publish / Artifacts
-    uses: playframework/.github/.github/workflows/publish.yml@v2
+    uses: playframework/.github/.github/workflows/publish.yml@v3
     secrets: inherit
+    with:
+      java: 8


### PR DESCRIPTION
## References

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/