### PR TITLE
Update "Building Play from source" docs

### DIFF
--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -84,7 +84,3 @@ Once you have done this, you can start the console and interact with your projec
 $ cd <projectdir>
 $ sbt
 ```
-
-## Using Code in Eclipse
-
-You can find at [Stackoverflow](https://stackoverflow.com/questions/10053201/how-to-setup-eclipse-ide-work-on-the-playframework-2-0/10055419#10055419) some information how to setup eclipse to work on the code.


### PR DESCRIPTION
https://www.playframework.com/documentation/2.8.x/BuildingFromSource

See
* https://github.com/playframework/playframework/pull/11505#issuecomment-1317172954
* https://github.com/playframework/play-meta/issues/203

- [ ] Describe sbt-dynver
- [ ] Maybe mention sdkman
- [ ] Describe some useful sbt things, like `-mem` or the hidden .sbtopts and .jvmopts files
- [ ] Mention the `PLAY_EDITOR`, `PLAY_HTTP_ADDRESS`, `PLAY_TEST_SERVER_HTTP_ADDRESS` env vars
- [ ] Maybe a few words about the target folder
- [ ] Describe how to import into IntelliJ
- [ ] Add how to run integration tests
- [ ] Describe how to run scripted tests
- [ ] Mentiond `[error] Unable to locate class corresponding to inner class entry for TemporaryFile...` error
- [ ] Mention which Java version to use
- [ ] Mention `validateCode` and `formatCode` task
- [ ] Mention how to debug integration tests (or in general when fork is true)
- [ ] Mention how to run documentation locally
- [ ] Probably link to https://github.com/playframework/.github/blob/main/CONTRIBUTING.md