### PR TITLE
play-ws 2.2.0-M3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -287,7 +287,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.2.0-M2"
+  val playWsStandaloneVersion = "2.2.0-M3"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone"      % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-xml"  % playWsStandaloneVersion,


### PR DESCRIPTION
Pulls in correct akka Scala 3 dependencies (before it was using `.cross(CrossVersion.for3Use2_13))`)