### PR TITLE
Log websocket communication problems + handle special Netty case

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
@@ -17,3 +17,6 @@ update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWar
 libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
+
+// Tyrus is the reference implementation for Java Websocket API (JSR-356)
+libraryDependencies += "org.glassfish.tyrus" % "tyrus-container-jdk-client" % "2.1.1" % Test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/resources/logback.xml
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>
+        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <logger name="controllers.HomeController" level="DEBUG" />
+  <logger name="akka.stream.Materializer" level="DEBUG" />
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/resources/routes
@@ -1,3 +1,5 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET     /                           controllers.HomeController.index
+GET     /websocket                  controllers.HomeController.websocket
+GET     /websocket-feedback         controllers.HomeController.websocketFeedback

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/main/scala/controllers/HomeController.scala
@@ -4,13 +4,42 @@
 
 package controllers
 
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ BroadcastHub, Flow, Keep, MergeHub, Sink, Source }
+
 import javax.inject._
-import play.api._
+import play.api.http.websocket.{ CloseMessage, Message }
 import play.api.mvc._
 @Singleton
-class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+class HomeController @Inject()(cc: ControllerComponents)(implicit mat: Materializer) extends AbstractController(cc) {
 
   def index() = Action { implicit request: Request[AnyContent] =>
     Ok("Successful response.")
   }
+
+  // like a chat room: many clients -> merge hub -> broadcasthub -> many clients
+  // makes it easy to make two websockets communicate with each other
+  private val (chatSink, chatSource) = {
+    // Don't log MergeHub$ProducerFailed as error if the client disconnects.
+    // recoverWithRetries -1 is essentially "recoverWith"
+    val source = MergeHub.source[String]
+      .log("source") // See logback.xml (-> logger "akka.stream.Materializer")
+      .recoverWithRetries(-1, { case _: Exception => Source.empty })
+
+    val sink = BroadcastHub.sink[String]
+
+    source.toMat(sink)(Keep.both).run()
+  }
+
+  // WebSocket that sends out messages that have been put into chatSink
+  def websocketFeedback: WebSocket = WebSocket.accept[String, String](rh => Flow.fromSinkAndSource(Sink.ignore, chatSource))
+
+  def websocket: WebSocket = WebSocket.accept[Message, Message](rh =>
+    Flow.fromSinkAndSource(Sink.foreach(_ match {
+      // When the client closes this WebSocket, send the status code
+      // that we received from the client to the feedback-websocket
+      case CloseMessage(statusCode, _) => Source.single(statusCode.map(_.toString).getOrElse("")).runWith(chatSink)
+      case _ =>
+    }), Source.maybe[Message]) // Keep connection open
+  )
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/java/ws/WebSocketClient.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/java/ws/WebSocketClient.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package ws;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+
+import jakarta.websocket.*;
+
+// Stupid WebSocket client, but good enough for tests
+@ClientEndpoint
+public class WebSocketClient {
+
+    private Session session;
+    private WsHandler wsHandler;
+    private final URI endpointURI;
+
+    public WebSocketClient(String endpoint) {
+        try {
+            this.endpointURI = new URI(endpoint);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public WebSocketClient(URI endpointURI) {
+        this.endpointURI = endpointURI;
+    }
+
+    public WebSocketClient addHandler(WsHandler wsHandler) {
+        this.wsHandler = wsHandler;
+        return this;
+    }
+
+    public void connect() {
+        try {
+            ContainerProvider.getWebSocketContainer().connectToServer(this, endpointURI);
+        } catch (DeploymentException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @OnOpen
+    public void onOpen(Session session, EndpointConfig config) {
+        this.session = session;
+        this.wsHandler.onOpen();
+    }
+
+    @OnClose
+    public void onClose(Session session, CloseReason reason) {
+        this.wsHandler.onClose(reason);
+        this.session = null;
+    }
+
+    @OnMessage
+    public void onMessage(Session session, String message) {
+        if (this.wsHandler != null) {
+            this.wsHandler.handleStringMessage(message);
+        }
+    }
+
+   @OnMessage
+   public void onMessage(Session session, ByteBuffer bytes) {
+       if (this.wsHandler != null) {
+           this.wsHandler.handleBinaryMessage(bytes);
+       }
+    }
+
+    @OnMessage
+    public void onMessage(Session session, PongMessage pong) {
+        if (this.wsHandler != null) {
+            this.wsHandler.handlePongMessage(pong);
+        }
+    }
+
+    @OnError
+    public void onError(Session session, Throwable t) {
+        if (this.wsHandler != null) {
+            this.wsHandler.onError(t);
+        } else {
+            t.printStackTrace();
+        }
+    }
+
+    public void sendMessage(String message) {
+        try {
+            this.session.getBasicRemote().sendText(message);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean close(int closeCode) {
+        return this.close(closeCode, null);
+    }
+
+    public boolean close(int closeCode, String reason) {
+        try {
+            this.session.close(new CloseReason(CloseReason.CloseCodes.getCloseCode(closeCode), reason));
+            return true;
+        } catch (final IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    public static interface WsHandler {
+        default void onOpen() {}
+        default void onClose(CloseReason reason) {}
+        default void onError(Throwable t) {}
+        default void handleStringMessage(String message) {}
+        default void handleBinaryMessage(ByteBuffer bytes) {}
+        default void handlePongMessage(PongMessage pong) {}
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
@@ -11,6 +11,7 @@ import play.api.test.PlaySpecification
 import play.api.test._
 
 import play.api.http.HttpProtocol
+import ws.WebSocketClient
 
 class IntegrationTest extends ForServer with PlaySpecification with ApplicationFactories {
 
@@ -20,6 +21,15 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     val ws  = running.app.injector.instanceOf[WSClient]
     val url = running.endpoints.httpEndpoint.get.pathUrl(path)
     ws.url(url).withVirtualHost("127.0.0.1")
+  }
+
+  def websocketUrl(path: String)(implicit running: RunningServer): String = {
+    val scheme = running.endpoints.httpEndpoint.get.scheme
+    val wsScheme = scheme match {
+      case "http"  => "ws"
+      case "https" => "wss"
+    }
+    running.endpoints.httpEndpoint.get.pathUrl(path).replace(s"$scheme://", s"$wsScheme://")
   }
 
   "Integration test" should {
@@ -38,6 +48,35 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
 
     "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>
       rs.endpoints.endpoints.filter(_.protocols.contains(HttpProtocol.HTTP_2_0)) must be(Nil)
+    }
+
+    "all close status codes should be pushed to app" >> { implicit rs: RunningServer =>
+
+      var receivedCloseCode = ""
+
+      // We open two websockets, one that gets closed with status code 2000
+      // Another one which tells us the close status code of the mentioned connection so we can check it.
+
+      new WebSocketClient(websocketUrl("/websocket-feedback")).addHandler(new WebSocketClient.WsHandler {
+        override def handleStringMessage(message: String) = receivedCloseCode = message
+      }).connect();
+
+      val ws = new WebSocketClient(websocketUrl("/websocket"))
+      ws.addHandler(new WebSocketClient.WsHandler {
+        //
+        // Immediately after opening the connection we close it again.
+        //
+        // According to netty, close status code 2000 is invalid:
+        // https://github.com/netty/netty/blob/netty-4.1.84.Final/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java#L286-L291
+        // That's kind of true, because it's reserved for the protocol itself, not for users: https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2
+        // However, the akka-http backend does not care and pushes all status code down to the application,
+        // so the netty backend should do the same.
+        override def onOpen() = ws.close(2000)
+      }).connect();
+
+      Thread.sleep(1000) // Give feedback-websocket time to send message to client
+
+      receivedCloseCode mustEqual "2000"
     }
 
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/src/test/scala/controllers/IntegrationTest.scala
@@ -23,15 +23,6 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     ws.url(url).withVirtualHost("127.0.0.1")
   }
 
-  def websocketUrl(path: String)(implicit running: RunningServer): String = {
-    val scheme = running.endpoints.httpEndpoint.get.scheme
-    val wsScheme = scheme match {
-      case "http"  => "ws"
-      case "https" => "wss"
-    }
-    running.endpoints.httpEndpoint.get.pathUrl(path).replace(s"$scheme://", s"$wsScheme://")
-  }
-
   "Integration test" should {
 
     "use the controller successfully" >> { implicit rs: RunningServer =>
@@ -57,11 +48,11 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
       // We open two websockets, one that gets closed with status code 2000
       // Another one which tells us the close status code of the mentioned connection so we can check it.
 
-      new WebSocketClient(websocketUrl("/websocket-feedback")).addHandler(new WebSocketClient.WsHandler {
+      new WebSocketClient(rs.endpoints.httpEndpoint.get.wsPathUrl("/websocket-feedback")).addHandler(new WebSocketClient.WsHandler {
         override def handleStringMessage(message: String) = receivedCloseCode = message
       }).connect();
 
-      val ws = new WebSocketClient(websocketUrl("/websocket"))
+      val ws = new WebSocketClient(rs.endpoints.httpEndpoint.get.wsPathUrl("/websocket"))
       ws.addHandler(new WebSocketClient.WsHandler {
         //
         // Immediately after opening the connection we close it again.

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
@@ -18,3 +18,6 @@ update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWar
 libraryDependencies += guice
 libraryDependencies += specs2
 libraryDependencies += ws
+
+// Tyrus is the reference implementation for Java Websocket API (JSR-356)
+libraryDependencies += "org.glassfish.tyrus" % "tyrus-container-jdk-client" % "2.1.1" % Test

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/resources/logback.xml
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>
+        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <logger name="controllers.HomeController" level="DEBUG" />
+  <logger name="akka.stream.Materializer" level="DEBUG" />
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/resources/routes
@@ -1,3 +1,5 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 GET     /                           controllers.HomeController.index
+GET     /websocket                  controllers.HomeController.websocket
+GET     /websocket-feedback         controllers.HomeController.websocketFeedback

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/scala/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/main/scala/controllers/HomeController.scala
@@ -4,13 +4,42 @@
 
 package controllers
 
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ BroadcastHub, Flow, Keep, MergeHub, Sink, Source }
+
 import javax.inject._
-import play.api._
+import play.api.http.websocket.{ CloseMessage, Message }
 import play.api.mvc._
 @Singleton
-class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+class HomeController @Inject()(cc: ControllerComponents)(implicit mat: Materializer) extends AbstractController(cc) {
 
   def index() = Action { implicit request: Request[AnyContent] =>
     Ok("Successful response.")
   }
+
+  // like a chat room: many clients -> merge hub -> broadcasthub -> many clients
+  // makes it easy to make two websockets communicate with each other
+  private val (chatSink, chatSource) = {
+    // Don't log MergeHub$ProducerFailed as error if the client disconnects.
+    // recoverWithRetries -1 is essentially "recoverWith"
+    val source = MergeHub.source[String]
+      .log("source") // See logback.xml (-> logger "akka.stream.Materializer")
+      .recoverWithRetries(-1, { case _: Exception => Source.empty })
+
+    val sink = BroadcastHub.sink[String]
+
+    source.toMat(sink)(Keep.both).run()
+  }
+
+  // WebSocket that sends out messages that have been put into chatSink
+  def websocketFeedback: WebSocket = WebSocket.accept[String, String](rh => Flow.fromSinkAndSource(Sink.ignore, chatSource))
+
+  def websocket: WebSocket = WebSocket.accept[Message, Message](rh =>
+    Flow.fromSinkAndSource(Sink.foreach(_ match {
+      // When the client closes this WebSocket, send the status code
+      // that we received from the client to the feedback-websocket
+      case CloseMessage(statusCode, _) => Source.single(statusCode.map(_.toString).getOrElse("")).runWith(chatSink)
+      case _ =>
+    }), Source.maybe[Message]) // Keep connection open
+  )
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/java/ws/WebSocketClient.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/java/ws/WebSocketClient.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package ws;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+
+import jakarta.websocket.*;
+
+// Stupid WebSocket client, but good enough for tests
+@ClientEndpoint
+public class WebSocketClient {
+
+    private Session session;
+    private WsHandler wsHandler;
+    private final URI endpointURI;
+
+    public WebSocketClient(String endpoint) {
+        try {
+            this.endpointURI = new URI(endpoint);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public WebSocketClient(URI endpointURI) {
+        this.endpointURI = endpointURI;
+    }
+
+    public WebSocketClient addHandler(WsHandler wsHandler) {
+        this.wsHandler = wsHandler;
+        return this;
+    }
+
+    public void connect() {
+        try {
+            ContainerProvider.getWebSocketContainer().connectToServer(this, endpointURI);
+        } catch (DeploymentException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @OnOpen
+    public void onOpen(Session session, EndpointConfig config) {
+        this.session = session;
+        this.wsHandler.onOpen();
+    }
+
+    @OnClose
+    public void onClose(Session session, CloseReason reason) {
+        this.wsHandler.onClose(reason);
+        this.session = null;
+    }
+
+    @OnMessage
+    public void onMessage(Session session, String message) {
+        if (this.wsHandler != null) {
+            this.wsHandler.handleStringMessage(message);
+        }
+    }
+
+   @OnMessage
+   public void onMessage(Session session, ByteBuffer bytes) {
+       if (this.wsHandler != null) {
+           this.wsHandler.handleBinaryMessage(bytes);
+       }
+    }
+
+    @OnMessage
+    public void onMessage(Session session, PongMessage pong) {
+        if (this.wsHandler != null) {
+            this.wsHandler.handlePongMessage(pong);
+        }
+    }
+
+    @OnError
+    public void onError(Session session, Throwable t) {
+        if (this.wsHandler != null) {
+            this.wsHandler.onError(t);
+        } else {
+            t.printStackTrace();
+        }
+    }
+
+    public void sendMessage(String message) {
+        try {
+            this.session.getBasicRemote().sendText(message);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean close(int closeCode) {
+        return this.close(closeCode, null);
+    }
+
+    public boolean close(int closeCode, String reason) {
+        try {
+            this.session.close(new CloseReason(CloseReason.CloseCodes.getCloseCode(closeCode), reason));
+            return true;
+        } catch (final IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    public static interface WsHandler {
+        default void onOpen() {}
+        default void onClose(CloseReason reason) {}
+        default void onError(Throwable t) {}
+        default void handleStringMessage(String message) {}
+        default void handleBinaryMessage(ByteBuffer bytes) {}
+        default void handlePongMessage(PongMessage pong) {}
+    }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
@@ -11,6 +11,7 @@ import play.api.test.PlaySpecification
 import play.api.test._
 
 import play.api.http.HttpProtocol
+import ws.WebSocketClient
 
 class IntegrationTest extends ForServer with PlaySpecification with ApplicationFactories {
 
@@ -20,6 +21,15 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     val ws  = running.app.injector.instanceOf[WSClient]
     val url = running.endpoints.httpEndpoint.get.pathUrl(path)
     ws.url(url).withVirtualHost("127.0.0.1")
+  }
+
+  def websocketUrl(path: String)(implicit running: RunningServer): String = {
+    val scheme = running.endpoints.httpEndpoint.get.scheme
+    val wsScheme = scheme match {
+      case "http"  => "ws"
+      case "https" => "wss"
+    }
+    running.endpoints.httpEndpoint.get.pathUrl(path).replace(s"$scheme://", s"$wsScheme://")
   }
 
   "Integration test" should {
@@ -38,6 +48,35 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
 
     "use the user-configured HTTP transports during test" >> { implicit rs: RunningServer =>
       rs.endpoints.endpoints.filter(_.protocols.contains(HttpProtocol.HTTP_2_0)) must be(Nil)
+    }
+
+    "all close status codes should be pushed to app" >> { implicit rs: RunningServer =>
+
+      var receivedCloseCode = ""
+
+      // We open two websockets, one that gets closed with status code 2000
+      // Another one which tells us the close status code of the mentioned connection so we can check it.
+
+      new WebSocketClient(websocketUrl("/websocket-feedback")).addHandler(new WebSocketClient.WsHandler {
+        override def handleStringMessage(message: String) = receivedCloseCode = message
+      }).connect();
+
+      val ws = new WebSocketClient(websocketUrl("/websocket"))
+      ws.addHandler(new WebSocketClient.WsHandler {
+        //
+        // Immediately after opening the connection we close it again.
+        //
+        // According to netty, close status code 2000 is invalid:
+        // https://github.com/netty/netty/blob/netty-4.1.84.Final/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java#L286-L291
+        // That's kind of true, because it's reserved for the protocol itself, not for users: https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2
+        // However, the akka-http backend does not care and pushes all status code down to the application,
+        // so the netty backend should do the same.
+        override def onOpen() = ws.close(2000)
+      }).connect();
+
+      Thread.sleep(1000) // Give feedback-websocket time to send message to client
+
+      receivedCloseCode mustEqual "2000"
     }
 
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
@@ -23,15 +23,6 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
     ws.url(url).withVirtualHost("127.0.0.1")
   }
 
-  def websocketUrl(path: String)(implicit running: RunningServer): String = {
-    val scheme = running.endpoints.httpEndpoint.get.scheme
-    val wsScheme = scheme match {
-      case "http"  => "ws"
-      case "https" => "wss"
-    }
-    running.endpoints.httpEndpoint.get.pathUrl(path).replace(s"$scheme://", s"$wsScheme://")
-  }
-
   "Integration test" should {
 
     "use the controller successfully" >> { implicit rs: RunningServer =>
@@ -57,11 +48,11 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
       // We open two websockets, one that gets closed with status code 2000
       // Another one which tells us the close status code of the mentioned connection so we can check it.
 
-      new WebSocketClient(websocketUrl("/websocket-feedback")).addHandler(new WebSocketClient.WsHandler {
+      new WebSocketClient(rs.endpoints.httpEndpoint.get.wsPathUrl("/websocket-feedback")).addHandler(new WebSocketClient.WsHandler {
         override def handleStringMessage(message: String) = receivedCloseCode = message
       }).connect();
 
-      val ws = new WebSocketClient(websocketUrl("/websocket"))
+      val ws = new WebSocketClient(rs.endpoints.httpEndpoint.get.wsPathUrl("/websocket"))
       ws.addHandler(new WebSocketClient.WsHandler {
         //
         // Immediately after opening the connection we close it again.

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerEndpoint.scala
@@ -28,4 +28,15 @@ import akka.annotation.ApiMayChange
    * Create a full URL out of a path. E.g. a path of `/foo` becomes `http://localhost:12345/foo`
    */
   def pathUrl(path: String): String = s"$scheme://$host:$port$path"
+
+  /**
+   * Create a full WebSocket URL out of a path. E.g. a path of `/foo` becomes `ws://localhost:12345/foo`
+   */
+  def wsPathUrl(path: String): String = {
+    val wsScheme = scheme match {
+      case "http"  => "ws"
+      case "https" => "wss"
+    }
+    s"$wsScheme://$host:$port$path"
+  }
 }

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -207,6 +207,18 @@ object WebSocketFlowHandler {
         setHandler(
           remoteIn,
           new InHandler {
+            override def onUpstreamFailure(ex: Throwable): Unit = {
+              // This happens e.g. when using the Netty backend and a client sends
+              // an invalid close status code not defined in https://tools.ietf.org/html/rfc6455#section-7.4
+              if (state == Open) {
+                // Don't log the whole exception to not overwhelm the logs in case failures occur often
+                logger.warn(s"WebSocket communication problem: ${ex.getMessage}")
+              } else {
+                logger.debug("WebSocket communication problem after the WebSocket was closed", ex)
+              }
+              super.onUpstreamFailure(ex)
+            }
+
             override def onPush() = {
               val message = consumeMessage()
 


### PR DESCRIPTION
Manual forward port of #11519 because we don't need Scala 2.12 compatibility anymore.

Scala 2.13+ makes things easier, see https://stackoverflow.com/a/56780934/810109 and https://www.scala-lang.org/files/archive/api/2.13.x/scala/StringContext$s$.html#unapplySeq(s:String):Option[Seq[String]]