### PR TITLE
Do not use/recommend shutdownHook in Logback, Play handles that

### DIFF
--- a/core/play-logback/src/main/resources/logback-play-default.xml
+++ b/core/play-logback/src/main/resources/logback-play-default.xml
@@ -31,6 +31,4 @@
     <appender-ref ref="ASYNCSTDOUT" />
   </root>
 
-  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
-
 </configuration>

--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -18,7 +18,6 @@ A few things to note about these configurations:
 * These default configs specify only a console logger which outputs only 10 lines of an exception stack trace.
 * Play uses ANSI color codes by default in level messages.
 * For production, the default config puts the console logger behind the logback [AsyncAppender](http://logback.qos.ch/manual/appenders.html#AsyncAppender).  For details on the performance implications on this, see this [blog post](https://blog.overops.com/how-to-instantly-improve-your-java-logging-with-7-logback-tweaks/).
-* In order to guarantee that logged messages have had a chance to be processed by asynchronous appenders (including the TCP appender) and ensure background threads have been stopped, you'll need to cleanly shut down logback when your application exits. For details on a shutdown hook, see this [documentation](http://logback.qos.ch/manual/configuration.html#shutdownHook). Also [you must specify](https://jira.qos.ch/browse/LOGBACK-1090) DelayingShutdownHook explicitly: `<shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>` .
 
 To add a file logger, add the following appender to your `conf/logback.xml` file:
 

--- a/documentation/manual/working/commonGuide/database/code/logback-play-logSql.xml
+++ b/documentation/manual/working/commonGuide/database/code/logback-play-logSql.xml
@@ -37,7 +37,5 @@
     <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>
-
-  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/> 
   
 </configuration>


### PR DESCRIPTION
This reverts the changes from #8407 / #8277.
I am sure we don't want logback to shut down the logger context by using`<shutdownHook />` (anymore), because Play already handlest that (at least since v2.7). Actually with `<shutdownHook />` in place, a Play app closes the logger context to early and **logs are lost (!)**...

So what does `<shutdownHook />` actually do?
It [registers](https://github.com/qos-ch/logback/blob/v_1.2.11/logback-core/src/main/java/ch/qos/logback/core/joran/action/ShutdownHookAction.java#L85) a [JVM shutdown hoook](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.html#addShutdownHook(java.lang.Thread)). So when the JVM shuts down, this hook will automatically close the logger context after a delay... By default that delay is 0, so it will [do that immediately](https://github.com/qos-ch/logback/blob/v_1.2.11/logback-core/src/main/java/ch/qos/logback/core/hook/DelayingShutdownHook.java#L52-L57). So we end up [here](https://github.com/qos-ch/logback/blob/v_1.2.11/logback-core/src/main/java/ch/qos/logback/core/hook/ShutdownHookBase.java#L39) and then [here](https://github.com/qos-ch/logback/blob/v_1.2.11/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java#L156-L162).

That might was desirable back when #8407 was merged (but not sure if back then this also made sense), but meanwhile we switched to Akka's Coordinated Shutdown hooks in #8406 (see [this line](https://github.com/playframework/playframework/pull/8406/files#diff-8e5ce9c1e0073ffe4d07264b1194aed111ce37966e9d1fd71166ccf4b5181086R426)). So now when akka-http or netty shutdown, they also stop the logger context, see [here](https://github.com/playframework/playframework/blob/2.8.18/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala#L500-L505), which calls [this](https://github.com/playframework/playframework/blob/2.8.18/transport/server/play-server/src/main/scala/play/core/server/Server.scala#L47-L51), which then [shuts down the logger context](https://github.com/playframework/playframework/blob/2.8.18/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala#L137-L145).

So for production mode, that means, that when you add `<shutdownHook />`  to your logback config, what happens is, that when you signal your application to shutdown, at first the JVM shutdown hook registered by logback runs and shuts down the logger context. Only later the Akka Coordinated Shutdown hook kicks in (but then the context is closed already).
The bad thing about that is that when logbacks hooks runs, a Play app didn't finish it's shutdown yet, so if there are log statements (which there are), they will be lost.
You can easily reproduce that:
```sh
$ sbt new playframework/play-scala-seed.g8
...
Template applied in ./play-scala-seed

$ cd play-scala-seed/

$ sbt "playUpdateSecret; stage" # stage the app for production
...

$ ./target/universal/stage/bin/play-scala-seed # Run the production app 
...
2022-11-10 20:56:03 INFO  play.api.Play  Application started (Prod) (no global state)
2022-11-10 20:56:04 INFO  play.core.server.AkkaHttpServer  Listening for HTTP on /127.0.0.1:9000

### AFTER THE APP STARTED STOP IT WITH CTRL+C
### NOW WE WILL SEE FOLLOWING LOG STATEMENTS:

2022-11-10 20:56:06 INFO  p.a.i.l.c.CoordinatedShutdownSupport  Starting synchronous coordinated shutdown with ServerStoppedReason reason and 2147508000 milliseconds timeout
2022-11-10 20:56:06 INFO  play.core.server.AkkaHttpServer  Stopping Akka HTTP server...
2022-11-10 20:56:06 INFO  play.core.server.AkkaHttpServer  Terminating server binding for /127.0.0.1:9000
2022-11-10 20:56:06 INFO  play.core.server.AkkaHttpServer  Running provided shutdown stop hooks

$ vim conf/logback.xml # Let's add <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook" />

$ sbt stage # stage the app for productin again with updated logback config
...

$ ./target/universal/stage/bin/play-scala-seed # again run it in prod mode
...
2022-11-10 20:56:42 INFO  play.api.Play  Application started (Prod) (no global state)
2022-11-10 20:56:42 INFO  play.core.server.AkkaHttpServer  Listening for HTTP on /127.0.0.1:9000

### AFTER THE APP STARTED STOP IT WITH CTRL+C
### NO MORE LOG STATEMENTS! BECAUSE THE LOGBACK STOP HOOK ALREADY CLOSED THE LOG CONTEXT WAY TOO EARLY

$ 
```

I also debugged this behaviour thoroughly: I am 100% sure both stop hooks always call the stop method on the same object, both calls ending up [this method](https://github.com/qos-ch/logback/blob/v_1.2.11/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java#L156-L162) (It does not fail when close is called twice, it does not care).

So I am 100%, in a Play app, `<shutdownHook />` should never bet set, because it will alway be closed by the backend server.
(for dev mode that's a different story, see #10939, but unrelated to `<shutdownHook />`, which [isn't set in Play's default dev logback config](https://github.com/playframework/playframework/blob/main/core/play-logback/src/main/resources/logback-play-dev.xml))