### PR TITLE
Use uri parsing mode "relaxed" in akka-http 10.2.x

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/BadClientHandlingSpec.scala
@@ -84,6 +84,6 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
 
       response.status must_== 400
       response.body must beLeft("Bad path: /[ message: Cannot parse path from URI: /[")
-    }.skipUntilAkkaHttpFixed
+    }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/BadClientHandlingSpec.scala
@@ -75,7 +75,7 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
 
     "allow accessing the raw unparsed path from an error handler" in withServer(new HttpErrorHandler() {
       def onClientError(request: RequestHeader, statusCode: Int, message: String) =
-        Future.successful(Results.BadRequest("Bad path: " + request.path))
+        Future.successful(Results.BadRequest("Bad path: " + request.path + " message: " + message))
       def onServerError(request: RequestHeader, exception: Throwable) = Future.successful(Results.Ok)
     }) { port =>
       val response = BasicHttpClient.makeRequests(port)(
@@ -83,7 +83,7 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
       )(0)
 
       response.status must_== 400
-      response.body must beLeft("Bad path: /[")
+      response.body must beLeft("Bad path: /[ message: Cannot parse path from URI: /[")
     }.skipUntilAkkaHttpFixed
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/UriHandlingSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/UriHandlingSpec.scala
@@ -48,7 +48,6 @@ class UriHandlingSpec
         response.body.string must_== "a=1&b=1&b=2&b=3&b=4&b=5"
       }
     }
-    /*
     "handle '/pat/resources/BodhiApplication?where={%22name%22:%22hsdashboard%22}' as a valid URI" in makeRequest(
       "/pat/resources/BodhiApplication?where={%22name%22:%22hsdashboard%22}"
     ) {
@@ -56,7 +55,6 @@ class UriHandlingSpec
         response.body.string must_=== """/pat/resources/BodhiApplication?where={"name":"hsdashboard"}"""
       }
     }
-     */
 
     "handle '/dynatable/?queries%5Bsearch%5D=%7B%22condition%22%3A%22AND%22%2C%22rules%22%3A%5B%5D%7D&page=1&perPage=10&offset=0' as a URI" in makeRequest(
       "/dynatable/?queries%5Bsearch%5D=%7B%22condition%22%3A%22AND%22%2C%22rules%22%3A%5B%5D%7D&page=1&perPage=10&offset=0"

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -137,6 +137,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
       .withMaxContentLength(maxContentLength)
       .withMaxHeaderValueLength(maxHeaderValueLength)
       .withIncludeTlsSessionInfoHeader(includeTlsSessionInfoHeader)
+      .withUriParsingMode(Uri.ParsingMode.Relaxed)
       .withModeledHeaderParsing(false) // Disable most of Akka HTTP's header parsing; use RawHeaders instead
 
   /**

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -166,9 +166,6 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
       .withParserSettings(parserSettings)
   }
 
-  // Each request needs an id
-  private val requestIDs = new java.util.concurrent.atomic.AtomicLong(0)
-
   /**
    * Values that are cached based on the current application.
    */
@@ -305,9 +302,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
     val tryApp         = applicationProvider.get
     val (convertedRequestHeader, requestBodySource): (RequestHeader, Either[ByteString, Source[ByteString, Any]]) = {
       val remoteAddress: InetSocketAddress = remoteAddressOfRequest(request)
-      val requestId: Long                  = requestIDs.incrementAndGet()
       modelConversion(tryApp).convertRequest(
-        requestId = requestId,
         remoteAddress = remoteAddress,
         secureProtocol = secure,
         request = decodedRequest

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -50,13 +50,12 @@ private[server] class AkkaModelConversion(
    * for its body.
    */
   def convertRequest(
-      requestId: Long,
       remoteAddress: InetSocketAddress,
       secureProtocol: Boolean,
       request: HttpRequest
   ): (RequestHeader, Either[ByteString, Source[ByteString, Any]]) = {
     (
-      convertRequestHeader(requestId, remoteAddress, secureProtocol, request),
+      convertRequestHeader(remoteAddress, secureProtocol, request),
       convertRequestBody(request)
     )
   }
@@ -65,7 +64,6 @@ private[server] class AkkaModelConversion(
    * Convert an Akka `HttpRequest` to a `RequestHeader`.
    */
   private def convertRequestHeader(
-      requestId: Long,
       remoteAddress: InetSocketAddress,
       secureProtocol: Boolean,
       request: HttpRequest

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -110,7 +110,7 @@ private[server] class AkkaModelConversion(
 
         override lazy val queryMap: Map[String, Seq[String]] = {
           try {
-            request.uri.query().toMultiMap
+            request.uri.query(mode = Uri.ParsingMode.Relaxed).toMultiMap
           } catch {
             case NonFatal(e) =>
               logger.warn("Failed to parse query string; returning empty map.", e)

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -63,7 +63,7 @@ private[server] class AkkaModelConversion(
   /**
    * Convert an Akka `HttpRequest` to a `RequestHeader`.
    */
-  private def convertRequestHeader(
+  def convertRequestHeader(
       remoteAddress: InetSocketAddress,
       secureProtocol: Boolean,
       request: HttpRequest
@@ -125,7 +125,7 @@ private[server] class AkkaModelConversion(
   /**
    * Convert the request headers of an Akka `HttpRequest` to a Play `Headers` object.
    */
-  private def convertRequestHeadersAkka(request: HttpRequest): AkkaHeadersWrapper = {
+  def convertRequestHeadersAkka(request: HttpRequest): AkkaHeadersWrapper = {
     var knownContentLength: Option[String] = None
     var isChunked: Option[String]          = None
 
@@ -156,7 +156,7 @@ private[server] class AkkaModelConversion(
   /**
    * Convert an Akka `HttpRequest` to an `Enumerator` of the request body.
    */
-  private def convertRequestBody(request: HttpRequest): Either[ByteString, Source[ByteString, Any]] = {
+  def convertRequestBody(request: HttpRequest): Either[ByteString, Source[ByteString, Any]] = {
     request.entity match {
       case HttpEntity.Strict(_, data) =>
         Left(data)

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -104,7 +104,7 @@ private[play] class PlayRequestHandler(
     }
 
     def clientError(statusCode: Int, message: String): (RequestHeader, Handler) = {
-      val unparsedTarget = modelConversion(tryApp).createUnparsedRequestTarget(request)
+      val unparsedTarget = Server.createUnparsedRequestTarget(request.uri)
       val requestHeader  = modelConversion(tryApp).createRequestHeader(channel, request, unparsedTarget)
       val debugHeader    = attachDebugInfo(requestHeader)
       val result = errorHandler(tryApp).onClientError(


### PR DESCRIPTION
Partly fixes #11113 by enabling one of the two tests that had do be disabled when ugrading akka-http to 10.2.x.

~akka-http 10.2.0 introduced a parsing mode, which by default is set to strict~ (I was wrong here, the parsing mode existed before already). See
* comments in akka's reference.conf: https://github.com/akka/akka-http/blob/v10.2.10/akka-http-core/src/main/resources/reference.conf#L690-L698
* https://github.com/akka/akka-http/issues/3504