### PR TITLE
Re-enable akka-http HTTP pipelining (like in Play 2.8)

### DIFF
--- a/transport/server/play-akka-http-server/src/main/resources/reference.conf
+++ b/transport/server/play-akka-http-server/src/main/resources/reference.conf
@@ -58,6 +58,16 @@ play {
       # more information about how this works.
       tls-session-info-header = on
 
+      # The maximum number of requests that are accepted (and dispatched to
+      # the application) on one single connection before the first request
+      # has to be completed.
+      # Incoming requests that would cause the pipelining limit to be exceeded
+      # are not read from the connections socket so as to build up "back-pressure"
+      # to the client via TCP flow control.
+      # A setting of 1 disables HTTP pipelining, since only one request per
+      # connection can be "open" (i.e. being processed by the application) at any time.
+      # This value must be > 0 and <= 1024.
+      pipelining-limit = 16
     }
   }
 

--- a/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/transport/server/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -100,6 +100,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
   private val defaultHostHeader           = akkaServerConfigReader.getHostHeader.fold(throw _, identity)
   private val transparentHeadRequests     = akkaServerConfig.get[Boolean]("transparent-head-requests")
   private val serverHeaderConfig          = akkaServerConfig.getOptional[String]("server-header")
+  private val pipeliningLimit             = akkaServerConfig.get[Int]("pipelining-limit")
   private val serverHeader = serverHeaderConfig.collect {
     case s if s.nonEmpty => headers.Server(s)
   }
@@ -166,6 +167,7 @@ class AkkaHttpServer(context: AkkaHttpServer.Context) extends Server {
       .withServerHeader(serverHeader)
       .withDefaultHostHeader(defaultHostHeader)
       .withParserSettings(parserSettings)
+      .withPipeliningLimit(pipeliningLimit)
   }
 
   /**

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -70,7 +70,7 @@ play.server {
         # Example how to set native socket transport options
         # (Full qualified class name + "#" + option)
         # "io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT" = true
-        # "io.netty.channel.epoll.EpollChannelOption#TCP_FASTOPEN" = 1
+        # "io.netty.channel.ChannelOption#TCP_FASTOPEN" = 1
       }
 
     }


### PR DESCRIPTION
So I did quite some benchmarks today. 
This is what such a benchmark for latest Play 2.8.20 looks like on my machine ([link](https://www.techempower.com/benchmarks/#section=test&shareid=d1258817-06b8-489d-9ca8-e65cd494c394&test=plaintext)):
![image](https://github.com/playframework/playframework/assets/644927/2d9ce4ed-149f-4a8a-95fd-13604d020825)

Now I ran the same benchmark again on latest `main` branch and this is what I got ([link](https://www.techempower.com/benchmarks/#section=test&shareid=1c7f71cf-fffd-4a99-9a29-0fb8db02f2d6&test=plaintext)):
![image](https://github.com/playframework/playframework/assets/644927/1997b596-fc96-409f-bd07-6a049e403fc0)

So, I was shocked at first. Like why is there a ~40% performance decrease? Long story short (after trying to figure out what's going on for a while...) it turned out that for the Netty backend the benchmark are quite stable and "only" akka-http was affected.
To make it short: Play 2.8 is still using akka-http 10.1, but main is on 10.2 now. In 10.2 Server-side [HTTP pipelining](https://en.wikipedia.org/wiki/HTTP_pipelining) was disabled by default (see [akka-http migration guide](https://doc.akka.io/docs/akka-http/current/migration-guide/migration-guide-10.2.x.html#server-side-http-pipelining-now-disabled-by-default)), so that's why we see the performance decrease.

Enabled In Akka Http 10.1.x:
* https://github.com/akka/akka-http/blob/v10.1.15/akka-http-core/src/main/resources/reference.conf#L98

Disabled In Akka Http 10.2.x:
* https://github.com/akka/akka-http/blob/v10.2.10/akka-http-core/src/main/resources/reference.conf#L98



Most web browsers do not support HTTP 1 pipelining anyway, chrome dropped it,  Firefox as well (in favor of Http 2, I didn't save the links, you can google if you want :wink:). Of course there could be other clients accessing a Play app (like the clients used for benchmarking), so I re-enabled HTTP pipelining again for akka-http, more or less to stay on par with 2.8 and not break anything, if people did rely on the feature.
However I now made it configurable, so http pipelining can now be turned of by setting
```
play.server.akka.pipelining-limit = 1
```

With this pull request the numbers are now stable again on `main` as well ([link](https://www.techempower.com/benchmarks/#section=test&shareid=09bf33a3-74ee-4d62-b9a0-4952301e2626&test=plaintext)):
![image](https://github.com/playframework/playframework/assets/644927/e7afa041-26a2-429c-bcf5-807a93587b88)

<hr>

If you are interested, these are the numbers for the netty backend, they are always quite the same for 2.8.20 and main ([link](https://www.techempower.com/benchmarks/#section=test&shareid=4c30b934-b2fb-4152-a084-30781e7936eb&test=plaintext))
![image](https://github.com/playframework/playframework/assets/644927/12738ba4-f968-47c0-950b-47519af6fb13)

Be aware, netty does not support http pipelining:
* https://github.com/netty/netty/issues/12311
* https://github.com/netty/netty/issues/9430
* https://github.com/netty/netty/issues/8027

That means compared to akka-http with http pipelining disabled netty is the faster backend (nothing new, we know that since many years).

BTW:
I ran the akka-http benchmarks with Scala 3 as well, and the numbers are quite similar, so it seems there is not really a difference in using Scala 2 or 3 and even not when using the `for3Use2_13` workaround we do to make akka-http work with Scala 3.