### PR TITLE
avoid deprecated `java.net.URL` constructor

### DIFF
--- a/core/play-configuration/src/main/scala/play/api/Configuration.scala
+++ b/core/play-configuration/src/main/scala/play/api/Configuration.scala
@@ -497,7 +497,7 @@ object ConfigLoader {
   implicit val configurationLoader: ConfigLoader[Configuration]         = configLoader.map(Configuration(_))
   implicit val seqConfigurationLoader: ConfigLoader[Seq[Configuration]] = seqConfigLoader.map(_.map(Configuration(_)))
 
-  implicit val urlLoader: ConfigLoader[URL] = ConfigLoader(_.getString).map(new URL(_))
+  implicit val urlLoader: ConfigLoader[URL] = ConfigLoader(_.getString).map(new URI(_).toURL)
   implicit val uriLoader: ConfigLoader[URI] = ConfigLoader(_.getString).map(new URI(_))
 
   private def javaDurationToScala(javaDuration: java.time.Duration): FiniteDuration =

--- a/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
@@ -156,16 +156,16 @@ class ConfigurationSpec extends Specification {
       "valid URL" in {
         val conf  = config("my.url" -> validUrl)
         val value = conf.get[URL]("my.url")
-        value must beEqualTo(new URL(validUrl))
+        value must beEqualTo(new URI(validUrl).toURL)
       }
 
       "invalid URL" in {
         val conf = config("my.url" -> invalidUrl)
         def a: Nothing = {
           conf.get[URL]("my.url")
-          throw FailureException(failure("MalformedURLException should be thrown"))
+          throw FailureException(failure("IllegalArgumentException should be thrown"))
         }
-        theBlock(a) must throwA[MalformedURLException]
+        theBlock(a) must throwA[IllegalArgumentException]
       }
     }
 

--- a/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -5,6 +5,7 @@
 package play.api.libs.logback
 
 import java.io.File
+import java.net.URI
 import java.net.URL
 
 import ch.qos.logback.classic._
@@ -46,7 +47,7 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
     def explicitFileUrl = sys.props.get("logger.file").map(new File(_).toURI.toURL)
 
     // Get an explicitly configured URL
-    def explicitUrl = sys.props.get("logger.url").map(new URL(_))
+    def explicitUrl = sys.props.get("logger.url").map(new URI(_).toURL)
 
     def defaultResourceUrl = {
       import ContextInitializer._

--- a/core/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
+++ b/core/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
@@ -5,7 +5,6 @@
 package play.api.routing.sird
 
 import java.net.URI
-import java.net.URL
 
 import org.specs2.mutable.Specification
 import play.core.test.FakeRequest
@@ -110,7 +109,7 @@ class UrlContextSpec extends Specification {
     }
 
     "match a url" in {
-      new URL("http://example.com/foo/testing/bar") must beLike {
+      new URI("http://example.com/foo/testing/bar").toURL must beLike {
         case p"/foo/$id/bar" => id must_== "testing"
       }
     }

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
@@ -8,6 +8,7 @@ import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
+import java.net.URI
 import java.util.concurrent.Executors
 import java.util.jar.JarFile
 
@@ -518,7 +519,7 @@ object PlayDocsValidation {
     val futures = grouped.map { entry =>
       Future {
         val (url, refs) = entry
-        val connection  = new URL(url).openConnection().asInstanceOf[HttpURLConnection]
+        val connection  = new URI(url).toURL.openConnection().asInstanceOf[HttpURLConnection]
         try {
           connection.setRequestProperty(
             "User-Agent",

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -58,9 +58,8 @@ def retry[B](max: Int = 20, sleep: Long = 500, current: Int = 1)(block: => B): B
 
 InputKey[Unit]("checkConfig") := {
   val expected = Def.spaceDelimited().parsed.head
-  import java.net.URL
   val config = retry() {
-    IO.readLinesURL(new URL("http://localhost:9000/config")).mkString("\n")
+    IO.readLinesURL(url("http://localhost:9000/config")).mkString("\n")
   }
   if (expected != config) {
     sys.error(s"Expected config $expected but got $config")
@@ -69,9 +68,8 @@ InputKey[Unit]("checkConfig") := {
 
 InputKey[Unit]("countApplicationConf") := {
   val expected = Def.spaceDelimited().parsed.head
-  import java.net.URL
   val count = retry() {
-    IO.readLinesURL(new URL("http://localhost:9000/countApplicationConf")).mkString("\n")
+    IO.readLinesURL(url("http://localhost:9000/countApplicationConf")).mkString("\n")
   }
   if (expected != count) {
     sys.error(s"Expected application.conf to be $expected times on classpath, but it was there $count times")

--- a/web/play-openid/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
@@ -4,6 +4,7 @@
 
 package play.api.libs.openid
 
+import java.net.URI
 import java.net.URL
 import java.util.concurrent.TimeUnit
 
@@ -159,7 +160,7 @@ class DiscoveryClientSpec extends Specification {
 
         verify(ws.request).get()
 
-        (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.google.com/a/example.com/o8/ud")
+        (new URI(redirectUrl).toURL.hostAndPath must be).equalTo("https://www.google.com/a/example.com/o8/ud")
 
         verifyValidOpenIDRequest(parseQueryString(redirectUrl), openId, returnTo)
       }
@@ -176,7 +177,7 @@ class DiscoveryClientSpec extends Specification {
 
         verify(ws.request).get()
 
-        (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.google.com/a/example.com/o8/ud")
+        (new URI(redirectUrl).toURL.hostAndPath must be).equalTo("https://www.google.com/a/example.com/o8/ud")
 
         verifyValidOpenIDRequest(parseQueryString(redirectUrl), identifierSelection, returnTo)
       }
@@ -196,7 +197,7 @@ class DiscoveryClientSpec extends Specification {
 
         verify(ws.request).get()
 
-        (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server")
+        (new URI(redirectUrl).toURL.hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server")
 
         verifyValidOpenIDRequest(parseQueryString(redirectUrl), openId, returnTo)
       }
@@ -217,7 +218,7 @@ class DiscoveryClientSpec extends Specification {
 
         verify(ws.request).get()
 
-        (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server-1")
+        (new URI(redirectUrl).toURL.hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server-1")
 
         verifyValidOpenIDRequest(parseQueryString(redirectUrl), openId, returnTo)
       }
@@ -234,7 +235,7 @@ class DiscoveryClientSpec extends Specification {
 
         verify(ws.request).get()
 
-        (new URL(redirectUrl).hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server")
+        (new URI(redirectUrl).toURL.hostAndPath must be).equalTo("https://www.example.com/openidserver/openid.server")
 
         verifyValidOpenIDRequest(parseQueryString(redirectUrl), openId, returnTo)
       }
@@ -249,7 +250,8 @@ class DiscoveryClientSpec extends Specification {
 
         verify(ws.request).get()
 
-        (new URL(redirectUrl).hostAndPath must be).equalTo("http://www.example.com:8080/openidserver/openid.server")
+        (new URI(redirectUrl).toURL.hostAndPath must be)
+          .equalTo("http://www.example.com:8080/openidserver/openid.server")
 
         verifyValidOpenIDRequest(
           parseQueryString(redirectUrl),

--- a/web/play-openid/src/test/scala/play/api/libs/openid/package.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/package.scala
@@ -5,6 +5,7 @@
 package play.api.libs
 
 import java.net.MalformedURLException
+import java.net.URI
 import java.net.URL
 
 import scala.io.Source
@@ -29,7 +30,7 @@ package object openid {
 
   def parseQueryString(url: String): Params = {
     catching(classOf[MalformedURLException])
-      .opt(new URL(url))
+      .opt(new URI(url).toURL)
       .map { url =>
         new QueryStringDecoder(url.toURI.getRawQuery, false).parameters().asScala.view.mapValues(_.asScala.toSeq).toMap
       }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix warnings in JDK 20 or later

## Purpose

replace `new URL(arg)` to `new URI(arg).toURL` 

## Background Context


## References

- https://bugs.openjdk.org/browse/JDK-8295949
- https://github.com/openjdk/jdk/commit/4338f527aa81350e3636dcfbcd2eb17ddaad3914

