### PR TITLE
fix reverse routes escape with fixed param

### DIFF
--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -252,7 +252,7 @@ package object templates {
     route.call.parameters
       .getOrElse(Nil)
       .filter { p => localNames.contains(p.name) && p.fixed.isDefined }
-      .map { p => p.name + " == " + p.fixed.get } match {
+      .map { p => safeKeyword(p.name) + " == " + p.fixed.get } match {
       case Nil      => ""
       case nonEmpty => "if " + nonEmpty.mkString(" && ")
     }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/Application.scala
@@ -265,6 +265,9 @@ class Application @Inject() (c: ControllerComponents) extends AbstractController
   def routedefault(parameter: String) = Action {
     Ok(parameter)
   }
+  def fixedValue(parameter: String) = Action {
+    Ok(parameter)
+  }
   def hello = Action {
     Ok("Hello world!")
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/routes
@@ -116,6 +116,11 @@ GET         /routesdefault          controllers.Application.routedefault(type ?=
 
 GET         /public/*file           controllers.Assets.versioned(path="/public", file: controllers.Assets.Asset)
 
+# Test for fixed values for scala keywords
+
+GET         /fixed_value            controllers.Application.fixedValue(type = "x")
+GET         /fixed_value/:type       controllers.Application.fixedValue(type: String)
+
 # This triggers a string interpolation warning, since there is an identifier called "routes" in scope, and it
 # generates a non interpolated string containing $routes. As does this comment.
 GET         /intwarn/:routes        controllers.Application.interpolatorWarning(routes)


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fix reverse routes generated code. 

## Purpose

escape if Scala keyword

## Background Context


play generate following code and scalac report compile error before this fix

```
[error] target/scala-2.13/routes/main/controllers/ReverseRoutes.scala:382:35: illegal start of simple expression
[error]         case (_pf_escape_type) if type == "x" =>
[error]                                   ^
[error] target/scala-2.13/routes/main/controllers/ReverseRoutes.scala:383:97: '=>' expected but ';' found.
[error]           implicit lazy val _rrc = new play.core.routing.ReverseRouteContext(Map(("type", "x"))); _rrc
[error]                                                                                                 ^
[error] two errors found
```

## References

