### PR TITLE
replace specs2-mockito with vanilla mockito

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,7 @@ lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "testkit/play-test
 
 lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "testkit/play-specs2")
   .settings(
-    libraryDependencies ++= specs2Deps,
+    libraryDependencies ++= specs2Deps :+ mockitoAll,
     (Test / parallelExecution) := false
   )
   .dependsOn(PlayTestProject)

--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,8 @@ lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "testkit/play-test
 
 lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "testkit/play-specs2")
   .settings(
-    libraryDependencies ++= specs2Deps :+ mockitoAll,
+    libraryDependencies ++= specs2Deps :+ (if (ScalaArtifacts.isScala3(scalaVersion.value)) { mockitoAll }
+                                           else { specs2Mock }),
     (Test / parallelExecution) := false
   )
   .dependsOn(PlayTestProject)

--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/caffeine/CaffeineCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/caffeine/CaffeineCacheApiSpec.scala
@@ -13,9 +13,9 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import org.mockito.Mockito
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
-import org.specs2.mock.Mockito
 import play.api.cache.AsyncCacheApi
 import play.api.cache.SyncCacheApi
 import play.api.inject._
@@ -156,7 +156,7 @@ class CaffeineCacheApiSpec extends PlaySpecification {
       val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
       syncCacheApi.set("aaa", "bbb")
       trait OrElse { lazy val orElse: String = "ccc" }
-      val mockOrElse = Mockito.mock[OrElse]
+      val mockOrElse = Mockito.mock(classOf[OrElse])
       val result     = syncCacheApi.getOrElseUpdate[String]("aaa")(mockOrElse.orElse)
       result mustEqual "bbb"
       verify(mockOrElse, never).orElse
@@ -166,7 +166,7 @@ class CaffeineCacheApiSpec extends PlaySpecification {
       val asyncCacheApi = app.injector.instanceOf[AsyncCacheApi]
       asyncCacheApi.set("aaa", "bbb")
       trait OrElse { lazy val orElse: Future[String] = Future.successful("ccc") }
-      val mockOrElse   = Mockito.mock[OrElse]
+      val mockOrElse   = Mockito.mock(classOf[OrElse])
       val resultFuture = asyncCacheApi.getOrElseUpdate[String]("aaa")(mockOrElse.orElse)
       val result       = Await.result(resultFuture, 2.seconds)
       result mustEqual "bbb"

--- a/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
@@ -9,14 +9,13 @@ import java.util.Optional
 import scala.jdk.CollectionConverters._
 
 import akka.util.ByteString
-import org.specs2.mock.Mockito
 import play.api.mvc._
 import play.api.test._
 import play.mvc.Http
 import play.mvc.Http.RequestBody
 import play.mvc.Http.RequestImpl
 
-class JavaRequestsSpec extends PlaySpecification with Mockito {
+class JavaRequestsSpec extends PlaySpecification {
   "JavaHelpers" should {
     "create a request with an id" in {
       val request                   = FakeRequest().withHeaders("Content-type" -> "application/json")

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-import org.specs2.mock.Mockito
+import org.mockito.Mockito
 import org.specs2.mutable.After
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
@@ -28,7 +28,7 @@ import play.api.libs.Files._
 import play.api.routing.Router
 import play.api.ApplicationLoader.Context
 
-class TemporaryFileCreatorSpec extends Specification with Mockito {
+class TemporaryFileCreatorSpec extends Specification {
   sequential
 
   val utf8: Charset = Charset.forName("UTF8")
@@ -61,7 +61,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       val threadPool: ExecutorService = Executors.newFixedThreadPool(threads)
 
       val lifecycle = new DefaultApplicationLifecycle
-      val reaper    = mock[TemporaryFileReaper]
+      val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
       val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
       try {
@@ -96,7 +96,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
     "recreate directory if it is deleted" in new WithScope() {
       val lifecycle     = new DefaultApplicationLifecycle
-      val reaper        = mock[TemporaryFileReaper]
+      val reaper        = Mockito.mock(classOf[TemporaryFileReaper])
       val creator       = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
       val temporaryFile = creator.create("foo", "bar")
       JFiles.delete(temporaryFile.toPath)
@@ -108,7 +108,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
     "when copying file" in {
       "copy when destination does not exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("copy.txt")
@@ -133,7 +133,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "copy when destination does not exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("copy.txt")
@@ -157,7 +157,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "copy when destination exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("copy.txt")
@@ -182,7 +182,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "do not copy when destination exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("do-not-replace.txt")
@@ -197,7 +197,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "delete source file has no impact on the destination file" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file = parentDirectory.resolve("move.txt")
@@ -223,7 +223,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
     "when moving file" in {
       "move when destination does not exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
@@ -244,7 +244,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "move when destination does not exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
@@ -264,7 +264,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "move when destination exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
@@ -285,7 +285,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "do not move when destination exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("do-not-replace.txt")
@@ -300,7 +300,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "move a file atomically with replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file = parentDirectory.resolve("move.txt")
@@ -317,7 +317,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
     "when moving file with the deprecated API" in {
       "move when destination does not exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
@@ -338,7 +338,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "move when destination does not exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
@@ -358,7 +358,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "move when destination exists and replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("move.txt")
@@ -379,7 +379,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "do not move when destination exists and replace disabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file        = parentDirectory.resolve("do-not-replace.txt")
@@ -394,7 +394,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
       "move a file atomically with replace enabled" in new WithScope() {
         val lifecycle = new DefaultApplicationLifecycle
-        val reaper    = mock[TemporaryFileReaper]
+        val reaper    = Mockito.mock(classOf[TemporaryFileReaper])
         val creator   = new DefaultTemporaryFileCreator(lifecycle, reaper, Configuration.reference)
 
         val file = parentDirectory.resolve("move.txt")
@@ -435,7 +435,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
     "works when using custom temporary file directory" in new WithScope() {
       val lifecycle  = new DefaultApplicationLifecycle
-      val reaper     = mock[TemporaryFileReaper]
+      val reaper     = Mockito.mock(classOf[TemporaryFileReaper])
       val path       = parentDirectory.toAbsolutePath().toString()
       val customPath = s"$path/custom/"
       val conf       = Configuration.from(Map("play.temporaryFile.dir" -> customPath))

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -140,6 +140,28 @@ Application keeps on adding many items to the cache over time, then, with the Ca
 
 TBA
 
+## Dependency graph changes
+
+The [`"com.typesafe.play" %% "play-specs2"` artifact](https://mvnrepository.com/artifact/com.typesafe.play/play-specs2) no longer includes the
+[`"org.specs2" %% "specs2-mock"` dependency](https://mvnrepository.com/artifact/org.specs2/specs2-mock) because it is not available for scala3, 
+and only includes [`"org.mockito" % "mockito-core"` dependency](https://mvnrepository.com/artifact/org.mockito/mockito-core).
+If you are using scala2, you can add the dependency yourself, For example:
+
+```scala
+libraryDependencies += "org.specs2" %% "specs2-mock" % "4.19.0"
+```
+
+However, if you want to use scala3 the best alternative at the time of this writing, is to use `mockito` directly:
+
+```scala
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+
+
+val userRepository = mock(classOf[UserRepository])
+when(userRepository.roles(any[User])).thenReturn(Set(Role("ADMIN")))
+```
+
 ## Updated libraries
 
 Besides updates to newer versions of our own libraries (play-json, play-ws, twirl, cachecontrol, etc), many other important dependencies were updated to the newest versions:

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -142,21 +142,13 @@ TBA
 
 ## Dependency graph changes
 
-The [`"com.typesafe.play" %% "play-specs2"` artifact](https://mvnrepository.com/artifact/com.typesafe.play/play-specs2) no longer includes the
-[`"org.specs2" %% "specs2-mock"` dependency](https://mvnrepository.com/artifact/org.specs2/specs2-mock) because it is not available for scala3, 
-and only includes [`"org.mockito" % "mockito-core"` dependency](https://mvnrepository.com/artifact/org.mockito/mockito-core).
-If you are using scala2, you can add the dependency yourself, For example:
-
-```scala
-libraryDependencies += "org.specs2" %% "specs2-mock" % "4.19.0"
-```
-
-However, if you want to use scala3 the best alternative at the time of this writing, is to use `mockito` directly:
+If you start to use Scala 3 in your Play application, the Play `specs2` [[dependency|ScalaTestingWithSpecs2#Using-specs2]] will no longer pull in the [`"org.specs2" %% "specs2-mock"` dependency](https://mvnrepository.com/artifact/org.specs2/specs2-mock) because it is not available for Scala 3 anymore. 
+The Play `specs2` Scala 3 artifacts depend on [`"org.mockito" % "mockito-core"`](https://mvnrepository.com/artifact/org.mockito/mockito-core) instead to use [Mockito](https://github.com/mockito/mockito) directly, which we think is the best alternative to switch your existing test code to at the time of this writing.
+You need to adjust your code, e.g. here is a snippet of how to use Mockito:
 
 ```scala
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
-
 
 val userRepository = mock(classOf[UserRepository])
 when(userRepository.roles(any[User])).thenReturn(Set(Role("ADMIN")))

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
@@ -15,12 +15,13 @@ import javaguide.testhelpers.MockJavaActionHelper
 import javaguide.ws.JavaWS.Controller3
 import javaguide.ws.JavaWS.Controller4
 
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.slf4j.Logger
-import org.specs2.mock.Mockito
 import play.api.http.Status
 import play.api.{ Application => PlayApplication }
 
-object JavaWSSpec extends Specification with Results with Status with Mockito {
+object JavaWSSpec extends Specification with Results with Status {
   // It's much easier to test this in Scala because we need to set up a
   // fake application with routes.
 
@@ -68,13 +69,13 @@ object JavaWSSpec extends Specification with Results with Status with Mockito {
 
     "call WS with a filter" in new WithServer(app = fakeApplication, port = 3333) {
       val controller = app.injector.instanceOf[Controller3]
-      val logger     = mock[Logger]
+      val logger     = mock(classOf[Logger])
       controller.setLogger(logger)
 
       val result = MockJavaActionHelper.call(controller, fakeRequest())
 
       result.status() must equalTo(OK)
-      there.was(one(logger).debug("url = http://localhost:3333/feed"))
+      verify(logger).debug("url = http://localhost:3333/feed")
     }
 
     "call WS with a timeout" in new WithServer(app = fakeApplication) {

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -5,9 +5,10 @@
 package scalaguide.logging
 
 import javax.inject.Inject
-
 import org.junit.runner.RunWith
-import org.specs2.mock.Mockito
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito
+import org.mockito.Mockito._
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -16,12 +17,11 @@ import scala.concurrent.Future
 import org.slf4j._
 import play.api._
 import play.api.mvc._
-
 import play.api.test._
 import play.api.test.Helpers._
 
 @RunWith(classOf[JUnitRunner])
-class ScalaLoggingSpec extends Specification with Mockito {
+class ScalaLoggingSpec extends Specification {
   private def riskyCalculation: Int = {
     10 / scala.util.Random.nextInt(2)
   }
@@ -30,9 +30,9 @@ class ScalaLoggingSpec extends Specification with Mockito {
     "properly log" in {
       val logger = new play.api.LoggerLike {
         // Mock underlying logger implementation
-        val logger = mock[org.slf4j.Logger].smart
-        logger.isDebugEnabled().returns(true)
-        logger.isErrorEnabled().returns(true)
+        val logger = mock(classOf[org.slf4j.Logger], RETURNS_SMART_NULLS)
+        when(logger.isDebugEnabled()).thenReturn(true)
+        when(logger.isErrorEnabled()).thenReturn(true)
       }
 
       // #logging-example

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -52,10 +52,11 @@ class ScalaLoggingSpec extends Specification {
       }
       // #logging-example
 
-      there.was(atLeastOne(logger.logger).isDebugEnabled())
-      there.was(atLeastOne(logger.logger).debug(anyString))
-      there.was(atMostOne(logger.logger).isErrorEnabled())
-      there.was(atMostOne(logger.logger).error(anyString, any[Throwable]))
+      verify(logger.logger, Mockito.atLeastOnce()).isDebugEnabled()
+      verify(logger.logger, Mockito.atLeastOnce()).debug(anyString)
+      verify(logger.logger, Mockito.atMostOnce()).isErrorEnabled()
+      verify(logger.logger, Mockito.atMostOnce()).error(anyString, any[Throwable])
+      ok
     }
   }
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -59,9 +59,7 @@ There are also [optional matchers](https://etorreborre.github.io/specs2/guide/SP
 
 Mocks are used to isolate unit tests against external dependencies.  For example, if your class depends on an external `DataService` class, you can feed appropriate data to your class without instantiating a `DataService` object.
 
-[Mockito](https://github.com/mockito/mockito) is integrated into specs2 as the default [mocking library](https://etorreborre.github.io/specs2/guide/SPECS2-3.6.6/org.specs2.guide.UseMockito.html).
-
-To use Mockito, add the following import:
+To make use of [Mockito](https://github.com/mockito/mockito), a popular mocking library, add the following import:
 
 @[import-mockito](code/specs2/UserServiceSpec.scala)
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -63,7 +63,7 @@ Mocks are used to isolate unit tests against external dependencies.  For example
 
 To use Mockito, add the following import:
 
-@[import-mockito](code/models/UserSpec.scala)
+@[import-mockito](code/specs2/UserServiceSpec.scala)
 
 You can mock out references to classes like so:
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/models/UserSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/models/UserSpec.scala
@@ -28,4 +28,3 @@ class AnotherSpec extends Specification {
     // #assertion-example
   }
 }
-

--- a/documentation/manual/working/scalaGuide/main/tests/code/models/UserSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/models/UserSpec.scala
@@ -29,6 +29,3 @@ class AnotherSpec extends Specification {
   }
 }
 
-// #import-mockito
-import org.specs2.mock._
-// #import-mockito

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleMockitoSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleMockitoSpec.scala
@@ -5,16 +5,16 @@
 package scalaguide.tests.specs2
 
 // #specs2-mockito
-import org.specs2.mock._
+import org.mockito.Mockito._
 import org.specs2.mutable._
 
 import java.util._
 
-class ExampleMockitoSpec extends Specification with Mockito {
+class ExampleMockitoSpec extends Specification {
   "MyService#isDailyData" should {
     "return true if the data is from today" in {
-      val mockDataService = mock[DataService]
-      mockDataService.findData.returns(Data(retrievalDate = new java.util.Date()))
+      val mockDataService = mock(classOf[DataService])
+      when(mockDataService.findData).thenReturn(Data(retrievalDate = new java.util.Date()))
 
       val myService = new MyService() {
         override def dataService = mockDataService

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/UserServiceSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/UserServiceSpec.scala
@@ -4,18 +4,21 @@
 
 package scalaguide.tests.specs2
 
-import org.specs2.mock._
+import org.mockito.ArgumentMatchers._
+// #import-mockito
+import org.mockito.Mockito._
+// #import-mockito
 import org.specs2.mutable._
 
 import scalaguide.tests.models._
 import scalaguide.tests.services._
 
 // #scalatest-userservicespec
-class UserServiceSpec extends Specification with Mockito {
+class UserServiceSpec extends Specification {
   "UserService#isAdmin" should {
     "be true when the role is admin" in {
-      val userRepository = mock[UserRepository]
-      userRepository.roles(any[User]).returns(Set(Role("ADMIN")))
+      val userRepository = mock(classOf[UserRepository])
+      when(userRepository.roles(any[User])).thenReturn(Set(Role("ADMIN")))
 
       val userService = new UserService(userRepository)
       val actual      = userService.isAdmin(User("11", "Steve", "user@example.org"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,11 +17,12 @@ object Dependencies {
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.5"
 
-  val specs2Version = "4.19.0"
+  val specs2Version = "4.19.2"
   val specs2Deps = Seq(
     "specs2-core",
     "specs2-junit"
   ).map("org.specs2" %% _ % specs2Version)
+  val specs2Mock = "org.specs2" %% "specs2-mock" % specs2Version // Be aware: This lib is only published for Scala 2
 
   val specsMatcherExtra = "org.specs2" %% "specs2-matcher-extra" % specs2Version
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,12 +18,9 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.5"
 
   val specs2Version = "4.19.0"
-  val specs2CoreDeps = Seq(
+  val specs2Deps = Seq(
     "specs2-core",
     "specs2-junit"
-  ).map("org.specs2" %% _ % specs2Version)
-  val specs2Deps = specs2CoreDeps ++ Seq(
-    "specs2-mock"
   ).map("org.specs2" %% _ % specs2Version)
 
   val specsMatcherExtra = "org.specs2" %% "specs2-matcher-extra" % specs2Version
@@ -190,7 +187,7 @@ object Dependencies {
   val okHttp = "com.squareup.okhttp3" % "okhttp" % "4.10.0"
 
   def routesCompilerDependencies(scalaVersion: String) = {
-    specs2CoreDeps.map(_ % Test) ++ Seq(specsMatcherExtra % Test) ++ scalaParserCombinators(
+    specs2Deps.map(_ % Test) ++ Seq(specsMatcherExtra % Test) ++ scalaParserCombinators(
       scalaVersion
     ) ++ (logback % Test :: Nil)
   }
@@ -239,11 +236,12 @@ object Dependencies {
   val streamsDependencies = Seq(
     "org.reactivestreams" % "reactive-streams" % "1.0.4",
     "com.typesafe.akka"  %% "akka-stream"      % akkaVersion,
-  ) ++ specs2CoreDeps.map(_ % Test) ++ javaTestDeps
+  ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
 
   val playServerDependencies = specs2Deps.map(_ % Test) ++ Seq(
-    guava   % Test,
-    logback % Test
+    mockitoAll % Test,
+    guava      % Test,
+    logback    % Test
   )
 
   val clusterDependencies = Seq(
@@ -268,7 +266,7 @@ object Dependencies {
     "org.seleniumhq.selenium" % "selenium-api"            % seleniumVersion,
     "org.seleniumhq.selenium" % "selenium-support"        % seleniumVersion,
     "org.seleniumhq.selenium" % "selenium-firefox-driver" % seleniumVersion
-  ) ++ guiceDeps ++ specs2Deps.map(_ % Test)
+  ) ++ guiceDeps ++ specs2Deps.map(_ % Test) :+ mockitoAll % Test
 
   val playCacheDeps = specs2Deps.map(_ % Test) :+ logback % Test
 

--- a/testkit/play-test/src/test/scala/play/api/test/InjectingSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/InjectingSpec.scala
@@ -6,23 +6,23 @@ package play.api.test
 
 import scala.language.reflectiveCalls
 
-import org.specs2.mock.Mockito
+import org.mockito.Mockito
 import org.specs2.mutable._
 import play.api.inject.Injector
 import play.api.Application
 
-class InjectingSpec extends Specification with Mockito {
+class InjectingSpec extends Specification {
   class Foo
 
   class AppContainer(val app: Application)
 
   "Injecting trait" should {
     "provide an instance when asked for a class" in {
-      val injector = mock[Injector]
-      val app      = mock[Application]
-      app.injector.returns(injector)
+      val injector = Mockito.mock(classOf[Injector])
+      val app      = Mockito.mock(classOf[Application])
+      Mockito.when(app.injector).thenReturn(injector)
       val expected = new Foo
-      injector.instanceOf[Foo].returns(expected)
+      Mockito.when(injector.instanceOf[Foo]).thenReturn(expected)
 
       val appContainer = new AppContainer(app) with Injecting
       val actual: Foo  = appContainer.inject[Foo]

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -16,9 +16,9 @@ import akka.stream.scaladsl.Source
 import akka.stream.Materializer
 import akka.util.ByteString
 import akka.util.Timeout
+import org.mockito.Mockito
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.oauth.ConsumerKey
@@ -41,7 +41,6 @@ import play.shaded.ahc.org.asynchttpclient.Realm.AuthScheme
 
 class AhcWSSpec(implicit ee: ExecutionEnv)
     extends Specification
-    with Mockito
     with FutureMatchers
     with FutureAwaits
     with DefaultAwaitTimeout {
@@ -73,7 +72,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
   }
 
   def makeAhcRequest(url: String): AhcWSRequest = {
-    implicit val materializer = mock[Materializer]
+    implicit val materializer = Mockito.mock(classOf[Materializer])
 
     val client     = StandaloneAhcWSClient(AhcWSClientConfig())
     val standalone = StandaloneAhcWSRequest(client, url)
@@ -459,12 +458,12 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
 
   "Ahc WS Response" should {
     "get cookies from an AHC response" in {
-      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcResponse: AHCResponse = Mockito.mock(classOf[AHCResponse])
       val (name, value, wrap, domain, path, maxAge, secure, httpOnly) =
         ("someName", "someValue", true, "example.com", "/", 1000L, false, false)
 
       val ahcCookie = createCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
-      ahcResponse.getCookies.returns(util.Arrays.asList(ahcCookie))
+      Mockito.when(ahcResponse.getCookies).thenReturn(util.Arrays.asList(ahcCookie))
 
       val response = makeAhcResponse(ahcResponse)
 
@@ -480,12 +479,12 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
     }
 
     "get a single cookie from an AHC response" in {
-      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcResponse: AHCResponse = Mockito.mock(classOf[AHCResponse])
       val (name, value, wrap, domain, path, maxAge, secure, httpOnly) =
         ("someName", "someValue", true, "example.com", "/", 1000L, false, false)
 
       val ahcCookie = createCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
-      ahcResponse.getCookies.returns(util.Arrays.asList(ahcCookie))
+      Mockito.when(ahcResponse.getCookies).thenReturn(util.Arrays.asList(ahcCookie))
 
       val response = makeAhcResponse(ahcResponse)
 
@@ -501,10 +500,10 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
     }
 
     "return -1 values of expires and maxAge as None" in {
-      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcResponse: AHCResponse = Mockito.mock(classOf[AHCResponse])
 
       val ahcCookie = createCookie("someName", "value", true, "domain", "path", -1L, false, false)
-      ahcResponse.getCookies.returns(util.Arrays.asList(ahcCookie))
+      Mockito.when(ahcResponse.getCookies).thenReturn(util.Arrays.asList(ahcCookie))
 
       val response = makeAhcResponse(ahcResponse)
 
@@ -513,20 +512,20 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
     }
 
     "get the body as bytes from the AHC response" in {
-      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcResponse: AHCResponse = Mockito.mock(classOf[AHCResponse])
       val bytes                    = ByteString(-87, -72, 96, -63, -32, 46, -117, -40, -128, -7, 61, 109, 80, 45, 44, 30)
-      ahcResponse.getResponseBodyAsBytes.returns(bytes.toArray)
+      Mockito.when(ahcResponse.getResponseBodyAsBytes).thenReturn(bytes.toArray)
       val response = makeAhcResponse(ahcResponse)
       response.bodyAsBytes must_== bytes
     }
 
     "get headers from an AHC response in a case insensitive map" in {
-      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcResponse: AHCResponse = Mockito.mock(classOf[AHCResponse])
       val ahcHeaders               = new DefaultHttpHeaders(true)
       ahcHeaders.add("Foo", "bar")
       ahcHeaders.add("Foo", "baz")
       ahcHeaders.add("Bar", "baz")
-      ahcResponse.getHeaders.returns(ahcHeaders)
+      Mockito.when(ahcResponse.getHeaders).thenReturn(ahcHeaders)
       val response = makeAhcResponse(ahcResponse)
       val headers  = response.headers
       headers must beEqualTo(Map("Foo" -> Seq("bar", "baz"), "Bar" -> Seq("baz")))

--- a/transport/server/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
@@ -9,8 +9,8 @@ import java.util.Properties
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngine
 
+import org.mockito.Mockito
 import org.specs2.matcher.MustThrownExpectations
-import org.specs2.mock.Mockito
 import org.specs2.mutable.After
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
@@ -20,33 +20,31 @@ import play.server.api.SSLEngineProvider
 
 class WrongSSLEngineProvider {}
 
-class RightSSLEngineProvider(appPro: ApplicationProvider) extends SSLEngineProvider with Mockito {
+class RightSSLEngineProvider(appPro: ApplicationProvider) extends SSLEngineProvider {
   override def createSSLEngine: SSLEngine = {
     require(appPro != null)
-    mock[SSLEngine]
+    Mockito.mock(classOf[SSLEngine])
   }
 
   override def sslContext(): SSLContext = {
     require(appPro != null)
-    mock[SSLContext]
+    Mockito.mock(classOf[SSLContext])
   }
 }
 
-class JavaSSLEngineProvider(appPro: play.server.ApplicationProvider)
-    extends play.server.SSLEngineProvider
-    with Mockito {
+class JavaSSLEngineProvider(appPro: play.server.ApplicationProvider) extends play.server.SSLEngineProvider {
   override def createSSLEngine: SSLEngine = {
     require(appPro != null)
-    mock[SSLEngine]
+    Mockito.mock(classOf[SSLEngine])
   }
 
   override def sslContext(): SSLContext = {
     require(appPro != null)
-    mock[SSLContext]
+    Mockito.mock(classOf[SSLContext])
   }
 }
 
-class ServerSSLEngineSpec extends Specification with Mockito {
+class ServerSSLEngineSpec extends Specification {
   sequential
 
   trait ApplicationContext extends Mockito with Scope with MustThrownExpectations {}
@@ -71,12 +69,12 @@ class ServerSSLEngineSpec extends Specification with Mockito {
   }
 
   def createEngine(engineProvider: Option[String], tempDir: Option[File] = None): SSLEngine = {
-    val app = mock[play.api.Application]
-    app.classloader.returns(this.getClass.getClassLoader)
-    app.asJava.returns(mock[play.Application])
+    val app = Mockito.mock(classOf[play.api.Application])
+    Mockito.when(app.classloader).thenReturn(this.getClass.getClassLoader)
+    Mockito.when(app.asJava).thenReturn(Mockito.mock(classOf[play.Application]))
 
-    val appProvider = mock[ApplicationProvider]
-    appProvider.get.returns(scala.util.Success(app)) // Failure(new Exception("no app"))
+    val appProvider = Mockito.mock(classOf[ApplicationProvider])
+    Mockito.when(appProvider.get).thenReturn(scala.util.Success(app)) // Failure(new Exception("no app"))
     ServerSSLEngine
       .createSSLEngineProvider(serverConfig(tempDir.getOrElse(new File(".")), engineProvider), appProvider)
       .createSSLEngine()

--- a/web/play-openid/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
@@ -11,13 +11,15 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import org.specs2.mock._
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.when
 import org.specs2.mutable.Specification
 import play.api.http.HeaderNames
 import play.api.http.Status._
 import play.api.libs.ws._
 
-class DiscoveryClientSpec extends Specification with Mockito {
+class DiscoveryClientSpec extends Specification {
   val dur = Duration(10, TimeUnit.SECONDS)
 
   private def normalize(s: String) = {
@@ -92,34 +94,34 @@ class DiscoveryClientSpec extends Specification with Mockito {
     import Discovery._
 
     "parse a Google account response" in {
-      val response = mock[WSResponse]
-      response.header(HeaderNames.CONTENT_TYPE).returns(Some("application/xrds+xml"))
-      response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/google-account-response.xml")))
+      val response = mock(classOf[WSResponse])
+      when(response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("application/xrds+xml"))
+      when(response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/google-account-response.xml")))
       val maybeOpenIdServer = new XrdsResolver().resolve(response)
       maybeOpenIdServer.map(_.url) must beSome("https://www.google.com/accounts/o8/ud")
     }
 
     "parse an XRDS response with a single Service element" in {
-      val response = mock[WSResponse]
-      response.header(HeaderNames.CONTENT_TYPE).returns(Some("application/xrds+xml"))
-      response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml")))
+      val response = mock(classOf[WSResponse])
+      when(response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("application/xrds+xml"))
+      when(response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml")))
       val maybeOpenIdServer = new XrdsResolver().resolve(response)
       maybeOpenIdServer.map(_.url) must beSome("https://www.google.com/a/example.com/o8/ud?be=o8")
     }
 
     "parse an XRDS response with multiple Service elements" in {
-      val response = mock[WSResponse]
-      response.header(HeaderNames.CONTENT_TYPE).returns(Some("application/xrds+xml"))
-      response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/multi-service.xml")))
+      val response = mock(classOf[WSResponse])
+      when(response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("application/xrds+xml"))
+      when(response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/multi-service.xml")))
       val maybeOpenIdServer = new XrdsResolver().resolve(response)
       maybeOpenIdServer.map(_.url) must beSome("http://www.myopenid.com/server")
     }
 
     // See 7.3.2.2.  Extracting Authentication Data
     "return the OP Identifier over the Claimed Identifier if both are present" in {
-      val response = mock[WSResponse]
-      response.header(HeaderNames.CONTENT_TYPE).returns(Some("application/xrds+xml"))
-      response.xml.returns(
+      val response = mock(classOf[WSResponse])
+      when(response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("application/xrds+xml"))
+      when(response.xml).thenReturn(
         scala.xml.XML.loadString(readFixture("discovery/xrds/multi-service-with-op-and-claimed-id-service.xml"))
       )
       val maybeOpenIdServer = new XrdsResolver().resolve(response)
@@ -127,17 +129,17 @@ class DiscoveryClientSpec extends Specification with Mockito {
     }
 
     "extract and use OpenID Authentication 1.0 service elements from XRDS documents, if Yadis succeeds on an URL Identifier." in {
-      val response = mock[WSResponse]
-      response.header(HeaderNames.CONTENT_TYPE).returns(Some("application/xrds+xml"))
-      response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-openid-1-op.xml")))
+      val response = mock(classOf[WSResponse])
+      when(response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("application/xrds+xml"))
+      when(response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-openid-1-op.xml")))
       val maybeOpenIdServer = new XrdsResolver().resolve(response)
       maybeOpenIdServer.map(_.url) must beSome("http://openidprovider-server-1.example.com")
     }
 
     "extract and use OpenID Authentication 1.1 service elements from XRDS documents, if Yadis succeeds on an URL Identifier." in {
-      val response = mock[WSResponse]
-      response.header(HeaderNames.CONTENT_TYPE).returns(Some("application/xrds+xml"))
-      response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-openid-1.1-op.xml")))
+      val response = mock(classOf[WSResponse])
+      when(response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("application/xrds+xml"))
+      when(response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-openid-1.1-op.xml")))
       val maybeOpenIdServer = new XrdsResolver().resolve(response)
       maybeOpenIdServer.map(_.url) must beSome("http://openidprovider-server-1.1.example.com")
     }
@@ -147,14 +149,14 @@ class DiscoveryClientSpec extends Specification with Mockito {
     "resolve an OpenID server via Yadis" in {
       "with a single service element" in {
         val ws = new WSMock
-        ws.response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml")))
-        ws.response.header(HeaderNames.CONTENT_TYPE).returns(Some("application/xrds+xml"))
+        when(ws.response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml")))
+        when(ws.response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("application/xrds+xml"))
 
         val returnTo    = "http://foo.bar.com/openid"
         val openId      = "http://abc.example.com/foo"
         val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
-        there.was(one(ws.request).get())
+        verify(ws.request).get()
 
         (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.google.com/a/example.com/o8/ud")
 
@@ -163,15 +165,16 @@ class DiscoveryClientSpec extends Specification with Mockito {
 
       "should redirect to identifier selection" in {
         val ws = new WSMock
-        ws.response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op-non-unique.xml")))
-        ws.response.header(HeaderNames.CONTENT_TYPE).returns(Some("application/xrds+xml"))
+        when(ws.response.xml)
+          .thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op-non-unique.xml")))
+        when(ws.response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("application/xrds+xml"))
 
         val returnTo            = "http://foo.bar.com/openid"
         val openId              = "http://abc.example.com/foo"
         val identifierSelection = "http://specs.openid.net/auth/2.0/identifier_select"
         val redirectUrl         = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
-        there.was(one(ws.request).get())
+        verify(ws.request).get()
 
         (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.google.com/a/example.com/o8/ud")
 
@@ -180,19 +183,19 @@ class DiscoveryClientSpec extends Specification with Mockito {
 
       "should fall back to HTML based discovery if OP Identifier cannot be found in the XRDS" in {
         val ws = new WSMock
-        ws.response.status.returns(OK).thenReturns(OK)
-        ws.response.body.returns(readFixture("discovery/html/openIDProvider.html"))
-        ws.response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/invalid-op-identifier.xml")))
-        ws.response
-          .header(HeaderNames.CONTENT_TYPE)
-          .returns(Some("text/html"))
-          .thenReturns(Some("application/xrds+xml"))
+        when(ws.response.status).thenReturn(OK).thenReturn(OK)
+        when(ws.response.body).thenReturn(readFixture("discovery/html/openIDProvider.html"))
+        when(ws.response.xml)
+          .thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/invalid-op-identifier.xml")))
+        when(ws.response.header(HeaderNames.CONTENT_TYPE))
+          .thenReturn(Some("text/html"))
+          .thenReturn(Some("application/xrds+xml"))
 
         val returnTo    = "http://foo.bar.com/openid"
         val openId      = "http://abc.example.com/foo"
         val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
-        there.was(one(ws.request).get())
+        verify(ws.request).get()
 
         (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server")
 
@@ -202,19 +205,19 @@ class DiscoveryClientSpec extends Specification with Mockito {
       // OpenID 1.1 compatibility - http://openid.net/specs/openid-authentication-2_0.html#anchor38
       "should fall back to HTML based discovery (with an OpenID 1.1 document) if OP Identifier cannot be found in the XRDS" in {
         val ws = new WSMock
-        ws.response.status.returns(OK).thenReturns(OK)
-        ws.response.body.returns(readFixture("discovery/html/openIDProvider-OpenID-1.1.html"))
-        ws.response.xml.returns(scala.xml.XML.loadString(readFixture("discovery/xrds/invalid-op-identifier.xml")))
-        ws.response
-          .header(HeaderNames.CONTENT_TYPE)
-          .returns(Some("text/html"))
-          .thenReturns(Some("application/xrds+xml"))
+        when(ws.response.status).thenReturn(OK).thenReturn(OK)
+        when(ws.response.body).thenReturn(readFixture("discovery/html/openIDProvider-OpenID-1.1.html"))
+        when(ws.response.xml)
+          .thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/invalid-op-identifier.xml")))
+        when(ws.response.header(HeaderNames.CONTENT_TYPE))
+          .thenReturn(Some("text/html"))
+          .thenReturn(Some("application/xrds+xml"))
 
         val returnTo    = "http://foo.bar.com/openid"
         val openId      = "http://abc.example.com/foo"
         val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
-        there.was(one(ws.request).get())
+        verify(ws.request).get()
 
         (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server-1")
 
@@ -225,13 +228,13 @@ class DiscoveryClientSpec extends Specification with Mockito {
     "resolve an OpenID server via HTML" in {
       "when given a response that includes openid meta information" in {
         val ws = new WSMock
-        ws.response.body.returns(readFixture("discovery/html/openIDProvider.html"))
+        when(ws.response.body).thenReturn(readFixture("discovery/html/openIDProvider.html"))
 
         val returnTo    = "http://foo.bar.com/openid"
         val openId      = "http://abc.example.com/foo"
         val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
-        there.was(one(ws.request).get())
+        verify(ws.request).get()
 
         (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server")
 
@@ -240,13 +243,13 @@ class DiscoveryClientSpec extends Specification with Mockito {
 
       "when given a response that includes a local identifier (using openid2.local_id openid.delegate)" in {
         val ws = new WSMock
-        ws.response.body.returns(readFixture("discovery/html/opLocalIdentityPage.html"))
+        when(ws.response.body).thenReturn(readFixture("discovery/html/opLocalIdentityPage.html"))
 
         val returnTo = "http://foo.bar.com/openid"
         val redirectUrl =
           Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL("http://example.com/", returnTo), dur)
 
-        there.was(one(ws.request).get())
+        verify(ws.request).get()
 
         (new URL(redirectUrl).hostAndPath must be).equalTo("http://www.example.com:8080/openidserver/openid.server")
 
@@ -269,10 +272,10 @@ class DiscoveryClientSpec extends Specification with Mockito {
       realm: Option[String] = None
   ) = {
     "valid request parameters need to be present" in {
-      params.get("openid.ns") must beSome(Seq("http://specs.openid.net/auth/2.0"))
-      params.get("openid.mode") must beSome(Seq("checkid_setup"))
-      params.get("openid.claimed_id") must beSome(Seq(claimedId))
-      params.get("openid.return_to") must beSome(Seq(returnTo))
+      params.get("openid.ns") must beSome(===(Seq("http://specs.openid.net/auth/2.0")))
+      params.get("openid.mode") must beSome(===(Seq("checkid_setup")))
+      params.get("openid.claimed_id") must beSome(===(Seq(claimedId)))
+      params.get("openid.return_to") must beSome(===(Seq(returnTo)))
     }
 
     "realm must be handled correctly (absent if not defined)" in {
@@ -282,7 +285,7 @@ class DiscoveryClientSpec extends Specification with Mockito {
     "OP-Local Identifiers must be handled correctly (if a different OP-Local Identifier is not specified, the claimed identifier MUST be used as the value for openid.identity." in {
       val value = params.get("openid.identity")
       opLocalIdentifier match {
-        case Some(id) => value must beSome(Seq(id))
+        case Some(id) => value must beSome(===(Seq(id)))
         case _        => (value must be).equalTo(params.get("openid.claimed_id"))
       }
     }
@@ -294,7 +297,7 @@ class DiscoveryClientSpec extends Specification with Mockito {
 
   // Define matchers based on the expected value. Param must be absent if the expected value is None, it must match otherwise
   private def verifyOptionalParam(params: Params, key: String, expected: Option[String] = None) = expected match {
-    case Some(value) => params.get(key) must beSome(Seq(value))
+    case Some(value) => params.get(key) must beSome(===(Seq(value)))
     case _           => params.get(key) must beNone
   }
 }

--- a/web/play-openid/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
@@ -270,10 +270,10 @@ class DiscoveryClientSpec extends Specification {
       realm: Option[String] = None
   ) = {
     "valid request parameters need to be present" in {
-      params.get("openid.ns") must beSome(===(Seq("http://specs.openid.net/auth/2.0")))
-      params.get("openid.mode") must beSome(===(Seq("checkid_setup")))
-      params.get("openid.claimed_id") must beSome(===(Seq(claimedId)))
-      params.get("openid.return_to") must beSome(===(Seq(returnTo)))
+      params.get("openid.ns") must beSome(Seq("http://specs.openid.net/auth/2.0"))
+      params.get("openid.mode") must beSome(Seq("checkid_setup"))
+      params.get("openid.claimed_id") must beSome(Seq(claimedId))
+      params.get("openid.return_to") must beSome(Seq(returnTo))
     }
 
     "realm must be handled correctly (absent if not defined)" in {
@@ -283,7 +283,7 @@ class DiscoveryClientSpec extends Specification {
     "OP-Local Identifiers must be handled correctly (if a different OP-Local Identifier is not specified, the claimed identifier MUST be used as the value for openid.identity." in {
       val value = params.get("openid.identity")
       opLocalIdentifier match {
-        case Some(id) => value must beSome(===(Seq(id)))
+        case Some(id) => value must beSome(Seq(id))
         case _        => (value must be).equalTo(params.get("openid.claimed_id"))
       }
     }
@@ -295,7 +295,7 @@ class DiscoveryClientSpec extends Specification {
 
   // Define matchers based on the expected value. Param must be absent if the expected value is None, it must match otherwise
   private def verifyOptionalParam(params: Params, key: String, expected: Option[String] = None) = expected match {
-    case Some(value) => params.get(key) must beSome(===(Seq(value)))
+    case Some(value) => params.get(key) must beSome(Seq(value))
     case _           => params.get(key) must beNone
   }
 }

--- a/web/play-openid/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
@@ -25,15 +25,15 @@ import play.api.libs.ws.BodyWritable
 import play.api.mvc.Request
 
 class OpenIDSpec extends Specification {
-  val claimedId     = "http://example.com/openid?id=C123"
-  val identity      = "http://example.com/openid?id=C123&id"
-  val defaultSigned = "op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle"
-  val dur           = Duration(10, TimeUnit.SECONDS)
+  private val claimedId     = "http://example.com/openid?id=C123"
+  private val identity      = "http://example.com/openid?id=C123&id"
+  private val defaultSigned = "op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle"
+  private val dur           = Duration(10, TimeUnit.SECONDS)
 
   // 9.1 Request parameters - http://openid.net/specs/openid-authentication-2_0.html#anchor27
-  def isValidOpenIDRequest(query: Params) = {
-    query.get("openid.mode") must beSome(===(Seq("checkid_setup")))
-    query.get("openid.ns") must beSome(===(Seq("http://specs.openid.net/auth/2.0")))
+  private def isValidOpenIDRequest(query: Params) = {
+    query.get("openid.mode") must beSome(Seq("checkid_setup"))
+    query.get("openid.ns") must beSome(Seq("http://specs.openid.net/auth/2.0"))
   }
 
   "OpenID" should {
@@ -56,7 +56,7 @@ class OpenIDSpec extends Specification {
       isValidOpenIDRequest(query)
 
       redirectUrl.endsWith("foo%24bar%3Dba%24z") must beTrue
-      query.get("openid.return_to") must beSome(===(Seq("http://foo.bar.com/returnto?foo$bar=ba$z")))
+      query.get("openid.return_to") must beSome(Seq("http://foo.bar.com/returnto?foo$bar=ba$z"))
       query.get("openid.realm") must beNone
     }
 
@@ -76,10 +76,10 @@ class OpenIDSpec extends Specification {
 
       isValidOpenIDRequest(query)
 
-      query.get("openid.ax.mode") must beSome(===(Seq("fetch_request")))
-      query.get("openid.ns.ax") must beSome(===(Seq("http://openid.net/srv/ax/1.0")))
-      query.get("openid.ax.required") must beSome(===(Seq("email")))
-      query.get("openid.ax.type.email") must beSome(===(Seq("http://schema.openid.net/contact/email")))
+      query.get("openid.ax.mode") must beSome(Seq("fetch_request"))
+      query.get("openid.ns.ax") must beSome(Seq("http://openid.net/srv/ax/1.0"))
+      query.get("openid.ax.required") must beSome(Seq("email"))
+      query.get("openid.ax.type.email") must beSome(Seq("http://schema.openid.net/contact/email"))
     }
 
     "generate a valid redirectUrl with a proper 'if_available' extended attributes request" in {
@@ -98,10 +98,10 @@ class OpenIDSpec extends Specification {
 
       isValidOpenIDRequest(query)
 
-      query.get("openid.ax.mode") must beSome(===(Seq("fetch_request")))
-      query.get("openid.ns.ax") must beSome(===(Seq("http://openid.net/srv/ax/1.0")))
-      query.get("openid.ax.if_available") must beSome(===(Seq("email")))
-      query.get("openid.ax.type.email") must beSome(===(Seq("http://schema.openid.net/contact/email")))
+      query.get("openid.ax.mode") must beSome(Seq("fetch_request"))
+      query.get("openid.ns.ax") must beSome(Seq("http://openid.net/srv/ax/1.0"))
+      query.get("openid.ax.if_available") must beSome(Seq("email"))
+      query.get("openid.ax.type.email") must beSome(Seq("http://schema.openid.net/contact/email"))
     }
 
     "generate a valid redirectUrl with a proper 'if_available' AND required extended attributes request" in {
@@ -121,12 +121,12 @@ class OpenIDSpec extends Specification {
 
       isValidOpenIDRequest(query)
 
-      query.get("openid.ax.mode") must beSome(===(Seq("fetch_request")))
-      query.get("openid.ns.ax") must beSome(===(Seq("http://openid.net/srv/ax/1.0")))
-      query.get("openid.ax.required") must beSome(===(Seq("first")))
-      query.get("openid.ax.type.first") must beSome(===(Seq("http://axschema.org/namePerson/first")))
-      query.get("openid.ax.if_available") must beSome(===(Seq("email")))
-      query.get("openid.ax.type.email") must beSome(===(Seq("http://schema.openid.net/contact/email")))
+      query.get("openid.ax.mode") must beSome(Seq("fetch_request"))
+      query.get("openid.ns.ax") must beSome(Seq("http://openid.net/srv/ax/1.0"))
+      query.get("openid.ax.required") must beSome(Seq("first"))
+      query.get("openid.ax.type.first") must beSome(Seq("http://axschema.org/namePerson/first"))
+      query.get("openid.ax.if_available") must beSome(Seq("email"))
+      query.get("openid.ax.type.email") must beSome(Seq("http://schema.openid.net/contact/email"))
     }
 
     "verify the response" in {
@@ -148,7 +148,7 @@ class OpenIDSpec extends Specification {
         val verificationQuery = argument.getValue
 
         "openid.mode was set to check_authentication" in {
-          verificationQuery.get("openid.mode") must beSome(===(Seq("check_authentication")))
+          verificationQuery.get("openid.mode") must beSome(Seq("check_authentication"))
         }
 
         "every query parameter apart from openid.mode is used in the verification request" in {
@@ -248,7 +248,7 @@ class OpenIDSpec extends Specification {
     }
   }
 
-  def createMockWithValidOpDiscoveryAndVerification = {
+  private def createMockWithValidOpDiscoveryAndVerification = {
     val ws = new WSMock
     when(ws.response.status).thenReturn(OK).thenReturn(OK)
     when(ws.response.header(HeaderNames.CONTENT_TYPE))
@@ -260,11 +260,11 @@ class OpenIDSpec extends Specification {
     ws
   }
 
-  def setupMockRequest(queryString: Params = openIdResponse) = {
+  private def setupMockRequest(queryString: Params = openIdResponse) = {
     val request = mock(classOf[Request[_]])
     when(request.queryString).thenReturn(queryString)
     request
   }
 
-  def openIdResponse = createDefaultResponse(claimedId, identity, defaultSigned)
+  private def openIdResponse = createDefaultResponse(claimedId, identity, defaultSigned)
 }

--- a/web/play-openid/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.Predef._
+import scala.xml.XML.{ loadString => xmlLoadString }
 
 import org.mockito._
 import org.mockito.ArgumentMatchers.any
@@ -197,7 +197,7 @@ class OpenIDSpec extends Specification {
       when(ws.response.header(HeaderNames.CONTENT_TYPE))
         .thenReturn(Some("application/xrds+xml"))
         .thenReturn(Some("text/plain"))
-      when(ws.response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml")))
+      when(ws.response.xml).thenReturn(xmlLoadString(readFixture("discovery/xrds/simple-op.xml")))
       when(ws.response.body).thenReturn("is_valid:false\n")
 
       val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
@@ -215,7 +215,7 @@ class OpenIDSpec extends Specification {
       when(ws.response.header(HeaderNames.CONTENT_TYPE))
         .thenReturn(Some("application/xrds+xml"))
         .thenReturn(Some("text/plain"))
-      when(ws.response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml")))
+      when(ws.response.xml).thenReturn(xmlLoadString(readFixture("discovery/xrds/simple-op.xml")))
       when(ws.response.body).thenReturn("is_valid:false\n")
 
       val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
@@ -254,7 +254,7 @@ class OpenIDSpec extends Specification {
     when(ws.response.header(HeaderNames.CONTENT_TYPE))
       .thenReturn(Some("application/xrds+xml"))
       .thenReturn(Some("text/plain"))
-    when(ws.response.xml).thenReturn(scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml")))
+    when(ws.response.xml).thenReturn(xmlLoadString(readFixture("discovery/xrds/simple-op.xml")))
     when(ws.response.body)
       .thenReturn("is_valid:true\n") // http://openid.net/specs/openid-authentication-2_0.html#kvform
     ws

--- a/web/play-openid/src/test/scala/play/api/libs/openid/WsMock.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/WsMock.scala
@@ -6,26 +6,29 @@ package play.api.libs.openid
 
 import scala.concurrent.Future
 
-import org.specs2.mock.Mockito
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.when
 import play.api.http.HeaderNames
 import play.api.http.Status._
 import play.api.libs.ws._
 
-class WSMock extends Mockito with WSClient {
-  val request  = mock[WSRequest]
-  val response = mock[WSResponse]
+class WSMock extends WSClient {
+  val request  = mock(classOf[WSRequest])
+  val response = mock(classOf[WSResponse])
 
   val urls: collection.mutable.Buffer[String] = new collection.mutable.ArrayBuffer[String]()
 
-  response.status.returns(OK)
-  response.header(HeaderNames.CONTENT_TYPE).returns(Some("text/html;charset=UTF-8"))
-  response.body.returns("")
+  when(response.status).thenReturn(OK)
+  when(response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("text/html;charset=UTF-8"))
+  when(response.body).thenReturn("")
 
-  request.get().returns(Future.successful(response.asInstanceOf[request.Response]))
-  request.post(anyString)(any[BodyWritable[String]]).returns(Future.successful(response.asInstanceOf[request.Response]))
-  request
-    .post(any[Map[String, Seq[String]]])(any[BodyWritable[Map[String, Seq[String]]]])
-    .returns(Future.successful(response.asInstanceOf[request.Response]))
+  when(request.get()).thenReturn(Future.successful(response.asInstanceOf[request.Response]))
+  when(request.post(anyString)(any[BodyWritable[String]]))
+    .thenReturn(Future.successful(response.asInstanceOf[request.Response]))
+  when(request.post(any[Map[String, Seq[String]]])(any[BodyWritable[Map[String, Seq[String]]]]))
+    .thenReturn(Future.successful(response.asInstanceOf[request.Response]))
 
   def url(url: String): WSRequest = {
     urls += url


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Replace specs2-mockito with vanilla mockito in preparation for scala 3. 

## Background Context

author of specs2 [recommends switching to ScalaMock](https://github.com/etorreborre/specs2/issues/1079#issuecomment-1092863601), but that doesn't have Scala 3 artifacts yet as well: https://github.com/paulbutcher/ScalaMock/issues/429

## References

https://github.com/playframework/playframework/pull/11266
https://github.com/playframework/playframework/pull/11550
