### PR TITLE
Upgrade Scalafmt to latest release of `2.4.x` serias

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # sbt-java-formatter 0.8.0 now sorts Java imports
 7b6f6e6ebf7ca2cb4de903e9590872ec9b16aeb8
+# Upgrade Scalafmt to 2.4.x
+33eee4309ab453f6fd90c929378c7b87444cadc3

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -11,4 +11,4 @@ rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifi
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
-version = 2.3.2
+version = 2.4.2

--- a/cache/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
@@ -96,9 +96,7 @@ private[play] final class SerializableResult(constructorResult: Result) extends 
 
     {
       out.writeBoolean(cachedResult.body.contentType.nonEmpty)
-      cachedResult.body.contentType.foreach { ct =>
-        out.writeUTF(ct)
-      }
+      cachedResult.body.contentType.foreach { ct => out.writeUTF(ct) }
       val body = cachedResult.body match {
         case HttpEntity.Strict(data, _) => data
         case other                      => throw new IllegalStateException("Non strict body cannot be materialized")

--- a/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -163,20 +163,14 @@ class CachedSpec extends PlaySpecification {
     }
   }
 
-  val dummyAction = Action { (request: Request[_]) =>
-    Results.Ok(Random.nextInt().toString)
-  }
+  val dummyAction = Action { (request: Request[_]) => Results.Ok(Random.nextInt().toString) }
 
-  val notFoundAction = Action { (request: Request[_]) =>
-    Results.NotFound(Random.nextInt().toString)
-  }
+  val notFoundAction = Action { (request: Request[_]) => Results.NotFound(Random.nextInt().toString) }
 
   "Cached EssentialAction composition" should {
     "cache infinite ok results" in new WithApplication() {
       val cacheOk = cached(app)
-        .empty { x =>
-          x.uri
-        }
+        .empty { x => x.uri }
         .includeStatus(200)
 
       val actionOk       = cacheOk.build(dummyAction)
@@ -196,9 +190,7 @@ class CachedSpec extends PlaySpecification {
     }
 
     "cache everything for infinite" in new WithApplication() {
-      val cache = cached(app).everything { x =>
-        x.uri
-      }
+      val cache = cached(app).everything { x => x.uri }
 
       val actionOk       = cache.build(dummyAction)
       val actionNotFound = cache.build(notFoundAction)

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -181,8 +181,9 @@ abstract class GuiceBuilder[Self] protected (
       ),
       binderOptions
     )
-    val enabledModules  = modules.map(_.disable(disabled))
-    val bindingModules  = GuiceableModule.guiced(environment, configuration, binderOptions)(enabledModules) :+ injectorModule
+    val enabledModules = modules.map(_.disable(disabled))
+    val bindingModules =
+      GuiceableModule.guiced(environment, configuration, binderOptions)(enabledModules) :+ injectorModule
     val overrideModules = GuiceableModule.guiced(environment, configuration, binderOptions)(overrides)
     GuiceModules.`override`(bindingModules.asJava).`with`(overrideModules.asJava)
   }
@@ -318,9 +319,7 @@ object GuiceableModule extends GuiceableModuleConversions {
   def guiced(env: Environment, conf: Configuration, binderOptions: Set[BinderOption])(
       builders: Seq[GuiceableModule]
   ): Seq[GuiceModule] =
-    builders.flatMap { module =>
-      module.guiced(env, conf, binderOptions)
-    }
+    builders.flatMap { module => module.guiced(env, conf, binderOptions) }
 }
 
 /**

--- a/core/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -188,7 +188,10 @@ class GuiceInjectorBuilderSpec extends Specification {
         )
         .disable[GuiceInjectorBuilderSpec.EnvironmentModule]
         .disable[GuiceInjectorBuilderSpec.JavaEnvironmentModule]
-        .disable(classOf[GuiceInjectorBuilderSpec.AModule], classOf[GuiceInjectorBuilderSpec.CModule]) // C won't be disabled
+        .disable(
+          classOf[GuiceInjectorBuilderSpec.AModule],
+          classOf[GuiceInjectorBuilderSpec.CModule]
+        ) // C won't be disabled
         .injector()
 
       injector.instanceOf[Environment] must throwA[com.google.inject.ConfigurationException]

--- a/core/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/HeadActionSpec.scala
@@ -38,16 +38,12 @@ trait HeadActionSpec
   "HEAD requests" should {
     def webSocketResponse(implicit Action: DefaultActionBuilder): Routes = {
       case GET(p"/ws") =>
-        WebSocket.acceptOrResult[String, String] { request =>
-          Future.successful(Left(Results.Forbidden))
-        }
+        WebSocket.acceptOrResult[String, String] { request => Future.successful(Left(Results.Forbidden)) }
     }
 
     def chunkedResponse(implicit Action: DefaultActionBuilder): Routes = {
       case GET(p"/chunked") =>
-        Action { request =>
-          Results.Ok.chunked(Source(List("a", "b", "c")))
-        }
+        Action { request => Results.Ok.chunked(Source(List("a", "b", "c"))) }
     }
 
     def routes(implicit Action: DefaultActionBuilder) =
@@ -70,9 +66,7 @@ trait HeadActionSpec
     def serverWithHandler[T](handler: Handler)(block: WSClient => T): T = {
       Server.withRouter() {
         case _ => handler
-      } { implicit port =>
-        WsTestClient.withClient(block)
-      }
+      } { implicit port => WsTestClient.withClient(block) }
     }
 
     "return 400 in response to a HEAD in a WebSocket handler" in withServer { client =>

--- a/core/play-integration-test/src/it/scala/play/it/http/AkkaRequestTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/AkkaRequestTimeoutSpec.scala
@@ -66,18 +66,14 @@ class AkkaRequestTimeoutSpec extends PlaySpecification with AkkaHttpIntegrationS
         Thread.sleep(1400L)
         Results.Ok
       }
-    }) { port =>
-      doRequests() must throwA[IOException]
-    }
+    }) { port => doRequests() must throwA[IOException] }
 
     "support multi-second timeouts" in withServer(1500.millis)(EssentialAction { req =>
       Accumulator(Sink.ignore).map { _ =>
         Thread.sleep(1600L)
         Results.Ok
       }
-    }) { port =>
-      doRequests() must throwA[IOException]
-    }
+    }) { port => doRequests() must throwA[IOException] }
 
     "not timeout for slow requests with a sub-second timeout" in withServer(700.millis)(EssentialAction { req =>
       Accumulator(Sink.ignore).map { _ =>

--- a/core/play-integration-test/src/it/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/BadClientHandlingSpec.scala
@@ -30,9 +30,7 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
           import sird._
           Router.from {
             case sird.POST(p"/action" ? q_o"query=$query") =>
-              Action { request =>
-                Results.Ok(query.getOrElse("_"))
-              }
+              Action { request => Results.Ok(query.getOrElse("_")) }
             case _ =>
               Action {
                 Results.Ok

--- a/core/play-integration-test/src/it/scala/play/it/http/BasicHttpClient.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/BasicHttpClient.scala
@@ -103,9 +103,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
     val outputStream = s.getOutputStream
     outputStream.write("POST / HTTP/1.1\r\n".getBytes("UTF-8"))
     outputStream.write("Host: localhost\r\n".getBytes("UTF-8"))
-    headers.foreach { header =>
-      outputStream.write(s"${header._1}: ${header._2}\r\n".getBytes("UTF-8"))
-    }
+    headers.foreach { header => outputStream.write(s"${header._1}: ${header._2}\r\n".getBytes("UTF-8")) }
     outputStream.flush()
 
     outputStream.write("\r\n".getBytes("UTF-8"))
@@ -131,9 +129,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
   ): Seq[BasicResponse] = {
     out.write(s"${request.method} ${request.uri} ${request.version}\r\n")
     out.write("Host: localhost\r\n")
-    request.headers.foreach { header =>
-      out.write(s"${header._1}: ${header._2}\r\n")
-    }
+    request.headers.foreach { header => out.write(s"${header._1}: ${header._2}\r\n") }
     out.write("\r\n")
 
     def writeBody() = {
@@ -246,9 +242,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
         .toRight {
           headers
             .get(CONTENT_LENGTH)
-            .map { length =>
-              readCompletely(length.toInt)
-            }
+            .map { length => readCompletely(length.toInt) }
             .getOrElse {
               val httpConfig = HttpConfiguration()
               val serverResultUtils = new ServerResultUtils(

--- a/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/IdleTimeoutSpec.scala
@@ -43,9 +43,7 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
       withConfigAndRouter(extraConfig) { (components: BuiltInComponents) =>
         Router.from {
           case _ =>
-            EssentialAction { rh =>
-              Accumulator(Sink.ignore).map(_ => Results.Ok)
-            }
+            EssentialAction { rh => Accumulator(Sink.ignore).map(_ => Results.Ok) }
         }
       }
     }

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -123,9 +123,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         override def action(request: Request): Result = Results.ok()
       },
       Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true")
-    ) { response =>
-      response.body must beEqualTo("java.lang.Classcontrollerjava.lang.reflect.Methodaction")
-    }
+    ) { response => response.body must beEqualTo("java.lang.Classcontrollerjava.lang.reflect.Methodaction") }
 
     "execute controller composition when action is not annotated" in makeRequest(new ComposedController {
       override def action(request: Request): Result = Results.ok()
@@ -141,9 +139,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         override def action(request: Request): Result = Results.ok()
       },
       Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false")
-    ) { response =>
-      response.body must beEqualTo("java.lang.reflect.Methodactionjava.lang.Classcontroller")
-    }
+    ) { response => response.body must beEqualTo("java.lang.reflect.Methodactionjava.lang.Classcontroller") }
 
     "execute action composition when controller is not annotated" in makeRequest(
       new MockController {
@@ -151,16 +147,12 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         override def action(request: Request): Result = Results.ok()
       },
       Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false")
-    ) { response =>
-      response.body must beEqualTo("java.lang.reflect.Methodaction")
-    }
+    ) { response => response.body must beEqualTo("java.lang.reflect.Methodaction") }
 
     "execute action composition first is the default" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action(request: Request): Result = Results.ok()
-    }) { response =>
-      response.body must beEqualTo("java.lang.reflect.Methodactionjava.lang.Classcontroller")
-    }
+    }) { response => response.body must beEqualTo("java.lang.reflect.Methodactionjava.lang.Classcontroller") }
   }
 
   "Java action composition" should {
@@ -169,9 +161,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         @WithUsername("foo")
         def action(request: Request) = Results.ok(request.attrs().get(Security.USERNAME))
       }
-    ) { response =>
-      response.body must_== "foo"
-    }
+    ) { response => response.body must_== "foo" }
     "ensure withNewSession maintains Session" in makeRequest(new MockController {
       @WithUsername("foo")
       def action(request: Request) = {
@@ -263,9 +253,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
 
     "run @Repeatable action composition annotations backward compatible" in makeRequest(
       new RepeatableBackwardCompatibilityController()
-    ) { response =>
-      response.body must beEqualTo("do_NOT_treat_me_as_container_annotation")
-    }
+    ) { response => response.body must beEqualTo("do_NOT_treat_me_as_container_annotation") }
 
     "run @With annotation on a controller type" in makeRequest(new WithOnTypeController()) { response =>
       response.body must beEqualTo("""java.lang.Classaction1
@@ -337,9 +325,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
         "play.http.actionCreator"                                     -> "play.it.http.ActionCompositionActionCreator"
       )
-    ) { response =>
-      response.body must beEqualTo("actioncreatorjava.lang.Classcontroller")
-    }
+    ) { response => response.body must beEqualTo("actioncreatorjava.lang.Classcontroller") }
 
     "execute request handler action first with only action composition" in makeRequest(
       new MockController {
@@ -350,9 +336,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
         "play.http.actionCreator"                                     -> "play.it.http.ActionCompositionActionCreator"
       )
-    ) { response =>
-      response.body must beEqualTo("actioncreatorjava.lang.reflect.Methodaction")
-    }
+    ) { response => response.body must beEqualTo("actioncreatorjava.lang.reflect.Methodaction") }
   }
 
   "When action composition is configured to invoke request handler action last" should {
@@ -392,9 +376,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
         "play.http.actionCreator"                                     -> "play.it.http.ActionCompositionActionCreator"
       )
-    ) { response =>
-      response.body must beEqualTo("java.lang.Classcontrolleractioncreator")
-    }
+    ) { response => response.body must beEqualTo("java.lang.Classcontrolleractioncreator") }
 
     "execute request handler action last with only action composition" in makeRequest(
       new MockController {
@@ -405,9 +387,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
         "play.http.actionCreator"                                     -> "play.it.http.ActionCompositionActionCreator"
       )
-    ) { response =>
-      response.body must beEqualTo("java.lang.reflect.Methodactionactioncreator")
-    }
+    ) { response => response.body must beEqualTo("java.lang.reflect.Methodactionactioncreator") }
 
     "execute request handler action last is the default and controller composition before action composition" in makeRequest(
       new ComposedController {
@@ -445,9 +425,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
         "play.http.actionCreator"                                     -> "play.it.http.ActionCompositionActionCreator"
       )
-    ) { response =>
-      response.body must beEqualTo("actioncreator")
-    }
+    ) { response => response.body must beEqualTo("actioncreator") }
 
     "execute request handler action first without action composition" in makeRequest(
       new MockController {
@@ -457,9 +435,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
         "play.http.actionCreator"                                     -> "play.it.http.ActionCompositionActionCreator"
       )
-    ) { response =>
-      response.body must beEqualTo("actioncreator")
-    }
+    ) { response => response.body must beEqualTo("actioncreator") }
   }
 }
 

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaActionSpec.scala
@@ -106,9 +106,7 @@ trait JavaActionSpec extends PlaySpecification with WsTestClient {
             s"hasBody: ${request.hasBody}, Content-Length: ${request.header(HeaderNames.CONTENT_LENGTH).orElse("")}"
           )
       }
-    ) { response =>
-      response.body must beEqualTo("hasBody: false, Content-Length: 0")
-    }
+    ) { response => response.body must beEqualTo("hasBody: false, Content-Length: 0") }
     "with body should result in hasBody = true" in makeRequest(
       "POST",
       new MockController {
@@ -118,8 +116,6 @@ trait JavaActionSpec extends PlaySpecification with WsTestClient {
           )
       },
       body = InMemoryBody(ByteString("a"))
-    ) { response =>
-      response.body must beEqualTo("hasBody: true, Content-Length: 1")
-    }
+    ) { response => response.body must beEqualTo("hasBody: true, Content-Length: 1") }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaHttpHandlerSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaHttpHandlerSpec.scala
@@ -39,9 +39,7 @@ trait JavaHttpHandlerSpec extends PlaySpecification with WsTestClient with Serve
   val TestAttr = TypedKey[String]("testAttr")
   val javaHandler: JavaHandler = new JavaHandler {
     override def withComponents(components: JavaHandlerComponents): Handler = {
-      ActionBuilder.ignoringBody { req =>
-        Results.Ok(req.attrs.get(TestAttr).toString)
-      }
+      ActionBuilder.ignoringBody { req => Results.Ok(req.attrs.get(TestAttr).toString) }
     }
   }
 
@@ -51,8 +49,6 @@ trait JavaHttpHandlerSpec extends PlaySpecification with WsTestClient with Serve
     }
     "route a modified request to a JavaHandler's Action" in handlerResponse(
       Handler.Stage.modifyRequest(req => req.addAttr(TestAttr, "Hello!"), javaHandler)
-    ) { response =>
-      response.body must beEqualTo("Some(Hello!)")
-    }
+    ) { response => response.body must beEqualTo("Some(Hello!)") }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -83,17 +83,13 @@ trait JavaResultsHandlingSpec
       def action(request: Http.Request) = {
         Results.ok("Hello world")
       }
-    }) { response =>
-      response.header(DATE) must beSome
-    }
+    }) { response => response.header(DATE) must beSome }
 
     "work with non-standard HTTP response codes" in makeRequest(new MockController {
       def action(request: Http.Request) = {
         Results.status(498)
       }
-    }) { response =>
-      response.status must beEqualTo(498)
-    }
+    }) { response => response.status must beEqualTo(498) }
 
     "add Content-Length for strict results" in makeRequest(new MockController {
       def action(request: Http.Request) = {
@@ -217,9 +213,7 @@ trait JavaResultsHandlingSpec
         def action(request: Http.Request) = {
           Results.ok("Hello world").withHeader("Other", null)
         }
-      }) { response =>
-        response.status must_== INTERNAL_SERVER_ERROR
-      }
+      }) { response => response.status must_== INTERNAL_SERVER_ERROR }
     }
 
     "discard headers" should {
@@ -227,17 +221,13 @@ trait JavaResultsHandlingSpec
         def action(request: Http.Request) = {
           Results.ok("Hello world").withHeader("Other", "some-value").withoutHeader("Other")
         }
-      }) { response =>
-        response.header("Other") must beNone
-      }
+      }) { response => response.header("Other") must beNone }
 
       "treat headers case insensitively" in makeRequest(new MockController {
         def action(request: Http.Request) = {
           Results.ok("Hello world").withHeader("Other", "some-value").withoutHeader("other")
         }
-      }) { response =>
-        response.header("Other") must beNone
-      }
+      }) { response => response.header("Other") must beNone }
     }
 
     "discard cookies from result" in {
@@ -470,9 +460,7 @@ trait JavaResultsHandlingSpec
           }
         },
         Map("play.http.session.sameSite" -> "lax")
-      ) { response =>
-        response.header("Set-Cookie") must beSome.which(_.contains("SameSite=Lax"))
-      }
+      ) { response => response.header("Set-Cookie") must beSome.which(_.contains("SameSite=Lax")) }
 
       "when configured to strict" in makeRequest(
         new MockController {
@@ -488,9 +476,7 @@ trait JavaResultsHandlingSpec
           }
         },
         Map("play.http.session.sameSite" -> "strict")
-      ) { response =>
-        response.header("Set-Cookie") must beSome.which(_.contains("SameSite=Strict"))
-      }
+      ) { response => response.header("Set-Cookie") must beSome.which(_.contains("SameSite=Strict")) }
     }
 
     "handle duplicate withCookies in Result" in {
@@ -587,9 +573,7 @@ trait JavaResultsHandlingSpec
 
     "chunk event source results" in makeRequest(new MockController {
       def action(request: Http.Request) = {
-        val dataSource = akka.stream.javadsl.Source.from(List("a", "b").asJava).map { t =>
-          EventSource.Event.event(t)
-        }
+        val dataSource  = akka.stream.javadsl.Source.from(List("a", "b").asJava).map { t => EventSource.Event.event(t) }
         val eventSource = dataSource.via(EventSource.flow())
         Results.ok().chunked(eventSource).as("text/event-stream")
       }
@@ -712,9 +696,7 @@ trait JavaResultsHandlingSpec
           val source = akka.stream.javadsl.Source.single(ByteString("entity source"))
           Results.ok().streamed(source, Optional.empty())
         }
-      }) { response =>
-        response.header(CONTENT_TYPE) must beNone
-      }
+      }) { response => response.header(CONTENT_TYPE) must beNone }
 
       "correct set it for streamed entities" in makeRequest(new MockController {
         def action(request: Http.Request) = {
@@ -818,9 +800,7 @@ trait JavaResultsHandlingSpec
           val dataSource = akka.stream.javadsl.Source.from(chunks.asJava)
           Results.ok().chunked(dataSource).as(null)
         }
-      }) { response =>
-        response.header(CONTENT_TYPE) must beNone
-      }
+      }) { response => response.header(CONTENT_TYPE) must beNone }
 
       "have no content type if set to null in streamed entities" in makeRequest(new MockController {
         def action(request: Http.Request) = {
@@ -830,9 +810,7 @@ trait JavaResultsHandlingSpec
             new HttpEntity.Streamed(source, Optional.empty(), Optional.of(HTML))
           ).as(null) // start with HTML but later change it to null which means no content type
         }
-      }) { response =>
-        response.header(CONTENT_TYPE) must beNone
-      }
+      }) { response => response.header(CONTENT_TYPE) must beNone }
 
       "correct set it when sending entity as attachment" in makeRequest(new MockController {
         def action(request: Http.Request) = {
@@ -854,7 +832,13 @@ trait JavaResultsHandlingSpec
         def action(request: Http.Request) = {
           val objectNode = Json.newObject
           objectNode.put("foo", "bar")
-          Results.ok().sendJson(objectNode, false, Optional.of("file.txt")) // even though the extension is txt, the content-type is json
+          Results
+            .ok()
+            .sendJson(
+              objectNode,
+              false,
+              Optional.of("file.txt")
+            ) // even though the extension is txt, the content-type is json
         }
       }) { response =>
         // Use starts with because there is also the charset

--- a/core/play-integration-test/src/it/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/RequestHeadersSpec.scala
@@ -26,11 +26,7 @@ class AkkaHttpRequestHeadersSpec extends RequestHeadersSpec with AkkaHttpIntegra
       // to fail. I think it's still worth including this test because it
       // will still often report correct failures, even if it's not perfect.
 
-      withServerAndConfig()((Action, _) =>
-        Action { rh =>
-          Results.Ok(rh.headers.get("User-Agent").toString)
-        }
-      ) { port =>
+      withServerAndConfig()((Action, _) => Action { rh => Results.Ok(rh.headers.get("User-Agent").toString) }) { port =>
         def testAgent(agent: String) = {
           val (_, logMessages) = LogTester.recordLogEvents {
             val Seq(response) = BasicHttpClient.makeRequests(port)(
@@ -100,9 +96,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
 
   "Play request header handling" should {
     "get request headers properly" in withServer((Action, _) =>
-      Action { rh =>
-        Results.Ok(rh.headers.getAll("Origin").mkString(","))
-      }
+      Action { rh => Results.Ok(rh.headers.getAll("Origin").mkString(",")) }
     ) { port =>
       val Seq(response) = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.1", Map("origin" -> "http://foo"), "")
@@ -111,9 +105,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
     }
 
     "remove request headers properly" in withServer((Action, _) =>
-      Action { rh =>
-        Results.Ok(rh.headers.remove("ORIGIN").getAll("Origin").mkString(","))
-      }
+      Action { rh => Results.Ok(rh.headers.remove("ORIGIN").getAll("Origin").mkString(",")) }
     ) { port =>
       val Seq(response) = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.1", Map("origin" -> "http://foo"), "")
@@ -122,9 +114,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
     }
 
     "replace request headers properly" in withServer((Action, _) =>
-      Action { rh =>
-        Results.Ok(rh.headers.replace("Origin" -> "https://bar.com").getAll("Origin").mkString(","))
-      }
+      Action { rh => Results.Ok(rh.headers.replace("Origin" -> "https://bar.com").getAll("Origin").mkString(",")) }
     ) { port =>
       val Seq(response) = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.1", Map("origin" -> "http://foo"), "")
@@ -168,9 +158,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
         Action { rh =>
           Results.Ok(
             Seq("Content-Encoding", "Authorization", "X-Custom-Header")
-              .map { headerName =>
-                s"$headerName -> ${rh.headers.get(headerName)}"
-              }
+              .map { headerName => s"$headerName -> ${rh.headers.get(headerName)}" }
               .mkString(", ")
           )
         }
@@ -198,11 +186,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
 
     "preserve the value of headers" in {
       def headerValueInRequest(headerName: String, headerValue: String): MatchResult[Either[String, _]] = {
-        withServer((Action, _) =>
-          Action { rh =>
-            Results.Ok(rh.headers.get(headerName).toString)
-          }
-        ) { port =>
+        withServer((Action, _) => Action { rh => Results.Ok(rh.headers.get(headerName).toString) }) { port =>
           val Seq(response) = BasicHttpClient.makeRequests(port)(
             // an empty body implies no parsing is used and no content type is derived from the body.
             BasicRequest("GET", "/", "HTTP/1.1", Map(headerName -> headerValue), "")
@@ -225,9 +209,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
     "preserve the case of header names" in {
       def headerNameInRequest(headerName: String, headerValue: String): MatchResult[Either[String, _]] = {
         withServer((Action, _) =>
-          Action { rh =>
-            Results.Ok(rh.headers.keys.filter(_.equalsIgnoreCase(headerName)).mkString)
-          }
+          Action { rh => Results.Ok(rh.headers.keys.filter(_.equalsIgnoreCase(headerName)).mkString) }
         ) { port =>
           val Seq(response) = BasicHttpClient.makeRequests(port)(
             // an empty body implies no parsing is used and no content type is derived from the body.
@@ -274,9 +256,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
     "maintain uri and path consistency" in {
       def uriInRequest(uri: String): MatchResult[Either[String, _]] = {
         withServer((Action, _) =>
-          Action { rh =>
-            Results.Ok((rh.uri.contains(rh.path) && rh.uri.contains(rh.rawQueryString)).toString)
-          }
+          Action { rh => Results.Ok((rh.uri.contains(rh.path) && rh.uri.contains(rh.rawQueryString)).toString) }
         ) { port =>
           val Seq(response) = BasicHttpClient.makeRequests(port)(
             BasicRequest("GET", uri, "HTTP/1.1", Map(), "")

--- a/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -58,9 +58,7 @@ trait ScalaResultsHandlingSpec
       }
     }
 
-    "add Date header" in makeRequest(Results.Ok("Hello world")) { response =>
-      response.header(DATE) must beSome
-    }
+    "add Date header" in makeRequest(Results.Ok("Hello world")) { response => response.header(DATE) must beSome }
 
     "when adding headers" should {
       "accept simple values" in makeRequest(Results.Ok("Hello world").withHeaders("Other" -> "foo")) { response =>
@@ -83,15 +81,11 @@ trait ScalaResultsHandlingSpec
     "discard headers" should {
       "remove the header" in makeRequest(
         Results.Ok.withHeaders("Some" -> "foo", "Other" -> "bar").discardingHeader("Other")
-      ) { response =>
-        response.header("Other") must beNone
-      }
+      ) { response => response.header("Other") must beNone }
 
       "treat headers case insensitively" in makeRequest(
         Results.Ok.withHeaders("Some" -> "foo", "Other" -> "bar").discardingHeader("other")
-      ) { response =>
-        response.header("Other") must beNone
-      }
+      ) { response => response.header("Other") must beNone }
     }
 
     "work with non-standard HTTP response codes" in makeRequest(Result(ResponseHeader(498), HttpEntity.NoEntity)) {

--- a/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/ScalaResultsSpec.scala
@@ -56,7 +56,9 @@ class ScalaResultsSpec extends PlaySpecification {
 
   "bake cookies should not depends on global state" in withApplication("play.allowGlobalApplication" -> false) {
     implicit app =>
-      Ok.bakeCookies(cookieHeaderEncoding, sessionBaker, flashBaker) must not(beNull) // we are interested just that it executes without global state
+      Ok.bakeCookies(cookieHeaderEncoding, sessionBaker, flashBaker) must not(
+        beNull
+      ) // we are interested just that it executes without global state
   }
 
   "support a custom application context" in {

--- a/core/play-integration-test/src/it/scala/play/it/http/SecureFlagSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/SecureFlagSpec.scala
@@ -20,9 +20,7 @@ class SecureFlagSpec
 
   /** An ApplicationFactory with a single action that returns the request's `secure` flag. */
   val secureFlagAppFactory: ApplicationFactory = withAction { actionBuilder =>
-    actionBuilder { (request: Request[_]) =>
-      Results.Ok(request.secure.toString)
-    }
+    actionBuilder { (request: Request[_]) => Results.Ok(request.secure.toString) }
   }
 
   "Play https server" should {

--- a/core/play-integration-test/src/it/scala/play/it/http/SessionCookieSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/SessionCookieSpec.scala
@@ -41,9 +41,7 @@ trait SessionCookieSpec extends PlaySpecification with ServerIntegrationSpecific
             }
         }
       }.application
-    } { implicit port =>
-      withClient(block)
-    }
+    } { implicit port => withClient(block) }
   }
 
   "the session cookie" should {

--- a/core/play-integration-test/src/it/scala/play/it/http/UriHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/UriHandlingSpec.scala
@@ -26,13 +26,9 @@ class UriHandlingSpec
       import sird.UrlContext
       Router.from {
         case sird.GET(p"/path") =>
-          Action { (request: Request[_]) =>
-            Results.Ok(request.queryString)
-          }
+          Action { (request: Request[_]) => Results.Ok(request.queryString) }
         case _ =>
-          Action { (request: Request[_]) =>
-            Results.Ok(request.path + queryToString(request.queryString))
-          }
+          Action { (request: Request[_]) => Results.Ok(request.path + queryToString(request.queryString)) }
       }
     }.withAllOkHttpEndpoints { (okEndpoint: OkHttpEndpoint) =>
       val response: okhttp3.Response = okEndpoint.call(path)

--- a/core/play-integration-test/src/it/scala/play/it/http/assets/AssetsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/assets/AssetsSpec.scala
@@ -45,9 +45,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
           defaultCacheControl = configuration.get[Option[String]]("play.assets.defaultCache")
           aggressiveCacheControl = configuration.get[Option[String]]("play.assets.aggressiveCache")
         }.application
-      } { implicit port =>
-        withClient(block)
-      }
+      } { implicit port => withClient(block) }
     }
 
     val etagPattern = """([wW]/)?"([^"]|\\")*""""
@@ -559,9 +557,7 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
             }
           }.application
         } {
-          withClient { client =>
-            await(client.url("/collection").get()).status must_== NOT_FOUND
-          }(_)
+          withClient { client => await(client.url("/collection").get()).status must_== NOT_FOUND }(_)
         }
       }
     }
@@ -758,7 +754,9 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
           val result = await(
             client
               .url("/encoding.js")
-              .addHttpHeaders(ACCEPT_ENCODING -> "gzip, deflate, sdch, br, bz2") // even with a space, like chrome does it
+              .addHttpHeaders(
+                ACCEPT_ENCODING -> "gzip, deflate, sdch, br, bz2"
+              ) // even with a space, like chrome does it
               // something is wrong here... if we just have "gzip, deflate, sdch, br", the "br" does not end up in the ACCEPT_ENCODING header
               //          .withHeaders(ACCEPT_ENCODING -> "gzip, deflate, sdch, br")
               .get()

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/BodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/BodyParserSpec.scala
@@ -41,14 +41,10 @@ class BodyParserSpec extends PlaySpecification with ScalaCheck {
   }
 
   def constant[A](a: A): BodyParser[A] =
-    BodyParser("constant") { request =>
-      Accumulator.done(Right(a))
-    }
+    BodyParser("constant") { request => Accumulator.done(Right(a)) }
 
   def simpleResult(s: Result): BodyParser[Any] =
-    BodyParser("simple result") { request =>
-      Accumulator.done(Left(s))
-    }
+    BodyParser("simple result") { request => Accumulator.done(Left(s)) }
 
   implicit val arbResult: Arbitrary[Result] =
     Arbitrary {
@@ -114,9 +110,7 @@ class BodyParserSpec extends PlaySpecification with ScalaCheck {
           .mapM(inc)
           .mapM(dbl)
       } must_== run {
-        constant(x).mapM { y =>
-          inc(y).flatMap(dbl)
-        }
+        constant(x).mapM { y => inc(y).flatMap(dbl) }
       }
     }
 
@@ -143,9 +137,7 @@ class BodyParserSpec extends PlaySpecification with ScalaCheck {
           .validate(inc)
           .validate(dbl)
       } must_== run {
-        constant(x).validate { y =>
-          inc(y).flatMap(dbl)
-        }
+        constant(x).validate { y => inc(y).flatMap(dbl) }
       }
     }
 
@@ -157,17 +149,13 @@ class BodyParserSpec extends PlaySpecification with ScalaCheck {
 
     "pass through simple result (case 2)" in prop { (s1: Result, s2: Result) =>
       run {
-        simpleResult(s1).validate { _ =>
-          Left(s2)
-        }
+        simpleResult(s1).validate { _ => Left(s2) }
       } must beLeft(s1)
     }
 
     "fail with simple result" in prop { (s: Result) =>
       run {
-        constant(0).validate { _ =>
-          Left(s)
-        }
+        constant(0).validate { _ => Left(s) }
       } must beLeft(s)
     }
   }
@@ -186,33 +174,25 @@ class BodyParserSpec extends PlaySpecification with ScalaCheck {
       run {
         constant(x).validateM(inc).validateM(dbl)
       } must_== run {
-        constant(x).validateM { y =>
-          Future.successful(Right((y + 1) * 2))
-        }
+        constant(x).validateM { y => Future.successful(Right((y + 1) * 2)) }
       }
     }
 
     "pass through simple result (case 1)" in prop { (s: Result) =>
       run {
-        simpleResult(s).validateM { x =>
-          Future.successful(Right(x))
-        }
+        simpleResult(s).validateM { x => Future.successful(Right(x)) }
       } must beLeft(s)
     }
 
     "pass through simple result (case 2)" in prop { (s1: Result, s2: Result) =>
       run {
-        simpleResult(s1).validateM { _ =>
-          Future.successful(Left(s2))
-        }
+        simpleResult(s1).validateM { _ => Future.successful(Left(s2)) }
       } must beLeft(s1)
     }
 
     "fail with simple result" in prop { (s: Result) =>
       run {
-        constant(0).validateM { _ =>
-          Future.successful(Left(s))
-        }
+        constant(0).validateM { _ => Future.successful(Left(s)) }
       } must beLeft(s)
     }
   }

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/JacksonJsonBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/JacksonJsonBodyParserSpec.scala
@@ -49,11 +49,10 @@ class JacksonJsonBodyParserSpec extends PlaySpecification with Matchers {
       mapper.getRegisteredModuleIds.contains("play.utils.JacksonJsonNodeModule") must_== true
     }
 
-    "parse a simple JSON body with custom Jackson json-read-features" in new WithApplication(
-      guiceBuilder =>
-        guiceBuilder.configure(
-          "akka.serialization.jackson.play.json-read-features.ALLOW_SINGLE_QUOTES" -> "true"
-        )
+    "parse a simple JSON body with custom Jackson json-read-features" in new WithApplication(guiceBuilder =>
+      guiceBuilder.configure(
+        "akka.serialization.jackson.play.json-read-features.ALLOW_SINGLE_QUOTES" -> "true"
+      )
     ) {
 
       val configuration: Configuration = implicitly[Application].configuration

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -307,9 +307,7 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
             }
         }
       }.application
-    } { implicit port =>
-      withClient(block)
-    }
+    } { implicit port => withClient(block) }
   }
 
   "The multipart/form-data parser" should {

--- a/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -72,9 +72,7 @@ trait PingWebSocketSpec
   "backend server" should {
     "respond to pings" in {
       withServer(app =>
-        WebSocket.accept[String, String] { req =>
-          Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
-        }
+        WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) }
       ) { app =>
         import app.materializer
         val frames = runWebSocket { flow =>
@@ -94,9 +92,7 @@ trait PingWebSocketSpec
 
     "not respond to pongs" in {
       withServer(app =>
-        WebSocket.accept[String, String] { req =>
-          Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
-        }
+        WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) }
       ) { app =>
         import app.materializer
         val frames = runWebSocket { flow =>
@@ -179,21 +175,15 @@ trait WebSocketSpec
       }
 
       "allow sending messages" in allowSendingMessages { _ => messages =>
-        WebSocket.accept[String, String] { req =>
-          Flow.fromSinkAndSource(Sink.ignore, Source(messages))
-        }
+        WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source(messages)) }
       }
 
       "close when the consumer is done" in closeWhenTheConsumerIsDone { _ =>
-        WebSocket.accept[String, String] { req =>
-          Flow.fromSinkAndSource(Sink.cancelled, Source.maybe[String])
-        }
+        WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.cancelled, Source.maybe[String]) }
       }
 
       "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult { _ => statusCode =>
-        WebSocket.acceptOrResult[String, String] { req =>
-          Future.successful(Left(Results.Status(statusCode)))
-        }
+        WebSocket.acceptOrResult[String, String] { req => Future.successful(Left(Results.Status(statusCode))) }
       }
 
       "allow handling non-upgrade requests withh 426 status code" in handleNonUpgradeRequestsGracefully { _ =>
@@ -251,9 +241,7 @@ trait WebSocketSpec
 
       "close the websocket when the buffer limit is exceeded" in {
         withServer(app =>
-          WebSocket.accept[String, String] { req =>
-            Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
-          }
+          WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) }
         ) { app =>
           import app.materializer
           val frames = runWebSocket { flow =>
@@ -271,19 +259,16 @@ trait WebSocketSpec
       }
 
       "select one of the subprotocols proposed by the client" in {
-        withServer(app =>
-          WebSocket.accept[String, String] { req =>
-            Flow.fromSinkAndSource(Sink.ignore, Source(Nil))
-          }
-        ) { app =>
-          import app.materializer
-          val (_, headers) = runWebSocket({ flow =>
-            sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
-          }, Some("my_crazy_subprotocol"), c => c)
-          (headers
-            .map { case (key, value) => (key.toLowerCase, value) }
-            .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
-            .head must be).equalTo("my_crazy_subprotocol")
+        withServer(app => WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source(Nil)) }) {
+          app =>
+            import app.materializer
+            val (_, headers) = runWebSocket({ flow =>
+              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
+            }, Some("my_crazy_subprotocol"), c => c)
+            (headers
+              .map { case (key, value) => (key.toLowerCase, value) }
+              .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
+              .head must be).equalTo("my_crazy_subprotocol")
         }
       }
 
@@ -291,9 +276,7 @@ trait WebSocketSpec
       // java.util.concurrent.TimeoutException: Futures timed out after [5 seconds] (Helpers.scala:186)
       "close the websocket when the wrong type of frame is received" in {
         withServer(app =>
-          WebSocket.accept[String, String] { req =>
-            Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
-          }
+          WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) }
         ) { app =>
           import app.materializer
           val frames = runWebSocket { flow =>
@@ -316,7 +299,7 @@ trait WebSocketSpec
         import app.materializer
         implicit val system = app.actorSystem
         WebSocket.accept[String, String] { req =>
-          ActorFlow.actorRef({ out =>
+          ActorFlow.actorRef { out =>
             Props(new Actor() {
               var messages = List.empty[String]
               def receive = {
@@ -327,7 +310,7 @@ trait WebSocketSpec
                 consumed.success(messages.reverse)
               }
             })
-          })
+          }
         }
       }
 
@@ -335,15 +318,13 @@ trait WebSocketSpec
         import app.materializer
         implicit val system = app.actorSystem
         WebSocket.accept[String, String] { req =>
-          ActorFlow.actorRef({ out =>
+          ActorFlow.actorRef { out =>
             Props(new Actor() {
-              messages.foreach { msg =>
-                out ! msg
-              }
+              messages.foreach { msg => out ! msg }
               out ! Status.Success(())
               def receive = PartialFunction.empty
             })
-          })
+          }
         }
       }
 
@@ -351,12 +332,12 @@ trait WebSocketSpec
         import app.materializer
         implicit val system = app.actorSystem
         WebSocket.accept[String, String] { req =>
-          ActorFlow.actorRef({ out =>
+          ActorFlow.actorRef { out =>
             Props(new Actor() {
               system.scheduler.scheduleOnce(10.millis, out, Status.Success(()))
               def receive = PartialFunction.empty
             })
-          })
+          }
         }
       }
 
@@ -364,13 +345,13 @@ trait WebSocketSpec
         import app.materializer
         implicit val system = app.actorSystem
         WebSocket.accept[String, String] { req =>
-          ActorFlow.actorRef({ out =>
+          ActorFlow.actorRef { out =>
             Props(new Actor() {
               def receive = {
                 case _ => context.stop(self)
               }
             })
-          })
+          }
         }
       }
 
@@ -378,22 +359,20 @@ trait WebSocketSpec
         import app.materializer
         implicit val system = app.actorSystem
         WebSocket.accept[String, String] { req =>
-          ActorFlow.actorRef({ out =>
+          ActorFlow.actorRef { out =>
             Props(new Actor() {
               def receive = PartialFunction.empty
               override def postStop() = {
                 cleanedUp.success(true)
               }
             })
-          })
+          }
         }
       }
 
       "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult {
         implicit app => statusCode =>
-          WebSocket.acceptOrResult[String, String] { req =>
-            Future.successful(Left(Results.Status(statusCode)))
-          }
+          WebSocket.acceptOrResult[String, String] { req => Future.successful(Left(Results.Status(statusCode))) }
       }
     }
 
@@ -542,9 +521,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   def allowSendingMessages(webSocket: Application => List[String] => Handler) = {
     withServer(app => webSocket(app)(List("a", "b"))) { app =>
       import app.materializer
-      val frames = runWebSocket { (flow) =>
-        Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames)
-      }
+      val frames = runWebSocket { (flow) => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) }
       frames must contain(
         exactly(
           textFrame(be_==("a")),
@@ -655,10 +632,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
       expectedFrames: Seq[Matcher[ExtendedMessage]]
   ) = {
     withServer(
-      app =>
-        WebSocket.accept[String, String] { req =>
-          Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
-        },
+      app => WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) },
       Map(
         "play.server.websocket.periodic-keep-alive-mode"     -> `periodic-keep-alive-mode`,
         "play.server.websocket.periodic-keep-alive-max-idle" -> `periodic-keep-alive-max-idle`,

--- a/core/play-integration-test/src/it/scala/play/it/libs/JavaWSSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/JavaWSSpec.scala
@@ -220,26 +220,18 @@ trait JavaWSSpec
   }
 
   def withServer[T](block: play.libs.ws.WSClient => T) = {
-    Server.withApplication(app) { implicit port =>
-      withClient(block)
-    }
+    Server.withApplication(app) { implicit port => withClient(block) }
   }
 
   def withEchoServer[T](block: play.libs.ws.WSClient => T) = {
     def echo = BodyParser { req =>
-      Accumulator.source[ByteString].mapFuture { source =>
-        Future.successful(source).map(Right.apply)
-      }
+      Accumulator.source[ByteString].mapFuture { source => Future.successful(source).map(Right.apply) }
     }
 
     Server.withRouterFromComponents()(components => {
       case _ =>
-        components.defaultActionBuilder(echo) { req =>
-          Ok.chunked(req.body)
-        }
-    }) { implicit port =>
-      withClient(block)
-    }
+        components.defaultActionBuilder(echo) { req => Ok.chunked(req.body) }
+    }) { implicit port => withClient(block) }
   }
 
   def withResult[T](result: Result)(block: play.libs.ws.WSClient => T) = {
@@ -247,9 +239,7 @@ trait JavaWSSpec
       {
         case _ => components.defaultActionBuilder(result)
       }
-    } { implicit port =>
-      withClient(block)
-    }
+    } { implicit port => withClient(block) }
   }
 
   def withClient[T](block: play.libs.ws.WSClient => T)(implicit port: Port): T = {
@@ -271,8 +261,6 @@ trait JavaWSSpec
             Ok(s"Content-Length: ${contentLength.getOrElse(-1)}; Transfer-Encoding: ${transferEncoding.getOrElse(-1)}")
           }
       }
-    } { implicit port =>
-      withClient(block)
-    }
+    } { implicit port => withClient(block) }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/libs/ScalaWSSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/ScalaWSSpec.scala
@@ -136,9 +136,7 @@ trait ScalaWSSpec
                 Results.Ok(req.headers.keys.filter(_.equalsIgnoreCase("authorization")).mkString)
               }
           }
-        } { implicit port =>
-          WsTestClient.withClient(block)
-        }
+        } { implicit port => WsTestClient.withClient(block) }
       }
 
       "when signing with the OAuthCalculator" in {
@@ -198,28 +196,20 @@ trait ScalaWSSpec
   implicit val materializer = app.materializer
 
   def withServer[T](block: play.api.libs.ws.WSClient => T) = {
-    Server.withApplication(app) { implicit port =>
-      WsTestClient.withClient(block)
-    }
+    Server.withApplication(app) { implicit port => WsTestClient.withClient(block) }
   }
 
   def withEchoServer[T](block: play.api.libs.ws.WSClient => T) = {
     def echo = BodyParser { req =>
-      Accumulator.source[ByteString].mapFuture { source =>
-        Future.successful(source).map(Right.apply)
-      }
+      Accumulator.source[ByteString].mapFuture { source => Future.successful(source).map(Right.apply) }
     }
 
     Server.withRouterFromComponents() { components =>
       {
         case _ =>
-          components.defaultActionBuilder(echo) { (req: Request[Source[ByteString, _]]) =>
-            Ok.chunked(req.body)
-          }
+          components.defaultActionBuilder(echo) { (req: Request[Source[ByteString, _]]) => Ok.chunked(req.body) }
       }
-    } { implicit port =>
-      WsTestClient.withClient(block)
-    }
+    } { implicit port => WsTestClient.withClient(block) }
   }
 
   def withResult[T](result: Result)(block: play.api.libs.ws.WSClient => T): T = {
@@ -227,9 +217,7 @@ trait ScalaWSSpec
       {
         case _ => c.defaultActionBuilder(result)
       }
-    } { implicit port =>
-      WsTestClient.withClient(block)
-    }
+    } { implicit port => WsTestClient.withClient(block) }
   }
 
   def withHeaderCheck[T](block: play.api.libs.ws.WSClient => T) = {
@@ -242,9 +230,7 @@ trait ScalaWSSpec
             Ok(s"Content-Length: ${contentLength.getOrElse(-1)}; Transfer-Encoding: ${transferEncoding.getOrElse(-1)}")
           }
       }
-    } { implicit port =>
-      WsTestClient.withClient(block)
-    }
+    } { implicit port => WsTestClient.withClient(block) }
   }
 
   class CustomSigner extends WSSignatureCalculator with SignatureCalculator {

--- a/core/play-integration-test/src/it/scala/play/it/mvc/FiltersSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/mvc/FiltersSpec.scala
@@ -57,9 +57,7 @@ trait DefaultFiltersSpec extends FiltersSpec {
       )
     }.application
 
-    Server.withApplication(app) { implicit port =>
-      WsTestClient.withClient(block)
-    }
+    Server.withApplication(app) { implicit port => WsTestClient.withClient(block) }
   }
 
   // Only run this test for injected filters; we can't use it for GlobalSettings
@@ -326,9 +324,7 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
   object SkipNextFilter extends EssentialFilter {
     val expectedText = "This filter does not call next"
 
-    def apply(next: EssentialAction) = EssentialAction { request =>
-      Accumulator.done(Results.Ok(expectedText))
-    }
+    def apply(next: EssentialAction) = EssentialAction { request => Accumulator.done(Results.Ok(expectedText)) }
   }
 
   object SkipNextWithErrorFilter extends EssentialFilter {
@@ -343,9 +339,7 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
     val expectedText = "This filter calls next and throws an exception afterwards"
 
     def apply(next: EssentialAction) = EssentialAction { request =>
-      next(request).map { _ =>
-        throw new RuntimeException(expectedText)
-      }(ec)
+      next(request).map { _ => throw new RuntimeException(expectedText) }(ec)
     }
   }
 
@@ -354,9 +348,7 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
     val expectedValue = "1"
 
     def apply(next: EssentialAction) = EssentialAction { request =>
-      next(request).map { result =>
-        result.withHeaders(header -> expectedValue)
-      }(ec)
+      next(request).map { result => result.withHeaders(header -> expectedValue) }(ec)
     }
   }
 
@@ -382,33 +374,19 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
     val Action = components.defaultActionBuilder
     Router.from {
       case GET(p"/") =>
-        Action { request =>
-          Results.Ok(expectedOkText)
-        }
+        Action { request => Results.Ok(expectedOkText) }
       case GET(p"/ok") =>
-        Action { request =>
-          Results.Ok(expectedOkText)
-        }
+        Action { request => Results.Ok(expectedOkText) }
       case POST(p"/ok") =>
-        Action { request =>
-          Results.Ok(request.body.asText.getOrElse(""))
-        }
+        Action { request => Results.Ok(request.body.asText.getOrElse("")) }
       case GET(p"/error") =>
-        Action { request =>
-          throw new RuntimeException(expectedErrorText)
-        }
+        Action { request => throw new RuntimeException(expectedErrorText) }
       case POST(p"/error") =>
-        Action { request =>
-          throw new RuntimeException(request.body.asText.getOrElse(""))
-        }
+        Action { request => throw new RuntimeException(request.body.asText.getOrElse("")) }
       case GET(p"/error-async") =>
-        Action.async { request =>
-          Future { throw new RuntimeException(expectedErrorText) }(ec)
-        }
+        Action.async { request => Future { throw new RuntimeException(expectedErrorText) }(ec) }
       case POST(p"/error-async") =>
-        Action.async { request =>
-          Future { throw new RuntimeException(request.body.asText.getOrElse("")) }(ec)
-        }
+        Action.async { request => Future { throw new RuntimeException(request.body.asText.getOrElse("")) }(ec) }
     }
   }
 

--- a/core/play-integration-test/src/it/scala/play/it/routing/ServerSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/routing/ServerSpec.scala
@@ -93,9 +93,7 @@ trait ServerSpec extends Specification with BeforeAll {
     "get the address the server is running" in {
       withServer(
         Server.forRouter(9999, (_: JBuiltInComponents) => Router.empty.asJava)
-      ) { server =>
-        server.mainAddress().getPort must beEqualTo(9999)
-      }
+      ) { server => server.mainAddress().getPort must beEqualTo(9999) }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
@@ -33,9 +33,7 @@ class EndpointIntegrationSpecificationSpec
       }
     }
     "respond with the correct server attribute" in withAction { (Action: DefaultActionBuilder) =>
-      Action { (request: Request[_]) =>
-        Results.Ok(request.attrs.get(RequestAttrKey.Server).toString)
-      }
+      Action { (request: Request[_]) => Results.Ok(request.attrs.get(RequestAttrKey.Server).toString) }
     }.withAllOkHttpEndpoints { (okHttpEndpoint: OkHttpEndpoint) =>
       val response: Response = okHttpEndpoint.call("/")
       response.body.string must_== okHttpEndpoint.endpoint.serverAttribute.toString

--- a/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/OkHttpEndpointSupport.scala
@@ -102,9 +102,7 @@ trait OkHttpEndpointSupport {
      * }}}
      */
     def withOkHttpEndpoints[A: AsResult](endpoints: Seq[ServerEndpointRecipe])(block: OkHttpEndpoint => A): Fragment =
-      appFactory.withEndpoints(endpoints) { (endpoint: ServerEndpoint) =>
-        withOkHttpEndpoint(endpoint)(block)
-      }
+      appFactory.withEndpoints(endpoints) { (endpoint: ServerEndpoint) => withOkHttpEndpoint(endpoint)(block) }
 
     /**
      * Helper that creates a specs2 fragment for the server endpoints given in
@@ -120,8 +118,6 @@ trait OkHttpEndpointSupport {
      * }}}
      */
     def withAllOkHttpEndpoints[A: AsResult](block: OkHttpEndpoint => A): Fragment =
-      appFactory.withAllEndpoints { (endpoint: ServerEndpoint) =>
-        withOkHttpEndpoint(endpoint)(block)
-      }
+      appFactory.withAllEndpoints { (endpoint: ServerEndpoint) => withOkHttpEndpoint(endpoint)(block) }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSupport.scala
+++ b/core/play-integration-test/src/it/scala/play/it/test/WSEndpointSupport.scala
@@ -124,8 +124,6 @@ trait WSEndpointSupport {
      * }}}
      */
     def withAllWSEndpoints[A: AsResult](block: WSEndpoint => A): Fragment =
-      appFactory.withAllEndpoints { (endpoint: ServerEndpoint) =>
-        withWSEndpoint(endpoint)(block)
-      }
+      appFactory.withAllEndpoints { (endpoint: ServerEndpoint) => withWSEndpoint(endpoint)(block) }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/tools/HttpBin.scala
+++ b/core/play-integration-test/src/it/scala/play/it/tools/HttpBin.scala
@@ -68,58 +68,42 @@ object HttpBinApplication {
 
   def getIp(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/ip") =>
-      Action { request =>
-        Ok(Json.obj("origin" -> request.remoteAddress))
-      }
+      Action { request => Ok(Json.obj("origin" -> request.remoteAddress)) }
   }
 
   def getUserAgent(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/user-agent") =>
-      Action { request =>
-        Ok(Json.obj("user-agent" -> request.headers.get("User-Agent")))
-      }
+      Action { request => Ok(Json.obj("user-agent" -> request.headers.get("User-Agent"))) }
   }
 
   def getHeaders(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/headers") =>
-      Action { request =>
-        Ok(Json.obj("headers" -> request.headers.toSimpleMap))
-      }
+      Action { request => Ok(Json.obj("headers" -> request.headers.toSimpleMap)) }
   }
 
   def get(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/get") =>
-      Action { request =>
-        Ok(requestHeaderWriter.writes(request))
-      }
+      Action { request => Ok(requestHeaderWriter.writes(request)) }
   }
 
   def patch(implicit Action: DefaultActionBuilder): Routes = {
     case PATCH(p"/patch") =>
-      Action { request =>
-        Ok(requestWriter.writes(request))
-      }
+      Action { request => Ok(requestWriter.writes(request)) }
   }
 
   def post(implicit Action: DefaultActionBuilder): Routes = {
     case POST(p"/post") =>
-      Action { request =>
-        Ok(requestWriter.writes(request))
-      }
+      Action { request => Ok(requestWriter.writes(request)) }
   }
 
   def put(implicit Action: DefaultActionBuilder): Routes = {
     case PUT(p"/put") =>
-      Action { request =>
-        Ok(requestWriter.writes(request))
-      }
+      Action { request => Ok(requestWriter.writes(request)) }
   }
 
   def delete(implicit Action: DefaultActionBuilder): Routes = {
     case DELETE(p"/delete") =>
-      Action { request =>
-        Ok(requestHeaderWriter.writes(request))
-      }
+      Action { request => Ok(requestHeaderWriter.writes(request)) }
   }
 
   private def gzipFilter(mat: Materializer) = new GzipFilter()(mat)
@@ -147,9 +131,7 @@ object HttpBinApplication {
 
   def responseHeaders(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/response-header") =>
-      Action { request =>
-        Ok("").withHeaders(request.queryString.view.mapValues(_.mkString(",")).toSeq: _*)
-      }
+      Action { request => Ok("").withHeaders(request.queryString.view.mapValues(_.mkString(",")).toSeq: _*) }
   }
 
   def redirect(implicit Action: DefaultActionBuilder): Routes = {
@@ -168,9 +150,7 @@ object HttpBinApplication {
       Action { request =>
         request.queryString
           .get("url")
-          .map { u =>
-            Redirect(u.head)
-          }
+          .map { u => Redirect(u.head) }
           .getOrElse {
             BadRequest("")
           }

--- a/core/play-java/src/main/scala/play/core/FileMimeTypesModule.scala
+++ b/core/play-java/src/main/scala/play/core/FileMimeTypesModule.scala
@@ -28,9 +28,7 @@ class FileMimeTypesProvider @Inject() (lifecycle: ApplicationLifecycle, scalaFil
   lazy val get: FileMimeTypes = {
     val fileMimeTypes = new FileMimeTypes(scalaFileMimeTypes)
     StaticFileMimeTypes.setFileMimeTypes(fileMimeTypes)
-    lifecycle.addStopHook { () =>
-      Future.successful(StaticFileMimeTypes.setFileMimeTypes(null))
-    }
+    lifecycle.addStopHook { () => Future.successful(StaticFileMimeTypes.setFileMimeTypes(null)) }
     fileMimeTypes
   }
 }

--- a/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
+++ b/core/play-java/src/main/scala/play/core/ObjectMapperModule.scala
@@ -45,9 +45,7 @@ class ObjectMapperProvider @Inject() (lifecycle: ApplicationLifecycle, actorSyst
     if (staticObjectMapperInitialized.compareAndSet(false, true)) {
       Json.setObjectMapper(mapper)
 
-      lifecycle.addStopHook { () =>
-        Future.successful(Json.setObjectMapper(null))
-      }
+      lifecycle.addStopHook { () => Future.successful(Json.setObjectMapper(null)) }
     }
     mapper
   }

--- a/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -45,9 +45,7 @@ class AccumulatorSpec extends Specification {
   "a sink accumulator" should {
     def sum: Accumulator[Int, Int] = Accumulator(Sink.fold[Int, Int](0)(_ + _))
 
-    "provide map" in withMaterializer { implicit m =>
-      await(sum.map(_ + 10).run(source)) must_== 16
-    }
+    "provide map" in withMaterializer { implicit m => await(sum.map(_ + 10).run(source)) must_== 16 }
 
     "provide mapFuture" in withMaterializer { implicit m =>
       await(sum.mapFuture(r => Future(r + 10)).run(source)) must_== 16
@@ -132,9 +130,7 @@ class AccumulatorSpec extends Specification {
         ) must_== 6
       }
 
-      "Scala asJava" in withMaterializer { implicit m =>
-        await(sum.asJava.run(source.asJava, m).asScala) must_== 6
-      }
+      "Scala asJava" in withMaterializer { implicit m => await(sum.asJava.run(source.asJava, m).asScala) must_== 6 }
     }
   }
 
@@ -143,9 +139,7 @@ class AccumulatorSpec extends Specification {
       Accumulator.strict[Int, Int](e => Future.successful(e.getOrElse(0)), Sink.fold[Int, Int](0)(_ + _))
 
     "run with a stream" in {
-      "provide map" in withMaterializer { implicit m =>
-        await(sum.map(_ + 10).run(source)) must_== 16
-      }
+      "provide map" in withMaterializer { implicit m => await(sum.map(_ + 10).run(source)) must_== 16 }
 
       "provide mapFuture" in withMaterializer { implicit m =>
         await(sum.mapFuture(r => Future(r + 10)).run(source)) must_== 16
@@ -230,16 +224,12 @@ class AccumulatorSpec extends Specification {
           ) must_== 6
         }
 
-        "Scala asJava" in withMaterializer { implicit m =>
-          await(sum.asJava.run(source.asJava, m).asScala) must_== 6
-        }
+        "Scala asJava" in withMaterializer { implicit m => await(sum.asJava.run(source.asJava, m).asScala) must_== 6 }
       }
     }
 
     "run with a single element" in {
-      "provide map" in withMaterializer { implicit m =>
-        await(sum.map(_ + 10).run(6)) must_== 16
-      }
+      "provide map" in withMaterializer { implicit m => await(sum.map(_ + 10).run(6)) must_== 16 }
 
       "provide mapFuture" in withMaterializer { implicit m =>
         await(sum.mapFuture(r => Future(r + 10)).run(6)) must_== 16
@@ -291,9 +281,7 @@ class AccumulatorSpec extends Specification {
           ) must_== 6
         }
 
-        "Scala asJava" in withMaterializer { implicit m =>
-          await(sum.asJava.run(6, m).asScala) must_== 6
-        }
+        "Scala asJava" in withMaterializer { implicit m => await(sum.asJava.run(6, m).asScala) must_== 6 }
       }
     }
   }

--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -52,7 +52,8 @@ import scala.reflect.ClassTag
  *
  */
 @implicitNotFound(
-  msg = "You do not have an implicit Application in scope. If you want to bring the current running Application into context, please use dependency injection."
+  msg =
+    "You do not have an implicit Application in scope. If you want to bring the current running Application into context, please use dependency injection."
 )
 trait Application {
 

--- a/core/play/src/main/scala/play/api/Configuration.scala
+++ b/core/play/src/main/scala/play/api/Configuration.scala
@@ -242,9 +242,7 @@ case class Configuration(underlying: Config) {
    */
   def getPrototypedSeq(path: String, prototypePath: String = "prototype.$path"): Seq[Configuration] = {
     val prototype = underlying.getConfig(prototypePath.replace("$path", path))
-    get[Seq[Config]](path).map { config =>
-      Configuration(config.withFallback(prototype))
-    }
+    get[Seq[Config]](path).map { config => Configuration(config.withFallback(prototype)) }
   }
 
   /**

--- a/core/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/core/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -59,9 +59,7 @@ trait LoggerConfigurator {
 
 object LoggerConfigurator {
   def apply(classLoader: ClassLoader): Option[LoggerConfigurator] = {
-    findFromResources(classLoader).flatMap { className =>
-      apply(className, classLoader)
-    }
+    findFromResources(classLoader).flatMap { className => apply(className, classLoader) }
   }
 
   /**

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -805,8 +805,7 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata) extend
    * @param aggressiveCaching if true then an aggressive set of caching directives will be used. Defaults to false.
    */
   def at(path: String, file: String, aggressiveCaching: Boolean = false): Action[AnyContent] = Action.async {
-    implicit request =>
-      assetAt(path, file, aggressiveCaching)
+    implicit request => assetAt(path, file, aggressiveCaching)
   }
 
   private def assetAt(path: String, file: String, aggressiveCaching: Boolean)(
@@ -814,9 +813,7 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata) extend
   ): Future[Result] = {
     val assetName: Option[String] = resourceNameAt(path, file)
     val assetInfoFuture: Future[Option[(AssetInfo, AcceptEncoding)]] = assetName
-      .map { name =>
-        assetInfoForRequest(request, name)
-      }
+      .map { name => assetInfoForRequest(request, name) }
       .getOrElse(Future.successful(None))
 
     def notFound = errorHandler.onClientError(request, NOT_FOUND, "Resource not found by Assets controller")

--- a/core/play/src/main/scala/play/api/data/Form.scala
+++ b/core/play/src/main/scala/play/api/data/Form.scala
@@ -1096,9 +1096,7 @@ trait ObjectMapping {
    */
   def merge(results: Either[Seq[FormError], Any]*): Either[Seq[FormError], Seq[Any]] = {
     val all: Seq[Either[Seq[FormError], Seq[Any]]] = results.map(_.map(Seq(_)))
-    all.fold(Right(Nil)) { (s, i) =>
-      merge2(s, i)
-    }
+    all.fold(Right(Nil)) { (s, i) => merge2(s, i) }
   }
 }
 

--- a/core/play/src/main/scala/play/api/data/format/Format.scala
+++ b/core/play/src/main/scala/play/api/data/format/Format.scala
@@ -178,9 +178,7 @@ object Formats {
     def unbind(key: String, value: BigDecimal) =
       Map(
         key -> precision
-          .map({ p =>
-            value.setScale(p._2)
-          })
+          .map { p => value.setScale(p._2) }
           .getOrElse(value)
           .toString
       )

--- a/core/play/src/main/scala/play/api/data/validation/Validation.scala
+++ b/core/play/src/main/scala/play/api/data/validation/Validation.scala
@@ -264,9 +264,7 @@ object ParameterValidator {
     }.flatten match {
       case Nil => Valid
       case invalids =>
-        invalids.reduceLeft { (a, b) =>
-          a ++ b
-        }
+        invalids.reduceLeft { (a, b) => a ++ b }
     }
 }
 

--- a/core/play/src/main/scala/play/api/http/AcceptEncoding.scala
+++ b/core/play/src/main/scala/play/api/http/AcceptEncoding.scala
@@ -88,9 +88,7 @@ trait AcceptEncoding {
    */
   lazy val preferences: Seq[EncodingPreference] = headers
     .flatMap(AcceptEncoding.parseHeader)
-    .map { e =>
-      e.copy(name = e.name.toLowerCase)
-    }
+    .map { e => e.copy(name = e.name.toLowerCase) }
     .sorted
 
   /**
@@ -194,9 +192,7 @@ object AcceptEncoding {
      *
      * These patterns are translated directly using the same naming
      */
-    val ctl = acceptIf { c =>
-      (c >= 0 && c <= 0x1F) || c == 0x7F
-    }(_ => "Expected a control character")
+    val ctl  = acceptIf { c => (c >= 0 && c <= 0x1F) || c == 0x7F }(_ => "Expected a control character")
     val char = acceptIf(_ < 0x80)(_ => "Expected an ascii character")
     val text = not(ctl) ~> any
     val separators = {

--- a/core/play/src/main/scala/play/api/http/FileMimeTypes.scala
+++ b/core/play/src/main/scala/play/api/http/FileMimeTypes.scala
@@ -84,8 +84,6 @@ class DefaultFileMimeTypes @Inject() (config: FileMimeTypesConfiguration) extend
    * @return the MIME type, if defined
    */
   override def forFileName(name: String): Option[String] = {
-    name.split('.').takeRight(1).headOption.flatMap { ext =>
-      config.mimeTypes.get(ext.toLowerCase(Locale.ENGLISH))
-    }
+    name.split('.').takeRight(1).headOption.flatMap { ext => config.mimeTypes.get(ext.toLowerCase(Locale.ENGLISH)) }
   }
 }

--- a/core/play/src/main/scala/play/api/http/MediaRange.scala
+++ b/core/play/src/main/scala/play/api/http/MediaRange.scala
@@ -191,9 +191,7 @@ object MediaRange {
      *
      * These patterns are translated directly using the same naming
      */
-    val ctl = acceptIf { c =>
-      (c >= 0 && c <= 0x1F) || c == 0x7F
-    }(_ => "Expected a control character")
+    val ctl  = acceptIf { c => (c >= 0 && c <= 0x1F) || c == 0x7F }(_ => "Expected a control character")
     val char = acceptIf(_ < 0x80)(_ => "Expected an ascii character")
     val text = not(ctl) ~> any
     val separators = {

--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -93,9 +93,9 @@ trait DefaultWriteables extends LowPriorityWriteables {
     Writeable(formData =>
       codec.encode(
         formData
-          .flatMap({ item =>
+          .flatMap { item =>
             item._2.map(c => URLEncoder.encode(item._1, "UTF-8") + "=" + URLEncoder.encode(c, "UTF-8"))
-          })
+          }
           .mkString("&")
       )
     )
@@ -156,9 +156,7 @@ trait DefaultWriteables extends LowPriorityWriteables {
       val name     = s""""${file.key}""""
       val filename = s""""${file.filename}""""
       val contentType = file.contentType
-        .map { ct =>
-          s"${HeaderNames.CONTENT_TYPE}: $ct\r\n"
-        }
+        .map { ct => s"${HeaderNames.CONTENT_TYPE}: $ct\r\n" }
         .getOrElse("")
       codec.encode(
         s"--$boundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name=$name; filename=$filename\r\n$contentType\r\n"

--- a/core/play/src/main/scala/play/api/libs/Comet.scala
+++ b/core/play/src/main/scala/play/api/libs/Comet.scala
@@ -59,9 +59,7 @@ object Comet {
    */
   def json(callbackName: String): Flow[JsValue, ByteString, NotUsed] = {
     Flow[JsValue]
-      .map { msg =>
-        ByteString.fromString(Json.asciiStringify(msg))
-      }
+      .map { msg => ByteString.fromString(Json.asciiStringify(msg)) }
       .via(flow(callbackName))
   }
 

--- a/core/play/src/main/scala/play/api/libs/Files.scala
+++ b/core/play/src/main/scala/play/api/libs/Files.scala
@@ -414,9 +414,9 @@ object Files {
           )
       }
 
-      cancellable = Some(actorSystem.scheduler.scheduleAtFixedRate(initialDelay, interval) { () =>
-        reap()
-      }(actorSystem.dispatcher))
+      cancellable = Some(
+        actorSystem.scheduler.scheduleAtFixedRate(initialDelay, interval) { () => reap() }(actorSystem.dispatcher)
+      )
     }
   }
 

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -305,9 +305,7 @@ trait BodyParserUtils {
    */
   def empty: BodyParser[Unit] = ignore(())
 
-  def ignore[A](body: A): BodyParser[A] = BodyParser("ignore") { request =>
-    Accumulator.done(Right(body))
-  }
+  def ignore[A](body: A): BodyParser[A] = BodyParser("ignore") { request => Accumulator.done(Right(body)) }
 
   /**
    * A body parser that always returns an error.
@@ -614,12 +612,8 @@ trait PlayBodyParsers extends BodyParserUtils {
               )
             }, {
               val buffer = RawBuffer(memoryThreshold, temporaryFileCreator)
-              val sink = Sink.fold[RawBuffer, ByteString](buffer) { (bf, bs) =>
-                bf.push(bs); bf
-              }
-              sink.mapMaterializedValue { future =>
-                future.andThen { case _ => buffer.close() }
-              }
+              val sink   = Sink.fold[RawBuffer, ByteString](buffer) { (bf, bs) => bf.push(bs); bf }
+              sink.mapMaterializedValue { future => future.andThen { case _ => buffer.close() } }
             }
           )
           .map(buffer => Right(buffer))
@@ -698,9 +692,7 @@ trait PlayBodyParsers extends BodyParserUtils {
         case Right(jsValue) =>
           jsValue
             .validate(reader)
-            .map { a =>
-              Future.successful(Right(a))
-            }
+            .map { a => Future.successful(Right(a)) }
             .recoverTotal { jsError =>
               val msg = s"Json validation error ${JsError.toFlatForm(jsError)}"
               createBadResult(msg)(request).map(Left.apply)
@@ -772,9 +764,7 @@ trait PlayBodyParsers extends BodyParserUtils {
             // Otherwise, there should be no default, it will be detected by the XML parser.
           }
         )
-        .foreach { charset =>
-          inputSource.setEncoding(charset)
-        }
+        .foreach { charset => inputSource.setEncoding(charset) }
       Play.XML.load(inputSource)
     }
 
@@ -1027,8 +1017,7 @@ trait PlayBodyParsers extends BodyParserUtils {
   }
 
   protected def createBadResult(msg: String, statusCode: Int = BAD_REQUEST): RequestHeader => Future[Result] = {
-    request =>
-      errorHandler.onClientError(request, statusCode, msg)
+    request => errorHandler.onClientError(request, statusCode, msg)
   }
 
   /**

--- a/core/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/core/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -296,9 +296,7 @@ trait CookieHeaderEncoding {
    */
   def encodeCookieHeader(cookies: Seq[Cookie]): String = {
     val encoder = config.clientEncoder
-    encoder.encode(cookies.map { cookie =>
-      new DefaultCookie(cookie.name, cookie.value)
-    }.asJava)
+    encoder.encode(cookies.map { cookie => new DefaultCookie(cookie.name, cookie.value) }.asJava)
   }
 
   /**
@@ -658,9 +656,7 @@ trait JWTCookieDataCodec extends CookieDataCodec {
 
       // Pull out the JWT data claim and only return that.
       val data = claimMap(jwtConfiguration.dataClaim).asInstanceOf[java.util.Map[String, AnyRef]]
-      data.asScala.view.mapValues { v =>
-        v.toString
-      }.toMap
+      data.asScala.view.mapValues { v => v.toString }.toMap
     } catch {
       case e: IllegalStateException =>
         // Used in the case where the header algorithm does not match.

--- a/core/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/core/play/src/main/scala/play/api/mvc/Filters.scala
@@ -56,18 +56,18 @@ trait Filter extends EssentialFilter {
       val bodyAccumulator = Promise[Accumulator[ByteString, Result]]()
 
       // Invoke the filter
-      val result = self.apply({ (rh: RequestHeader) =>
+      val result = self.apply { (rh: RequestHeader) =>
         // Invoke the delegate
         bodyAccumulator.success(next(rh))
         promisedResult.future
-      })(rh)
+      }(rh)
 
-      result.onComplete({ resultTry =>
+      result.onComplete { resultTry =>
         // It is possible that the delegate function (the next filter in the chain) was never invoked by this Filter.
         // Therefore, as a fallback, we try to redeem the bodyAccumulator Promise here with an iteratee that consumes
         // the request body.
         bodyAccumulator.tryComplete(resultTry.map(simpleResult => Accumulator.done(simpleResult)))
-      })
+      }
 
       Accumulator.flatten(bodyAccumulator.future.map { it =>
         it.mapFuture { simpleResult =>
@@ -110,9 +110,7 @@ object Filters {
  */
 object FilterChain {
   def apply(action: EssentialAction, filters: List[EssentialFilter]): EssentialAction = (rh: RequestHeader) => {
-    val chain = filters.reverse.foldLeft(action) { (a, i) =>
-      i(a)
-    }
+    val chain = filters.reverse.foldLeft(action) { (a, i) => i(a) }
     chain(rh)
   }
 }

--- a/core/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/core/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -280,9 +280,7 @@ private[mvc] object RangeSet {
   }
 
   private def headerToRanges(entityLength: Option[Long], header: String): RangeSet = {
-    val ranges = header.split("=")(1).split(",").map { r =>
-      Range(entityLength, r)
-    }
+    val ranges = header.split("=")(1).split(",").map { r => Range(entityLength, r) }
     SatisfiableRangeSet(entityLength, ranges.toSeq)
   }
 }
@@ -415,9 +413,7 @@ object RangeResult {
 
       buf += ACCEPT_RANGES -> "bytes"
 
-      fileName.foreach { f =>
-        buf ++= Results.contentDispositionHeader(inline = false, fileName)
-      }
+      fileName.foreach { f => buf ++= Results.contentDispositionHeader(inline = false, fileName) }
 
       buf.result()
     }

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -358,9 +358,7 @@ case class Result(
         if (data.isEmpty) sessionBaker.discard.toCookie else sessionBaker.encodeAsCookie(data)
       }
       val flash = newFlash
-        .map { data =>
-          if (data.isEmpty) flashBaker.discard.toCookie else flashBaker.encodeAsCookie(data)
-        }
+        .map { data => if (data.isEmpty) flashBaker.discard.toCookie else flashBaker.encodeAsCookie(data) }
         .orElse {
           if (requestHasFlash) Some(flashBaker.discard.toCookie) else None
         }
@@ -648,9 +646,7 @@ trait Results {
     )(implicit ec: ExecutionContext, fileMimeTypes: FileMimeTypes): Result = {
       val io = FileIO
         .fromPath(content)
-        .mapMaterializedValue(_.onComplete { _ =>
-          onClose()
-        })
+        .mapMaterializedValue(_.onComplete { _ => onClose() })
       streamFile(io, fileName(content), Some(Files.size(content)), inline)
     }
 
@@ -676,9 +672,7 @@ trait Results {
       val stream = classLoader.getResourceAsStream(resource)
       val io = StreamConverters
         .fromInputStream(() => stream)
-        .mapMaterializedValue(_.onComplete { _ =>
-          onClose()
-        })
+        .mapMaterializedValue(_.onComplete { _ => onClose() })
       streamFile(io, fileName(resource), Some(stream.available()), inline)
     }
 

--- a/core/play/src/main/scala/play/api/mvc/Security.scala
+++ b/core/play/src/main/scala/play/api/mvc/Security.scala
@@ -56,9 +56,7 @@ object Security {
   )(action: A => EssentialAction): EssentialAction = {
     EssentialAction { request =>
       userinfo(request)
-        .map { user =>
-          action(user)(request)
-        }
+        .map { user => action(user)(request) }
         .getOrElse {
           Accumulator.done(onUnauthorized(request))
         }
@@ -148,9 +146,7 @@ object Security {
      */
     def authenticate[A](request: Request[A], block: (AuthenticatedRequest[A, U]) => Future[Result]) = {
       userinfo(request)
-        .map { user =>
-          block(new AuthenticatedRequest(user, request))
-        }
+        .map { user => block(new AuthenticatedRequest(user, request)) }
         .getOrElse {
           Future.successful(onUnauthorized(request))
         }

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -37,8 +37,7 @@ trait WebSocket extends Handler {
  */
 object WebSocket {
   def apply(f: RequestHeader => Future[Either[Result, Flow[Message, Message, _]]]): WebSocket = {
-    (request: RequestHeader) =>
-      f(request)
+    (request: RequestHeader) => f(request)
   }
 
   /**
@@ -87,8 +86,7 @@ object WebSocket {
 
   object MessageFlowTransformer {
     implicit val identityMessageFlowTransformer: MessageFlowTransformer[Message, Message] = {
-      (flow: Flow[Message, Message, _]) =>
-        flow
+      (flow: Flow[Message, Message, _]) => flow
     }
 
     /**
@@ -141,9 +139,7 @@ object WebSocket {
         AkkaStreams.bypassWith[Message, JsValue, Message](Flow[Message].collect {
           case BinaryMessage(data) => closeOnException(Json.parse(data.iterator.asInputStream))
           case TextMessage(text)   => closeOnException(Json.parse(text))
-        })(flow.map { json =>
-          TextMessage(Json.stringify(json))
-        })
+        })(flow.map { json => TextMessage(Json.stringify(json)) })
       }
     }
 
@@ -184,9 +180,7 @@ object WebSocket {
   def acceptOrResult[In, Out](
       f: RequestHeader => Future[Either[Result, Flow[In, Out, _]]]
   )(implicit transformer: MessageFlowTransformer[In, Out]): WebSocket = {
-    WebSocket { request =>
-      f(request).map(_.map(transformer.transform))
-    }
+    WebSocket { request => f(request).map(_.map(transformer.transform)) }
   }
 
   /**

--- a/core/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/core/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -163,9 +163,7 @@ object Multipart {
               case _ => throw new UnsupportedOperationException()
             }
             renderDisposition(f, dispositionType, key, filename)
-            contentType.foreach { ct =>
-              renderContentType(f, ct)
-            }
+            contentType.foreach { ct => renderContentType(f, ct) }
             renderBuffer(f)
             push(out, completePartFormatting())
           }
@@ -207,9 +205,7 @@ object Multipart {
       filename: Option[String]
   ): Unit = {
     f ~~ "Content-Disposition: " ~~ dispositionType ~~ "; name=" ~~ '"' ~~ contentDisposition ~~ '"'
-    filename.foreach { name =>
-      f ~~ "; filename=" ~~ '"' ~~ name ~~ '"'
-    }
+    filename.foreach { name => f ~~ "; filename=" ~~ '"' ~~ name ~~ '"' }
     f ~~ CrLf
   }
 

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -34,9 +34,7 @@ object Route {
   def apply(method: String, pathPattern: PathPattern) = new ParamsExtractor {
     def unapply(request: RequestHeader): Option[RouteParams] = {
       if (method == request.method) {
-        pathPattern(request.path).map { groups =>
-          RouteParams(groups, request.queryString)
-        }
+        pathPattern(request.path).map { groups => RouteParams(groups, request.queryString) }
       } else {
         None
       }
@@ -461,10 +459,8 @@ a1 <- pa1.value
   // format: on
 
   def call[T](params: List[Param[_]])(generator: (Seq[_]) => Handler): Handler =
-    (params
-      .foldLeft[Either[String, Seq[_]]](Right(Seq[T]())) { (seq, param) =>
-        seq.flatMap(s => param.value.map(s :+ _))
-      })
+    params
+      .foldLeft[Either[String, Seq[_]]](Right(Seq[T]())) { (seq, param) => seq.flatMap(s => param.value.map(s :+ _)) }
       .fold(badRequest, generator)
   def fakeValue[A]: A = throw new UnsupportedOperationException("Can't get a fake value")
 

--- a/core/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
+++ b/core/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
@@ -105,9 +105,7 @@ class ValidationSpec extends Specification {
           Form("value" -> email)
             .bind(Map("value" -> addr))
             .fold(
-              formWithErrors => false, { _ =>
-                true
-              }
+              formWithErrors => false, { _ => true }
             )
         }
         .exists(_.unary_!) must beFalse
@@ -127,9 +125,7 @@ class ValidationSpec extends Specification {
           Form("value" -> email)
             .bind(Map("value" -> addr))
             .fold(
-              formWithErrors => true, { _ =>
-                false
-              }
+              formWithErrors => true, { _ => false }
             )
         }
         .exists(_.unary_!) must beFalse

--- a/core/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/concurrent/ActorSystemProviderSpec.scala
@@ -48,23 +48,19 @@ class ActorSystemProviderSpec extends Specification {
     }
 
     s"fail to start if '$akkaExitJvmKey = on'" in {
-      withConfiguration { config =>
-        ConfigFactory.parseString(s"$akkaExitJvmKey = on").withFallback(config)
-      }(identity) must throwA[PlayException]
+      withConfiguration { config => ConfigFactory.parseString(s"$akkaExitJvmKey = on").withFallback(config) }(identity) must throwA[
+        PlayException
+      ]
     }
 
     s"start as expected if '$akkaExitJvmKey = off'" in {
-      withConfiguration { config =>
-        ConfigFactory.parseString(s"$akkaExitJvmKey = off").withFallback(config)
-      } { actorSystem =>
-        actorSystem.dispatcher must not beNull
+      withConfiguration { config => ConfigFactory.parseString(s"$akkaExitJvmKey = off").withFallback(config) } {
+        actorSystem => actorSystem.dispatcher must not beNull
       }
     }
 
     s"start as expected with the default configuration for $akkaExitJvmKey" in {
-      withConfiguration(identity) { actorSystem =>
-        actorSystem.dispatcher must not beNull
-      }
+      withConfiguration(identity) { actorSystem => actorSystem.dispatcher must not beNull }
     }
 
     "run all the phases for coordinated shutdown" in {

--- a/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -84,9 +84,7 @@ class BindersSpec extends Specification {
     "propagate errors that occur during bind" in {
       implicit val brokenBinder: QueryStringBindable[String] = {
         new QueryStringBindable.Parsing[String](
-          { x =>
-            if (x == "i" || x == "nantucket") x else sys.error(s"failed: ${x}")
-          },
+          { x => if (x == "i" || x == "nantucket") x else sys.error(s"failed: ${x}") },
           identity,
           (key, ex) => s"failed to parse ${key}: ${ex.getMessage}"
         )

--- a/core/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -78,9 +78,7 @@ class CookiesSpec extends Specification {
     def c: Cookies     = Cookies.fromCookieHeader(Some(headerString))
 
     "get a cookie" in withApplication {
-      c.get("cookie") must beSome[Cookie].which { cookie =>
-        cookie.name must be_==("cookie")
-      }
+      c.get("cookie") must beSome[Cookie].which { cookie => cookie.name must be_==("cookie") }
     }
 
     "return none if no cookie" in {
@@ -126,9 +124,7 @@ class CookiesSpec extends Specification {
       val c: Cookies   = Cookies.fromCookieHeader(Some(headerString))
 
       var myCookie: Cookie = null
-      c.foreach { cookie =>
-        myCookie = cookie
-      }
+      c.foreach { cookie => myCookie = cookie }
       myCookie must beEqualTo(cookie1)
     }
   }

--- a/core/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
@@ -88,9 +88,7 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
   }
 
   def enforceMaxLengthEnforced(result: Either[Result, _]) = {
-    result must beLeft[Result].which { inner =>
-      inner.header.status must_== Status.REQUEST_ENTITY_TOO_LARGE
-    }
+    result must beLeft[Result].which { inner => inner.header.status must_== Status.REQUEST_ENTITY_TOO_LARGE }
   }
 
   def maxLengthParserEnforced(
@@ -149,9 +147,7 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
       val result = feed(
         parse.maxLength(MaxLength20, BodyParser(req => parse.enforceMaxLength(req, MaxLength20, parser))).apply(req)
       )
-      result must beRight.which { inner =>
-        inner must beRight(Body15)
-      }
+      result must beRight.which { inner => inner must beRight(Body15) }
       Await.result(parsed, 5.seconds) must_== (())
     }
 
@@ -237,9 +233,7 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
       maxLengthParser.toString() in {
         val ai     = new AtomicInteger()
         val result = feed(maxLengthParser.apply(reqCLH15), food = Body15, ai = ai)
-        result must beRight.which { inner =>
-          inner must beRight(Body15)
-        }
+        result must beRight.which { inner => inner must beRight(Body15) }
         ai.get must_== 1 // makes sure parsing took place
       }
     }
@@ -264,9 +258,7 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
       maxLengthParser.toString() in {
         val ai     = new AtomicInteger()
         val result = feed(maxLengthParser.apply(req), food = Body15, ai = ai)
-        result must beRight.which { inner =>
-          inner must beRight(Body15)
-        }
+        result must beRight.which { inner => inner must beRight(Body15) }
         ai.get must_== 1 // makes sure parsing took place
       }
     }

--- a/core/play/src/test/scala/play/libs/FTupleSpec.scala
+++ b/core/play/src/test/scala/play/libs/FTupleSpec.scala
@@ -29,21 +29,13 @@ class FTupleSpec extends Specification with ScalaCheck {
 
   def checkEquality[A: Arbitrary](name: String): Unit = {
     s"$name equality" should {
-      "be commutative" in prop { (a1: A, a2: A) =>
-        (a1.equals(a2)) == (a2.equals(a1))
-      }
+      "be commutative" in prop { (a1: A, a2: A) => (a1.equals(a2)) == (a2.equals(a1)) }
 
-      "be reflexive" in prop { (a: A) =>
-        a.equals(a)
-      }
+      "be reflexive" in prop { (a: A) => a.equals(a) }
 
-      "check for null" in prop { (a: A) =>
-        !a.equals(null)
-      }
+      "check for null" in prop { (a: A) => !a.equals(null) }
 
-      "check object type" in prop { (a: A, s: String) =>
-        !a.equals(s)
-      }
+      "check object type" in prop { (a: A, s: String) => !a.equals(s) }
 
       "obey hashCode contract" in prop { (a1: A, a2: A) =>
         // (a1 equals a2) ==> (a1.hashCode == a2.hashCode)

--- a/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
@@ -78,9 +78,13 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatch
       Some("application/xml"),
       ByteString("<foo>15 b</foo>") // 15 bytes
     ),
-    (new BodyParser.TolerantXml(15, defaultHttpErrorHandler), None, ByteString("<foo>15 b</foo>")),                  // 15 bytes
-    (new BodyParser.Json(15, defaultHttpErrorHandler), Some("application/json"), ByteString("""{ "x": "15 b" }""")), // 15 bytes
-    (new BodyParser.TolerantJson(15, defaultHttpErrorHandler), None, ByteString("""{ "x": "15 b" }""")),             // 15 bytes
+    (new BodyParser.TolerantXml(15, defaultHttpErrorHandler), None, ByteString("<foo>15 b</foo>")), // 15 bytes
+    (
+      new BodyParser.Json(15, defaultHttpErrorHandler),
+      Some("application/json"),
+      ByteString("""{ "x": "15 b" }""")
+    ),                                                                                                   // 15 bytes
+    (new BodyParser.TolerantJson(15, defaultHttpErrorHandler), None, ByteString("""{ "x": "15 b" }""")), // 15 bytes
     (new BodyParser.FormUrlEncoded(15, defaultHttpErrorHandler), Some("application/x-www-form-urlencoded"), Body15),
     (
       new BodyParser.MultipartFormData(underlyingParsers, 15),

--- a/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -166,9 +166,7 @@ class HelpersSpec extends Specification {
     val form = Form(single("foo" -> Forms.seq(Forms.text)))
     def renderFoo(form: Form[_], min: Int = 1) =
       repeat
-        .apply(form("foo"), min) { f =>
-          Html(f.name + ":" + f.value.getOrElse(""))
-        }
+        .apply(form("foo"), min) { f => Html(f.name + ":" + f.value.getOrElse("")) }
         .map(_.toString)
 
     val complexForm = Form(

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
@@ -353,9 +353,7 @@ object PlayDocsValidation {
         .get
         ._2
         .toEither
-        .fold({ incomplete =>
-          throw incomplete.directCause.get
-        }, result => result)
+        .fold({ incomplete => throw incomplete.directCause.get }, result => result)
     } else {
       file
     }
@@ -400,9 +398,7 @@ object PlayDocsValidation {
 
     def assertLinksNotMissing(desc: String, links: Seq[LinkRef], errorMessage: String): Unit = {
       doAssertion(desc, links) {
-        links.foreach { link =>
-          logErrorAtLocation(log, link.file, link.position, errorMessage + " " + link.link)
-        }
+        links.foreach { link => logErrorAtLocation(log, link.file, link.position, errorMessage + " " + link.link) }
       }
     }
 
@@ -412,9 +408,7 @@ object PlayDocsValidation {
       .filter(v => v._2.size > 1)
 
     doAssertion("Duplicate markdown file name test", duplicates.toSeq) {
-      duplicates.foreach { d =>
-        log.error(d._1 + ":\n" + d._2.mkString("\n    "))
-      }
+      duplicates.foreach { d => log.error(d._1 + ":\n" + d._2.mkString("\n    ")) }
     }
 
     assertLinksNotMissing(
@@ -485,9 +479,7 @@ object PlayDocsValidation {
       // Make sure all pages are in the page index
       val orphanPages = pages.filterNot(p => idx.get(p._1).isDefined)
       doAssertion("Orphan pages test", orphanPages.toSeq) {
-        orphanPages.foreach { page =>
-          log.error("Page " + page._2 + " is not referenced by the index")
-        }
+        orphanPages.foreach { page => log.error("Page " + page._2 + " is not referenced by the index") }
       }
     }
 

--- a/dev-mode/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/dev-mode/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -33,9 +33,7 @@ class DocServerStart {
       new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
         lazy val router = Router.from {
           case GET(p"/@documentation/$file*") =>
-            Action { request =>
-              buildDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[Result]].get
-            }
+            Action { request => buildDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[Result]].get }
           case GET(p"/@report") =>
             Action { request =>
               if (request.getQueryString("force").isDefined) {

--- a/dev-mode/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
+++ b/dev-mode/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
@@ -54,8 +54,8 @@ class DocumentationHandler(repo: FileRepository, apiRepo: FileRepository, toClos
     )
   }
 
-  val locator: String => String = new Memoise(
-    name => repo.findFileWithName(name).orElse(apiRepo.findFileWithName(name)).getOrElse(name)
+  val locator: String => String = new Memoise(name =>
+    repo.findFileWithName(name).orElse(apiRepo.findFileWithName(name)).getOrElse(name)
   )
 
   // Method without Scala types. Required by BuildDocHandler to allow communication

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -117,9 +117,7 @@ object RoutesFileParser {
     }
 
     // make sure there are no routes using overloaded handler methods, or handler methods with default parameters without declaring them all
-    val sameHandlerMethodGroup = routes.groupBy { r =>
-      (r.call.packageName, r.call.controller, r.call.method)
-    }
+    val sameHandlerMethodGroup = routes.groupBy { r => (r.call.packageName, r.call.controller, r.call.method) }
 
     val sameHandlerMethodParameterCountGroup = sameHandlerMethodGroup.groupBy { g =>
       (g._1, g._2.groupBy(route => route.call.parameters.map(p => p.length).getOrElse(0)))

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
@@ -114,18 +114,14 @@ object InjectedRoutesGenerator extends RoutesGenerator {
         .zipWithIndex
         .flatMap {
           case ((router, includes), index) =>
-            includes.headOption.map { inc =>
-              router -> Dependency(router.replace('.', '_') + "_" + index, router, inc)
-            }
+            includes.headOption.map { inc => router -> Dependency(router.replace('.', '_') + "_" + index, router, inc) }
         }
         .toMap
 
     // Generate dependency descriptors for all routes
     val routesDeps: Map[(Option[String], String, Boolean), Dependency[Route]] =
       routes
-        .groupBy { r =>
-          (r.call.packageName, r.call.controller, r.call.instantiate)
-        }
+        .groupBy { r => (r.call.packageName, r.call.controller, r.call.instantiate) }
         .zipWithIndex
         .flatMap {
           case ((key @ (packageName, controller, instantiate), routes), index) =>

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
@@ -65,9 +65,7 @@ case class HandlerCall(
   lazy val passJavaRequest: Boolean    = parameters.getOrElse(Nil).exists(_.isJavaRequest)
   override def toString =
     dynamic + packageName.map(_ + ".").getOrElse("") + controller + dynamic + "." + method + parameters
-      .map { params =>
-        "(" + params.mkString(", ") + ")"
-      }
+      .map { params => "(" + params.mkString(", ") + ")" }
       .getOrElse("")
 }
 

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -47,9 +47,7 @@ package object templates {
     if (seq.isEmpty) {
       Nil
     } else {
-      Seq(f(seq.head), seq.tail.map { t =>
-        Seq(sep, f(t))
-      })
+      Seq(f(seq.head), seq.tail.map { t => Seq(sep, f(t)) })
     }
   }
 
@@ -63,9 +61,7 @@ package object templates {
       s"$ident.${r.call.method}"
     }
     val paramPart = r.call.parameters
-      .map { params =>
-        params.map(paramFormat).mkString(", ")
-      }
+      .map { params => params.map(paramFormat).mkString(", ") }
       .map("(" + _ + ")")
       .getOrElse("")
     methodPart + paramPart
@@ -88,9 +84,7 @@ package object templates {
         val ps = params.filterNot(_.isJavaRequest).map { p =>
           val paramName: String = paramNameOnQueryString(p.name)
           p.fixed
-            .map { v =>
-              """Param[""" + p.typeName + """]("""" + paramName + """", Right(""" + v + """))"""
-            }
+            .map { v => """Param[""" + p.typeName + """]("""" + paramName + """", Right(""" + v + """))""" }
             .getOrElse {
               """params.""" + (if (route.path.has(paramName)) "fromPath" else "fromQuery") + """[""" + p.typeName + """]("""" + paramName + """", """ + p.default
                 .map("Some(" + _ + ")")
@@ -110,9 +104,7 @@ package object templates {
   def tupleNames(route: Route): String =
     route.call.parameters
       .filterNot(_.isEmpty)
-      .map { params =>
-        params.filterNot(_.isJavaRequest).map(x => safeKeyword(x.name)).mkString(", ")
-      }
+      .map { params => params.filterNot(_.isJavaRequest).map(x => safeKeyword(x.name)).mkString(", ") }
       .filterNot(_.isEmpty)
       .map("(" + _ + ") =>")
       .getOrElse("")
@@ -243,12 +235,8 @@ package object templates {
   def reverseParameterConstraints(route: Route, localNames: Map[String, String]): String = {
     route.call.parameters
       .getOrElse(Nil)
-      .filter { p =>
-        localNames.contains(p.name) && p.fixed.isDefined
-      }
-      .map { p =>
-        p.name + " == " + p.fixed.get
-      } match {
+      .filter { p => localNames.contains(p.name) && p.fixed.isDefined }
+      .map { p => p.name + " == " + p.fixed.get } match {
       case Nil      => ""
       case nonEmpty => "if " + nonEmpty.mkString(" && ")
     }
@@ -379,9 +367,7 @@ package object templates {
   def javascriptParameterConstraints(route: Route, localNames: Map[String, String]): Option[String] = {
     Option(
       route.call.routeParams
-        .filter { p =>
-          localNames.contains(p.name) && p.fixed.isDefined
-        }
+        .filter { p => localNames.contains(p.name) && p.fixed.isDefined }
         .map { p =>
           localNames(p.name) + " == \"\"\" + implicitly[play.api.mvc.JavascriptLiteral[" + p.typeName + "]].to(" + p.fixed.get + ") + \"\"\""
         }

--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -505,9 +505,7 @@ class Reloader(
               val classpathFiles =
                 classpath.iterator.filter(_.exists()).flatMap(_.toScala.listRecursively).map(_.toJava)
               val newLastModified =
-                classpathFiles.foldLeft(0L) { (acc, file) =>
-                  math.max(acc, file.lastModified)
-                }
+                classpathFiles.foldLeft(0L) { (acc, file) => math.max(acc, file.lastModified) }
               val triggered = newLastModified > lastModified
               lastModified = newLastModified
 

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
@@ -23,9 +23,7 @@ object ApplicationSecretGenerator {
     val random = new SecureRandom()
 
     (1 to 64)
-      .map { _ =>
-        (random.nextInt(75) + 48).toChar
-      }
+      .map { _ => (random.nextInt(75) + 48).toChar }
       .mkString
       .replaceAll("\\\\+", "/")
   }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -24,9 +24,7 @@ object PlayCommands {
 
     (currentRef / name)
       .get(structure.data)
-      .map { name =>
-        "[" + Colors.cyan(name) + "] $ "
-      }
+      .map { name => "[" + Colors.cyan(name) + "] $ " }
       .getOrElse("> ")
   }
 

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -213,9 +213,7 @@ object PlaySettings {
     }.value,
     Universal / mappings ++= {
       val pathFinder = baseDirectory.value * "README*"
-      pathFinder.get.map { (readmeFile: File) =>
-        readmeFile -> readmeFile.getName
-      }
+      pathFinder.get.map { (readmeFile: File) => readmeFile -> readmeFile.getName }
     },
     // Adds the Play application directory to the command line args passed to Play
     bashScriptExtraDefines += "addJava \"-Duser.dir=$(realpath \"$(cd \"${app_home}/..\"; pwd -P)\"  $(is_cygwin && echo \"fix\"))\"\n",

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -78,9 +78,7 @@ object RoutesCompiler extends AutoPlugin {
 
       // Aggregate all the routes file tasks that we want to compile the reverse routers for.
       aggregateReverseRoutes.value
-        .map { agg =>
-          (agg.project / configuration.value / routesCompilerTasks)
-        }
+        .map { agg => (agg.project / configuration.value / routesCompilerTasks) }
         .join
         .map {
           (aggTasks: Seq[Seq[RoutesCompilerTask]]) =>

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -54,9 +54,7 @@ object PlayReload {
       val newFile: Option[File] = pos
         .sourcePath()
         .asScala
-        .map { path =>
-          convertSbtVirtualFile(path)
-        }
+        .map { path => convertSbtVirtualFile(path) }
 
       newFile
         .map { file =>
@@ -82,9 +80,7 @@ object PlayReload {
     // Stolen from https://github.com/sbt/sbt/blob/v1.4.8/main/src/main/scala/sbt/Defaults.scala#L2299-L2316
     // Slightly modified because reportAbsolutePath and fileConverter settings do not exist pre sbt 1.4 yet
     def foldMappers(mappers: Seq[Position => Option[Position]]) =
-      mappers.foldRight({ (p: Position) =>
-        toAbsoluteSource(p) // Fallback if sourcePositionMappers is empty
-      }) {
+      mappers.foldRight { (p: Position) => toAbsoluteSource(p) } { // Fallback if sourcePositionMappers is empty
         (mapper, previousPosition) =>
           { (p: Position) =>
             // To each mapper we pass the position with the absolute source

--- a/documentation/.scalafmt.conf
+++ b/documentation/.scalafmt.conf
@@ -12,4 +12,4 @@ rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifi
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
-version = 2.3.2
+version = 2.4.2

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -32,7 +32,9 @@ lazy val main = Project("Play-Documentation", file("."))
     // a dependency of `docsJarFile` setting.
     Test / test := ((Test / test).dependsOn(playDocs / publishLocal)).value,
     resolvers += Resolver
-      .sonatypeRepo("releases"), // TODO: Delete this eventually, just needed for lag between deploying to sonatype and getting on maven central
+      .sonatypeRepo(
+        "releases"
+      ), // TODO: Delete this eventually, just needed for lag between deploying to sonatype and getting on maven central
     version := PlayVersion.current,
     libraryDependencies ++= Seq(
       "com.typesafe"   % "config"       % "1.4.2"   % Test,

--- a/documentation/manual/working/commonGuide/akka/code/scalaguide/akka/typed/oo/ConfiguredActor.scala
+++ b/documentation/manual/working/commonGuide/akka/code/scalaguide/akka/typed/oo/ConfiguredActor.scala
@@ -19,9 +19,7 @@ object ConfiguredActor {
   def create(
       configuration: Configuration,
   ): Behavior[ConfiguredActor.GetConfig] = {
-    Behaviors.setup { context =>
-      new ConfiguredActor(context, configuration)
-    }
+    Behaviors.setup { context => new ConfiguredActor(context, configuration) }
   }
 }
 

--- a/documentation/manual/working/commonGuide/build/code/scalaguide/common/build/controllers/SubProjectsAssetsBuilder.scala
+++ b/documentation/manual/working/commonGuide/build/code/scalaguide/common/build/controllers/SubProjectsAssetsBuilder.scala
@@ -22,9 +22,7 @@ package common.build.controllers {
     import javax.inject.Inject
 
     class HomeController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
-      def index = Action { implicit request =>
-        Ok("admin")
-      }
+      def index = Action { implicit request => Ok("admin") }
     }
     //#admin-home-controller
   }

--- a/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
@@ -152,9 +152,7 @@ class Samples @Inject() (components: ControllerComponents)(implicit ec: Executio
     extends AbstractController(components) {
   def someAsyncAction = Action.async {
     someCalculation()
-      .map { result =>
-        Ok(s"The answer is $result")
-      }
+      .map { result => Ok(s"The answer is $result") }
       .recover {
         case e: TimeoutException =>
           InternalServerError("Calculation timed out!")

--- a/documentation/manual/working/commonGuide/filters/code/scalaguide/detailed/filters/csp/CSPActionController.scala
+++ b/documentation/manual/working/commonGuide/filters/code/scalaguide/detailed/filters/csp/CSPActionController.scala
@@ -12,8 +12,6 @@ import play.filters.csp.CSPActionBuilder
 // #csp-action-controller
 class CSPActionController @Inject() (cspAction: CSPActionBuilder, cc: ControllerComponents)
     extends AbstractController(cc) {
-  def index = cspAction { implicit request =>
-    Ok("result containing CSP")
-  }
+  def index = cspAction { implicit request => Ok("result containing CSP") }
 }
 // #csp-action-controller

--- a/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/TasksCustomExecutionContext.scala
+++ b/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/TasksCustomExecutionContext.scala
@@ -19,8 +19,8 @@ class TasksCustomExecutionContext @Inject() (actorSystem: ActorSystem)
 
 //#task-using-custom-execution-context
 class SomeTask @Inject() (actorSystem: ActorSystem, executor: TasksCustomExecutionContext) {
-  actorSystem.scheduler.scheduleAtFixedRate(initialDelay = 10.seconds, interval = 1.minute)({ () =>
+  actorSystem.scheduler.scheduleAtFixedRate(initialDelay = 10.seconds, interval = 1.minute) { () =>
     actorSystem.log.info("Executing something...")
-  })(executor) // using the custom execution context
+  }(executor) // using the custom execution context
 }
 //#task-using-custom-execution-context

--- a/documentation/manual/working/commonGuide/shutdown/code/shutdown/ResourceAllocatingScalaClass.scala
+++ b/documentation/manual/working/commonGuide/shutdown/code/shutdown/ResourceAllocatingScalaClass.scala
@@ -18,9 +18,7 @@ package scalaguide {
     val resources = Resources.allocate()
 
     // Register a shutdown task as soon as possible.
-    cs.addTask(CoordinatedShutdown.PhaseServiceUnbind, "free-some-resource") { () =>
-      resources.release()
-    }
+    cs.addTask(CoordinatedShutdown.PhaseServiceUnbind, "free-some-resource") { () => resources.release() }
 
     // ... some more code
   }

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
@@ -190,8 +190,8 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
   }
 
   def testRequest(port: Int) = {
-    withClient { client =>
-      Await.result(client.url("/hello/world").get(), Duration.Inf).body must_== "Hello world"
-    }(new play.api.http.Port(port))
+    withClient { client => Await.result(client.url("/hello/world").get(), Duration.Inf).body must_== "Hello world" }(
+      new play.api.http.Port(port)
+    )
   }
 }

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaNettyEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaNettyEmbeddingPlay.scala
@@ -139,8 +139,8 @@ class ScalaNettyEmbeddingPlay extends Specification with WsTestClient {
   }
 
   def testRequest(port: Int) = {
-    withClient { client =>
-      Await.result(client.url("/hello/world").get(), Duration.Inf).body must_== "Hello world"
-    }(new play.api.http.Port(port))
+    withClient { client => Await.result(client.url("/hello/world").get(), Duration.Inf).body must_== "Hello world" }(
+      new play.api.http.Port(port)
+    )
   }
 }

--- a/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
+++ b/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
@@ -51,9 +51,7 @@ package scalaguide.akka {
         implicit val timeout: Timeout = 5.seconds
 
         def sayHello(name: String) = Action.async {
-          (helloActor ? SayHello(name)).mapTo[String].map { message =>
-            Ok(message)
-          }
+          (helloActor ? SayHello(name)).mapTo[String].map { message => Ok(message) }
         }
         //#ask
 
@@ -126,9 +124,7 @@ package scalaguide.akka {
       implicit val timeout: Timeout = 5.seconds
 
       def getConfig = Action.async {
-        (configuredActor ? GetConfig).mapTo[String].map { message =>
-          Ok(message)
-        }
+        (configuredActor ? GetConfig).mapTo[String].map { message => Ok(message) }
       }
     }
 //#inject

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -66,9 +66,7 @@ class ScalaAsyncSamples @Inject() (val controllerComponents: ControllerComponent
     //#future-result
 
     val futurePIValue: Future[Double] = computePIAsynchronously()
-    val futureResult: Future[Result] = futurePIValue.map { pi =>
-      Ok("PI value computed: " + pi)
-    }
+    val futureResult: Future[Result]  = futurePIValue.map { pi => Ok("PI value computed: " + pi) }
     //#future-result
     futureResult
   }
@@ -110,9 +108,7 @@ class ScalaAsyncSamples @Inject() (val controllerComponents: ControllerComponent
       // that by injecting it into your controller's constructor
       intensiveComputation()
         .withTimeout(1.seconds)
-        .map { i =>
-          Ok("Got result: " + i)
-        }
+        .map { i => Ok("Got result: " + i) }
         .recover {
           case e: scala.concurrent.TimeoutException =>
             InternalServerError("timeout")

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -169,9 +169,7 @@ object Controller1 {
   class Application @Inject() (cc: ControllerComponents)(implicit system: ActorSystem, mat: Materializer)
       extends AbstractController(cc) {
     def socket = WebSocket.accept[String, String] { request =>
-      ActorFlow.actorRef { out =>
-        MyWebSocketActor.props(out)
-      }
+      ActorFlow.actorRef { out => MyWebSocketActor.props(out) }
     }
   }
   //#actor-accept
@@ -210,9 +208,7 @@ object Controller2 {
       Future.successful(request.session.get("user") match {
         case None => Left(Forbidden)
         case Some(_) =>
-          Right(ActorFlow.actorRef { out =>
-            MyWebSocketActor.props(out)
-          })
+          Right(ActorFlow.actorRef { out => MyWebSocketActor.props(out) })
       })
     }
   }
@@ -245,9 +241,7 @@ object Controller4 {
   class Application @Inject() (cc: ControllerComponents)(implicit system: ActorSystem, mat: Materializer)
       extends AbstractController(cc) {
     def socket = WebSocket.accept[JsValue, JsValue] { request =>
-      ActorFlow.actorRef { out =>
-        MyWebSocketActor.props(out)
-      }
+      ActorFlow.actorRef { out => MyWebSocketActor.props(out) }
     }
   }
   //#actor-json
@@ -295,9 +289,7 @@ object Controller5 {
   class Application @Inject() (cc: ControllerComponents)(implicit system: ActorSystem, mat: Materializer)
       extends AbstractController(cc) {
     def socket = WebSocket.accept[InEvent, OutEvent] { request =>
-      ActorFlow.actorRef { out =>
-        MyWebSocketActor.props(out)
-      }
+      ActorFlow.actorRef { out => MyWebSocketActor.props(out) }
     }
   }
   //#actor-json-in-out

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -129,9 +129,7 @@ package scalaguide.cache {
     }
 
     def testAction[A](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK) = {
-      assertAction(action, request, expectedResponse) { result =>
-        success
-      }
+      assertAction(action, request, expectedResponse) { result => success }
     }
 
     def assertAction[A, T: AsResult](
@@ -203,9 +201,7 @@ package scalaguide.cache {
       def userProfile = WithAuthentication(_.session.get("username")) { userId =>
         cached(req => "profile." + userId) {
           Action.async {
-            User.find(userId).map { user =>
-              Ok(views.html.profile(user))
-            }
+            User.find(userId).map { user => Ok(views.html.profile(user)) }
           }
         }
       }

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaEhCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaEhCache.scala
@@ -129,9 +129,7 @@ package scalaguide.ehcache {
     }
 
     def testAction[A](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK) = {
-      assertAction(action, request, expectedResponse) { result =>
-        success
-      }
+      assertAction(action, request, expectedResponse) { result => success }
     }
 
     def assertAction[A, T: AsResult](
@@ -203,9 +201,7 @@ package scalaguide.ehcache {
       def userProfile = WithAuthentication(_.session.get("username")) { userId =>
         cached(req => "profile." + userId) {
           Action.async {
-            User.find(userId).map { user =>
-              Ok(views.html.profile(user))
-            }
+            User.find(userId).map { user => Ok(views.html.profile(user)) }
           }
         }
       }

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -16,9 +16,7 @@ class RuntimeDependencyInjection extends PlaySpecification {
       app.injector.instanceOf[singleton.CurrentSharePrice].get must_== 10
     }
     "support stopping" in {
-      running() { app =>
-        app.injector.instanceOf[cleanup.MessageQueueConnection]
-      }
+      running() { app => app.injector.instanceOf[cleanup.MessageQueueConnection] }
       cleanup.MessageQueue.stopped must_== true
     }
     "support implemented by annotation" in new WithApplication() {
@@ -68,9 +66,7 @@ package cleanup {
   @Singleton
   class MessageQueueConnection @Inject() (lifecycle: ApplicationLifecycle) {
     val connection = connectToMessageQueue()
-    lifecycle.addStopHook { () =>
-      Future.successful(connection.stop())
-    }
+    lifecycle.addStopHook { () => Future.successful(connection.stop()) }
 
     //...
   }
@@ -186,9 +182,7 @@ package eagerguicestartup {
   @Singleton
   class ApplicationStart @Inject() (lifecycle: ApplicationLifecycle) {
     // Shut-down hook
-    lifecycle.addStopHook { () =>
-      Future.successful(())
-    }
+    lifecycle.addStopHook { () => Future.successful(()) }
     //...
   }
 //#eager-guice-startup

--- a/documentation/manual/working/scalaGuide/main/forms/code/CustomValidations.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/CustomValidations.scala
@@ -19,7 +19,7 @@ package scalaguide.forms.scalaforms {
     val allNumbers = """\d*""".r
     val allLetters = """[A-Za-z]*""".r
 
-    val passwordCheckConstraint: Constraint[String] = Constraint("constraints.passwordcheck")({ plainText =>
+    val passwordCheckConstraint: Constraint[String] = Constraint("constraints.passwordcheck") { plainText =>
       val errors = plainText match {
         case allNumbers() => Seq(ValidationError("Password is all numbers"))
         case allLetters() => Seq(ValidationError("Password is all letters"))
@@ -30,7 +30,7 @@ package scalaguide.forms.scalaforms {
       } else {
         Invalid(errors)
       }
-    })
+    }
     // #passwordcheck-constraint
 
     val MIN_PASSWORD_LENGTH = 10

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
@@ -66,9 +66,7 @@ class ScalaCsrf extends PlaySpecification {
     }
 
     def tokenFormAction(implicit app: Application) =
-      addToken(Action { implicit request =>
-        Ok(scalaguide.forms.html.csrf())
-      })
+      addToken(Action { implicit request => Ok(scalaguide.forms.html.csrf()) })
 
     "allow rendering a token in a query string" in new WithApplication() {
       val csrfTokenSigner = app.injector.instanceOf[CSRFTokenSigner]
@@ -121,9 +119,7 @@ class ScalaCsrf extends PlaySpecification {
       import play.filters.csrf._
 
       def form = addToken {
-        Action { implicit req =>
-          Ok(views.html.itemsForm)
-        }
+        Action { implicit req => Ok(views.html.itemsForm) }
       }
       //#csrf-add-token
 
@@ -164,9 +160,7 @@ class ScalaCsrf extends PlaySpecification {
         Ok
       }
 
-      def form = getAction { implicit req =>
-        Ok(views.html.itemsForm)
-      }
+      def form = getAction { implicit req => Ok(views.html.itemsForm) }
       //#csrf-actions
 
       await(

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -213,9 +213,7 @@ package scalaguide.forms.scalaforms {
       }
 
       // #form-render
-      def index = Action { implicit request =>
-        Ok(views.html.user(userForm))
-      }
+      def index = Action { implicit request => Ok(views.html.user(userForm)) }
       // #form-render
 
       def userPostHandlingFailure() = Action { implicit request =>
@@ -265,9 +263,7 @@ package scalaguide.forms.scalaforms {
       }
       // #form-bodyparser-errors
 
-      def submit = Action { implicit request =>
-        BadRequest("Not used")
-      }
+      def submit = Action { implicit request => BadRequest("Not used") }
 
       val userFormName = {
         //#userForm-get
@@ -585,9 +581,7 @@ package scalaguide.forms.scalaforms {
         )(views.html.UserData.apply)(views.html.UserData.unapply)
       )
 
-      def index = Action { implicit request =>
-        Ok(views.html.user(userForm))
-      }
+      def index = Action { implicit request => Ok(views.html.user(userForm)) }
     }
 //#messages-controller
 
@@ -605,9 +599,7 @@ package scalaguide.forms.scalaforms {
         )(views.html.UserData.apply)(views.html.UserData.unapply)
       )
 
-      def index = messagesAction { implicit request: MessagesRequest[AnyContent] =>
-        Ok(views.html.messages(userForm))
-      }
+      def index = messagesAction { implicit request: MessagesRequest[AnyContent] => Ok(views.html.messages(userForm)) }
 
       def post = TODO
     }
@@ -627,9 +619,7 @@ package scalaguide.forms.scalaforms {
         )(views.html.UserData.apply)(views.html.UserData.unapply)
       )
 
-      def index = Action { implicit request: MessagesRequest[AnyContent] =>
-        Ok(views.html.messages(userForm))
-      }
+      def index = Action { implicit request: MessagesRequest[AnyContent] => Ok(views.html.messages(userForm)) }
 
       def post() = TODO
     }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
@@ -18,9 +18,7 @@ package scalaguide.http.scalaactions {
     "A scala action" should {
       "allow writing a simple echo action" in {
         //#echo-action
-        def echo = Action { request =>
-          Ok("Got request [" + request + "]")
-        }
+        def echo = Action { request => Ok("Got request [" + request + "]") }
         //#echo-action
         testAction(echo)
       }
@@ -38,9 +36,7 @@ package scalaguide.http.scalaactions {
       "pass the request to the action" in {
         testAction(
           //#request-action
-          Action { request =>
-            Ok("Got request [" + request + "]")
-          }
+          Action { request => Ok("Got request [" + request + "]") }
           //#request-action
         )
       }
@@ -48,9 +44,7 @@ package scalaguide.http.scalaactions {
       "pass the request implicitly to the action" in {
         testAction(
           //#implicit-request-action
-          Action { implicit request =>
-            Ok("Got request [" + request + "]")
-          }
+          Action { implicit request => Ok("Got request [" + request + "]") }
           //#implicit-request-action
         )
       }
@@ -72,9 +66,7 @@ package scalaguide.http.scalaactions {
       "allow specifying a parser" in {
         testAction(
           action = //#json-parser-action
-            Action(parse.json) { implicit request =>
-              Ok("Got request [" + request + "]")
-            }
+            Action(parse.json) { implicit request => Ok("Got request [" + request + "]") }
           //#json-parser-action
           ,
           request = FakeRequest().withBody(Json.obj()).withHeaders(CONTENT_TYPE -> "application/json")
@@ -92,9 +84,7 @@ package scalaguide.http.scalaactions {
         }
         //#parameter-action
 
-        assertAction(hello("world")) { result =>
-          contentAsString(result) must_== "Hello world"
-        }
+        assertAction(hello("world")) { result => contentAsString(result) must_== "Hello world" }
       }
 
       "support returning a simple result" in {
@@ -108,9 +98,7 @@ package scalaguide.http.scalaactions {
           )
         }
         //#simple-result-action
-        assertAction(index) { result =>
-          contentAsString(result) must_== "Hello world!"
-        }
+        assertAction(index) { result => contentAsString(result) must_== "Hello world!" }
       }
 
       "support ok helper" in {
@@ -168,9 +156,7 @@ package scalaguide.http.scalaactions {
     }
 
     def testAction[A](action: Action[A], expectedResponse: Int = OK, request: Request[A] = FakeRequest()) = {
-      assertAction(action, expectedResponse, request) { result =>
-        success
-      }
+      assertAction(action, expectedResponse, request) { result => success }
     }
 
     def assertAction[A, T: AsResult](

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -62,9 +62,7 @@ package scalaguide.http.scalaactionscomposition {
         testAction(new MyController(loggingAction, Helpers.stubControllerComponents()).index)
 
         //#basic-logging-parse
-        def submit = loggingAction(parse.text) { request =>
-          Ok("Got a body " + request.body.length + " bytes long")
-        }
+        def submit = loggingAction(parse.text) { request => Ok("Got a body " + request.body.length + " bytes long") }
         //#basic-logging-parse
 
         val request = FakeRequest().withTextBody("hello with the parse")
@@ -197,9 +195,7 @@ package scalaguide.http.scalaactionscomposition {
         }
         //#modify-result
 
-        assertAction(addUaHeader(Action(Ok))) { result =>
-          header("X-UA-Compatible", result) must beSome("Chrome=1")
-        }
+        assertAction(addUaHeader(Action(Ok))) { result => header("X-UA-Compatible", result) must beSome("Chrome=1") }
       }
 
       "allow action builders with different request types" in {
@@ -218,9 +214,7 @@ package scalaguide.http.scalaactionscomposition {
         //#authenticated-action-builder
         val userAction = new UserAction(defaultParser)
 
-        def currentUser = userAction { request =>
-          Ok("The current user is " + request.username.getOrElse("anonymous"))
-        }
+        def currentUser = userAction { request => Ok("The current user is " + request.username.getOrElse("anonymous")) }
 
         testAction(currentUser)
 
@@ -278,9 +272,7 @@ package scalaguide.http.scalaactionscomposition {
 
     import play.api.mvc._
     def testAction[A](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK) = {
-      assertAction(action, request, expectedResponse) { result =>
-        success
-      }
+      assertAction(action, request, expectedResponse) { result => success }
     }
 
     def assertAction[A, T: AsResult](

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -52,9 +52,7 @@ package scalaguide.http.scalabodyparsers {
 
           // Expecting json body
           jsonBody
-            .map { json =>
-              Ok("Got: " + (json \ "name").as[String])
-            }
+            .map { json => Ok("Got: " + (json \ "name").as[String]) }
             .getOrElse {
               BadRequest("Expecting application/json request body")
             }
@@ -101,9 +99,7 @@ package scalaguide.http.scalabodyparsers {
         val text = "hello"
         //#body-parser-limit-text
         // Accept only 10KB of data.
-        def save = Action(parse.text(maxLength = 1024 * 10)) { (request: Request[String]) =>
-          Ok("Got: " + text)
-        }
+        def save = Action(parse.text(maxLength = 1024 * 10)) { (request: Request[String]) => Ok("Got: " + text) }
         //#body-parser-limit-text
         testAction(save, FakeRequest("POST", "/").withTextBody("foo"))
       }
@@ -143,9 +139,7 @@ package scalaguide.http.scalabodyparsers {
             }
           }
 
-          def myAction = Action(forward(ws.url("https://example.com"))) { req =>
-            Ok("Uploaded")
-          }
+          def myAction = Action(forward(ws.url("https://example.com"))) { req => Ok("Uploaded") }
         }
         //#forward-body
 
@@ -182,9 +176,7 @@ package scalaguide.http.scalabodyparsers {
     }
 
     def testAction[A: Writeable](action: EssentialAction, request: => FakeRequest[A], expectedResponse: Int = OK) = {
-      assertAction(action, request, expectedResponse) { result =>
-        success
-      }
+      assertAction(action, request, expectedResponse) { result => success }
     }
 
     def assertAction[A: Writeable, T: AsResult](
@@ -213,17 +205,13 @@ package scalaguide.http.scalabodyparsers {
       val storeInUserFile = parse.using { request =>
         request.session
           .get("username")
-          .map { user =>
-            parse.file(to = new File("/tmp/" + user + ".upload"))
-          }
+          .map { user => parse.file(to = new File("/tmp/" + user + ".upload")) }
           .getOrElse {
             sys.error("You don't have the right to upload here")
           }
       }
 
-      def save = Action(storeInUserFile) { request =>
-        Ok("Saved the request content to " + request.body)
-      }
+      def save = Action(storeInUserFile) { request => Ok("Saved the request content to " + request.body) }
 
       //#body-parser-combining
     }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
@@ -171,9 +171,7 @@ package scalaguide.http.scalaresults {
     }
 
     def testAction[A](action: Action[A], expectedResponse: Int = OK, request: Request[A] = FakeRequest()) = {
-      assertAction(action, expectedResponse, request) { (_, _) =>
-        success
-      }
+      assertAction(action, expectedResponse, request) { (_, _) => success }
     }
 
     def assertAction[A, T: AsResult](

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -23,9 +23,7 @@ package controllers {
     def show(id: Long) = Action {
       Client
         .findById(id)
-        .map { client =>
-          Ok(views.html.Clients.display(client))
-        }
+        .map { client => Ok(views.html.Clients.display(client)) }
         .getOrElse(NotFound)
     }
     // #show-client-action
@@ -42,9 +40,7 @@ package controllers {
     // #show-page-action
     def show(page: String) = Action {
       loadContentFromDatabase(page)
-        .map { htmlContent =>
-          Ok(htmlContent).as("text/html")
-        }
+        .map { htmlContent => Ok(htmlContent).as("text/html") }
         .getOrElse(NotFound)
     }
     // #show-page-action
@@ -58,9 +54,7 @@ package controllers {
     def list(version: Option[String])   = Action(Ok("version " + version))
     def listItems(params: List[String]) = Action(Ok("params " + params.mkString(",")))
     def listIntItems(params: List[Int]) = Action(Ok("params " + params.mkString(",")))
-    def newThing = Action(parse.json) { request =>
-      Ok(request.body)
-    }
+    def newThing                        = Action(parse.json) { request => Ok(request.body) }
   }
 }
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -22,9 +22,7 @@ package scalaguide.http.scalasessionflash {
         def index = Action { request =>
           request.session
             .get("connected")
-            .map { user =>
-              Ok("Hello " + user)
-            }
+            .map { user => Ok("Hello " + user) }
             .getOrElse {
               Unauthorized("Oops, you are not connected")
             }
@@ -96,15 +94,14 @@ package scalaguide.http.scalasessionflash {
         assertAction(index, OK, FakeRequest().withFlash("success" -> "success!"))(res =>
           contentAsString(res) must contain("success!")
         )
-        assertAction(save, SEE_OTHER, FakeRequest())(res => testFlash(res, "success", Some("The item has been created"))
+        assertAction(save, SEE_OTHER, FakeRequest())(res =>
+          testFlash(res, "success", Some("The item has been created"))
         )
       }
 
       "access flash in template" in {
         //#flash-implicit-request
-        def index = Action { implicit request =>
-          Ok(views.html.index())
-        }
+        def index = Action { implicit request => Ok(views.html.index()) }
         //#flash-implicit-request
 
         assertAction(index, OK, FakeRequest())(result => contentAsString(result) must contain("Welcome!"))

--- a/documentation/manual/working/scalaGuide/main/http/code/scalaguide/http/routing/relative/controllers/Relative.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/scalaguide/http/routing/relative/controllers/Relative.scala
@@ -11,9 +11,7 @@ import play.api.mvc._
 
 @Singleton
 class Relative @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
-  def helloview = Action { implicit request =>
-    Ok(views.html.hello("Bob"))
-  }
+  def helloview = Action { implicit request => Ok(views.html.hello("Bob")) }
 
   def hello(name: String) = Action {
     Ok(s"Hello $name!")

--- a/documentation/manual/working/scalaGuide/main/i18n/code/scalaguide/i18n/ScalaI18nService.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/scalaguide/i18n/ScalaI18nService.scala
@@ -88,9 +88,7 @@ class MyController @Inject() (val controllerComponents: ControllerComponents) ex
   // #lang-cookies
 
   // #http-supported-langs
-  def index = Action { request =>
-    Ok("Languages: " + request.acceptLanguages.map(_.code).mkString(", "))
-  }
+  def index = Action { request => Ok("Languages: " + request.acceptLanguages.map(_.code).mkString(", ")) }
   // #http-supported-langs
 }
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
@@ -29,8 +29,12 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       val classLoader = new URLClassLoader(Array.empty)
       // #set-environment
       val application = new GuiceApplicationBuilder()
-        .load(new play.api.inject.BuiltinModule, new play.api.i18n.I18nModule, new play.api.mvc.CookiesModule) // ###skip
-        .loadConfig(Configuration.reference)                                                                   // ###skip
+        .load(
+          new play.api.inject.BuiltinModule,
+          new play.api.i18n.I18nModule,
+          new play.api.mvc.CookiesModule
+        )                                    // ###skip
+        .loadConfig(Configuration.reference) // ###skip
         .configure("play.http.filters" -> "play.api.http.NoHttpFilters") // ###skip
         .in(Environment(new File("path/to/app"), classLoader, Mode.Test))
         .build()
@@ -45,8 +49,12 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       val classLoader = new URLClassLoader(Array.empty)
       // #set-environment-values
       val application = new GuiceApplicationBuilder()
-        .load(new play.api.inject.BuiltinModule, new play.api.i18n.I18nModule, new play.api.mvc.CookiesModule) // ###skip
-        .loadConfig(Configuration.reference)                                                                   // ###skip
+        .load(
+          new play.api.inject.BuiltinModule,
+          new play.api.i18n.I18nModule,
+          new play.api.mvc.CookiesModule
+        )                                    // ###skip
+        .loadConfig(Configuration.reference) // ###skip
         .configure("play.http.filters" -> "play.api.http.NoHttpFilters") // ###skip
         .in(new File("path/to/app"))
         .in(Mode.Test)

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -17,9 +17,7 @@ package client {
     @Inject def this(ws: WSClient, ec: ExecutionContext) = this(ws, "https://api.github.com")(ec)
 
     def repositories(): Future[Seq[String]] = {
-      ws.url(baseUrl + "/repositories").get().map { response =>
-        (response.json \\ "full_name").map(_.as[String]).toSeq
-      }
+      ws.url(baseUrl + "/repositories").get().map { response => (response.json \\ "full_name").map(_.as[String]).toSeq }
     }
   }
 //#client
@@ -112,9 +110,7 @@ class ScalaTestingWebServiceClients extends Specification {
         new BuiltInComponentsFromContext(context) with HttpFiltersComponents {
           override def router: Router = Router.from {
             case GET(p"/repositories") =>
-              Action { req =>
-                Results.Ok.sendResource("github/repositories.json")(executionContext, fileMimeTypes)
-              }
+              Action { req => Results.Ok.sendResource("github/repositories.json")(executionContext, fileMimeTypes) }
           }
         }.application
       } { implicit port =>
@@ -137,16 +133,10 @@ class ScalaTestingWebServiceClients extends Specification {
           new BuiltInComponentsFromContext(context) with HttpFiltersComponents {
             override def router: Router = Router.from {
               case GET(p"/repositories") =>
-                Action { req =>
-                  Results.Ok.sendResource("github/repositories.json")(executionContext, fileMimeTypes)
-                }
+                Action { req => Results.Ok.sendResource("github/repositories.json")(executionContext, fileMimeTypes) }
             }
           }.application
-        } { implicit port =>
-          WsTestClient.withClient { client =>
-            block(new GitHubClient(client, ""))
-          }
-        }
+        } { implicit port => WsTestClient.withClient { client => block(new GitHubClient(client, "")) } }
       }
       //#with-github-client
 

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -123,9 +123,7 @@ package scalaguide.upload.fileupload {
       }
       //#upload-file-directly-action
 
-      def index = Action { request =>
-        Ok("Upload failed")
-      }
+      def index = Action { request => Ok("Upload failed") }
 
       //#upload-file-customparser
       type FilePartHandler[A] = FileInfo => Accumulator[ByteString, FilePart[A]]

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -92,9 +92,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
    */
   val largeSource: Source[ByteString, _] = {
     val source = Source.single(ByteString("abcdefghij" * 100))
-    (1 to 9).foldLeft(source) { (acc, _) =>
-      (acc ++ source)
-    }
+    (1 to 9).foldLeft(source) { (acc, _) => (acc ++ source) }
   }
 
   "WSClient" should {
@@ -293,9 +291,8 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case other => Action { NotFound }
       } { ws =>
         // #scalaws-process-json
-        val futureResult: Future[String] = ws.url(url).get().map { response =>
-          (response.json \ "person" \ "name").as[String]
-        }
+        val futureResult: Future[String] =
+          ws.url(url).get().map { response => (response.json \ "person" \ "name").as[String] }
         // #scalaws-process-json
 
         await(futureResult) must_== "Steve"
@@ -315,9 +312,8 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
 
         implicit val personReads = Json.reads[Person]
 
-        val futureResult: Future[JsResult[Person]] = ws.url(url).get().map { response =>
-          (response.json \ "person").validate[Person]
-        }
+        val futureResult: Future[JsResult[Person]] =
+          ws.url(url).get().map { response => (response.json \ "person").validate[Person] }
         // #scalaws-process-json-with-implicit
 
         val actual = await(futureResult)
@@ -337,9 +333,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case other => Action { NotFound }
       } { ws =>
         // #scalaws-process-xml
-        val futureResult: Future[scala.xml.NodeSeq] = ws.url(url).get().map { response =>
-          response.xml \ "message"
-        }
+        val futureResult: Future[scala.xml.NodeSeq] = ws.url(url).get().map { response => response.xml \ "message" }
         // #scalaws-process-xml
         await(futureResult).text must_== "Hello"
       }
@@ -355,9 +349,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
 
         val bytesReturned: Future[Long] = futureResponse.flatMap { res =>
           // Count the number of bytes returned
-          res.bodyAsSource.runWith(Sink.fold[Long, ByteString](0L) { (total, bytes) =>
-            total + bytes.length
-          })
+          res.bodyAsSource.runWith(Sink.fold[Long, ByteString](0L) { (total, bytes) => total + bytes.length })
         }
         //#stream-count-bytes
         await(bytesReturned) must_== 10000L
@@ -378,9 +370,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
             val outputStream = java.nio.file.Files.newOutputStream(file.toPath)
 
             // The sink that writes to the output stream
-            val sink = Sink.foreach[ByteString] { bytes =>
-              outputStream.write(bytes.toArray)
-            }
+            val sink = Sink.foreach[ByteString] { bytes => outputStream.write(bytes.toArray) }
 
             // materialize and run the stream
             res.bodyAsSource
@@ -448,9 +438,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         //#stream-put
 
         val bytesReturned: Future[Long] = futureResponse.flatMap { res =>
-          res.bodyAsSource.runWith(Sink.fold[Long, ByteString](0L) { (total, bytes) =>
-            total + bytes.length
-          })
+          res.bodyAsSource.runWith(Sink.fold[Long, ByteString](0L) { (total, bytes) => total + bytes.length })
         }
         //#stream-count-bytes
         await(bytesReturned) must_== 10000L
@@ -511,9 +499,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
     "map to async result" in withSimpleServer { ws =>
       //#async-result
       def wsAction = Action.async {
-        ws.url(url).get().map { response =>
-          Ok(response.body)
-        }
+        ws.url(url).get().map { response => Ok(response.body) }
       }
       status(wsAction(FakeRequest())) must_== OK
       //#async-result
@@ -533,9 +519,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
           .withTimeout(1.second)
           .flatMap { response =>
             // val url2 = response.json \ "url"
-            ws.url(url2).get().map { response2 =>
-              Ok(response.body)
-            }
+            ws.url(url2).get().map { response2 => Ok(response.body) }
           }
           .recover {
             case e: scala.concurrent.TimeoutException =>

--- a/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala
+++ b/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala
@@ -28,9 +28,7 @@ package scalaguide.xml.scalaxmlrequests {
             .map { xml =>
               (xml \\ "name" headOption)
                 .map(_.text)
-                .map { name =>
-                  Ok("Hello " + name)
-                }
+                .map { name => Ok("Hello " + name) }
                 .getOrElse {
                   BadRequest("Missing parameter [name]")
                 }
@@ -51,9 +49,7 @@ package scalaguide.xml.scalaxmlrequests {
         def sayHello = Action(parse.xml) { request =>
           (request.body \\ "name" headOption)
             .map(_.text)
-            .map { name =>
-              Ok("Hello " + name)
-            }
+            .map { name => Ok("Hello " + name) }
             .getOrElse {
               BadRequest("Missing parameter [name]")
             }

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -489,7 +489,8 @@ class DatabaseEvolutions(
 
           logger.error(error)
 
-          val humanScript = "-- Rev:" + revision + "," + (if (state == "applying_up") "Ups" else "Downs") + " - " + hash + "\n\n" + script
+          val humanScript =
+            "-- Rev:" + revision + "," + (if (state == "applying_up") "Ups" else "Downs") + " - " + hash + "\n\n" + script
 
           throw InconsistentDatabase(database.name, humanScript, error, revision, autocommit)
         }

--- a/persistence/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -86,9 +86,7 @@ class DBApiProvider(
       Configuration(config).getPrototypedMap(dbKey, "play.db.prototype").view.mapValues(_.underlying).toMap
     } else Map.empty[String, Config]
     val db = new DefaultDBApi(configs, pool, environment, maybeInjector.getOrElse(NewInstanceInjector))
-    lifecycle.addStopHook { () =>
-      Future.fromTry(Try(db.shutdown()))
-    }
+    lifecycle.addStopHook { () => Future.fromTry(Try(db.shutdown())) }
     db.initialize(logInitialization = environment.mode != Mode.Test)
     db
   }

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -323,9 +323,7 @@ object Docs {
   def allClasspaths(projectRef: ProjectRef, structure: BuildStructure): Task[Seq[File]] = {
     val projects = allApiProjects(projectRef.build, structure)
     // Full classpath is necessary to ensure that scaladoc and javadoc can see the compiled classes of the other language.
-    val tasks = projects.flatMap { p =>
-      (p / Compile / fullClasspath).get(structure.data)
-    }
+    val tasks = projects.flatMap { p => (p / Compile / fullClasspath).get(structure.data) }
     tasks.join.map(_.flatten.map(_.data).distinct)
   }
 

--- a/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -26,9 +26,7 @@ class FakesSpec extends PlaySpecification {
       GuiceApplicationBuilder()
         .routes {
           case (PUT, "/process") =>
-            Action { req =>
-              Results.Ok(req.headers.get(CONTENT_TYPE).getOrElse(""))
-            }
+            Action { req => Results.Ok(req.headers.get(CONTENT_TYPE).getOrElse("")) }
         }
         .build()
 
@@ -82,11 +80,9 @@ class FakesSpec extends PlaySpecification {
 
   def contentTypeForFakeRequest(request: FakeRequest[AnyContentAsJson])(implicit mat: Materializer): String = {
     var testContentType: Option[String] = None
-    val action = Action { (request: Request[_]) =>
-      testContentType = request.headers.get(CONTENT_TYPE); Ok
-    }
-    val headers   = new WrappedRequest(request)
-    val execution = (new TestActionCaller).call(action, headers, request.body)
+    val action                          = Action { (request: Request[_]) => testContentType = request.headers.get(CONTENT_TYPE); Ok }
+    val headers                         = new WrappedRequest(request)
+    val execution                       = (new TestActionCaller).call(action, headers, request.body)
     Await.result(execution, Duration(3, TimeUnit.SECONDS))
     testContentType.getOrElse("No Content-Type found")
   }

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSModule.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSModule.scala
@@ -89,9 +89,7 @@ class OptionalAhcHttpCacheProvider @Inject() (
 )(implicit executionContext: ExecutionContext)
     extends Provider[Option[AhcHttpCache]] {
   lazy val get: Option[AhcHttpCache] = {
-    optionalCache.map { cache =>
-      new AhcHttpCache(cache, cacheConfig.heuristicsEnabled)
-    }
+    optionalCache.map { cache => new AhcHttpCache(cache, cacheConfig.heuristicsEnabled) }
   }
 
   private val cacheConfig: AhcHttpCacheConfiguration = AhcHttpCacheParser.fromConfiguration(configuration)

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
@@ -255,9 +255,7 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
 
   override def stream(): Future[Response] = {
     val futureResponse: Future[StandaloneWSResponse] = underlying.stream()
-    futureResponse.map { f =>
-      AhcWSResponse(f)
-    }(play.core.Execution.trampoline)
+    futureResponse.map { f => AhcWSResponse(f) }(play.core.Execution.trampoline)
   }
 
   def execute(method: String): Future[Response] = {
@@ -266,9 +264,7 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
 
   override def execute(): Future[Response] = {
     val futureResponse: Future[StandaloneWSResponse] = underlying.execute()
-    futureResponse.map { f =>
-      AhcWSResponse(f)
-    }(play.core.Execution.trampoline)
+    futureResponse.map { f => AhcWSResponse(f) }(play.core.Execution.trampoline)
   }
 
   private def toWSRequest(request: StandaloneWSRequest): Self = {

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -464,9 +464,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
       val response = makeAhcResponse(ahcResponse)
 
       val optionCookie = response.cookie("someName")
-      optionCookie must beSome[WSCookie].which { cookie =>
-        cookie.maxAge must beNone
-      }
+      optionCookie must beSome[WSCookie].which { cookie => cookie.maxAge must beNone }
     }
 
     "get the body as bytes from the AHC response" in {

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -450,12 +450,8 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
   mode match {
     case Mode.Test =>
     case _ =>
-      httpServerBinding.foreach { http =>
-        logger.info(s"Listening for HTTP on ${http.localAddress}")
-      }
-      httpsServerBinding.foreach { https =>
-        logger.info(s"Listening for HTTPS on ${https.localAddress}")
-      }
+      httpServerBinding.foreach { http => logger.info(s"Listening for HTTP on ${http.localAddress}") }
+      httpsServerBinding.foreach { https => logger.info(s"Listening for HTTPS on ${https.localAddress}") }
   }
 
   override def stop(): Unit = CoordinatedShutdownSupport.syncShutdown(context.actorSystem, ServerStoppedReason)

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -226,9 +226,7 @@ private[server] class AkkaModelConversion(
       ContentType
         .parse(ct)
         .left
-        .map { errors =>
-          throw new RuntimeException(s"Error parsing response Content-Type: <$ct>: $errors")
-        }
+        .map { errors => throw new RuntimeException(s"Error parsing response Content-Type: <$ct>: $errors") }
         .merge
     }
   }

--- a/transport/server/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/transport/server/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -20,9 +20,7 @@ object AkkaTestServer extends App {
   val server = AkkaHttpServer.fromRouterWithComponents(serverConfig) { c =>
     {
       case GET(p"/") =>
-        c.defaultActionBuilder { implicit req =>
-          Results.Ok(s"Hello world")
-        }
+        c.defaultActionBuilder { implicit req => Results.Ok(s"Hello world") }
       case GET(p"/akkaHttpApi") =>
         AkkaHttpHandler { request =>
           Future.successful(

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -264,9 +264,7 @@ private[server] class NettyModelConversion(
         }
       }
 
-      connectionHeader.header.foreach { headerValue =>
-        response.headers().set(CONNECTION, headerValue)
-      }
+      connectionHeader.header.foreach { headerValue => response.headers().set(CONNECTION, headerValue) }
 
       // Netty doesn't add the required Date header for us, so make sure there is one here
       if (!response.headers().contains(DATE)) {

--- a/transport/server/play-netty-server/src/test/scala/play/NettyTestServer.scala
+++ b/transport/server/play-netty-server/src/test/scala/play/NettyTestServer.scala
@@ -18,9 +18,7 @@ object NettyTestServer extends App {
   val server = NettyServer.fromRouterWithComponents(serverConfig) { c =>
     {
       case GET(p"/") =>
-        c.defaultActionBuilder { implicit req =>
-          Results.Ok(s"Hello world")
-        }
+        c.defaultActionBuilder { implicit req => Results.Ok(s"Hello world") }
     }
   }
   println("Server (Netty) started: http://127.0.0.1:8000/ ")

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -45,9 +45,7 @@ trait Server extends ReloadableServer {
   def reload(): Unit = applicationProvider.get
 
   def stop(): Unit = {
-    applicationProvider.get.foreach { app =>
-      LoggerConfigurator(app.classloader).foreach(_.shutdown())
-    }
+    applicationProvider.get.foreach { app => LoggerConfigurator(app.classloader).foreach(_.shutdown()) }
   }
 
   /**
@@ -317,9 +315,7 @@ private[server] trait ServerFromRouter {
     "2.7.0"
   )
   def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): Server = {
-    createServerFromRouter(config) { _ =>
-      Router.from(routes)
-    }
+    createServerFromRouter(config) { _ => Router.from(routes) }
   }
 
   /**

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -187,9 +187,7 @@ private[server] object ForwardedHeaderHandler {
           }
           .toMap))
 
-        params.map { (paramMap: Map[String, String]) =>
-          ForwardedEntry(paramMap.get("for"), paramMap.get("proto"))
-        }
+        params.map { (paramMap: Map[String, String]) => ForwardedEntry(paramMap.get("for"), paramMap.get("proto")) }
       }
 
       case Xforwarded =>

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -322,9 +322,7 @@ private[play] final class ServerResultUtils(
       headers.toSeq.flatMap {
         case (SET_COOKIE, value) =>
           splitSetCookieHeaderValue(value)
-            .map { cookiePart =>
-              SET_COOKIE -> cookiePart
-            }
+            .map { cookiePart => SET_COOKIE -> cookiePart }
         case (name, value) =>
           Seq((name, value))
       }

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -87,9 +87,9 @@ private[cors] trait AbstractCORSPolicy {
      * appropriate control directives to prevent caching of such responses, which may be
      * inaccurate if re-used across-origins.
      */
-    resultAcc.map { result =>
-      result.withHeaders(result.header.varyWith(HeaderNames.ORIGIN))
-    }(play.core.Execution.trampoline)
+    resultAcc.map { result => result.withHeaders(result.header.varyWith(HeaderNames.ORIGIN)) }(
+      play.core.Execution.trampoline
+    )
   }
 
   /* Handles a CORS request

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
@@ -93,9 +93,7 @@ object CSPConfig {
         !whitelistModifiers.exists(rh.hasRouteModifier)
       }
     }
-    val shouldFilterRequest: RequestHeader => Boolean = { rh =>
-      checkRouteModifiers(rh)
-    }
+    val shouldFilterRequest: RequestHeader => Boolean = { rh => checkRouteModifiers(rh) }
 
     val nonce = config.get[Configuration]("nonce")
     val nonceConfig = CSPNonceConfig(

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPProcessor.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPProcessor.scala
@@ -69,9 +69,7 @@ class DefaultCSPProcessor @Inject() (config: CSPConfig) extends CSPProcessor {
 
   protected def generateLine(nonce: Option[String]): String = {
     val cspLineWithNonce = nonce
-      .map { n =>
-        noncePattern.matcher(cspLine).replaceAll(Matcher.quoteReplacement(s"'nonce-$n'"))
-      }
+      .map { n => noncePattern.matcher(cspLine).replaceAll(Matcher.quoteReplacement(s"'nonce-$n'")) }
       .getOrElse(cspLine)
 
     hashPatterns.foldLeft(cspLineWithNonce)((line, pair) =>

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
@@ -41,14 +41,12 @@ class DefaultCSPResultProcessor @Inject() (cspProcessor: CSPProcessor) extends C
       .process(request)
       .map { cspResult =>
         val maybeNonceRequest = cspResult.nonce
-          .map { nonce =>
-            request.addAttr(RequestAttrKey.CSPNonce, nonce)
-          }
+          .map { nonce => request.addAttr(RequestAttrKey.CSPNonce, nonce) }
           .getOrElse(request)
 
-        next(maybeNonceRequest).map { result =>
-          result.withHeaders(generateHeaders(cspResult): _*)
-        }(play.core.Execution.trampoline)
+        next(maybeNonceRequest).map { result => result.withHeaders(generateHeaders(cspResult): _*) }(
+          play.core.Execution.trampoline
+        )
       }
       .getOrElse {
         next(request)

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -178,7 +178,9 @@ class CSRFAction(
           }
         }))
         .splitWhen(_ => false)
-        .prefixAndTail(0) // TODO rewrite BodyHandler such that it emits sub-source then we can avoid all these dancing around
+        .prefixAndTail(
+          0
+        ) // TODO rewrite BodyHandler such that it emits sub-source then we can avoid all these dancing around
         .map(_._2)
         .concatSubstreams
         .toMat(Sink.head[Source[ByteString, _]])(Keep.right)
@@ -617,7 +619,7 @@ case class CSRFCheck @Inject() (
             csrfActionHelper
               .getHeaderToken(request)
               // Or from body if not found
-              .orElse({
+              .orElse {
                 val form = request.body match {
                   case body: play.api.mvc.AnyContent if body.asFormUrlEncoded.isDefined => body.asFormUrlEncoded.get
                   case body: play.api.mvc.AnyContent if body.asMultipartFormData.isDefined =>
@@ -627,7 +629,7 @@ case class CSRFCheck @Inject() (
                   case _                                       => Map.empty[String, Seq[String]]
                 }
                 form.get(config.tokenName).flatMap(_.headOption)
-              })
+              }
               // Execute if it matches
               .collect {
                 case queryToken if tokenProvider.compareTokens(queryToken, headerToken) => wrapped(request)

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -110,9 +110,8 @@ object CSRFConfig {
     val checkMethod: String => Boolean = if (methodWhiteList.nonEmpty) {
       !methodWhiteList.contains(_)
     } else {
-      if (methodBlackList.isEmpty) { _ =>
-        true
-      } else {
+      if (methodBlackList.isEmpty) { _ => true }
+      else {
         methodBlackList.contains
       }
     }
@@ -123,9 +122,8 @@ object CSRFConfig {
     val checkContentType: Option[String] => Boolean = if (contentTypeWhiteList.nonEmpty) {
       _.forall(!contentTypeWhiteList.contains(_))
     } else {
-      if (contentTypeBlackList.isEmpty) { _ =>
-        true
-      } else {
+      if (contentTypeBlackList.isEmpty) { _ => true }
+      else {
         _.exists(contentTypeBlackList.contains)
       }
     }
@@ -153,9 +151,7 @@ object CSRFConfig {
       (protectHeaders.isEmpty || foundHeaderValues(protectHeaders)) && !foundHeaderValues(bypassHeaders)
     }
 
-    val shouldProtect: RequestHeader => Boolean = { rh =>
-      checkRouteModifiers(rh) && checkHeaders(rh)
-    }
+    val shouldProtect: RequestHeader => Boolean = { rh => checkRouteModifiers(rh) && checkHeaders(rh) }
 
     CSRFConfig(
       tokenName = config.get[String]("token.name"),

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSActionBuilderSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSActionBuilderSpec.scala
@@ -34,9 +34,7 @@ class CORSActionBuilderSpec extends CORSCommonSpec {
     running(_.configure(conf).routes {
       case (_, "/error") =>
         CORSActionBuilder(Configuration.from(conf).withFallback(Configuration.reference), configPath = configPath)
-          .apply { req =>
-            throw sys.error("error")
-          }
+          .apply { req => throw sys.error("error") }
       case _ =>
         CORSActionBuilder(Configuration.from(conf).withFallback(Configuration.reference), configPath = configPath)
           .apply(Results.Ok)

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
@@ -25,13 +25,9 @@ object CORSFilterSpec {
   class CorsApplicationRouter @Inject() (action: DefaultActionBuilder)
       extends SimpleRouterImpl({
         case p"/error" =>
-          action { req =>
-            throw sys.error("error")
-          }
+          action { req => throw sys.error("error") }
         case p"/vary" =>
-          action { req =>
-            Results.Ok("Hello").withHeaders(VARY -> ACCEPT_ENCODING)
-          }
+          action { req => Results.Ok("Hello").withHeaders(VARY -> ACCEPT_ENCODING) }
         case _ => action(Results.Ok)
       })
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
@@ -45,9 +45,7 @@ object CORSWithCSRFSpec {
 
     override def routes = {
       case p"/error" =>
-        action { req =>
-          throw sys.error("error")
-        }
+        action { req => throw sys.error("error") }
       case _ =>
         val csrfCheck = CSRFCheck(play.filters.csrf.CSRFConfig(), signer, sessionConfiguration)
         csrfCheck(action(Results.Ok), CSRF.DefaultErrorHandler)

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPFilterSpec.scala
@@ -251,9 +251,7 @@ class CSPFilterSpec extends PlaySpecification {
       implicit app => {
         case _ =>
           val Action = inject[DefaultActionBuilder]
-          Action { request =>
-            Ok(request.attrs.get(RequestAttrKey.CSPNonce).getOrElse("undefined"))
-          }
+          Action { request => Ok(request.attrs.get(RequestAttrKey.CSPNonce).getOrElse("undefined")) }
       }
     ) { app =>
       val result           = route(app, FakeRequest()).get
@@ -268,9 +266,7 @@ class CSPFilterSpec extends PlaySpecification {
       implicit app => {
         case _ =>
           val Action = inject[DefaultActionBuilder]
-          Action { implicit request =>
-            Ok(views.html.helper.CSPNonce.get.getOrElse("undefined"))
-          }
+          Action { implicit request => Ok(views.html.helper.CSPNonce.get.getOrElse("undefined")) }
       }
     ) { app =>
       val result           = route(app, FakeRequest(GET, "/template")).get

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -184,12 +184,12 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       buildCsrfAddToken(
         "play.filters.csrf.cookie.name" -> "csrf",
         "play.filters.csrf.token.name"  -> "csrf"
-      )({ req =>
+      ) { req =>
         req
           .addHttpHeaders(ACCEPT -> "text/html")
           .withSession("csrf" -> signedTokenProvider.generateToken)
           .get()
-      })(_.cookies must not be empty)
+      }(_.cookies must not be empty)
     }
   }
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -308,9 +308,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
             val Action = inject[DefaultActionBuilder]
             Action(Results.Ok)
         }
-      } { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      } { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 
@@ -328,9 +326,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
             val Action = inject[DefaultActionBuilder]
             Action(Results.Ok)
         }
-      } { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      } { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 
@@ -344,14 +340,10 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
           Action { implicit req =>
             CSRF
               .getToken(req)
-              .map { token =>
-                Results.Ok(token.value)
-              }
+              .map { token => Results.Ok(token.value) }
               .getOrElse(Results.NotFound)
           }
-      }) { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      }) { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 
@@ -372,9 +364,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
           } else {
             Action(Results.Ok("Hello world!"))
           }
-      }) { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      }) { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 
@@ -388,9 +378,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
           Action { implicit request: RequestHeader =>
             Results.Ok(CSRF.getToken.fold("")(_.value)).withHeaders(responseHeaders: _*)
           }
-      }) { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      }) { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -55,9 +55,7 @@ class JavaCSRFActionSpec extends CSRFCommonSpecs {
           case _ =>
             javaAction[JavaCSRFActionSpec.MyAction]("check", myAction.check)
         }
-      } { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      } { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 
@@ -65,9 +63,7 @@ class JavaCSRFActionSpec extends CSRFCommonSpecs {
     def apply[T](makeRequest: (WSRequest) => Future[WSResponse])(handleResponse: (WSResponse) => T) = {
       withActionServer(configuration) { implicit app =>
         { case _ => javaAction[JavaCSRFActionSpec.MyAction]("add", myAction.add) }
-      } { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      } { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 
@@ -75,9 +71,7 @@ class JavaCSRFActionSpec extends CSRFCommonSpecs {
     def apply[T](makeRequest: (WSRequest) => Future[WSResponse])(handleResponse: (WSResponse) => T) = {
       withActionServer(configuration) { implicit app =>
         { case _ => javaAction[JavaCSRFActionSpec.MyAction]("withSession", myAction.withSession) }
-      } { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      } { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 
@@ -95,9 +89,7 @@ class JavaCSRFActionSpec extends CSRFCommonSpecs {
       Seq(
         "play.http.filters" -> "play.filters.csrf.CsrfFilters"
       )
-    ) { implicit app =>
-      { case _ => javaAction[JavaCSRFActionSpec.MyAction]("getToken", myAction.getToken) }
-    } { ws =>
+    ) { implicit app => { case _ => javaAction[JavaCSRFActionSpec.MyAction]("getToken", myAction.getToken) } } { ws =>
       lazy val token = signedTokenProvider.generateToken
       val returned   = await(ws.url("http://localhost:" + testServerPort).withSession(TokenName -> token).get()).body
       signedTokenProvider.compareTokens(token, returned) must beTrue

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
@@ -32,9 +32,7 @@ class ScalaCSRFActionSpec extends CSRFCommonSpecs {
             val csrfAction = csrfCheck(app)
             csrfAction(myAction(req => Results.Ok))
           }
-      }) { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      }) { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 
@@ -46,14 +44,10 @@ class ScalaCSRFActionSpec extends CSRFCommonSpecs {
           val csrfAction = csrfAddToken(app)
           csrfAction(myAction { implicit req =>
             CSRF.getToken
-              .map { token =>
-                Results.Ok(token.value)
-              }
+              .map { token => Results.Ok(token.value) }
               .getOrElse(Results.NotFound)
           })
-      }) { ws =>
-        handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort))))
-      }
+      }) { ws => handleResponse(await(makeRequest(ws.url("http://localhost:" + testServerPort)))) }
     }
   }
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -121,122 +121,88 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     "gzip content type which is on the whiteList" in withApplication(
       Ok("hello").as("text/css"),
       whiteList = contentTypes
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "gzip content type which is on the whiteList ignoring case" in withApplication(
       Ok("hello").as("TeXt/CsS"),
       whiteList = List("TExT/HtMl", "tExT/cSs")
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "gzip uppercase content type which is on the whiteList" in withApplication(
       Ok("hello").as("TEXT/CSS"),
       whiteList = contentTypes
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "gzip content type with charset which is on the whiteList" in withApplication(
       Ok("hello").as("text/css; charset=utf-8"),
       whiteList = contentTypes
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "don't gzip content type which is not on the whiteList" in withApplication(
       Ok("hello").as("text/plain"),
       whiteList = contentTypes
-    ) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer) }
 
     "don't gzip content type with charset which is not on the whiteList" in withApplication(
       Ok("hello").as("text/plain; charset=utf-8"),
       whiteList = contentTypes
-    ) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer) }
 
     "don't gzip content type which is on the blackList" in withApplication(
       Ok("hello").as("text/css"),
       blackList = contentTypes
-    ) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer) }
 
     "don't gzip content type with charset which is on the blackList" in withApplication(
       Ok("hello").as("text/css; charset=utf-8"),
       blackList = contentTypes
-    ) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer) }
 
     "gzip content type which is not on the blackList" in withApplication(
       Ok("hello").as("text/plain"),
       blackList = contentTypes
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "gzip content type with charset which is not on the blackList" in withApplication(
       Ok("hello").as("text/plain; charset=utf-8"),
       blackList = contentTypes
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "ignore blackList if there is a whiteList" in withApplication(
       Ok("hello").as("text/css; charset=utf-8"),
       whiteList = contentTypes,
       blackList = contentTypes
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "gzip 'text/html' content type when using media range 'text/*' in the whiteList" in withApplication(
       Ok("hello").as("text/css"),
       whiteList = List("text/*")
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "don't gzip 'application/javascript' content type when using media range 'text/*' in the whiteList" in withApplication(
       Ok("hello").as("application/javascript"),
       whiteList = List("text/*")
-    ) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer) }
 
     "fail closed to not gziping an invalid contentType if there is a whiteList and no blacklist" in withApplication(
       Ok("hello").as("aA(\\A@*- 1  a-"),
       whiteList = List("text/*")
-    ) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer) }
 
     "fail closed to not gziping an invalid contentType if there is a whiteList and a blacklist" in withApplication(
       Ok("hello").as("aA(\\A@*- 1  a-"),
       whiteList = List("text/*"),
       blackList = List("text/*")
-    ) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer) }
 
     "fail opened to gziping an invalid contentType if there is a blacklist and no whitelist" in withApplication(
       Ok("hello").as("aA(\\A@*- 1  a-"),
       blackList = List("text/*")
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "gzip an invalid contentType if there is neither a blacklist nor a whitelist" in withApplication(
       Ok("hello").as("aA(\\A@*- 1  a-")
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer) }
 
     "gzip chunked responses" in withApplication(Ok.chunked(Source(List("foo", "bar")))) { implicit app =>
       val result = makeGzipRequest(app)
@@ -247,23 +213,17 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     "not gzip responses whose bodies are equals or smaller than the byte threshold" in withApplication(
       Ok("these are 18 bytes"),
       threshold = 18
-    ) { implicit app =>
-      checkNotGzipped(makeGzipRequest(app), "these are 18 bytes")(app.materializer)
-    }
+    ) { implicit app => checkNotGzipped(makeGzipRequest(app), "these are 18 bytes")(app.materializer) }
 
     "gzip responses whose bodies are larger than the byte threshold" in withApplication(
       Ok("these are 1_9 bytes"),
       threshold = 18
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "these are 1_9 bytes")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "these are 1_9 bytes")(app.materializer) }
 
     "gzip responses if a byte threshold is set but the body size cannot be determined" in withApplication(
       Ok.chunked(Source(List("these are 18 bytes"))),
       threshold = 18
-    ) { implicit app =>
-      checkGzippedBody(makeGzipRequest(app), "these are 18 bytes")(app.materializer)
-    }
+    ) { implicit app => checkGzippedBody(makeGzipRequest(app), "these are 18 bytes")(app.materializer) }
 
     val body = Random.nextString(1000)
 
@@ -494,9 +454,7 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
   ): MatchResult[Any] = {
     checkGzipped(result)
     val resultBody = contentAsBytes(result)
-    await(result).body.contentLength.foreach { cl =>
-      resultBody.length must_== cl
-    }
+    await(result).body.contentLength.foreach { cl => resultBody.length must_== cl }
     gunzip(resultBody) must_== body
   }
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -269,9 +269,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
                     Seq("anyhost")
                   )
                 ),
-                Action { _ =>
-                  Ok("allowed")
-                }
+                Action { _ => Ok("allowed") }
               )
             }
           }
@@ -311,9 +309,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
                     Seq("filter-hosts")
                   )
                 ),
-                Action { _ =>
-                  Ok("allowed")
-                }
+                Action { _ => Ok("allowed") }
               )
             }
           }

--- a/web/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
+++ b/web/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
@@ -18,11 +18,7 @@ object PlayFormsMagicForJava {
       null,
       jField.name.orElse(null),
       Option(jField.constraints)
-        .map(c =>
-          c.asScala.toSeq.map { jT =>
-            jT._1 -> jT._2.asScala.toSeq
-          }
-        )
+        .map(c => c.asScala.toSeq.map { jT => jT._1 -> jT._2.asScala.toSeq })
         .getOrElse(Nil),
       Option(jField.format).map(f => f._1 -> f._2.asScala.toSeq),
       Option(jField.errors)

--- a/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -263,8 +263,8 @@ class DynamicFormSpec extends CommonFormSpec {
 
     "fail with exception when the json paylod is bigger than default maxBufferSize" in {
       val cfg  = ConfigFactory.parseString("""
-                                            |play.http.parser.maxMemoryBuffer = 32
-                                            |""".stripMargin).withFallback(config)
+                                             |play.http.parser.maxMemoryBuffer = 32
+                                             |""".stripMargin).withFallback(config)
       val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, cfg)
       val longString =
         "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -647,21 +647,38 @@ trait FormSpec extends CommonFormSpec {
         .bindFromRequest(
           FormSpec.dummyRequest(
             Map(
-              "entry.name"                  -> Array("Bill"),
-              "entry.value"                 -> Array("3"),
-              "entries[].name"              -> Array("Calvin", "John", "Edward"), //   -> entries[0|1|2].name
-              "entries[].value"             -> Array("14", "26", "76"), //             -> entries[0|1|2].value
-              "entries[].entries[].name"    -> Array("Robin Hood", "Donald Duck"), //  -> entries[0].entries[0|1].name
-              "entries[].entries[].street"  -> Array("Wall Street", "Main Street"), // -> entries[0].entries[0|1].street
-              "entries[].entries[].value"   -> Array("143", "196"), //                 -> entries[0].entries[0|1].value
-              "entries[].entries[].notes[]" -> Array("Note 1", "Note 2", "Note 3"), // -> entries[0].entries[0].notes[0|1|2]
+              "entry.name"                 -> Array("Bill"),
+              "entry.value"                -> Array("3"),
+              "entries[].name"             -> Array("Calvin", "John", "Edward"), //   -> entries[0|1|2].name
+              "entries[].value"            -> Array("14", "26", "76"), //             -> entries[0|1|2].value
+              "entries[].entries[].name"   -> Array("Robin Hood", "Donald Duck"), //  -> entries[0].entries[0|1].name
+              "entries[].entries[].street" -> Array("Wall Street", "Main Street"), // -> entries[0].entries[0|1].street
+              "entries[].entries[].value"  -> Array("143", "196"), //                 -> entries[0].entries[0|1].value
+              "entries[].entries[].notes[]" -> Array(
+                "Note 1",
+                "Note 2",
+                "Note 3"
+              ), // -> entries[0].entries[0].notes[0|1|2]
               // Now with some indices
-              "entries[].entries[1].notes[]"  -> Array("Note 4", "Note 5", "Note x", "Note y"),          // -> entries[0].entries[1].notes[0|1|2|3]
-              "entries[1].entries[].name"     -> Array("Batman", "Robin", "Joker"),                      // -> entries[1].entries[0|1|2].name
-              "entries[1].entries[].street"   -> Array("First Street", "Second Street", "Third Street"), // -> entries[1].entries[0|1|2].street
-              "entries[1].entries[].value"    -> Array("372", "641", "961"),                             // -> entries[1].entries[0|1|2].value
-              "entries[1].entries[].notes[]"  -> Array("Note 6", "Note 7"),                              // -> entries[1].entries[0].notes[0|1]
-              "entries[1].entries[1].notes[]" -> Array("Note 8", "Note 9", "Note 10"),                   // -> entries[1].entries[1].notes[0|1|2]
+              "entries[].entries[1].notes[]" -> Array(
+                "Note 4",
+                "Note 5",
+                "Note x",
+                "Note y"
+              ), // -> entries[0].entries[1].notes[0|1|2|3]
+              "entries[1].entries[].name" -> Array("Batman", "Robin", "Joker"), // -> entries[1].entries[0|1|2].name
+              "entries[1].entries[].street" -> Array(
+                "First Street",
+                "Second Street",
+                "Third Street"
+              ), // -> entries[1].entries[0|1|2].street
+              "entries[1].entries[].value"   -> Array("372", "641", "961"), // -> entries[1].entries[0|1|2].value
+              "entries[1].entries[].notes[]" -> Array("Note 6", "Note 7"),  // -> entries[1].entries[0].notes[0|1]
+              "entries[1].entries[1].notes[]" -> Array(
+                "Note 8",
+                "Note 9",
+                "Note 10"
+              ), // -> entries[1].entries[1].notes[0|1|2]
             )
           )
         )

--- a/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -58,9 +58,7 @@ object UserInfo {
           .lift(key)
           .flatMap {
             case (fullKey, shortKey) if signedFields.contains(fullKey) =>
-              values.headOption.map { value =>
-                Map(shortKey -> value)
-              }
+              values.headOption.map { value => Map(shortKey -> value) }
             case _ => None
           }
           .map(result ++ _)
@@ -111,7 +109,7 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
     val claimedIdCandidate = discovery.normalizeIdentifier(openID)
     discovery
       .discoverServer(openID)
-      .map({ server =>
+      .map { server =>
         val (claimedId, identity) =
           if (server.protocolVersion != "http://specs.openid.net/auth/2.0/server")
             (claimedIdCandidate, server.delegate.getOrElse(claimedIdCandidate))
@@ -131,7 +129,7 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
               URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(v, "UTF-8")
           })
           .mkString("&")
-      })
+      }
   }
 
   /**
@@ -291,8 +289,7 @@ private[openid] object Discovery {
 
     private def findUriWithType(xml: Node)(typeId: String) =
       (xml \ "XRD" \ "Service").find(node => (node \ "Type").find(inner => inner.text == typeId).isDefined).map {
-        node =>
-          (typeId, (node \ "URI").text.trim)
+        node => (typeId, (node \ "URI").text.trim)
       }
   }
 
@@ -312,7 +309,11 @@ private[openid] object Discovery {
           .findFirstIn(response.body)
           .orElse(delegateRegex.findFirstIn(response.body))
           .flatMap(extractHref(_))
-        OpenIDServer("http://specs.openid.net/auth/2.0/signon", url, delegate) //protocol version due to http://openid.net/specs/openid-authentication-2_0.html#html_disco
+        OpenIDServer(
+          "http://specs.openid.net/auth/2.0/signon",
+          url,
+          delegate
+        ) //protocol version due to http://openid.net/specs/openid-authentication-2_0.html#html_disco
       })
     }
 


### PR DESCRIPTION
It's a first step of https://github.com/playframework/playframework/issues/11510
I think we should migrate to **Scalafmt 3** step by step.

Changes in this PR as a result of https://github.com/scalameta/scalafmt/pull/1660

I've really liked these changes, IMHO.

- [ ] Backport to `[2.8.x]` manually 