### PR TITLE
Upgrade interplay, provides Scala 3.3.0-RC2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ val webjarsLocatorCore = "0.52"
 val sbtHeader          = "5.8.0"
 val scalafmt           = "2.4.6"
 val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.6.0-M7") // sync with documentation/project/plugins.sbt
-val interplay: String  = sys.props.getOrElse("interplay.version", "3.1.0-RC6")
+val interplay: String  = sys.props.getOrElse("interplay.version", "3.1.0-RC7")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackager,


### PR DESCRIPTION
Pull in just released Scala 3.3.0-RC2:
* https://contributors.scala-lang.org/t/3-3-0-release-thread/6079
* https://github.com/lampepfl/dotty/releases/tag/3.3.0-RC2