### PR TITLE
Make it easy to identify the cookie in which the error occurred

### DIFF
--- a/core/play/src/main/java/play/core/cookie/encoding/CookieEncoder.java
+++ b/core/play/src/main/java/play/core/cookie/encoding/CookieEncoder.java
@@ -32,18 +32,18 @@ abstract class CookieEncoder {
 
       if ((pos = firstInvalidCookieNameOctet(name)) >= 0) {
         throw new IllegalArgumentException(
-            "Cookie name contains an invalid char: " + name.charAt(pos));
+            "Cookie (" + name + ") contains an invalid char: " + name.charAt(pos));
       }
 
       CharSequence unwrappedValue = unwrapValue(value);
       if (unwrappedValue == null) {
         throw new IllegalArgumentException(
-            "Cookie value wrapping quotes are not balanced: " + value);
+            "Cookie (" + name + ") value wrapping quotes are not balanced: " + value);
       }
 
       if ((pos = firstInvalidCookieValueOctet(unwrappedValue)) >= 0) {
         throw new IllegalArgumentException(
-            "Cookie value contains an invalid char: " + value.charAt(pos));
+            "Cookie (" + name + ") value contains an invalid char: " + value.charAt(pos));
       }
     }
   }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Play Framework raises an exception when cookie strict mode is enabled.
When an exception occurs, there is no way to know by exception which cookie it occurred on.
Include the name of the cookie in the exception to quickly grab the source.

## Background Context

Other class that handles a cookie include the cookie name.
https://github.com/playframework/playframework/blob/2.8.19/core/play/src/main/java/play/core/cookie/encoding/CookieUtil.java#L172-L173

## References

https://discuss.lightbend.com/t/setting-cookie-in-response/3949
