### PR TITLE
Makes the log message for starting http server more eye-catching

### DIFF
--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -450,8 +450,8 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
   mode match {
     case Mode.Test =>
     case _ =>
-      httpServerBinding.foreach { http => logger.info(s"Listening for HTTP on ${http.localAddress}") }
-      httpsServerBinding.foreach { https => logger.info(s"Listening for HTTPS on ${https.localAddress}") }
+      httpServerBinding.foreach { http => logger.info(s"🚀 Listening for HTTP on ${http.localAddress}") }
+      httpsServerBinding.foreach { https => logger.info(s"🚀 Listening for HTTPS on ${https.localAddress}") }
   }
 
   override def stop(): Unit = CoordinatedShutdownSupport.syncShutdown(context.actorSystem, ServerStoppedReason)


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

This PR adds a 🚀 to the log message that says that the server are now accepting connections

## Background Context

I work in a project where this log line is hidden in hundreds of lines of output which makes it hard to see

