### PR TITLE
Make Play compatible with akka 2.8+ / akka-http 10.5+ when using Scala 3

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -117,21 +117,26 @@ object PlayAkkaHttpServer extends AutoPlugin {
     "com.fasterxml.jackson.module" -> (PlayVersion.jacksonVersion, Seq("jackson-module-scala"))
   )
 
-  private def usingAkka26Scala3(scalaVersion: String, deps: Seq[ModuleID]): Boolean = {
-    scalaVersion == "3" &&
-    deps.exists(m => m.organization == "com.typesafe.akka" && m.name == "akka-actor" && m.revision.startsWith("2.6."))
-  }
-
-  override def projectSettings = Seq(
+  override def projectSettings = Def.settings(
     libraryDependencies += PlayImport.akkaHttpServer,
+    PlaySettings.akkaHttpSettings,
     excludeDependencies ++=
-      (if (usingAkka26Scala3(scalaBinaryVersion.value, libraryDependencies.value)) {
-         scala2Deps.flatMap(e => e._2._2.map(_ + "_3").map(ExclusionRule(e._1, _))).toSeq
+      (if (scalaBinaryVersion.value == "3") {
+         if (PlayKeys.akkaHttpScala3Artifacts.value) {
+           // The user upgraded to akka-http 10.5+, which provides Scala 3 artifacts. We need to exclude the akka-http Scala 2.13 artifacts that Play
+           // depends on per default (since akka-http 10.2.x did not yet have Scala 3 artifacts), see Dependencies.scala (".cross(CrossVersion.for3Use2_13)")
+           Seq(ExclusionRule("com.typesafe.akka", "akka-http-core_2.13"))
+         } else {
+           // The user project switched to Scala 3, but did not upgrade akka-http beyond 10.2.x, which does not ship Scala 3 artifacts,
+           // therefore we need to make some dependencies keep using Scala 2 artifacts to make them work well with the akka-http 10.2.x Scala 2 artifacts
+           scala2Deps.flatMap(e => e._2._2.map(_ + "_3").map(ExclusionRule(e._1, _))).toSeq
+         }
        } else {
          Seq.empty
        }),
     libraryDependencies ++=
-      (if (usingAkka26Scala3(scalaBinaryVersion.value, libraryDependencies.value)) {
+      (if (scalaBinaryVersion.value == "3" && !PlayKeys.akkaHttpScala3Artifacts.value) {
+         // see comment above
          scala2Deps.flatMap(e => e._2._2.map(e._1 %% _ % e._2._1).map(_.cross(CrossVersion.for3Use2_13))).toSeq
        } else {
          Seq.empty
@@ -142,7 +147,15 @@ object PlayAkkaHttpServer extends AutoPlugin {
 
 object PlayAkkaHttp2Support extends AutoPlugin {
   override def requires = PlayAkkaHttpServer
-  override def projectSettings = Seq(
+  override def projectSettings = Def.settings(
     libraryDependencies += "com.typesafe.play" %% "play-akka-http2-support" % PlayVersion.current,
+    excludeDependencies ++=
+      (if (scalaBinaryVersion.value == "3" && PlayKeys.akkaHttpScala3Artifacts.value) {
+         // The user upgraded to akka-http 10.5+, which provides Scala 3 artifacts. We need to exclude the akka-http Scala 2.13 artifacts that Play
+         // depends on per default (since akka-http 10.2.x did not yet have Scala 3 artifacts), see Dependencies.scala (".cross(CrossVersion.for3Use2_13)")
+         Seq(ExclusionRule("com.typesafe.akka", "akka-http2-support_2.13"))
+       } else {
+         Seq.empty
+       }),
   )
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -117,16 +117,21 @@ object PlayAkkaHttpServer extends AutoPlugin {
     "com.fasterxml.jackson.module" -> (PlayVersion.jacksonVersion, Seq("jackson-module-scala"))
   )
 
+  private def usingAkka26Scala3(scalaVersion: String, deps: Seq[ModuleID]): Boolean = {
+    scalaVersion == "3" &&
+    deps.exists(m => m.organization == "com.typesafe.akka" && m.name == "akka-actor" && m.revision.startsWith("2.6."))
+  }
+
   override def projectSettings = Seq(
     libraryDependencies += PlayImport.akkaHttpServer,
     excludeDependencies ++=
-      (if (scalaBinaryVersion.value == "3") {
+      (if (usingAkka26Scala3(scalaBinaryVersion.value, libraryDependencies.value)) {
          scala2Deps.flatMap(e => e._2._2.map(_ + "_3").map(ExclusionRule(e._1, _))).toSeq
        } else {
          Seq.empty
        }),
     libraryDependencies ++=
-      (if (scalaBinaryVersion.value == "3") {
+      (if (usingAkka26Scala3(scalaBinaryVersion.value, libraryDependencies.value)) {
          scala2Deps.flatMap(e => e._2._2.map(e._1 %% _ % e._2._1).map(_.cross(CrossVersion.for3Use2_13))).toSeq
        } else {
          Seq.empty

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -129,5 +129,10 @@ object PlayImport {
 
     val includeDocumentationInBinary =
       SettingKey[Boolean]("includeDocumentationInBinary", "Includes the Documentation inside the distribution binary.")
+
+    val akkaHttpScala3Artifacts = SettingKey[Boolean](
+      "akkaHttpScala3Artifacts",
+      "Needs to be set to true to use Akka HTTP Scala 3 artifacts (available since Akka HTTP 10.5.0)"
+    )
   }
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -266,6 +266,10 @@ object PlaySettings {
     Test / fullClasspath += Attributed.blank((TestAssets / assets).value.getParentFile)
   )
 
+  lazy val akkaHttpSettings = Seq[Setting[_]](
+    akkaHttpScala3Artifacts := false // Play ships with Akka HTTP 10.2.x which does not provide Scala 3 artifacts yet
+  )
+
   /**
    * Settings for creating a jar that excludes externalized resources
    */

--- a/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
+++ b/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
@@ -139,9 +139,19 @@ If you want to use a newer version of Akka, one that is not used by Play yet, yo
 
 Of course, other Akka artifacts can be added transitively. Use [sbt-dependency-graph](https://github.com/jrudolph/sbt-dependency-graph) to better inspect your build and check which ones you need to add explicitly.
 
-If you also want to update Akka HTTP, you should also add its dependencies explicitly:
+If you haven't switched to the Netty server backend and therefore are using Play's default Akka HTTP server backend, you also have to update Akka HTTP. Therefore, you need to add its dependencies explicitly as well:
 
 @[akka-http-update](code/javaguide.akkaupdate.sbt)
+
+### Using akka 2.8+ and akka-http 10.5+ with Scala 3
+
+Starting with akka version 2.7.0 and akka-http version 10.4.0, those libraries are published under the  [Business Source License (BSL) v1.1](https://doc.akka.io/docs/akka/current/project/licenses.html). This means that when using these akka/akka-http versions (or newer), your company might need to pay license fees. For more details, refer to the [Akka License FAQ](https://www.lightbend.com/akka/license-faq).
+Play does not ship with those newer versions but instead, it defaults to using akka 2.6 and akka-http 10.2.x. You are free to upgrade to the newer commercial versions, as described in the previous section. However, if you choose to do so, you will need to exclude the akka-http Scala 2.13 artifacts that Play depends on by default when using Scala 3:
+
+@[akka-exclude-213artifacts](code/javaguide.akkaupdate.sbt)
+
+FYI: Play depends on that Scala 2.13 akka-http artifacts by default even when using Scala 3 (via the `for3Use2_13` cross version workaround) because akka-http 10.2.x does not have Scala 3 artifacts published. 
+
 
 > **Note:** When doing such updates, keep in mind that you need to follow Akka's [Binary Compatibility Rules](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html). And if you are manually adding other Akka artifacts, remember to keep the version of all the Akka artifacts consistent since [mixed versioning is not allowed](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed).
 

--- a/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
+++ b/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
@@ -143,15 +143,14 @@ If you haven't switched to the Netty server backend and therefore are using Play
 
 @[akka-http-update](code/javaguide.akkaupdate.sbt)
 
-### Using akka 2.8+ and akka-http 10.5+ with Scala 3
+### Important note on using Akka HTTP 10.5.0 or newer with Scala 3
 
-Starting with akka version 2.7.0 and akka-http version 10.4.0, those libraries are published under the  [Business Source License (BSL) v1.1](https://doc.akka.io/docs/akka/current/project/licenses.html). This means that when using these akka/akka-http versions (or newer), your company might need to pay license fees. For more details, refer to the [Akka License FAQ](https://www.lightbend.com/akka/license-faq).
-Play does not ship with those newer versions but instead, it defaults to using akka 2.6 and akka-http 10.2.x. You are free to upgrade to the newer commercial versions, as described in the previous section. However, if you choose to do so, you will need to exclude the akka-http Scala 2.13 artifacts that Play depends on by default when using Scala 3:
+Starting with Akka version [2.7.0](https://github.com/akka/akka/pull/31561) and Akka HTTP version [10.4.0](https://doc.akka.io/docs/akka-http/current/release-notes/10.4.x.html#10-4-0), those libraries are published under the  [Business Source License (BSL) v1.1](https://doc.akka.io/docs/akka/current/project/licenses.html). This means that when using these Akka or Akka HTTP versions (or newer), your company might need to pay license fees. For more details, refer to the [Akka License FAQ](https://www.lightbend.com/akka/license-faq). On another note, starting with Akka HTTP version 10.5.0 [native Scala 3 artifacts get published](https://github.com/akka/akka-http/releases/tag/v10.5.0).
+Play does not ship with those newer versions, but instead it defaults to using Akka 2.6 and Akka HTTP 10.2.x. You are free to upgrade to the newer commercial versions, as described in the previous section.  However, if you choose to do so and want to use Scala 3, you need to set `akkaHttpScala3Artifacts := true`  to exclude any Akka HTTP Scala 2.13 artifacts that Play depends on by default:
 
 @[akka-exclude-213artifacts](code/javaguide.akkaupdate.sbt)
 
-FYI: Play depends on that Scala 2.13 akka-http artifacts by default even when using Scala 3 (via the `for3Use2_13` cross version workaround) because akka-http 10.2.x does not have Scala 3 artifacts published. 
-
+This is necessary because Play uses the `for3Use2_13` cross version [workaround](https://www.scala-lang.org/blog/2021/04/08/scala-3-in-sbt.html#using-scala-213-libraries-in-scala-3) to make Akka HTTP 10.2.x work with Scala 3. The above setting disables this behaviour to make sure there are no Akka HTTP Scala 2 artifacts on the classpath (which very likely will conflict with the Akka HTTP Scala 3 artifacts you upgrade to).
 
 > **Note:** When doing such updates, keep in mind that you need to follow Akka's [Binary Compatibility Rules](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html). And if you are manually adding other Akka artifacts, remember to keep the version of all the Akka artifacts consistent since [mixed versioning is not allowed](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed).
 

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide.akkaupdate.sbt
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide.akkaupdate.sbt
@@ -2,13 +2,15 @@
 
 //#akka-update
 // The newer Akka version you want to use.
-val akkaVersion = "2.5.16"
+val akkaVersion = "2.6.21"
 
 // Akka dependencies used by Play
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor"  % akkaVersion,
+  "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
   "com.typesafe.akka" %% "akka-slf4j"  % akkaVersion,
+  "com.typesafe.akka" %% "akka-serialization-jackson"  % akkaVersion,
   // Only if you are using Akka Testkit
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion
 )
@@ -16,7 +18,7 @@ libraryDependencies ++= Seq(
 
 //#akka-http-update
 // The newer Akka HTTP version you want to use.
-val akkaHTTPVersion = "10.1.4"
+val akkaHTTPVersion = "10.2.10"
 
 // Akka HTTP dependencies used by Play
 libraryDependencies ++= Seq(
@@ -25,3 +27,17 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http2-support" % akkaHTTPVersion
 )
 //#akka-http-update
+
+//#akka-exclude-213artifacts
+// ...
+// scalaVersion := "3.x.x" // When using Scala 3 you need belows excludes
+// ...
+
+// If using Scala 3 and latest (commercial) akka-http version 10.5.x
+// or newer you have to exclude the akka-http Scala 2.13 artifacts
+// Play ships with by default:
+excludeDependencies ++= Seq(
+  "com.typesafe.akka" % "akka-http-core_2.13",
+  "com.typesafe.akka" % "akka-http2-support_2.13"
+)
+//#akka-exclude-213artifacts

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide.akkaupdate.sbt
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide.akkaupdate.sbt
@@ -24,20 +24,17 @@ val akkaHTTPVersion = "10.2.10"
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-core" % akkaHTTPVersion,
   // Add this one if you are using HTTP/2
+  // (e.g. with enabled PlayAkkaHttp2Support sbt plugin in build.sbt)
   "com.typesafe.akka" %% "akka-http2-support" % akkaHTTPVersion
 )
 //#akka-http-update
 
 //#akka-exclude-213artifacts
 // ...
-// scalaVersion := "3.x.x" // When using Scala 3 you need belows excludes
+// scalaVersion := "3.x.x" // When using Scala 3...
 // ...
 
-// If using Scala 3 and latest (commercial) akka-http version 10.5.x
-// or newer you have to exclude the akka-http Scala 2.13 artifacts
-// Play ships with by default:
-excludeDependencies ++= Seq(
-  "com.typesafe.akka" % "akka-http-core_2.13",
-  "com.typesafe.akka" % "akka-http2-support_2.13"
-)
+// ...and if using Akka HTTP version 10.5.x or newer
+// you need to set following setting in your build.sbt file:
+PlayKeys.akkaHttpScala3Artifacts := true
 //#akka-exclude-213artifacts

--- a/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
@@ -141,15 +141,14 @@ If you haven't switched to the Netty server backend and therefore are using Play
 
 @[akka-http-update](code/scalaguide.akkaupdate.sbt)
 
-### Using akka 2.8+ and akka-http 10.5+ with Scala 3
+### Important note on using Akka HTTP 10.5.0 or newer with Scala 3
 
-Starting with akka version 2.7.0 and akka-http version 10.4.0, those libraries are published under the  [Business Source License (BSL) v1.1](https://doc.akka.io/docs/akka/current/project/licenses.html). This means that when using these akka/akka-http versions (or newer), your company might need to pay license fees. For more details, refer to the [Akka License FAQ](https://www.lightbend.com/akka/license-faq).
-Play does not ship with those newer versions but instead, it defaults to using akka 2.6 and akka-http 10.2.x. You are free to upgrade to the newer commercial versions, as described in the previous section. However, if you choose to do so, you will need to exclude the akka-http Scala 2.13 artifacts that Play depends on by default when using Scala 3:
+Starting with Akka version [2.7.0](https://github.com/akka/akka/pull/31561) and Akka HTTP version [10.4.0](https://doc.akka.io/docs/akka-http/current/release-notes/10.4.x.html#10-4-0), those libraries are published under the  [Business Source License (BSL) v1.1](https://doc.akka.io/docs/akka/current/project/licenses.html). This means that when using these Akka or Akka HTTP versions (or newer), your company might need to pay license fees. For more details, refer to the [Akka License FAQ](https://www.lightbend.com/akka/license-faq). On another note, starting with Akka HTTP version 10.5.0 [native Scala 3 artifacts get published](https://github.com/akka/akka-http/releases/tag/v10.5.0).
+Play does not ship with those newer versions, but instead it defaults to using Akka 2.6 and Akka HTTP 10.2.x. You are free to upgrade to the newer commercial versions, as described in the previous section.  However, if you choose to do so and want to use Scala 3, you need to set `akkaHttpScala3Artifacts := true`  to exclude any Akka HTTP Scala 2.13 artifacts that Play depends on by default:
 
 @[akka-exclude-213artifacts](code/scalaguide.akkaupdate.sbt)
 
-FYI: Play depends on that Scala 2.13 akka-http artifacts by default even when using Scala 3 (via the `for3Use2_13` cross version workaround) because akka-http 10.2.x does not have Scala 3 artifacts published. 
-
+This is necessary because Play uses the `for3Use2_13` cross version [workaround](https://www.scala-lang.org/blog/2021/04/08/scala-3-in-sbt.html#using-scala-213-libraries-in-scala-3) to make Akka HTTP 10.2.x work with Scala 3. The above setting disables this behaviour to make sure there are no Akka HTTP Scala 2 artifacts on the classpath (which very likely will conflict with the Akka HTTP Scala 3 artifacts you upgrade to).
 
 > **Note:** When doing such updates, keep in mind that you need to follow Akka's [Binary Compatibility Rules](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html). And if you are manually adding other Akka artifacts, remember to keep the version of all the Akka artifacts consistent since [mixed versioning is not allowed](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed).
 

--- a/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
@@ -137,9 +137,19 @@ If you want to use a newer version of Akka, one that is not used by Play yet, yo
 
 Of course, other Akka artifacts can be added transitively. Use [sbt-dependency-graph](https://github.com/jrudolph/sbt-dependency-graph) to better inspect your build and check which ones you need to add explicitly.
 
-If you also want to update Akka HTTP, you should also add its dependencies explicitly:
+If you haven't switched to the Netty server backend and therefore are using Play's default Akka HTTP server backend, you also have to update Akka HTTP. Therefore, you need to add its dependencies explicitly as well:
 
 @[akka-http-update](code/scalaguide.akkaupdate.sbt)
+
+### Using akka 2.8+ and akka-http 10.5+ with Scala 3
+
+Starting with akka version 2.7.0 and akka-http version 10.4.0, those libraries are published under the  [Business Source License (BSL) v1.1](https://doc.akka.io/docs/akka/current/project/licenses.html). This means that when using these akka/akka-http versions (or newer), your company might need to pay license fees. For more details, refer to the [Akka License FAQ](https://www.lightbend.com/akka/license-faq).
+Play does not ship with those newer versions but instead, it defaults to using akka 2.6 and akka-http 10.2.x. You are free to upgrade to the newer commercial versions, as described in the previous section. However, if you choose to do so, you will need to exclude the akka-http Scala 2.13 artifacts that Play depends on by default when using Scala 3:
+
+@[akka-exclude-213artifacts](code/scalaguide.akkaupdate.sbt)
+
+FYI: Play depends on that Scala 2.13 akka-http artifacts by default even when using Scala 3 (via the `for3Use2_13` cross version workaround) because akka-http 10.2.x does not have Scala 3 artifacts published. 
+
 
 > **Note:** When doing such updates, keep in mind that you need to follow Akka's [Binary Compatibility Rules](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html). And if you are manually adding other Akka artifacts, remember to keep the version of all the Akka artifacts consistent since [mixed versioning is not allowed](https://doc.akka.io/docs/akka/2.6/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed).
 

--- a/documentation/manual/working/scalaGuide/main/akka/code/scalaguide.akkaupdate.sbt
+++ b/documentation/manual/working/scalaGuide/main/akka/code/scalaguide.akkaupdate.sbt
@@ -2,13 +2,15 @@
 
 //#akka-update
 // The newer Akka version you want to use.
-val akkaVersion = "2.5.16"
+val akkaVersion = "2.6.21"
 
 // Akka dependencies used by Play
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor"  % akkaVersion,
+  "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
   "com.typesafe.akka" %% "akka-slf4j"  % akkaVersion,
+  "com.typesafe.akka" %% "akka-serialization-jackson"  % akkaVersion,
   // Only if you are using Akka Testkit
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion
 )
@@ -16,7 +18,7 @@ libraryDependencies ++= Seq(
 
 //#akka-http-update
 // The newer Akka HTTP version you want to use.
-val akkaHTTPVersion = "10.1.4"
+val akkaHTTPVersion = "10.2.10"
 
 // Akka HTTP dependencies used by Play
 libraryDependencies ++= Seq(
@@ -25,3 +27,17 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http2-support" % akkaHTTPVersion
 )
 //#akka-http-update
+
+//#akka-exclude-213artifacts
+// ...
+// scalaVersion := "3.x.x" // When using Scala 3 you need belows excludes
+// ...
+
+// If using Scala 3 and latest (commercial) akka-http version 10.5.x
+// or newer you have to exclude the akka-http Scala 2.13 artifacts
+// Play ships with by default:
+excludeDependencies ++= Seq(
+  "com.typesafe.akka" % "akka-http-core_2.13",
+  "com.typesafe.akka" % "akka-http2-support_2.13"
+)
+//#akka-exclude-213artifacts

--- a/documentation/manual/working/scalaGuide/main/akka/code/scalaguide.akkaupdate.sbt
+++ b/documentation/manual/working/scalaGuide/main/akka/code/scalaguide.akkaupdate.sbt
@@ -24,20 +24,17 @@ val akkaHTTPVersion = "10.2.10"
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-core" % akkaHTTPVersion,
   // Add this one if you are using HTTP/2
+  // (e.g. with enabled PlayAkkaHttp2Support sbt plugin in build.sbt)
   "com.typesafe.akka" %% "akka-http2-support" % akkaHTTPVersion
 )
 //#akka-http-update
 
 //#akka-exclude-213artifacts
 // ...
-// scalaVersion := "3.x.x" // When using Scala 3 you need belows excludes
+// scalaVersion := "3.x.x" // When using Scala 3...
 // ...
 
-// If using Scala 3 and latest (commercial) akka-http version 10.5.x
-// or newer you have to exclude the akka-http Scala 2.13 artifacts
-// Play ships with by default:
-excludeDependencies ++= Seq(
-  "com.typesafe.akka" % "akka-http-core_2.13",
-  "com.typesafe.akka" % "akka-http2-support_2.13"
-)
+// ...and if using Akka HTTP version 10.5.x or newer
+// you need to set following setting in your build.sbt file:
+PlayKeys.akkaHttpScala3Artifacts := true
 //#akka-exclude-213artifacts


### PR DESCRIPTION
We don't ship with those versions, but people a are free to upgrade akka/akka-http themselves.
~This PR makes sure that when using the default `PlayAkkaHttpServer` plugin detect the usage of Scala 3 and akka 2.8+ to avoid applying any workarounds that are needed for akka-http 10.2.x (since this version does not ship Scala 3 artifacts)~
Detection is not reliable possible, so I introduced `PlayKeys.akkaHttpScala3Artifacts`.