### PR TITLE
Scala's ActorFlow.actorRef() should fail on overflow, like Java does

### DIFF
--- a/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -37,7 +37,7 @@ object ActorFlow {
   def actorRef[In, Out](
       props: ActorRef => Props,
       bufferSize: Int = 16,
-      overflowStrategy: OverflowStrategy = OverflowStrategy.dropNew
+      overflowStrategy: OverflowStrategy = OverflowStrategy.fail
   )(implicit factory: ActorRefFactory, mat: Materializer): Flow[In, Out, _] = {
     val (outActor, publisher) = Source
       .actorRef[Out](bufferSize, overflowStrategy)


### PR DESCRIPTION
[The Java API always worked like this](https://github.com/playframework/playframework/blob/a0aacb6555ab92b71528d2e46863d9f2118b7368/core/play-streams/src/main/java/play/libs/streams/ActorFlow.java#L100) and I think that makes most sense, otherwise one might not be aware that message get dropped, see #6246