### PR TITLE
Fix missed ContextInitializer#configureByResource

### DIFF
--- a/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -9,9 +9,11 @@ import java.net.URI
 import java.net.URL
 
 import ch.qos.logback.classic._
+import ch.qos.logback.classic.joran.JoranConfigurator
 import ch.qos.logback.classic.jul.LevelChangePropagator
 import ch.qos.logback.classic.util.ContextInitializer
 import ch.qos.logback.core.util._
+import ch.qos.logback.core.LogbackException
 import org.slf4j.bridge._
 import org.slf4j.ILoggerFactory
 import org.slf4j.LoggerFactory
@@ -122,13 +124,23 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
 
       config match {
         case Some(url) =>
-          val initializer = new ContextInitializer(ctx)
-          initializer.configureByResource(url)
+          configureByResource(ctx, url)
         case None =>
           System.err.println("Could not detect a logback configuration file, not configuring logback")
       }
 
       StatusPrinter.printIfErrorsOccured(ctx)
+    }
+  }
+
+  private def configureByResource(ctx: LoggerContext, url: URL): Unit = {
+    val urlString = url.toString
+    if (urlString.endsWith("xml")) {
+      val configurator = new JoranConfigurator()
+      configurator.setContext(ctx)
+      configurator.doConfigure(url)
+    } else {
+      throw new LogbackException("Unexpected filename extension of file [" + url + "]. Should be .xml")
     }
   }
 

--- a/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -133,6 +133,10 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
     }
   }
 
+  /**
+   * Copied from https://github.com/qos-ch/logback/commit/4b06e062488e4cb87f22be6ae96e4d7d6350ed6b
+   * See #11907
+   */
   private def configureByResource(ctx: LoggerContext, url: URL): Unit = {
     val urlString = url.toString
     if (urlString.endsWith("xml")) {

--- a/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/core/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -9,11 +9,10 @@ import java.net.URI
 import java.net.URL
 
 import ch.qos.logback.classic._
-import ch.qos.logback.classic.joran.JoranConfigurator
 import ch.qos.logback.classic.jul.LevelChangePropagator
 import ch.qos.logback.classic.util.ContextInitializer
+import ch.qos.logback.classic.util.DefaultJoranConfigurator
 import ch.qos.logback.core.util._
-import ch.qos.logback.core.LogbackException
 import org.slf4j.bridge._
 import org.slf4j.ILoggerFactory
 import org.slf4j.LoggerFactory
@@ -124,27 +123,14 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
 
       config match {
         case Some(url) =>
-          configureByResource(ctx, url)
+          val joranConfigurator = new DefaultJoranConfigurator()
+          joranConfigurator.setContext(ctx)
+          joranConfigurator.configureByResource(url)
         case None =>
           System.err.println("Could not detect a logback configuration file, not configuring logback")
       }
 
       StatusPrinter.printIfErrorsOccured(ctx)
-    }
-  }
-
-  /**
-   * Copied from https://github.com/qos-ch/logback/commit/4b06e062488e4cb87f22be6ae96e4d7d6350ed6b
-   * See #11907
-   */
-  private def configureByResource(ctx: LoggerContext, url: URL): Unit = {
-    val urlString = url.toString
-    if (urlString.endsWith("xml")) {
-      val configurator = new JoranConfigurator()
-      configurator.setContext(ctx)
-      configurator.doConfigure(url)
-    } else {
-      throw new LogbackException("Unexpected filename extension of file [" + url + "]. Should be .xml")
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   val playJsonVersion = "2.10.0-RC9"
 
-  val logback = "ch.qos.logback" % "logback-classic" % "1.4.8"
+  val logback = "ch.qos.logback" % "logback-classic" % "1.4.9"
 
   val specs2Version = "4.20.0"
   val specs2Deps = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   val playJsonVersion = "2.10.0-RC9"
 
-  val logback = "ch.qos.logback" % "logback-classic" % "1.4.9"
+  val logback = "ch.qos.logback" % "logback-classic" % "1.4.11"
 
   val specs2Version = "4.20.0"
   val specs2Deps = Seq(


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #11907

## Purpose

Library users can update their Logback libraries to the latest version by porting ContextInitializer#configureByResource, which was removed in Logback 1.4.9 and 1.3.9.

## Background Context

As noted in the referenced issue, this is due to the fact that Logback has removed the deprecated method.

## References

Nothing
