### PR TITLE
Add ConfigLoader implicits for java.time.Duration

### DIFF
--- a/core/play-configuration/src/main/scala/play/api/Configuration.scala
+++ b/core/play-configuration/src/main/scala/play/api/Configuration.scala
@@ -465,6 +465,11 @@ object ConfigLoader {
   implicit val seqDurationLoader: ConfigLoader[Seq[Duration]] =
     seqFiniteDurationLoader.map(identity[Seq[Duration]])
 
+  implicit val javaDurationLoader: ConfigLoader[java.time.Duration] = ConfigLoader(_.getDuration)
+
+  implicit val javaSeqDurationLoader: ConfigLoader[Seq[java.time.Duration]] =
+    ConfigLoader(_.getDurationList).map(_.asScala.toSeq)
+
   implicit val periodLoader: ConfigLoader[Period] = ConfigLoader(_.getPeriod)
 
   implicit val temporalLoader: ConfigLoader[TemporalAmount] = ConfigLoader(_.getTemporal)

--- a/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
@@ -87,6 +87,14 @@ class ConfigurationSpec extends Specification {
       }
     }
 
+    "support getting java durations" in {
+      "simple duration" in {
+        val conf  = config("my.duration" -> "10s")
+        val value = conf.get[java.time.Duration]("my.duration")
+        value must beEqualTo(java.time.Duration.ofSeconds(10))
+      }
+    }
+
     "support getting periods" in {
       "month units" in {
         val conf  = config("my.period" -> "10 m")


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Implement implicits for `ConfigLoader[java.time.Duration]` and `ConfigLoader[Seq[java.time.Duration]]`. This makes it easier to parse configuration that is used for java API's that expect a `java.time.Duration`. 
