### PR TITLE
Filters should be restrictive when their route modifier black-/whitelist both are empty

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPConfig.scala
@@ -88,7 +88,7 @@ object CSPConfig {
     @inline def checkRouteModifiers(rh: RequestHeader): Boolean = {
       import play.api.routing.Router.RequestImplicits._
       if (whitelistModifiers.isEmpty) {
-        blacklistModifiers.exists(rh.hasRouteModifier)
+        blacklistModifiers.isEmpty || blacklistModifiers.exists(rh.hasRouteModifier)
       } else {
         !whitelistModifiers.exists(rh.hasRouteModifier)
       }

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -133,7 +133,7 @@ object CSRFConfig {
     @inline def checkRouteModifiers(rh: RequestHeader): Boolean = {
       import play.api.routing.Router.RequestImplicits._
       if (whitelistModifiers.isEmpty) {
-        blacklistModifiers.exists(rh.hasRouteModifier)
+        blacklistModifiers.isEmpty || blacklistModifiers.exists(rh.hasRouteModifier)
       } else {
         !whitelistModifiers.exists(rh.hasRouteModifier)
       }

--- a/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -111,10 +111,10 @@ object AllowedHostsConfig {
 
     @inline def shouldProtectViaRouteModifiers(rh: RequestHeader): Boolean = {
       import play.api.routing.Router.RequestImplicits._
-      if (whiteListRouteModifiers.nonEmpty)
-        !whiteListRouteModifiers.exists(rh.hasRouteModifier)
-      else
+      if (whiteListRouteModifiers.isEmpty)
         blackListRouteModifiers.isEmpty || blackListRouteModifiers.exists(rh.hasRouteModifier)
+      else
+        !whiteListRouteModifiers.exists(rh.hasRouteModifier)
     }
 
     AllowedHostsConfig(

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -427,7 +427,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
   }
 
   def withActionServer[T](
-      config: Seq[(String, String)]
+      config: Seq[(String, Any)]
   )(router: Application => PartialFunction[(String, String), Handler])(block: WSClient => T) = {
     implicit val app = GuiceApplicationBuilder()
       .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -337,6 +337,18 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       status(request(app, "good.com")) must_== OK
       status(request(app, "evil.com")) must_== OK
     }
+
+    "protect untagged routes when route modifier blackList and whiteList are empty" in withApplication(
+      okWithHost,
+      """
+        |play.filters.hosts.allowed = [good.com]
+        |play.filters.hosts.routeModifiers.whiteList = []
+        |play.filters.hosts.routeModifiers.blackList = []
+        |""".stripMargin
+    ) { app =>
+      status(request(app, "good.com")) must_== OK
+      status(request(app, "evil.com")) must_== BAD_REQUEST
+    }
   }
 }
 


### PR DESCRIPTION
For the CSP, CSRF and AllowedHosts filters, route modifier tags can be used to whitelist routes, which then should not be checked by the filter, also blacklists can be used, see e.g. the explanation of the [config here](https://github.com/playframework/playframework/blob/cc3040da2e56e4868525abe4d66534169e9c4668/web/play-filters-helpers/src/main/resources/reference.conf#L100-L109).

Now while reviewing #10536 I realized that when both the white and the blacklist are empty the filters suddenly starte to be permissive and do not check anything anymore...

E.g. if you have a routes file
```
POST /    app.controllers.AppController.foo
+ nocsrf
POST /    app.controllers.AppController.bar
```
and keep the default whitelist that ships with Play, the `bar` route will not be checked ("nocsrf" = do not do any csrf check), but the foo route will be checked.
Now, if we keep the above routes file unchanged, but change the config so that `play.filters.csrf.routeModifiers.whiteList = []`, suddenly the `foo` route will be permissive and will not be checked anymore... Actually no route will be checked anymore.
I don't think this is a good default, and Play usually is restrictive by default and should be here too.

Currently only the AllowedHosts handles this correct IMHO and defaults to be restrictive, meaning if both lists are empty it will always do the check.

Even highly unlikely that someone ever changed the default config, it is possible, due to misconfiguration done by devs, that this could lead to unexpected security implications... I doubt that is a real world issue, but good to be fixed nevertheless.