### PR TITLE
Work around missing `akka-http` Scala 3 artifacts for tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,7 +227,7 @@ lazy val PlayDocsProject = PlayCrossBuiltProject("Play-Docs", "dev-mode/play-doc
   .settings(
     libraryDependencies ++= playDocsDependencies
   )
-  .dependsOn(PlayAkkaHttpServerProject)
+  .dependsOn(PlayNettyServerProject)
 
 lazy val PlayGuiceProject = PlayCrossBuiltProject("Play-Guice", "core/play-guice")
   .settings(libraryDependencies ++= guiceDeps ++ specs2Deps.map(_ % "test"))

--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,8 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
           sbtVersion.value,
           Dependencies.akkaVersion,
           Dependencies.akkaHttpVersion,
+          Dependencies.jacksonVersion,
+          Dependencies.sslConfigCoreVersion,
           (Compile / sourceManaged).value
         )
       )
@@ -246,6 +248,8 @@ lazy val SbtPluginProject = PlaySbtPluginProject("Sbt-Plugin", "dev-mode/sbt-plu
         sbtVersion.value,
         Dependencies.akkaVersion,
         Dependencies.akkaHttpVersion,
+        Dependencies.jacksonVersion,
+        Dependencies.sslConfigCoreVersion,
         (Compile / sourceManaged).value
       )
     }.taskValue,

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -131,16 +131,6 @@ object PlayAkkaHttpServer extends AutoPlugin {
        } else {
          Seq.empty
        }),
-    onLoadMessage := onLoadMessage.value +
-      s"""
-         |You are using Scala 3 with the PlayAkkaHttpServer sbt plugin enabled.
-         |akka-http 10.2.x was not published for Scala 3 however. To make use of akka-http in a Scala 3 project
-         |it is necessary to pull in some dependencies' Scala 2 artifacts instead of their Scala 3 equivalents.
-         |For this project Play therefore automatically switched following dependencies to depend on Scala 2 artifacts:
-         |
-         |""".stripMargin + scala2Deps
-        .flatMap(e => e._2._2.map(d => s"${e._1} %% ${d}_2.13 % ${e._2._1}"))
-        .mkString("\n") + "\n\n"
   )
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,26 @@
  */
 
 import sbt._
+import sbt.librarymanagement.CrossVersion
 
 import buildinfo.BuildInfo
 import Keys._
 
 object Dependencies {
+
+  /**
+   * Temporary workarounds while using akka-http 10.2.x which does not provide Scala 3 artifacts.
+   */
+  private implicit class AkkaHttpScala3Workarounds(module: ModuleID) {
+    private def sysPropsCheck(m: => ModuleID) = if (sys.props.getOrElse("scala3Tests", "") == "true") m else module
+    def forScala3TestsUse2_13()               = sysPropsCheck(module.cross(CrossVersion.for3Use2_13))
+    def forScala3TestsExcludeScalaParserCombinators_3() = sysPropsCheck(
+      module.exclude("org.scala-lang.modules", "scala-parser-combinators_3")
+    )
+    def forScala3TestsExcludeSslConfigCore_213() = sysPropsCheck(module.exclude("com.typesafe", "ssl-config-core_2.13"))
+    def forScala3TestsExcludeAkkaOrganization()  = sysPropsCheck(module.excludeAll(ExclusionRule("com.typesafe.akka")))
+  }
+
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.20")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.2.10")
 
@@ -46,8 +61,8 @@ object Dependencies {
   val akkaSerializationJacksonOverrides = Seq(
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
     "com.fasterxml.jackson.module"     % "jackson-module-parameter-names",
-    "com.fasterxml.jackson.module"    %% "jackson-module-scala",
-  ).map(_ % jacksonVersion)
+  ).map(_ % jacksonVersion) ++
+    Seq(("com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion).forScala3TestsUse2_13())
 
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
 
@@ -155,9 +170,11 @@ object Dependencies {
   def runtime(scalaVersion: String) =
     slf4j ++
       Seq("akka-actor", "akka-actor-typed", "akka-slf4j", "akka-serialization-jackson")
-        .map("com.typesafe.akka" %% _ % akkaVersion) ++
+        .map("com.typesafe.akka" %% _ % akkaVersion)
+        .map(_.forScala3TestsUse2_13()) ++
       Seq("akka-testkit", "akka-actor-testkit-typed")
-        .map("com.typesafe.akka" %% _ % akkaVersion % Test) ++
+        .map("com.typesafe.akka" %% _ % akkaVersion % Test)
+        .map(_.forScala3TestsUse2_13()) ++
       jacksons ++
       akkaSerializationJacksonOverrides ++
       jjwts ++
@@ -167,7 +184,9 @@ object Dependencies {
         "jakarta.transaction" % "jakarta.transaction-api" % "2.0.1",
         javaxInject,
         sslConfig
-      ) ++ scalaParserCombinators(scalaVersion) ++ specs2Deps.map(_ % Test) ++ javaTestDeps ++
+      ) ++ scalaParserCombinators(scalaVersion).map(_.forScala3TestsUse2_13()) ++ specs2Deps.map(
+        _ % Test
+      ) ++ javaTestDeps ++
       scalaReflect(scalaVersion)
 
   val nettyVersion = "4.1.90.Final"
@@ -177,9 +196,9 @@ object Dependencies {
     ("io.netty"          % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
   ) ++ specs2Deps.map(_ % Test)
 
-  val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
+  val akkaHttp = ("com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion).cross(CrossVersion.for3Use2_13)
 
-  val akkaHttp2Support = "com.typesafe.akka" %% "akka-http2-support" % akkaHttpVersion
+  val akkaHttp2Support = ("com.typesafe.akka" %% "akka-http2-support" % akkaHttpVersion).cross(CrossVersion.for3Use2_13)
 
   val cookieEncodingDependencies = slf4j
 
@@ -236,7 +255,9 @@ object Dependencies {
 
   val streamsDependencies = Seq(
     "org.reactivestreams" % "reactive-streams" % "1.0.4",
-    "com.typesafe.akka"  %% "akka-stream"      % akkaVersion,
+    ("com.typesafe.akka" %% "akka-stream"      % akkaVersion)
+      .forScala3TestsUse2_13()
+      .forScala3TestsExcludeSslConfigCore_213()
   ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
 
   val playServerDependencies = specs2Deps.map(_ % Test) ++ Seq(
@@ -246,7 +267,9 @@ object Dependencies {
   )
 
   val clusterDependencies = Seq(
-    "com.typesafe.akka" %% "akka-cluster-sharding-typed" % akkaVersion
+    ("com.typesafe.akka" %% "akka-cluster-sharding-typed" % akkaVersion)
+      .forScala3TestsUse2_13()
+      .forScala3TestsExcludeSslConfigCore_213()
   )
 
   val fluentleniumVersion = "5.0.4"
@@ -289,16 +312,22 @@ object Dependencies {
 
   val playWsStandaloneVersion = "2.2.0-M3"
   val playWsDeps = Seq(
-    "com.typesafe.play" %% "play-ws-standalone"      % playWsStandaloneVersion,
-    "com.typesafe.play" %% "play-ws-standalone-xml"  % playWsStandaloneVersion,
-    "com.typesafe.play" %% "play-ws-standalone-json" % playWsStandaloneVersion,
+    ("com.typesafe.play" %% "play-ws-standalone"      % playWsStandaloneVersion).forScala3TestsExcludeAkkaOrganization(),
+    ("com.typesafe.play" %% "play-ws-standalone-xml"  % playWsStandaloneVersion).forScala3TestsExcludeAkkaOrganization(),
+    ("com.typesafe.play" %% "play-ws-standalone-json" % playWsStandaloneVersion)
+      .forScala3TestsExcludeAkkaOrganization(),
     // Update transitive Akka version as needed:
-    "com.typesafe.akka" %% "akka-stream" % akkaVersion
-  ) ++ (specs2Deps :+ specsMatcherExtra).map(_ % Test) :+ mockitoAll % Test
+    ("com.typesafe.akka" %% "akka-stream" % akkaVersion)
+      .forScala3TestsUse2_13()
+      .forScala3TestsExcludeSslConfigCore_213()
+  ) ++ (specs2Deps :+ specsMatcherExtra.forScala3TestsExcludeScalaParserCombinators_3())
+    .map(_ % Test) :+ mockitoAll % Test
 
   // Must use a version of ehcache that supports jcache 1.0.0
   val playAhcWsDeps = Seq(
-    "com.typesafe.play"            %% "play-ahc-ws-standalone" % playWsStandaloneVersion,
+    ("com.typesafe.play" %% "play-ahc-ws-standalone" % playWsStandaloneVersion)
+      .forScala3TestsExcludeAkkaOrganization()
+      .forScala3TestsExcludeScalaParserCombinators_3(),
     "com.typesafe.play"             % "shaded-asynchttpclient" % playWsStandaloneVersion,
     "com.typesafe.play"             % "shaded-oauth"           % playWsStandaloneVersion,
     "com.github.ben-manes.caffeine" % "jcache"                 % caffeineVersion % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,8 @@ object Dependencies {
   val akkaVersion: String = sys.props.getOrElse("akka.version", "2.6.20")
   val akkaHttpVersion     = sys.props.getOrElse("akka.http.version", "10.2.10")
 
-  val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.1"
+  val sslConfigCoreVersion = "0.6.1"
+  val sslConfig            = "com.typesafe" %% "ssl-config-core" % sslConfigCoreVersion
 
   val playJsonVersion = "2.10.0-RC7"
 

--- a/project/Tasks.scala
+++ b/project/Tasks.scala
@@ -13,6 +13,8 @@ object Generators {
       sbtVersion: String,
       akkaVersion: String,
       akkaHttpVersion: String,
+      jacksonVersion: String,
+      sslConfigCoreVersion: String,
       dir: File
   ): Seq[File] = {
     val file = dir / "PlayVersion.scala"
@@ -25,6 +27,8 @@ object Generators {
           |  val sbtVersion = "$sbtVersion"
           |  val akkaVersion = "$akkaVersion"
           |  val akkaHttpVersion = "$akkaHttpVersion"
+          |  val jacksonVersion = "$jacksonVersion"
+          |  val sslConfigCoreVersion = "$sslConfigCoreVersion"
           |}
           |""".stripMargin
 


### PR DESCRIPTION
Running tests with Scala 3 needs to be done with a `-Dscala3Tests=true` flag.
This causes akka dependencies to use `cross(CrossVersion.for3Use2_13)`.  That's because we use `for3Use2_13` for akka-http as well. If we wouldn't apply `for3Use2_13` for akka now, akka-http would not be able to work with akka Scala 3 artifacts... In short: It sucks.
The flag also excludes some other dependencies were _3 and _2.13 are conflicting now because of the above.

The flag only should be applied when running tests. because for publishing we do want to publish all dependencies with `_3`.
I am working on some sbt plugin magic for the akka-http sbt plugin so it switches to `for3Use2_13` when using it with Scala 3 automatically. Not sure if it will work, but we will see.