### PR TITLE
use `groupMap` if possible

### DIFF
--- a/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/core/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -20,7 +20,7 @@ object FormUrlEncodedParser {
    */
   def parseNotPreservingOrder(data: String, encoding: String = "utf-8"): Map[String, Seq[String]] = {
     // Generate the pairs of values from the string.
-    parseToPairs(data, encoding).groupBy(_._1).view.mapValues(_.map(_._2)).toMap
+    parseToPairs(data, encoding).groupMap(_._1)(_._2)
   }
 
   /**

--- a/core/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
+++ b/core/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
@@ -117,7 +117,7 @@ class UrlContextSpec extends Specification {
 
   "query string interpolation" should {
     def qs(params: (String, String)*): Map[String, Seq[String]] = {
-      params.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
+      params.groupMap(_._1)(_._2)
     }
 
     "allow required parameter extraction" in {


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist


* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes


## Purpose


## Background Context


## References

https://github.com/scala/scala/blob/aa326fcc429d9a8e7f262eaab71f43a500d37b17/src/library/scala/collection/Iterable.scala#L573-L608
