### PR TITLE
For nightly builds fetch and determine akka-http 10.2.x snapshot, not 10.1.x (but don't use it actually)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
             AKKA_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-actor_2.13/ | grep -oEi '2\.6\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
-            AKKA_HTTP_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-http-core_2.13/ | grep -oEi '10\.1\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
+            AKKA_HTTP_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-http-core_2.13/ | grep -oEi '10\.2\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
             echo "akka_opts=-Dakka.version=$AKKA_VERSION" >> $GITHUB_OUTPUT
             echo "akka_http_opts=-Dakka.http.version=$AKKA_HTTP_VERSION" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,7 +32,8 @@ jobs:
             AKKA_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-actor_2.13/ | grep -oEi '2\.6\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
             AKKA_HTTP_VERSION=$(curl -s https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-http-core_2.13/ | grep -oEi '10\.2\.[0-9]+\+[RCM0-9]+-[0-9a-f]{8}-SNAPSHOT' | sort -V | tail -n 1)
             echo "akka_opts=-Dakka.version=$AKKA_VERSION" >> $GITHUB_OUTPUT
-            echo "akka_http_opts=-Dakka.http.version=$AKKA_HTTP_VERSION" >> $GITHUB_OUTPUT
+            # We can't use the latest akka-http 10.2.x SNAPSHOT anymore because it's not compatible with akka 2.6 anymore
+            #echo "akka_http_opts=-Dakka.http.version=$AKKA_HTTP_VERSION" >> $GITHUB_OUTPUT
           else
             echo "akka_opts=" >> $GITHUB_OUTPUT
             echo "akka_http_opts=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The nightly build [is failing](https://github.com/playframework/playframework/actions/workflows/build-test.yml?query=event%3Aschedule) since #11523 got merged. That's because there akka-http was upgraded from 10.2.7 to 10.2.10, which changed it's behaviour in regards to idle timeouts (for the better), see https://github.com/akka/akka-http/pull/3965

It turns out that at some point in our main branch we upgraded from akka-http 10.1.x to 10.2.x before, however the nightly tests kept using the latest 10.1.x snapshot. Seems like we didn't notice that because all tests passed until now... (Which speaks for akka-http's compatibility :wink:)
Now I tried to change the version used by nightlies so that GitHub actions pulls in the latest akka-http 10.2.x snaphots, but that is failing now with the exception:
```
akka.UnsupportedAkkaVersion: Current version of Akka is [2.6.20], but akka-http requires version [2.7.0-M1]
```
That means we can't use the latest [10.2.10+7-fb689334-SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-http-core_2.13/10.2.10+7-fb689334-SNAPSHOT/) anymore because the akka team already worked on the akka 2.7 transition back then. so we have to stick with latest akka-http version 10.2.10.

