### PR TITLE
Fix transforming of PathBindable and also the anyValPathBindable macro

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -769,7 +769,7 @@ object PathBindable {
           case "false" | "0" => false
         },
         _.toString,
-        (key: String, e: Exception) => "Cannot parse parameter %s as Boolean: should be true, false, 0 or 1".format(key)
+        (s, _) => s"Cannot parse parameter $s as Boolean: should be true, false, 0 or 1"
       ) {
     override def javascriptUnbind = """function(k,v){return !!v}"""
   }

--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -184,6 +184,7 @@ trait PathBindable[A] {
   def transform[B](toB: A => B, toA: B => A) = new PathBindable[B] {
     def bind(key: String, value: String): Either[String, B] = self.bind(key, value).map(toB)
     def unbind(key: String, value: B): String               = self.unbind(key, toA(value))
+    override def javascriptUnbind: String                   = self.javascriptUnbind
   }
 }
 

--- a/core/play/src/main/scala/play/api/mvc/macros/BinderMacros.scala
+++ b/core/play/src/main/scala/play/api/mvc/macros/BinderMacros.scala
@@ -14,17 +14,8 @@ class BinderMacros(val c: MacroContext) {
       // currently we do not need to invoke `import _root_.play.api.mvc.PathBindable._`
       // since we are in the same package
       q"""
-         new _root_.play.api.mvc.PathBindable[${t.tpe}] {
-           private val binder = _root_.scala.Predef.implicitly[_root_.play.api.mvc.PathBindable[${param.typeSignature}]]
-           override def bind(key: String, value: String): Either[String, ${t.tpe}] = {
-             binder.bind(key, value).map((p: ${param.typeSignature}) => new ${t.tpe}(p))
-           }
-
-           override def unbind(key: String, value: ${t.tpe}): String = {
-             binder.unbind(key, value.${param.name.toTermName})
-           }
-
-         }
+         private val binder = _root_.scala.Predef.implicitly[_root_.play.api.mvc.PathBindable[${param.typeSignature}]]
+         binder.transform((p: ${param.typeSignature}) => new ${t.tpe}(p), (p: ${t.tpe}) => p.${param.name.toTermName})
        """
     }.getOrElse(fail("PathBindable", t.tpe))
   }

--- a/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -10,6 +10,7 @@ import org.specs2.mutable._
 
 case class Demo(value: Long) extends AnyVal
 case class Hase(x: String)   extends AnyVal
+case class Pferd(x: Boolean) extends AnyVal
 
 class BindersSpec extends Specification {
   val uuid = UUID.randomUUID
@@ -249,6 +250,12 @@ class BindersSpec extends Specification {
     "Unbind Hase as String" in {
       implicitly[PathBindable[Hase]].unbind("key", Hase("Disney_Land")) must equalTo("Disney_Land")
     }
+    "JavaScript Unbind Hase as String" in {
+      implicitly[PathBindable[Hase]].javascriptUnbind must equalTo("function(k,v) {return v}")
+    }
+    "JavaScript Unbind Pferd as String which is a Boolean and uses special js unbind" in {
+      implicitly[PathBindable[Pferd]].javascriptUnbind must equalTo("function(k,v){return !!v}")
+    }
   }
 
   "AnyVal QueryStringBindable" should {
@@ -261,6 +268,14 @@ class BindersSpec extends Specification {
     }
     "Unbind Hase as String" in {
       implicitly[QueryStringBindable[Hase]].unbind("key", Hase("Disney_Land")) must equalTo("key=Disney_Land")
+    }
+    "JavaScript Unbind Hase as String" in {
+      implicitly[QueryStringBindable[Hase]].javascriptUnbind must equalTo(
+        "function(k,v) {return encodeURIComponent(k)+'='+encodeURIComponent(v)}"
+      )
+    }
+    "JavaScript Unbind Pferd as String which is a Boolean and uses special js unbind" in {
+      implicitly[QueryStringBindable[Pferd]].javascriptUnbind must equalTo("""function(k,v){return k+'='+(!!v)}""")
     }
     "Unbind with keys and values needing encode (String)" in {
       val boundValue = implicitly[QueryStringBindable[Hase]].unbind("ke=y", Hase("Kre=mlin"))


### PR DESCRIPTION
While working on the macro stuff for Scala 3 I noticed two bugs:
* When transforming a PathBindable the original javascript unbind method does not get used anymore, which can cause problems for certain types that do not use the default javascript unbind method (e.g. Boolean). All Java types are affected from this "bug", however in real life it should not matter since all use the default method anyway, except boolean, but even for that the default js function should work anyway. It could cause problems for user defind binders however...  This has been fixed for the QuerystringBindable long time ago already: #3854
* The macro code handling `AnyVal` regarding Pathbindable also does not correctly transform an AnyVal. Even when the above is fixed, the macro does create a new instance which does not override the js method... calling transform is the preferred way here.

The added tests test both scenarios.