### PR TITLE
fix warnings

### DIFF
--- a/testkit/play-test/src/test/java/play/test/HelpersTest.java
+++ b/testkit/play-test/src/test/java/play/test/HelpersTest.java
@@ -149,7 +149,7 @@ public class HelpersTest {
   @Test
   public void shouldSuccessfullyExecutePostRequestWithMultipartFormData() {
     Application app = Helpers.fakeApplication();
-    Map<String, String[]> postParams = new java.util.HashMap();
+    Map<String, String[]> postParams = new java.util.HashMap<>();
     postParams.put("key", new String[] {"value"});
     Http.RequestBuilder request =
         new Http.RequestBuilder().method(POST).bodyMultipart(postParams, Collections.emptyList());

--- a/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
@@ -19,7 +19,6 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import com.google.common.io.{ Files => GFiles }
 import org.specs2.mutable.Specification
 import play.api.Mode
 import play.api.Play
@@ -90,7 +89,7 @@ class ProdServerStartSpec extends Specification {
   sequential
 
   def withTempDir[T](block: File => T) = {
-    val temp = GFiles.createTempDir()
+    val temp = Files.createTempDirectory("tmp").toFile
     try {
       block(temp)
     } finally {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix warings

## Purpose


## Background Context



```
[warn] /home/runner/work/playframework/playframework/testkit/play-test/src/test/java/play/test/HelpersTest.java:152:1: unchecked conversion
[warn]   required: java.util.Map<java.lang.String,java.lang.String[]>
[warn]   found:    java.util.HashMap
[warn] new java.util.HashMap()
```

https://github.com/google/guava/blob/4d2b6ffb312a4ebf8aa377982fc98a7ece0bc3fd/android/guava/src/com/google/common/io/Files.java#L428-L429

```
[warn] /home/runner/work/playframework/playframework/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala:93:23: method createTempDir in class Files is deprecated
[warn]     val temp = GFiles.createTempDir()
[warn]                       ^
```

## References

