### PR TITLE
Scala 3: Can't use BeanProperty in Scala code to test Java API

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/libs/JavaFormSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/JavaFormSpec.scala
@@ -5,7 +5,6 @@
 package play.it.libs
 
 import scala.annotation.meta.field
-import scala.beans.BeanProperty
 import scala.jdk.CollectionConverters._
 
 import play.api.test._
@@ -27,10 +26,8 @@ class JavaFormSpec extends PlaySpecification {
 }
 
 class FooForm {
-  @BeanProperty
   var id: Long = _
 
   @(Required @field)
-  @BeanProperty
   var fooName: String = _
 }

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -17,7 +17,6 @@ import javax.validation.Valid
 import javax.validation.Validation
 import javax.validation.ValidatorFactory
 
-import scala.beans.BeanProperty
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
@@ -1621,57 +1620,64 @@ object FormSpec {
   }
 }
 
-class JavaForm(@BeanProperty var foo: java.util.List[JavaSubForm]) {
+class JavaForm(var foo: java.util.List[JavaSubForm]) {
   def this() = this(null)
 }
-class JavaSubForm(@BeanProperty var a: String, @BeanProperty var b: String) {
+class JavaSubForm(var a: String, var b: String) {
   def this() = this(null, null)
 }
 
 @Constraints.Validate
 class JavaMainForm extends Constraints.Validatable[ValidationError] {
 
-  @BeanProperty
   @Constraints.Required
   @Size(max = 1)
   @Valid
-  var entries: java.util.List[JavaChildForm] = _
+  var entries: java.util.List[JavaChildForm]             = _
+  def getEntries()                                       = entries
+  def setEntries(entries: java.util.List[JavaChildForm]) = this.entries = entries
 
-  @BeanProperty
   @Constraints.Required
   @Valid
-  var entry: JavaChildForm = _
+  var entry: JavaChildForm           = _
+  def getEntry()                     = entry
+  def setEntry(entry: JavaChildForm) = this.entry = entry
 
   override def validate = new ValidationError("entry", "validate of parent: I always get called!")
 }
 
 class AnotherJavaMainForm {
 
-  @BeanProperty
   @Constraints.Required
   @Size(max = 3)
   @Valid
-  var entries: java.util.List[JavaChildForm] = _
+  var entries: java.util.List[JavaChildForm]             = _
+  def getEntries()                                       = entries
+  def setEntries(entries: java.util.List[JavaChildForm]) = this.entries = entries
 
-  @BeanProperty
   @Constraints.Required
   @Valid
-  var entry: JavaChildForm = _
+  var entry: JavaChildForm           = _
+  def getEntry()                     = entry
+  def setEntry(entry: JavaChildForm) = this.entry = entry
 }
 
 @Constraints.Validate
 class JavaChildForm extends Constraints.Validatable[ValidationError] {
 
-  @BeanProperty
   @Constraints.Required
-  var name: String = _
+  var name: String          = _
+  def getName()             = name
+  def setName(name: String) = this.name = name
 
-  @BeanProperty
-  var value: java.lang.Integer = _
+  var value: java.lang.Integer           = _
+  def getValue()                         = value
+  def setValue(value: java.lang.Integer) = this.value = value
 
-  @BeanProperty
   @Valid
-  var entries: java.util.List[JavaChildChildForm] = _
+  var entries: java.util.List[JavaChildChildForm]             = _
+  def getEntries()                                            = entries
+  def setEntries(entries: java.util.List[JavaChildChildForm]) = this.entries = entries
 
   override def validate: ValidationError =
     if (value == null) new ValidationError("value", "validate of child: value can't be null!") else null
@@ -1680,19 +1686,23 @@ class JavaChildForm extends Constraints.Validatable[ValidationError] {
 @Constraints.Validate
 class JavaChildChildForm extends Constraints.Validatable[ValidationError] {
 
-  @BeanProperty
   @Constraints.Required
-  var name: String = _
+  var name: String          = _
+  def getName()             = name
+  def setName(name: String) = this.name = name
 
-  @BeanProperty
   @Constraints.Required
-  var street: String = _
+  var street: String            = _
+  def getStreet()               = street
+  def setStreet(street: String) = this.street = street
 
-  @BeanProperty
-  var value: java.lang.Integer = _
+  var value: java.lang.Integer           = _
+  def getValue()                         = value
+  def setValue(value: java.lang.Integer) = this.value = value
 
-  @BeanProperty
-  var notes: java.util.List[String] = _
+  var notes: java.util.List[String]           = _
+  def getNotes()                              = notes
+  def setNotes(notes: java.util.List[String]) = this.notes = notes
 
   override def validate: ValidationError =
     if (value == null) new ValidationError("value", "validate of child of child: value can't be null!") else null

--- a/web/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -4,7 +4,6 @@
 
 package play.data
 
-import scala.beans.BeanProperty
 import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.ConfigFactory
@@ -54,16 +53,19 @@ class PartialValidationSpec extends Specification {
 trait Partial
 
 class SomeForm {
-  @BeanProperty
   @Required
-  var prop1: String = _
+  var prop1: String           = _
+  def getProp1()              = prop1
+  def setProp1(prop1: String) = this.prop1 = prop1
 
-  @BeanProperty
   @Required(groups = Array(classOf[Partial]))
-  var prop2: String = _
+  var prop2: String           = _
+  def getProp2()              = prop2
+  def setProp2(prop2: String) = this.prop2 = prop2
 
-  @BeanProperty
   @Required(groups = Array(classOf[Partial]))
   @MaxLength(value = 3, groups = Array(classOf[Partial]))
-  var prop3: String = _
+  var prop3: String           = _
+  def getProp3()              = prop3
+  def setProp3(prop3: String) = this.prop3 = prop3
 }


### PR DESCRIPTION
Split off from #11551, but slightly different by keeping getters and setters because we want to test the Java Form api (even though it's a bit stupid to do that in Scala code, but I am not going to put that in Java files now. It's "just" tests anyway.)

See 
* https://docs.scala-lang.org/scala3/guides/migration/incompat-other-changes.html#invisible-bean-property
* https://github.com/lampepfl/dotty/issues/11972