### PR TITLE
Draft: Remove deprecated methods since #11371

### DIFF
--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -716,21 +716,11 @@ object Assets {
 
 @Singleton
 class Assets @Inject() (errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: Environment)
-    extends AssetsBuilder(errorHandler, meta, env) {
-  @deprecated("Use Assets(errorHandler,meta,env) instead.", "2.9")
-  def this(errorHandler: HttpErrorHandler, meta: AssetsMetadata) = {
-    this(errorHandler, meta, null)
-  }
-}
+    extends AssetsBuilder(errorHandler, meta, env)
 
 class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: Environment) extends ControllerHelpers {
   import meta._
   import Assets._
-
-  @deprecated("Use AssetsBuilder(errorHandler,meta,env) instead.", "2.9")
-  def this(errorHandler: HttpErrorHandler, meta: AssetsMetadata) = {
-    this(errorHandler, meta, null)
-  }
 
   protected val Action: ActionBuilder[Request, AnyContent] = new ActionBuilder.IgnoringBody()(Execution.trampoline)
 

--- a/core/play/src/main/scala/play/utils/Resources.scala
+++ b/core/play/src/main/scala/play/utils/Resources.scala
@@ -25,11 +25,6 @@ object Resources {
       throw new IllegalArgumentException(s"Cannot check isDirectory for a URL with protocol='${url.getProtocol}'")
   }
 
-  @deprecated("Use isUrlConnectionADirectory(classLoader,urlConnection) instead.", "2.9")
-  def isUrlConnectionADirectory(urlConnection: URLConnection): Boolean = {
-    isUrlConnectionADirectory(null, urlConnection)
-  }
-
   /**
    * Tries to work out whether the given URL connection is a directory or not.
    *


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Remove deprecated methods added in #11371. 

## Purpose

Deprecated methods are removed in order to organize methods that should be maintained.

## Background Context

Please merge in 2.10 or later as it breaks backwards compatibility.

## References

Ref #11371