### PR TITLE
[2.8.x] Add WebSocket ping/pong support

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -53,47 +53,76 @@ trait PingWebSocketSpec
     with WebSocketSpecMethods {
   sequential
 
-  "respond to pings" in {
-    withServer(app =>
-      WebSocket.accept[String, String] { req =>
-        Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
-      }
-    ) { app =>
-      import app.materializer
-      val frames = runWebSocket { flow =>
-        sendFrames(
-          PingMessage(ByteString("hello")),
-          CloseMessage(1000)
-        ).via(flow).runWith(consumeFrames)
-      }
-      frames must contain(
-        exactly(
-          pongFrame(be_==("hello")),
-          closeFrame()
+  "backend server" should {
+    "respond to pings" in {
+      withServer(app =>
+        WebSocket.accept[String, String] { req =>
+          Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+        }
+      ) { app =>
+        import app.materializer
+        val frames = runWebSocket { flow =>
+          sendFrames(
+            PingMessage(ByteString("hello")),
+            CloseMessage(1000)
+          ).via(flow).runWith(consumeFrames)
+        }
+        frames must contain(
+          exactly(
+            pongFrame(be_==("hello")),
+            closeFrame()
+          )
         )
-      )
+      }
     }
-  }
 
-  "not respond to pongs" in {
-    withServer(app =>
-      WebSocket.accept[String, String] { req =>
-        Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
-      }
-    ) { app =>
-      import app.materializer
-      val frames = runWebSocket { flow =>
-        sendFrames(
-          PongMessage(ByteString("hello")),
-          CloseMessage(1000)
-        ).via(flow).runWith(consumeFrames)
-      }
-      frames must contain(
-        exactly(
-          closeFrame()
+    "not respond to pongs" in {
+      withServer(app =>
+        WebSocket.accept[String, String] { req =>
+          Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+        }
+      ) { app =>
+        import app.materializer
+        val frames = runWebSocket { flow =>
+          sendFrames(
+            PongMessage(ByteString("hello")),
+            CloseMessage(1000)
+          ).via(flow).runWith(consumeFrames)
+        }
+        frames must contain(
+          exactly(
+            closeFrame()
+          )
         )
-      )
+      }
     }
+
+    "ping client every 2 seconds, 4 times total within 9 seconds" in handleKeepAlive(
+      "ping",
+      "2 seconds",
+      9.seconds,
+      List.fill(4)(pingFrame(be_==("")))
+    )
+    "ping client every 3 seconds, 2 times total within 8 seconds" in handleKeepAlive(
+      "ping",
+      "3 seconds",
+      8.seconds,
+      List.fill(2)(pingFrame(be_==("")))
+    )
+    "never ping client 9 seconds" in handleKeepAlive("ping", "infinite", 9.seconds, List.empty)
+    "pong client every 2 seconds, 4 times total within 9 seconds" in handleKeepAlive(
+      "pong",
+      "2 seconds",
+      9.seconds,
+      List.fill(4)(pongFrame(be_==("")))
+    )
+    "pong client every 3 seconds, 2 times total within 8 seconds" in handleKeepAlive(
+      "pong",
+      "3 seconds",
+      8.seconds,
+      List.fill(2)(pongFrame(be_==("")))
+    )
+    "never pong client 9 seconds" in handleKeepAlive("pong", "infinite", 9.seconds, List.empty)
   }
 }
 
@@ -447,6 +476,10 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
     case SimpleMessage(PongMessage(data), _) => data.utf8String must matcher
   }
 
+  def pingFrame(matcher: Matcher[String]): Matcher[ExtendedMessage] = beLike {
+    case SimpleMessage(PingMessage(data), _) => data.utf8String must matcher
+  }
+
   def textFrame(matcher: Matcher[String]): Matcher[ExtendedMessage] = beLike {
     case SimpleMessage(TextMessage(text), _) => text must matcher
   }
@@ -591,6 +624,32 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
         _.recover(t => ()) // recover from "failed" `disconnected`, see onUpstreamFailure in WebSocketClient
       )
       result must_== expectedMessages // when connection was closed to early, no messages were got send and therefore not consumed
+    }
+  }
+
+  def handleKeepAlive(
+      `periodic-keep-alive-mode`: String,
+      `periodic-keep-alive-max-idle`: String,
+      sendCloseAfterDelay: FiniteDuration,
+      expectedFrames: Seq[Matcher[ExtendedMessage]]
+  ) = {
+    withServer(
+      app =>
+        WebSocket.accept[String, String] { req =>
+          Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+        },
+      Map(
+        "play.server.websocket.periodic-keep-alive-mode"     -> `periodic-keep-alive-mode`,
+        "play.server.websocket.periodic-keep-alive-max-idle" -> `periodic-keep-alive-max-idle`,
+      )
+    ) { app =>
+      import app.materializer
+      val frames = runWebSocket { flow =>
+        sendFrames(
+          CloseMessage(1000)
+        ).delay(sendCloseAfterDelay).via(flow).runWith(consumeFrames)
+      }
+      frames must contain(exactly(expectedFrames ++ List(closeFrame()): _*))
     }
   }
 }

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -106,3 +106,37 @@ sbt -Dwebsocket.frame.maxLength=64k run
 ```
 
 This configuration gives you more control of WebSocket frame length and can be adjusted to your application requirements. It may also reduce denial of service attacks using long data frames.
+
+## Configuring keep-alive Frames
+
+First of all, if a client sends a `ping` Frame to the Play backend server, it automatically answers with a `pong` frame. This is a requirement according to [RFC 6455 Section 5.5.2](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2), therefore this is hardcoded within Play, you don't need to set up or configure anything.
+Related to that, be aware, that when using web browsers as clients, that they do not send periodically `ping` frames nor do they support JavaScript APIs to do so (Only Firefox has a `network.websocket.timeout.ping.request` config that can be manually set in `about:config`, but that does not really help).
+
+By default, the Play backend server will not send periodically `ping` frames to the client. That means, if neither the server nor the client send periodically pings or pongs, an idle WebSocket connection will be closed by Play after `play.server.http[s].idleTimeout` has been reached.
+
+To avoid that, you can make the Play backend server ping the client after an idle timeout (within the server did not hear anything from the client) has been reached:
+
+```
+play.server.websocket.periodic-keep-alive-max-idle = 10 seconds
+```
+
+Play will then send an empty `ping` frame to the client. Usually that means that an active client will answer with a `pong` frame that you can handle in your application if desired.
+
+Instead of using bi-directional ping/pong keep-alive heartbeating by sending a `ping` frame, you can make Play send an empty `pong` frame for uni-directional pong keep-alive heartbeating, which means the client is not supposed to answer:
+
+```
+play.server.websocket.periodic-keep-alive-mode = "pong"
+```
+
+> **Note:**  Be aware that these configs are not picked up in dev mode (when using `sbt run`) if you solely set them in your `application.conf`. Because these are backend server configs you have to set them via `PlayKeys.devSettings` in your `build.sbt` to make them work in dev mode. More details why and how can be found [[here|ConfigFile#Using-with-the-run-command]].
+
+For development, to test these keep-alive frames, we recommend using [Wireshark](https://www.wireshark.org/) for monitoring (e.g. using a display filter like `(http or websocket)`) and [websocat](https://github.com/vi/websocat) to send frames to the server, e.g. with:
+
+```
+# Add --ping-interval 5 if you want to ping the server every 5 seconds
+websocat -vv --close-status-code 1000 --close-reason "bye bye" ws://127.0.0.1:9000/websocket
+```
+
+If clients send close status codes other than the default 1000 to your Play app, make sure they use the ones that are defined and valid according to [RFC 6455 Section 7.4.1](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1) to avoid any problems. For example web browsers usually throw exceptions when trying to use such status codes and some server implementations (e.g. Netty) fail with exceptions if they receive them (and close the connection).
+
+> **Note:** The akka-http specific configs `akka.http.server.websocket.periodic-keep-alive-max-idle` and `akka.http.server.websocket.periodic-keep-alive-mode` do **not** affect Play. To be backend server agnostic, Play uses its own low-level WebSocket implementation and therefore handles frames itself.

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -118,3 +118,37 @@ sbt -Dwebsocket.frame.maxLength=64k run
 ```
 
 This configuration gives you more control of WebSocket frame length and can be adjusted to your application requirements. It may also reduce denial of service attacks using long data frames.
+
+## Configuring keep-alive Frames
+
+First of all, if a client sends a `ping` Frame to the Play backend server, it automatically answers with a `pong` frame. This is a requirement according to [RFC 6455 Section 5.5.2](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2), therefore this is hardcoded within Play, you don't need to set up or configure anything.
+Related to that, be aware, that when using web browsers as clients, that they do not send periodically `ping` frames nor do they support JavaScript APIs to do so (Only Firefox has a `network.websocket.timeout.ping.request` config that can be manually set in `about:config`, but that does not really help).
+
+By default, the Play backend server will not send periodically `ping` frames to the client. That means, if neither the server nor the client send periodically pings or pongs, an idle WebSocket connection will be closed by Play after `play.server.http[s].idleTimeout` has been reached.
+
+To avoid that, you can make the Play backend server ping the client after an idle timeout (within the server did not hear anything from the client) has been reached:
+
+```
+play.server.websocket.periodic-keep-alive-max-idle = 10 seconds
+```
+
+Play will then send an empty `ping` frame to the client. Usually that means that an active client will answer with a `pong` frame that you can handle in your application if desired.
+
+Instead of using bi-directional ping/pong keep-alive heartbeating by sending a `ping` frame, you can make Play send an empty `pong` frame for uni-directional pong keep-alive heartbeating, which means the client is not supposed to answer:
+
+```
+play.server.websocket.periodic-keep-alive-mode = "pong"
+```
+
+> **Note:**  Be aware that these configs are not picked up in dev mode (when using `sbt run`) if you solely set them in your `application.conf`. Because these are backend server configs you have to set them via `PlayKeys.devSettings` in your `build.sbt` to make them work in dev mode. More details why and how can be found [[here|ConfigFile#Using-with-the-run-command]].
+
+For development, to test these keep-alive frames, we recommend using [Wireshark](https://www.wireshark.org/) for monitoring (e.g. using a display filter like `(http or websocket)`) and [websocat](https://github.com/vi/websocat) to send frames to the server, e.g. with:
+
+```
+# Add --ping-interval 5 if you want to ping the server every 5 seconds
+websocat -vv --close-status-code 1000 --close-reason "bye bye" ws://127.0.0.1:9000/websocket
+```
+
+If clients send close status codes other than the default 1000 to your Play app, make sure they use the ones that are defined and valid according to [RFC 6455 Section 7.4.1](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1) to avoid any problems. For example web browsers usually throw exceptions when trying to use such status codes and some server implementations (e.g. Netty) fail with exceptions if they receive them (and close the connection).
+
+> **Note:** The akka-http specific configs `akka.http.server.websocket.periodic-keep-alive-max-idle` and `akka.http.server.websocket.periodic-keep-alive-mode` do **not** affect Play. To be backend server agnostic, Play uses its own low-level WebSocket implementation and therefore handles frames itself.

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -51,14 +51,6 @@ Sometimes you may wish to reject a WebSocket request, for example, if the user m
 
 > **Note**: the WebSocket protocol does not implement [Same Origin Policy](https://en.wikipedia.org/wiki/Same-origin_policy), and so does not protect against [Cross-Site WebSocket Hijacking](http://www.christian-schneider.net/CrossSiteWebSocketHijacking.html).  To secure a websocket against hijacking, the `Origin` header in the request must be checked against the server's origin, and manual authentication (including CSRF tokens) should be implemented.  If a WebSocket request does not pass the security checks, then `acceptOrResult` should reject the request by returning a Forbidden result.
 
-### Keeping a WebSocket Alive
-
-Play server will close a Websocket connection once the `idleTimeout` duration specified in Play configuration has passed without any messages being sent from either end.
-
-At the moment, Play does not support [Automatic Keep-Alive Ping Support](https://doc.akka.io/docs/akka-http/current/server-side/websocket-support.html#automatic-keep-alive-ping-support). It is planned for a future release. See [issue](https://github.com/playframework/playframework/issues/3861) for workarounds.
-
-You may send messages at regular intervals from either server or client to keep the connection alive.
-
 ### Handling different types of messages
 
 So far we have only seen handling `String` frames.  Play also has built in handlers for `Array[Byte]` frames, and `JsValue` messages parsed from `String` frames.  You can pass these as the type parameters to the WebSocket creation method, for example:

--- a/transport/server/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
@@ -34,7 +34,16 @@ object WebSocketHandler {
    */
   @deprecated("Please specify the subprotocol (or be explicit that you specif None)", "2.7.0")
   def handleWebSocket(upgrade: UpgradeToWebSocket, flow: Flow[Message, Message, _], bufferLimit: Int): HttpResponse =
-    handleWebSocket(upgrade, flow, bufferLimit, None, "ping", Duration.Inf)
+    handleWebSocket(upgrade, flow, bufferLimit, None)
+
+  @deprecated("Please specify the keep-alive mode (ping or pong) and max-idle time", "2.8.19")
+  def handleWebSocket(
+      upgrade: UpgradeToWebSocket,
+      flow: Flow[Message, Message, _],
+      bufferLimit: Int,
+      subprotocol: Option[String]
+  ): HttpResponse =
+    handleWebSocket(upgrade, flow, bufferLimit, subprotocol, "ping", Duration.Inf)
 
   /**
    * Handle a WebSocket
@@ -52,6 +61,16 @@ object WebSocketHandler {
     case other =>
       throw new IllegalArgumentException("UpgradeToWebsocket is not an Akka HTTP UpgradeToWebsocketLowLevel")
   }
+
+  /**
+   * Convert a flow of messages to a flow of frame events.
+   *
+   * This implements the WebSocket control logic, including handling ping frames and closing the connection in a spec
+   * compliant manner.
+   */
+  @deprecated("Please specify the keep-alive mode (ping or pong) and max-idle time", "2.8.19")
+  def messageFlowToFrameFlow(flow: Flow[Message, Message, _], bufferLimit: Int): Flow[FrameEvent, FrameEvent, _] =
+    messageFlowToFrameFlow(flow, bufferLimit, "ping", Duration.Inf)
 
   /**
    * Convert a flow of messages to a flow of frame events.

--- a/transport/server/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
@@ -20,6 +20,8 @@ import play.core.server.common.WebSocketFlowHandler
 import play.core.server.common.WebSocketFlowHandler.MessageType
 import play.core.server.common.WebSocketFlowHandler.RawMessage
 
+import scala.concurrent.duration.Duration
+
 object WebSocketHandler {
 
   /**
@@ -32,7 +34,7 @@ object WebSocketHandler {
    */
   @deprecated("Please specify the subprotocol (or be explicit that you specif None)", "2.7.0")
   def handleWebSocket(upgrade: UpgradeToWebSocket, flow: Flow[Message, Message, _], bufferLimit: Int): HttpResponse =
-    handleWebSocket(upgrade, flow, bufferLimit, None)
+    handleWebSocket(upgrade, flow, bufferLimit, None, "ping", Duration.Inf)
 
   /**
    * Handle a WebSocket
@@ -41,10 +43,12 @@ object WebSocketHandler {
       upgrade: UpgradeToWebSocket,
       flow: Flow[Message, Message, _],
       bufferLimit: Int,
-      subprotocol: Option[String]
+      subprotocol: Option[String],
+      wsKeepAliveMode: String,
+      wsKeepAliveMaxIdle: Duration,
   ): HttpResponse = upgrade match {
     case lowLevel: UpgradeToWebSocketLowLevel =>
-      lowLevel.handleFrames(messageFlowToFrameFlow(flow, bufferLimit), subprotocol)
+      lowLevel.handleFrames(messageFlowToFrameFlow(flow, bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle), subprotocol)
     case other =>
       throw new IllegalArgumentException("UpgradeToWebsocket is not an Akka HTTP UpgradeToWebsocketLowLevel")
   }
@@ -55,13 +59,22 @@ object WebSocketHandler {
    * This implements the WebSocket control logic, including handling ping frames and closing the connection in a spec
    * compliant manner.
    */
-  def messageFlowToFrameFlow(flow: Flow[Message, Message, _], bufferLimit: Int): Flow[FrameEvent, FrameEvent, _] = {
+  def messageFlowToFrameFlow(
+      flow: Flow[Message, Message, _],
+      bufferLimit: Int,
+      wsKeepAliveMode: String,
+      wsKeepAliveMaxIdle: Duration
+  ): Flow[FrameEvent, FrameEvent, _] = {
     // Each of the stages here transforms frames to an Either[Message, ?], where Message is a close message indicating
     // some sort of protocol failure. The handleProtocolFailures function then ensures that these messages skip the
     // flow that we are wrapping, are sent to the client and the close procedure is implemented.
     Flow[FrameEvent]
       .via(aggregateFrames(bufferLimit))
-      .via(handleProtocolFailures(WebSocketFlowHandler.webSocketProtocol(bufferLimit).join(flow)))
+      .via(
+        handleProtocolFailures(
+          WebSocketFlowHandler.webSocketProtocol(bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle).join(flow)
+        )
+      )
       .map(messageToFrameEvent)
   }
 

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -110,7 +110,9 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
   private val httpsWantClientAuth = serverConfig.get[Boolean]("https.wantClientAuth")
   private val illegalResponseHeaderValueProcessingMode =
     akkaServerConfig.get[String]("illegal-response-header-value-processing-mode")
-  private val wsBufferLimit = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
+  private val wsBufferLimit      = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
+  private val wsKeepAliveMode    = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
+  private val wsKeepAliveMaxIdle = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
 
   private val http2Enabled: Boolean = akkaServerConfig.getOptional[Boolean]("http2.enabled").getOrElse(false)
 
@@ -373,7 +375,10 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
             // Eventually it would be better to allow the handler to specify the protocol it selected
             // See also https://github.com/playframework/playframework/issues/7895
             val selectedSubprotocol = upgrade.requestedProtocols.headOption
-            Future.successful(WebSocketHandler.handleWebSocket(upgrade, flow, wsBufferLimit, selectedSubprotocol))
+            Future.successful(
+              WebSocketHandler
+                .handleWebSocket(upgrade, flow, wsBufferLimit, selectedSubprotocol, wsKeepAliveMode, wsKeepAliveMaxIdle)
+            )
         }
 
       case (websocket: WebSocket, None) =>

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -81,6 +81,8 @@ class NettyServer(
   private val httpIdleTimeout     = serverConfig.get[Duration]("http.idleTimeout")
   private val httpsIdleTimeout    = serverConfig.get[Duration]("https.idleTimeout")
   private val wsBufferLimit       = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
+  private val wsKeepAliveMode     = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
+  private val wsKeepAliveMaxIdle  = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
 
   private lazy val transport = nettyConfig.get[String]("transport") match {
     case "native" => Native
@@ -187,7 +189,7 @@ class NettyServer(
    * Create a new PlayRequestHandler.
    */
   protected[this] def newRequestHandler(): ChannelInboundHandler =
-    new PlayRequestHandler(this, serverHeader, maxContentLength, wsBufferLimit)
+    new PlayRequestHandler(this, serverHeader, maxContentLength, wsBufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle)
 
   /**
    * Create a sink for the incoming connection channels.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -26,6 +26,7 @@ import play.core.server.common.ServerDebugInfo
 import play.core.server.common.ServerResultUtils
 
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -39,7 +40,9 @@ private[play] class PlayRequestHandler(
     val server: NettyServer,
     val serverHeader: Option[String],
     val maxContentLength: Long,
-    val wsBufferLimit: Int
+    val wsBufferLimit: Int,
+    val wsKeepAliveMode: String,
+    val wsKeepAliveMaxIdle: Duration,
 ) extends ChannelInboundHandlerAdapter {
   import PlayRequestHandler._
 
@@ -153,7 +156,8 @@ private[play] class PlayRequestHandler(
               handleAction(action, requestHeader, request, tryApp)
             case Right(flow) =>
               import app.materializer
-              val processor = WebSocketHandler.messageFlowToFrameProcessor(flow, wsBufferLimit)
+              val processor =
+                WebSocketHandler.messageFlowToFrameProcessor(flow, wsBufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle)
               Future.successful(
                 new DefaultWebSocketHttpResponse(request.protocolVersion(), HttpResponseStatus.OK, processor, factory)
               )

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -95,6 +95,21 @@ play {
       # requirement may reduce denial of service attacks using long data frames.
       frame.maxLength = 64k
       frame.maxLength = ${?websocket.frame.maxLength}
+
+      # Periodic keep alive may be implemented using by sending Ping frames
+      # upon which the other side is expected to reply with a Pong frame,
+      # or by sending a Pong frame, which serves as unidirectional heartbeat.
+      # Valid values:
+      #   ping - default, for bi-directional ping/pong keep-alive heartbeating
+      #   pong - for uni-directional pong keep-alive heartbeating
+      periodic-keep-alive-mode = ping
+
+      # Interval for sending periodic keep-alives
+      # If a client does not send a frame within this idle time, the server will sent the the keep-alive frame.
+      # The frame sent will be the one configured in play.server.websocket.periodic-keep-alive-mode
+      # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
+      # The value `infinite` means that *no* keep-alive heartbeat will be sent, as: "the allowed idle time is infinite"
+      periodic-keep-alive-max-idle = infinite
     }
 
     debug {

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -19,6 +19,15 @@ object WebSocketFlowHandler {
    * Implements the WebSocket protocol, including correctly handling the closing of the WebSocket, as well as
    * other control frames like ping/pong.
    */
+  @deprecated("Please specify the keep-alive mode (ping or pong) and max-idle time", "2.8.19")
+  def webSocketProtocol(
+      bufferLimit: Int
+  ): BidiFlow[RawMessage, Message, Message, Message, NotUsed] = webSocketProtocol(bufferLimit, "ping", Duration.Inf)
+
+  /**
+   * Implements the WebSocket protocol, including correctly handling the closing of the WebSocket, as well as
+   * other control frames like ping/pong.
+   */
   def webSocketProtocol(
       bufferLimit: Int,
       wsKeepAliveMode: String,

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -11,6 +11,7 @@ import akka.stream.stage._
 import akka.util.ByteString
 import play.api.Logger
 import play.api.http.websocket._
+import scala.concurrent.duration._
 
 object WebSocketFlowHandler {
 
@@ -18,8 +19,37 @@ object WebSocketFlowHandler {
    * Implements the WebSocket protocol, including correctly handling the closing of the WebSocket, as well as
    * other control frames like ping/pong.
    */
-  def webSocketProtocol(bufferLimit: Int): BidiFlow[RawMessage, Message, Message, Message, NotUsed] = {
-    BidiFlow.fromGraph(new GraphStage[BidiShape[RawMessage, Message, Message, Message]] {
+  def webSocketProtocol(
+      bufferLimit: Int,
+      wsKeepAliveMode: String,
+      wsKeepAliveMaxIdle: Duration
+  ): BidiFlow[RawMessage, Message, Message, Message, NotUsed] = {
+
+    /** The layer that transparently injects (if enabled) keepAlive Ping or Pong messages when client is idle */
+    val periodicKeepAlive: BidiFlow[RawMessage, RawMessage, Message, Message, NotUsed] = wsKeepAliveMaxIdle match {
+      case maxIdle: FiniteDuration =>
+        val mkRawMsg = wsKeepAliveMode match {
+          case "ping" =>
+            () =>
+              RawMessage(MessageType.DirectPing, ByteString.empty, true) // sending Ping should result in a Pong back
+          case "pong" =>
+            () =>
+              RawMessage(MessageType.DirectPong, ByteString.empty, true) // sending Pong means we do not expect a reply
+          case other =>
+            throw new IllegalArgumentException(
+              s"Unsupported websocket periodic-keep-alive-mode. " +
+                s"Found: [$other] however only [ping] and [pong] are supported"
+            )
+        }
+        BidiFlow.fromFlows(
+          Flow[RawMessage].keepAlive(maxIdle, mkRawMsg),
+          Flow[Message]
+        )
+      case _ =>
+        BidiFlow.identity
+    }
+
+    val messageHandling = BidiFlow.fromGraph(new GraphStage[BidiShape[RawMessage, Message, Message, Message]] {
       // The stream of incoming messages from the websocket connection
       val remoteIn = Inlet[RawMessage]("WebSocketFlowHandler.remote.in")
       // The stream of websocket messages going out to the websocket connection
@@ -35,6 +65,7 @@ object WebSocketFlowHandler {
 
       override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
         var state: State           = Open
+        var pingToSend: Message    = null
         var pongToSend: Message    = null
         var messageToSend: Message = null
 
@@ -95,6 +126,26 @@ object WebSocketFlowHandler {
           val read = grab(remoteIn)
 
           read.messageType match {
+            case MessageType.DirectPing =>
+              // Ping the client (Part of idle handling)
+              if (isAvailable(remoteOut)) {
+                // Send immediately
+                push(remoteOut, PingMessage(ByteString.empty))
+              } else {
+                // Store to send later
+                pingToSend = PingMessage(ByteString.empty)
+              }
+              null
+            case MessageType.DirectPong =>
+              // Pong the client (Part of idle handling)
+              if (isAvailable(remoteOut)) {
+                // Send immediately
+                push(remoteOut, PongMessage(ByteString.empty))
+              } else {
+                // Store to send later
+                pongToSend = PongMessage(ByteString.empty)
+              }
+              null
             case MessageType.Continuation if currentPartialMessage == null =>
               serverInitiatedClose(CloseMessage(CloseCodes.ProtocolError, "Unexpected continuation frame"))
               null
@@ -282,6 +333,10 @@ object WebSocketFlowHandler {
                     // We have a pong to send
                     push(remoteOut, pongToSend)
                     pongToSend = null
+                  } else if (pingToSend != null) {
+                    // We have a ping to send
+                    push(remoteOut, pingToSend)
+                    pingToSend = null
                   } else {
                     // Nothing to send, pull from app if not already pulled
                     if (!hasBeenPulled(appIn)) {
@@ -294,6 +349,7 @@ object WebSocketFlowHandler {
         )
       }
     })
+    periodicKeepAlive.atop(messageHandling)
   }
 
   private sealed trait State
@@ -308,7 +364,7 @@ object WebSocketFlowHandler {
   case class RawMessage(messageType: MessageType.Type, data: ByteString, isFinal: Boolean)
   object MessageType extends Enumeration {
     type Type = Value
-    val Ping, Pong, Text, Binary, Continuation, Close = Value
+    val Ping, DirectPing, Pong, DirectPong, Text, Binary, Continuation, Close = Value
   }
 
   def parseCloseMessage(data: ByteString): CloseMessage = {


### PR DESCRIPTION
Finally.

Fixes #3861
Fixes https://github.com/akka/akka-http/issues/4147

Needs
- [x] documentation
- [x] ... probably tests ...

With this patch one can set
```
play.server.websocket.periodic-keep-alive-max-idle = 10 seconds
```
in `application.conf` (or `PlayKeys.devSettings` for dev mode) to ping the client after the server didn't hear anything from it after 10 seconds. This is _exactly_ the way how it works in akka-http as well. You might also want to look at the notes in the [RFC about the ping and pong frames](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2).

This was inspired by akka-http's [implementation](https://github.com/akka/akka-http/blob/27598478891acc679c82654f1b0b7dbc6dc04647/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala#L60-L84), however I did not implement a custom payload for the frames. Not sure if that's even important for someone.

Also, this is not akka-http specific, it's implemented backend agnostic, so it work with the netty backend as well.
I did lots of testing on this and it works absolutly great.