### PR TITLE
Fix length validation in Multipart.randomBoundary

### DIFF
--- a/core/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/core/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -55,7 +55,7 @@ object Multipart {
    *                                  <a href="https://tools.ietf.org/html/rfc2046#section-5.1.1">rfc2046</a>
    */
   def randomBoundary(length: Int = 18, random: java.util.Random = ThreadLocalRandom.current()): String = {
-    if (length < 1 && length > 70) throw new IllegalArgumentException("length can't be greater than 70 or less than 1")
+    if (length < 1 || length > 70) throw new IllegalArgumentException("length can't be greater than 70 or less than 1")
     val bytes: Seq[Byte] = for (byte <- 1 to length) yield {
       alphabet(random.nextInt(alphabet.length))
     }


### PR DESCRIPTION


<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] ~~Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?~~
* [x] ~~Have you added copyright headers to new files?~~
* [x] ~~Have you checked that both Scala and Java APIs are updated?~~
* [x] ~~Have you updated the documentation for both Scala and Java sections?~~
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Previously, given a `length` argument outside of the acceptable range (1 to 70, inclusive) `Multipart.randomBoundary` would fail to throw the expected exception.

This change will allow the expected exception to be thrown.