### PR TITLE
Use scala.jdk converter also for Scala 3 in twirl templates

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -31,11 +31,9 @@ object PlaySettings {
   lazy val minimalJavaSettings = Seq[Setting[_]](
     templateImports ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, v)) if v >= 13 =>
-          TemplateImports.minimalJavaTemplateImports.asScala :+ "scala.jdk.CollectionConverters._"
         case Some((2, v)) if v <= 12 =>
           TemplateImports.minimalJavaTemplateImports.asScala :+ "scala.collection.JavaConverters._"
-        case _ => TemplateImports.minimalJavaTemplateImports.asScala :+ "scala.collection.JavaConverters._"
+        case _ => TemplateImports.minimalJavaTemplateImports.asScala :+ "scala.jdk.CollectionConverters._"
       }
     },
     routesImport ++= Seq("play.libs.F")
@@ -44,11 +42,9 @@ object PlaySettings {
   lazy val defaultJavaSettings = Seq[Setting[_]](
     templateImports ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, v)) if v >= 13 =>
-          TemplateImports.defaultJavaTemplateImports.asScala :+ "scala.jdk.CollectionConverters._"
         case Some((2, v)) if v <= 12 =>
           TemplateImports.defaultJavaTemplateImports.asScala :+ "scala.collection.JavaConverters._"
-        case _ => TemplateImports.defaultJavaTemplateImports.asScala :+ "scala.collection.JavaConverters._"
+        case _ => TemplateImports.defaultJavaTemplateImports.asScala :+ "scala.jdk.CollectionConverters._"
       }
     },
     routesImport ++= Seq("play.libs.F")

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -109,7 +109,7 @@ object BuildSettings {
       // disable the new scaladoc feature for scala 2.12+ (https://github.com/scala/scala-dev/issues/249 and https://github.com/scala/bug/issues/11340)
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, v)) if v >= 12 => Seq("-no-java-comments")
-        case _                       => Seq()
+        case _                       => Seq() // Not available/needed in Scala 3 according to https://github.com/lampepfl/dotty/issues/11907
       }
     },
     (Test / fork)                 := true,


### PR DESCRIPTION
Just bumped into that when using `-Werror`/`-Xfatal-warnings` in Scala 3.