### PR TITLE
Updating documentation - ConfiguringHttps.md

### DIFF
--- a/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
+++ b/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
@@ -56,8 +56,6 @@ To disable binding on the HTTP port, set the `http.port` system property to be `
 
 ## Production usage of HTTPS
 
-If Play is serving HTTPS in production, it should be running JDK 1.8.  JDK 1.8 provides a number of new features that make JSSE feasible as a [TLS termination layer](https://blog.ivanristic.com/2014/03/ssl-tls-improvements-in-java-8.html).  If not using JDK 1.8, using a [[reverse proxy|HTTPServer]] in front of Play will give better control and security of HTTPS.
-
 If you intend to use Play for TLS termination layer, please note the following settings:
 
 * **[`SSLParameters.setUseCipherSuiteorder()`](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#cipher_suite_preference)** - Reorders cipher suite order to the server's preference.


### PR DESCRIPTION
I think documentation wrongly advised downgrading JDK to JDK 8. Given that minimal JDK version seems to be 8, whole paragraph is not applicable. I deleted it.
