### PR TITLE
use `lazyZip` instead of `zip` if possible

### DIFF
--- a/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -51,14 +51,13 @@ private[routing] class RouterBuilderHelper(
               }
 
               // Bind params if required
-              val params = groups.zip(route.params.asScala).map {
-                case (param, routeParam) =>
-                  val rawParam = if (routeParam.decode) {
-                    UriEncoding.decodePathSegment(param, "utf-8")
-                  } else {
-                    param
-                  }
-                  routeParam.pathBindable.bind(routeParam.name, rawParam)
+              val params = groups.lazyZip(route.params.asScala).map { (param, routeParam) =>
+                val rawParam = if (routeParam.decode) {
+                  UriEncoding.decodePathSegment(param, "utf-8")
+                } else {
+                  param
+                }
+                routeParam.pathBindable.bind(routeParam.name, rawParam)
               }
 
               val maybeParams = params.foldLeft[Either[String, Seq[AnyRef]]](Right(Nil)) {

--- a/core/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
+++ b/core/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
@@ -34,7 +34,7 @@ class PathExtractor(regex: Regex, partDescriptors: Seq[PathPart.Value]) {
 
   private def extract(path: String): Option[List[String]] = {
     regex.unapplySeq(path).map { parts =>
-      parts.zip(partDescriptors).map {
+      parts.lazyZip(partDescriptors).map {
         case (part, PathPart.Decoded) => UriEncoding.decodePathSegment(part, "utf-8")
         case (part, PathPart.Raw)     => part
         case (part, pathPart)         => throw new MatchError(s"unexpected ($path, $pathPart)")

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -159,15 +159,14 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
         }
       logger.debug("### Start of action order")
       actionChain
-        .zip(LazyList.from(1))
-        .foreach {
-          case (action, index) =>
-            logger.debug(
-              s"${index}. ${action.getClass.getName}" +
-                (if (action.annotatedElement != null) {
-                   s" defined on ${action.annotatedElement}"
-                 })
-            )
+        .lazyZip(LazyList.from(1))
+        .foreach { (action, index) =>
+          logger.debug(
+            s"${index}. ${action.getClass.getName}" +
+              (if (action.annotatedElement != null) {
+                 s" defined on ${action.annotatedElement}"
+               })
+          )
         }
       logger.debug("### End of action order")
     }

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -195,8 +195,8 @@ private[server] object ForwardedHeaderHandler {
         val forHeaders                 = h(headers, "X-Forwarded-For")
         val protoHeaders               = h(headers, "X-Forwarded-Proto")
         if (forHeaders.length == protoHeaders.length) {
-          forHeaders.zip(protoHeaders).map {
-            case (f, p) => ForwardedEntry(Some(f), Some(p))
+          forHeaders.lazyZip(protoHeaders).map { (f, p) =>
+            ForwardedEntry(Some(f), Some(p))
           }
         } else {
           // If the lengths vary, then discard the protoHeaders because we can't tell which


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist


* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes



## Purpose

use `lazyZip` 

## Background Context

`lazyZip` is more efficient

https://github.com/scala/scala/blob/aa326fcc429d9a8e7f262eaab71f43a500d37b17/src/library/scala/collection/LazyZipOps.scala#L26-L34

## References
