### PR TITLE
Render sha and dirty part in version only when on CI

### DIFF
--- a/project/VersionHelper.scala
+++ b/project/VersionHelper.scala
@@ -46,6 +46,7 @@ object VersionHelper {
     } else {
       val dirtyPart    = if (out.isDirty()) out.dirtySuffix.value else ""
       val snapshotPart = if (dynverSonatypeSnapshots && out.isSnapshot()) "-SNAPSHOT" else ""
+      val isCI         = sys.env.get("CI").exists(_.toBoolean)
       (if (out.ref.dropPrefix.matches(""".*-(M|RC)\d+$""")) {
          // tag is a milestone or release candidate, therefore we increase the version after the -RC or -M (e.g. -RC1 becomes -RC2)
          // it does not matter on which branch we are on
@@ -63,7 +64,7 @@ object VersionHelper {
            // Therefore we are e.g. on 2.8.x or a branch that is forked off from 2.8.x or 2.9.x or ... you get it ;)
            VersionHelper.increasePatchVersion(out.ref.dropPrefix)
          }
-       }) + Option(out.commitSuffix.sha).filter(_.nonEmpty).map("-" + _).getOrElse("") + dirtyPart + snapshotPart
+       }) + (if (isCI) Option(out.commitSuffix.sha).filter(_.nonEmpty).map("-" + _).getOrElse("") + dirtyPart else "") + snapshotPart
     }
   }
 


### PR DESCRIPTION
I think this change is actually important for newcomers that want to run scripted tests and/or want to test changes locally in apps without unnecessary hassles.
Currently when cloning the Play repo and running sbt, the version of the project looks like
* `2.9.0-M3-55c8861d+20230124-0041-SNAPSHOT` if the worktree is "dirty"
* `2.9.0-M3-55c8861d-SNAPSHOT` if the worktree is "clean"

(before #11168 `...-M3-...` would have been `...-M2-...`, but that does not matter here)

This might not look like a big deal and we couldn't care less about that version string, however it could turn into an annoying problem when running scripted tests. It did happen to me not just once, that after I ran `publishLocal` and then did some minor, often not relevant changes and, for whatever reason restarted sbt, and then wanted to run scripted tests or wanted to test changes locally in a test application that the artifacts couldn't be found: As you can see from the string each time your re-start sbt or just reload within an running instance it can easily happen that the timestamp or the sha changes. For scripted tests that means if the version you pass to the scripted tests is newer than the actual published artifacts on your machine it makes booom.
For newcomers that want to run scripted tests that might be a problem because they probably have no idea why the scripted tests don't run...

That's why I suggest with this pull request that when runnig sbt _not_ on CI, the version string should simply be
* `2.9.0-M3-SNAPSHOT` (no matter if the worktree is dirty or not).

**In all those years I never had one single use case why I would want the sha and/or the dirty part in the version string of my local Play repo. Not one.** And I hacked on the code a lot.

Also I prefer to just always override the local published snapshot instead of creating many many artifacts in parallel. Just a waste of space IMHO, If you want a clean start instead of overriding the existing snapshot you can clean the local `~/.ivy2/local` folder yourself anyway.

Seems like other have the same thoughts: https://github.com/sbt/sbt-dynver/issues/234