### PR TITLE
Fix the shutdown scripted tests

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
@@ -17,6 +17,7 @@ lazy val root = (project in file("."))
     libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test,
     test / fork                                     := true,
     PlayKeys.playInteractionMode                    := play.sbt.StaticPlayNonBlockingInteractionMode,
+    PlayKeys.devSettings                            += "akka.http.server.socket-options.tcp-no-delay" -> "true",
     commands += ScriptedTools.assertProcessIsStopped,
     InputKey[Unit]("awaitPidfileDeletion") := {
       val pidFile = target.value / "universal" / "stage" / "RUNNING_PID"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/resources/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/resources/application.conf
@@ -1,3 +1,5 @@
 play.akka.actor-system = "application-actorsystem-name"
 
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b
+
+akka.coordinated-shutdown.phases.service-unbind.timeout = 15 seconds

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/resources/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/src/main/resources/application.conf
@@ -3,3 +3,5 @@ play.akka.actor-system = "application-actorsystem-name"
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b
 
 akka.coordinated-shutdown.phases.service-unbind.timeout = 15 seconds
+
+akka.http.server.socket-options.tcp-no-delay = true

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
@@ -19,6 +19,7 @@ lazy val root = (project in file("."))
     libraryDependencies += guice,
     libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test,
     test / fork                                     := false,
+    PlayKeys.devSettings                            += "akka.http.server.socket-options.tcp-no-delay" -> "true",
     PlayKeys.playInteractionMode                    := play.sbt.StaticPlayNonBlockingInteractionMode,
     commands += ScriptedTools.assertProcessIsStopped,
     InputKey[Unit]("awaitPidfileDeletion") := {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/resources/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/resources/application.conf
@@ -1,3 +1,5 @@
 play.akka.actor-system = "application-actorsystem-name"
 
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b
+
+akka.coordinated-shutdown.phases.service-unbind.timeout = 15 seconds

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/resources/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/src/main/resources/application.conf
@@ -3,3 +3,5 @@ play.akka.actor-system = "application-actorsystem-name"
 play.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b
 
 akka.coordinated-shutdown.phases.service-unbind.timeout = 15 seconds
+
+akka.http.server.socket-options.tcp-no-delay = true


### PR DESCRIPTION
Those scripted tests fail randomly, in the last weeks and months even more often.
So I took time to figure out what's the cause and I think I found it: We need to give the (forced) coordinated shutdown hooks more time to finish. If we don't, the server immediately shuts down all connections after a hard timeout of 5 seconds and the pending request can not be answered anymore, which makes the scripted test fail (which tries to re-send the request like 10 times until it fails)