### PR TITLE
Deprecate TypedMap symbols and replace with named functions

### DIFF
--- a/core/play/src/main/java/play/libs/typedmap/TypedMap.java
+++ b/core/play/src/main/java/play/libs/typedmap/TypedMap.java
@@ -87,7 +87,7 @@ public final class TypedMap {
    * @return A new instance of the map with the new entry added.
    */
   public TypedMap putAll(TypedEntry<?> e1) {
-    return new TypedMap(underlying.$plus(e1.asScala()));
+    return new TypedMap(underlying.updated(e1.asScala()));
   }
 
   /**
@@ -98,7 +98,7 @@ public final class TypedMap {
    * @return A new instance of the map with the new entries added.
    */
   public TypedMap putAll(TypedEntry<?> e1, TypedEntry<?> e2) {
-    return new TypedMap(underlying.$plus(e1.asScala(), e2.asScala()));
+    return new TypedMap(underlying.updated(e1.asScala(), e2.asScala()));
   }
 
   /**
@@ -110,7 +110,7 @@ public final class TypedMap {
    * @return A new instance of the map with the new entries added.
    */
   public TypedMap putAll(TypedEntry<?> e1, TypedEntry<?> e2, TypedEntry<?> e3) {
-    return new TypedMap(underlying.$plus(e1.asScala(), e2.asScala(), e3.asScala()));
+    return new TypedMap(underlying.updated(e1.asScala(), e2.asScala(), e3.asScala()));
   }
 
   /**
@@ -132,7 +132,7 @@ public final class TypedMap {
   public TypedMap putAll(List<TypedEntry<?>> entries) {
     play.api.libs.typedmap.TypedMap newUnderlying = underlying;
     for (TypedEntry<?> e : entries) {
-      newUnderlying = newUnderlying.$plus(e.asScala());
+      newUnderlying = newUnderlying.updated(e.asScala());
     }
     return new TypedMap(newUnderlying);
   }
@@ -144,7 +144,7 @@ public final class TypedMap {
    * @return A new instance of the map with the entry removed.
    */
   public TypedMap remove(TypedKey<?> k1) {
-    return new TypedMap(underlying.$minus(k1.asScala()));
+    return new TypedMap(underlying.removed(k1.asScala()));
   }
 
   /**
@@ -155,7 +155,7 @@ public final class TypedMap {
    * @return A new instance of the map with the entries removed.
    */
   public TypedMap remove(TypedKey<?> k1, TypedKey<?> k2) {
-    return new TypedMap(underlying.$minus(k1.asScala(), k2.asScala()));
+    return new TypedMap(underlying.removed(k1.asScala(), k2.asScala()));
   }
 
   /**
@@ -167,7 +167,7 @@ public final class TypedMap {
    * @return A new instance of the map with the entries removed.
    */
   public TypedMap remove(TypedKey<?> k1, TypedKey<?> k2, TypedKey<?> k3) {
-    return new TypedMap(underlying.$minus(k1.asScala(), k2.asScala(), k3.asScala()));
+    return new TypedMap(underlying.removed(k1.asScala(), k2.asScala(), k3.asScala()));
   }
 
   /**
@@ -179,7 +179,7 @@ public final class TypedMap {
   public TypedMap remove(TypedKey<?>... keys) {
     play.api.libs.typedmap.TypedMap newUnderlying = underlying;
     for (TypedKey<?> k : keys) {
-      newUnderlying = newUnderlying.$minus(k.asScala());
+      newUnderlying = newUnderlying.removed(k.asScala());
     }
     return new TypedMap(newUnderlying);
   }

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -279,14 +279,6 @@ public class Http {
      * @param entries The new attributes.
      * @return The new version of this object with the new attributes.
      */
-    RequestHeader addAttrs(TypedEntry<?>... entries);
-
-    /**
-     * Create a new versions of this object with the given attributes attached to it.
-     *
-     * @param entries The new attributes.
-     * @return The new version of this object with the new attributes.
-     */
     RequestHeader addAttrs(List<TypedEntry<?>> entries);
 
     /**
@@ -531,9 +523,6 @@ public class Http {
 
     // Override return type
     Request addAttrs(TypedEntry<?> e1, TypedEntry<?> e2, TypedEntry<?> e3);
-
-    // Override return type
-    Request addAttrs(TypedEntry<?>... entries);
 
     // Override return type
     Request addAttrs(List<TypedEntry<?>> entries);

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -64,6 +64,42 @@ trait TypedMap {
    * @param e1 The new entry to add to the map.
    * @return A new instance of the map with the new entry added.
    */
+  def updated(e1: TypedEntry[_]): TypedMap
+
+  /**
+   * Update the map with two entries, returning a new instance of the map.
+   *
+   * @param e1 The first new entry to add to the map.
+   * @param e2 The second new entry to add to the map.
+   * @return A new instance of the map with the new entries added.
+   */
+  def updated(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap
+
+  /**
+   * Update the map with three entries, returning a new instance of the map.
+   *
+   * @param e1 The first new entry to add to the map.
+   * @param e2 The second new entry to add to the map.
+   * @param e3 The third new entry to add to the map.
+   * @return A new instance of the map with the new entries added.
+   */
+  def updated(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap
+
+  /**
+   * Update the map with several entries, returning a new instance of the map.
+   *
+   * @param entries The new entries to add to the map.
+   * @return A new instance of the map with the new entries added.
+   */
+  def updated(entries: TypedEntry[_]*): TypedMap
+
+  /**
+   * Update the map with one entry, returning a new instance of the map.
+   *
+   * @param e1 The new entry to add to the map.
+   * @return A new instance of the map with the new entry added.
+   */
+  @deprecated(message = "Use `updated` instead.", since = "2.9.0")
   def +(e1: TypedEntry[_]): TypedMap
 
   /**
@@ -73,6 +109,7 @@ trait TypedMap {
    * @param e2 The second new entry to add to the map.
    * @return A new instance of the map with the new entries added.
    */
+  @deprecated(message = "Use `updated` instead.", since = "2.9.0")
   def +(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap
 
   /**
@@ -83,6 +120,7 @@ trait TypedMap {
    * @param e3 The third new entry to add to the map.
    * @return A new instance of the map with the new entries added.
    */
+  @deprecated(message = "Use `updated` instead.", since = "2.9.0")
   def +(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap
 
   /**
@@ -91,6 +129,7 @@ trait TypedMap {
    * @param entries The new entries to add to the map.
    * @return A new instance of the map with the new entries added.
    */
+  @deprecated(message = "Use `updated` instead.", since = "2.9.0")
   def +(entries: TypedEntry[_]*): TypedMap
 
   /**
@@ -99,6 +138,42 @@ trait TypedMap {
    * @param e1 The key to remove.
    * @return A new instance of the map with the entry removed.
    */
+  def removed(e1: TypedKey[_]): TypedMap
+
+  /**
+   * Removes two keys from the map, returning a new instance of the map.
+   *
+   * @param e1 The first key to remove.
+   * @param e2 The second key to remove.
+   * @return A new instance of the map with the entries removed.
+   */
+  def removed(e1: TypedKey[_], e2: TypedKey[_]): TypedMap
+
+  /**
+   * Removes three keys from the map, returning a new instance of the map.
+   *
+   * @param e1 The first key to remove.
+   * @param e2 The second key to remove.
+   * @param e3 The third key to remove.
+   * @return A new instance of the map with the entries removed.
+   */
+  def removed(e1: TypedKey[_], e2: TypedKey[_], e3: TypedKey[_]): TypedMap
+
+  /**
+   * Removes keys from the map, returning a new instance of the map.
+   *
+   * @param keys The keys to remove.
+   * @return A new instance of the map with the entries removed.
+   */
+  def removed(keys: TypedKey[_]*): TypedMap
+
+  /**
+   * Removes a key from the map, returning a new instance of the map.
+   *
+   * @param e1 The key to remove.
+   * @return A new instance of the map with the entry removed.
+   */
+  @deprecated(message = "Use `removed` instead.", since = "2.9.0")
   def -(e1: TypedKey[_]): TypedMap
 
   /**
@@ -108,6 +183,7 @@ trait TypedMap {
    * @param e2 The second key to remove.
    * @return A new instance of the map with the entries removed.
    */
+  @deprecated(message = "Use `removed` instead.", since = "2.9.0")
   def -(e1: TypedKey[_], e2: TypedKey[_]): TypedMap
 
   /**
@@ -118,6 +194,7 @@ trait TypedMap {
    * @param e3 The third key to remove.
    * @return A new instance of the map with the entries removed.
    */
+  @deprecated(message = "Use `removed` instead.", since = "2.9.0")
   def -(e1: TypedKey[_], e2: TypedKey[_], e3: TypedKey[_]): TypedMap
 
   /**
@@ -126,6 +203,7 @@ trait TypedMap {
    * @param keys The keys to remove.
    * @return A new instance of the map with the entries removed.
    */
+  @deprecated(message = "Use `removed` instead.", since = "2.9.0")
   def -(keys: TypedKey[_]*): TypedMap
 
   /**
@@ -172,25 +250,32 @@ private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Ma
   override def get[A](key: TypedKey[A]): Option[A]              = m.get(key).asInstanceOf[Option[A]]
   override def contains(key: TypedKey[_]): Boolean              = m.contains(key)
   override def updated[A](key: TypedKey[A], value: A): TypedMap = new DefaultTypedMap(m.updated(key, value))
-  override def +(e1: TypedEntry[_]): TypedMap                   = new DefaultTypedMap(m.updated(e1.key, e1.value))
-  override def +(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap =
+  override def updated(e1: TypedEntry[_]): TypedMap             = new DefaultTypedMap(m.updated(e1.key, e1.value))
+  override def updated(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap =
     new DefaultTypedMap(m.updated(e1.key, e1.value).updated(e2.key, e2.value))
-  override def +(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap =
+  override def updated(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap =
     new DefaultTypedMap(m.updated(e1.key, e1.value).updated(e2.key, e2.value).updated(e3.key, e3.value))
-  override def +(entries: TypedEntry[_]*): TypedMap = {
+  override def updated(entries: TypedEntry[_]*): TypedMap = {
     val m2 = entries.foldLeft(m) {
       case (m1, e) => m1.updated(e.key, e.value)
     }
     new DefaultTypedMap(m2)
   }
-  override def -(k1: TypedKey[_]): TypedMap                                   = new DefaultTypedMap(m - k1)
-  override def -(k1: TypedKey[_], k2: TypedKey[_]): TypedMap                  = new DefaultTypedMap(m - k1 - k2)
-  override def -(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap = new DefaultTypedMap(m - k1 - k2 - k3)
-  override def -(keys: TypedKey[_]*): TypedMap = {
-    val m2 = keys.foldLeft(m) {
-      case (m1, k) => m1 - k
-    }
-    new DefaultTypedMap(m2)
-  }
-  override def toString: String = m.mkString("{", ", ", "}")
+  override def +(e1: TypedEntry[_]): TypedMap                    = updated(e1)
+  override def +(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap = updated(e1, e2)
+  override def +(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap =
+    updated(e1, e2, e3)
+  override def +(entries: TypedEntry[_]*): TypedMap = updated(entries: _*)
+  override def removed(k1: TypedKey[_]): TypedMap   = new DefaultTypedMap(m - k1)
+  override def removed(k1: TypedKey[_], k2: TypedKey[_]): TypedMap =
+    new DefaultTypedMap(m - k1 - k2)
+  override def removed(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap =
+    new DefaultTypedMap(m - k1 - k2 - k3)
+  override def removed(keys: TypedKey[_]*): TypedMap         = new DefaultTypedMap(m.removedAll(keys.iterator))
+  override def -(k1: TypedKey[_]): TypedMap                  = removed(k1)
+  override def -(k1: TypedKey[_], k2: TypedKey[_]): TypedMap = removed(k1, k2)
+  override def -(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap =
+    removed(k1, k2, k3)
+  override def -(keys: TypedKey[_]*): TypedMap = removed(keys: _*)
+  override def toString: String                = m.mkString("{", ", ", "}")
 }

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -94,36 +94,6 @@ trait TypedMap {
   def updated(entries: TypedEntry[_]*): TypedMap
 
   /**
-   * Update the map with one entry, returning a new instance of the map.
-   *
-   * @param e1 The new entry to add to the map.
-   * @return A new instance of the map with the new entry added.
-   */
-  @deprecated(message = "Use `updated` instead.", since = "2.9.0")
-  def +(e1: TypedEntry[_]): TypedMap
-
-  /**
-   * Update the map with two entries, returning a new instance of the map.
-   *
-   * @param e1 The first new entry to add to the map.
-   * @param e2 The second new entry to add to the map.
-   * @return A new instance of the map with the new entries added.
-   */
-  @deprecated(message = "Use `updated` instead.", since = "2.9.0")
-  def +(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap
-
-  /**
-   * Update the map with three entries, returning a new instance of the map.
-   *
-   * @param e1 The first new entry to add to the map.
-   * @param e2 The second new entry to add to the map.
-   * @param e3 The third new entry to add to the map.
-   * @return A new instance of the map with the new entries added.
-   */
-  @deprecated(message = "Use `updated` instead.", since = "2.9.0")
-  def +(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap
-
-  /**
    * Update the map with several entries, returning a new instance of the map.
    *
    * @param entries The new entries to add to the map.
@@ -166,36 +136,6 @@ trait TypedMap {
    * @return A new instance of the map with the entries removed.
    */
   def removed(keys: TypedKey[_]*): TypedMap
-
-  /**
-   * Removes a key from the map, returning a new instance of the map.
-   *
-   * @param e1 The key to remove.
-   * @return A new instance of the map with the entry removed.
-   */
-  @deprecated(message = "Use `removed` instead.", since = "2.9.0")
-  def -(e1: TypedKey[_]): TypedMap
-
-  /**
-   * Removes two keys from the map, returning a new instance of the map.
-   *
-   * @param e1 The first key to remove.
-   * @param e2 The second key to remove.
-   * @return A new instance of the map with the entries removed.
-   */
-  @deprecated(message = "Use `removed` instead.", since = "2.9.0")
-  def -(e1: TypedKey[_], e2: TypedKey[_]): TypedMap
-
-  /**
-   * Removes three keys from the map, returning a new instance of the map.
-   *
-   * @param e1 The first key to remove.
-   * @param e2 The second key to remove.
-   * @param e3 The third key to remove.
-   * @return A new instance of the map with the entries removed.
-   */
-  @deprecated(message = "Use `removed` instead.", since = "2.9.0")
-  def -(e1: TypedKey[_], e2: TypedKey[_], e3: TypedKey[_]): TypedMap
 
   /**
    * Removes keys from the map, returning a new instance of the map.
@@ -261,21 +201,13 @@ private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Ma
     }
     new DefaultTypedMap(m2)
   }
-  override def +(e1: TypedEntry[_]): TypedMap                    = updated(e1)
-  override def +(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap = updated(e1, e2)
-  override def +(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap =
-    updated(e1, e2, e3)
   override def +(entries: TypedEntry[_]*): TypedMap = updated(entries: _*)
   override def removed(k1: TypedKey[_]): TypedMap   = new DefaultTypedMap(m - k1)
   override def removed(k1: TypedKey[_], k2: TypedKey[_]): TypedMap =
     new DefaultTypedMap(m - k1 - k2)
   override def removed(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap =
     new DefaultTypedMap(m - k1 - k2 - k3)
-  override def removed(keys: TypedKey[_]*): TypedMap         = new DefaultTypedMap(m.removedAll(keys))
-  override def -(k1: TypedKey[_]): TypedMap                  = removed(k1)
-  override def -(k1: TypedKey[_], k2: TypedKey[_]): TypedMap = removed(k1, k2)
-  override def -(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap =
-    removed(k1, k2, k3)
-  override def -(keys: TypedKey[_]*): TypedMap = removed(keys: _*)
-  override def toString: String                = m.mkString("{", ", ", "}")
+  override def removed(keys: TypedKey[_]*): TypedMap = new DefaultTypedMap(m.removedAll(keys))
+  override def -(keys: TypedKey[_]*): TypedMap       = removed(keys: _*)
+  override def toString: String                      = m.mkString("{", ", ", "}")
 }

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -271,7 +271,7 @@ private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Ma
     new DefaultTypedMap(m - k1 - k2)
   override def removed(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap =
     new DefaultTypedMap(m - k1 - k2 - k3)
-  override def removed(keys: TypedKey[_]*): TypedMap         = new DefaultTypedMap(m.removedAll(keys.iterator))
+  override def removed(keys: TypedKey[_]*): TypedMap         = new DefaultTypedMap(m.removedAll(keys))
   override def -(k1: TypedKey[_]): TypedMap                  = removed(k1)
   override def -(k1: TypedKey[_], k2: TypedKey[_]): TypedMap = removed(k1, k2)
   override def -(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap =

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -91,14 +91,14 @@ trait Request[+A] extends RequestHeader {
     new RequestImpl[A](connection, method, target, version, headers, newAttrs, body)
   override def addAttr[B](key: TypedKey[B], value: B): Request[A] =
     withAttrs(attrs.updated(key, value))
-  override def addAttrs(e1: TypedEntry[_]): Request[A]                    = withAttrs(attrs + e1)
-  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Request[A] = withAttrs(attrs + (e1, e2))
+  override def addAttrs(e1: TypedEntry[_]): Request[A]                    = withAttrs(attrs.updated(e1))
+  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Request[A] = withAttrs(attrs.updated(e1, e2))
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): Request[A] =
-    withAttrs(attrs + (e1, e2, e3))
+    withAttrs(attrs.updated(e1, e2, e3))
   override def addAttrs(entries: TypedEntry[_]*): Request[A] =
-    withAttrs(attrs.+(entries: _*))
+    withAttrs(attrs.updated(entries: _*))
   override def removeAttr(key: TypedKey[_]): Request[A] =
-    withAttrs(attrs - key)
+    withAttrs(attrs.removed(key))
   override def withTransientLang(lang: Lang): Request[A] =
     addAttr(Messages.Attrs.CurrentLang, lang)
   override def withTransientLang(code: String): Request[A] =

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -177,7 +177,9 @@ trait RequestHeader {
    * @param e3 The third new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): RequestHeader = withAttrs(attrs.updated(e1, e2, e3))
+  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): RequestHeader = withAttrs(
+    attrs.updated(e1, e2, e3)
+  )
 
   /**
    * Create a new versions of this object with the given attributes attached to it.

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -158,7 +158,7 @@ trait RequestHeader {
    * @param e1 The new attribute.
    * @return The new version of this object with the new attribute.
    */
-  def addAttrs(e1: TypedEntry[_]): RequestHeader = withAttrs(attrs + e1)
+  def addAttrs(e1: TypedEntry[_]): RequestHeader = withAttrs(attrs.updated(e1))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -167,7 +167,7 @@ trait RequestHeader {
    * @param e2 The second new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): RequestHeader = withAttrs(attrs + (e1, e2))
+  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): RequestHeader = withAttrs(attrs.updated(e1, e2))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -177,7 +177,7 @@ trait RequestHeader {
    * @param e3 The third new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): RequestHeader = withAttrs(attrs + (e1, e2, e3))
+  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): RequestHeader = withAttrs(attrs.updated(e1, e2, e3))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -186,7 +186,7 @@ trait RequestHeader {
    * @return The new version of this object with the new attributes.
    */
   def addAttrs(entries: TypedEntry[_]*): RequestHeader =
-    withAttrs(attrs.+(entries: _*))
+    withAttrs(attrs.updated(entries: _*))
 
   /**
    * Create a new versions of this object with the given attribute removed.
@@ -195,7 +195,7 @@ trait RequestHeader {
    * @return The new version of this object with the attribute removed.
    */
   def removeAttr(key: TypedKey[_]): RequestHeader =
-    withAttrs(attrs - key)
+    withAttrs(attrs.removed(key))
 
   // -- Computed
 

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -408,7 +408,7 @@ case class Result(
    * @param e2 The second new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Result = withAttrs(attrs.updated(e1,e2))
+  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Result = withAttrs(attrs.updated(e1, e2))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -399,7 +399,7 @@ case class Result(
    * @param e1 The new attribute.
    * @return The new version of this object with the new attribute.
    */
-  def addAttrs(e1: TypedEntry[_]): Result = withAttrs(attrs + e1)
+  def addAttrs(e1: TypedEntry[_]): Result = withAttrs(attrs.updated(e1))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -408,7 +408,7 @@ case class Result(
    * @param e2 The second new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Result = withAttrs(attrs + e1 + e2)
+  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Result = withAttrs(attrs.updated(e1,e2))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -418,7 +418,7 @@ case class Result(
    * @param e3 The third new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): Result = withAttrs(attrs + e1 + e2 + e3)
+  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): Result = withAttrs(attrs.updated(e1, e2, e3))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -427,7 +427,7 @@ case class Result(
    * @return The new version of this object with the new attributes.
    */
   def addAttrs(entries: TypedEntry[_]*): Result =
-    withAttrs(attrs.+(entries: _*))
+    withAttrs(attrs.updated(entries: _*))
 
   /**
    * Create a new versions of this object with the given attribute removed.
@@ -436,7 +436,7 @@ case class Result(
    * @return The new version of this object with the attribute removed.
    */
   def removeAttr(key: TypedKey[_]): Result =
-    withAttrs(attrs - key)
+    withAttrs(attrs.removed(key))
 }
 
 /**

--- a/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
@@ -124,7 +124,7 @@ class DefaultRequestFactory @Inject() (
       protected override def emptyMarker: Flash = null
       protected override def create: Flash      = flashBaker.decodeFromCookie(cookieCell.value.get(flashBaker.COOKIE_NAME))
     }
-    val updatedAttrMap = attrs + (
+    val updatedAttrMap = attrs.updated(
       RequestAttrKey.Id      -> requestId,
       RequestAttrKey.Cookies -> cookieCell,
       RequestAttrKey.Session -> sessionCell,

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -208,7 +208,6 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): JRequestHeader = withAttrs(attrs.putAll(e1, e2))
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): JRequestHeader =
     withAttrs(attrs.putAll(e1, e2, e3))
-  override def addAttrs(entries: TypedEntry[_]*): JRequestHeader           = withAttrs(attrs.putAll(entries: _*))
   override def addAttrs(entries: util.List[TypedEntry[_]]): JRequestHeader = withAttrs(attrs.putAll(entries))
   override def removeAttr(key: TypedKey[_]): JRequestHeader                = withAttrs(attrs.remove(key))
 
@@ -263,16 +262,7 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override lazy val headers: Http.Headers = header.headers.asJava
 }
 
-/**
- * trait needed as workaround for https://github.com/scala/bug/issues/11944
- * Also see original pull request: https://github.com/playframework/playframework/pull/10199
- * sealed so that lack of implementation can't be accidentally used elsewhere
- */
-private[j] sealed trait RequestImplHelper extends JRequest {
-  override def addAttrs(entries: TypedEntry[_]*): JRequest = ???
-}
-
-class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(request) with RequestImplHelper {
+class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(request) with JRequest {
   override def asScala: Request[RequestBody] = request
 
   override def attrs: TypedMap                                          = new TypedMap(asScala.attrs)
@@ -282,7 +272,6 @@ class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(reque
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): JRequest = withAttrs(attrs.putAll(e1, e2))
   override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): JRequest =
     withAttrs(attrs.putAll(e1, e2, e3))
-  override def addAttrs(entries: TypedEntry[_]*): JRequest           = withAttrs(attrs.putAll(entries: _*))
   override def addAttrs(entries: util.List[TypedEntry[_]]): JRequest = withAttrs(attrs.putAll(entries))
   override def removeAttr(key: TypedKey[_]): JRequest                = withAttrs(attrs.remove(key))
 

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -59,9 +59,9 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
   override def addAttr[B](key: TypedKey[B], value: B): FakeRequest[A] =
     withAttrs(attrs.updated(key, value))
   override def addAttrs(entries: TypedEntry[_]*): FakeRequest[A] =
-    withAttrs(attrs + (entries: _*))
+    withAttrs(attrs.updated(entries: _*))
   override def removeAttr(key: TypedKey[_]): FakeRequest[A] =
-    withAttrs(attrs - key)
+    withAttrs(attrs.removed(key))
   override def withBody[B](body: B): FakeRequest[B] =
     new FakeRequest(request.withBody(body))
 
@@ -203,7 +203,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       },
       version,
       headers,
-      attrs + (RequestAttrKey.Id -> id),
+      attrs.updated(RequestAttrKey.Id -> id),
       body
     )
     new FakeRequest(request)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -383,6 +383,9 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.mvc.Http#RequestHeader.cookie"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.cookie"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.headers"),
+      // Added fully named methods to TypedMaps, to prepare for deprecation of the symbol-named methods
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.updated"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.removed")
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -233,11 +233,10 @@ object BuildSettings {
       // Removed @varargs (which removed the array forwarder method)
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.typedmap.DefaultTypedMap.-"),
       // Add .addAttrs(...) varargs and override methods to Request/RequestHeader and TypedMap's
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.removed"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.updated"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#Request.addAttrs"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.addAttrs"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.+"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.-"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.typedmap.DefaultTypedMap.-"),
       // Remove outdated (internal) method
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.streams.Execution.defaultExecutionContext"),
       // Add allowEmptyFiles config to allow empty file uploads
@@ -383,9 +382,6 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.mvc.Http#RequestHeader.cookie"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.cookie"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.headers"),
-      // Added fully named methods to TypedMaps, to prepare for deprecation of the symbol-named methods
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.updated"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.typedmap.TypedMap.removed")
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -216,7 +216,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       },
       version,
       headers,
-      attrs + (RequestAttrKey.Id -> id),
+      attrs.updated(RequestAttrKey.Id -> id),
       body
     )
     new FakeRequest(request)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #10221 

## Purpose

* Deprecates `-` and `+` Scala symbol methods in `TypedMap`. 
* Adds `updated` and `removed` functions that serve the same purpose.
* Changes outside calls to `+`, `-`, `$plus`, and `$minus` to `updated`/`removed`.
* Adds an ignore rule for MiMa compatibility - new signature doesn't break backwards compatibility.

In the future, postfix symbolic operators are going to be deprecated for methods with multiple parameters. Thus, this change is necessary to meet that need. The original ticket suggests removing _all_ of those operators.

## Background Context

I opted to deprecate the old methods, in case others are using them.
