### PR TITLE
Upgrade sbt-web and sbt-js-engine

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -238,8 +238,8 @@ object Dependencies {
       playFileWatch,
       sbtDep("com.typesafe.play" % "sbt-twirl"           % BuildInfo.sbtTwirlVersion),
       sbtDep("com.github.sbt"    % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
-      sbtDep("com.typesafe.sbt"  % "sbt-web"             % "1.4.4"),
-      sbtDep("com.typesafe.sbt"  % "sbt-js-engine"       % "1.2.3"),
+      sbtDep("com.github.sbt"    % "sbt-web"             % "1.5.0-M1"),
+      sbtDep("com.github.sbt"    % "sbt-js-engine"       % "1.3.0-M3"),
       logback % Test
     ) ++ specs2Deps.map(_ % Test) ++ scalaReflect(scalaVersion)
   }


### PR DESCRIPTION
So, I have been busy hacking on

* [sbt-web PRs](https://github.com/sbt/sbt-web/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+updated%3A%3E%3D2023-05-01+)
* [sbt-web-build-base PRs](https://github.com/sbt/sbt-web-build-base/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+updated%3A%3E%3D2023-05-01+)
* [sbt-js-engine PRs](https://github.com/sbt/sbt-js-engine/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+updated%3A%3E%3D2023-05-01+)

Summary:
* Thanks to jroper, sbt-web removed it's dependency on akka (https://github.com/sbt/sbt-web/pull/169) which simplifies the the project and the other projects ([specially the sbt-js-engine one](https://github.com/sbt/sbt-js-engine/pull/66)) quite a lot. Also it fixes a [memory leak.](https://github.com/sbt/sbt-web/issues/170).
* The [npm](https://github.com/typesafehub/npm) and [js-engine](https://github.com/typesafehub/js-engine) project were folded into sbt-js-engine.
* Closed/Fixed quite some bugs/feature requests, specially for sbt-js-engine ([link](https://github.com/sbt/sbt-js-engine/issues?q=sort%3Aupdated-desc+is%3Aclosed+updated%3A%3E%3D2023-05-01+))
* Dropped sbt 0.13.x
* Everything is build now with sbt 1.9.0(-RC3), meaning the plugins are cross build for that version now, so that will be the minimium requirement now.
* Migrated everything from Travis to GitHub actions + sbt-cli-release
* The `groupId` changed
* maybe more?

Anyway, I published milestone releases to make use of them. Actually I am very confident they can be release as final soon.
I upgrades some sbt-web plugins locally and they pretty much worked, no show stoppers.