### PR TITLE
Scala3: No `-Xsource:3` for RoutesCompilerProject (with explanations)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,9 +43,12 @@ lazy val RunSupportProject = PlaySbtProject("Run-Support", "dev-mode/run-support
   )
   .dependsOn(BuildLinkProject)
 
+// This project is actually not needed by Play, we (cross) publish it for the community only:
+// https://github.com/playframework/playframework/issues/5290
 lazy val RoutesCompilerProject = PlayDevelopmentProject("Routes-Compiler", "dev-mode/routes-compiler")
   .enablePlugins(SbtTwirl)
   .settings(
+    scalacOptions -= "-Xsource:3", // Since this is actually a sbt plugin and the codebase is 2.12, this flag causes problems when cross compiling
     libraryDependencies ++= routesCompilerDependencies(scalaVersion.value),
     TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")
   )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -105,6 +105,7 @@ object BuildSettings {
     evictionSettings,
     ivyConfigurations ++= Seq(DocsApplication, SourcesApplication),
     javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:unchecked", "-Xlint:deprecation"),
+    scalacOptions ++= Seq("-release:11"),
     (Compile / doc / scalacOptions) := {
       // disable the new scaladoc feature for scala 2.12+ (https://github.com/scala/scala-dev/issues/249 and https://github.com/scala/bug/issues/11340)
       CrossVersion.partialVersion(scalaVersion.value) match {
@@ -397,7 +398,6 @@ object BuildSettings {
       }
       (Compile / sourceDirectory).value / s"scala-$suffix"
     },
-    // Argument for setting size of permgen space or meta space for all forked processes
     Docs.apiDocsInclude := true
   )
 
@@ -437,9 +437,6 @@ object BuildSettings {
       .enablePlugins(PlayLibrary, AutomateHeaderPlugin, AkkaSnapshotRepositories, MimaPlugin)
       .settings(playRuntimeSettings: _*)
       .settings(omnidocSettings: _*)
-      .settings(
-        scalacOptions += "-release:11"
-      )
   }
 
   def omnidocSettings: Seq[Setting[_]] = Def.settings(


### PR DESCRIPTION
Trying to apply `-Xsource:3` makes this project fail to compile (but interestingly it compiles with Scala 3...)

I was asking myself why this project even exists, it's not used anywhere, turns out:
* https://github.com/playframework/playframework/issues/5290

In theory we could remove it and Play would still work...