### PR TITLE
Guice 6.0.0-rc2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -162,7 +162,7 @@ object Dependencies {
     logback
   ).map(_ % Test)
 
-  val guiceVersion = "5.1.0"
+  val guiceVersion = "6.0.0-rc1"
   val guiceDeps = Seq(
     "com.google.inject"            % "guice"                % guiceVersion,
     "com.google.inject.extensions" % "guice-assistedinject" % guiceVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -162,7 +162,7 @@ object Dependencies {
     logback
   ).map(_ % Test)
 
-  val guiceVersion = "6.0.0-rc1"
+  val guiceVersion = "6.0.0-rc2"
   val guiceDeps = Seq(
     "com.google.inject"            % "guice"                % guiceVersion,
     "com.google.inject.extensions" % "guice-assistedinject" % guiceVersion


### PR DESCRIPTION
See [this discussion](https://github.com/google/guice/issues/1383), specially https://github.com/google/guice/issues/1383#issuecomment-1523410855: 
The way I see it right now is that we probably should wait for Guice 7 (which should also come soon) before we switch to the jakarta namespace.

Upgrading Guice also unlocks Java 18-21 as a side effect because it upgrades asm.