### PR TITLE
PlayConfiguration project should be checked by MiMa

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,7 +255,6 @@ lazy val PlayConfiguration = PlayCrossBuiltProject("Play-Configuration", "core/p
   .settings(
     libraryDependencies ++= Seq(typesafeConfig, slf4jApi) ++ specs2Deps.map(_ % Test),
     (Test / parallelExecution) := false,
-    mimaPreviousArtifacts := Set.empty,
     // quieten deprecation warnings in tests
     (Test / scalacOptions) := (Test / scalacOptions).value.diff(Seq("-deprecation"))
   )


### PR DESCRIPTION
Can be merged after Play 2.9.0(-M2/RC1 ?), when artifacts for the play-configuration project got published so mima has something to check against.