### PR TITLE
Scala 3: Wrap body of WithServer, WithApplication[Loader], WithBrowser in running() method

### DIFF
--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -28,114 +28,152 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
   "Java AsyncCacheApi" should {
     "set cache values" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
-    }
-    "set cache values with an expiration time" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar", oneSecondExpiration).asScala)
-
-      after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await }
-    }
-    "set cache values with an expiration time" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar", tenSecondsExpiration).asScala)
-
-      after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await }
-    }
-    "get or update" should {
-      "get value when it exists" in new WithApplication {
+      override def running() = {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         await(cacheApi.set("foo", "bar").asScala)
         cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
       }
-      "update cache when value does not exists" in new WithApplication {
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      override def running() = {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-        val future = cacheApi
-          .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"))
-          .asScala
-
-        future must beEqualTo("bar").await
-        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
-      }
-      "update cache with an expiration time when value does not exists" in new WithApplication {
-        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-        val future = cacheApi
-          .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"), oneSecondExpiration)
-          .asScala
-
-        future must beEqualTo("bar").await
+        await(cacheApi.set("foo", "bar", oneSecondExpiration).asScala)
 
         after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await }
       }
     }
-    "remove values from cache" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+    "set cache values with an expiration time" in new WithApplication {
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        await(cacheApi.set("foo", "bar", tenSecondsExpiration).asScala)
 
-      await(cacheApi.remove("foo").asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+        after2sec {
+          cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+        }
+      }
+    }
+    "get or update" should {
+      "get value when it exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+          await(cacheApi.set("foo", "bar").asScala)
+          cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+        }
+      }
+      "update cache when value does not exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+          val future = cacheApi
+            .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"))
+            .asScala
+
+          future must beEqualTo("bar").await
+          cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+        }
+      }
+      "update cache with an expiration time when value does not exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+          val future = cacheApi
+            .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"), oneSecondExpiration)
+            .asScala
+
+          future must beEqualTo("bar").await
+
+          after2sec {
+            cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+          }
+        }
+      }
+    }
+    "remove values from cache" in new WithApplication {
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        await(cacheApi.set("foo", "bar").asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+
+        await(cacheApi.remove("foo").asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+      }
     }
 
     "remove all values from cache" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        await(cacheApi.set("foo", "bar").asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
 
-      await(cacheApi.removeAll().asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+        await(cacheApi.removeAll().asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+      }
     }
   }
 
   "Java SyncCacheApi" should {
     "set cache values" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-      cacheApi.set("foo", "bar")
-      cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
-    }
-    "set cache values with an expiration time" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-      cacheApi.set("foo", "bar", oneSecondExpiration)
-
-      cacheApi.get[String]("foo") must beEqualTo(Optional.empty()).eventually(3, 2.seconds)
-    }
-    "set cache values with an expiration time" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-      cacheApi.set("foo", "bar", tenSecondsExpiration)
-
-      after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar")) }
-    }
-    "get or update" should {
-      "get value when it exists" in new WithApplication {
+      override def running() = {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
         cacheApi.set("foo", "bar")
         cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
       }
-      "update cache when value does not exists" in new WithApplication {
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      override def running() = {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-        val value    = cacheApi.getOrElseUpdate[String]("foo", () => "bar")
+        cacheApi.set("foo", "bar", oneSecondExpiration)
 
-        value must beEqualTo("bar")
-        cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+        cacheApi.get[String]("foo") must beEqualTo(Optional.empty()).eventually(3, 2.seconds)
+      }
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+        cacheApi.set("foo", "bar", tenSecondsExpiration)
+
+        after2sec {
+          cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+        }
+      }
+    }
+    "get or update" should {
+      "get value when it exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+          cacheApi.set("foo", "bar")
+          cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+        }
+      }
+      "update cache when value does not exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+          val value    = cacheApi.getOrElseUpdate[String]("foo", () => "bar")
+
+          value must beEqualTo("bar")
+          cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+        }
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
-        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-        val future   = cacheApi.getOrElseUpdate[String]("foo", () => "bar", oneSecondExpiration)
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+          val future   = cacheApi.getOrElseUpdate[String]("foo", () => "bar", oneSecondExpiration)
 
-        future must beEqualTo("bar")
+          future must beEqualTo("bar")
 
-        after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.empty()) }
+          after2sec {
+            cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
+          }
+        }
       }
     }
     "remove values from cache" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-      cacheApi.set("foo", "bar")
-      cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+        cacheApi.set("foo", "bar")
+        cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
 
-      cacheApi.remove("foo")
-      cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
+        cacheApi.remove("foo")
+        cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
+      }
     }
   }
 }

--- a/cache/play-caffeine-cache/src/test/scala/play/api/cache/caffeine/CaffeineCacheApiSpec.scala
+++ b/cache/play-caffeine-cache/src/test/scala/play/api/cache/caffeine/CaffeineCacheApiSpec.scala
@@ -32,14 +32,16 @@ class CaffeineCacheApiSpec extends PlaySpecification {
         "play.cache.bindCaches" -> Seq("custom")
       )
     ) {
-      val controller = app.injector.instanceOf[NamedCacheController]
-      val syncCacheName =
-        controller.cache.asInstanceOf[SyncCaffeineCacheApi].cache.getName
-      val asyncCacheName =
-        controller.asyncCache.asInstanceOf[CaffeineCacheApi].cache.getName
+      override def running() = {
+        val controller = app.injector.instanceOf[NamedCacheController]
+        val syncCacheName =
+          controller.cache.asInstanceOf[SyncCaffeineCacheApi].cache.getName
+        val asyncCacheName =
+          controller.asyncCache.asInstanceOf[CaffeineCacheApi].cache.getName
 
-      syncCacheName must_== "custom"
-      asyncCacheName must_== "custom"
+        syncCacheName must_== "custom"
+        asyncCacheName must_== "custom"
+      }
     }
 
     "configure cache builder by name" in new WithApplication(
@@ -53,18 +55,20 @@ class CaffeineCacheApiSpec extends PlaySpecification {
         "play.cache.caffeine.caches.custom-two.soft-values"      -> true
       )
     ) {
-      val caffeineCacheManager: CaffeineCacheManager = app.injector.instanceOf[CaffeineCacheManager]
+      override def running() = {
+        val caffeineCacheManager: CaffeineCacheManager = app.injector.instanceOf[CaffeineCacheManager]
 
-      val cacheBuilderStrCustom: String    = caffeineCacheManager.getCacheBuilder("custom").toString
-      val cacheBuilderStrCustomTwo: String = caffeineCacheManager.getCacheBuilder("custom-two").toString
+        val cacheBuilderStrCustom: String    = caffeineCacheManager.getCacheBuilder("custom").toString
+        val cacheBuilderStrCustomTwo: String = caffeineCacheManager.getCacheBuilder("custom-two").toString
 
-      cacheBuilderStrCustom.contains("initialCapacity=130") must be
-      cacheBuilderStrCustom.contains("maximumSize=50") must be
-      cacheBuilderStrCustom.contains("keyStrength=weak") must be
-      cacheBuilderStrCustom.contains("valueStrength=weak") must be
+        cacheBuilderStrCustom.contains("initialCapacity=130") must be
+        cacheBuilderStrCustom.contains("maximumSize=50") must be
+        cacheBuilderStrCustom.contains("keyStrength=weak") must be
+        cacheBuilderStrCustom.contains("valueStrength=weak") must be
 
-      cacheBuilderStrCustomTwo.contains("initialCapacity=140") must be
-      cacheBuilderStrCustomTwo.contains("valueStrength=soft") must be
+        cacheBuilderStrCustomTwo.contains("initialCapacity=140") must be
+        cacheBuilderStrCustomTwo.contains("valueStrength=soft") must be
+      }
     }
 
     "get cache names" in new WithApplication(
@@ -72,28 +76,32 @@ class CaffeineCacheApiSpec extends PlaySpecification {
         "play.cache.bindCaches" -> Seq("custom")
       )
     ) {
-      import scala.jdk.CollectionConverters._
-      val caffeineCacheManager: CaffeineCacheManager = app.injector.instanceOf[CaffeineCacheManager]
-      caffeineCacheManager.getCache("custom")
-      caffeineCacheManager.getCache("custom-two")
-      caffeineCacheManager.getCache("random")
+      override def running() = {
+        import scala.jdk.CollectionConverters._
+        val caffeineCacheManager: CaffeineCacheManager = app.injector.instanceOf[CaffeineCacheManager]
+        caffeineCacheManager.getCache("custom")
+        caffeineCacheManager.getCache("custom-two")
+        caffeineCacheManager.getCache("random")
 
-      val caches = caffeineCacheManager.cacheNames
-      caches must have size 3
-      caches must contain(exactly("custom", "custom-two", "random"))
+        val caches = caffeineCacheManager.cacheNames
+        caches must have size 3
+        caches must contain(exactly("custom", "custom-two", "random"))
 
-      caffeineCacheManager.getCache("new-cache")
-      val cacheNames = caffeineCacheManager.getCacheNames()
-      cacheNames.asScala must have size 4
-      cacheNames.asScala must contain(exactly("custom", "custom-two", "random", "new-cache"))
+        caffeineCacheManager.getCache("new-cache")
+        val cacheNames = caffeineCacheManager.getCacheNames()
+        cacheNames.asScala must have size 4
+        cacheNames.asScala must contain(exactly("custom", "custom-two", "random", "new-cache"))
+      }
     }
 
     "get values from cache" in new WithApplication() {
-      val cacheApi     = app.injector.instanceOf[AsyncCacheApi]
-      val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
-      syncCacheApi.set("foo", "bar")
-      Await.result(cacheApi.getOrElseUpdate[String]("foo")(Future.successful("baz")), 1.second) must_== "bar"
-      syncCacheApi.getOrElseUpdate("foo")("baz") must_== "bar"
+      override def running() = {
+        val cacheApi     = app.injector.instanceOf[AsyncCacheApi]
+        val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
+        syncCacheApi.set("foo", "bar")
+        Await.result(cacheApi.getOrElseUpdate[String]("foo")(Future.successful("baz")), 1.second) must_== "bar"
+        syncCacheApi.getOrElseUpdate("foo")("baz") must_== "bar"
+      }
     }
 
     "get values from cache without deadlocking" in new WithApplication(
@@ -101,76 +109,96 @@ class CaffeineCacheApiSpec extends PlaySpecification {
         bind[ExecutionContext].toInstance(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1)))
       )
     ) {
-      val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
-      syncCacheApi.set("foo", "bar")
-      syncCacheApi.getOrElseUpdate[String]("foo")("baz") must_== "bar"
+      override def running() = {
+        val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
+        syncCacheApi.set("foo", "bar")
+        syncCacheApi.getOrElseUpdate[String]("foo")("baz") must_== "bar"
+      }
     }
 
     "remove values from cache" in new WithApplication() {
-      val cacheApi     = app.injector.instanceOf[AsyncCacheApi]
-      val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
-      syncCacheApi.set("foo", "bar")
-      Await.result(cacheApi.getOrElseUpdate[String]("foo")(Future.successful("baz")), 1.second) must_== "bar"
-      syncCacheApi.remove("foo")
-      Await.result(cacheApi.get[String]("foo"), 1.second) must beNone
+      override def running() = {
+        val cacheApi     = app.injector.instanceOf[AsyncCacheApi]
+        val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
+        syncCacheApi.set("foo", "bar")
+        Await.result(cacheApi.getOrElseUpdate[String]("foo")(Future.successful("baz")), 1.second) must_== "bar"
+        syncCacheApi.remove("foo")
+        Await.result(cacheApi.get[String]("foo"), 1.second) must beNone
+      }
     }
 
     "remove all values from cache" in new WithApplication() {
-      val cacheApi     = app.injector.instanceOf[AsyncCacheApi]
-      val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
-      syncCacheApi.set("foo", "bar")
-      Await.result(cacheApi.getOrElseUpdate[String]("foo")(Future.successful("baz")), 1.second) must_== "bar"
-      Await.result(cacheApi.removeAll(), 1.second) must be(akka.Done)
-      Await.result(cacheApi.get[String]("foo"), 1.second) must beNone
+      override def running() = {
+        val cacheApi     = app.injector.instanceOf[AsyncCacheApi]
+        val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
+        syncCacheApi.set("foo", "bar")
+        Await.result(cacheApi.getOrElseUpdate[String]("foo")(Future.successful("baz")), 1.second) must_== "bar"
+        Await.result(cacheApi.removeAll(), 1.second) must be(akka.Done)
+        Await.result(cacheApi.get[String]("foo"), 1.second) must beNone
+      }
     }
 
     "put and return the value given with orElse function if there is no value with the given key" in new WithApplication() {
-      val syncCacheApi   = app.injector.instanceOf[SyncCacheApi]
-      val result: String = syncCacheApi.getOrElseUpdate("aaa")("ddd")
-      result mustEqual "ddd"
-      val resultFromCacheMaybe = syncCacheApi.get[String]("aaa")
-      resultFromCacheMaybe must beSome("ddd")
+      override def running() = {
+        val syncCacheApi   = app.injector.instanceOf[SyncCacheApi]
+        val result: String = syncCacheApi.getOrElseUpdate("aaa")("ddd")
+        result mustEqual "ddd"
+        val resultFromCacheMaybe = syncCacheApi.get[String]("aaa")
+        resultFromCacheMaybe must beSome("ddd")
+      }
     }
 
     "asynchronously put and return the value given with orElse function if there is no value with the given key" in new WithApplication() {
-      val asyncCacheApi = app.injector.instanceOf[AsyncCacheApi]
-      val resultFuture  = asyncCacheApi.getOrElseUpdate[String]("aaa")(Future.successful("ddd"))
-      val result        = Await.result(resultFuture, 2.seconds)
-      result mustEqual "ddd"
-      val resultFromCacheFuture = asyncCacheApi.get[String]("aaa")
-      val resultFromCacheMaybe  = Await.result(resultFromCacheFuture, 2.seconds)
-      resultFromCacheMaybe must beSome("ddd")
+      override def running() = {
+        val asyncCacheApi = app.injector.instanceOf[AsyncCacheApi]
+        val resultFuture  = asyncCacheApi.getOrElseUpdate[String]("aaa")(Future.successful("ddd"))
+        val result        = Await.result(resultFuture, 2.seconds)
+        result mustEqual "ddd"
+        val resultFromCacheFuture = asyncCacheApi.get[String]("aaa")
+        val resultFromCacheMaybe  = Await.result(resultFromCacheFuture, 2.seconds)
+        resultFromCacheMaybe must beSome("ddd")
+      }
     }
 
     "expire the item after the given amount of time is passed" in new WithApplication() {
-      val syncCacheApi   = app.injector.instanceOf[SyncCacheApi]
-      val expiration     = 1.second
-      val result: String = syncCacheApi.getOrElseUpdate("aaa", expiration)("ddd")
-      result mustEqual "ddd"
-      Thread.sleep(expiration.toMillis + 100) // be sure that expire duration passes
-      val resultMaybe = syncCacheApi.get[String]("aaa")
-      resultMaybe must beNone
+      override def running() = {
+        val syncCacheApi   = app.injector.instanceOf[SyncCacheApi]
+        val expiration     = 1.second
+        val result: String = syncCacheApi.getOrElseUpdate("aaa", expiration)("ddd")
+        result mustEqual "ddd"
+        Thread.sleep(expiration.toMillis + 100) // be sure that expire duration passes
+        val resultMaybe = syncCacheApi.get[String]("aaa")
+        resultMaybe must beNone
+      }
     }
 
     "SyncCacheApi.getOrElseUpdate method should not evaluate the orElse part if the cache contains an item with the given key" in new WithApplication() {
-      val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
-      syncCacheApi.set("aaa", "bbb")
-      trait OrElse { lazy val orElse: String = "ccc" }
-      val mockOrElse = Mockito.mock(classOf[OrElse])
-      val result     = syncCacheApi.getOrElseUpdate[String]("aaa")(mockOrElse.orElse)
-      result mustEqual "bbb"
-      verify(mockOrElse, never).orElse
+      override def running() = {
+        val syncCacheApi = app.injector.instanceOf[SyncCacheApi]
+        syncCacheApi.set("aaa", "bbb")
+        trait OrElse {
+          lazy val orElse: String = "ccc"
+        }
+        val mockOrElse = Mockito.mock(classOf[OrElse])
+        val result     = syncCacheApi.getOrElseUpdate[String]("aaa")(mockOrElse.orElse)
+        result mustEqual "bbb"
+        verify(mockOrElse, never).orElse
+      }
     }
 
     "AsyncCacheApi.getOrElseUpdate method should not evaluate the orElse part if the cache contains an item with the given key" in new WithApplication() {
-      val asyncCacheApi = app.injector.instanceOf[AsyncCacheApi]
-      asyncCacheApi.set("aaa", "bbb")
-      trait OrElse { lazy val orElse: Future[String] = Future.successful("ccc") }
-      val mockOrElse   = Mockito.mock(classOf[OrElse])
-      val resultFuture = asyncCacheApi.getOrElseUpdate[String]("aaa")(mockOrElse.orElse)
-      val result       = Await.result(resultFuture, 2.seconds)
-      result mustEqual "bbb"
-      verify(mockOrElse, never).orElse
+      override def running() = {
+        val asyncCacheApi = app.injector.instanceOf[AsyncCacheApi]
+        asyncCacheApi.set("aaa", "bbb")
+        trait OrElse {
+          lazy val orElse: Future[String] = Future.successful("ccc")
+        }
+        val mockOrElse   = Mockito.mock(classOf[OrElse])
+        val resultFuture = asyncCacheApi.getOrElseUpdate[String]("aaa")(mockOrElse.orElse)
+        val result       = Await.result(resultFuture, 2.seconds)
+        result mustEqual "bbb"
+        verify(mockOrElse, never).orElse
+      }
     }
   }
 }

--- a/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -29,137 +29,155 @@ class CachedSpec extends PlaySpecification {
 
   "the cached action" should {
     "cache values using injected CachedApi" in new WithApplication() {
-      val controller = app.injector.instanceOf[CachedController]
-      val result1    = controller.action(FakeRequest()).run()
-      contentAsString(result1) must_== "1"
-      controller.invoked.get() must_== 1
-      val result2 = controller.action(FakeRequest()).run()
-      contentAsString(result2) must_== "1"
-      controller.invoked.get() must_== 1
+      override def running() = {
+        val controller = app.injector.instanceOf[CachedController]
+        val result1    = controller.action(FakeRequest()).run()
+        contentAsString(result1) must_== "1"
+        controller.invoked.get() must_== 1
+        val result2 = controller.action(FakeRequest()).run()
+        contentAsString(result2) must_== "1"
+        controller.invoked.get() must_== 1
 
-      // Test that the same headers are added
-      header(ETAG, result2) must_== header(ETAG, result1)
-      header(EXPIRES, result2) must_== header(EXPIRES, result1)
+        // Test that the same headers are added
+        header(ETAG, result2) must_== header(ETAG, result1)
+        header(EXPIRES, result2) must_== header(EXPIRES, result1)
+      }
     }
 
     "cache values using named injected CachedApi" >> new WithApplication(
       _.configure("play.cache.bindCaches" -> Seq("custom"))
     ) {
-      val controller = app.injector.instanceOf[NamedCachedController]
-      val result1    = controller.action(FakeRequest()).run()
-      contentAsString(result1) must_== "1"
-      controller.invoked.get() must_== 1
-      val result2 = controller.action(FakeRequest()).run()
-      contentAsString(result2) must_== "1"
-      controller.invoked.get() must_== 1
+      override def running() = {
+        val controller = app.injector.instanceOf[NamedCachedController]
+        val result1    = controller.action(FakeRequest()).run()
+        contentAsString(result1) must_== "1"
+        controller.invoked.get() must_== 1
+        val result2 = controller.action(FakeRequest()).run()
+        contentAsString(result2) must_== "1"
+        controller.invoked.get() must_== 1
 
-      // Test that the same headers are added
-      header(ETAG, result2) must_== header(ETAG, result1)
-      header(EXPIRES, result2) must_== header(EXPIRES, result1)
+        // Test that the same headers are added
+        header(ETAG, result2) must_== header(ETAG, result1)
+        header(EXPIRES, result2) must_== header(EXPIRES, result1)
 
-      // Test that the values are in the right cache
-      app.injector.instanceOf[SyncCacheApi].get[String]("foo") must beNone
-      controller.isCached("foo-etag") must beTrue
+        // Test that the values are in the right cache
+        app.injector.instanceOf[SyncCacheApi].get[String]("foo") must beNone
+        controller.isCached("foo-etag") must beTrue
+      }
     }
 
     "cache values to disk using injected CachedApi" in new WithApplication() {
-      import net.sf.ehcache._
-      import net.sf.ehcache.config._
-      import net.sf.ehcache.store.MemoryStoreEvictionPolicy
-      // FIXME: Do this properly
-      val cacheManager = app.injector.instanceOf[CacheManager]
-      val diskEhcache = new Cache(
-        new CacheConfiguration("disk", 30)
-          .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LFU)
-          .eternal(false)
-          .timeToLiveSeconds(60)
-          .timeToIdleSeconds(30)
-          .diskExpiryThreadIntervalSeconds(0)
-          .persistence(new PersistenceConfiguration().strategy(PersistenceConfiguration.Strategy.LOCALTEMPSWAP))
-      )
-      cacheManager.addCache(diskEhcache)
-      val diskEhcache2 = cacheManager.getCache("disk")
-      assert(diskEhcache2 != null)
-      val diskCache  = new EhCacheApi(diskEhcache2)(app.materializer.executionContext)
-      val diskCached = new Cached(diskCache)
-      val invoked    = new AtomicInteger()
-      val action     = diskCached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
-      val result1    = action(FakeRequest()).run()
-      contentAsString(result1) must_== "1"
-      invoked.get() must_== 1
-      val result2 = action(FakeRequest()).run()
-      contentAsString(result2) must_== "1"
+      override def running() = {
+        import net.sf.ehcache._
+        import net.sf.ehcache.config._
+        import net.sf.ehcache.store.MemoryStoreEvictionPolicy
+        // FIXME: Do this properly
+        val cacheManager = app.injector.instanceOf[CacheManager]
+        val diskEhcache = new Cache(
+          new CacheConfiguration("disk", 30)
+            .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LFU)
+            .eternal(false)
+            .timeToLiveSeconds(60)
+            .timeToIdleSeconds(30)
+            .diskExpiryThreadIntervalSeconds(0)
+            .persistence(new PersistenceConfiguration().strategy(PersistenceConfiguration.Strategy.LOCALTEMPSWAP))
+        )
+        cacheManager.addCache(diskEhcache)
+        val diskEhcache2 = cacheManager.getCache("disk")
+        assert(diskEhcache2 != null)
+        val diskCache  = new EhCacheApi(diskEhcache2)(app.materializer.executionContext)
+        val diskCached = new Cached(diskCache)
+        val invoked    = new AtomicInteger()
+        val action     = diskCached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
+        val result1    = action(FakeRequest()).run()
+        contentAsString(result1) must_== "1"
+        invoked.get() must_== 1
+        val result2 = action(FakeRequest()).run()
+        contentAsString(result2) must_== "1"
 
-      // Test that the same headers are added
-      header(ETAG, result2) must_== header(ETAG, result1)
-      header(EXPIRES, result2) must_== header(EXPIRES, result1)
+        // Test that the same headers are added
+        header(ETAG, result2) must_== header(ETAG, result1)
+        header(EXPIRES, result2) must_== header(EXPIRES, result1)
 
-      invoked.get() must_== 1
+        invoked.get() must_== 1
+      }
     }
 
     "cache values using Application's Cached" in new WithApplication() {
-      val invoked = new AtomicInteger()
-      val action = cached(app)(_ => "foo") {
-        Action(Results.Ok("" + invoked.incrementAndGet()))
+      override def running() = {
+        val invoked = new AtomicInteger()
+        val action = cached(app)(_ => "foo") {
+          Action(Results.Ok("" + invoked.incrementAndGet()))
+        }
+        val result1 = action(FakeRequest()).run()
+        contentAsString(result1) must_== "1"
+        invoked.get() must_== 1
+        val result2 = action(FakeRequest()).run()
+        contentAsString(result2) must_== "1"
+
+        // Test that the same headers are added
+        header(ETAG, result2) must_== header(ETAG, result1)
+        header(EXPIRES, result2) must_== header(EXPIRES, result1)
+
+        invoked.get() must_== 1
       }
-      val result1 = action(FakeRequest()).run()
-      contentAsString(result1) must_== "1"
-      invoked.get() must_== 1
-      val result2 = action(FakeRequest()).run()
-      contentAsString(result2) must_== "1"
-
-      // Test that the same headers are added
-      header(ETAG, result2) must_== header(ETAG, result1)
-      header(EXPIRES, result2) must_== header(EXPIRES, result1)
-
-      invoked.get() must_== 1
     }
 
     "use etags for values" in new WithApplication() {
-      val invoked = new AtomicInteger()
-      val action  = cached(app)(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
-      val result1 = action(FakeRequest()).run()
-      status(result1) must_== 200
-      invoked.get() must_== 1
-      val etag = header(ETAG, result1)
-      etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) // """
-      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run()
-      status(result2) must_== NOT_MODIFIED
-      invoked.get() must_== 1
+      override def running() = {
+        val invoked = new AtomicInteger()
+        val action  = cached(app)(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
+        val result1 = action(FakeRequest()).run()
+        status(result1) must_== 200
+        invoked.get() must_== 1
+        val etag = header(ETAG, result1)
+        etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) // """
+        val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run()
+        status(result2) must_== NOT_MODIFIED
+        invoked.get() must_== 1
+      }
     }
 
     "support wildcard etags" in new WithApplication() {
-      val invoked = new AtomicInteger()
-      val action  = cached(app)(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
-      val result1 = action(FakeRequest()).run()
-      status(result1) must_== 200
-      invoked.get() must_== 1
-      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> "*")).run()
-      status(result2) must_== NOT_MODIFIED
-      invoked.get() must_== 1
+      override def running() = {
+        val invoked = new AtomicInteger()
+        val action  = cached(app)(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
+        val result1 = action(FakeRequest()).run()
+        status(result1) must_== 200
+        invoked.get() must_== 1
+        val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> "*")).run()
+        status(result2) must_== NOT_MODIFIED
+        invoked.get() must_== 1
+      }
     }
 
     "use etags weak comparison" in new WithApplication() {
-      val invoked = new AtomicInteger()
-      val action  = cached(app)(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
-      val result1 = action(FakeRequest()).run()
-      status(result1) must_== 200
-      invoked.get() must_== 1
-      val etag = header(ETAG, result1).map("W/" + _)
-      etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) // """
-      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run()
-      status(result2) must_== NOT_MODIFIED
-      invoked.get() must_== 1
+      override def running() = {
+        val invoked = new AtomicInteger()
+        val action  = cached(app)(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
+        val result1 = action(FakeRequest()).run()
+        status(result1) must_== 200
+        invoked.get() must_== 1
+        val etag = header(ETAG, result1).map("W/" + _)
+        etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) // """
+        val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run()
+        status(result2) must_== NOT_MODIFIED
+        invoked.get() must_== 1
+      }
     }
 
     "work with etag cache misses" in new WithApplication() {
-      val action  = cached(app)(_.uri)(Action(Results.Ok))
-      val resultA = action(FakeRequest("GET", "/a")).run()
-      status(resultA) must_== 200
-      status(action(FakeRequest("GET", "/a").withHeaders(IF_NONE_MATCH -> "\"foo\"")).run()) must_== 200
-      status(action(FakeRequest("GET", "/b").withHeaders(IF_NONE_MATCH -> header(ETAG, resultA).get)).run()) must_== 200
-      status(action(FakeRequest("GET", "/c").withHeaders(IF_NONE_MATCH -> "*")).run()) must_== 200
-      status(action(FakeRequest("GET", "/d").withHeaders(IF_NONE_MATCH -> "illegal")).run()) must_== 200
+      override def running() = {
+        val action  = cached(app)(_.uri)(Action(Results.Ok))
+        val resultA = action(FakeRequest("GET", "/a")).run()
+        status(resultA) must_== 200
+        status(action(FakeRequest("GET", "/a").withHeaders(IF_NONE_MATCH -> "\"foo\"")).run()) must_== 200
+        status(
+          action(FakeRequest("GET", "/b").withHeaders(IF_NONE_MATCH -> header(ETAG, resultA).get)).run()
+        ) must_== 200
+        status(action(FakeRequest("GET", "/c").withHeaders(IF_NONE_MATCH -> "*")).run()) must_== 200
+        status(action(FakeRequest("GET", "/d").withHeaders(IF_NONE_MATCH -> "illegal")).run()) must_== 200
+      }
     }
   }
 
@@ -169,165 +187,181 @@ class CachedSpec extends PlaySpecification {
 
   "Cached EssentialAction composition" should {
     "cache infinite ok results" in new WithApplication() {
-      val cacheOk = cached(app)
-        .empty { x => x.uri }
-        .includeStatus(200)
+      override def running() = {
+        val cacheOk = cached(app)
+          .empty { x => x.uri }
+          .includeStatus(200)
 
-      val actionOk       = cacheOk.build(dummyAction)
-      val actionNotFound = cacheOk.build(notFoundAction)
+        val actionOk       = cacheOk.build(dummyAction)
+        val actionNotFound = cacheOk.build(notFoundAction)
 
-      val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
-      val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
+        val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
+        val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
 
-      // println(("res0", header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run)))
+        // println(("res0", header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run)))
 
-      res0 must equalTo(res1)
+        res0 must equalTo(res1)
 
-      val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
-      val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+        val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+        val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
 
-      (res2 must not).equalTo(res3)
+        (res2 must not).equalTo(res3)
+      }
     }
 
     "cache everything for infinite" in new WithApplication() {
-      val cache = cached(app).everything { x => x.uri }
+      override def running() = {
+        val cache = cached(app).everything { x => x.uri }
 
-      val actionOk       = cache.build(dummyAction)
-      val actionNotFound = cache.build(notFoundAction)
+        val actionOk       = cache.build(dummyAction)
+        val actionNotFound = cache.build(notFoundAction)
 
-      val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
-      val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
+        val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
+        val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
 
-      res0 must equalTo(res1)
+        res0 must equalTo(res1)
 
-      val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
-      val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+        val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+        val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
 
-      res2 must equalTo(res3)
+        res2 must equalTo(res3)
+      }
     }
 
     "cache everything one hour" in new WithApplication() {
-      val cache = cached(app).everything((x: RequestHeader) => x.uri, 3600)
+      override def running() = {
+        val cache = cached(app).everything((x: RequestHeader) => x.uri, 3600)
 
-      val actionOk       = cache.build(dummyAction)
-      val actionNotFound = cache.build(notFoundAction)
+        val actionOk       = cache.build(dummyAction)
+        val actionNotFound = cache.build(notFoundAction)
 
-      val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run())
-      val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run())
+        val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run())
+        val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run())
 
-      def toDuration(header: String) = {
-        val now    = Instant.now().toEpochMilli
-        val target = Instant.from(http.dateFormat.parse(header)).toEpochMilli
-        Duration(target - now, MILLISECONDS)
+        def toDuration(header: String) = {
+          val now    = Instant.now().toEpochMilli
+          val target = Instant.from(http.dateFormat.parse(header)).toEpochMilli
+          Duration(target - now, MILLISECONDS)
+        }
+
+        val beInOneHour = beBetween((Duration(1, HOURS) - Duration(10, SECONDS)).toMillis, Duration(1, HOURS).toMillis)
+
+        res0.map(toDuration).map(_.toMillis) must beSome(beInOneHour)
+        res1.map(toDuration).map(_.toMillis) must beSome(beInOneHour)
       }
-
-      val beInOneHour = beBetween((Duration(1, HOURS) - Duration(10, SECONDS)).toMillis, Duration(1, HOURS).toMillis)
-
-      res0.map(toDuration).map(_.toMillis) must beSome(beInOneHour)
-      res1.map(toDuration).map(_.toMillis) must beSome(beInOneHour)
     }
 
     "cache everything for a given duration" in new WithApplication {
-      val duration = 15.minutes
-      val cache    = cached.everything((x: RequestHeader) => x.uri, duration)
+      override def running() = {
+        val duration = 15.minutes
+        val cache    = cached.everything((x: RequestHeader) => x.uri, duration)
 
-      val actionOk       = cache.build(dummyAction)
-      val actionNotFound = cache.build(notFoundAction)
+        val actionOk       = cache.build(dummyAction)
+        val actionNotFound = cache.build(notFoundAction)
 
-      val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run())
-      val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run())
+        val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run())
+        val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run())
 
-      def toDuration(header: String) = {
-        val now    = Instant.now().toEpochMilli
-        val target = Instant.from(http.dateFormat.parse(header)).toEpochMilli
-        Duration(target - now, MILLISECONDS)
+        def toDuration(header: String) = {
+          val now    = Instant.now().toEpochMilli
+          val target = Instant.from(http.dateFormat.parse(header)).toEpochMilli
+          Duration(target - now, MILLISECONDS)
+        }
+
+        res0.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
+        res1.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
       }
-
-      res0.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
-      res1.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
     }
 
     "cache 200 OK results for a given duration" in new WithApplication {
-      val duration = 15.minutes
-      val cache    = cached.status((x: RequestHeader) => x.uri, OK, duration)
+      override def running() = {
+        val duration = 15.minutes
+        val cache    = cached.status((x: RequestHeader) => x.uri, OK, duration)
 
-      val actionOk       = cache.build(dummyAction)
-      val actionNotFound = cache.build(notFoundAction)
+        val actionOk       = cache.build(dummyAction)
+        val actionNotFound = cache.build(notFoundAction)
 
-      val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run())
-      val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run())
+        val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run())
+        val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run())
 
-      def toDuration(header: String) = {
-        val now    = Instant.now().toEpochMilli
-        val target = Instant.from(http.dateFormat.parse(header)).toEpochMilli
-        Duration(target - now, MILLISECONDS)
+        def toDuration(header: String) = {
+          val now    = Instant.now().toEpochMilli
+          val target = Instant.from(http.dateFormat.parse(header)).toEpochMilli
+          Duration(target - now, MILLISECONDS)
+        }
+
+        res0.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
+        res1.map(toDuration) must beNone
       }
-
-      res0.map(toDuration) must beSome(beBetween(duration - 10.seconds, duration))
-      res1.map(toDuration) must beNone
     }
   }
 
   "AsyncCacheApi" should {
     "get items from cache" in new WithApplication() {
-      val defaultCache = app.injector.instanceOf[AsyncCacheApi].sync
-      defaultCache.set("foo", "bar")
-      defaultCache.get[String]("foo") must beSome("bar")
+      override def running() = {
+        val defaultCache = app.injector.instanceOf[AsyncCacheApi].sync
+        defaultCache.set("foo", "bar")
+        defaultCache.get[String]("foo") must beSome("bar")
 
-      defaultCache.set("int", 31)
-      defaultCache.get[Int]("int") must beSome(31)
+        defaultCache.set("int", 31)
+        defaultCache.get[Int]("int") must beSome(31)
 
-      defaultCache.set("long", 31L)
-      defaultCache.get[Long]("long") must beSome(31L)
+        defaultCache.set("long", 31L)
+        defaultCache.get[Long]("long") must beSome(31L)
 
-      defaultCache.set("double", 3.14)
-      defaultCache.get[Double]("double") must beSome(3.14)
+        defaultCache.set("double", 3.14)
+        defaultCache.get[Double]("double") must beSome(3.14)
 
-      defaultCache.set("boolean", true)
-      defaultCache.get[Boolean]("boolean") must beSome(true)
+        defaultCache.set("boolean", true)
+        defaultCache.get[Boolean]("boolean") must beSome(true)
 
-      defaultCache.set("unit", ())
-      defaultCache.get[Unit]("unit") must beSome(())
+        defaultCache.set("unit", ())
+        defaultCache.get[Unit]("unit") must beSome(())
+      }
     }
 
     "doesnt give items from cache with wrong type" in new WithApplication() {
-      val defaultCache = app.injector.instanceOf[AsyncCacheApi].sync
-      defaultCache.set("foo", "bar")
-      defaultCache.set("int", 31)
-      defaultCache.set("long", 31L)
-      defaultCache.set("double", 3.14)
-      defaultCache.set("boolean", true)
-      defaultCache.set("unit", ())
+      override def running() = {
+        val defaultCache = app.injector.instanceOf[AsyncCacheApi].sync
+        defaultCache.set("foo", "bar")
+        defaultCache.set("int", 31)
+        defaultCache.set("long", 31L)
+        defaultCache.set("double", 3.14)
+        defaultCache.set("boolean", true)
+        defaultCache.set("unit", ())
 
-      defaultCache.get[Int]("foo") must beNone
-      defaultCache.get[Long]("foo") must beNone
-      defaultCache.get[Double]("foo") must beNone
-      defaultCache.get[Boolean]("foo") must beNone
-      defaultCache.get[String]("int") must beNone
-      defaultCache.get[Long]("int") must beNone
-      defaultCache.get[Double]("int") must beNone
-      defaultCache.get[Boolean]("int") must beNone
-      defaultCache.get[Unit]("foo") must beNone
-      defaultCache.get[Int]("unit") must beNone
+        defaultCache.get[Int]("foo") must beNone
+        defaultCache.get[Long]("foo") must beNone
+        defaultCache.get[Double]("foo") must beNone
+        defaultCache.get[Boolean]("foo") must beNone
+        defaultCache.get[String]("int") must beNone
+        defaultCache.get[Long]("int") must beNone
+        defaultCache.get[Double]("int") must beNone
+        defaultCache.get[Boolean]("int") must beNone
+        defaultCache.get[Unit]("foo") must beNone
+        defaultCache.get[Int]("unit") must beNone
+      }
     }
 
     "get items from the cache without giving the type" in new WithApplication() {
-      val defaultCache = app.injector.instanceOf[AsyncCacheApi].sync
-      defaultCache.set("foo", "bar")
-      defaultCache.get[String]("foo") must beSome("bar")
-      defaultCache.get[Any]("foo") must beSome("bar")
+      override def running() = {
+        val defaultCache = app.injector.instanceOf[AsyncCacheApi].sync
+        defaultCache.set("foo", "bar")
+        defaultCache.get[String]("foo") must beSome("bar")
+        defaultCache.get[Any]("foo") must beSome("bar")
 
-      defaultCache.set("baz", false)
-      defaultCache.get[Boolean]("baz") must beSome(false)
-      defaultCache.get[Any]("baz") must beSome(false)
+        defaultCache.set("baz", false)
+        defaultCache.get[Boolean]("baz") must beSome(false)
+        defaultCache.get[Any]("baz") must beSome(false)
 
-      defaultCache.set("int", 31)
-      defaultCache.get[Int]("int") must beSome(31)
-      defaultCache.get[Any]("int") must beSome(31)
+        defaultCache.set("int", 31)
+        defaultCache.get[Int]("int") must beSome(31)
+        defaultCache.get[Any]("int") must beSome(31)
 
-      defaultCache.set("unit", ())
-      defaultCache.get[Unit]("unit") must beSome(())
-      defaultCache.get[Any]("unit") must beSome(())
+        defaultCache.set("unit", ())
+        defaultCache.get[Unit]("unit") must beSome(())
+        defaultCache.get[Any]("unit") must beSome(())
+      }
     }
   }
 
@@ -335,11 +369,13 @@ class CachedSpec extends PlaySpecification {
     "support binding multiple different caches" in new WithApplication(
       _.configure("play.cache.bindCaches" -> Seq("custom"))
     ) {
-      val component    = app.injector.instanceOf[SomeComponent]
-      val defaultCache = app.injector.instanceOf[AsyncCacheApi]
-      component.set("foo", "bar")
-      defaultCache.sync.get[String]("foo") must beNone
-      component.get("foo") must beSome("bar")
+      override def running() = {
+        val component    = app.injector.instanceOf[SomeComponent]
+        val defaultCache = app.injector.instanceOf[AsyncCacheApi]
+        component.set("foo", "bar")
+        defaultCache.sync.get[String]("foo") must beNone
+        component.get("foo") must beSome("bar")
+      }
     }
   }
 }

--- a/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -28,114 +28,156 @@ class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
   "Java AsyncCacheApi" should {
     "set cache values" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
-    }
-    "set cache values with an expiration time" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar", oneSecondExpiration).asScala)
-
-      after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await }
-    }
-    "set cache values with an expiration time" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar", tenSecondsExpiration).asScala)
-
-      after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await }
-    }
-    "get or update" should {
-      "get value when it exists" in new WithApplication {
+      override def running() = {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
         await(cacheApi.set("foo", "bar").asScala)
         cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
       }
-      "update cache when value does not exists" in new WithApplication {
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      override def running() = {
         val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-        val future = cacheApi
-          .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"))
-          .asScala
+        await(cacheApi.set("foo", "bar", oneSecondExpiration).asScala)
 
-        future must beEqualTo("bar").await
-        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+        after2sec {
+          cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+        }
+      }
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        await(cacheApi.set("foo", "bar", tenSecondsExpiration).asScala)
+
+        after2sec {
+          cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+        }
+      }
+    }
+    "get or update" should {
+      "get value when it exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+          await(cacheApi.set("foo", "bar").asScala)
+          cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+        }
+      }
+      "update cache when value does not exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+          val future = cacheApi
+            .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"))
+            .asScala
+
+          future must beEqualTo("bar").await
+          cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+        }
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
-        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-        val future = cacheApi
-          .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"), oneSecondExpiration)
-          .asScala
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+          val future = cacheApi
+            .getOrElseUpdate[String]("foo", () => CompletableFuture.completedFuture[String]("bar"), oneSecondExpiration)
+            .asScala
 
-        future must beEqualTo("bar").await
+          future must beEqualTo("bar").await
 
-        after2sec { cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await }
+          after2sec {
+            cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+          }
+        }
       }
     }
     "remove values from cache" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        await(cacheApi.set("foo", "bar").asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
 
-      await(cacheApi.remove("foo").asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+        await(cacheApi.remove("foo").asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+      }
     }
 
     "remove all values from cache" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
-      await(cacheApi.set("foo", "bar").asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        await(cacheApi.set("foo", "bar").asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.of("bar")).await
 
-      await(cacheApi.removeAll().asScala)
-      cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+        await(cacheApi.removeAll().asScala)
+        cacheApi.get[String]("foo").asScala must beEqualTo(Optional.empty()).await
+      }
     }
   }
 
   "Java SyncCacheApi" should {
     "set cache values" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-      cacheApi.set("foo", "bar")
-      cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
-    }
-    "set cache values with an expiration time" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-      cacheApi.set("foo", "bar", oneSecondExpiration)
-
-      after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.empty()) }
-    }
-    "set cache values with an expiration time" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-      cacheApi.set("foo", "bar", tenSecondsExpiration)
-
-      after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar")) }
-    }
-    "get or update" should {
-      "get value when it exists" in new WithApplication {
+      override def running() = {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
         cacheApi.set("foo", "bar")
         cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
       }
-      "update cache when value does not exists" in new WithApplication {
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      override def running() = {
         val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-        val value    = cacheApi.getOrElseUpdate[String]("foo", () => "bar")
+        cacheApi.set("foo", "bar", oneSecondExpiration)
 
-        value must beEqualTo("bar")
-        cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+        after2sec {
+          cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
+        }
+      }
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+        cacheApi.set("foo", "bar", tenSecondsExpiration)
+
+        after2sec {
+          cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+        }
+      }
+    }
+    "get or update" should {
+      "get value when it exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+          cacheApi.set("foo", "bar")
+          cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+        }
+      }
+      "update cache when value does not exists" in new WithApplication {
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+          val value    = cacheApi.getOrElseUpdate[String]("foo", () => "bar")
+
+          value must beEqualTo("bar")
+          cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+        }
       }
       "update cache with an expiration time when value does not exists" in new WithApplication {
-        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-        val future   = cacheApi.getOrElseUpdate[String]("foo", () => "bar", oneSecondExpiration)
+        override def running() = {
+          val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+          val future   = cacheApi.getOrElseUpdate[String]("foo", () => "bar", oneSecondExpiration)
 
-        future must beEqualTo("bar")
+          future must beEqualTo("bar")
 
-        after2sec { cacheApi.get[String]("foo") must beEqualTo(Optional.empty()) }
+          after2sec {
+            cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
+          }
+        }
       }
     }
     "remove values from cache" in new WithApplication {
-      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
-      cacheApi.set("foo", "bar")
-      cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
+      override def running() = {
+        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+        cacheApi.set("foo", "bar")
+        cacheApi.get[String]("foo") must beEqualTo(Optional.of("bar"))
 
-      cacheApi.remove("foo")
-      cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
+        cacheApi.remove("foo")
+        cacheApi.get[String]("foo") must beEqualTo(Optional.empty())
+      }
     }
   }
 }

--- a/cache/play-jcache/src/test/scala/play/api/libs/jcache/JCacheSpec.scala
+++ b/cache/play-jcache/src/test/scala/play/api/libs/jcache/JCacheSpec.scala
@@ -15,8 +15,10 @@ import play.api.test._
 class JCacheSpec extends PlaySpecification {
   "CacheManager" should {
     "be instantiated" in new WithApplication() with Injecting {
-      val cacheManager = inject[CacheManager]
-      cacheManager must not beNull
+      override def running() = {
+        val cacheManager = inject[CacheManager]
+        cacheManager must not beNull
+      }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -54,9 +54,11 @@ trait ServerIntegrationSpecificationSpec
     "run the right server when using WithServer trait" in new WithServer(
       app = GuiceApplicationBuilder().routes(httpServerTagRoutes).build()
     ) {
-      val response = await(wsUrl("/httpServerTag").get())
-      response.status must equalTo(OK)
-      response.body[String] must_== expectedServerTag.toString
+      override def running() = {
+        val response = await(wsUrl("/httpServerTag").get())
+        response.status must equalTo(OK)
+        response.body[String] must_== expectedServerTag.toString
+      }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/action/FormActionSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/action/FormActionSpec.scala
@@ -81,18 +81,24 @@ class FormActionSpec extends PlaySpecification with WsTestClient {
       )
 
       "bind all parameters for multipart request" in new WithApplication(application) {
-        val request = FakeRequest(POST, "/multipart").withMultipartFormDataBody(multipartBody)
-        contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+        override def running() = {
+          val request = FakeRequest(POST, "/multipart").withMultipartFormDataBody(multipartBody)
+          contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+        }
       }
 
       "bind all parameters for multipart request with max length" in new WithApplication(application) {
-        val request = FakeRequest(POST, "/multipart/max-length").withMultipartFormDataBody(multipartBody)
-        contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+        override def running() = {
+          val request = FakeRequest(POST, "/multipart/max-length").withMultipartFormDataBody(multipartBody)
+          contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+        }
       }
 
       "bind all parameters for multipart request to temporary file" in new WithApplication(application) {
-        val request = FakeRequest(POST, "/multipart/wrapped-max-length").withMultipartFormDataBody(multipartBody)
-        contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+        override def running() = {
+          val request = FakeRequest(POST, "/multipart/wrapped-max-length").withMultipartFormDataBody(multipartBody)
+          contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+        }
       }
     }
   }

--- a/core/play-integration-test/src/it/scala/play/it/auth/SecuritySpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/auth/SecuritySpec.scala
@@ -42,12 +42,14 @@ class SecuritySpec extends PlaySpecification {
 
   "AuthenticatedActionBuilder" should {
     "be injected using Guice" in new WithApplication() with Injecting {
-      val builder = inject[AuthenticatedActionBuilder]
-      val result = builder.apply { req => Results.Ok(s"${req.messages("derp")}:${req.user.name}") }(
-        FakeRequest().withSession("user" -> "Phil")
-      )
-      status(result) must_== OK
-      contentAsString(result) must_== "derp:Phil"
+      override def running() = {
+        val builder = inject[AuthenticatedActionBuilder]
+        val result = builder.apply { req => Results.Ok(s"${req.messages("derp")}:${req.user.name}") }(
+          FakeRequest().withSession("user" -> "Phil")
+        )
+        status(result) must_== OK
+        contentAsString(result) must_== "derp:Phil"
+      }
     }
   }
 

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
@@ -22,57 +22,77 @@ class AnyContentBodyParserSpec extends PlaySpecification {
     }
 
     "parse text bodies for DELETE requests" in new WithApplication(_.globalApp(false)) {
-      parse("DELETE", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      override def running() = {
+        parse("DELETE", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      }
     }
 
     "parse text bodies for GET requests" in new WithApplication(_.globalApp(false)) {
-      parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      override def running() = {
+        parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      }
     }
 
     "parse empty bodies as raw for GET requests" in new WithApplication(_.globalApp(false)) {
-      parse("PUT", None, ByteString.empty) must beRight.like {
-        case AnyContentAsRaw(rawBuffer) =>
-          rawBuffer.asBytes() must beSome[ByteString].like {
-            case outBytes => outBytes must beEmpty
-          }
+      override def running() = {
+        parse("PUT", None, ByteString.empty) must beRight.like {
+          case AnyContentAsRaw(rawBuffer) =>
+            rawBuffer.asBytes() must beSome[ByteString].like {
+              case outBytes => outBytes must beEmpty
+            }
+        }
       }
     }
 
     "parse text bodies for HEAD requests" in new WithApplication(_.globalApp(false)) {
-      parse("HEAD", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      override def running() = {
+        parse("HEAD", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      }
     }
 
     "parse text bodies for OPTIONS requests" in new WithApplication(_.globalApp(false)) {
-      parse("OPTIONS", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      override def running() = {
+        parse("OPTIONS", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      }
     }
 
     "parse XML bodies for PATCH requests" in new WithApplication(_.globalApp(false)) {
-      parse("POST", Some("text/xml"), ByteString("<bar></bar>")) must beRight(AnyContentAsXml(<bar></bar>))
+      override def running() = {
+        parse("POST", Some("text/xml"), ByteString("<bar></bar>")) must beRight(AnyContentAsXml(<bar></bar>))
+      }
     }
 
     "parse text bodies for POST requests" in new WithApplication(_.globalApp(false)) {
-      parse("POST", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      override def running() = {
+        parse("POST", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
+      }
     }
 
     "parse JSON bodies for PUT requests" in new WithApplication(_.globalApp(false)) {
-      parse("PUT", Some("application/json"), ByteString("""{"foo":"bar"}""")) must beRight.like {
-        case AnyContentAsJson(json) => (json \ "foo").as[String] must_== "bar"
+      override def running() = {
+        parse("PUT", Some("application/json"), ByteString("""{"foo":"bar"}""")) must beRight.like {
+          case AnyContentAsJson(json) => (json \ "foo").as[String] must_== "bar"
+        }
       }
     }
 
     "parse unknown bodies as raw for PUT requests" in new WithApplication(_.globalApp(false)) {
-      parse("PUT", None, ByteString.empty) must beRight.like {
-        case AnyContentAsRaw(rawBuffer) =>
-          rawBuffer.asBytes() must beSome[ByteString].like {
-            case outBytes => outBytes must beEmpty
-          }
+      override def running() = {
+        parse("PUT", None, ByteString.empty) must beRight.like {
+          case AnyContentAsRaw(rawBuffer) =>
+            rawBuffer.asBytes() must beSome[ByteString].like {
+              case outBytes => outBytes must beEmpty
+            }
+        }
       }
     }
 
     "accept greater than 2G bytes. not Int overflow" in new WithApplication(_.globalApp(false)) {
-      parse("POST", Some("text/plain"), ByteString("bar"), maxLength = Some(Int.MaxValue.toLong + 2L)) must beRight(
-        AnyContentAsText("bar")
-      )
+      override def running() = {
+        parse("POST", Some("text/plain"), ByteString("bar"), maxLength = Some(Int.MaxValue.toLong + 2L)) must beRight(
+          AnyContentAsText("bar")
+        )
+      }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/ByteStringBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/ByteStringBodyParserSpec.scala
@@ -16,24 +16,30 @@ class ByteStringBodyParserSpec extends PlaySpecification {
     def parser(implicit mat: Materializer)  = parsers.byteString.apply(FakeRequest())
 
     "parse single byte string bodies" in new WithApplication() {
-      await(parser.run(ByteString("bar"))) must beRight(===(ByteString("bar")))
+      override def running() = {
+        await(parser.run(ByteString("bar"))) must beRight(===(ByteString("bar")))
+      }
     }
 
     "parse multiple chunk byte string bodies" in new WithApplication() {
-      await(
-        parser.run(
-          Source(List(ByteString("foo"), ByteString("bar")))
-        )
-      ) must beRight(===(ByteString("foobar")))
+      override def running() = {
+        await(
+          parser.run(
+            Source(List(ByteString("foo"), ByteString("bar")))
+          )
+        ) must beRight(===(ByteString("foobar")))
+      }
     }
 
     "refuse to parse bodies greater than max length" in new WithApplication() {
-      val parser = parsers.byteString(4).apply(FakeRequest())
-      await(
-        parser.run(
-          Source(List(ByteString("foo"), ByteString("bar")))
-        )
-      ) must beLeft
+      override def running() = {
+        val parser = parsers.byteString(4).apply(FakeRequest())
+        await(
+          parser.run(
+            Source(List(ByteString("foo"), ByteString("bar")))
+          )
+        ) must beLeft
+      }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -27,45 +27,63 @@ class DefaultBodyParserSpec extends PlaySpecification {
     }
 
     "parse text bodies for DELETE requests" in new WithApplication() {
-      (parse("GET", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      override def running() = {
+        (parse("GET", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      }
     }
 
     "parse text bodies for GET requests" in new WithApplication() {
-      (parse("GET", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      override def running() = {
+        (parse("GET", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      }
     }
 
     "parse text bodies for HEAD requests" in new WithApplication() {
-      (parse("HEAD", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      override def running() = {
+        (parse("HEAD", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      }
     }
 
     "parse text bodies for OPTIONS requests" in new WithApplication() {
-      (parse("GET", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      override def running() = {
+        (parse("GET", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      }
     }
 
     "parse XML bodies for PATCH requests" in new WithApplication() {
-      (parse("POST", Some("text/xml"), ByteString("<bar></bar>")) must be).right(AnyContentAsXml(<bar></bar>))
+      override def running() = {
+        (parse("POST", Some("text/xml"), ByteString("<bar></bar>")) must be).right(AnyContentAsXml(<bar></bar>))
+      }
     }
 
     "parse text bodies for POST requests" in new WithApplication() {
-      (parse("POST", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      override def running() = {
+        (parse("POST", Some("text/plain"), ByteString("bar")) must be).right(AnyContentAsText("bar"))
+      }
     }
 
     "parse JSON bodies for PUT requests" in new WithApplication() {
-      parse("PUT", Some("application/json"), ByteString("""{"foo":"bar"}""")) must beRight.like {
-        case AnyContentAsJson(json) => (json \ "foo").as[String] must_== "bar"
+      override def running() = {
+        parse("PUT", Some("application/json"), ByteString("""{"foo":"bar"}""")) must beRight.like {
+          case AnyContentAsJson(json) => (json \ "foo").as[String] must_== "bar"
+        }
       }
     }
 
     "parse unknown empty bodies as empty for PUT requests" in new WithApplication() {
-      (parse("PUT", None, ByteString.empty) must be).right(AnyContentAsEmpty)
+      override def running() = {
+        (parse("PUT", None, ByteString.empty) must be).right(AnyContentAsEmpty)
+      }
     }
 
     "parse unknown bodies as raw for PUT requests" in new WithApplication() {
-      parse("PUT", None, ByteString("abc")) must beRight.like {
-        case AnyContentAsRaw(rawBuffer) =>
-          rawBuffer.asBytes() must beSome[ByteString].like {
-            case outBytes => outBytes must_== ByteString("abc")
-          }
+      override def running() = {
+        parse("PUT", None, ByteString("abc")) must beRight.like {
+          case AnyContentAsRaw(rawBuffer) =>
+            rawBuffer.asBytes() must beSome[ByteString].like {
+              case outBytes => outBytes must_== ByteString("abc")
+            }
+        }
       }
     }
   }

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
@@ -29,12 +29,16 @@ class EmptyBodyParserSpec extends PlaySpecification {
     }
 
     "parse empty bodies" in new WithApplication() {
-      parse(ByteString.empty, Some("text/plain"), "utf-8") must beRight(())
+      override def running() = {
+        parse(ByteString.empty, Some("text/plain"), "utf-8") must beRight(())
+      }
     }
 
     "parse non-empty bodies" in new WithApplication() {
-      parse(ByteString(1), Some("application/xml"), "utf-8") must beRight(())
-      parse(ByteString(1, 2, 3), None, "utf-8") must beRight(())
+      override def running() = {
+        parse(ByteString(1), Some("application/xml"), "utf-8") must beRight(())
+        parse(ByteString(1, 2, 3), None, "utf-8") must beRight(())
+      }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
@@ -23,12 +23,16 @@ class IgnoreBodyParserSpec extends PlaySpecification {
     }
 
     "ignore empty bodies" in new WithApplication() {
-      parse("foo", ByteString.empty, Some("text/plain"), "utf-8") must beRight("foo")
+      override def running() = {
+        parse("foo", ByteString.empty, Some("text/plain"), "utf-8") must beRight("foo")
+      }
     }
 
     "ignore non-empty bodies" in new WithApplication() {
-      parse(42, ByteString(1), Some("application/xml"), "utf-8") must beRight(42)
-      parse("foo", ByteString(1, 2, 3), None, "utf-8") must beRight("foo")
+      override def running() = {
+        parse(42, ByteString(1), Some("application/xml"), "utf-8") must beRight(42)
+        parse("foo", ByteString(1, 2, 3), None, "utf-8") must beRight("foo")
+      }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -316,102 +316,116 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
 
   "The multipart/form-data parser" should {
     "parse some content" in new WithApplication() {
-      val parser = parse.multipartFormData.apply(
-        FakeRequest().withHeaders(
-          CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      override def running() = {
+        val parser = parse.multipartFormData.apply(
+          FakeRequest().withHeaders(
+            CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+          )
         )
-      )
 
-      val result = await(parser.run(Source.single(ByteString(body))))
+        val result = await(parser.run(Source.single(ByteString(body))))
 
-      checkResult(result)
+        checkResult(result)
+      }
     }
 
     "parse some content with empty file allowed" in new WithApplication() {
-      val parser = parse
-        .multipartFormData(allowEmptyFiles = true)
-        .apply(
-          FakeRequest().withHeaders(
-            CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      override def running() = {
+        val parser = parse
+          .multipartFormData(allowEmptyFiles = true)
+          .apply(
+            FakeRequest().withHeaders(
+              CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+            )
           )
-        )
 
-      val result = await(parser.run(Source.single(ByteString(body))))
+        val result = await(parser.run(Source.single(ByteString(body))))
 
-      checkResultEmptyFileAllowed(result)
+        checkResultEmptyFileAllowed(result)
+      }
     }
 
     "parse some content that arrives one byte at a time" in new WithApplication() {
-      val parser = parse.multipartFormData.apply(
-        FakeRequest().withHeaders(
-          CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
-        )
-      )
-
-      val bytes  = body.getBytes.map(byte => ByteString(byte)).toVector
-      val result = await(parser.run(Source(bytes)))
-
-      checkResult(result)
-    }
-
-    "parse some content that arrives one byte at a time with empty file allowed" in new WithApplication() {
-      val parser = parse
-        .multipartFormData(allowEmptyFiles = true)
-        .apply(
+      override def running() = {
+        val parser = parse.multipartFormData.apply(
           FakeRequest().withHeaders(
             CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
           )
         )
 
-      val bytes  = body.getBytes.map(byte => ByteString(byte)).toVector
-      val result = await(parser.run(Source(bytes)))
+        val bytes  = body.getBytes.map(byte => ByteString(byte)).toVector
+        val result = await(parser.run(Source(bytes)))
 
-      checkResultEmptyFileAllowed(result)
+        checkResult(result)
+      }
+    }
+
+    "parse some content that arrives one byte at a time with empty file allowed" in new WithApplication() {
+      override def running() = {
+        val parser = parse
+          .multipartFormData(allowEmptyFiles = true)
+          .apply(
+            FakeRequest().withHeaders(
+              CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+            )
+          )
+
+        val bytes  = body.getBytes.map(byte => ByteString(byte)).toVector
+        val result = await(parser.run(Source(bytes)))
+
+        checkResultEmptyFileAllowed(result)
+      }
     }
 
     "return bad request for invalid body" in new WithApplication() {
-      val parser = parse.multipartFormData.apply(
-        FakeRequest().withHeaders(
-          CONTENT_TYPE -> "multipart/form-data" // no boundary
+      override def running() = {
+        val parser = parse.multipartFormData.apply(
+          FakeRequest().withHeaders(
+            CONTENT_TYPE -> "multipart/form-data" // no boundary
+          )
         )
-      )
 
-      val result = await(parser.run(Source.single(ByteString(body))))
+        val result = await(parser.run(Source.single(ByteString(body))))
 
-      result must beLeft[Result].like {
-        case error => error.header.status must_== BAD_REQUEST
+        result must beLeft[Result].like {
+          case error => error.header.status must_== BAD_REQUEST
+        }
       }
     }
 
     "validate the full length of the body" in new WithApplication(
       _.configure("play.http.parser.maxDiskBuffer" -> "100")
     ) {
-      val parser = parse.multipartFormData.apply(
-        FakeRequest().withHeaders(
-          CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      override def running() = {
+        val parser = parse.multipartFormData.apply(
+          FakeRequest().withHeaders(
+            CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+          )
         )
-      )
 
-      val result = await(parser.run(Source.single(ByteString(body))))
+        val result = await(parser.run(Source.single(ByteString(body))))
 
-      result must beLeft[Result].like {
-        case error => error.header.status must_== REQUEST_ENTITY_TOO_LARGE
+        result must beLeft[Result].like {
+          case error => error.header.status must_== REQUEST_ENTITY_TOO_LARGE
+        }
       }
     }
 
     "not parse more than the max data length" in new WithApplication(
       _.configure("play.http.parser.maxMemoryBuffer" -> "30")
     ) {
-      val parser = parse.multipartFormData.apply(
-        FakeRequest().withHeaders(
-          CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      override def running() = {
+        val parser = parse.multipartFormData.apply(
+          FakeRequest().withHeaders(
+            CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+          )
         )
-      )
 
-      val result = await(parser.run(Source.single(ByteString(body))))
+        val result = await(parser.run(Source.single(ByteString(body))))
 
-      result must beLeft.like {
-        case error => error.header.status must_== REQUEST_ENTITY_TOO_LARGE
+        result must beLeft.like {
+          case error => error.header.status must_== REQUEST_ENTITY_TOO_LARGE
+        }
       }
     }
 
@@ -437,15 +451,17 @@ class MultipartFormDataParserSpec extends PlaySpecification with WsTestClient {
     }
 
     "work if there's no crlf at the start" in new WithApplication() {
-      val parser = parse.multipartFormData.apply(
-        FakeRequest().withHeaders(
-          CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      override def running() = {
+        val parser = parse.multipartFormData.apply(
+          FakeRequest().withHeaders(
+            CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+          )
         )
-      )
 
-      val result = await(parser.run(Source.single(ByteString(body))))
+        val result = await(parser.run(Source.single(ByteString(body))))
 
-      checkResult(result)
+        checkResult(result)
+      }
     }
 
     "parse headers with semicolon inside quotes" in {

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/TextBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/TextBodyParserSpec.scala
@@ -28,29 +28,39 @@ class TextBodyParserSpec extends PlaySpecification {
     }
 
     "parse text bodies" in new WithApplication() {
-      parse("bar", Some("text/plain"), "utf-8") must beRight("bar")
+      override def running() = {
+        parse("bar", Some("text/plain"), "utf-8") must beRight("bar")
+      }
     }
 
     "honour the declared charset" in new WithApplication() {
-      parse("bär", Some("text/plain; charset=utf-8"), "utf-8") must beRight("bär")
-      parse("bär", Some("text/plain; charset=utf-16"), "utf-16") must beRight("bär")
-      parse("bär", Some("text/plain; charset=iso-8859-1"), "iso-8859-1") must beRight("bär")
+      override def running() = {
+        parse("bär", Some("text/plain; charset=utf-8"), "utf-8") must beRight("bär")
+        parse("bär", Some("text/plain; charset=utf-16"), "utf-16") must beRight("bär")
+        parse("bär", Some("text/plain; charset=iso-8859-1"), "iso-8859-1") must beRight("bär")
+      }
     }
 
     "default to us-ascii encoding" in new WithApplication() {
-      parse("bär", Some("text/plain"), "us-ascii") must beRight("b?r")
-      parse("bär", None, "us-ascii") must beRight("b?r")
-      parse("bär", None, "us-ascii") must beRight("b?r")
+      override def running() = {
+        parse("bär", Some("text/plain"), "us-ascii") must beRight("b?r")
+        parse("bär", None, "us-ascii") must beRight("b?r")
+        parse("bär", None, "us-ascii") must beRight("b?r")
+      }
     }
 
     "accept text/plain content type" in new WithApplication() {
-      parse("bar", Some("text/plain"), "utf-8") must beRight("bar")
+      override def running() = {
+        parse("bar", Some("text/plain"), "utf-8") must beRight("bar")
+      }
     }
 
     "reject non text/plain content types" in new WithApplication() {
-      val textBodyParser = app.injector.instanceOf[PlayBodyParsers].text
-      parse("bar", Some("application/xml"), "utf-8")(app.materializer, textBodyParser) must beLeft
-      parse("bar", None, "utf-8")(app.materializer, textBodyParser) must beLeft
+      override def running() = {
+        val textBodyParser = app.injector.instanceOf[PlayBodyParsers].text
+        parse("bar", Some("application/xml"), "utf-8")(app.materializer, textBodyParser) must beLeft
+        parse("bar", None, "utf-8")(app.materializer, textBodyParser) must beLeft
+      }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -36,138 +36,173 @@ class XmlBodyParserSpec extends PlaySpecification {
     }
 
     "parse XML bodies" in new WithApplication() {
-      parse("<foo>bar</foo>", Some("application/xml; charset=utf-8"), "utf-8") must beRight.like {
-        case xml => xml.text must_== "bar"
+      override def running() = {
+        parse("<foo>bar</foo>", Some("application/xml; charset=utf-8"), "utf-8") must beRight.like {
+          case xml => xml.text must_== "bar"
+        }
       }
     }
 
     "honour the external charset for application sub types" in new WithApplication() {
-      parse("<foo>bär</foo>", Some("application/xml; charset=iso-8859-1"), "iso-8859-1") must beRight.like {
-        case xml => xml.text must_== "bär"
-      }
-      parse("<foo>bär</foo>", Some("application/xml; charset=utf-16"), "utf-16") must beRight.like {
-        case xml => xml.text must_== "bär"
+      override def running() = {
+        parse("<foo>bär</foo>", Some("application/xml; charset=iso-8859-1"), "iso-8859-1") must beRight.like {
+          case xml => xml.text must_== "bär"
+        }
+        parse("<foo>bär</foo>", Some("application/xml; charset=utf-16"), "utf-16") must beRight.like {
+          case xml => xml.text must_== "bär"
+        }
       }
     }
 
     "honour the external charset for text sub types" in new WithApplication() {
-      parse("<foo>bär</foo>", Some("text/xml; charset=iso-8859-1"), "iso-8859-1") must beRight.like {
-        case xml => xml.text must_== "bär"
-      }
-      parse("<foo>bär</foo>", Some("text/xml; charset=utf-16"), "utf-16") must beRight.like {
-        case xml => xml.text must_== "bär"
+      override def running() = {
+        parse("<foo>bär</foo>", Some("text/xml; charset=iso-8859-1"), "iso-8859-1") must beRight.like {
+          case xml => xml.text must_== "bär"
+        }
+        parse("<foo>bär</foo>", Some("text/xml; charset=utf-16"), "utf-16") must beRight.like {
+          case xml => xml.text must_== "bär"
+        }
       }
     }
 
     "default to iso-8859-1 for text sub types" in new WithApplication() {
-      parse("<foo>bär</foo>", Some("text/xml"), "iso-8859-1") must beRight.like {
-        case xml => xml.text must_== "bär"
+      override def running() = {
+        parse("<foo>bär</foo>", Some("text/xml"), "iso-8859-1") must beRight.like {
+          case xml => xml.text must_== "bär"
+        }
       }
     }
 
     "default to reading the encoding from the prolog for application sub types" in new WithApplication() {
-      parse("""<?xml version="1.0" encoding="utf-16"?><foo>bär</foo>""", Some("application/xml"), "utf-16") must beRight
-        .like {
-          case xml => xml.text must_== "bär"
-        }
-      parse(
-        """<?xml version="1.0" encoding="iso-8859-1"?><foo>bär</foo>""",
-        Some("application/xml"),
-        "iso-8859-1"
-      ) must beRight
-        .like {
-          case xml => xml.text must_== "bär"
-        }
+      override def running() = {
+        parse(
+          """<?xml version="1.0" encoding="utf-16"?><foo>bär</foo>""",
+          Some("application/xml"),
+          "utf-16"
+        ) must beRight
+          .like {
+            case xml => xml.text must_== "bär"
+          }
+        parse(
+          """<?xml version="1.0" encoding="iso-8859-1"?><foo>bär</foo>""",
+          Some("application/xml"),
+          "iso-8859-1"
+        ) must beRight
+          .like {
+            case xml => xml.text must_== "bär"
+          }
+      }
     }
 
     "default to reading the encoding from the prolog for no content type" in new WithApplication() {
-      parse("""<?xml version="1.0" encoding="utf-16"?><foo>bär</foo>""", None, "utf-16") must beRight.like {
-        case xml => xml.text must_== "bär"
-      }
-      parse("""<?xml version="1.0" encoding="iso-8859-1"?><foo>bär</foo>""", None, "iso-8859-1") must beRight.like {
-        case xml => xml.text must_== "bär"
+      override def running() = {
+        parse("""<?xml version="1.0" encoding="utf-16"?><foo>bär</foo>""", None, "utf-16") must beRight.like {
+          case xml => xml.text must_== "bär"
+        }
+        parse("""<?xml version="1.0" encoding="iso-8859-1"?><foo>bär</foo>""", None, "iso-8859-1") must beRight.like {
+          case xml => xml.text must_== "bär"
+        }
       }
     }
 
     "accept all common xml content types" in new WithApplication() {
-      parse("<foo>bar</foo>", Some("application/xml; charset=utf-8"), "utf-8") must beRight.like {
-        case xml => xml.text must_== "bar"
-      }
-      parse("<foo>bar</foo>", Some("text/xml; charset=utf-8"), "utf-8") must beRight.like {
-        case xml => xml.text must_== "bar"
-      }
-      parse("<foo>bar</foo>", Some("application/xml+rdf; charset=utf-8"), "utf-8") must beRight.like {
-        case xml => xml.text must_== "bar"
+      override def running() = {
+        parse("<foo>bar</foo>", Some("application/xml; charset=utf-8"), "utf-8") must beRight.like {
+          case xml => xml.text must_== "bar"
+        }
+        parse("<foo>bar</foo>", Some("text/xml; charset=utf-8"), "utf-8") must beRight.like {
+          case xml => xml.text must_== "bar"
+        }
+        parse("<foo>bar</foo>", Some("application/xml+rdf; charset=utf-8"), "utf-8") must beRight.like {
+          case xml => xml.text must_== "bar"
+        }
       }
     }
 
     "reject non XML content types" in new WithApplication() {
-      parse("<foo>bar</foo>", Some("text/plain; charset=utf-8"), "utf-8")(app.materializer, xmlBodyParser) must beLeft
-      parse("<foo>bar</foo>", Some("xml/xml; charset=utf-8"), "utf-8")(app.materializer, xmlBodyParser) must beLeft
-      parse("<foo>bar</foo>", None, "utf-8")(app.materializer, xmlBodyParser) must beLeft
+      override def running() = {
+        parse("<foo>bar</foo>", Some("text/plain; charset=utf-8"), "utf-8")(app.materializer, xmlBodyParser) must beLeft
+        parse("<foo>bar</foo>", Some("xml/xml; charset=utf-8"), "utf-8")(app.materializer, xmlBodyParser) must beLeft
+        parse("<foo>bar</foo>", None, "utf-8")(app.materializer, xmlBodyParser) must beLeft
+      }
     }
 
     "gracefully handle invalid xml" in new WithApplication() {
-      parse("<foo", Some("text/xml; charset=utf-8"), "utf-8") must beLeft
+      override def running() = {
+        parse("<foo", Some("text/xml; charset=utf-8"), "utf-8") must beLeft
+      }
     }
 
     "parse XML bodies without loading in a related schema" in new WithApplication() {
-      val f = File.createTempFile("xxe", ".txt")
-      Files.write(f.toPath, "I shouldn't be there!".getBytes(StandardCharsets.UTF_8))
-      f.deleteOnExit()
-      val xml = s"""<?xml version="1.0" encoding="ISO-8859-1"?>
-                   | <!DOCTYPE foo [
-                   |   <!ELEMENT foo ANY >
-                   |   <!ENTITY xxe SYSTEM "${f.toURI}">]><foo>hello&xxe;</foo>""".stripMargin
+      override def running() = {
+        val f = File.createTempFile("xxe", ".txt")
+        Files.write(f.toPath, "I shouldn't be there!".getBytes(StandardCharsets.UTF_8))
+        f.deleteOnExit()
+        val xml =
+          s"""<?xml version="1.0" encoding="ISO-8859-1"?>
+             | <!DOCTYPE foo [
+             |   <!ELEMENT foo ANY >
+             |   <!ENTITY xxe SYSTEM "${f.toURI}">]><foo>hello&xxe;</foo>""".stripMargin
 
-      parse(xml, Some("text/xml; charset=iso-8859-1"), "iso-8859-1") must beLeft
+        parse(xml, Some("text/xml; charset=iso-8859-1"), "iso-8859-1") must beLeft
+      }
     }
 
     "parse XML bodies without loading in a related schema from a parameter" in new WithApplication() {
-      val externalParameterEntity = File.createTempFile("xep", ".dtd")
-      val externalGeneralEntity   = File.createTempFile("xxe", ".txt")
-      Files.write(
-        externalParameterEntity.toPath,
-        s"""
-           |<!ENTITY % xge SYSTEM "${externalGeneralEntity.toURI}">
-           |<!ENTITY % pe "<!ENTITY xxe '%xge;'>">
+      override def running() = {
+        val externalParameterEntity = File.createTempFile("xep", ".dtd")
+        val externalGeneralEntity   = File.createTempFile("xxe", ".txt")
+        Files.write(
+          externalParameterEntity.toPath,
+          s"""
+             |<!ENTITY % xge SYSTEM "${externalGeneralEntity.toURI}">
+             |<!ENTITY % pe "<!ENTITY xxe '%xge;'>">
         """.stripMargin.getBytes(StandardCharsets.UTF_8)
-      )
-      Files.write(externalGeneralEntity.toPath, "I shouldnt be there!".getBytes(StandardCharsets.UTF_8))
-      externalGeneralEntity.deleteOnExit()
-      externalParameterEntity.deleteOnExit()
-      val xml = s"""<?xml version="1.0" encoding="ISO-8859-1"?>
-                   | <!DOCTYPE foo [
-                   |   <!ENTITY % xpe SYSTEM "${externalParameterEntity.toURI}">
-                   |   %xpe;
-                   |   %pe;
-                   |   ]><foo>hello&xxe;</foo>""".stripMargin
+        )
+        Files.write(externalGeneralEntity.toPath, "I shouldnt be there!".getBytes(StandardCharsets.UTF_8))
+        externalGeneralEntity.deleteOnExit()
+        externalParameterEntity.deleteOnExit()
+        val xml =
+          s"""<?xml version="1.0" encoding="ISO-8859-1"?>
+             | <!DOCTYPE foo [
+             |   <!ENTITY % xpe SYSTEM "${externalParameterEntity.toURI}">
+             |   %xpe;
+             |   %pe;
+             |   ]><foo>hello&xxe;</foo>""".stripMargin
 
-      parse(xml, Some("text/xml; charset=iso-8859-1"), "iso-8859-1") must beLeft
+        parse(xml, Some("text/xml; charset=iso-8859-1"), "iso-8859-1") must beLeft
+      }
     }
 
     "gracefully fail when there are too many nested entities" in new WithApplication() {
-      val nested = for (x <- 1 to 30) yield "<!ENTITY laugh" + x + " \"&laugh" + (x - 1) + ";&laugh" + (x - 1) + ";\">"
-      val xml = s"""<?xml version="1.0"?>
-                   | <!DOCTYPE billion [
-                   | <!ELEMENT billion (#PCDATA)>
-                   | <!ENTITY laugh0 "ha">
-                   | ${nested.mkString("\n")}
-                   | ]>
-                   | <billion>&laugh30;</billion>""".stripMargin
-      parse(xml, Some("text/xml; charset=utf-8"), "utf-8") must beLeft
-      success
+      override def running() = {
+        val nested =
+          for (x <- 1 to 30) yield "<!ENTITY laugh" + x + " \"&laugh" + (x - 1) + ";&laugh" + (x - 1) + ";\">"
+        val xml =
+          s"""<?xml version="1.0"?>
+             | <!DOCTYPE billion [
+             | <!ELEMENT billion (#PCDATA)>
+             | <!ENTITY laugh0 "ha">
+             | ${nested.mkString("\n")}
+             | ]>
+             | <billion>&laugh30;</billion>""".stripMargin
+        parse(xml, Some("text/xml; charset=utf-8"), "utf-8") must beLeft
+        success
+      }
     }
 
     "gracefully fail when an entity expands to be very large" in new WithApplication() {
-      val as       = "a" * 50000
-      val entities = "&a;" * 50000
-      val xml = s"""<?xml version="1.0"?>
-                   | <!DOCTYPE kaboom [
-                   | <!ENTITY a "$as">
-                   | ]>
-                   | <kaboom>$entities</kaboom>""".stripMargin
-      parse(xml, Some("text/xml; charset=utf-8"), "utf-8") must beLeft
+      override def running() = {
+        val as       = "a" * 50000
+        val entities = "&a;" * 50000
+        val xml =
+          s"""<?xml version="1.0"?>
+             | <!DOCTYPE kaboom [
+             | <!ENTITY a "$as">
+             | ]>
+             | <kaboom>$entities</kaboom>""".stripMargin
+        parse(xml, Some("text/xml; charset=utf-8"), "utf-8") must beLeft
+      }
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/i18n/MessagesSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/i18n/MessagesSpec.scala
@@ -20,20 +20,24 @@ class MessagesSpec extends PlaySpecification with ControllerHelpers {
 
   "Messages" should {
     "provide default messages" in new WithApplication(_.requireExplicitBindings()) {
-      val messagesApi     = app.injector.instanceOf[MessagesApi]
-      val javaMessagesApi = app.injector.instanceOf[play.i18n.MessagesApi]
+      override def running() = {
+        val messagesApi     = app.injector.instanceOf[MessagesApi]
+        val javaMessagesApi = app.injector.instanceOf[play.i18n.MessagesApi]
 
-      val msg     = messagesApi("constraint.email")
-      val javaMsg = javaMessagesApi.get(new play.i18n.Lang(lang), "constraint.email")
+        val msg     = messagesApi("constraint.email")
+        val javaMsg = javaMessagesApi.get(new play.i18n.Lang(lang), "constraint.email")
 
-      msg must ===("Email")
-      msg must ===(javaMsg)
+        msg must ===("Email")
+        msg must ===(javaMsg)
+      }
     }
     "permit default override" in new WithApplication(_.requireExplicitBindings()) {
-      val messagesApi = app.injector.instanceOf[MessagesApi]
-      val msg         = messagesApi("constraint.required")
+      override def running() = {
+        val messagesApi = app.injector.instanceOf[MessagesApi]
+        val msg         = messagesApi("constraint.required")
 
-      msg must ===("Required!")
+        msg must ===("Required!")
+      }
     }
   }
 
@@ -42,27 +46,33 @@ class MessagesSpec extends PlaySpecification with ControllerHelpers {
     import java.util
     val enUS: Lang = new play.i18n.Lang(play.api.i18n.Lang("en-US"))
     "allow translation without parameters" in new WithApplication() {
-      val messagesApi = app.injector.instanceOf[MessagesApi]
-      val msg         = messagesApi.get(enUS, "constraint.email")
+      override def running() = {
+        val messagesApi = app.injector.instanceOf[MessagesApi]
+        val msg         = messagesApi.get(enUS, "constraint.email")
 
-      msg must ===("Email")
+        msg must ===("Email")
+      }
     }
     "allow translation with any non-list parameter" in new WithApplication() {
-      val messagesApi = app.injector.instanceOf[MessagesApi]
-      val msg         = messagesApi.get(enUS, "constraint.min", "Croissant")
+      override def running() = {
+        val messagesApi = app.injector.instanceOf[MessagesApi]
+        val msg         = messagesApi.get(enUS, "constraint.min", "Croissant")
 
-      msg must ===("Minimum value: Croissant")
+        msg must ===("Minimum value: Croissant")
+      }
     }
     "allow translation with any list parameter" in new WithApplication() {
-      val messagesApi = app.injector.instanceOf[MessagesApi]
+      override def running() = {
+        val messagesApi = app.injector.instanceOf[MessagesApi]
 
-      val msg = {
-        val list: util.ArrayList[String] = new util.ArrayList[String]()
-        list.add("Croissant")
-        messagesApi.get(enUS, "constraint.min", list)
+        val msg = {
+          val list: util.ArrayList[String] = new util.ArrayList[String]()
+          list.add("Croissant")
+          messagesApi.get(enUS, "constraint.min", list)
+        }
+
+        msg must ===("Minimum value: Croissant")
       }
-
-      msg must ===("Minimum value: Croissant")
     }
   }
 }

--- a/core/play-integration-test/src/it/scala/play/it/libs/JavaFormSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/libs/JavaFormSpec.scala
@@ -13,13 +13,15 @@ import play.data.validation.Constraints.Required
 class JavaFormSpec extends PlaySpecification {
   "A Java form" should {
     "throw a meaningful exception when get is called on an invalid form" in new WithApplication() {
-      val formFactory = app.injector.instanceOf[play.data.FormFactory]
-      val lang        = play.api.i18n.Lang.defaultLang.asJava
-      val attrs       = play.libs.typedmap.TypedMap.empty()
-      val myForm      = formFactory.form(classOf[FooForm]).bind(lang, attrs, Map("id" -> "1234567891").asJava)
-      myForm.hasErrors must beEqualTo(true)
-      myForm.get must throwAn[IllegalStateException].like {
-        case e => e.getMessage must contain("fooName")
+      override def running() = {
+        val formFactory = app.injector.instanceOf[play.data.FormFactory]
+        val lang        = play.api.i18n.Lang.defaultLang.asJava
+        val attrs       = play.libs.typedmap.TypedMap.empty()
+        val myForm      = formFactory.form(classOf[FooForm]).bind(lang, attrs, Map("id" -> "1234567891").asJava)
+        myForm.hasErrors must beEqualTo(true)
+        myForm.get must throwAn[IllegalStateException].like {
+          case e => e.getMessage must contain("fooName")
+        }
       }
     }
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/tests/ServerSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-system-property/tests/ServerSpec.scala
@@ -29,10 +29,12 @@ class ServerSpec extends PlaySpecification {
     "support starting an Netty server in a test" in new WithServer(
       app = GuiceApplicationBuilder().appRoutes(httpServerTagRoutes).build()
     ) {
-      val ws       = app.injector.instanceOf[WSClient]
-      val response = await(ws.url("http://localhost:19001/httpServerTag").get())
-      response.status must equalTo(OK)
-      response.body[String] must_== "netty"
+      override def running() = {
+        val ws = app.injector.instanceOf[WSClient]
+        val response = await(ws.url("http://localhost:19001/httpServerTag").get())
+        response.status must equalTo(OK)
+        response.body[String] must_== "netty"
+      }
     }
   }
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/build.sbt
@@ -60,11 +60,9 @@ scalacOptions ++= {
         "-Xlint",
         "-Ywarn-dead-code",
         "-Ywarn-numeric-widen",
-        "-Ywarn-value-discard",
       )
     case _ =>
       Seq(
-        "-Wvalue-discard"
       )
   })
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/tests/RouterSpec.scala
@@ -44,162 +44,198 @@ object RouterSpec extends PlaySpecification {
 
   "bind boolean parameters" in {
     "from the query string" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
-      contentAsString(result) must equalTo("/take-bool?b=true true")
-      val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
-      contentAsString(result2) must equalTo("/take-bool?b=false false")
-      // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("/take-bool?b=1 true")
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("/take-bool?b=0 false")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
+        contentAsString(result) must equalTo("/take-bool?b=true true")
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
+        contentAsString(result2) must equalTo("/take-bool?b=false false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("/take-bool?b=1 true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("/take-bool?b=0 false")
+      }
     }
     "from the path" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-bool-2/true")).get
-      contentAsString(result) must equalTo("/take-bool-2/true true")
-      val result2 = route(implicitApp, FakeRequest(GET, "/take-bool-2/false")).get
-      contentAsString(result2) must equalTo("/take-bool-2/false false")
-      // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo("/take-bool-2/1 true")
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo("/take-bool-2/0 false")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool-2/true")).get
+        contentAsString(result) must equalTo("/take-bool-2/true true")
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool-2/false")).get
+        contentAsString(result2) must equalTo("/take-bool-2/false false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo("/take-bool-2/1 true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo("/take-bool-2/0 false")
+      }
     }
   }
 
   "bind int parameters from the query string as a list" in {
 
     "from a list of numbers" in new WithApplication() {
-      val result = route(
-        implicitApp,
-        FakeRequest(
-          GET,
-          controllers.routes.Application
-            .takeList(List(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)).asJava)
-            .url
-        )
-      ).get
-      contentAsString(result) must equalTo("/take-list?x=1&x=2&x=3 1,2,3")
+      override def running() = {
+        val result = route(
+          implicitApp,
+          FakeRequest(
+            GET,
+            controllers.routes.Application
+              .takeList(List(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)).asJava)
+              .url
+          )
+        ).get
+        contentAsString(result) must equalTo("/take-list?x=1&x=2&x=3 1,2,3")
+      }
     }
     "from a list of numbers and letters" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2")).get
-      status(result) must equalTo(BAD_REQUEST)
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2")).get
+        status(result) must equalTo(BAD_REQUEST)
+      }
     }
     "when there is no parameter at all" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list")).get
-      contentAsString(result) must equalTo("/take-list ")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list")).get
+        contentAsString(result) must equalTo("/take-list ")
+      }
     }
     "using the Java API" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3")).get
-      contentAsString(result) must equalTo("/take-java-list?x=1&x=2&x=3 1,2,3")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3")).get
+        contentAsString(result) must equalTo("/take-java-list?x=1&x=2&x=3 1,2,3")
+      }
     }
   }
 
   "use a new instance for each instantiated controller" in new WithApplication() {
-    route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
-      case result => contentAsString(result) must_== "/instance 1"
-    }
-    route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
-      case result => contentAsString(result) must_== "/instance 1"
+    override def running() = {
+      route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
+        case result => contentAsString(result) must_== "/instance 1"
+      }
+      route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
+        case result => contentAsString(result) must_== "/instance 1"
+      }
     }
   }
 
   "URL encoding and decoding works correctly" in new WithApplication() {
-    def checkDecoding(
-        dynamicEncoded: String,
-        staticEncoded: String,
-        queryEncoded: String,
-        dynamicDecoded: String,
-        staticDecoded: String,
-        queryDecoded: String
-    ) = {
-      val path = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
-      val expected =
-        s"/urlcoding/$dynamicEncoded/$staticDecoded?q=$queryEncoded dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
-      val result = route(implicitApp, FakeRequest(GET, path)).get
-      val actual = contentAsString(result)
-      actual must equalTo(expected)
+    override def running() = {
+      def checkDecoding(
+                         dynamicEncoded: String,
+                         staticEncoded: String,
+                         queryEncoded: String,
+                         dynamicDecoded: String,
+                         staticDecoded: String,
+                         queryDecoded: String
+                       ) = {
+        val path = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
+        val expected =
+          s"/urlcoding/$dynamicEncoded/$staticDecoded?q=$queryEncoded dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
+        val result = route(implicitApp, FakeRequest(GET, path)).get
+        val actual = contentAsString(result)
+        actual must equalTo(expected)
+      }
+
+      def checkEncoding(
+                         dynamicDecoded: String,
+                         staticDecoded: String,
+                         queryDecoded: String,
+                         dynamicEncoded: String,
+                         staticEncoded: String,
+                         queryEncoded: String
+                       ) = {
+        val expected = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
+        val call = controllers.routes.Application.urlcoding(dynamicDecoded, staticDecoded, queryDecoded)
+        call.url must equalTo(expected)
+      }
+
+      checkDecoding("a", "a", "a", "a", "a", "a")
+      checkDecoding("%2B", "%2B", "%2B", "+", "%2B", "+")
+      checkDecoding("+", "+", "+", "+", "+", " ")
+      checkDecoding("%20", "%20", "%20", " ", "%20", " ")
+      checkDecoding("&", "&", "-", "&", "&", "-")
+      checkDecoding("=", "=", "-", "=", "=", "-")
+
+      checkEncoding("+", "+", "+", "+", "+", "%2B")
+      checkEncoding(" ", " ", " ", "%20", " ", "+")
+      checkEncoding("&", "&", "&", "&", "&", "%26")
+      checkEncoding("=", "=", "=", "=", "=", "%3D")
+
+      // We use java.net.URLEncoder for query string encoding, which is not
+      // RFC compliant, e.g. it percent-encodes "/" which is not a delimiter
+      // for query strings, and it percent-encodes "~" which is an "unreserved" character
+      // that should never be percent-encoded. The following tests, therefore
+      // don't really capture our ideal desired behaviour for query string
+      // encoding. However, the behaviour for dynamic and static paths is correct.
+      checkEncoding("/", "/", "/", "%2F", "/", "%2F")
+      checkEncoding("~", "~", "~", "~", "~", "%7E")
+
+      checkDecoding("123", "456", "789", "123", "456", "789")
+      checkEncoding("123", "456", "789", "123", "456", "789")
     }
-    def checkEncoding(
-        dynamicDecoded: String,
-        staticDecoded: String,
-        queryDecoded: String,
-        dynamicEncoded: String,
-        staticEncoded: String,
-        queryEncoded: String
-    ) = {
-      val expected = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
-      val call     = controllers.routes.Application.urlcoding(dynamicDecoded, staticDecoded, queryDecoded)
-      call.url must equalTo(expected)
-    }
-    checkDecoding("a", "a", "a", "a", "a", "a")
-    checkDecoding("%2B", "%2B", "%2B", "+", "%2B", "+")
-    checkDecoding("+", "+", "+", "+", "+", " ")
-    checkDecoding("%20", "%20", "%20", " ", "%20", " ")
-    checkDecoding("&", "&", "-", "&", "&", "-")
-    checkDecoding("=", "=", "-", "=", "=", "-")
-
-    checkEncoding("+", "+", "+", "+", "+", "%2B")
-    checkEncoding(" ", " ", " ", "%20", " ", "+")
-    checkEncoding("&", "&", "&", "&", "&", "%26")
-    checkEncoding("=", "=", "=", "=", "=", "%3D")
-
-    // We use java.net.URLEncoder for query string encoding, which is not
-    // RFC compliant, e.g. it percent-encodes "/" which is not a delimiter
-    // for query strings, and it percent-encodes "~" which is an "unreserved" character
-    // that should never be percent-encoded. The following tests, therefore
-    // don't really capture our ideal desired behaviour for query string
-    // encoding. However, the behaviour for dynamic and static paths is correct.
-    checkEncoding("/", "/", "/", "%2F", "/", "%2F")
-    checkEncoding("~", "~", "~", "~", "~", "%7E")
-
-    checkDecoding("123", "456", "789", "123", "456", "789")
-    checkEncoding("123", "456", "789", "123", "456", "789")
   }
 
   "allow reverse routing of routes includes" in new WithApplication() {
-    // Force the router to bootstrap the prefix
-    implicitApp.injector.instanceOf[play.api.routing.Router]
-    controllers.module.routes.ModuleController.index().url must_== "/module/index"
+    override def running() = {
+      // Force the router to bootstrap the prefix
+      implicitApp.injector.instanceOf[play.api.routing.Router]
+      controllers.module.routes.ModuleController.index().url must_== "/module/index"
+    }
   }
 
   "document the router" in new WithApplication() {
-    // The purpose of this test is to alert anyone that changes the format of the router documentation that
-    // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
-    val someRoute = implicitApp.injector
-      .instanceOf[play.api.routing.Router]
-      .documentation
-      .find(r => r._1 == "GET" && r._2.startsWith("/with/"))
-    someRoute must beSome[(String, String, String)]
-    val route = someRoute.get
-    route._2 must_== "/with/$param<[^/]+>"
-    route._3 must startWith("controllers.Application.withParam")
+    override def running() = {
+      // The purpose of this test is to alert anyone that changes the format of the router documentation that
+      // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
+      val someRoute = implicitApp.injector
+        .instanceOf[play.api.routing.Router]
+        .documentation
+        .find(r => r._1 == "GET" && r._2.startsWith("/with/"))
+      someRoute must beSome[(String, String, String)]
+      val route = someRoute.get
+      route._2 must_== "/with/$param<[^/]+>"
+      route._3 must startWith("controllers.Application.withParam")
+    }
   }
 
   "reverse routes complex query params " in new WithApplication() {
-    controllers.routes.Application
-      .takeList(List(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)).asJava)
-      .url must_== "/take-list?x=1&x=2&x=3"
+    override def running() = {
+      controllers.routes.Application
+        .takeList(List(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)).asJava)
+        .url must_== "/take-list?x=1&x=2&x=3"
+    }
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {
-    controllers.routes.Application.hello().url must_== "/hello"
+    override def running() = {
+      controllers.routes.Application.hello().url must_== "/hello"
+    }
   }
 
   "reverse routing a route with parameter that has default value and comes _after_ the request param" in new WithApplication() {
-    controllers.routes.Application.routedefault().url must_== "/routesdefault"
+    override def running() = {
+      controllers.routes.Application.routedefault().url must_== "/routesdefault"
+    }
   }
 
   "The assets reverse route support" should {
     "fingerprint assets" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      }
     }
     "selected the minified version" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      }
     }
     "work for non fingerprinted assets" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/nonfingerprinted.css").url must_== "/public/css/nonfingerprinted.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/nonfingerprinted.css").url must_== "/public/css/nonfingerprinted.css"
+      }
     }
     "selected the minified non fingerprinted version" in new WithApplication() {
-      controllers.routes.Assets
-        .versioned("css/nonfingerprinted-minmain.css")
-        .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      override def running() = {
+        controllers.routes.Assets
+          .versioned("css/nonfingerprinted-minmain.css")
+          .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      }
     }
   }
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/build.sbt
@@ -60,11 +60,9 @@ scalacOptions ++= {
         "-Xlint",
         "-Ywarn-dead-code",
         "-Ywarn-numeric-widen",
-        "-Ywarn-value-discard",
       )
     case _ =>
       Seq(
-        "-Wvalue-discard"
       )
   })
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
@@ -43,158 +43,196 @@ object RouterSpec extends PlaySpecification {
 
   "bind boolean parameters" in {
     "from the query string" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
-      contentAsString(result) must equalTo("true")
-      val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
-      contentAsString(result2) must equalTo("false")
-      // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("true")
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("false")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
+        contentAsString(result) must equalTo("true")
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
+        contentAsString(result2) must equalTo("false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("false")
+      }
     }
     "from the path" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-bool-2/true")).get
-      contentAsString(result) must equalTo("true")
-      val result2 = route(implicitApp, FakeRequest(GET, "/take-bool-2/false")).get
-      contentAsString(result2) must equalTo("false")
-      // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo("true")
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo("false")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool-2/true")).get
+        contentAsString(result) must equalTo("true")
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool-2/false")).get
+        contentAsString(result2) must equalTo("false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo("true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo("false")
+      }
     }
   }
 
   "bind int parameters from the query string as a list" in {
 
     "from a list of numbers" in new WithApplication() {
-      val result =
-        route(implicitApp, FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url)).get
-      contentAsString(result) must equalTo("1,2,3")
+      override def running() = {
+        val result =
+          route(implicitApp, FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url)).get
+        contentAsString(result) must equalTo("1,2,3")
+      }
     }
     "from a list of numbers and letters" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2")).get
-      status(result) must equalTo(BAD_REQUEST)
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2")).get
+        status(result) must equalTo(BAD_REQUEST)
+      }
     }
     "when there is no parameter at all" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list")).get
-      contentAsString(result) must equalTo("")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list")).get
+        contentAsString(result) must equalTo("")
+      }
     }
     "using the Java API" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3")).get
-      contentAsString(result) must equalTo("1,2,3")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3")).get
+        contentAsString(result) must equalTo("1,2,3")
+      }
     }
     "using backticked names on route params" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b[]=4&b[]=5&b[]=6")).get
-      contentAsString(result) must equalTo("4,5,6")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b[]=4&b[]=5&b[]=6")).get
+        contentAsString(result) must equalTo("4,5,6")
+      }
     }
     "using backticked names urlencoded on route params" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b%5B%5D=4&b%5B%5D=5&b%5B%5D=6")).get
-      contentAsString(result) must equalTo("4,5,6")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b%5B%5D=4&b%5B%5D=5&b%5B%5D=6")).get
+        contentAsString(result) must equalTo("4,5,6")
+      }
     }
   }
 
   "use a new instance for each instantiated controller" in new WithApplication() {
-    route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
-      case result => contentAsString(result) must_== "1"
-    }
-    route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
-      case result => contentAsString(result) must_== "1"
+    override def running() = {
+      route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
+        case result => contentAsString(result) must_== "1"
+      }
+      route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
+        case result => contentAsString(result) must_== "1"
+      }
     }
   }
 
   "URL encoding and decoding works correctly" in new WithApplication() {
-    def checkDecoding(
-        dynamicEncoded: String,
-        staticEncoded: String,
-        queryEncoded: String,
-        dynamicDecoded: String,
-        staticDecoded: String,
-        queryDecoded: String
-    ) = {
-      val path     = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
-      val expected = s"dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
-      val result   = route(implicitApp, FakeRequest(GET, path)).get
-      val actual   = contentAsString(result)
-      actual must equalTo(expected)
+    override def running() = {
+      def checkDecoding(
+                         dynamicEncoded: String,
+                         staticEncoded: String,
+                         queryEncoded: String,
+                         dynamicDecoded: String,
+                         staticDecoded: String,
+                         queryDecoded: String
+                       ) = {
+        val path = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
+        val expected = s"dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
+        val result = route(implicitApp, FakeRequest(GET, path)).get
+        val actual = contentAsString(result)
+        actual must equalTo(expected)
+      }
+
+      def checkEncoding(
+                         dynamicDecoded: String,
+                         staticDecoded: String,
+                         queryDecoded: String,
+                         dynamicEncoded: String,
+                         staticEncoded: String,
+                         queryEncoded: String
+                       ) = {
+        val expected = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
+        val call = controllers.routes.Application.urlcoding(dynamicDecoded, staticDecoded, queryDecoded)
+        call.url must equalTo(expected)
+      }
+
+      checkDecoding("a", "a", "a", "a", "a", "a")
+      checkDecoding("%2B", "%2B", "%2B", "+", "%2B", "+")
+      checkDecoding("+", "+", "+", "+", "+", " ")
+      checkDecoding("%20", "%20", "%20", " ", "%20", " ")
+      checkDecoding("&", "&", "-", "&", "&", "-")
+      checkDecoding("=", "=", "-", "=", "=", "-")
+
+      checkEncoding("+", "+", "+", "+", "+", "%2B")
+      checkEncoding(" ", " ", " ", "%20", " ", "+")
+      checkEncoding("&", "&", "&", "&", "&", "%26")
+      checkEncoding("=", "=", "=", "=", "=", "%3D")
+
+      // We use java.net.URLEncoder for query string encoding, which is not
+      // RFC compliant, e.g. it percent-encodes "/" which is not a delimiter
+      // for query strings, and it percent-encodes "~" which is an "unreserved" character
+      // that should never be percent-encoded. The following tests, therefore
+      // don't really capture our ideal desired behaviour for query string
+      // encoding. However, the behaviour for dynamic and static paths is correct.
+      checkEncoding("/", "/", "/", "%2F", "/", "%2F")
+      checkEncoding("~", "~", "~", "~", "~", "%7E")
+
+      checkDecoding("123", "456", "789", "123", "456", "789")
+      checkEncoding("123", "456", "789", "123", "456", "789")
     }
-    def checkEncoding(
-        dynamicDecoded: String,
-        staticDecoded: String,
-        queryDecoded: String,
-        dynamicEncoded: String,
-        staticEncoded: String,
-        queryEncoded: String
-    ) = {
-      val expected = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
-      val call     = controllers.routes.Application.urlcoding(dynamicDecoded, staticDecoded, queryDecoded)
-      call.url must equalTo(expected)
-    }
-    checkDecoding("a", "a", "a", "a", "a", "a")
-    checkDecoding("%2B", "%2B", "%2B", "+", "%2B", "+")
-    checkDecoding("+", "+", "+", "+", "+", " ")
-    checkDecoding("%20", "%20", "%20", " ", "%20", " ")
-    checkDecoding("&", "&", "-", "&", "&", "-")
-    checkDecoding("=", "=", "-", "=", "=", "-")
-
-    checkEncoding("+", "+", "+", "+", "+", "%2B")
-    checkEncoding(" ", " ", " ", "%20", " ", "+")
-    checkEncoding("&", "&", "&", "&", "&", "%26")
-    checkEncoding("=", "=", "=", "=", "=", "%3D")
-
-    // We use java.net.URLEncoder for query string encoding, which is not
-    // RFC compliant, e.g. it percent-encodes "/" which is not a delimiter
-    // for query strings, and it percent-encodes "~" which is an "unreserved" character
-    // that should never be percent-encoded. The following tests, therefore
-    // don't really capture our ideal desired behaviour for query string
-    // encoding. However, the behaviour for dynamic and static paths is correct.
-    checkEncoding("/", "/", "/", "%2F", "/", "%2F")
-    checkEncoding("~", "~", "~", "~", "~", "%7E")
-
-    checkDecoding("123", "456", "789", "123", "456", "789")
-    checkEncoding("123", "456", "789", "123", "456", "789")
   }
 
   "allow reverse routing of routes includes" in new WithApplication() {
-    // Force the router to bootstrap the prefix
-    implicitApp.injector.instanceOf[play.api.routing.Router]
-    controllers.module.routes.ModuleController.index.url must_== "/module/index"
+    override def running() = {
+      // Force the router to bootstrap the prefix
+      implicitApp.injector.instanceOf[play.api.routing.Router]
+      controllers.module.routes.ModuleController.index.url must_== "/module/index"
+    }
   }
 
   "document the router" in new WithApplication() {
-    // The purpose of this test is to alert anyone that changes the format of the router documentation that
-    // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
-    val someRoute = implicitApp.injector
-      .instanceOf[play.api.routing.Router]
-      .documentation
-      .find(r => r._1 == "GET" && r._2.startsWith("/with/"))
-    someRoute must beSome[(String, String, String)]
-    val route = someRoute.get
-    route._2 must_== "/with/$param<[^/]+>"
-    route._3 must startWith("controllers.Application.withParam")
+    override def running() = {
+      // The purpose of this test is to alert anyone that changes the format of the router documentation that
+      // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
+      val someRoute = implicitApp.injector
+        .instanceOf[play.api.routing.Router]
+        .documentation
+        .find(r => r._1 == "GET" && r._2.startsWith("/with/"))
+      someRoute must beSome[(String, String, String)]
+      val route = someRoute.get
+      route._2 must_== "/with/$param<[^/]+>"
+      route._3 must startWith("controllers.Application.withParam")
+    }
   }
 
   "reverse routes complex query params " in new WithApplication() {
-    controllers.routes.Application
-      .takeListTickedParam(List(1, 2, 3))
-      .url must_== "/take-list-tick-param?b%5B%5D=1&b%5B%5D=2&b%5B%5D=3" // ?b[]=1&b[]=2&b[]=3
+    override def running() = {
+      controllers.routes.Application
+        .takeListTickedParam(List(1, 2, 3))
+        .url must_== "/take-list-tick-param?b%5B%5D=1&b%5B%5D=2&b%5B%5D=3" // ?b[]=1&b[]=2&b[]=3
+    }
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {
-    controllers.routes.Application.hello.url must_== "/hello"
+    override def running() = {
+      controllers.routes.Application.hello.url must_== "/hello"
+    }
   }
 
   "The assets reverse route support" should {
     "fingerprint assets" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      }
     }
     "selected the minified version" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      }
     }
     "work for non fingerprinted assets" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/nonfingerprinted.css").url must_== "/public/css/nonfingerprinted.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/nonfingerprinted.css").url must_== "/public/css/nonfingerprinted.css"
+      }
     }
     "selected the minified non fingerprinted version" in new WithApplication() {
-      controllers.routes.Assets
-        .versioned("css/nonfingerprinted-minmain.css")
-        .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      override def running() = {
+        controllers.routes.Assets
+          .versioned("css/nonfingerprinted-minmain.css")
+          .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      }
     }
   }
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/build.sbt
@@ -50,11 +50,9 @@ scalacOptions ++= {
         "-Xlint",
         "-Ywarn-dead-code",
         "-Ywarn-numeric-widen",
-        "-Ywarn-value-discard",
       )
     case _ =>
       Seq(
-        "-Wvalue-discard"
       )
   })
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/tests/RouterSpec.scala
@@ -9,34 +9,44 @@ import play.api.test._
 object RouterSpec extends PlaySpecification {
 
   "document the router" in new WithApplication() {
-    val someRoute = implicitApp.injector
-      .instanceOf[play.api.routing.Router]
-      .documentation
-      .find(r => r._1 == "GET" && r._2.startsWith("/public/"))
-    someRoute must beSome[(String, String, String)]
-    val route = someRoute.get
-    route._2 must_== "/public/$file<.+>"
-    route._3 must startWith(
-      """_root_.controllers.Assets.versioned(path:String = "/public", file:_root_.controllers.Assets.Asset)"""
-    )
+    override def running() = {
+      val someRoute = implicitApp.injector
+        .instanceOf[play.api.routing.Router]
+        .documentation
+        .find(r => r._1 == "GET" && r._2.startsWith("/public/"))
+      someRoute must beSome[(String, String, String)]
+      val route = someRoute.get
+      route._2 must_== "/public/$file<.+>"
+      route._3 must startWith(
+        """_root_.controllers.Assets.versioned(path:String = "/public", file:_root_.controllers.Assets.Asset)"""
+      )
+    }
   }
 
   "The assets reverse route support" should {
     "fingerprint assets" in new WithApplication() {
-      router.controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      override def running() = {
+        router.controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      }
     }
     "selected the minified version" in new WithApplication() {
-      router.controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      override def running() = {
+        router.controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      }
     }
     "work for non fingerprinted assets" in new WithApplication() {
-      router.controllers.routes.Assets
-        .versioned("css/nonfingerprinted.css")
-        .url must_== "/public/css/nonfingerprinted.css"
+      override def running() = {
+        router.controllers.routes.Assets
+          .versioned("css/nonfingerprinted.css")
+          .url must_== "/public/css/nonfingerprinted.css"
+      }
     }
     "selected the minified non fingerprinted version" in new WithApplication() {
-      router.controllers.routes.Assets
-        .versioned("css/nonfingerprinted-minmain.css")
-        .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      override def running() = {
+        router.controllers.routes.Assets
+          .versioned("css/nonfingerprinted-minmain.css")
+          .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      }
     }
   }
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/build.sbt
@@ -62,11 +62,9 @@ scalacOptions ++= {
         "-Xlint",
         "-Ywarn-dead-code",
         "-Ywarn-numeric-widen",
-        "-Ywarn-value-discard",
       )
     case _ =>
       Seq(
-        "-Wvalue-discard"
       )
   })
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/tests/RouterSpec.scala
@@ -43,59 +43,77 @@ object RouterSpec extends PlaySpecification {
 
   "bind boolean parameters" in {
     "from the query string" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
-      contentAsString(result) must equalTo("true")
-      val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
-      contentAsString(result2) must equalTo("false")
-      // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("true")
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("false")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
+        contentAsString(result) must equalTo("true")
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
+        contentAsString(result2) must equalTo("false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("false")
+      }
     }
     "from the path" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-bool-2/true")).get
-      contentAsString(result) must equalTo("true")
-      val result2 = route(implicitApp, FakeRequest(GET, "/take-bool-2/false")).get
-      contentAsString(result2) must equalTo("false")
-      // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo("true")
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo("false")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool-2/true")).get
+        contentAsString(result) must equalTo("true")
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool-2/false")).get
+        contentAsString(result2) must equalTo("false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo("true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo("false")
+      }
     }
   }
 
   "bind int parameters from the query string as a list" in {
 
     "from a list of numbers" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, router.routes.Application.takeList(List(1, 2, 3)).url)).get
-      contentAsString(result) must equalTo("1,2,3")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, router.routes.Application.takeList(List(1, 2, 3)).url)).get
+        contentAsString(result) must equalTo("1,2,3")
+      }
     }
     "from a list of numbers and letters" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2")).get
-      status(result) must equalTo(BAD_REQUEST)
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2")).get
+        status(result) must equalTo(BAD_REQUEST)
+      }
     }
     "when there is no parameter at all" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list")).get
-      contentAsString(result) must equalTo("")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list")).get
+        contentAsString(result) must equalTo("")
+      }
     }
     "using the Java API" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3")).get
-      contentAsString(result) must equalTo("1,2,3")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3")).get
+        contentAsString(result) must equalTo("1,2,3")
+      }
     }
     "using backticked names on route params" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b[]=4&b[]=5&b[]=6")).get
-      contentAsString(result) must equalTo("4,5,6")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b[]=4&b[]=5&b[]=6")).get
+        contentAsString(result) must equalTo("4,5,6")
+      }
     }
     "using backticked names urlencoded on route params" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b%5B%5D=4&b%5B%5D=5&b%5B%5D=6")).get
-      contentAsString(result) must equalTo("4,5,6")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b%5B%5D=4&b%5B%5D=5&b%5B%5D=6")).get
+        contentAsString(result) must equalTo("4,5,6")
+      }
     }
   }
 
   "use a new instance for each instantiated controller" in new WithApplication() {
-    route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
-      case result => contentAsString(result) must_== "1"
-    }
-    route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
-      case result => contentAsString(result) must_== "1"
+    override def running() = {
+      route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
+        case result => contentAsString(result) must_== "1"
+      }
+      route(implicitApp, FakeRequest(GET, "/instance")) must beSome[Future[Result]].like {
+        case result => contentAsString(result) must_== "1"
+      }
     }
   }
 
@@ -108,10 +126,10 @@ object RouterSpec extends PlaySpecification {
         staticDecoded: String,
         queryDecoded: String
     ) = {
-      val path     = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
+      val path = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
       val expected = s"dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
-      val result   = route(implicitApp, FakeRequest(GET, path)).get
-      val actual   = contentAsString(result)
+      val result = route(implicitApp, FakeRequest(GET, path)).get
+      val actual = contentAsString(result)
       actual must equalTo(expected)
     }
     def checkEncoding(
@@ -126,73 +144,91 @@ object RouterSpec extends PlaySpecification {
       val call     = router.routes.Application.urlcoding(dynamicDecoded, staticDecoded, queryDecoded)
       call.url must equalTo(expected)
     }
-    checkDecoding("a", "a", "a", "a", "a", "a")
-    checkDecoding("%2B", "%2B", "%2B", "+", "%2B", "+")
-    checkDecoding("+", "+", "+", "+", "+", " ")
-    checkDecoding("%20", "%20", "%20", " ", "%20", " ")
-    checkDecoding("&", "&", "-", "&", "&", "-")
-    checkDecoding("=", "=", "-", "=", "=", "-")
+    override def running() = {
+      checkDecoding("a", "a", "a", "a", "a", "a")
+      checkDecoding("%2B", "%2B", "%2B", "+", "%2B", "+")
+      checkDecoding("+", "+", "+", "+", "+", " ")
+      checkDecoding("%20", "%20", "%20", " ", "%20", " ")
+      checkDecoding("&", "&", "-", "&", "&", "-")
+      checkDecoding("=", "=", "-", "=", "=", "-")
 
-    checkEncoding("+", "+", "+", "+", "+", "%2B")
-    checkEncoding(" ", " ", " ", "%20", " ", "+")
-    checkEncoding("&", "&", "&", "&", "&", "%26")
-    checkEncoding("=", "=", "=", "=", "=", "%3D")
+      checkEncoding("+", "+", "+", "+", "+", "%2B")
+      checkEncoding(" ", " ", " ", "%20", " ", "+")
+      checkEncoding("&", "&", "&", "&", "&", "%26")
+      checkEncoding("=", "=", "=", "=", "=", "%3D")
 
-    // We use java.net.URLEncoder for query string encoding, which is not
-    // RFC compliant, e.g. it percent-encodes "/" which is not a delimiter
-    // for query strings, and it percent-encodes "~" which is an "unreserved" character
-    // that should never be percent-encoded. The following tests, therefore
-    // don't really capture our ideal desired behaviour for query string
-    // encoding. However, the behaviour for dynamic and static paths is correct.
-    checkEncoding("/", "/", "/", "%2F", "/", "%2F")
-    checkEncoding("~", "~", "~", "~", "~", "%7E")
+      // We use java.net.URLEncoder for query string encoding, which is not
+      // RFC compliant, e.g. it percent-encodes "/" which is not a delimiter
+      // for query strings, and it percent-encodes "~" which is an "unreserved" character
+      // that should never be percent-encoded. The following tests, therefore
+      // don't really capture our ideal desired behaviour for query string
+      // encoding. However, the behaviour for dynamic and static paths is correct.
+      checkEncoding("/", "/", "/", "%2F", "/", "%2F")
+      checkEncoding("~", "~", "~", "~", "~", "%7E")
 
-    checkDecoding("123", "456", "789", "123", "456", "789")
-    checkEncoding("123", "456", "789", "123", "456", "789")
+      checkDecoding("123", "456", "789", "123", "456", "789")
+      checkEncoding("123", "456", "789", "123", "456", "789")
+    }
   }
 
   "allow reverse routing of routes includes" in new WithApplication() {
-    // Force the router to bootstrap the prefix
-    implicitApp.injector.instanceOf[play.api.routing.Router]
-    router.module.routes.ModuleController.index.url must_== "/module/index"
+    override def running() = {
+      // Force the router to bootstrap the prefix
+      implicitApp.injector.instanceOf[play.api.routing.Router]
+      router.module.routes.ModuleController.index.url must_== "/module/index"
+    }
   }
 
   "document the router" in new WithApplication() {
-    // The purpose of this test is to alert anyone that changes the format of the router documentation that
-    // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
-    val someRoute = implicitApp.injector
-      .instanceOf[play.api.routing.Router]
-      .documentation
-      .find(r => r._1 == "GET" && r._2.startsWith("/with/"))
-    someRoute must beSome[(String, String, String)]
-    val route = someRoute.get
-    route._2 must_== "/with/$param<[^/]+>"
-    route._3 must startWith("Application.withParam")
+    override def running() = {
+      // The purpose of this test is to alert anyone that changes the format of the router documentation that
+      // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
+      val someRoute = implicitApp.injector
+        .instanceOf[play.api.routing.Router]
+        .documentation
+        .find(r => r._1 == "GET" && r._2.startsWith("/with/"))
+      someRoute must beSome[(String, String, String)]
+      val route = someRoute.get
+      route._2 must_== "/with/$param<[^/]+>"
+      route._3 must startWith("Application.withParam")
+    }
   }
 
   "reverse routes complex query params " in new WithApplication() {
-    val actual = router.routes.Application.takeListTickedParam(List(1, 2, 3)).url
-    actual must_== "/take-list-tick-param?b%5B%5D=1&b%5B%5D=2&b%5B%5D=3" // ?b[]=1&b[]=2&b[]=3
+    override def running() = {
+      val actual = router.routes.Application.takeListTickedParam(List(1, 2, 3)).url
+      actual must_== "/take-list-tick-param?b%5B%5D=1&b%5B%5D=2&b%5B%5D=3" // ?b[]=1&b[]=2&b[]=3
+    }
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {
-    router.routes.Application.hello.url must_== "/hello"
+    override def running() = {
+      router.routes.Application.hello.url must_== "/hello"
+    }
   }
 
   "The assets reverse route support" should {
     "fingerprint assets" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      }
     }
     "selected the minified version" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      }
     }
     "work for non fingerprinted assets" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/nonfingerprinted.css").url must_== "/public/css/nonfingerprinted.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/nonfingerprinted.css").url must_== "/public/css/nonfingerprinted.css"
+      }
     }
     "selected the minified non fingerprinted version" in new WithApplication() {
-      controllers.routes.Assets
-        .versioned("css/nonfingerprinted-minmain.css")
-        .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      override def running() = {
+        controllers.routes.Assets
+          .versioned("css/nonfingerprinted-minmain.css")
+          .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      }
     }
   }
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/build.sbt
@@ -48,11 +48,9 @@ scalacOptions ++= {
         "-Xlint",
         "-Ywarn-dead-code",
         "-Ywarn-numeric-widen",
-        "-Ywarn-value-discard",
       )
     case _ =>
       Seq(
-        "-Wvalue-discard"
       )
   })
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
@@ -42,43 +42,55 @@ object RouterSpec extends PlaySpecification {
 
   "bind boolean parameters" in {
     "from the query string" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
-      contentAsString(result) must equalTo("true")
-      val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
-      contentAsString(result2) must equalTo("false")
-      // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("true")
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("false")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
+        contentAsString(result) must equalTo("true")
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
+        contentAsString(result2) must equalTo("false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("false")
+      }
     }
     "from the path" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-bool-2/true")).get
-      contentAsString(result) must equalTo("true")
-      val result2 = route(implicitApp, FakeRequest(GET, "/take-bool-2/false")).get
-      contentAsString(result2) must equalTo("false")
-      // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo("true")
-      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo("false")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool-2/true")).get
+        contentAsString(result) must equalTo("true")
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool-2/false")).get
+        contentAsString(result2) must equalTo("false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo("true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo("false")
+      }
     }
   }
 
   "bind int parameters from the query string as a list" in {
 
     "from a list of numbers" in new WithApplication() {
-      val result =
-        route(implicitApp, FakeRequest(GET, controllers.routes.Application.takeListInt(List(1, 2, 3)).url)).get
-      contentAsString(result) must equalTo("1,2,3")
+      override def running() = {
+        val result =
+          route(implicitApp, FakeRequest(GET, controllers.routes.Application.takeListInt(List(1, 2, 3)).url)).get
+        contentAsString(result) must equalTo("1,2,3")
+      }
     }
     "from a list of numbers and letters" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-slist-int?x=1&x=a&x=2")).get
-      status(result) must equalTo(BAD_REQUEST)
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-slist-int?x=1&x=a&x=2")).get
+        status(result) must equalTo(BAD_REQUEST)
+      }
     }
     "when there is no parameter at all" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-slist-int")).get
-      contentAsString(result) must equalTo("")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-slist-int")).get
+        contentAsString(result) must equalTo("")
+      }
     }
     "using the Java API" in new WithApplication() {
-      val result = route(implicitApp, FakeRequest(GET, "/take-jlist-jint?x=1&x=2&x=3")).get
-      contentAsString(result) must equalTo("1,2,3")
+      override def running() = {
+        val result = route(implicitApp, FakeRequest(GET, "/take-jlist-jint?x=1&x=2&x=3")).get
+        contentAsString(result) must equalTo("1,2,3")
+      }
     }
   }
 
@@ -104,21 +116,29 @@ object RouterSpec extends PlaySpecification {
     lazy val resolvedPath = s"/${path}${if (withDefault) "-d" else ""}"
     s"bind ${paramType} parameter${if (withDefault) " with default value" else ""} from the query string" in {
       "successfully" in new WithApplication() {
-        val result = route(implicitApp, FakeRequest(GET, s"${resolvedPath}?${successParams}")).get
-        contentAsString(result) must equalTo(successExpectation)
-        status(result) must equalTo(OK)
+        override def running() = {
+          val result = route(implicitApp, FakeRequest(GET, s"${resolvedPath}?${successParams}")).get
+          contentAsString(result) must equalTo(successExpectation)
+          status(result) must equalTo(OK)
+        }
       }
       "when there is a parameter but without value (=empty string)" in new WithApplication() {
-        val result = route(implicitApp, FakeRequest(GET, s"${resolvedPath}?x=")).get
-        whenNoValue(result)
+        override def running() = {
+          val result = route(implicitApp, FakeRequest(GET, s"${resolvedPath}?x=")).get
+          whenNoValue(result)
+        }
       }
       "when there is a parameter but without value (=empty string) and without equals sign" in new WithApplication() {
-        val result = route(implicitApp, FakeRequest(GET, s"${resolvedPath}?x")).get
-        whenNoValue(result)
+        override def running() = {
+          val result = route(implicitApp, FakeRequest(GET, s"${resolvedPath}?x")).get
+          whenNoValue(result)
+        }
       }
       "when there is no parameter at all" in new WithApplication() {
-        val result = route(implicitApp, FakeRequest(GET, resolvedPath)).get
-        whenNoParam(result)
+        override def running() = {
+          val result = route(implicitApp, FakeRequest(GET, resolvedPath)).get
+          whenNoParam(result)
+        }
       }
     }
   }
@@ -749,94 +769,112 @@ object RouterSpec extends PlaySpecification {
   )
 
   "URL encoding and decoding works correctly" in new WithApplication() {
-    def checkDecoding(
-        dynamicEncoded: String,
-        staticEncoded: String,
-        queryEncoded: String,
-        dynamicDecoded: String,
-        staticDecoded: String,
-        queryDecoded: String
-    ) = {
-      val path     = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
-      val expected = s"dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
-      val result   = route(implicitApp, FakeRequest(GET, path)).get
-      val actual   = contentAsString(result)
-      actual must equalTo(expected)
+    override def running() = {
+      def checkDecoding(
+                         dynamicEncoded: String,
+                         staticEncoded: String,
+                         queryEncoded: String,
+                         dynamicDecoded: String,
+                         staticDecoded: String,
+                         queryDecoded: String
+                       ) = {
+        val path = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
+        val expected = s"dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
+        val result = route(implicitApp, FakeRequest(GET, path)).get
+        val actual = contentAsString(result)
+        actual must equalTo(expected)
+      }
+
+      def checkEncoding(
+                         dynamicDecoded: String,
+                         staticDecoded: String,
+                         queryDecoded: String,
+                         dynamicEncoded: String,
+                         staticEncoded: String,
+                         queryEncoded: String
+                       ) = {
+        val expected = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
+        val call = controllers.routes.Application.urlcoding(dynamicDecoded, staticDecoded, queryDecoded)
+        call.url must equalTo(expected)
+      }
+
+      checkDecoding("a", "a", "a", "a", "a", "a")
+      checkDecoding("%2B", "%2B", "%2B", "+", "%2B", "+")
+      checkDecoding("+", "+", "+", "+", "+", " ")
+      checkDecoding("%20", "%20", "%20", " ", "%20", " ")
+      checkDecoding("&", "&", "-", "&", "&", "-")
+      checkDecoding("=", "=", "-", "=", "=", "-")
+
+      checkEncoding("+", "+", "+", "+", "+", "%2B")
+      checkEncoding(" ", " ", " ", "%20", " ", "+")
+      checkEncoding("&", "&", "&", "&", "&", "%26")
+      checkEncoding("=", "=", "=", "=", "=", "%3D")
+
+      // We use java.net.URLEncoder for query string encoding, which is not
+      // RFC compliant, e.g. it percent-encodes "/" which is not a delimiter
+      // for query strings, and it percent-encodes "~" which is an "unreserved" character
+      // that should never be percent-encoded. The following tests, therefore
+      // don't really capture our ideal desired behaviour for query string
+      // encoding. However, the behaviour for dynamic and static paths is correct.
+      checkEncoding("/", "/", "/", "%2F", "/", "%2F")
+      checkEncoding("~", "~", "~", "~", "~", "%7E")
+
+      checkDecoding("123", "456", "789", "123", "456", "789")
+      checkEncoding("123", "456", "789", "123", "456", "789")
     }
-    def checkEncoding(
-        dynamicDecoded: String,
-        staticDecoded: String,
-        queryDecoded: String,
-        dynamicEncoded: String,
-        staticEncoded: String,
-        queryEncoded: String
-    ) = {
-      val expected = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
-      val call     = controllers.routes.Application.urlcoding(dynamicDecoded, staticDecoded, queryDecoded)
-      call.url must equalTo(expected)
-    }
-    checkDecoding("a", "a", "a", "a", "a", "a")
-    checkDecoding("%2B", "%2B", "%2B", "+", "%2B", "+")
-    checkDecoding("+", "+", "+", "+", "+", " ")
-    checkDecoding("%20", "%20", "%20", " ", "%20", " ")
-    checkDecoding("&", "&", "-", "&", "&", "-")
-    checkDecoding("=", "=", "-", "=", "=", "-")
-
-    checkEncoding("+", "+", "+", "+", "+", "%2B")
-    checkEncoding(" ", " ", " ", "%20", " ", "+")
-    checkEncoding("&", "&", "&", "&", "&", "%26")
-    checkEncoding("=", "=", "=", "=", "=", "%3D")
-
-    // We use java.net.URLEncoder for query string encoding, which is not
-    // RFC compliant, e.g. it percent-encodes "/" which is not a delimiter
-    // for query strings, and it percent-encodes "~" which is an "unreserved" character
-    // that should never be percent-encoded. The following tests, therefore
-    // don't really capture our ideal desired behaviour for query string
-    // encoding. However, the behaviour for dynamic and static paths is correct.
-    checkEncoding("/", "/", "/", "%2F", "/", "%2F")
-    checkEncoding("~", "~", "~", "~", "~", "%7E")
-
-    checkDecoding("123", "456", "789", "123", "456", "789")
-    checkEncoding("123", "456", "789", "123", "456", "789")
   }
 
   "allow reverse routing of routes includes" in new WithApplication() {
-    // Force the router to bootstrap the prefix
-    implicitApp.injector.instanceOf[play.api.routing.Router]
-    controllers.module.routes.ModuleController.index.url must_== "/module/index"
+    override def running() = {
+      // Force the router to bootstrap the prefix
+      implicitApp.injector.instanceOf[play.api.routing.Router]
+      controllers.module.routes.ModuleController.index.url must_== "/module/index"
+    }
   }
 
   "document the router" in new WithApplication() {
-    // The purpose of this test is to alert anyone that changes the format of the router documentation that
-    // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
-    val someRoute = implicitApp.injector
-      .instanceOf[play.api.routing.Router]
-      .documentation
-      .find(r => r._1 == "GET" && r._2.startsWith("/with/"))
-    someRoute must beSome[(String, String, String)]
-    val route = someRoute.get
-    route._2 must_== "/with/$param<[^/]+>"
-    route._3 must startWith("controllers.Application.withParam")
+    override def running() = {
+      // The purpose of this test is to alert anyone that changes the format of the router documentation that
+      // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
+      val someRoute = implicitApp.injector
+        .instanceOf[play.api.routing.Router]
+        .documentation
+        .find(r => r._1 == "GET" && r._2.startsWith("/with/"))
+      someRoute must beSome[(String, String, String)]
+      val route = someRoute.get
+      route._2 must_== "/with/$param<[^/]+>"
+      route._3 must startWith("controllers.Application.withParam")
+    }
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {
-    controllers.routes.Application.hello.url must_== "/hello"
+    override def running() = {
+      controllers.routes.Application.hello.url must_== "/hello"
+    }
   }
 
   "The assets reverse route support" should {
     "fingerprint assets" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/main.css").url must_== "/public/css/abcd1234-main.css"
+      }
     }
     "selected the minified version" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/minmain.css").url must_== "/public/css/abcd1234-minmain-min.css"
+      }
     }
     "work for non fingerprinted assets" in new WithApplication() {
-      controllers.routes.Assets.versioned("css/nonfingerprinted.css").url must_== "/public/css/nonfingerprinted.css"
+      override def running() = {
+        controllers.routes.Assets.versioned("css/nonfingerprinted.css").url must_== "/public/css/nonfingerprinted.css"
+      }
     }
     "selected the minified non fingerprinted version" in new WithApplication() {
-      controllers.routes.Assets
-        .versioned("css/nonfingerprinted-minmain.css")
-        .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      override def running() = {
+        controllers.routes.Assets
+          .versioned("css/nonfingerprinted-minmain.css")
+          .url must_== "/public/css/nonfingerprinted-minmain-min.css"
+      }
     }
   }
 }

--- a/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
@@ -20,8 +20,10 @@ import play.api.test._
 class ThreadPoolsSpec extends PlaySpecification {
   "Play's thread pools" should {
     "make a global thread pool available" in new WithApplication() {
-      val controller = app.injector.instanceOf[Samples]
-      contentAsString(controller.someAsyncAction(FakeRequest())) must startWith("The answer is 42")
+      override def running() = {
+        val controller = app.injector.instanceOf[Samples]
+        contentAsString(controller.someAsyncAction(FakeRequest())) must startWith("The answer is 42")
+      }
     }
 
     "allow configuring a custom thread pool" in runningWithConfig(
@@ -59,10 +61,12 @@ class ThreadPoolsSpec extends PlaySpecification {
     }
 
     "allow access to the application classloader" in new WithApplication() {
-      val myClassName = "java.lang.String"
-      // #using-app-classloader
-      val myClass = app.classloader.loadClass(myClassName)
-      // #using-app-classloader
+      override def running() = {
+        val myClassName = "java.lang.String"
+        // #using-app-classloader
+        val myClass = app.classloader.loadClass(myClassName)
+        // #using-app-classloader
+      }
     }
 
     "allow a synchronous thread pool" in {

--- a/documentation/manual/working/commonGuide/filters/code/scalaguide/detailed/filters/UserControllerSpec.scala
+++ b/documentation/manual/working/commonGuide/filters/code/scalaguide/detailed/filters/UserControllerSpec.scala
@@ -15,12 +15,14 @@ import play.api.test.WithApplication
 class UserControllerSpec extends Specification {
   "UserController GET" should {
     "render the index page from the application" in new WithApplication() {
-      val controller = app.injector.instanceOf[UserController]
-      val request    = FakeRequest().withCSRFToken
-      val result     = controller.userGet().apply(request)
+      override def running() = {
+        val controller = app.injector.instanceOf[UserController]
+        val request    = FakeRequest().withCSRFToken
+        val result     = controller.userGet().apply(request)
 
-      status(result) must beEqualTo(OK)
-      contentType(result) must beSome("text/html")
+        status(result) must beEqualTo(OK)
+        contentType(result) must beSome("text/html")
+      }
     }
   }
 }
@@ -32,12 +34,14 @@ class UserControllerWithoutFiltersSpec extends Specification {
     "render the index page from the application" in new WithApplication(
       GuiceApplicationBuilder().configure("play.http.filters" -> "play.api.http.NoHttpFilters").build()
     ) {
-      val controller = app.injector.instanceOf[UserController]
-      val request    = FakeRequest().withCSRFToken
-      val result     = controller.userGet().apply(request)
+      override def running() = {
+        val controller = app.injector.instanceOf[UserController]
+        val request    = FakeRequest().withCSRFToken
+        val result     = controller.userGet().apply(request)
 
-      status(result) must beEqualTo(OK)
-      contentType(result) must beSome("text/html")
+        status(result) must beEqualTo(OK)
+        contentType(result) must beSome("text/html")
+      }
     }
   }
 }

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
@@ -40,47 +40,59 @@ class JavaFormHelpers extends PlaySpecification {
       }
 
       "allow rendering a form" in new WithApplication() {
-        val form = segment("form")
-        form must contain("<form")
-        form must contain("""action="/form"""")
+        override def running() = {
+          val form = segment("form")
+          form must contain("<form")
+          form must contain("""action="/form"""")
+        }
       }
 
       "allow rendering a form with an id" in new WithApplication() {
-        val form = segment("form-with-id")
-        form must contain("<form")
-        form must contain("""id="myForm"""")
+        override def running() = {
+          val form = segment("form-with-id")
+          form must contain("<form")
+          form must contain("""id="myForm"""")
+        }
       }
 
       "allow passing extra parameters to an input" in new WithApplication() {
-        val input = segment("extra-params")
-        input must contain("""id="email"""")
-        input must contain("""size="30"""")
+        override def running() = {
+          val input = segment("extra-params")
+          input must contain("""id="email"""")
+          input must contain("""size="30"""")
+        }
       }
 
       "allow repeated form fields" in new WithApplication() {
-        val input = segment("repeat")
-        input must contain("emails.0")
-        input must contain("emails.1")
+        override def running() = {
+          val input = segment("repeat")
+          input must contain("emails.0")
+          input must contain("emails.1")
+        }
       }
     }
 
     {
       "allow rendering input fields" in new WithApplication() {
-        withFormFactory { (formFactory: play.data.FormFactory, messages: play.i18n.Messages) =>
-          val form = formFactory.form(classOf[User])
-          val body = html.fullform(form)(messages).body
-          body must contain("""type="text"""")
-          body must contain("""type="password"""")
-          body must contain("""name="email"""")
-          body must contain("""name="password"""")
+        override def running() = {
+          withFormFactory { (formFactory: play.data.FormFactory, messages: play.i18n.Messages) =>
+            val form = formFactory.form(classOf[User])
+            val body = html.fullform(form)(messages).body
+            body must contain("""type="text"""")
+            body must contain("""type="password"""")
+            body must contain("""name="email"""")
+            body must contain("""name="password"""")
+          }
         }
       }
 
       "allow custom field constructors" in new WithApplication() {
-        withFormFactory { (formFactory: play.data.FormFactory, messages: play.i18n.Messages) =>
-          val form = formFactory.form(classOf[User])
-          val body = html.withFieldConstructor(form)(messages).body
-          body must contain("foobar")
+        override def running() = {
+          withFormFactory { (formFactory: play.data.FormFactory, messages: play.i18n.Messages) =>
+            val form = formFactory.form(classOf[User])
+            val body = html.withFieldConstructor(form)(messages).body
+            body must contain("foobar")
+          }
         }
       }
     }

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaErrorHandling.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaErrorHandling.scala
@@ -26,11 +26,15 @@ class JavaErrorHandling extends PlaySpecification with WsTestClient {
 
   "java error handling" should {
     "allow providing a custom error handler" in new WithServer(fakeApp[javaguide.application.root.ErrorHandler]) {
-      await(wsUrl("/error").get()).body must startWith("A server error occurred: ")
+      override def running() = {
+        await(wsUrl("/error").get()).body must startWith("A server error occurred: ")
+      }
     }
 
     "allow providing a custom error handler" in new WithServer(fakeApp[ErrorHandler]) {
-      (await(wsUrl("/error").get()).body must not).startWith("A server error occurred: ")
+      override def running() = {
+        (await(wsUrl("/error").get()).body must not).startWith("A server error occurred: ")
+      }
     }
   }
 }

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
@@ -54,35 +54,43 @@ object JavaWSSpec extends Specification with Results with Status {
 
   "The Java WSClient" should {
     "call WS correctly" in new WithServer(app = fakeApplication, port = 3333) {
-      val result = MockJavaActionHelper.call(app.injector.instanceOf[JavaWS.Controller1], fakeRequest())
+      override def running() = {
+        val result = MockJavaActionHelper.call(app.injector.instanceOf[JavaWS.Controller1], fakeRequest())
 
-      result.status() must equalTo(OK)
+        result.status() must equalTo(OK)
+      }
     }
 
     "compose WS calls successfully" in new WithServer(app = fakeApplication, port = 3333) {
-      val result = MockJavaActionHelper.call(app.injector.instanceOf[JavaWS.Controller2], fakeRequest())
+      override def running() = {
+        val result = MockJavaActionHelper.call(app.injector.instanceOf[JavaWS.Controller2], fakeRequest())
 
-      result.status() must equalTo(OK)
-      contentAsString(result) must beEqualTo("Number of comments: 10")
+        result.status() must equalTo(OK)
+        contentAsString(result) must beEqualTo("Number of comments: 10")
+      }
     }
 
     "call WS with a filter" in new WithServer(app = fakeApplication, port = 3333) {
-      val controller = app.injector.instanceOf[Controller3]
-      val logger     = mock(classOf[Logger])
-      controller.setLogger(logger)
+      override def running() = {
+        val controller = app.injector.instanceOf[Controller3]
+        val logger     = mock(classOf[Logger])
+        controller.setLogger(logger)
 
-      val result = MockJavaActionHelper.call(controller, fakeRequest())
+        val result = MockJavaActionHelper.call(controller, fakeRequest())
 
-      result.status() must equalTo(OK)
-      verify(logger).debug("url = http://localhost:3333/feed")
+        result.status() must equalTo(OK)
+        verify(logger).debug("url = http://localhost:3333/feed")
+      }
     }
 
     "call WS with a timeout" in new WithServer(app = fakeApplication) {
-      val controller = app.injector.instanceOf[Controller4]
+      override def running() = {
+        val controller = app.injector.instanceOf[Controller4]
 
-      val result = MockJavaActionHelper.call(controller, fakeRequest())
+        val result = MockJavaActionHelper.call(controller, fakeRequest())
 
-      contentAsString(result) must beEqualTo("Timeout after 1 second")
+        contentAsString(result) must beEqualTo("Timeout after 1 second")
+      }
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
@@ -20,165 +20,185 @@ class ScalaSirdRouter extends Specification {
 
   "sird router" should {
     "allow a simple match" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #simple
-      val router = Router.from {
-        case GET(p"/hello/$to") =>
-          Action {
-            Results.Ok(s"Hello $to")
-          }
-      }
-      // #simple
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #simple
+        val router = Router.from {
+          case GET(p"/hello/$to") =>
+            Action {
+              Results.Ok(s"Hello $to")
+            }
+        }
+        // #simple
 
-      router.routes.lift(FakeRequest("GET", "/hello/world")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/goodbye/world")) must beNone
+        router.routes.lift(FakeRequest("GET", "/hello/world")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/goodbye/world")) must beNone
+      }
     }
 
     "allow a full path match" in new WithApplication {
-      val Assets = app.injector.instanceOf[controllers.Assets]
-      // #full-path
-      val router = Router.from {
-        case GET(p"/assets/$file*") =>
-          Assets.versioned(path = "/public", file = file)
-      }
-      // #full-path
+      override def running() = {
+        val Assets = app.injector.instanceOf[controllers.Assets]
+        // #full-path
+        val router = Router.from {
+          case GET(p"/assets/$file*") =>
+            Assets.versioned(path = "/public", file = file)
+        }
+        // #full-path
 
-      router.routes.lift(FakeRequest("GET", "/assets/javascripts/main.js")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/foo/bar")) must beNone
+        router.routes.lift(FakeRequest("GET", "/assets/javascripts/main.js")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/foo/bar")) must beNone
+      }
     }
 
     "allow a regex match" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #regexp
-      val router = Router.from {
-        case GET(p"/items/$id<[0-9]+>") =>
-          Action {
-            Results.Ok(s"Item $id")
-          }
-      }
-      // #regexp
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #regexp
+        val router = Router.from {
+          case GET(p"/items/$id<[0-9]+>") =>
+            Action {
+              Results.Ok(s"Item $id")
+            }
+        }
+        // #regexp
 
-      router.routes.lift(FakeRequest("GET", "/items/21")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/items/foo")) must beNone
+        router.routes.lift(FakeRequest("GET", "/items/21")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items/foo")) must beNone
+      }
     }
 
     "allow extracting required query parameters" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #required
-      val router = Router.from {
-        case GET(p"/search" ? q"query=$query") =>
-          Action {
-            Results.Ok(s"Searching for $query")
-          }
-      }
-      // #required
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #required
+        val router = Router.from {
+          case GET(p"/search" ? q"query=$query") =>
+            Action {
+              Results.Ok(s"Searching for $query")
+            }
+        }
+        // #required
 
-      router.routes.lift(FakeRequest("GET", "/search?query=foo")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/search")) must beNone
+        router.routes.lift(FakeRequest("GET", "/search?query=foo")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/search")) must beNone
+      }
     }
 
     "allow extracting optional query parameters" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #optional
-      val router = Router.from {
-        case GET(p"/items" ? q_o"page=$page") =>
-          Action {
-            val thisPage = page.getOrElse("1")
-            Results.Ok(s"Showing page $thisPage")
-          }
-      }
-      // #optional
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #optional
+        val router = Router.from {
+          case GET(p"/items" ? q_o"page=$page") =>
+            Action {
+              val thisPage = page.getOrElse("1")
+              Results.Ok(s"Showing page $thisPage")
+            }
+        }
+        // #optional
 
-      router.routes.lift(FakeRequest("GET", "/items?page=10")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items?page=10")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+      }
     }
 
     "allow extracting multi value query parameters" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #many
-      val router = Router.from {
-        case GET(p"/items" ? q_s"tag=$tags") =>
-          Action {
-            val allTags = tags.mkString(", ")
-            Results.Ok(s"Showing items tagged: $allTags")
-          }
-      }
-      // #many
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #many
+        val router = Router.from {
+          case GET(p"/items" ? q_s"tag=$tags") =>
+            Action {
+              val allTags = tags.mkString(", ")
+              Results.Ok(s"Showing items tagged: $allTags")
+            }
+        }
+        // #many
 
-      router.routes.lift(FakeRequest("GET", "/items?tag=a&tag=b")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items?tag=a&tag=b")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+      }
     }
 
     "allow extracting multiple query parameters" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #multiple
-      val router = Router.from {
-        case GET(
-              p"/items" ? q_o"page=$page"
-              & q_o"per_page=$perPage"
-            ) =>
-          Action {
-            val thisPage   = page.getOrElse("1")
-            val pageLength = perPage.getOrElse("10")
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #multiple
+        val router = Router.from {
+          case GET(
+                p"/items" ? q_o"page=$page"
+                & q_o"per_page=$perPage"
+              ) =>
+            Action {
+              val thisPage   = page.getOrElse("1")
+              val pageLength = perPage.getOrElse("10")
 
-            Results.Ok(s"Showing page $thisPage of length $pageLength")
-          }
+              Results.Ok(s"Showing page $thisPage of length $pageLength")
+            }
+        }
+        // #multiple
+
+        router.routes.lift(FakeRequest("GET", "/items?page=10&per_page=20")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
       }
-      // #multiple
-
-      router.routes.lift(FakeRequest("GET", "/items?page=10&per_page=20")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
     }
 
     "allow sub extractor" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #int
-      val router = Router.from {
-        case GET(p"/items/${int(id)}") =>
-          Action {
-            Results.Ok(s"Item $id")
-          }
-      }
-      // #int
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #int
+        val router = Router.from {
+          case GET(p"/items/${int(id)}") =>
+            Action {
+              Results.Ok(s"Item $id")
+            }
+        }
+        // #int
 
-      router.routes.lift(FakeRequest("GET", "/items/21")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/items/foo")) must beNone
+        router.routes.lift(FakeRequest("GET", "/items/21")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items/foo")) must beNone
+      }
     }
 
     "allow sub extractor on a query parameter" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #query-int
-      val router = Router.from {
-        case GET(p"/items" ? q_o"page=${int(page)}") =>
-          Action {
-            val thePage = page.getOrElse(1)
-            Results.Ok(s"Items page $thePage")
-          }
-      }
-      // #query-int
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #query-int
+        val router = Router.from {
+          case GET(p"/items" ? q_o"page=${int(page)}") =>
+            Action {
+              val thePage = page.getOrElse(1)
+              Results.Ok(s"Items page $thePage")
+            }
+        }
+        // #query-int
 
-      router.routes.lift(FakeRequest("GET", "/items?page=21")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/items?page=foo")) must beNone
-      router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items?page=21")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items?page=foo")) must beNone
+        router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+      }
     }
 
     "allow complex extractors" in new WithApplication {
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      // #complex
-      val router = Router.from {
-        case rh @ GET(
-              p"/items/${idString @ int(id)}" ?
-              q"price=${int(price)}"
-            ) if price > 200 =>
-          Action {
-            Results.Ok(s"Expensive item $id")
-          }
-      }
-      // #complex
+      override def running() = {
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        // #complex
+        val router = Router.from {
+          case rh @ GET(
+                p"/items/${idString @ int(id)}" ?
+                q"price=${int(price)}"
+              ) if price > 200 =>
+            Action {
+              Results.Ok(s"Expensive item $id")
+            }
+        }
+        // #complex
 
-      router.routes.lift(FakeRequest("GET", "/items/21?price=400")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/items/21?price=foo")) must beNone
-      router.routes.lift(FakeRequest("GET", "/items/foo?price=400")) must beNone
+        router.routes.lift(FakeRequest("GET", "/items/21?price=400")) must beSome[Handler]
+        router.routes.lift(FakeRequest("GET", "/items/21?price=foo")) must beNone
+        router.routes.lift(FakeRequest("GET", "/items/foo?price=400")) must beNone
+      }
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -18,20 +18,28 @@ class ScalaAsyncSpec extends PlaySpecification {
 
   "scala async" should {
     "allow returning a future" in new WithApplication() {
-      contentAsString(samples.futureResult) must startWith("PI value computed: 3.14")
+      override def running() = {
+        contentAsString(samples.futureResult) must startWith("PI value computed: 3.14")
+      }
     }
 
     "allow dispatching an intensive computation" in new WithApplication() {
-      await(samples.intensiveComp) must_== 10
+      override def running() = {
+        await(samples.intensiveComp) must_== 10
+      }
     }
 
     "allow returning an async result" in new WithApplication() {
-      contentAsString(samples.asyncResult()(FakeRequest())) must_== "Got result: 10"
+      override def running() = {
+        contentAsString(samples.asyncResult()(FakeRequest())) must_== "Got result: 10"
+      }
     }
 
     "allow timing out a future" in new WithApplication() {
-      status(samples.timeout(1200)(FakeRequest())) must_== INTERNAL_SERVER_ERROR
-      status(samples.timeout(10)(FakeRequest())) must_== OK
+      override def running() = {
+        status(samples.timeout(1200)(FakeRequest())) must_== INTERNAL_SERVER_ERROR
+        status(samples.timeout(10)(FakeRequest())) must_== OK
+      }
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
@@ -39,26 +39,30 @@ class MockController(val controllerComponents: ControllerComponents)(implicit ma
 class ScalaCometSpec extends PlaySpecification {
   "play comet" should {
     "work with string" in new WithApplication() with Injecting {
-      try {
-        val controllerComponents = inject[ControllerComponents]
-        val controller           = new MockController(controllerComponents)
-        val result               = controller.cometString.apply(FakeRequest())
-        contentAsString(result) must contain(
-          "<html><body><script>parent.cometMessage('kiki');</script><script>parent.cometMessage('foo');</script><script>parent.cometMessage('bar');</script>"
-        )
-      } finally {
-        app.stop()
+      override def running() = {
+        try {
+          val controllerComponents = inject[ControllerComponents]
+          val controller           = new MockController(controllerComponents)
+          val result               = controller.cometString.apply(FakeRequest())
+          contentAsString(result) must contain(
+            "<html><body><script>parent.cometMessage('kiki');</script><script>parent.cometMessage('foo');</script><script>parent.cometMessage('bar');</script>"
+          )
+        } finally {
+          app.stop()
+        }
       }
     }
 
     "work with json" in new WithApplication() with Injecting {
-      try {
-        val controllerComponents = inject[ControllerComponents]
-        val controller           = new MockController(controllerComponents)
-        val result               = controller.cometJson.apply(FakeRequest())
-        contentAsString(result) must contain("<html><body><script>parent.cometMessage(\"jsonString\");</script>")
-      } finally {
-        app.stop()
+      override def running() = {
+        try {
+          val controllerComponents = inject[ControllerComponents]
+          val controller           = new MockController(controllerComponents)
+          val result               = controller.cometJson.apply(FakeRequest())
+          contentAsString(result) must contain("<html><body><script>parent.cometMessage(\"jsonString\");</script>")
+        } finally {
+          app.stop()
+        }
       }
     }
   }

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -9,18 +9,24 @@ import play.api.test._
 class RuntimeDependencyInjection extends PlaySpecification {
   "Play's runtime dependency injection support" should {
     "support constructor injection" in new WithApplication() {
-      app.injector.instanceOf[constructor.MyComponent] must beAnInstanceOf[constructor.MyComponent]
+      override def running() = {
+        app.injector.instanceOf[constructor.MyComponent] must beAnInstanceOf[constructor.MyComponent]
+      }
     }
     "support singleton scope" in new WithApplication() {
-      app.injector.instanceOf[singleton.CurrentSharePrice].set(10)
-      app.injector.instanceOf[singleton.CurrentSharePrice].get must_== 10
+      override def running() = {
+        app.injector.instanceOf[singleton.CurrentSharePrice].set(10)
+        app.injector.instanceOf[singleton.CurrentSharePrice].get must_== 10
+      }
     }
     "support stopping" in {
       running() { app => app.injector.instanceOf[cleanup.MessageQueueConnection] }
       cleanup.MessageQueue.stopped must_== true
     }
     "support implemented by annotation" in new WithApplication() {
-      app.injector.instanceOf[implemented.Hello].sayHello("world") must_== "Hello world"
+      override def running() = {
+        app.injector.instanceOf[implemented.Hello].sayHello("world") must_== "Hello world"
+      }
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -39,105 +39,121 @@ package scalaguide.forms.scalaforms {
 
     "A scala forms" should {
       "generate from map" in new WithApplication {
-        val controller = app.injector.instanceOf[controllers.Application]
-        val userForm   = controller.userForm
+        override def running() = {
+          val controller = app.injector.instanceOf[controllers.Application]
+          val userForm   = controller.userForm
 
-        // #userForm-generate-map
-        val anyData  = Map("name" -> "bob", "age" -> "21")
-        val userData = userForm.bind(anyData).get
-        // #userForm-generate-map
+          // #userForm-generate-map
+          val anyData  = Map("name" -> "bob", "age" -> "21")
+          val userData = userForm.bind(anyData).get
+          // #userForm-generate-map
 
-        userData.name === "bob"
+          userData.name === "bob"
+        }
       }
 
       "generate from request" in new WithApplication {
-        import play.api.data.FormBinding.Implicits._
-        import play.api.libs.json.Json
+        override def running() = {
+          import play.api.data.FormBinding.Implicits._
+          import play.api.libs.json.Json
 
-        val controller = app.injector.instanceOf[controllers.Application]
-        val userForm   = controller.userForm
+          val controller = app.injector.instanceOf[controllers.Application]
+          val userForm   = controller.userForm
 
-        val anyData                                = Json.parse("""{"name":"bob","age":"21"}""")
-        implicit val request: FakeRequest[JsValue] = FakeRequest().withBody(anyData)
-        // #userForm-generate-request
-        val userData = userForm.bindFromRequest().get
-        // #userForm-generate-request
+          val anyData                                = Json.parse("""{"name":"bob","age":"21"}""")
+          implicit val request: FakeRequest[JsValue] = FakeRequest().withBody(anyData)
+          // #userForm-generate-request
+          val userData = userForm.bindFromRequest().get
+          // #userForm-generate-request
 
-        userData.name === "bob"
+          userData.name === "bob"
+        }
       }
 
       "get user info from form" in new WithApplication {
-        val controller = app.injector.instanceOf[controllers.Application]
-        controller.userFormName === "bob"
-        controller.userFormVerifyName === "bob"
-        controller.userFormConstraintsName === "bob"
-        controller.userFormConstraints2Name === "bob"
-        controller.userFormConstraintsAdhocName === "bob"
-        controller.userFormNestedWorkCity === "Shanghai"
-        controller.userFormRepeatedEmails === List("benewu@gmail.com", "bob@gmail.com")
-        controller.userFormOptionalEmail === None
-        controller.userFormStaticId === 23
-        controller.userFormTupleName === "bob"
+        override def running() = {
+          val controller = app.injector.instanceOf[controllers.Application]
+          controller.userFormName === "bob"
+          controller.userFormVerifyName === "bob"
+          controller.userFormConstraintsName === "bob"
+          controller.userFormConstraints2Name === "bob"
+          controller.userFormConstraintsAdhocName === "bob"
+          controller.userFormNestedWorkCity === "Shanghai"
+          controller.userFormRepeatedEmails === List("benewu@gmail.com", "bob@gmail.com")
+          controller.userFormOptionalEmail === None
+          controller.userFormStaticId === 23
+          controller.userFormTupleName === "bob"
+        }
       }
 
       "handling form with errors" in new WithApplication {
-        val controller           = app.injector.instanceOf[controllers.Application]
-        val userFormConstraints2 = controller.userFormConstraints2
+        override def running() = {
+          val controller           = app.injector.instanceOf[controllers.Application]
+          val userFormConstraints2 = controller.userFormConstraints2
 
-        implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest().withFormUrlEncodedBody("name" -> "", "age" -> "25")
+          implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+            FakeRequest().withFormUrlEncodedBody("name" -> "", "age" -> "25")
 
-        // #userForm-constraints-2-with-errors
-        val boundForm = userFormConstraints2.bind(Map("bob" -> "", "age" -> "25"))
-        boundForm.hasErrors must beTrue
-        // #userForm-constraints-2-with-errors
+          // #userForm-constraints-2-with-errors
+          val boundForm = userFormConstraints2.bind(Map("bob" -> "", "age" -> "25"))
+          boundForm.hasErrors must beTrue
+          // #userForm-constraints-2-with-errors
+        }
       }
 
       "handling binding failure" in new WithApplication {
-        val controller = app.injector.instanceOf[controllers.Application]
-        val userForm   = controller.userFormConstraints
+        override def running() = {
+          val controller = app.injector.instanceOf[controllers.Application]
+          val userForm   = controller.userFormConstraints
 
-        implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest().withFormUrlEncodedBody("name" -> "", "age" -> "25")
-        import play.api.data.FormBinding.Implicits._
+          implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+            FakeRequest().withFormUrlEncodedBody("name" -> "", "age" -> "25")
+          import play.api.data.FormBinding.Implicits._
 
-        val boundForm = userForm.bindFromRequest()
-        boundForm.hasErrors must beTrue
+          val boundForm = userForm.bindFromRequest()
+          boundForm.hasErrors must beTrue
+        }
       }
 
       "display global errors user template" in new WithApplication {
-        val controller = app.injector.instanceOf[controllers.Application]
-        val userForm   = controller.userFormConstraintsAdHoc
+        override def running() = {
+          val controller = app.injector.instanceOf[controllers.Application]
+          val userForm   = controller.userFormConstraintsAdHoc
 
-        import play.api.data.FormBinding.Implicits._
-        implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest().withFormUrlEncodedBody("name" -> "Johnny Utah", "age" -> "25")
+          import play.api.data.FormBinding.Implicits._
+          implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+            FakeRequest().withFormUrlEncodedBody("name" -> "Johnny Utah", "age" -> "25")
 
-        val boundForm = userForm.bindFromRequest()
-        boundForm.hasGlobalErrors must beTrue
+          val boundForm = userForm.bindFromRequest()
+          boundForm.hasGlobalErrors must beTrue
 
-        val html = views.html.user(boundForm)
-        html.body must contain("Failed form constraints!")
+          val html = views.html.user(boundForm)
+          html.body must contain("Failed form constraints!")
+        }
       }
 
       "map single values" in new WithApplication {
-        // #form-single-value
-        val singleForm = Form(
-          single(
-            "email" -> email
+        override def running() = {
+          // #form-single-value
+          val singleForm = Form(
+            single(
+              "email" -> email
+            )
           )
-        )
 
-        val emailValue = singleForm.bind(Map("email" -> "bob@example.com")).get
-        // #form-single-value
-        emailValue must beEqualTo("bob@example.com")
+          val emailValue = singleForm.bind(Map("email" -> "bob@example.com")).get
+          // #form-single-value
+          emailValue must beEqualTo("bob@example.com")
+        }
       }
 
       "fill selects with options and set their defaults" in new WithApplication {
-        val controller = app.injector.instanceOf[controllers.Application]
-        val boundForm  = controller.filledAddressSelectForm
-        val html       = views.html.select(boundForm)
-        html.body must contain("option value=\"London\" selected")
+        override def running() = {
+          val controller = app.injector.instanceOf[controllers.Application]
+          val boundForm  = controller.filledAddressSelectForm
+          val html       = views.html.select(boundForm)
+          html.body must contain("option value=\"London\" selected")
+        }
       }
     }
   }

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/csrf/UserControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/csrf/UserControllerSpec.scala
@@ -25,12 +25,14 @@ import play.api.test.WithApplication
 class UserControllerSpec extends Specification {
   "UserController GET" should {
     "render the index page from the application" in new WithApplication() {
-      val controller = app.injector.instanceOf[UserController]
-      val request    = FakeRequest().withCSRFToken
-      val result     = controller.userGet().apply(request)
+      override def running() = {
+        val controller = app.injector.instanceOf[UserController]
+        val request    = FakeRequest().withCSRFToken
+        val result     = controller.userGet().apply(request)
 
-      status(result) must beEqualTo(OK)
-      contentType(result) must beSome("text/html")
+        status(result) must beEqualTo(OK)
+        contentType(result) must beSome("text/html")
+      }
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -25,7 +25,9 @@ class ScalaErrorHandling extends PlaySpecification with WsTestClient {
 
   "scala error handling" should {
     "allow providing a custom error handler" in new WithServer(fakeApp[root.ErrorHandler]) {
-      await(wsUrl("/error").get()).body must_== "A server error occurred: foo"
+      override def running() = {
+        await(wsUrl("/error").get()).body must_== "A server error occurred: foo"
+      }
     }
 
     "allow extending the default error handler" in {

--- a/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
@@ -88,19 +88,23 @@ package scalaguide.i18n.scalai18n {
 
     "An i18nsupport controller" should {
       "return the right message" in new WithApplication(GuiceApplicationBuilder().loadConfig(conf).build()) {
-        val controller = app.injector.instanceOf[MySupportController]
+        override def running() = {
+          val controller = app.injector.instanceOf[MySupportController]
 
-        val result = controller.index(FakeRequest())
-        contentAsString(result) must contain("You aren't logged in!")
+          val result = controller.index(FakeRequest())
+          contentAsString(result) must contain("You aren't logged in!")
+        }
       }
     }
 
     "An messages controller" should {
       "return the right message" in new WithApplication(GuiceApplicationBuilder().loadConfig(conf).build()) {
-        val controller = app.injector.instanceOf[MyMessagesController]
+        override def running() = {
+          val controller = app.injector.instanceOf[MyMessagesController]
 
-        val result = controller.index(FakeRequest())
-        contentAsString(result) must contain("You aren't logged in!")
+          val result = controller.index(FakeRequest())
+          contentAsString(result) must contain("You aren't logged in!")
+        }
       }
     }
 

--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
@@ -17,75 +17,78 @@ import play.api.test._
 class ScalaJsonHttpSpec extends PlaySpecification with Results {
   "JSON with HTTP" should {
     "allow serving JSON" in new WithApplication() with Injecting {
-      val Action = inject[DefaultActionBuilder]
+      override def running() = {
+        val Action = inject[DefaultActionBuilder]
 
-      // #serve-json-imports
-      // ###insert: import play.api.mvc._
-      import play.api.libs.functional.syntax._
-      import play.api.libs.json._
-      // #serve-json-imports
+        // #serve-json-imports
+        // ###insert: import play.api.mvc._
+        import play.api.libs.functional.syntax._
+        import play.api.libs.json._
+        // #serve-json-imports
 
-      // #serve-json-implicits
-      implicit val locationWrites: Writes[Location] =
-        (JsPath \ "lat").write[Double].and((JsPath \ "long").write[Double])(unlift(Location.unapply))
+        // #serve-json-implicits
+        implicit val locationWrites: Writes[Location] =
+          (JsPath \ "lat").write[Double].and((JsPath \ "long").write[Double])(unlift(Location.unapply))
 
-      implicit val placeWrites: Writes[Place] =
-        (JsPath \ "name").write[String].and((JsPath \ "location").write[Location])(unlift(Place.unapply))
-      // #serve-json-implicits
+        implicit val placeWrites: Writes[Place] =
+          (JsPath \ "name").write[String].and((JsPath \ "location").write[Location])(unlift(Place.unapply))
+        // #serve-json-implicits
 
-      // #serve-json
-      def listPlaces() = Action {
-        val json = Json.toJson(Place.list)
-        Ok(json)
+        // #serve-json
+        def listPlaces() = Action {
+          val json = Json.toJson(Place.list)
+          Ok(json)
+        }
+        // #serve-json
+
+        val result: Future[Result] = listPlaces().apply(FakeRequest())
+        status(result) === OK
+        contentType(result) === Some("application/json")
+        contentAsString(
+          result
+        ) === """[{"name":"Sandleford","location":{"lat":51.377797,"long":-1.318965}},{"name":"Watership Down","location":{"lat":51.235685,"long":-1.309197}}]"""
       }
-      // #serve-json
-
-      val result: Future[Result] = listPlaces().apply(FakeRequest())
-      status(result) === OK
-      contentType(result) === Some("application/json")
-      contentAsString(
-        result
-      ) === """[{"name":"Sandleford","location":{"lat":51.377797,"long":-1.318965}},{"name":"Watership Down","location":{"lat":51.235685,"long":-1.309197}}]"""
     }
 
     "allow handling JSON" in new WithApplication() with Injecting {
-      val Action = inject[DefaultActionBuilder]
+      override def running() = {
+        val Action = inject[DefaultActionBuilder]
 
-      // #handle-json-imports
-      import play.api.libs.functional.syntax._
-      import play.api.libs.json._
-      // #handle-json-imports
+        // #handle-json-imports
+        import play.api.libs.functional.syntax._
+        import play.api.libs.json._
+        // #handle-json-imports
 
-      // #handle-json-implicits
-      implicit val locationReads: Reads[Location] =
-        (JsPath \ "lat").read[Double].and((JsPath \ "long").read[Double])(Location.apply _)
+        // #handle-json-implicits
+        implicit val locationReads: Reads[Location] =
+          (JsPath \ "lat").read[Double].and((JsPath \ "long").read[Double])(Location.apply _)
 
-      implicit val placeReads: Reads[Place] =
-        (JsPath \ "name").read[String].and((JsPath \ "location").read[Location])(Place.apply _)
-      // #handle-json-implicits
+        implicit val placeReads: Reads[Place] =
+          (JsPath \ "name").read[String].and((JsPath \ "location").read[Location])(Place.apply _)
+        // #handle-json-implicits
 
-      // #handle-json
-      def savePlace(): Action[AnyContent] = Action { request =>
-        request.body.asJson
-          .map { json =>
-            val placeResult = json.validate[Place]
-            placeResult.fold(
-              errors => {
-                BadRequest(Json.obj("message" -> JsError.toJson(errors)))
-              },
-              place => {
-                Place.save(place)
-                Ok(Json.obj("message" -> ("Place '" + place.name + "' saved.")))
-              }
-            )
-          }
-          .getOrElse {
-            BadRequest(Json.obj("message" -> "Expecting JSON data."))
-          }
-      }
-      // #handle-json
+        // #handle-json
+        def savePlace(): Action[AnyContent] = Action { request =>
+          request.body.asJson
+            .map { json =>
+              val placeResult = json.validate[Place]
+              placeResult.fold(
+                errors => {
+                  BadRequest(Json.obj("message" -> JsError.toJson(errors)))
+                },
+                place => {
+                  Place.save(place)
+                  Ok(Json.obj("message" -> ("Place '" + place.name + "' saved.")))
+                }
+              )
+            }
+            .getOrElse {
+              BadRequest(Json.obj("message" -> "Expecting JSON data."))
+            }
+        }
+        // #handle-json
 
-      val body = Json.parse("""
+        val body = Json.parse("""
       {
         "name" : "Nuthanger Farm",
         "location" : {
@@ -94,43 +97,45 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
         }
       }
       """)
-      val request                = FakeRequest().withHeaders(CONTENT_TYPE -> "application/json").withJsonBody(body)
-      val result: Future[Result] = savePlace().apply(request)
+        val request                = FakeRequest().withHeaders(CONTENT_TYPE -> "application/json").withJsonBody(body)
+        val result: Future[Result] = savePlace().apply(request)
 
-      status(result) === OK
-      contentType(result) === Some("application/json")
-      contentAsString(result) === """{"message":"Place 'Nuthanger Farm' saved."}"""
+        status(result) === OK
+        contentType(result) === Some("application/json")
+        contentAsString(result) === """{"message":"Place 'Nuthanger Farm' saved."}"""
+      }
     }
 
     "allow handling JSON with BodyParser" in new WithApplication() with Injecting {
-      import play.api.libs.functional.syntax._
-      import play.api.libs.json._
+      override def running() = {
+        import play.api.libs.functional.syntax._
+        import play.api.libs.json._
 
-      implicit val locationReads: Reads[Location] =
-        (JsPath \ "lat").read[Double].and((JsPath \ "long").read[Double])(Location.apply _)
+        implicit val locationReads: Reads[Location] =
+          (JsPath \ "lat").read[Double].and((JsPath \ "long").read[Double])(Location.apply _)
 
-      implicit val placeReads: Reads[Place] =
-        (JsPath \ "name").read[String].and((JsPath \ "location").read[Location])(Place.apply _)
+        implicit val placeReads: Reads[Place] =
+          (JsPath \ "name").read[String].and((JsPath \ "location").read[Location])(Place.apply _)
 
-      val parse  = inject[PlayBodyParsers]
-      val Action = inject[DefaultActionBuilder]
+        val parse  = inject[PlayBodyParsers]
+        val Action = inject[DefaultActionBuilder]
 
-      // #handle-json-bodyparser
-      def savePlace(): Action[JsValue] = Action(parse.json) { request =>
-        val placeResult = request.body.validate[Place]
-        placeResult.fold(
-          errors => {
-            BadRequest(Json.obj("message" -> JsError.toJson(errors)))
-          },
-          place => {
-            Place.save(place)
-            Ok(Json.obj("message" -> ("Place '" + place.name + "' saved.")))
-          }
-        )
-      }
-      // #handle-json-bodyparser
+        // #handle-json-bodyparser
+        def savePlace(): Action[JsValue] = Action(parse.json) { request =>
+          val placeResult = request.body.validate[Place]
+          placeResult.fold(
+            errors => {
+              BadRequest(Json.obj("message" -> JsError.toJson(errors)))
+            },
+            place => {
+              Place.save(place)
+              Ok(Json.obj("message" -> ("Place '" + place.name + "' saved.")))
+            }
+          )
+        }
+        // #handle-json-bodyparser
 
-      val body: JsValue = Json.parse("""
+        val body: JsValue = Json.parse("""
       {
         "name" : "Nuthanger Farm",
         "location" : {
@@ -139,51 +144,53 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
         }
       }
       """)
-      val request                = FakeRequest().withHeaders(CONTENT_TYPE -> "application/json").withBody(body)
-      val result: Future[Result] = savePlace().apply(request)
-      val bodyText: String       = contentAsString(result)
-      status(result) === OK
-      contentType(result) === Some("application/json")
-      contentAsString(result) === """{"message":"Place 'Nuthanger Farm' saved."}"""
+        val request                = FakeRequest().withHeaders(CONTENT_TYPE -> "application/json").withBody(body)
+        val result: Future[Result] = savePlace().apply(request)
+        val bodyText: String       = contentAsString(result)
+        status(result) === OK
+        contentType(result) === Some("application/json")
+        contentAsString(result) === """{"message":"Place 'Nuthanger Farm' saved."}"""
+      }
     }
 
     "allow concise handling JSON with BodyParser" in new WithApplication() with Injecting {
-      import scala.concurrent.ExecutionContext.Implicits.global
+      override def running() = {
+        import scala.concurrent.ExecutionContext.Implicits.global
 
-      val parse  = inject[PlayBodyParsers]
-      val Action = inject[DefaultActionBuilder]
+        val parse  = inject[PlayBodyParsers]
+        val Action = inject[DefaultActionBuilder]
 
-      // #handle-json-bodyparser-concise
-      import play.api.libs.functional.syntax._
-      import play.api.libs.json._
-      import play.api.libs.json.Reads._
+        // #handle-json-bodyparser-concise
+        import play.api.libs.functional.syntax._
+        import play.api.libs.json._
+        import play.api.libs.json.Reads._
 
-      implicit val locationReads: Reads[Location] =
-        (JsPath \ "lat")
-          .read[Double](min(-90.0).keepAnd(max(90.0)))
-          .and((JsPath \ "long").read[Double](min(-180.0).keepAnd(max(180.0))))(Location.apply _)
+        implicit val locationReads: Reads[Location] =
+          (JsPath \ "lat")
+            .read[Double](min(-90.0).keepAnd(max(90.0)))
+            .and((JsPath \ "long").read[Double](min(-180.0).keepAnd(max(180.0))))(Location.apply _)
 
-      implicit val placeReads: Reads[Place] =
-        (JsPath \ "name").read[String](minLength[String](2)).and((JsPath \ "location").read[Location])(Place.apply _)
+        implicit val placeReads: Reads[Place] =
+          (JsPath \ "name").read[String](minLength[String](2)).and((JsPath \ "location").read[Location])(Place.apply _)
 
-      // This helper parses and validates JSON using the implicit `placeReads`
-      // above, returning errors if the parsed json fails validation.
-      def validateJson[A: Reads] = parse.json.validate(
-        _.validate[A].asEither.left.map(e => BadRequest(JsError.toJson(e)))
-      )
+        // This helper parses and validates JSON using the implicit `placeReads`
+        // above, returning errors if the parsed json fails validation.
+        def validateJson[A: Reads] = parse.json.validate(
+          _.validate[A].asEither.left.map(e => BadRequest(JsError.toJson(e)))
+        )
 
-      // if we don't care about validation we could replace `validateJson[Place]`
-      // with `BodyParsers.parse.json[Place]` to get an unvalidated case class
-      // in `request.body` instead.
-      def savePlaceConcise: Action[Place] = Action(validateJson[Place]) { request =>
-        // `request.body` contains a fully validated `Place` instance.
-        val place = request.body
-        Place.save(place)
-        Ok(Json.obj("message" -> ("Place '" + place.name + "' saved.")))
-      }
-      // #handle-json-bodyparser-concise
+        // if we don't care about validation we could replace `validateJson[Place]`
+        // with `BodyParsers.parse.json[Place]` to get an unvalidated case class
+        // in `request.body` instead.
+        def savePlaceConcise: Action[Place] = Action(validateJson[Place]) { request =>
+          // `request.body` contains a fully validated `Place` instance.
+          val place = request.body
+          Place.save(place)
+          Ok(Json.obj("message" -> ("Place '" + place.name + "' saved.")))
+        }
+        // #handle-json-bodyparser-concise
 
-      val body: JsValue = Json.parse("""
+        val body: JsValue = Json.parse("""
       {
         "name" : "Nuthanger Farm",
         "location" : {
@@ -192,13 +199,14 @@ class ScalaJsonHttpSpec extends PlaySpecification with Results {
         }
       }
       """)
-      val request =
-        FakeRequest().withHeaders(CONTENT_TYPE -> "application/json").withBody(Json.fromJson[Place](body).get)
-      val result: Future[Result] = savePlaceConcise.apply(request)
-      val bodyText: String       = contentAsString(result)
-      status(result) === OK
-      contentType(result) === Some("application/json")
-      contentAsString(result) === """{"message":"Place 'Nuthanger Farm' saved."}"""
+        val request =
+          FakeRequest().withHeaders(CONTENT_TYPE -> "application/json").withBody(Json.fromJson[Place](body).get)
+        val result: Future[Result] = savePlaceConcise.apply(request)
+        val bodyText: String       = contentAsString(result)
+        status(result) === OK
+        contentType(result) === Some("application/json")
+        contentAsString(result) === """{"message":"Place 'Nuthanger Farm' saved."}"""
+      }
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -261,10 +261,12 @@ class ScalaLoggingSpec extends Specification {
     }
 
     "implicitly pass marker context in controller" in new WithApplication() with Injecting {
-      val controller = inject[ImplicitRequestController]
+      override def running() = {
+        val controller = inject[ImplicitRequestController]
 
-      val result = controller.asyncIndex()(FakeRequest())
-      contentAsString(result) must be_==("testing")
+        val result = controller.asyncIndex()(FakeRequest())
+        contentAsString(result) must be_==("testing")
+      }
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
@@ -13,20 +13,22 @@ import play.api.test._
 class ExampleEssentialActionSpec extends PlaySpecification {
   "An essential action" should {
     "can parse a JSON body" in new WithApplication() with Injecting {
-      val Action = inject[DefaultActionBuilder]
-      val parse  = inject[PlayBodyParsers]
+      override def running() = {
+        val Action = inject[DefaultActionBuilder]
+        val parse  = inject[PlayBodyParsers]
 
-      val action: EssentialAction = Action(parse.json) { request =>
-        val value = (request.body \ "field").as[String]
-        Ok(value)
+        val action: EssentialAction = Action(parse.json) { request =>
+          val value = (request.body \ "field").as[String]
+          Ok(value)
+        }
+
+        val request = FakeRequest(POST, "/").withJsonBody(Json.parse("""{ "field": "value" }"""))
+
+        val result = call(action, request)
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual "value"
       }
-
-      val request = FakeRequest(POST, "/").withJsonBody(Json.parse("""{ "field": "value" }"""))
-
-      val result = call(action, request)
-
-      status(result) mustEqual OK
-      contentAsString(result) mustEqual "value"
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleHelpersSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleHelpersSpec.scala
@@ -20,15 +20,19 @@ import play.api.test.WithApplication
 class ExampleHelpersSpec extends PlaySpecification {
   // #scalafunctionaltest-noinjecting
   "test" in new WithApplication() {
-    val executionContext = app.injector.instanceOf[ExecutionContext]
-    executionContext must beAnInstanceOf[ExecutionContext]
+    override def running() = {
+      val executionContext = app.injector.instanceOf[ExecutionContext]
+      executionContext must beAnInstanceOf[ExecutionContext]
+    }
   }
   // #scalafunctionaltest-noinjecting
 
   // #scalafunctionaltest-injecting
   "test" in new WithApplication() with play.api.test.Injecting {
-    val executionContext = inject[ExecutionContext]
-    executionContext must beAnInstanceOf[ExecutionContext]
+    override def running() = {
+      val executionContext = inject[ExecutionContext]
+      executionContext must beAnInstanceOf[ExecutionContext]
+    }
   }
   // #scalafunctionaltest-injecting
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalExampleControllerSpec.scala
@@ -10,12 +10,14 @@ import scalaguide.tests.controllers
 class FunctionalExampleControllerSpec extends PlaySpecification {
   // #scalafunctionaltest-functionalexamplecontrollerspec
   "respond to the index Action" in new WithApplication {
-    val controller = app.injector.instanceOf[scalaguide.tests.controllers.HomeController]
-    val result     = controller.index()(FakeRequest())
+    override def running() = {
+      val controller = app.injector.instanceOf[scalaguide.tests.controllers.HomeController]
+      val result     = controller.index()(FakeRequest())
 
-    status(result) must equalTo(OK)
-    contentType(result) must beSome("text/plain")
-    contentAsString(result) must contain("Hello Bob")
+      status(result) must equalTo(OK)
+      contentType(result) must beSome("text/plain")
+      contentAsString(result) must contain("Hello Bob")
+    }
   }
   // #scalafunctionaltest-functionalexamplecontrollerspec
 }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalTemplateSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalTemplateSpec.scala
@@ -12,9 +12,11 @@ import play.api.test.Helpers._
 class FunctionalTemplateSpec extends Specification {
   // #scalatest-functionaltemplatespec
   "render index template" in new WithApplication {
-    val html = views.html.index("Coco")
+    override def running() = {
+      val html = views.html.index("Coco")
 
-    contentAsString(html) must contain("Hello Coco")
+      contentAsString(html) must contain("Hello Coco")
+    }
   }
   // #scalatest-functionaltemplatespec
 }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
@@ -44,31 +44,37 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
 
     // #scalafunctionaltest-respondtoroute
     "respond to the index Action" in new WithApplication(applicationWithRouter) {
-      // ###replace: val Some(result) = route(app, FakeRequest(GET, "/Bob"))
-      val Some(result) = route(app, FakeRequest(GET_REQUEST, "/Bob"))
+      override def running() = {
+        // ###replace: val Some(result) = route(app, FakeRequest(GET, "/Bob"))
+        val Some(result) = route(app, FakeRequest(GET_REQUEST, "/Bob"))
 
-      status(result) must equalTo(OK)
-      contentType(result) must beSome("text/html")
-      charset(result) must beSome("utf-8")
-      contentAsString(result) must contain("Hello Bob")
+        status(result) must equalTo(OK)
+        contentType(result) must beSome("text/html")
+        charset(result) must beSome("utf-8")
+        contentAsString(result) must contain("Hello Bob")
+      }
     }
     // #scalafunctionaltest-respondtoroute
 
     // #scalafunctionaltest-testview
     "render index template" in new WithApplication {
-      val html = views.html.index("Coco")
+      override def running() = {
+        val html = views.html.index("Coco")
 
-      contentAsString(html) must contain("Hello Coco")
+        contentAsString(html) must contain("Hello Coco")
+      }
     }
     // #scalafunctionaltest-testview
 
     // #scalafunctionaltest-testmodel
     def appWithMemoryDatabase = new GuiceApplicationBuilder().configure(inMemoryDatabase("test")).build()
     "run an application" in new WithApplication(appWithMemoryDatabase) {
-      val Some(macintosh) = Computer.findById(21)
+      override def running() = {
+        val Some(macintosh) = Computer.findById(21)
 
-      macintosh.name must equalTo("Macintosh")
-      macintosh.introduced must beSome[String].which(_ must beEqualTo("1984-01-24"))
+        macintosh.name must equalTo("Macintosh")
+        macintosh.introduced must beSome[String].which(_ must beEqualTo("1984-01-24"))
+      }
     }
     // #scalafunctionaltest-testmodel
 
@@ -105,15 +111,17 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
     }
 
     "run in a browser" in new WithBrowser(webDriver = WebDriverFactory(HTMLUNIT), app = applicationWithBrowser) {
-      browser.goTo("/")
+      override def running() = {
+        browser.goTo("/")
 
-      // Check the page
-      browser.el("#title").text() must equalTo("Hello Guest")
+        // Check the page
+        browser.el("#title").text() must equalTo("Hello Guest")
 
-      browser.el("a").click()
+        browser.el("a").click()
 
-      browser.url must equalTo("login")
-      browser.el("#title").text() must equalTo("Hello Coco")
+        browser.url must equalTo("login")
+        browser.el("#title").text() must equalTo("Hello Coco")
+      }
     }
     // #scalafunctionaltest-testwithbrowser
 
@@ -122,15 +130,18 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
     val testPaymentGatewayURL = s"http://$myPublicAddress"
     // #scalafunctionaltest-testpaymentgateway
     "test server logic" in new WithServer(app = applicationWithBrowser, port = testPort) {
-      // The test payment gateway requires a callback to this server before it returns a result...
-      val callbackURL = s"http://$myPublicAddress/callback"
+      override def running() = {
+        // The test payment gateway requires a callback to this server before it returns a result...
+        val callbackURL = s"http://$myPublicAddress/callback"
 
-      val ws = app.injector.instanceOf[WSClient]
+        val ws = app.injector.instanceOf[WSClient]
 
-      // await is from play.api.test.FutureAwaits
-      val response = await(ws.url(testPaymentGatewayURL).withQueryStringParameters("callbackURL" -> callbackURL).get())
+        // await is from play.api.test.FutureAwaits
+        val response =
+          await(ws.url(testPaymentGatewayURL).withQueryStringParameters("callbackURL" -> callbackURL).get())
 
-      response.status must equalTo(OK)
+        response.status must equalTo(OK)
+      }
     }
     // #scalafunctionaltest-testpaymentgateway
 
@@ -148,8 +159,10 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
       .build()
 
     "test WSClient logic" in new WithServer(app = appWithRoutes, port = 3333) {
-      val ws = app.injector.instanceOf[WSClient]
-      await(ws.url("http://localhost:3333").get()).status must equalTo(OK)
+      override def running() = {
+        val ws = app.injector.instanceOf[WSClient]
+        await(ws.url("http://localhost:3333").get()).status must equalTo(OK)
+      }
     }
     // #scalafunctionaltest-testws
 
@@ -160,15 +173,19 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
       implicit val lang = Lang("en-US")
 
       "provide default messages with the Java API" in new WithApplication() with Injecting {
-        val javaMessagesApi = inject[play.i18n.MessagesApi]
-        val msg             = javaMessagesApi.get(new play.i18n.Lang(lang), "constraint.email")
-        msg must ===("Email")
+        override def running() = {
+          val javaMessagesApi = inject[play.i18n.MessagesApi]
+          val msg             = javaMessagesApi.get(new play.i18n.Lang(lang), "constraint.email")
+          msg must ===("Email")
+        }
       }
 
       "provide default messages with the Scala API" in new WithApplication() with Injecting {
-        val messagesApi = inject[MessagesApi]
-        val msg         = messagesApi("constraint.email")
-        msg must ===("Email")
+        override def running() = {
+          val messagesApi = inject[MessagesApi]
+          val msg         = messagesApi("constraint.email")
+          msg must ===("Email")
+        }
       }
     }
     // #scalafunctionaltest-testmessages

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/WithDbDataSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/WithDbDataSpec.scala
@@ -11,7 +11,7 @@ import play.api.test._
 class WithDbDataSpec extends PlaySpecification {
   // #scalafunctionaltest-withdbdata
   abstract class WithDbData extends WithApplication {
-    override def around[T: AsResult](t: => T): Result = super.around {
+    override def wrap[T: AsResult](t: => T): Result = super.wrap {
       setupData()
       t
     }
@@ -23,10 +23,14 @@ class WithDbDataSpec extends PlaySpecification {
 
   "Computer model" should {
     "be retrieved by id" in new WithDbData {
-      // your test code
+      override def running() = {
+        // your test code
+      }
     }
     "be retrieved by email" in new WithDbData {
-      // your test code
+      override def running() = {
+        // your test code
+      }
     }
   }
   // #scalafunctionaltest-withdbdata

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
@@ -32,69 +32,71 @@ object routes {
 class ScalaOAuthSpec extends PlaySpecification {
   "Scala OAuth" should {
     "be injectable" in new WithApplication() with Injecting {
-      val controller = new HomeController(inject[WSClient], inject[ControllerComponents])(inject[ExecutionContext]) {
-        // #flow
-        val KEY = ConsumerKey("xxxxx", "xxxxx")
+      override def running() = {
+        val controller = new HomeController(inject[WSClient], inject[ControllerComponents])(inject[ExecutionContext]) {
+          // #flow
+          val KEY = ConsumerKey("xxxxx", "xxxxx")
 
-        val oauth = OAuth(
-          ServiceInfo(
-            "https://api.twitter.com/oauth/request_token",
-            "https://api.twitter.com/oauth/access_token",
-            "https://api.twitter.com/oauth/authorize",
-            KEY
-          ),
-          true
-        )
+          val oauth = OAuth(
+            ServiceInfo(
+              "https://api.twitter.com/oauth/request_token",
+              "https://api.twitter.com/oauth/access_token",
+              "https://api.twitter.com/oauth/authorize",
+              KEY
+            ),
+            true
+          )
 
-        def sessionTokenPair(implicit request: RequestHeader): Option[RequestToken] = {
-          for {
-            token  <- request.session.get("token")
-            secret <- request.session.get("secret")
-          } yield {
-            RequestToken(token, secret)
+          def sessionTokenPair(implicit request: RequestHeader): Option[RequestToken] = {
+            for {
+              token  <- request.session.get("token")
+              secret <- request.session.get("secret")
+            } yield {
+              RequestToken(token, secret)
+            }
           }
-        }
 
-        def authenticate = Action { (request: Request[AnyContent]) =>
-          request
-            .getQueryString("oauth_verifier")
-            .map { verifier =>
-              val tokenPair = sessionTokenPair(request).get
-              // We got the verifier; now get the access token, store it and back to index
-              oauth.retrieveAccessToken(tokenPair, verifier) match {
+          def authenticate = Action { (request: Request[AnyContent]) =>
+            request
+              .getQueryString("oauth_verifier")
+              .map { verifier =>
+                val tokenPair = sessionTokenPair(request).get
+                // We got the verifier; now get the access token, store it and back to index
+                oauth.retrieveAccessToken(tokenPair, verifier) match {
+                  case Right(t) => {
+                    // We received the authorized tokens in the OAuth object - store it before we proceed
+                    Redirect(routes.Application.index).withSession("token" -> t.token, "secret" -> t.secret)
+                  }
+                  case Left(e) => throw e
+                }
+              }
+              .getOrElse(oauth.retrieveRequestToken("https://localhost:9000/auth") match {
                 case Right(t) => {
-                  // We received the authorized tokens in the OAuth object - store it before we proceed
-                  Redirect(routes.Application.index).withSession("token" -> t.token, "secret" -> t.secret)
+                  // We received the unauthorized tokens in the OAuth object - store it before we proceed
+                  Redirect(oauth.redirectUrl(t.token)).withSession("token" -> t.token, "secret" -> t.secret)
                 }
                 case Left(e) => throw e
-              }
-            }
-            .getOrElse(oauth.retrieveRequestToken("https://localhost:9000/auth") match {
-              case Right(t) => {
-                // We received the unauthorized tokens in the OAuth object - store it before we proceed
-                Redirect(oauth.redirectUrl(t.token)).withSession("token" -> t.token, "secret" -> t.secret)
-              }
-              case Left(e) => throw e
-            })
-        }
-        // #flow
-
-        // #extended
-        def timeline = Action.async { implicit request: Request[AnyContent] =>
-          sessionTokenPair match {
-            case Some(credentials) => {
-              wsClient
-                .url("https://api.twitter.com/1.1/statuses/home_timeline.json")
-                .sign(OAuthCalculator(KEY, credentials))
-                .get()
-                .map(result => Ok(result.json))
-            }
-            case _ => Future.successful(Redirect(routes.Application.authenticate))
+              })
           }
+          // #flow
+
+          // #extended
+          def timeline = Action.async { implicit request: Request[AnyContent] =>
+            sessionTokenPair match {
+              case Some(credentials) => {
+                wsClient
+                  .url("https://api.twitter.com/1.1/statuses/home_timeline.json")
+                  .sign(OAuthCalculator(KEY, credentials))
+                  .get()
+                  .map(result => Ok(result.json))
+              }
+              case _ => Future.successful(Redirect(routes.Application.authenticate))
+            }
+          }
+          // #extended
         }
-        // #extended
+        controller must beAnInstanceOf[HomeController]
       }
-      controller must beAnInstanceOf[HomeController]
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -28,56 +28,58 @@ class IdController @Inject() (val openIdClient: OpenIdClient, c: ControllerCompo
 class ScalaOpenIdSpec extends PlaySpecification {
   "Scala OpenId" should {
     "be injectable" in new WithApplication() with Injecting {
-      val controller =
-        new IdController(inject[OpenIdClient], inject[ControllerComponents])(inject[ExecutionContext]) with Logging {
-          // #flow
-          def login = Action {
-            Ok(views.html.login())
-          }
+      override def running() = {
+        val controller =
+          new IdController(inject[OpenIdClient], inject[ControllerComponents])(inject[ExecutionContext]) with Logging {
+            // #flow
+            def login = Action {
+              Ok(views.html.login())
+            }
 
-          def loginPost = Action.async { implicit request =>
-            Form(
-              single(
-                "openid" -> nonEmptyText
-              )
-            ).bindFromRequest()
-              .fold(
-                { error =>
-                  logger.info(s"bad request ${error.toString}")
-                  Future.successful(BadRequest(error.toString))
-                },
-                { openId =>
-                  openIdClient
-                    .redirectURL(openId, routes.Application.openIdCallback.absoluteURL())
-                    .map(url => Redirect(url))
-                    .recover { case t: Throwable => Redirect(routes.Application.login) }
+            def loginPost = Action.async { implicit request =>
+              Form(
+                single(
+                  "openid" -> nonEmptyText
+                )
+              ).bindFromRequest()
+                .fold(
+                  { error =>
+                    logger.info(s"bad request ${error.toString}")
+                    Future.successful(BadRequest(error.toString))
+                  },
+                  { openId =>
+                    openIdClient
+                      .redirectURL(openId, routes.Application.openIdCallback.absoluteURL())
+                      .map(url => Redirect(url))
+                      .recover { case t: Throwable => Redirect(routes.Application.login) }
+                  }
+                )
+            }
+
+            def openIdCallback = Action.async { implicit request: Request[AnyContent] =>
+              openIdClient
+                .verifiedId(request)
+                .map(info => Ok(info.id + "\n" + info.attributes))
+                .recover {
+                  case t: Throwable =>
+                    // Here you should look at the error, and give feedback to the user
+                    Redirect(routes.Application.login)
                 }
+            }
+            // #flow
+
+            def extended(openId: String)(implicit request: RequestHeader) = {
+              // #extended
+              openIdClient.redirectURL(
+                openId,
+                routes.Application.openIdCallback.absoluteURL(),
+                Seq("email" -> "http://schema.openid.net/contact/email")
               )
+              // #extended
+            }
           }
-
-          def openIdCallback = Action.async { implicit request: Request[AnyContent] =>
-            openIdClient
-              .verifiedId(request)
-              .map(info => Ok(info.id + "\n" + info.attributes))
-              .recover {
-                case t: Throwable =>
-                  // Here you should look at the error, and give feedback to the user
-                  Redirect(routes.Application.login)
-              }
-          }
-          // #flow
-
-          def extended(openId: String)(implicit request: RequestHeader) = {
-            // #extended
-            openIdClient.redirectURL(
-              openId,
-              routes.Application.openIdCallback.absoluteURL(),
-              Seq("email" -> "http://schema.openid.net/contact/email")
-            )
-            // #extended
-          }
-        }
-      controller must beAnInstanceOf[IdController]
+        controller must beAnInstanceOf[IdController]
+      }
     }
   }
 }

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -537,12 +537,13 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
     }
 
     "allow simple programmatic configuration" in new WithApplication() {
+      implicit val materializer: Materializer = app.materializer
       override def running() = {
         // #simple-ws-custom-client
         import play.api.libs.ws.ahc._
 
         // usually injected through @Inject()(implicit mat: Materializer)
-        implicit val materializer: Materializer = app.materializer
+        // ###insert: implicit val materializer: Materializer = app.materializer
         val wsClient = AhcWSClient()
         // #simple-ws-custom-client
 

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -511,63 +511,69 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
     }
 
     "allow timeout across futures" in new WithServer() with Injecting {
-      val url2                      = url
-      implicit val futures: Futures = inject[Futures]
-      val ws                        = inject[WSClient]
-      // #ws-futures-timeout
-      // Adds withTimeout as type enrichment on Future[WSResponse]
-      import play.api.libs.concurrent.Futures._
+      override def running() = {
+        val url2                      = url
+        implicit val futures: Futures = inject[Futures]
+        val ws                        = inject[WSClient]
+        // #ws-futures-timeout
+        // Adds withTimeout as type enrichment on Future[WSResponse]
+        import play.api.libs.concurrent.Futures._
 
-      val result: Future[Result] =
-        ws.url(url)
-          .get()
-          .withTimeout(1.second)
-          .flatMap { response =>
-            // val url2 = response.json \ "url"
-            ws.url(url2).get().map { response2 => Ok(response.body) }
-          }
-          .recover {
-            case e: scala.concurrent.TimeoutException =>
-              GatewayTimeout
-          }
-      // #ws-futures-timeout
-      status(result) must_== OK
+        val result: Future[Result] =
+          ws.url(url)
+            .get()
+            .withTimeout(1.second)
+            .flatMap { response =>
+              // val url2 = response.json \ "url"
+              ws.url(url2).get().map { response2 => Ok(response.body) }
+            }
+            .recover {
+              case e: scala.concurrent.TimeoutException =>
+                GatewayTimeout
+            }
+        // #ws-futures-timeout
+        status(result) must_== OK
+      }
     }
 
     "allow simple programmatic configuration" in new WithApplication() {
-      // #simple-ws-custom-client
-      import play.api.libs.ws.ahc._
+      override def running() = {
+        // #simple-ws-custom-client
+        import play.api.libs.ws.ahc._
 
-      // usually injected through @Inject()(implicit mat: Materializer)
-      implicit val materializer: Materializer = app.materializer
-      val wsClient                            = AhcWSClient()
-      // #simple-ws-custom-client
+        // usually injected through @Inject()(implicit mat: Materializer)
+        implicit val materializer: Materializer = app.materializer
+        val wsClient = AhcWSClient()
+        // #simple-ws-custom-client
 
-      wsClient.close()
+        wsClient.close()
 
-      ok
+        ok
+      }
     }
 
     "allow programmatic configuration" in new WithApplication() {
-      // #ws-custom-client
-      import play.api._
-      import play.api.libs.ws._
-      import play.api.libs.ws.ahc._
+      override def running() = {
+        // #ws-custom-client
+        import play.api._
+        import play.api.libs.ws._
+        import play.api.libs.ws.ahc._
 
-      val configuration = Configuration("ws.followRedirects" -> true).withFallback(Configuration.reference)
+        val configuration = Configuration("ws.followRedirects" -> true).withFallback(Configuration.reference)
 
-      // If running in Play, environment should be injected
-      val environment        = Environment(new File("."), this.getClass.getClassLoader, Mode.Prod)
-      val wsConfig           = AhcWSClientConfigFactory.forConfig(configuration.underlying, environment.classLoader)
-      val mat                = app.materializer
-      val wsClient: WSClient = AhcWSClient(wsConfig)(mat)
-      // #ws-custom-client
+        // If running in Play, environment should be injected
+        val environment        = Environment(new File("."), this.getClass.getClassLoader, Mode.Prod)
+        val wsConfig           = AhcWSClientConfigFactory.forConfig(configuration.underlying, environment.classLoader)
+        val mat                = app.materializer
+        val wsClient: WSClient = AhcWSClient(wsConfig)(mat)
+        // #ws-custom-client
 
-      // #close-client
-      wsClient.close()
-      // #close-client
+        // #close-client
+        wsClient.close()
+        // #close-client
 
-      ok
+        ok
+      }
     }
 
     "grant access to the underlying client" in withSimpleServer { ws =>

--- a/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala
+++ b/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala
@@ -23,64 +23,70 @@ package scalaguide.xml.scalaxmlrequests {
 
     "A scala XML request" should {
       "request body as xml" in new WithApplication {
-        // #xml-request-body-asXml
-        def sayHello = Action { request =>
-          request.body.asXml
-            .map { xml =>
-              (xml \\ "name" headOption)
-              .map(_.text)
-              .map { name => Ok("Hello " + name) }
-              .getOrElse {
-                BadRequest("Missing parameter [name]")
+        override def running() = {
+          // #xml-request-body-asXml
+          def sayHello = Action { request =>
+            request.body.asXml
+              .map { xml =>
+                (xml \\ "name" headOption)
+                .map(_.text)
+                .map { name => Ok("Hello " + name) }
+                .getOrElse {
+                  BadRequest("Missing parameter [name]")
+                }
               }
-            }
-            .getOrElse {
-              BadRequest("Expecting Xml data")
-            }
+              .getOrElse {
+                BadRequest("Expecting Xml data")
+              }
+          }
+
+          // #xml-request-body-asXml
+
+          val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
+          status(call(sayHello, request)) must beEqualTo(Helpers.OK)
         }
-
-        // #xml-request-body-asXml
-
-        private val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
-        status(call(sayHello, request)) must beEqualTo(Helpers.OK)
       }
 
       "request body as xml body parser" in new WithApplication {
-        // #xml-request-body-parser
-        def sayHello = Action(parse.xml) { request =>
-          (request.body \\ "name" headOption)
-          .map(_.text)
-          .map { name => Ok("Hello " + name) }
-          .getOrElse {
-            BadRequest("Missing parameter [name]")
+        override def running() = {
+          // #xml-request-body-parser
+          def sayHello = Action(parse.xml) { request =>
+            (request.body \\ "name" headOption)
+            .map(_.text)
+            .map { name => Ok("Hello " + name) }
+            .getOrElse {
+              BadRequest("Missing parameter [name]")
+            }
           }
+
+          // #xml-request-body-parser
+
+          val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
+          status(call(sayHello, request)) must beEqualTo(Helpers.OK)
         }
-
-        // #xml-request-body-parser
-
-        private val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
-        status(call(sayHello, request)) must beEqualTo(Helpers.OK)
       }
 
       "request body as xml body parser and xml response" in new WithApplication {
-        // #xml-request-body-parser-xml-response
-        def sayHello = Action(parse.xml) { request =>
-          (request.body \\ "name" headOption)
-          .map(_.text)
-          .map { name =>
-            Ok(<message status="OK">Hello
-              {name}
-            </message>)
+        override def running() = {
+          // #xml-request-body-parser-xml-response
+          def sayHello = Action(parse.xml) { request =>
+            (request.body \\ "name" headOption)
+            .map(_.text)
+            .map { name =>
+              Ok(<message status="OK">Hello
+                  {name}
+                </message>)
+            }
+            .getOrElse {
+              BadRequest(<message status="KO">Missing parameter [name]</message>)
+            }
           }
-          .getOrElse {
-            BadRequest(<message status="KO">Missing parameter [name]</message>)
-          }
+
+          // #xml-request-body-parser-xml-response
+
+          val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
+          status(call(sayHello, request)) must beEqualTo(Helpers.OK)
         }
-
-        // #xml-request-body-parser-xml-response
-
-        private val request = FakeRequest().withXmlBody(<name>XF</name>).map(_.xml)
-        status(call(sayHello, request)) must beEqualTo(Helpers.OK)
       }
     }
   }

--- a/persistence/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
@@ -18,9 +18,11 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
         "db.other.url"    -> "jdbc:h2:mem:other"
       )
     ) {
-      val db = app.injector.instanceOf[DBApi].database("default")
-      db must beLike {
-        case pdb: PooledDatabase => pdb.pool must haveClass[HikariCPConnectionPool]
+      override def running() = {
+        val db = app.injector.instanceOf[DBApi].database("default")
+        db must beLike {
+          case pdb: PooledDatabase => pdb.pool must haveClass[HikariCPConnectionPool]
+        }
       }
     }
 
@@ -32,9 +34,11 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
         "db.other.url"    -> "jdbc:h2:mem:other"
       )
     ) {
-      val db = app.injector.instanceOf[DBApi].database("default")
-      db must beLike {
-        case pdb: PooledDatabase => pdb.pool must haveClass[HikariCPConnectionPool]
+      override def running() = {
+        val db = app.injector.instanceOf[DBApi].database("default")
+        db must beLike {
+          case pdb: PooledDatabase => pdb.pool must haveClass[HikariCPConnectionPool]
+        }
       }
     }
 
@@ -46,9 +50,11 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
         "db.other.url"    -> "jdbc:h2:mem:other"
       )
     ) {
-      val db = app.injector.instanceOf[DBApi].database("default")
-      db must beLike {
-        case pdb: PooledDatabase => pdb.pool must haveClass[CustomConnectionPool]
+      override def running() = {
+        val db = app.injector.instanceOf[DBApi].database("default")
+        db must beLike {
+          case pdb: PooledDatabase => pdb.pool must haveClass[CustomConnectionPool]
+        }
       }
     }
 
@@ -60,9 +66,11 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
         "db.other.url"    -> "jdbc:h2:mem:other"
       )
     ) {
-      val db = app.injector.instanceOf[DBApi].database("default")
-      db must beLike {
-        case pdb: PooledDatabase => pdb.pool must haveClass[CustomConnectionPool]
+      override def running() = {
+        val db = app.injector.instanceOf[DBApi].database("default")
+        db must beLike {
+          case pdb: PooledDatabase => pdb.pool must haveClass[CustomConnectionPool]
+        }
       }
     }
 
@@ -72,8 +80,10 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
         "db.default.url"    -> "jdbc:h2:mem:default"
       )
     ) {
-      val db = app.injector.instanceOf[DBApi]
-      db.database("default").dataSource.getClass.getName must not contain "ConnectionPoolDataSourceProxy"
+      override def running() = {
+        val db = app.injector.instanceOf[DBApi]
+        db.database("default").dataSource.getClass.getName must not contain "ConnectionPoolDataSourceProxy"
+      }
     }
 
     "use ConnectionPoolDataSourceProxy when logSql is true" in new WithApplication(
@@ -83,8 +93,10 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
         "db.default.logSql" -> "true"
       )
     ) {
-      val db = app.injector.instanceOf[DBApi]
-      db.database("default").dataSource.getClass.getName must contain("ConnectionPoolDataSourceProxy")
+      override def running() = {
+        val db = app.injector.instanceOf[DBApi]
+        db.database("default").dataSource.getClass.getName must contain("ConnectionPoolDataSourceProxy")
+      }
     }
   }
 }

--- a/persistence/play-jdbc/src/test/scala/play/api/db/NamedDatabaseSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/NamedDatabaseSpec.scala
@@ -18,10 +18,12 @@ class NamedDatabaseSpec extends PlaySpecification {
         "db.other.url"      -> "jdbc:h2:mem:other"
       )
     ) {
-      app.injector.instanceOf[DBApi].databases() must have size 2
-      app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:default"
-      app.injector.instanceOf[NamedDefaultComponent].db.url must_== "jdbc:h2:mem:default"
-      app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
+      override def running() = {
+        app.injector.instanceOf[DBApi].databases() must have size 2
+        app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:default"
+        app.injector.instanceOf[NamedDefaultComponent].db.url must_== "jdbc:h2:mem:default"
+        app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
+      }
     }
 
     "not bind default databases without configuration" in new WithApplication(
@@ -30,17 +32,21 @@ class NamedDatabaseSpec extends PlaySpecification {
         "db.other.url"    -> "jdbc:h2:mem:other"
       )
     ) {
-      app.injector.instanceOf[DBApi].databases() must have size 1
-      app.injector.instanceOf[DefaultComponent] must throwA[com.google.inject.ConfigurationException]
-      app.injector.instanceOf[NamedDefaultComponent] must throwA[com.google.inject.ConfigurationException]
-      app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
+      override def running() = {
+        app.injector.instanceOf[DBApi].databases() must have size 1
+        app.injector.instanceOf[DefaultComponent] must throwA[com.google.inject.ConfigurationException]
+        app.injector.instanceOf[NamedDefaultComponent] must throwA[com.google.inject.ConfigurationException]
+        app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
+      }
     }
 
     "not bind databases without configuration" in new WithApplication() {
-      app.injector.instanceOf[DBApi].databases() must beEmpty
-      app.injector.instanceOf[DefaultComponent] must throwA[com.google.inject.ConfigurationException]
-      app.injector.instanceOf[NamedDefaultComponent] must throwA[com.google.inject.ConfigurationException]
-      app.injector.instanceOf[NamedOtherComponent] must throwA[com.google.inject.ConfigurationException]
+      override def running() = {
+        app.injector.instanceOf[DBApi].databases() must beEmpty
+        app.injector.instanceOf[DefaultComponent] must throwA[com.google.inject.ConfigurationException]
+        app.injector.instanceOf[NamedDefaultComponent] must throwA[com.google.inject.ConfigurationException]
+        app.injector.instanceOf[NamedOtherComponent] must throwA[com.google.inject.ConfigurationException]
+      }
     }
 
     "allow default database name to be configured" in new WithApplication(
@@ -50,10 +56,12 @@ class NamedDatabaseSpec extends PlaySpecification {
         "db.other.url"    -> "jdbc:h2:mem:other"
       )
     ) {
-      app.injector.instanceOf[DBApi].databases() must have size 1
-      app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:other"
-      app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
-      app.injector.instanceOf[NamedDefaultComponent] must throwA[com.google.inject.ConfigurationException]
+      override def running() = {
+        app.injector.instanceOf[DBApi].databases() must have size 1
+        app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:other"
+        app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
+        app.injector.instanceOf[NamedDefaultComponent] must throwA[com.google.inject.ConfigurationException]
+      }
     }
 
     "allow db config key to be configured" in new WithApplication(
@@ -63,9 +71,11 @@ class NamedDatabaseSpec extends PlaySpecification {
         "databases.default.url"    -> "jdbc:h2:mem:default"
       )
     ) {
-      app.injector.instanceOf[DBApi].databases() must have size 1
-      app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:default"
-      app.injector.instanceOf[NamedDefaultComponent].db.url must_== "jdbc:h2:mem:default"
+      override def running() = {
+        app.injector.instanceOf[DBApi].databases() must have size 1
+        app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:default"
+        app.injector.instanceOf[NamedDefaultComponent].db.url must_== "jdbc:h2:mem:default"
+      }
     }
   }
 }

--- a/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -32,50 +32,58 @@ class FakesSpec extends PlaySpecification {
         .build()
 
     "Define Content-Type header based on body" in new WithApplication(app) {
-      val xml =
-        <foo>
-          <bar>
-            baz
-          </bar>
-        </foo>
-      val bytes = ByteString(xml.toString, "utf-16le")
-      val req = FakeRequest(PUT, "/process")
-        .withRawBody(bytes)
-      route(this.app, req).aka("response") must beSome[Future[Result]].which { resp =>
-        contentAsString(resp).aka("content") must_== "application/octet-stream"
+      override def running() = {
+        val xml =
+          <foo>
+            <bar>
+              baz
+            </bar>
+          </foo>
+        val bytes = ByteString(xml.toString, "utf-16le")
+        val req = FakeRequest(PUT, "/process")
+          .withRawBody(bytes)
+        route(this.app, req).aka("response") must beSome[Future[Result]].which { resp =>
+          contentAsString(resp).aka("content") must_== "application/octet-stream"
+        }
       }
     }
 
     "Not override explicit Content-Type header" in new WithApplication(app) {
-      val xml =
-        <foo>
-          <bar>
-            baz
-          </bar>
-        </foo>
-      val bytes = ByteString(xml.toString, "utf-16le")
-      val req = FakeRequest(PUT, "/process")
-        .withRawBody(bytes)
-        .withHeaders(
-          CONTENT_TYPE -> "text/xml;charset=utf-16le"
-        )
-      route(this.app, req).aka("response") must beSome[Future[Result]].which { resp =>
-        contentAsString(resp).aka("content") must_== "text/xml;charset=utf-16le"
+      override def running() = {
+        val xml =
+          <foo>
+            <bar>
+              baz
+            </bar>
+          </foo>
+        val bytes = ByteString(xml.toString, "utf-16le")
+        val req = FakeRequest(PUT, "/process")
+          .withRawBody(bytes)
+          .withHeaders(
+            CONTENT_TYPE -> "text/xml;charset=utf-16le"
+          )
+        route(this.app, req).aka("response") must beSome[Future[Result]].which { resp =>
+          contentAsString(resp).aka("content") must_== "text/xml;charset=utf-16le"
+        }
       }
     }
 
     "set a Content-Type header when one is unspecified and required" in new WithApplication() {
-      val request = FakeRequest(GET, "/testCall")
-        .withJsonBody(Json.obj("foo" -> "bar"))
+      override def running() = {
+        val request = FakeRequest(GET, "/testCall")
+          .withJsonBody(Json.obj("foo" -> "bar"))
 
-      contentTypeForFakeRequest(request) must contain("application/json")
+        contentTypeForFakeRequest(request) must contain("application/json")
+      }
     }
     "not overwrite the Content-Type header when specified" in new WithApplication() {
-      val request = FakeRequest(GET, "/testCall")
-        .withJsonBody(Json.obj("foo" -> "bar"))
-        .withHeaders(CONTENT_TYPE -> "application/test+json")
+      override def running() = {
+        val request = FakeRequest(GET, "/testCall")
+          .withJsonBody(Json.obj("foo" -> "bar"))
+          .withHeaders(CONTENT_TYPE -> "application/test+json")
 
-      contentTypeForFakeRequest(request) must contain("application/test+json")
+        contentTypeForFakeRequest(request) must contain("application/test+json")
+      }
     }
   }
 

--- a/testkit/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
+++ b/testkit/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
@@ -15,12 +15,16 @@ class SpecsSpec extends Specification {
 
   "WithApplication context" should {
     "provide an app" in new WithApplication(_.configure("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
-      app.configuration.getOptional[String]("foo") must beSome("bar")
+      override def running() = {
+        app.configuration.getOptional[String]("foo") must beSome("bar")
+      }
     }
     "make the app available implicitly" in new WithApplication(
       _.configure("foo" -> "bar", "ehcacheplugin" -> "disabled")
     ) {
-      getConfig("foo") must beSome("bar")
+      override def running() = {
+        getConfig("foo") must beSome("bar")
+      }
     }
   }
 
@@ -31,7 +35,9 @@ class SpecsSpec extends Specification {
     val builder = new GuiceApplicationBuilder().bindings(myModule)
     class WithMyApplicationLoader extends WithApplicationLoader(new GuiceApplicationLoader(builder))
     "allow adding modules" in new WithMyApplicationLoader {
-      app.injector.instanceOf(classOf[Int]) must equalTo(42)
+      override def running() = {
+        app.injector.instanceOf(classOf[Int]) must equalTo(42)
+      }
     }
   }
 }

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
@@ -38,8 +38,10 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
         Configuration.load(env, settings)
       }).build()
     ) {
-      val provider = app.injector.instanceOf[OptionalAhcHttpCacheProvider]
-      provider.get must beSome[AhcHttpCache].which { cache => cache.isShared must beFalse }
+      override def running() = {
+        val provider = app.injector.instanceOf[OptionalAhcHttpCacheProvider]
+        provider.get must beSome[AhcHttpCache].which { cache => cache.isShared must beFalse }
+      }
     }
 
     "work with a cache defined using caffeine through jcache" in new WithApplication(
@@ -52,8 +54,10 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
         Configuration.load(env, settings)
       }).build()
     ) {
-      val provider = app.injector.instanceOf[OptionalAhcHttpCacheProvider]
-      provider.get must beSome[AhcHttpCache].which { cache => cache.isShared must beFalse }
+      override def running() = {
+        val provider = app.injector.instanceOf[OptionalAhcHttpCacheProvider]
+        provider.get must beSome[AhcHttpCache].which { cache => cache.isShared must beFalse }
+      }
     }
   }
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -398,25 +398,27 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
       notBufferedFakeApp,
       testServerPort
     ) {
-      val token = signedTokenProvider.generateToken
-      val ws    = inject[WSClient]
-      val response = await(
-        ws.url("http://localhost:" + port)
-          .withSession(TokenName -> token)
-          .addHttpHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")
-          .post(
-            Seq(
-              // Ensure token is first so that it makes it into the buffered part
-              TokenName  -> token,
-              "buffered" -> "buffer",
-              // This value must go over the edge of csrf.body.bufferSize
-              "longvalue" -> Random.alphanumeric.take(1024).mkString(""),
-              "foo"       -> "bar"
-            ).map(f => f._1 + "=" + f._2).mkString("&")
-          )
-      )
-      response.status must_== OK
-      response.body[String] must_== "bar buffer"
+      override def running() = {
+        val token = signedTokenProvider.generateToken
+        val ws    = inject[WSClient]
+        val response = await(
+          ws.url("http://localhost:" + port)
+            .withSession(TokenName -> token)
+            .addHttpHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")
+            .post(
+              Seq(
+                // Ensure token is first so that it makes it into the buffered part
+                TokenName  -> token,
+                "buffered" -> "buffer",
+                // This value must go over the edge of csrf.body.bufferSize
+                "longvalue" -> Random.alphanumeric.take(1024).mkString(""),
+                "foo"       -> "bar"
+              ).map(f => f._1 + "=" + f._2).mkString("&")
+            )
+        )
+        response.status must_== OK
+        response.body[String] must_== "bar buffer"
+      }
     }
 
     "work with a Java error handler" in {

--- a/web/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -55,34 +55,38 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
   "security headers" should {
     "work with default singleton apply method with all default options" in new WithApplication() {
-      val filter = SecurityHeadersFilter()
-      val rh     = FakeRequest()
+      override def running() = {
+        val filter = SecurityHeadersFilter()
+        val rh     = FakeRequest()
 
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      val action = Action(Ok("success"))
-      val result = filter(action)(rh).run()
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        val action = Action(Ok("success"))
+        val result = filter(action)(rh).run()
 
-      header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
-      header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
-      header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
-      header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
-      header(CONTENT_SECURITY_POLICY_HEADER, result) must beNone
-      header(REFERRER_POLICY, result) must beSome("origin-when-cross-origin, strict-origin-when-cross-origin")
+        header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
+        header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
+        header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
+        header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
+        header(CONTENT_SECURITY_POLICY_HEADER, result) must beNone
+        header(REFERRER_POLICY, result) must beSome("origin-when-cross-origin, strict-origin-when-cross-origin")
+      }
     }
 
     "work with singleton apply method using configuration" in new WithApplication() {
-      val filter = SecurityHeadersFilter(Configuration.reference)
-      val rh     = FakeRequest()
-      val Action = app.injector.instanceOf[DefaultActionBuilder]
-      val action = Action(Ok("success"))
-      val result = filter(action)(rh).run()
+      override def running() = {
+        val filter = SecurityHeadersFilter(Configuration.reference)
+        val rh     = FakeRequest()
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        val action = Action(Ok("success"))
+        val result = filter(action)(rh).run()
 
-      header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
-      header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
-      header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
-      header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
-      header(CONTENT_SECURITY_POLICY_HEADER, result) must beNone
-      header(REFERRER_POLICY, result) must beSome("origin-when-cross-origin, strict-origin-when-cross-origin")
+        header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
+        header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
+        header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
+        header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
+        header(CONTENT_SECURITY_POLICY_HEADER, result) must beNone
+        header(REFERRER_POLICY, result) must beSome("origin-when-cross-origin, strict-origin-when-cross-origin")
+      }
     }
 
     "frame options" should {

--- a/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -40,11 +40,13 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
     "redirect when not on https including the path and url query parameters" in new WithApplication(
       buildApp(mode = Mode.Prod)
     ) with Injecting {
-      val req    = request("/please/dont?remove=this&foo=bar")
-      val result = route(app, req).get
+      override def running() = {
+        val req    = request("/please/dont?remove=this&foo=bar")
+        val result = route(app, req).get
 
-      status(result) must_== PERMANENT_REDIRECT
-      header(LOCATION, result) must beSome("https://playframework.com/please/dont?remove=this&foo=bar")
+        status(result) must_== PERMANENT_REDIRECT
+        header(LOCATION, result) must beSome("https://playframework.com/please/dont?remove=this&foo=bar")
+      }
     }
 
     "redirect with custom redirect status code if configured" in new WithApplication(
@@ -55,36 +57,44 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Prod
       )
     ) with Injecting {
-      val req    = request("/please/dont?remove=this&foo=bar")
-      val result = route(app, req).get
+      override def running() = {
+        val req    = request("/please/dont?remove=this&foo=bar")
+        val result = route(app, req).get
 
-      status(result) must_== 301
+        status(result) must_== 301
+      }
     }
 
     "not redirect when on http in test" in new WithApplication(buildApp(mode = Mode.Test)) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure)).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beNone
-      status(result) must_== OK
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== OK
+      }
     }
 
     "redirect when on http in test and redirectEnabled = true" in new WithApplication(
       buildApp("play.filters.https.redirectEnabled = true", mode = Mode.Test)
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure)).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beNone
-      status(result) must_== PERMANENT_REDIRECT
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== PERMANENT_REDIRECT
+      }
     }
 
     "not redirect when on https but send HSTS header" in new WithApplication(buildApp(mode = Mode.Prod)) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure)).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
-      status(result) must_== OK
+        header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
+        status(result) must_== OK
+      }
     }
 
     "not redirect when X-Forwarded-Proto header is 'https' (and not on https) but send HSTS header" in new WithApplication(
@@ -95,33 +105,41 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Prod
       )
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "https")).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "https")).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
-      status(result) must_== OK
+        header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
+        status(result) must_== OK
+      }
     }
 
     "redirect to custom HTTPS port if configured" in new WithApplication(
       buildApp("play.filters.https.port = 9443", mode = Mode.Prod)
     ) {
-      val result = route(app, request("/please/dont?remove=this&foo=bar")).get
+      override def running() = {
+        val result = route(app, request("/please/dont?remove=this&foo=bar")).get
 
-      header(LOCATION, result) must beSome("https://playframework.com:9443/please/dont?remove=this&foo=bar")
+        header(LOCATION, result) must beSome("https://playframework.com:9443/please/dont?remove=this&foo=bar")
+      }
     }
 
     "not contain default HSTS header if secure in test" in new WithApplication(buildApp(mode = Mode.Test)) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure)).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+      }
     }
 
     "contain default HSTS header if secure in production" in new WithApplication(buildApp(mode = Mode.Prod)) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure)).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
+        header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
+      }
     }
 
     "contain custom HSTS header if configured explicitly in prod" in new WithApplication(
@@ -132,10 +150,12 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Prod
       )
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure)).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=12345; includeSubDomains")
+        header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=12345; includeSubDomains")
+      }
     }
 
     "not redirect when xForwardedProtoEnabled is set but no header present" in new WithApplication(
@@ -147,11 +167,13 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Test
       )
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure)).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beNone
-      status(result) must_== OK
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== OK
+      }
     }
     "redirect when xForwardedProtoEnabled is not set and no header present" in new WithApplication(
       buildApp(
@@ -162,11 +184,13 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Test
       )
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure)).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beNone
-      status(result) must_== PERMANENT_REDIRECT
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== PERMANENT_REDIRECT
+      }
     }
     "redirect when xForwardedProtoEnabled is set and header is present" in new WithApplication(
       buildApp(
@@ -177,11 +201,13 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Test
       )
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beNone
-      status(result) must_== PERMANENT_REDIRECT
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== PERMANENT_REDIRECT
+      }
     }
 
     "send HSTS header when request itself is not secure but X-Forwarded-Proto header is 'https'" in new WithApplication(
@@ -193,11 +219,13 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Test
       )
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "https")).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "https")).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
-      status(result) must_== OK
+        header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
+        status(result) must_== OK
+      }
     }
 
     "not redirect when path included in redirectExcludePath" in new WithApplication(
@@ -210,11 +238,13 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Test
       )
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(app, request("/skip").withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request("/skip").withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beNone
-      status(result) must_== OK
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== OK
+      }
     }
 
     "not redirect when path included in redirectExcludePath and request has query params" in new WithApplication(
@@ -227,14 +257,16 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         mode = Mode.Test
       )
     ) {
-      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-      val result = route(
-        app,
-        request("/skip", Some("foo=bar")).withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")
-      ).get
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(
+          app,
+          request("/skip", Some("foo=bar")).withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")
+        ).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must beNone
-      status(result) must_== OK
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== OK
+      }
     }
   }
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/ip/IPFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/ip/IPFilterSpec.scala
@@ -36,10 +36,12 @@ class IPFilterSpec extends PlaySpecification {
     "accept request when ip whitelist and blacklists are empty, which is the default" in new WithApplication(
       buildApp()
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when ip whitelist and blacklists are explicitly empty" in new WithApplication(
@@ -48,10 +50,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.blackList = [ ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when ip whitelist and blacklists are empty which is the default and the routeModifiers white/blacklist are empty too" in new WithApplication(
@@ -64,10 +68,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.routeModifiers.blackList = [ ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "forbidden request when ip is blacklisted and the routeModifiers white/blacklist are empty" in new WithApplication(
@@ -79,10 +85,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.routeModifiers.blackList = [ ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
 
     "accept request when ip is not blacklisted and the routeModifiers white/blacklist are empty" in new WithApplication(
@@ -93,10 +101,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.routeModifiers.blackList = [ ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP isn't whitelisted and it's an excluded path" in new WithApplication(
@@ -105,24 +115,26 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = []
       """.stripMargin)
     ) with Injecting {
-      val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.2")
-        .addAttr(
-          Router.Attrs.HandlerDef,
-          HandlerDef(
-            app.classloader,
-            "routes",
-            "FooController",
-            "foo",
-            Seq.empty,
-            "GET",
-            "/my-excluded-path",
-            "comments",
-            Seq("anyip")
+      override def running() = {
+        val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.2")
+          .addAttr(
+            Router.Attrs.HandlerDef,
+            HandlerDef(
+              app.classloader,
+              "routes",
+              "FooController",
+              "foo",
+              Seq.empty,
+              "GET",
+              "/my-excluded-path",
+              "comments",
+              Seq("anyip")
+            )
           )
-        )
-      val result: Future[Result] = route(app, req).get
+        val result: Future[Result] = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP is not whitelisted but it's an excluded path" in new WithApplication(
@@ -131,24 +143,26 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "192.167.0.3" ]
       """.stripMargin)
     ) with Injecting {
-      val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.3")
-        .addAttr(
-          Router.Attrs.HandlerDef,
-          HandlerDef(
-            app.classloader,
-            "routes",
-            "FooController",
-            "foo",
-            Seq.empty,
-            "GET",
-            "/my-excluded-path",
-            "comments",
-            Seq("anyip")
+      override def running() = {
+        val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.3")
+          .addAttr(
+            Router.Attrs.HandlerDef,
+            HandlerDef(
+              app.classloader,
+              "routes",
+              "FooController",
+              "foo",
+              Seq.empty,
+              "GET",
+              "/my-excluded-path",
+              "comments",
+              Seq("anyip")
+            )
           )
-        )
-      val result: Future[Result] = route(app, req).get
+        val result: Future[Result] = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "forbidden request because the route does get explicitly checked and the IP is blacklisted" in new WithApplication(
@@ -159,24 +173,26 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.routeModifiers.blackList = [ "checkip" ]
       """.stripMargin)
     ) with Injecting {
-      val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.3")
-        .addAttr(
-          Router.Attrs.HandlerDef,
-          HandlerDef(
-            app.classloader,
-            "routes",
-            "FooController",
-            "foo",
-            Seq.empty,
-            "GET",
-            "/my-excluded-path",
-            "comments",
-            Seq("checkip")
+      override def running() = {
+        val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.3")
+          .addAttr(
+            Router.Attrs.HandlerDef,
+            HandlerDef(
+              app.classloader,
+              "routes",
+              "FooController",
+              "foo",
+              Seq.empty,
+              "GET",
+              "/my-excluded-path",
+              "comments",
+              Seq("checkip")
+            )
           )
-        )
-      val result: Future[Result] = route(app, req).get
+        val result: Future[Result] = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
 
     // same test again, but the route definition does not have a route modifier
@@ -188,24 +204,26 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.routeModifiers.blackList = [ "checkip" ]
       """.stripMargin)
     ) with Injecting {
-      val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.3")
-        .addAttr(
-          Router.Attrs.HandlerDef,
-          HandlerDef(
-            app.classloader,
-            "routes",
-            "FooController",
-            "foo",
-            Seq.empty,
-            "GET",
-            "/my-excluded-path",
-            "comments",
-            Seq() // <-- we don't tell the route to check the IP, so there will be no check
+      override def running() = {
+        val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.3")
+          .addAttr(
+            Router.Attrs.HandlerDef,
+            HandlerDef(
+              app.classloader,
+              "routes",
+              "FooController",
+              "foo",
+              Seq.empty,
+              "GET",
+              "/my-excluded-path",
+              "comments",
+              Seq() // <-- we don't tell the route to check the IP, so there will be no check
+            )
           )
-        )
-      val result: Future[Result] = route(app, req).get
+        val result: Future[Result] = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP is whitelisted" in new WithApplication(
@@ -213,10 +231,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "192.168.0.1" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.1")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/my-excluded-path", "192.168.0.1")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP isn't whitelisted and also not blacklisted" in new WithApplication(
@@ -225,10 +245,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.blackList = [ "192.168.0.1" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.2")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.2")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "forbidden request when IP isn't whitelisted" in new WithApplication(
@@ -236,10 +258,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "192.168.0.100" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.2")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.2")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
 
     "forbidden request when IP isn't whitelisted but it's blacklisted" in new WithApplication(
@@ -248,10 +272,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.blackList = [ "192.168.0.1" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.1")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
 
     "401 http status code when IP isn't whitelisted with custom http status code" in new WithApplication(
@@ -260,10 +286,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "192.168.0.1" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.2")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "192.168.0.2")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== UNAUTHORIZED
+        status(result) must_== UNAUTHORIZED
+      }
     }
   }
 
@@ -271,10 +299,12 @@ class IPFilterSpec extends PlaySpecification {
     "accept request when ip whitelist and blacklist are empty which is the default" in new WithApplication(
       buildApp()
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "8f:f3b:0:0:0:0:0:ff")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "8f:f3b:0:0:0:0:0:ff")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when ip whitelist and blacklist are explicitly empty" in new WithApplication(
@@ -283,10 +313,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.blackList = [ ]
         """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "8f:f3b:0:0:0:0:0:ff")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "8f:f3b:0:0:0:0:0:ff")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP isn't whitelisted and it's an excluded path" in new WithApplication(
@@ -295,24 +327,26 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = []
       """.stripMargin)
     ) with Injecting {
-      val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "8f:f3b:0:0:0:0:0:ff")
-        .addAttr(
-          Router.Attrs.HandlerDef,
-          HandlerDef(
-            app.classloader,
-            "routes",
-            "FooController",
-            "foo",
-            Seq.empty,
-            "GET",
-            "/my-excluded-path",
-            "comments",
-            Seq("anyip")
+      override def running() = {
+        val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "8f:f3b:0:0:0:0:0:ff")
+          .addAttr(
+            Router.Attrs.HandlerDef,
+            HandlerDef(
+              app.classloader,
+              "routes",
+              "FooController",
+              "foo",
+              Seq.empty,
+              "GET",
+              "/my-excluded-path",
+              "comments",
+              Seq("anyip")
+            )
           )
-        )
-      val result: Future[Result] = route(app, req).get
+        val result: Future[Result] = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP is not whitelisted but it's an excluded path" in new WithApplication(
@@ -321,24 +355,26 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "8f:f3b:0:0:0:0:0:ff" ]
       """.stripMargin)
     ) with Injecting {
-      val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "8f:f2b:0:0:0:0:0:ff")
-        .addAttr(
-          Router.Attrs.HandlerDef,
-          HandlerDef(
-            app.classloader,
-            "routes",
-            "FooController",
-            "foo",
-            Seq.empty,
-            "GET",
-            "/my-excluded-path",
-            "comments",
-            Seq("anyip")
+      override def running() = {
+        val req: Request[AnyContentAsEmpty.type] = request("/my-excluded-path", "8f:f2b:0:0:0:0:0:ff")
+          .addAttr(
+            Router.Attrs.HandlerDef,
+            HandlerDef(
+              app.classloader,
+              "routes",
+              "FooController",
+              "foo",
+              Seq.empty,
+              "GET",
+              "/my-excluded-path",
+              "comments",
+              Seq("anyip")
+            )
           )
-        )
-      val result: Future[Result] = route(app, req).get
+        val result: Future[Result] = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP is whitelisted" in new WithApplication(
@@ -346,10 +382,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "8f:f3b:0:0:0:0:0:ff" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/my-excluded-path", "8f:f3b:0:0:0:0:0:ff")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/my-excluded-path", "8f:f3b:0:0:0:0:0:ff")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP isn't whitelisted and also not blacklisted" in new WithApplication(
@@ -358,10 +396,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.blackList = [ "8f:f3b:0:0:0:0:0:ff" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "ff:ffb:0:0:0:0:0:ff")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "ff:ffb:0:0:0:0:0:ff")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "forbidden request when IP isn't whitelisted" in new WithApplication(
@@ -369,10 +409,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "8f:f3b:0:0:0:0:0:ff" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "ff:ffb:0:0:0:0:0:ff")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "ff:ffb:0:0:0:0:0:ff")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
 
     "forbidden request when IP isn't whitelisted but it's blacklisted" in new WithApplication(
@@ -381,10 +423,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.blackList = [ "8f:f3b:0:0:0:0:0:ff" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "8f:f3b:0:0:0:0:0:ff")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "8f:f3b:0:0:0:0:0:ff")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
 
     "401 http status code when IP isn't whitelisted with custom http status code" in new WithApplication(
@@ -393,10 +437,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "8f:f3b:0:0:0:0:0:ff" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "ff:ffb:0:0:0:0:0:ff")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "ff:ffb:0:0:0:0:0:ff")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== UNAUTHORIZED
+        status(result) must_== UNAUTHORIZED
+      }
     }
 
     "forbidden request when IP isn't whitelisted, whitelisted IP written in short from notation)" in new WithApplication(
@@ -404,10 +450,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "2001:cdba::3257:9652" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9653")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9653")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
 
     "accept request when IP is whitelisted, whitelisted IP written in short from notation)" in new WithApplication(
@@ -415,10 +463,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "2001:cdba::3257:9652" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9652")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9652")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "accept request when IP is whitelisted, whitelisted IP written in short from notation with zeros)" in new WithApplication(
@@ -426,10 +476,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.whiteList = [ "2001:cdba:0000:0000:0000:0000:3257:9652" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9652")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9652")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== OK
+        status(result) must_== OK
+      }
     }
 
     "forbidden request when IP is blacklisted, blacklisted IP written in short from notation)" in new WithApplication(
@@ -437,10 +489,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.blackList = [ "2001:cdba::3257:9652" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9652")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9652")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
 
     "forbidden request when IP is blacklisted, blacklisted IP written in short from notation with zeros)" in new WithApplication(
@@ -448,10 +502,12 @@ class IPFilterSpec extends PlaySpecification {
                  |play.filters.ip.blackList = [ "2001:cdba:0000:0000:0000:0000:3257:9652" ]
       """.stripMargin)
     ) with Injecting {
-      val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9652")
-      val result: Future[Result]                   = route(app, req).get
+      override def running() = {
+        val req: FakeRequest[AnyContentAsEmpty.type] = request("/", "2001:cdba:0:0:0:0:3257:9652")
+        val result: Future[Result]                   = route(app, req).get
 
-      status(result) must_== FORBIDDEN
+        status(result) must_== FORBIDDEN
+      }
     }
   }
 

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -243,34 +243,40 @@ trait FormSpec extends CommonFormSpec {
       "allow to access the value of an invalid form prefixing fields with the root name" in new WithApplication(
         application()
       ) {
-        val req = FormSpec.dummyRequest(
-          Map(
-            "task.id"      -> Array("notAnInt"),
-            "task.name"    -> Array("peter"),
-            "task.done"    -> Array("true"),
-            "task.dueDate" -> Array("15/12/2009")
+        override def running() = {
+          val req = FormSpec.dummyRequest(
+            Map(
+              "task.id"      -> Array("notAnInt"),
+              "task.name"    -> Array("peter"),
+              "task.done"    -> Array("true"),
+              "task.dueDate" -> Array("15/12/2009")
+            )
           )
-        )
 
-        val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest(req)
+          val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest(req)
 
-        myForm.hasErrors() must beEqualTo(true)
-        myForm.field("task.name").value.toScala must beSome("peter")
+          myForm.hasErrors() must beEqualTo(true)
+          myForm.field("task.name").value.toScala must beSome("peter")
+        }
       }
       "have an error due to missing required value" in new WithApplication(application()) {
-        val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891x"), "task.name" -> Array("peter")))
+        override def running() = {
+          val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891x"), "task.name" -> Array("peter")))
 
-        val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest(req)
-        myForm.hasErrors() must beEqualTo(true)
-        myForm.errors("task.dueDate").get(0).messages().asScala must contain("error.required")
+          val myForm = formFactory.form("task", classOf[play.data.Task]).bindFromRequest(req)
+          myForm.hasErrors() must beEqualTo(true)
+          myForm.errors("task.dueDate").get(0).messages().asScala must contain("error.required")
+        }
       }
       "have an error due to missing required value with direct field access" in new WithApplication(application()) {
-        val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891x"), "task.name" -> Array("peter")))
+        override def running() = {
+          val req = FormSpec.dummyRequest(Map("task.id" -> Array("1234567891x"), "task.name" -> Array("peter")))
 
-        val myForm =
-          formFactory.form("task", classOf[play.data.Subtask]).withDirectFieldAccess(true).bindFromRequest(req)
-        myForm.hasErrors() must beEqualTo(true)
-        myForm.errors("task.dueDate").get(0).messages().asScala must contain("error.required")
+          val myForm =
+            formFactory.form("task", classOf[play.data.Subtask]).withDirectFieldAccess(true).bindFromRequest(req)
+          myForm.hasErrors() must beEqualTo(true)
+          myForm.errors("task.dueDate").get(0).messages().asScala must contain("error.required")
+        }
       }
     }
     "be valid with all fields" in {
@@ -323,17 +329,19 @@ trait FormSpec extends CommonFormSpec {
     "be valid with all fields with direct field access switched on in config" in new WithApplication(
       application("play.forms.binding.directFieldAccess" -> "true")
     ) {
-      val req = FormSpec.dummyRequest(
-        Map(
-          "id"      -> Array("1234567891"),
-          "name"    -> Array("peter"),
-          "dueDate" -> Array("15/12/2009"),
-          "endDate" -> Array("2008-11-21")
+      override def running() = {
+        val req = FormSpec.dummyRequest(
+          Map(
+            "id"      -> Array("1234567891"),
+            "name"    -> Array("peter"),
+            "dueDate" -> Array("15/12/2009"),
+            "endDate" -> Array("2008-11-21")
+          )
         )
-      )
 
-      val myForm = formFactory.form(classOf[play.data.Subtask]).bindFromRequest(req)
-      myForm.hasErrors() must beEqualTo(false)
+        val myForm = formFactory.form(classOf[play.data.Subtask]).bindFromRequest(req)
+        myForm.hasErrors() must beEqualTo(false)
+      }
     }
     "be valid with mandatory params passed" in {
       val req = FormSpec.dummyRequest(
@@ -442,116 +450,131 @@ trait FormSpec extends CommonFormSpec {
     }
 
     "have an error due to badly formatted date" in new WithApplication(application()) {
-      val req = FormSpec.dummyRequest(
-        Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11"))
-      )
+      override def running() = {
+        val req = FormSpec.dummyRequest(
+          Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11"))
+        )
 
-      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
-      myForm.hasErrors() must beEqualTo(true)
-      myForm.errors("dueDate").get(0).messages().size() must beEqualTo(2)
-      myForm.errors("dueDate").get(0).messages().get(1) must beEqualTo("error.invalid.java.util.Date")
-      myForm.errors("dueDate").get(0).messages().get(0) must beEqualTo("error.invalid")
-      myForm.errors("dueDate").get(0).message() must beEqualTo("error.invalid.java.util.Date")
+        val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
+        myForm.hasErrors() must beEqualTo(true)
+        myForm.errors("dueDate").get(0).messages().size() must beEqualTo(2)
+        myForm.errors("dueDate").get(0).messages().get(1) must beEqualTo("error.invalid.java.util.Date")
+        myForm.errors("dueDate").get(0).messages().get(0) must beEqualTo("error.invalid")
+        myForm.errors("dueDate").get(0).message() must beEqualTo("error.invalid.java.util.Date")
 
-      // make sure we can access the values of an invalid form
-      myForm.value().get().getId() must beEqualTo(1234567891)
-      myForm.value().get().getName() must beEqualTo("peter")
+        // make sure we can access the values of an invalid form
+        myForm.value().get().getId() must beEqualTo(1234567891)
+        myForm.value().get().getName() must beEqualTo("peter")
+      }
     }
     "throws an exception when trying to access value of invalid form via get()" in new WithApplication(application()) {
-      val req = FormSpec.dummyRequest(
-        Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11"))
-      )
+      override def running() = {
+        val req = FormSpec.dummyRequest(
+          Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11"))
+        )
 
-      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
-      myForm.get must throwAn[IllegalStateException]
+        val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
+        myForm.get must throwAn[IllegalStateException]
+      }
     }
     "allow to access the value of an invalid form even when not even one valid value was supplied" in new WithApplication(
       application()
     ) {
-      val req = FormSpec.dummyRequest(Map("id" -> Array("notAnInt"), "dueDate" -> Array("2009/11e/11")))
+      override def running() = {
+        val req = FormSpec.dummyRequest(Map("id" -> Array("notAnInt"), "dueDate" -> Array("2009/11e/11")))
 
-      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
-      myForm.value().get().getId() must_== null
-      myForm.value().get().getName() must_== null
+        val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
+        myForm.value().get().getId() must_== null
+        myForm.value().get().getName() must_== null
+      }
     }
     "have an error due to badly formatted date after using withTransientLang" in new WithApplication(
       application("play.i18n.langs" -> Seq("en", "en-US", "fr"))
     ) {
-      val req = FormSpec.dummyRequest(
-        Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11"))
-      )
+      override def running() = {
+        val req = FormSpec.dummyRequest(
+          Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11"))
+        )
 
-      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req.withTransientLang(Lang.forCode("fr")))
-      myForm.hasErrors() must beEqualTo(true)
-      myForm.errors("dueDate").get(0).messages().size() must beEqualTo(3)
-      myForm
-        .errors("dueDate")
-        .get(0)
-        .messages()
-        .get(2) must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
-      myForm
-        .errors("dueDate")
-        .get(0)
-        .messages()
-        .get(1) must beEqualTo("error.invalid.java.util.Date") // is defined in play's default messages file
-      myForm
-        .errors("dueDate")
-        .get(0)
-        .messages()
-        .get(0) must beEqualTo("error.invalid") // is defined in play's default messages file
-      myForm
-        .errors("dueDate")
-        .get(0)
-        .message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+        val myForm =
+          formFactory.form(classOf[play.data.Task]).bindFromRequest(req.withTransientLang(Lang.forCode("fr")))
+        myForm.hasErrors() must beEqualTo(true)
+        myForm.errors("dueDate").get(0).messages().size() must beEqualTo(3)
+        myForm
+          .errors("dueDate")
+          .get(0)
+          .messages()
+          .get(2) must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+        myForm
+          .errors("dueDate")
+          .get(0)
+          .messages()
+          .get(1) must beEqualTo("error.invalid.java.util.Date") // is defined in play's default messages file
+        myForm
+          .errors("dueDate")
+          .get(0)
+          .messages()
+          .get(0) must beEqualTo("error.invalid") // is defined in play's default messages file
+        myForm
+          .errors("dueDate")
+          .get(0)
+          .message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+      }
     }
     "have an error due to badly formatted date when using lang cookie" in new WithApplication(
       application("play.i18n.langs" -> Seq("en", "en-US", "fr"))
     ) {
-      val req = new RequestBuilder()
-        .method("POST")
-        .uri("http://localhost/test")
-        .bodyFormArrayValues(
-          Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")).asJava
-        )
-        .langCookie(Lang.forCode("fr"), Helpers.stubMessagesApi())
-        .build()
+      override def running() = {
+        val req = new RequestBuilder()
+          .method("POST")
+          .uri("http://localhost/test")
+          .bodyFormArrayValues(
+            Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")).asJava
+          )
+          .langCookie(Lang.forCode("fr"), Helpers.stubMessagesApi())
+          .build()
 
-      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
-      myForm.hasErrors() must beEqualTo(true)
-      myForm.errors("dueDate").get(0).messages().size() must beEqualTo(3)
-      myForm
-        .errors("dueDate")
-        .get(0)
-        .messages()
-        .get(2) must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
-      myForm
-        .errors("dueDate")
-        .get(0)
-        .messages()
-        .get(1) must beEqualTo("error.invalid.java.util.Date") // is defined in play's default messages file
-      myForm
-        .errors("dueDate")
-        .get(0)
-        .messages()
-        .get(0) must beEqualTo("error.invalid") // is defined in play's default messages file
-      myForm
-        .errors("dueDate")
-        .get(0)
-        .message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+        val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
+        myForm.hasErrors() must beEqualTo(true)
+        myForm.errors("dueDate").get(0).messages().size() must beEqualTo(3)
+        myForm
+          .errors("dueDate")
+          .get(0)
+          .messages()
+          .get(2) must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+        myForm
+          .errors("dueDate")
+          .get(0)
+          .messages()
+          .get(1) must beEqualTo("error.invalid.java.util.Date") // is defined in play's default messages file
+        myForm
+          .errors("dueDate")
+          .get(0)
+          .messages()
+          .get(0) must beEqualTo("error.invalid") // is defined in play's default messages file
+        myForm
+          .errors("dueDate")
+          .get(0)
+          .message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+      }
     }
     "have an error due to missing required value" in new WithApplication(application()) {
-      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
+      override def running() = {
+        val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
 
-      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
-      myForm.hasErrors() must beEqualTo(true)
-      myForm.errors("dueDate").get(0).messages().asScala must contain("error.required")
+        val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
+        myForm.hasErrors() must beEqualTo(true)
+        myForm.errors("dueDate").get(0).messages().asScala must contain("error.required")
+      }
     }
     "have an error due to missing required value with direct field access" in new WithApplication(application()) {
-      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
+      override def running() = {
+        val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
 
-      val myForm = formFactory.form(classOf[play.data.Subtask]).withDirectFieldAccess(true).bindFromRequest(req)
-      myForm.hasErrors() must beEqualTo(true)
-      myForm.errors("dueDate").get(0).messages().asScala must contain("error.required")
+        val myForm = formFactory.form(classOf[play.data.Subtask]).withDirectFieldAccess(true).bindFromRequest(req)
+        myForm.hasErrors() must beEqualTo(true)
+        myForm.errors("dueDate").get(0).messages().asScala must contain("error.required")
+      }
     }
     "be invalid when only fields (and no getters) exist but direct field access is disabled" in {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
@@ -564,28 +587,32 @@ trait FormSpec extends CommonFormSpec {
       }
     }
     "have an error due to bad value in Id field" in new WithApplication(application()) {
-      val req = FormSpec.dummyRequest(
-        Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009"))
-      )
+      override def running() = {
+        val req = FormSpec.dummyRequest(
+          Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009"))
+        )
 
-      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
-      myForm.hasErrors() must beEqualTo(true)
-      myForm.errors("id").get(0).messages().asScala must contain("error.invalid")
+        val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
+        myForm.hasErrors() must beEqualTo(true)
+        myForm.errors("id").get(0).messages().asScala must contain("error.invalid")
+      }
     }
 
     "have an error due to badly formatted date for default date binder" in new WithApplication(application()) {
-      val req = FormSpec.dummyRequest(
-        Map(
-          "id"      -> Array("1234567891"),
-          "name"    -> Array("peter"),
-          "dueDate" -> Array("15/12/2009"),
-          "endDate" -> Array("2008-11e-21")
+      override def running() = {
+        val req = FormSpec.dummyRequest(
+          Map(
+            "id"      -> Array("1234567891"),
+            "name"    -> Array("peter"),
+            "dueDate" -> Array("15/12/2009"),
+            "endDate" -> Array("2008-11e-21")
+          )
         )
-      )
 
-      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
-      myForm.hasErrors() must beEqualTo(true)
-      myForm.errors("endDate").get(0).messages().asScala must contain("error.invalid.java.util.Date")
+        val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest(req)
+        myForm.hasErrors() must beEqualTo(true)
+        myForm.errors("endDate").get(0).messages().asScala must contain("error.invalid.java.util.Date")
+      }
     }
 
     "support repeated values for Java binding" in {
@@ -783,158 +810,162 @@ trait FormSpec extends CommonFormSpec {
 
     "bind files" should {
       "be valid with all fields" in new WithApplication(application()) {
-        implicit val temporaryFileCreator: TemporaryFileCreator = tempFileCreator
+        override def running() = {
+          implicit val temporaryFileCreator: TemporaryFileCreator = tempFileCreator
 
-        val files = createThesisTemporaryFiles()
+          val files = createThesisTemporaryFiles()
 
-        try {
-          val req = createThesisRequestWithFileParts(files)
+          try {
+            val req = createThesisRequestWithFileParts(files)
 
-          val myForm = formFactory.form(classOf[play.data.Thesis]).bindFromRequest(req)
+            val myForm = formFactory.form(classOf[play.data.Thesis]).bindFromRequest(req)
 
-          myForm.hasErrors() must beEqualTo(false)
-          myForm.hasGlobalErrors() must beEqualTo(false)
+            myForm.hasErrors() must beEqualTo(false)
+            myForm.hasGlobalErrors() must beEqualTo(false)
 
-          myForm.rawData().size() must beEqualTo(3)
-          myForm.files().size() must beEqualTo(10)
+            myForm.rawData().size() must beEqualTo(3)
+            myForm.files().size() must beEqualTo(10)
 
-          val thesis = myForm.get
+            val thesis = myForm.get
 
-          thesis.getTitle must beEqualTo("How Scala works")
-          myForm.field("title").value().toScala must beSome("How Scala works")
-          myForm.field("title").file().toScala must beNone
+            thesis.getTitle must beEqualTo("How Scala works")
+            myForm.field("title").value().toScala must beSome("How Scala works")
+            myForm.field("title").file().toScala must beNone
 
-          thesis.getLetters().size() must beEqualTo(2)
-          myForm.field("letters").indexes() must beEqualTo(List(0, 1).asJava)
+            thesis.getLetters().size() must beEqualTo(2)
+            myForm.field("letters").indexes() must beEqualTo(List(0, 1).asJava)
 
-          thesis.getLetters().get(0).getAddress must beEqualTo("Vienna")
-          myForm.field("letters[0].address").value().toScala must beSome("Vienna")
-          myForm.field("letters[0].address").file().toScala must beNone
-          thesis.getLetters().get(1).getAddress must beEqualTo("Berlin")
-          myForm.field("letters[1].address").value().toScala must beSome("Berlin")
-          myForm.field("letters[1].address").file().toScala must beNone
+            thesis.getLetters().get(0).getAddress must beEqualTo("Vienna")
+            myForm.field("letters[0].address").value().toScala must beSome("Vienna")
+            myForm.field("letters[0].address").file().toScala must beNone
+            thesis.getLetters().get(1).getAddress must beEqualTo("Berlin")
+            myForm.field("letters[1].address").value().toScala must beSome("Berlin")
+            myForm.field("letters[1].address").file().toScala must beNone
 
-          checkFileParts(
-            Seq(thesis.getLetters().get(0).getCoverPage, myForm.field("letters[0].coverPage").file().get()),
-            "letters[].coverPage",
-            "text/plain",
-            "first-letter-cover_page.txt",
-            "First Letter Cover Page"
-          )
-          myForm.field("letters[0].coverPage").value().toScala must beNone
+            checkFileParts(
+              Seq(thesis.getLetters().get(0).getCoverPage, myForm.field("letters[0].coverPage").file().get()),
+              "letters[].coverPage",
+              "text/plain",
+              "first-letter-cover_page.txt",
+              "First Letter Cover Page"
+            )
+            myForm.field("letters[0].coverPage").value().toScala must beNone
 
-          checkFileParts(
-            Seq(thesis.getLetters().get(1).getCoverPage, myForm.field("letters[1].coverPage").file().get()),
-            "letters[].coverPage",
-            "application/vnd.oasis.opendocument.text",
-            "second-letter-cover_page.odt",
-            "Second Letter Cover Page"
-          )
-          myForm.field("letters[1].coverPage").value().toScala must beNone
+            checkFileParts(
+              Seq(thesis.getLetters().get(1).getCoverPage, myForm.field("letters[1].coverPage").file().get()),
+              "letters[].coverPage",
+              "application/vnd.oasis.opendocument.text",
+              "second-letter-cover_page.odt",
+              "Second Letter Cover Page"
+            )
+            myForm.field("letters[1].coverPage").value().toScala must beNone
 
-          thesis.getLetters().get(0).getLetterPages().size() must beEqualTo(2)
-          myForm.field("letters[0].letterPages").indexes() must beEqualTo(List(0, 1).asJava)
-          checkFileParts(
-            Seq(
-              thesis.getLetters().get(0).getLetterPages().get(0),
-              myForm.field("letters[0].letterPages[0]").file().get()
-            ),
-            "letters[].letterPages[]",
-            "application/msword",
-            "first-letter-page_1.doc",
-            "First Letter Page One"
-          )
-          myForm.field("letters[0].letterPages[0]").value().toScala must beNone
+            thesis.getLetters().get(0).getLetterPages().size() must beEqualTo(2)
+            myForm.field("letters[0].letterPages").indexes() must beEqualTo(List(0, 1).asJava)
+            checkFileParts(
+              Seq(
+                thesis.getLetters().get(0).getLetterPages().get(0),
+                myForm.field("letters[0].letterPages[0]").file().get()
+              ),
+              "letters[].letterPages[]",
+              "application/msword",
+              "first-letter-page_1.doc",
+              "First Letter Page One"
+            )
+            myForm.field("letters[0].letterPages[0]").value().toScala must beNone
 
-          checkFileParts(
-            Seq(
-              thesis.getLetters().get(0).getLetterPages().get(1),
-              myForm.field("letters[0].letterPages[1]").file().get()
-            ),
-            "letters[].letterPages[]",
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            "first-letter-page_2.docx",
-            "First Letter Page Two"
-          )
-          myForm.field("letters[0].letterPages[1]").value().toScala must beNone
+            checkFileParts(
+              Seq(
+                thesis.getLetters().get(0).getLetterPages().get(1),
+                myForm.field("letters[0].letterPages[1]").file().get()
+              ),
+              "letters[].letterPages[]",
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              "first-letter-page_2.docx",
+              "First Letter Page Two"
+            )
+            myForm.field("letters[0].letterPages[1]").value().toScala must beNone
 
-          thesis.getLetters().get(1).getLetterPages().size() must beEqualTo(1)
-          myForm.field("letters[1].letterPages").indexes() must beEqualTo(List(0).asJava)
-          checkFileParts(
-            Seq(
-              thesis.getLetters().get(1).getLetterPages().get(0),
-              myForm.field("letters[1].letterPages[0]").file().get()
-            ),
-            "letters[1].letterPages[]",
-            "application/rtf",
-            "second-letter-page_1.rtf",
-            "Second Letter Page One"
-          )
-          myForm.field("letters[1].letterPages[0]").value().toScala must beNone
+            thesis.getLetters().get(1).getLetterPages().size() must beEqualTo(1)
+            myForm.field("letters[1].letterPages").indexes() must beEqualTo(List(0).asJava)
+            checkFileParts(
+              Seq(
+                thesis.getLetters().get(1).getLetterPages().get(0),
+                myForm.field("letters[1].letterPages[0]").file().get()
+              ),
+              "letters[1].letterPages[]",
+              "application/rtf",
+              "second-letter-page_1.rtf",
+              "Second Letter Page One"
+            )
+            myForm.field("letters[1].letterPages[0]").value().toScala must beNone
 
-          checkFileParts(
-            Seq(thesis.getDocument, myForm.field("document").file().get()),
-            "document",
-            "application/pdf",
-            "best_thesis.pdf",
-            "by Lightbend founder Martin Odersky"
-          )
-          myForm.field("document").value().toScala must beNone
+            checkFileParts(
+              Seq(thesis.getDocument, myForm.field("document").file().get()),
+              "document",
+              "application/pdf",
+              "best_thesis.pdf",
+              "by Lightbend founder Martin Odersky"
+            )
+            myForm.field("document").value().toScala must beNone
 
-          thesis.getAttachments().size() must beEqualTo(2)
-          myForm.field("attachments").indexes() must beEqualTo(List(0, 1).asJava)
-          checkFileParts(
-            Seq(thesis.getAttachments().get(0), myForm.field("attachments[0]").file().get()),
-            "attachments[]",
-            "application/x-tex",
-            "final_draft.tex",
-            "the final draft"
-          )
-          myForm.field("attachments[0]").value().toScala must beNone
-          checkFileParts(
-            Seq(thesis.getAttachments().get(1), myForm.field("attachments[1]").file().get()),
-            "attachments[]",
-            "text/x-scala-source",
-            "examples.scala",
-            "some code snippets"
-          )
-          myForm.field("attachments[1]").value().toScala must beNone
+            thesis.getAttachments().size() must beEqualTo(2)
+            myForm.field("attachments").indexes() must beEqualTo(List(0, 1).asJava)
+            checkFileParts(
+              Seq(thesis.getAttachments().get(0), myForm.field("attachments[0]").file().get()),
+              "attachments[]",
+              "application/x-tex",
+              "final_draft.tex",
+              "the final draft"
+            )
+            myForm.field("attachments[0]").value().toScala must beNone
+            checkFileParts(
+              Seq(thesis.getAttachments().get(1), myForm.field("attachments[1]").file().get()),
+              "attachments[]",
+              "text/x-scala-source",
+              "examples.scala",
+              "some code snippets"
+            )
+            myForm.field("attachments[1]").value().toScala must beNone
 
-          thesis.getBibliography().size() must beEqualTo(2)
-          myForm.field("bibliography").indexes() must beEqualTo(List(0, 1).asJava)
-          checkFileParts(
-            Seq(thesis.getBibliography().get(0), myForm.field("bibliography[0]").file().get()),
-            "bibliography[0]",
-            "application/epub+zip",
-            "Java_Concurrency_in_Practice.epub",
-            "Java Concurrency in Practice"
-          )
-          myForm.field("bibliography[0]").value().toScala must beNone
-          checkFileParts(
-            Seq(thesis.getBibliography().get(1), myForm.field("bibliography[1]").file().get()),
-            "bibliography[1]",
-            "application/x-mobipocket-ebook",
-            "The-Java-Programming-Language.mobi",
-            "The Java Programming Language"
-          )
-          myForm.field("bibliography[1]").value().toScala must beNone
-        } finally {
-          files.values.foreach(temporaryFileCreator.delete(_))
+            thesis.getBibliography().size() must beEqualTo(2)
+            myForm.field("bibliography").indexes() must beEqualTo(List(0, 1).asJava)
+            checkFileParts(
+              Seq(thesis.getBibliography().get(0), myForm.field("bibliography[0]").file().get()),
+              "bibliography[0]",
+              "application/epub+zip",
+              "Java_Concurrency_in_Practice.epub",
+              "Java Concurrency in Practice"
+            )
+            myForm.field("bibliography[0]").value().toScala must beNone
+            checkFileParts(
+              Seq(thesis.getBibliography().get(1), myForm.field("bibliography[1]").file().get()),
+              "bibliography[1]",
+              "application/x-mobipocket-ebook",
+              "The-Java-Programming-Language.mobi",
+              "The Java Programming Language"
+            )
+            myForm.field("bibliography[1]").value().toScala must beNone
+          } finally {
+            files.values.foreach(temporaryFileCreator.delete(_))
+          }
         }
       }
 
       "have an error due to missing required file" in new WithApplication(application()) {
-        val myForm = formFactory
-          .form(classOf[play.data.Thesis])
-          .bindFromRequest(FormSpec.dummyMultipartRequest(Map("title" -> Array("How Scala works"))))
-        myForm.hasErrors() must beEqualTo(true)
-        myForm.hasGlobalErrors() must beEqualTo(false)
-        myForm.errors().size() must beEqualTo(4)
-        myForm.files().size() must beEqualTo(0)
-        myForm.error("document").get.message() must beEqualTo("error.required")
-        myForm.error("attachments").get.message() must beEqualTo("error.required")
-        myForm.error("bibliography").get.message() must beEqualTo("error.required")
-        myForm.error("letters").get.message() must beEqualTo("error.required")
+        override def running() = {
+          val myForm = formFactory
+            .form(classOf[play.data.Thesis])
+            .bindFromRequest(FormSpec.dummyMultipartRequest(Map("title" -> Array("How Scala works"))))
+          myForm.hasErrors() must beEqualTo(true)
+          myForm.hasGlobalErrors() must beEqualTo(false)
+          myForm.errors().size() must beEqualTo(4)
+          myForm.files().size() must beEqualTo(0)
+          myForm.error("document").get.message() must beEqualTo("error.required")
+          myForm.error("attachments").get.message() must beEqualTo("error.required")
+          myForm.error("bibliography").get.message() must beEqualTo("error.required")
+          myForm.error("letters").get.message() must beEqualTo("error.required")
+        }
       }
     }
 


### PR DESCRIPTION
specs2's `Around` trait makes use of Scala's [`DelayedInit`](https://www.scala-lang.org/api/2.13.10/scala/DelayedInit.html) which [has been dropped in Scala 3](https://docs.scala-lang.org/scala3/reference/dropped-features/delayed-init.html) (actually not removed, it just isn't doing anything anymore).
specs2 5.x, which is a Scala 3 only build, already [completly dropped](https://github.com/etorreborre/specs2/commit/6432cbec8491f666afa00f3eea448c76a47acb69) `Around` (we stay on specs2 4.x probably as long as we cross build to Scala 2.13.x)
Unfortunaly it seems there is no replacement for `DelayedInit` in Scala 3, e.g.
* https://contributors.scala-lang.org/t/scala-3-delayedinit/1902
* https://contributors.scala-lang.org/t/delayedinit-or-oncreate-any-solution/1748
* Also there [was a talk](https://scalaworld2015.d-d.me/#/29) where it was considered that by-name trait parameters would be kind of a replacement, however by-name trait parameters [didn't make it into Scala 3](https://github.com/lampepfl/dotty/pull/10324) (yet?) (because of https://github.com/lampepfl/dotty/issues/9886) (the example code from the slide doesn't even work in Scala 3).
 "Normal" trait parameters [do work in Scala 3](https://docs.scala-lang.org/scala3/reference/other-new-features/trait-parameters.html), but I don't think that really helps here. Also even if by-name trait params would work, it would not be a 1:1 drop in replacement IMHO.

So no matter how we look at it, test code that makes use of Play Scala's `WithApplication`, `WithServer`, etc. has to be refactored no matter what. To not make users completly refactor their tests the solution I came up with is to make them wrap their tests in a `running` method. The only other approach I see here is to completely remove the `WithXXX` helpers. However I am also not a fan of that because I don't want to make migration too costly so I think if the framework does the heavy lifting, wrapping code in a method is not too cumbersome (even though it is a bit of a weird API quirk). Also an "advantage" of the wrapper method is that I made it work in Scala 2 as well, so Scala 2 tests will even run if you wrap them in running, so such test code can be easily switched forth/back from/to Scala 2/3 and tests will work in both cases (which may help during migration)

This PR was thoroughly tested locally with a Play Scala 3 build. Soon CI will build/test with Scala 3 anyway as well.

The same approach was taken in scalatest: https://github.com/playframework/scalatestplus-play/pull/320.

Split off from #11551 (but refactored)

If someone comes up with a better idea please let me know.