### PR TITLE
[2.8.x] Interplay 2.1.11 to avoid out of memory with gpg

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ val webjarsLocatorCore = "0.43"
 val sbtHeader          = "5.7.0"
 val scalafmt           = "2.0.1"
 val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.5.1") // sync with documentation/project/plugins.sbt
-val interplay: String  = sys.props.getOrElse("interplay.version", "2.1.10")
+val interplay: String  = sys.props.getOrElse("interplay.version", "2.1.11")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackager,


### PR DESCRIPTION
For next Play 2.8.x release.
Details here: https://github.com/playframework/interplay/pull/230