### PR TITLE
Rename methods back to their original names after deprecations in 2.8.0

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/JavaRequestsSpec.scala
@@ -29,8 +29,8 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
       val request                   = FakeRequest().withHeaders("Content-type" -> "application/json")
       val javaRequest: Http.Request = new RequestImpl(request.withBody(null))
 
-      val ct: String = javaRequest.getHeaders.get("Content-Type").get()
-      val headers    = javaRequest.getHeaders
+      val ct: String = javaRequest.headers.get("Content-Type").get()
+      val headers    = javaRequest.headers
       ct must beEqualTo("application/json")
 
       headers.getAll("content-type").asScala must_== List(ct)

--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -234,7 +234,7 @@ public class RequestBuilderTest {
     RequestBuilder builder = new RequestBuilder().uri("http://www.playframework.com/");
 
     Request request = builder.build();
-    assertFalse(request.getCookie(Helpers.stubMessagesApi().langCookieName()).isPresent());
+    assertFalse(request.cookie(Helpers.stubMessagesApi().langCookieName()).isPresent());
     assertFalse(request.transientLang().isPresent());
     assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
   }
@@ -248,7 +248,7 @@ public class RequestBuilderTest {
 
     assertEquals(
         Optional.of(lang.code()),
-        request.getCookie(Helpers.stubMessagesApi().langCookieName()).map(Http.Cookie::value));
+        request.cookie(Helpers.stubMessagesApi().langCookieName()).map(Http.Cookie::value));
     assertFalse(request.transientLang().isPresent());
     assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
   }
@@ -262,7 +262,7 @@ public class RequestBuilderTest {
 
     assertEquals(
         Optional.of(locale.toLanguageTag()),
-        request.getCookie(Helpers.stubMessagesApi().langCookieName()).map(Http.Cookie::value));
+        request.cookie(Helpers.stubMessagesApi().langCookieName()).map(Http.Cookie::value));
     assertFalse(request.transientLang().isPresent());
     assertFalse(request.attrs().getOptional(Messages.Attrs.CurrentLang).isPresent());
   }

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -397,8 +397,16 @@ public class Http {
      * Retrieve all headers.
      *
      * @return the request headers for this request.
+     * @deprecated Deprecated as of 2.9.0. Renamed to {@link #headers()}.
      */
     Headers getHeaders();
+
+    /**
+     * Retrieve all headers.
+     *
+     * @return the request headers for this request.
+     */
+    Headers headers();
 
     /**
      * Retrieves a single header.

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -364,15 +364,15 @@ public class Http {
     /**
      * @param name Name of the cookie to retrieve
      * @return the cookie, if found, otherwise null
-     * @deprecated Deprecated as of 2.8.0. Use {@link #getCookie(String)} instead.
      */
-    @Deprecated
-    Cookie cookie(String name);
+    Optional<Cookie> cookie(String name);
 
     /**
      * @param name Name of the cookie to retrieve
      * @return the cookie, if found
+     * @deprecated Deprecated as of 2.9.0. Use {@link #cookie(String)} instead.
      */
+    @Deprecated
     Optional<Cookie> getCookie(String name);
 
     /**

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -1147,8 +1147,16 @@ public class Http {
       return this;
     }
 
-    /** @return the headers for this request builder */
+    /**
+     * @return the headers for this request builder
+     * @deprecated Deprecated as of 2.9.0. Renamed to {@link #headers()}.
+     */
     public Headers getHeaders() {
+      return headers();
+    }
+
+    /** @return the headers for this request builder */
+    public Headers headers() {
       return req.headers().asJava();
     }
 

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -415,7 +415,7 @@ public class Http {
      * @return the value corresponding to <code>headerName</code>, or empty if it was not present
      */
     default Optional<String> header(String headerName) {
-      return getHeaders().get(headerName);
+      return headers().get(headerName);
     }
 
     /**
@@ -425,7 +425,7 @@ public class Http {
      * @return <code>true</code> if the request did contain the header.
      */
     default boolean hasHeader(String headerName) {
-      return getHeaders().contains(headerName);
+      return headers().contains(headerName);
     }
 
     /** @return true if request has a body, false otherwise. */
@@ -646,11 +646,9 @@ public class Http {
       if (body == null || body.as(Object.class) == null) {
         // assume null signifies no body; RequestBody is a wrapper for the actual body content
         headers(
-            getHeaders()
-                .removing(HeaderNames.CONTENT_LENGTH)
-                .removing(HeaderNames.TRANSFER_ENCODING));
+            headers().removing(HeaderNames.CONTENT_LENGTH).removing(HeaderNames.TRANSFER_ENCODING));
       } else {
-        if (!getHeaders().get(HeaderNames.TRANSFER_ENCODING).isPresent()) {
+        if (!headers().get(HeaderNames.TRANSFER_ENCODING).isPresent()) {
           final MultipartFormData<?> multipartFormData = body.asMultipartFormData();
           if (multipartFormData != null) {
             header(
@@ -669,7 +667,7 @@ public class Http {
     private long calcMultipartFormDataBodyLength(final MultipartFormData<?> multipartFormData) {
       final String boundaryToContentTypeStart = MultipartFormatter.boundaryToContentType("");
       final String boundary =
-          getHeaders()
+          headers()
               .get(HeaderNames.CONTENT_TYPE)
               .filter(ct -> ct.startsWith(boundaryToContentTypeStart))
               .map(ct -> "\r\n--" + ct.substring(boundaryToContentTypeStart.length()))
@@ -1089,7 +1087,7 @@ public class Http {
 
     /** @return the host name from the header */
     public String host() {
-      return getHeaders().get(HeaderNames.HOST).orElse(null);
+      return headers().get(HeaderNames.HOST).orElse(null);
     }
 
     /**
@@ -1177,7 +1175,7 @@ public class Http {
      * @return the builder instance
      */
     public RequestBuilder header(String key, List<String> values) {
-      return this.headers(getHeaders().adding(key, values));
+      return this.headers(headers().adding(key, values));
     }
 
     /**
@@ -1186,7 +1184,7 @@ public class Http {
      * @return the builder instance
      */
     public RequestBuilder header(String key, String value) {
-      return this.headers(getHeaders().adding(key, value));
+      return this.headers(headers().adding(key, value));
     }
 
     /** @return the cookies in Java instances */

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -236,9 +236,9 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def queryString(key: String): Optional[String] = header.getQueryString(key).toJava
 
-  @deprecated override def cookie(name: String): JCookie = cookies().get(name).orElse(null)
+  override def cookie(name: String): Optional[JCookie] = cookies().get(name)
 
-  override def getCookie(name: String): Optional[JCookie] = cookies().get(name)
+  @deprecated override def getCookie(name: String): Optional[JCookie] = cookie(name)
 
   override def hasBody: Boolean = header.hasBody
 

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -258,9 +258,9 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def toString: String = header.toString
 
   @deprecated
-  override lazy val getHeaders: Http.Headers = header.headers.asJava
+  override lazy val getHeaders: Http.Headers = headers
 
-  override lazy val headers: Http.Headers = getHeaders
+  override lazy val headers: Http.Headers = header.headers.asJava
 }
 
 /**

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -257,7 +257,10 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def toString: String = header.toString
 
+  @deprecated
   override lazy val getHeaders: Http.Headers = header.headers.asJava
+
+  override lazy val headers: Http.Headers = getHeaders
 }
 
 /**

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -23,11 +23,11 @@ class RequestHeaderSpec extends Specification {
     "convert to java" in {
       "keep all the headers" in {
         val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
-        rh.asJava.getHeaders.contains(HOST) must beTrue
+        rh.asJava.headers.contains(HOST) must beTrue
       }
       "keep the headers accessible case insensitively" in {
         val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
-        rh.asJava.getHeaders.contains("host") must beTrue
+        rh.asJava.headers.contains("host") must beTrue
       }
     }
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -376,6 +376,13 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.api.ConfigLoader"),
       ProblemFilters.exclude[MissingClassProblem]("play.api.Mode$Test$"),
       ProblemFilters.exclude[MissingClassProblem]("play.api.Mode"),
+      // Renamed methods (method that were deprecated in 2.8.x back to their original name)
+      // Also, for consistency in general drop the get... prefix for methods in Java's RequestHeader/-Builder since
+      // all other methods in these classes don't use that
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.j.RequestHeaderImpl.cookie"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.mvc.Http#RequestHeader.cookie"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.cookie"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.headers"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Fixes #9297
