### PR TITLE
Handle incorrect percent-encoded query chars

### DIFF
--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -99,11 +99,12 @@ private[server] class NettyModelConversion(
       override def uriString: String   = request.uri
       override val path: String        = parsedPath
       override val queryString: String = parsedQueryString.stripPrefix("?")
-      override lazy val queryMap: Map[String, Seq[String]] = {
+      override val queryMap: Map[String, Seq[String]] = {
         val decoder = new QueryStringDecoder(parsedQueryString)
         try {
           decoder.parameters().asScala.view.mapValues(_.asScala.toList).toMap
         } catch {
+          case iae: IllegalArgumentException if iae.getMessage.startsWith("invalid hex byte") => throw iae
           case NonFatal(e) =>
             logger.warn("Failed to parse query string; returning empty map.", e)
             Map.empty


### PR DESCRIPTION
Fully fixes #11113
Since akka-http 10.2.0, an incorrect percent-encoded uri character will be immediately handled as 400 bad request by akka-http. It gives us (Play) no chance to handle that, so we never see this error in the Play akka-http backend. There is nothing we can do really. So I had to adjust the test, and as part of that I also made netty behave the same (not going through the error handler when it parses incorrect percent-encoded chars). This is because I want to have both http backends to be as much compatible as possible in case one gets replaced by the other.