### PR TITLE
New sbt-js-engine milestone

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -238,7 +238,7 @@ object Dependencies {
       sbtDep("com.typesafe.play" % "sbt-twirl"           % BuildInfo.sbtTwirlVersion),
       sbtDep("com.github.sbt"    % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
       sbtDep("com.github.sbt"    % "sbt-web"             % "1.5.0-M1"),
-      sbtDep("com.github.sbt"    % "sbt-js-engine"       % "1.3.0-M3"),
+      sbtDep("com.github.sbt"    % "sbt-js-engine"       % "1.3.0-M4"),
       logback % Test
     ) ++ specs2Deps.map(_ % Test) ++ scalaReflect(scalaVersion)
   }


### PR DESCRIPTION
Fixes incompatibility I experienced when working with the play-samples with a project that uses sbt-rjs