### PR TITLE
fix warning

### DIFF
--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -217,7 +217,7 @@ class DefaultApplication @Inject() (
     CoordinatedShutdownSupport.asyncShutdown(actorSystem, ApplicationStoppedReason)
 }
 
-private[play] final case object ApplicationStoppedReason extends CoordinatedShutdown.Reason
+private[play] case object ApplicationStoppedReason extends CoordinatedShutdown.Reason
 
 /**
  * Helper to provide the Play built in components.


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix waring in Scala 3

## Purpose

remove `final` modifier

## Background Context

```
[warn] -- [E147] Syntax Warning: /home/runner/work/playframework/playframework/core/play/src/main/scala/play/api/Application.scala:220:14 
[warn] 220 |private[play] final case object ApplicationStoppedReason extends CoordinatedShutdown.Reason
[warn]     |              ^^^^^
[warn]     |              Modifier final is redundant for this definition
```

## References

