### PR TITLE
Fix documentation of scheduleOnce

### DIFF
--- a/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/CodeBlockTask.scala
+++ b/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/CodeBlockTask.scala
@@ -22,7 +22,7 @@ class CodeBlockTask @Inject() (actorSystem: ActorSystem)(implicit executionConte
 
 //#schedule-block-once
 class ScheduleOnceTask @Inject() (actorSystem: ActorSystem)(implicit executionContext: ExecutionContext) {
-  actorSystem.scheduler.scheduleWithFixedDelay(initialDelay = 10.seconds, delay = 10.seconds) { () =>
+  actorSystem.scheduler.scheduleOnce(delay = 10.seconds) { () =>
     // the block of code that will be executed
     actorSystem.log.info("Executing something...")
   }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Documentation of [Scheduled Tasks](https://www.playframework.com/documentation/2.8.x/ScheduledTasks)

## Purpose

To show the correct Scala method to use when wanting a single delayed run of a task.

## Background Context

I noticed a difference between the Scala and Java examples for the section `Or to run a block of code once 10 seconds from now`. The Java code correctly uses `scheduleOnce` while Scala uses `scheduleWithFixedDelay`. Looking at the history of `CodeBlockTask.scala`, I saw that the change was an error.

## References

None
