### PR TITLE
[2.8.x] scala-xml 1.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,12 @@ lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
   .settings(
     libraryDependencies ++= runtime(scalaVersion.value) ++ scalacheckDependencies ++ cookieEncodingDependencies :+
       jimfs % Test,
+    // Among other things, scala-xml is used for body parsers. Play never explicitly depended on scala-xml, but it was pulled in by SbtTwirl (via twirl-api).
+    // In scala-xml 1.3.1+ an issue was fixed which could have caused body parsers to overflow the stack. Therefore we finally make Play depend on scala-xml.
+    // In theory we could have made twirl 1.5.x depend on that scala-xml version, however in practise this causes problems, since twirl is also published for scala-js 0.6.x,
+    // but scala-xml 1.3.1 is not published for scala-js 0.6.x anymore (1.3.0 still was). To avoid any bad side effects (and since publishing twirl 1.5.x is a bit of a pain), we keep twirl 1.5.1
+    // untouched. Users who want to use twirl standalone should just upgrade to 1.6.0, which depends on latest scala-xml 2.x (which includes the fix as well).
+    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.3.1",
     unmanagedSourceDirectories in Compile ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, v)) if v >= 13 => (sourceDirectory in Compile).value / s"java-scala-2.13+" :: Nil

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -288,7 +288,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.1.10"
+  val playWsStandaloneVersion = "2.1.11"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone"      % playWsStandaloneVersion,
     "com.typesafe.play" %% "play-ws-standalone-xml"  % playWsStandaloneVersion,


### PR DESCRIPTION
* https://github.com/scala/scala-xml/releases/tag/v1.3.1
* https://github.com/scala/scala-xml/pull/677

Avoids `StackOverflowError` in Play body parsers.

Made a lengthy comment with explanation.