### PR TITLE
Scala 3: Avoid making `AhcWSRequest` abstract

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -386,6 +386,9 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.mvc.Http#RequestHeader.cookie"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.cookie"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#RequestHeader.headers"),
+      // Scala3 compilation
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.WSRequest.addHttpHeaders"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.WSRequest.addQueryStringParameters"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
@@ -36,32 +36,6 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
   override def withHttpHeaders(headers: (String, String)*): Self
 
   /**
-   * Returns this request with the given headers, preserving the existing ones.
-   *
-   * @param hdrs the headers to be added
-   */
-  override def addHttpHeaders(hdrs: (String, String)*): Self
-
-  /**
-   * Get the value of the header with the specified name. If there are more than one values
-   * for this header, the first value is returned. If there are no values, than a None is
-   * returned.
-   *
-   * @param name the header name
-   * @return the header value
-   */
-  override def header(name: String): Option[String]
-
-  /**
-   * Get all the values of header with the specified name. If there are no values for
-   * the header with the specified name, than an empty sequence is returned.
-   *
-   * @param name the header name.
-   * @return all the values for this header name.
-   */
-  override def headerValues(name: String): Seq[String]
-
-  /**
    * Returns this request with the given query string parameters, adding to the existing ones.
    *
    * @param parameters the query string parameters
@@ -75,13 +49,6 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
    * @param parameters the query string parameters
    */
   override def withQueryStringParameters(parameters: (String, String)*): Self
-
-  /**
-   * Returns this request with the given query string parameters, preserving the existing ones.
-   *
-   * @param parameters the query string parameters
-   */
-  override def addQueryStringParameters(parameters: (String, String)*): Self
 
   /**
    * Returns this request with the given cookies, preserving the existing ones.


### PR DESCRIPTION
Avoids following compilation error in Scala 3:
```scala
[error] -- Error: ./transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala:21:11 
[error] 21 |case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest with WSBodyWritables {
[error]    |           ^
[error]    |class AhcWSRequest needs to be abstract, since:
[error]    |it has 4 unimplemented members.
[error]    |/** As seen from class AhcWSRequest, the missing signatures are as follows.
[error]    | *  For convenience, these are usable as stub implementations.
[error]    | */
[error]    |  override def addHttpHeaders(hdrs: Seq[(String, String)]): AhcWSRequest.this.Self = ???
[error]    |  override def addQueryStringParameters
[error]    |  (parameters: Seq[(String, String)]): AhcWSRequest.this.Self = ???
[error]    |  override def header(name: String): Option[String] = ???
[error]    |  override def headerValues(name: String): Seq[String] = ???
[error] one error found
```

Looks like intended Scala 3 behaviour (or behaviour in general, just Scala 2 didn't follow):
* https://github.com/lampepfl/dotty/issues/4770#issuecomment-403090584

I played around a bit, I _think_ just removing these overrides should be ok :crossed_fingers: 

Split off from #11551 (credits to @jtjeferreira, I keep you as committer where possible)