### PR TITLE
Avoid double submission of the dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -14,14 +14,15 @@ permissions:
 
 jobs:
   dependency-graph:
-    name: submit dependencies
+    name: Submit dependencies to GitHub
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
-      - uses: scalacenter/sbt-dependency-submission@v2 # for ./build.sbt in root folder
-      - uses: scalacenter/sbt-dependency-submission@v2 # for ./build.sbt in documentation folder
+      - uses: scalacenter/sbt-dependency-submission@v2
         with:
+          # We submit ./documentation/build.sbt because the documentation project depends on the root project(s)
+          # anyway. In the end, all projects will be checked (including the dependencies of the documentation project).
           working-directory: './documentation/'


### PR DESCRIPTION
However waiting on feedback for https://github.com/scalacenter/sbt-dependency-submission/issues/84 first.