### PR TITLE
Scala 3.3.0-RC6

### DIFF
--- a/core/play-integration-test/src/it/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/core/play-integration-test/src/it/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -135,7 +135,7 @@ class XmlBodyParserSpec extends PlaySpecification {
 
     "parse XML bodies without loading in a related schema" in new WithApplication() {
       override def running() = {
-        val f = File.createTempFile("xxe", ".txt")
+        val f = Files.createTempFile("xxe", ".txt").toFile
         Files.write(f.toPath, "I shouldn't be there!".getBytes(StandardCharsets.UTF_8))
         f.deleteOnExit()
         val xml =
@@ -150,8 +150,8 @@ class XmlBodyParserSpec extends PlaySpecification {
 
     "parse XML bodies without loading in a related schema from a parameter" in new WithApplication() {
       override def running() = {
-        val externalParameterEntity = File.createTempFile("xep", ".dtd")
-        val externalGeneralEntity   = File.createTempFile("xxe", ".txt")
+        val externalParameterEntity = Files.createTempFile("xep", ".dtd").toFile
+        val externalGeneralEntity   = Files.createTempFile("xxe", ".txt").toFile
         Files.write(
           externalParameterEntity.toPath,
           s"""

--- a/core/play/src/test/scala/play/libs/XMLSpec.scala
+++ b/core/play/src/test/scala/play/libs/XMLSpec.scala
@@ -5,6 +5,7 @@
 package play.libs
 
 import java.io.File
+import java.nio.file.Files
 
 import org.specs2.mutable.Specification
 import org.xml.sax.SAXException
@@ -29,7 +30,7 @@ class XMLSpec extends Specification {
     }
 
     "parse XML bodies without loading in a related schema" in {
-      val f = File.createTempFile("xxe", ".txt")
+      val f = Files.createTempFile("xxe", ".txt").toFile
       writeStringToFile(f, "I shouldn't be there!")
       f.deleteOnExit()
       val xml = s"""<?xml version="1.0" encoding="ISO-8859-1"?>
@@ -43,8 +44,8 @@ class XMLSpec extends Specification {
     }
 
     "parse XML bodies without loading in a related schema from a parameter" in {
-      val externalParameterEntity = File.createTempFile("xep", ".dtd")
-      val externalGeneralEntity   = File.createTempFile("xxe", ".txt")
+      val externalParameterEntity = Files.createTempFile("xep", ".dtd").toFile
+      val externalGeneralEntity   = Files.createTempFile("xxe", ".txt").toFile
       writeStringToFile(
         externalParameterEntity,
         s"""

--- a/core/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/core/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -9,6 +9,7 @@ import java.io.File
 import java.net.URL
 import java.net.URLConnection
 import java.net.URLStreamHandler
+import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -23,15 +24,15 @@ class ResourcesSpec extends Specification {
 
   lazy val app             = PlayCoreTestApplication()
   lazy val tmpDir          = createTempDir("resources-", ".tmp")
-  lazy val jar             = File.createTempFile("jar-", ".tmp", tmpDir)
-  lazy val fileRes         = File.createTempFile("file-", ".tmp", tmpDir)
+  lazy val jar             = Files.createTempFile(tmpDir.toPath, "jar-", ".tmp").toFile
+  lazy val fileRes         = Files.createTempFile(tmpDir.toPath, "file-", ".tmp").toFile
   lazy val dirRes          = createTempDir("dir-", ".tmp", tmpDir)
   lazy val dirSpacesRes    = createTempDir("dir spaces ", ".tmp", tmpDir)
   lazy val spacesDir       = createTempDir("spaces ", ".tmp", tmpDir)
-  lazy val spacesJar       = File.createTempFile("jar-spaces", ".tmp", spacesDir)
+  lazy val spacesJar       = Files.createTempFile(spacesDir.toPath, "jar-spaces", ".tmp").toFile
   lazy val resourcesDir    = new File(app.classloader.getResource("").getPath)
   lazy val tmpResourcesDir = createTempDir("test-bundle-", ".tmp", resourcesDir)
-  lazy val fileBundle      = File.createTempFile("file-", ".tmp", tmpResourcesDir)
+  lazy val fileBundle      = Files.createTempFile(tmpResourcesDir.toPath, "file-", ".tmp").toFile
   lazy val dirBundle       = createTempDir("dir-", ".tmp", tmpResourcesDir)
   lazy val spacesDirBundle = createTempDir("dir spaces ", ".tmp", tmpResourcesDir)
   lazy val classloader     = app.classloader
@@ -199,7 +200,11 @@ class ResourcesSpec extends Specification {
   }
 
   private def createTempDir(prefix: String, suffix: String, parent: File = null) = {
-    val f = File.createTempFile(prefix, suffix, parent)
+    val f = if (parent == null) {
+      Files.createTempFile(prefix, suffix).toFile
+    } else {
+      Files.createTempFile(parent.toPath, prefix, suffix).toFile
+    }
     f.delete()
     f.mkdir()
     f

--- a/dev-mode/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
+++ b/dev-mode/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
@@ -5,6 +5,7 @@
 package play.routes.compiler
 
 import java.io.File
+import java.nio.file.Files
 
 import org.specs2.matcher.FileMatchers
 import org.specs2.mutable.Specification
@@ -15,7 +16,7 @@ class RoutesCompilerSpec extends Specification with FileMatchers {
 
   "route file compiler" should {
     def withTempDir[T](block: File => T) = {
-      val tmp = File.createTempFile("RoutesCompilerSpec", "")
+      val tmp = Files.createTempFile("RoutesCompilerSpec", "").toFile
       tmp.delete()
       tmp.mkdir()
       try {

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -79,7 +79,7 @@ lazy val main = Project("Play-Documentation", file("."))
     Test / unmanagedResourceDirectories ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
     // Don't include sbt files in the resources
     Test / unmanagedResources / excludeFilter := (Test / unmanagedResources / excludeFilter).value || "*.sbt",
-    crossScalaVersions                        := Seq("2.13.10", "3.3.0-RC5"),
+    crossScalaVersions                        := Seq("2.13.10", "3.3.0-RC6"),
     scalaVersion                              := "2.13.10",
     Test / fork                               := true,
     Test / javaOptions ++= Seq("-Xmx512m", "-Xms128m"),

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -216,7 +216,7 @@ public class JavaWS {
         throws IOException, FileNotFoundException, InterruptedException, ExecutionException {
       String url = "http://example.com";
       // #stream-to-file
-      File file = File.createTempFile("stream-to-file-", ".txt");
+      File file = java.nio.file.Files.createTempFile("stream-to-file-", ".txt").toFile();
       OutputStream outputStream = java.nio.file.Files.newOutputStream(file.toPath());
 
       // Make the request

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -364,7 +364,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case ("GET", "/") => Action(Ok.chunked(largeSource))
         case other        => Action { NotFound }
       } { ws =>
-        val file = File.createTempFile("stream-to-file-", ".txt")
+        val file = java.nio.file.Files.createTempFile("stream-to-file-", ".txt").toFile
         try {
           // #stream-to-file
           // Make the request
@@ -425,7 +425,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
           }
         }
         // #stream-to-result
-        val file = File.createTempFile("stream-to-file-", ".txt")
+        val file = java.nio.file.Files.createTempFile("stream-to-file-", ".txt").toFile
         await(
           downloadFile(FakeRequest())
             .flatMap(_.body.dataStream.runFold(0L)((t, b) => t + b.length))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ val webjarsLocatorCore = "0.52"
 val sbtHeader          = "5.8.0"
 val scalafmt           = "2.4.6"
 val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.6.0-RC2") // sync with documentation/project/plugins.sbt
-val interplay: String  = sys.props.getOrElse("interplay.version", "3.1.0-RC12")
+val interplay: String  = sys.props.getOrElse("interplay.version", "3.1.0-RC13")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackager,

--- a/transport/server/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
@@ -5,6 +5,7 @@
 package play.core.server.ssl
 
 import java.io.File
+import java.nio.file.Files
 import java.util.Properties
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngine
@@ -50,7 +51,7 @@ class ServerSSLEngineSpec extends Specification {
   trait ApplicationContext extends Mockito with Scope with MustThrownExpectations {}
 
   trait TempConfDir extends After {
-    val tempDir: File = File.createTempFile("ServerSSLEngine", ".tmp")
+    val tempDir: File = Files.createTempFile("ServerSSLEngine", ".tmp").toFile
     tempDir.delete()
     val confDir = new File(tempDir, "conf")
     confDir.mkdirs()


### PR DESCRIPTION
Plus, after reading https://github.com/sbt/sbt/releases/tag/v1.8.3, prefer `java.nio.file.Files.createTempFile`, however that does not really matter for Play since only tests use `File.createTempFile` currently. But I changed it anyway because of best practice...