### PR TITLE
Scala3 migration guide

### DIFF
--- a/documentation/manual/Scala3Migration.md
+++ b/documentation/manual/Scala3Migration.md
@@ -39,6 +39,52 @@ At the time of this writing `1.8.2` is the latest version in the sbt 1.x family,
 
 ## How to migrate
 
+### Unapply changes
+
+Considering a simple case class with a title and a body:
+
+```scala
+case class PostFormInput(title: String, body: String)
+```
+
+We can define a Form object like so:
+
+```scala
+Form(
+	mapping(
+		"title" -> nonEmptyText,
+		"body" -> text
+	)(PostFormInput.apply)(PostFormInput.unapply)
+)
+```
+
+In Scala 3, you will need to update it to the following:
+
+```scala
+Form(
+	mapping(
+		"title" -> nonEmptyText,
+		"body" -> text
+	)(PostFormInput.apply)(t => Some(t.title, t.body))
+)
+```
+
+We run into this issue because the signature of the `unapply` method on the companion object of case classes has changed from:
+
+```scala
+object PostFormInput {
+	def unapply(postFormInput: PostFormInput): Option[(String, String)] = Some((postFormInput.title, postFormInput.body))
+}
+```
+
+to:
+
+```scala
+object PostFormInput {
+	def unapply(postFormInput: PostFormInput): PostFormInput = postFormInput
+}
+```
+
 TODO:
 - [ ] Mention mockito
 - [ ] Mention the `running()` wrapper when using scalatestplus-play

--- a/documentation/manual/Scala3Migration.md
+++ b/documentation/manual/Scala3Migration.md
@@ -58,17 +58,6 @@ Form(
 )
 ```
 
-In Scala 3, you will need to update it to the following:
-
-```scala
-Form(
-	mapping(
-		"title" -> nonEmptyText,
-		"body" -> text
-	)(PostFormInput.apply)(t => Some(t.title, t.body))
-)
-```
-
 We run into this issue because the signature of the `unapply` method on the companion object of case classes has changed from:
 
 ```scala
@@ -82,6 +71,16 @@ to:
 ```scala
 object PostFormInput {
 	def unapply(postFormInput: PostFormInput): PostFormInput = postFormInput
+}
+```
+
+You will need to manually create the unapply method with the correct signature in the companion object of your case class.
+
+```scala
+object PostFormInput {
+  def unapply(postFormInput: PostFormInput): Option[(String, String)] = {
+    Some((postFormInput.title, postFormInput.body))
+  }
 }
 ```
 

--- a/documentation/manual/Scala3Migration.md
+++ b/documentation/manual/Scala3Migration.md
@@ -2,7 +2,7 @@
 
 # Scala 3 Migration Guide
 
-This guide is for migrating Play applications from Scala 3 to Scala 3.
+This guide is for migrating Play applications from Scala 2 to Scala 3.
 
 ## Requirements
 

--- a/documentation/manual/Scala3Migration.md
+++ b/documentation/manual/Scala3Migration.md
@@ -1,0 +1,47 @@
+<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
+
+# Scala 3 Migration Guide
+
+This guide is for migrating Play applications from Scala 3 to Scala 3.
+
+## Requirements
+
+### Scala 3 version
+
+You need to use at least Scala 3.3.0. Make sure you set
+
+```scala
+scalaVersion := "3.3.0"
+```
+
+or newer in your `build.sbt`.
+
+### Play version
+
+To be able to run you Play application with Scala 3 you need to use at least Play 2.9.x, so check your `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.x")
+```
+
+Where the "x" in `2.9.x` is the minor version of Play you want to use, for instance `2.9.0`.
+Older versions of Play do not provide Scala 3 artifacts.
+
+### sbt version
+
+Play with Scala 3 also only works with sbt 1.8.x or newer, so make sure to your `project/build.properties` reads:
+
+```properties
+sbt.version=1.8.2
+```
+
+At the time of this writing `1.8.2` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for both Play's minor version [releases](https://github.com/playframework/playframework/releases) and sbt's [releases](https://github.com/sbt/sbt/releases) for details.
+
+## How to migrate
+
+TODO:
+- [ ] Mention mockito
+- [ ] Mention the `running()` wrapper when using scalatestplus-play
+- [ ] Likely the same for spec2 (but still needs to be done)
+- [ ] Mention the unapply changes
+- [ ] Mention the sird changes: Not everything is in the `UrlContext` implicit class anymore, so importing this class is not enough, it should be `._`


### PR DESCRIPTION
#11716

I think it's a good idea to document all the things we stumpled into during our own journey.

This is WIP.

TODO:

- [ ] Go through the https://github.com/playframework/playframework/labels/scala3 label and see what else should be mentioned here.
- [ ] Come up with better wording for `onLoadMessage` in `PlayAkkaHttpServer` related to Scala 3, see https://github.com/playframework/playframework/pull/11738#issuecomment-1490238354
- [ ] Mention 
```
libraryDependencies += clusterSharding
libraryDependencies += ("com.typesafe.akka" %% "akka-cluster-sharding-typed" % "2.6.20").cross(CrossVersion.for3Use2_13)
excludeDependencies += sbt.ExclusionRule("com.typesafe.akka", "akka-cluster-sharding-typed_3")
```
because it is not possible to override / replace the `clusterSharding` dependency from the akka-http sbt plugin.