### PR TITLE
Switch from coloredLevel to %highlight(%-5level)

### DIFF
--- a/core/play-logback/src/main/resources/logback-play-default.xml
+++ b/core/play-logback/src/main/resources/logback-play-default.xml
@@ -5,11 +5,9 @@
 <!-- The default logback configuration that Play uses if no other configuration is provided -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%highlight(%-5level) %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/core/play-logback/src/main/resources/logback-play-dev.xml
+++ b/core/play-logback/src/main/resources/logback-play-dev.xml
@@ -5,11 +5,9 @@
 <!-- The default logback configuration that Play uses in dev mode if no other configuration is provided -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%highlight(%-5level) %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/src/main/resources/logback.xml
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/maven-layout-twirl-reload/src/main/resources/logback.xml
@@ -1,8 +1,6 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
     <encoder>
@@ -12,7 +10,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%highlight(%-5level) %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/documentation/manual/working/commonGuide/database/code/logback-play-logSql.xml
+++ b/documentation/manual/working/commonGuide/database/code/logback-play-logSql.xml
@@ -4,8 +4,6 @@
 
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
      <file>${application.home:-.}/logs/application.log</file>
      <encoder>
@@ -15,7 +13,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%highlight(%-5level) %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
Fixes #11504
See https://logback.qos.ch/manual/layouts.html#coloring

`coloredLevel` dates back to Play 2.0-RC1 in 2011: https://github.com/playframework/playframework/commit/cdd8a71f2559bbbfa4c7d4cb93933a57399d3405#diff-dc85c729087445b29c1ed7724db1616b6613c3d852cfdc0775b9c322fa320fe8R88

This was 6 months before logback introduced the `%highlight` pattern in 2012:
https://github.com/qos-ch/logback/commit/ab97eb0bd5c9459ac1d21a32e57b4a0beea7be14

Intersting thing is we already use that in the play-scala and play-java seed projects anyway, so this is nothing really new.