### PR TITLE
Make Netty the Default

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecification.scala
+++ b/core/play-integration-test/src/it/scala/play/it/ServerIntegrationSpecification.scala
@@ -89,13 +89,6 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
 trait NettyIntegrationSpecification extends ServerIntegrationSpecification {
   self: SpecificationLike =>
 
-  // Do not run Netty tests in continuous integration, unless it is a cron build.
-  private val skipNettyTests = isContinuousIntegration && !isCronBuild
-  skipAllIf(skipNettyTests)
-
-  // Be silent about skipping Netty tests to avoid useless output
-  if (skipNettyTests) xonly
-
   final override def integrationServerProvider: ServerProvider = NettyServer.provider
 }
 

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -96,8 +96,8 @@ object PlayScala extends AutoPlugin {
  * This plugin enables the Play netty http server
  */
 object PlayNettyServer extends AutoPlugin {
-  override def requires        = PlayService
-  override def trigger         = allRequirements
+  override def requires = PlayService
+  override def trigger  = allRequirements
   override def projectSettings = Seq(
     libraryDependencies ++= (if (PlayKeys.playPlugin.value) Nil else Seq(PlayImport.nettyServer))
   )

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -96,7 +96,8 @@ object PlayScala extends AutoPlugin {
  * This plugin enables the Play netty http server
  */
 object PlayNettyServer extends AutoPlugin {
-  override def requires = PlayService
+  override def requires        = PlayService
+  override def trigger         = allRequirements
   override def projectSettings = Seq(
     libraryDependencies ++= (if (PlayKeys.playPlugin.value) Nil else Seq(PlayImport.nettyServer))
   )
@@ -107,7 +108,6 @@ object PlayNettyServer extends AutoPlugin {
  */
 object PlayAkkaHttpServer extends AutoPlugin {
   override def requires        = PlayService
-  override def trigger         = allRequirements
   override def projectSettings = Seq(libraryDependencies += PlayImport.akkaHttpServer)
 }
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -160,26 +160,3 @@ $ copy-file conf/application.original conf/application.conf
 > verifyResourceContains / 200
 
 > playStop
-
-# devSettings tests
-# -----------------
-
-# First a test without the dev-setting to ensure everything works
-> run
-> makeRequestWithHeader / 200 this-is-a-header-name-longer-than-32-chars
-> playStop
-
-# A test overriding a akka setting that should be picked by dev mode
-> set PlayKeys.devSettings ++= Seq("akka.http.parsing.max-header-name-length" -> "32 bytes")
-> run
-> makeRequestWithHeader / 431 this-is-a-header-name-longer-than-32-chars
-> playStop
-
-# Should prioritize play.akka.dev-mode
-> set PlayKeys.devSettings ++= Seq("play.akka.dev-mode.akka.http.parsing.max-header-name-length" -> "32 bytes")
-
-# This should NOT be picked
-> set PlayKeys.devSettings ++= Seq("akka.http.parsing.max-header-name-length" -> "1 megabyte")
-> run
-> makeRequestWithHeader / 431 this-is-a-header-name-longer-than-32-chars
-> playStop

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
@@ -19,12 +19,14 @@ $ exists target/universal/stage/share/doc/api
 > checkConfig foo
 > countApplicationConf 1
 > stopProd --no-exit-sbt
+$ sleep 1000
 
 # Change the configuration in the conf directory, make sure it takes effect
 $ copy-file conf/alternate.conf target/universal/stage/conf/application.conf
 > runProd --no-exit-sbt
 > checkConfig bar
 > stopProd --no-exit-sbt
+$ sleep 1000
 
 # Turn off externalize resources, rebuild, make sure the conf directory is not created or on the classpath
 > set PlayKeys.externalizeResources := false

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-akka-http/build.sbt
@@ -7,6 +7,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
+  .enablePlugins(PlayAkkaHttpServer)
   // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
   .disablePlugins(PlayLayoutPlugin)
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/build.sbt
@@ -7,8 +7,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
-  .enablePlugins(PlayNettyServer)
-  .disablePlugins(PlayAkkaHttpServer)
   .settings(
     scalaVersion := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/build.sbt
@@ -6,8 +6,7 @@ organization := "com.example"
 version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, PlayNettyServer)
-  .disablePlugins(PlayAkkaHttpServer)
+  .enablePlugins(PlayScala)
   // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
   .disablePlugins(PlayLayoutPlugin)
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
@@ -6,7 +6,8 @@ import sbt._
 import sbt.Keys.libraryDependencies
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala)
+  .enablePlugins(PlayScala, PlayAkkaHttpServer)
+  .disablePlugins(PlayNettyServer)
   // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
   .disablePlugins(PlayLayoutPlugin)
   .settings(

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
@@ -9,7 +9,8 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala)
+  .enablePlugins(PlayScala, PlayAkkaHttpServer)
+  .disablePlugins(PlayNettyServer)
   // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
   .disablePlugins(PlayLayoutPlugin)
   .settings(


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #11495 

## Unfinished

Not ready for review yet because:
* [ ] Need to update docs
* [ ] Need to evaluate subbing out Akka HTTP for Netty as the server for docs/unit tests
* [ ] Need to determine if we should use `.cross(CrossVersion.for3Use2_13))` for Akka HTTP and Scala 3 plugin testing

## Purpose

Changes the SBT default plugin behavior to use Netty instead of Akka HTTP. Also changes a couple of the sbt plugin tests to ensure that Netty is the default.
