### PR TITLE
Introduce `play.evolutions[.db.default].path`, allows custom evolutions location

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/app/controllers/HomeController.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/app/controllers/HomeController.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.db.Database
+import play.api.mvc._
+
+@Singleton
+class HomeController @Inject()(val controllerComponents: ControllerComponents, val database: Database) extends BaseController {
+
+  def index() = Action { implicit request: Request[AnyContent] =>
+    val value = database.withConnection(connection => {
+      val rs = connection
+        .prepareStatement("select * from table1")
+        .executeQuery()
+      rs.next()
+      rs.getString(1)
+    })
+    Ok(value)
+  }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/build.sbt
@@ -1,0 +1,33 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+lazy val root = (project in file("."))
+  //.enablePlugins(PlayScala)
+  .settings(
+    name := "evolutions-path-config",
+    scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
+    updateOptions := updateOptions.value.withLatestSnapshots(false),
+    update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),
+    PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
+    libraryDependencies ++= Seq(
+      guice,
+      jdbc,
+      evolutions,
+      "com.h2database" % "h2" % "2.2.220",
+    )
+  )
+
+lazy val itTests = (project in file("integration-tests"))
+  .enablePlugins(PlayScala)
+  .dependsOn(root)
+  .settings(
+    name := "evolutions-path-config-integration-tests",
+    scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
+    updateOptions := updateOptions.value.withLatestSnapshots(false),
+    update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),
+    PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
+    publish / skip := true,
+    // test dependencies
+    libraryDependencies ++= Seq(
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M6" % Test
+    )
+  )

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/conf/application.conf
@@ -1,0 +1,2 @@
+db.default.url="jdbc:h2:mem:play;MODE=MYSQL"
+db.default.driver=org.h2.Driver

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/conf/evolutions/default/1.sql
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/conf/evolutions/default/1.sql
@@ -1,0 +1,11 @@
+-- !Ups
+
+CREATE TABLE table1 (
+    column1 VARCHAR
+);
+
+INSERT INTO table1(column1) VALUES('hello');
+
+-- !Downs
+
+DROP TABLE table1;

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/conf/routes
@@ -1,0 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+GET     /                           controllers.HomeController.index()

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/integration-tests/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/integration-tests/conf/application.conf
@@ -1,0 +1,4 @@
+db.default.url="jdbc:h2:mem:play;MODE=MYSQL"
+db.default.driver=org.h2.Driver
+
+play.evolutions.db.default.path = ../conf/evolutions/

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/integration-tests/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/integration-tests/project/plugins.sbt
@@ -1,0 +1,5 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+updateOptions                   := updateOptions.value.withLatestSnapshots(false)
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-scripted-tools" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/integration-tests/test/controllers/HomeControllerSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/integration-tests/test/controllers/HomeControllerSpec.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers
+
+import org.scalatestplus.play._
+import org.scalatestplus.play.guice._
+import play.api.db.Database
+import play.api.test._
+
+class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
+
+  "access the database which requires evolutions to run" in {
+    val database = inject[Database]
+    val value = database.withConnection(connection => {
+      val rs = connection
+        .prepareStatement("select * from table1")
+        .executeQuery()
+      rs.next() mustBe true
+      rs.getString(1)
+    })
+    value mustBe "hello"
+  }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/project/plugins.sbt
@@ -1,0 +1,5 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+updateOptions                   := updateOptions.value.withLatestSnapshots(false)
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-scripted-tools" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolution-path-config/test
@@ -1,0 +1,1 @@
+> itTests/test

--- a/documentation/manual/releases/release29/Highlights29.md
+++ b/documentation/manual/releases/release29/Highlights29.md
@@ -10,6 +10,10 @@ TBA
 
 ## Other additions
 
+### The location of the evolution scripts can now be configured
+
+Using the new `play.evolutions[.db.default].path` config it is now possible the store evolution scripts in a custom location within a Play project or even outside the project's root folder by referencing the location with an absolute or relative path. All details can be found in the [[Evolutions documentation|Evolutions#Location-of-the-evolution-scripts]].
+
 ### Variable substitution in evolutions scripts
 
 You can now define placeholders in your evolutions scripts which will be replaced with their substitutions, defined in `application.conf`:

--- a/documentation/manual/working/javaGuide/main/tests/JavaTestingWithDatabases.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTestingWithDatabases.md
@@ -78,6 +78,10 @@ Sometimes it will be impractical to put your custom evolution scripts in code.  
 
 This will load evolutions, in the same structure and format as is done for development and production, from `testdatabase/evolutions/<databasename>/<n>.sql`.
 
+If you store evolution scripts outside your project folder, you can use the [`EnvironmentEvolutionsReader`](api/scala/play/api/db/evolutions/EnvironmentEvolutionsReader.html) to load the scripts from an absolute path on your filesystem or from a relative path as seen from your project folder:
+
+@[apply-evolutions-absolute-relative-path](code/javaguide/tests/JavaTestingWithDatabases.java)
+
 ### Integrating with JUnit
 
 Typically you will have many tests that you want to run with the same evolutions, so it will make sense to extract the evolutions setup code into before and after methods, along with the database setup and tear down code.  Here is what a complete test might look like:

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWithDatabases.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWithDatabases.java
@@ -11,6 +11,8 @@ import com.google.common.collect.ImmutableMap;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.junit.*;
+import play.Environment;
+import play.api.db.evolutions.EnvironmentEvolutionsReader;
 import play.db.Database;
 import play.db.Databases;
 import play.db.evolutions.*;
@@ -146,6 +148,29 @@ public class JavaTestingWithDatabases {
       Evolutions.applyEvolutions(
           database, Evolutions.fromClassLoader(getClass().getClassLoader(), "testdatabase/"));
       // #apply-evolutions-custom-path
+    } finally {
+      database.shutdown();
+    }
+  }
+
+  @Test
+  public void absoluteRelativePathEvolutions() throws Exception {
+    Database database = Databases.inMemory();
+    try {
+      // #apply-evolutions-absolute-relative-path
+      // ###insert: import play.Environment;
+      // ###insert: import play.api.db.evolutions.EnvironmentEvolutionsReader;
+
+      // Absolute path
+      Evolutions.applyEvolutions(
+          database,
+          new EnvironmentEvolutionsReader(Environment.simple().asScala(), "/opt/db_migration"));
+
+      // Relative path (based on your project's root folder)
+      Evolutions.applyEvolutions(
+          database,
+          new EnvironmentEvolutionsReader(Environment.simple().asScala(), "../db_migration"));
+      // #apply-evolutions-absolute-relative-path
     } finally {
       database.shutdown();
     }

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithDatabases.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithDatabases.md
@@ -100,6 +100,10 @@ Sometimes it will be impractical to put your custom evolution scripts in code.  
 
 This will load evolutions, in the same structure and format as is done for development and production, from `testdatabase/evolutions/<databasename>/<n>.sql`.
 
+If you store evolution scripts outside your project folder, you can use the [`EnvironmentEvolutionsReader`](api/scala/play/api/db/evolutions/EnvironmentEvolutionsReader.html) to load the scripts from an absolute path on your filesystem or from a relative path as seen from your project folder:
+
+@[apply-evolutions-absolute-relative-path](code/database/ScalaTestingWithDatabases.scala)
+
 ### Allowing Play to manage evolutions
 
 The `applyEvolutions` and `cleanupEvolutions` methods are useful if you're using a test framework to manage running the evolutions before and after a test.  Play also provides a convenient `withEvolutions` method to manage it for you, if this lighter weight approach is desired:

--- a/documentation/manual/working/scalaGuide/main/tests/code/database/ScalaTestingWithDatabases.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/database/ScalaTestingWithDatabases.scala
@@ -204,6 +204,26 @@ class ScalaTestingWithDatabases extends Specification {
       ok
     }
 
+    "allow running evolutions from an absolute and relative path" in play.api.db.Databases.withInMemory() { database =>
+      // #apply-evolutions-absolute-relative-path
+      import play.api.Environment
+      import play.api.db.evolutions._
+
+      // Absolute path
+      Evolutions.applyEvolutions(
+        database,
+        new EnvironmentEvolutionsReader(Environment.simple(), "/opt/db_migration")
+      )
+
+      // Relative path (based on your project's root folder)
+      Evolutions.applyEvolutions(
+        database,
+        new EnvironmentEvolutionsReader(Environment.simple(), "../db_migration")
+      )
+      // #apply-evolutions-absolute-relative-path
+      ok
+    }
+
     "allow play to manage evolutions for you" in play.api.db.Databases.withInMemory() { database =>
       // #with-evolutions
       import play.api.db.evolutions._

--- a/persistence/play-jdbc-evolutions/src/main/resources/reference.conf
+++ b/persistence/play-jdbc-evolutions/src/main/resources/reference.conf
@@ -37,6 +37,25 @@ play {
     # Whether evolutions should be skipped, if the scripts are all down.
     skipApplyDownsOnly = false
 
+    # Path to the location where evolution scripts are stored. By default this is conf/evolutions/{database name}.
+    # Supported paths are:
+    # - Simple names to keep the files within the conf folder:
+    #   E.g. "db_migration" for conf/db_migration/{database name}
+    # - Absolute paths:
+    #   E.g. "/opt/db_migration" for /opt/db_migration/{database name}
+    # - Relative paths (as seen from the project's root folder):
+    #   E.g. "../db_migration" for <project-root>/../db_migration/{database name}
+    # - Paths to keep the files within the project but outside the conf folder:
+    #   E.g. "./db_migration"
+    #   Be aware that in this case to make sure the folder gets packaged and is available in production
+    #   you have to set that up in your build.sbt:
+    #   ---
+    #   Universal / mappings ++= (baseDirectory.value / "db_migration" ** "*").get.map {
+    #     (f: File) => f -> f.relativeTo(baseDirectory.value).get.toString
+    #   }
+    #   ---
+    path = "evolutions"
+
     # Variable substitution configuration
     substitutions {
 

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -347,6 +347,7 @@ trait EvolutionsDatasourceConfig {
   def substitutionsSuffix: String
   def substitutionsMappings: Map[String, String]
   def substitutionsEscape: Boolean
+  def path: String
 }
 
 /**
@@ -372,6 +373,7 @@ case class DefaultEvolutionsDatasourceConfig(
     substitutionsSuffix: String,
     substitutionsMappings: Map[String, String],
     substitutionsEscape: Boolean,
+    path: String,
 ) extends EvolutionsDatasourceConfig
 
 /**
@@ -437,6 +439,7 @@ class DefaultEvolutionsConfigParser @Inject() (rootConfig: Configuration) extend
     val autoApply          = config.get[Boolean]("autoApply")
     val autoApplyDowns     = config.get[Boolean]("autoApplyDowns")
     val skipApplyDownsOnly = config.get[Boolean]("skipApplyDownsOnly")
+    val path               = config.get[String]("path")
     val substPrefix        = config.get[String]("substitutions.prefix")
     val substSuffix        = config.get[String]("substitutions.suffix")
     val substMappings      = loadSubstitutionsMappings(config)
@@ -454,7 +457,8 @@ class DefaultEvolutionsConfigParser @Inject() (rootConfig: Configuration) extend
       substPrefix,
       substSuffix,
       substMappings,
-      escapeEnabled
+      escapeEnabled,
+      path
     )
 
     // Load config specific to datasources
@@ -489,6 +493,7 @@ class DefaultEvolutionsConfigParser @Inject() (rootConfig: Configuration) extend
             "skipApplyDownsOnly",
             s"skipApplyDownsOnly.$datasource"
           )
+          val path          = dsConfig.get[String]("path")
           val substPrefix   = dsConfig.get[String]("substitutions.prefix")
           val substSuffix   = dsConfig.get[String]("substitutions.suffix")
           val escapeEnabled = dsConfig.get[Boolean]("substitutions.escapeEnabled")
@@ -505,7 +510,8 @@ class DefaultEvolutionsConfigParser @Inject() (rootConfig: Configuration) extend
             substPrefix,
             substSuffix,
             substMappings,
-            escapeEnabled
+            escapeEnabled,
+            path
           )
       }
 

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
@@ -34,7 +34,7 @@ trait EvolutionsComponents {
 
   lazy val dynamicEvolutions: DynamicEvolutions = new DynamicEvolutions
   lazy val evolutionsConfig: EvolutionsConfig   = new DefaultEvolutionsConfigParser(configuration).parse()
-  lazy val evolutionsReader: EvolutionsReader   = new EnvironmentEvolutionsReader(environment)
+  lazy val evolutionsReader: EvolutionsReader   = new EnvironmentEvolutionsReader(environment, evolutionsConfig)
   lazy val evolutionsApi: EvolutionsApi         = new DefaultEvolutionsApi(dbApi)
   lazy val applicationEvolutions: ApplicationEvolutions = new ApplicationEvolutions(
     evolutionsConfig,

--- a/persistence/play-jdbc-evolutions/src/test/resources/evolutions_non_default_path/db_migrations/prod_db/1.sql
+++ b/persistence/play-jdbc-evolutions/src/test/resources/evolutions_non_default_path/db_migrations/prod_db/1.sql
@@ -1,0 +1,10 @@
+# --- Test database schema
+
+# --- !Ups
+
+create table test (id bigint not null, name varchar(255));
+insert into test values (9, 'foobar');
+
+# --- !Downs
+
+drop table if exists test;

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
@@ -86,6 +86,9 @@ class DefaultEvolutionsConfigParserSpec extends Specification {
       "autoApplyDowns" in {
         testN("autoApplyDowns")(_.autoApplyDowns)
       }
+      "path" in {
+        testNString("path")(_.path)
+      }
       "substitutions.prefix" in {
         testNString("substitutions.prefix")(_.substitutionsPrefix)
       }
@@ -121,6 +124,9 @@ class DefaultEvolutionsConfigParserSpec extends Specification {
       "autoApplyDowns" in {
         testN("db.default.autoApplyDowns")(_.autoApplyDowns)
       }
+      "path" in {
+        testNString("db.default.path")(_.path)
+      }
       "substitutions.prefix" in {
         testNString("db.default.substitutions.prefix")(_.substitutionsPrefix)
       }
@@ -155,6 +161,9 @@ class DefaultEvolutionsConfigParserSpec extends Specification {
       }
       "autoApplyDowns" in {
         default.autoApplyDowns must_== false
+      }
+      "path" in {
+        default.path must_== "evolutions"
       }
       "substitutions.prefix" in {
         default.substitutionsPrefix must_== "$evolutions{{{"

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
@@ -69,7 +69,18 @@ class EvolutionsReaderSpec extends Specification {
         "Ignoring evolution script 0010.sql, using 010.sql instead already"
       )
     }
+    "read evolution files from classpath located in a custom (sub-)folder" in {
+      val environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
+      val reader      = new EnvironmentEvolutionsReader(environment, "evolutions_non_default_path/db_migrations")
 
+      reader.evolutions("prod_db") must_== Seq(
+        Evolution(
+          1,
+          "create table test (id bigint not null, name varchar(255));\ninsert into test values (9, 'foobar');",
+          "drop table if exists test;"
+        )
+      )
+    }
     "read evolution files with different comment syntax" in {
       val environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
       val reader      = new EnvironmentEvolutionsReader(environment)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -444,6 +444,8 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.db.jpa.DefaultJPAApi.em"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.db.jpa.JPAApi.em"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.jpa.JPAApi.em"),
+      // path config for evolutions
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.db.evolutions.EvolutionsDatasourceConfig.path"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -446,6 +446,16 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.db.jpa.JPAApi.em"),
       // path config for evolutions
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.db.evolutions.EvolutionsDatasourceConfig.path"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.evolutions.Evolutions.directoryName"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.evolutions.Evolutions.fileName"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.evolutions.Evolutions.resourceName"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.evolutions.Evolutions.updateEvolutionScript"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.api.db.evolutions.Evolutions.updateEvolutionScript$default$2"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.api.db.evolutions.Evolutions.updateEvolutionScript$default$3"
+      ),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Fixes #11816
Fixes #3966

Replaces #11819
Replaces #3967

sbt 1.9 [deprecated the `IntegrationTest` configuration](https://eed3si9n.com/sbt-1.9.0#deprecation-of-integrationtest-configuration) and it's recommend to move integration tests in  subprojects instead. This isn't a big deal really, however if you were running evolutions from your integration tests and now move that it-tests into it's own sub-project, the evolution files in the `conf` folder of the main project can not be accessed by the it-sub-project, see #11816.
So this could be a blocker for people trying to get rid of deprecation warnings (and probably upgrading sbt at some point).

Therefore I squeeze that in into Play 2.9 to by allowing to set a location where the evolutions scripts can be found.