### PR TITLE
Support trailing newline in SSR

### DIFF
--- a/core/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/core/play/src/main/scala/play/api/libs/EventSource.scala
@@ -72,7 +72,7 @@ object EventSource {
       val sb = new StringBuilder
       name.foreach(sb.append("event: ").append(_).append('\n'))
       id.foreach(sb.append("id: ").append(_).append('\n'))
-      for (line <- data.split("(\r?\n)|\r")) {
+      for (line <- data.split("(\r?\n)|\r", -1)) {
         sb.append("data: ").append(line).append('\n')
       }
       sb.append('\n')

--- a/core/play/src/test/scala/play/api/libs/EventSourceSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/EventSourceSpec.scala
@@ -36,6 +36,10 @@ class EventSourceSpec extends Specification {
     "support '\\r\\n' as an end of line" in {
       Event("a\r\nb").formatted must equalTo("data: a\ndata: b\n\n")
     }
+
+    "support trailing newline" in {
+      Event("a\n").formatted must equalTo("data: a\ndata: \n\n")
+    }
   }
 
   "EventSource.Event" should {


### PR DESCRIPTION
Fixes #11834 

I passed -1 to split in the formatted of the Event object to keep the trailing newline.