### PR TITLE
Add play-secret-rotation to public module docs

### DIFF
--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -158,6 +158,9 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 * **Documentation:** <https://github.com/sief/play-guard/blob/master/README.md>
 * **Short description:** Play2 module for blocking and throttling abusive requests
 
+### play-secret-rotation (Scala)
+* **Website:** <https://github.com/guardian/play-secret-rotation>
+* **Short description:** Provides a Play2 Application Secret rotation on an active cluster.
 
 ## Cloud Services
 


### PR DESCRIPTION
Signed-off-by: Felipe Bonezi <felipebonezi@gmail.com>

<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10911

## Purpose

Add the `play-secret-rotation` library into public module documentation.
