### PR TITLE
Add sbt-svelte to ModuleDirectory.md

### DIFF
--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -19,6 +19,9 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 * **Website:** <https://github.com/ArpNetworking/sbt-typescript>
 * **Short description:** A plugin for sbt that uses sbt-web to compile typescript resources
 
+### Svelte Plugin
+Website: https://github.com/tanin47/sbt-svelte
+Short description: A plugin for sbt that uses sbt-web to compile Svelte components
 
 ## Authentication (Login & Registration) and Authorization (Restricted Access)
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [NA] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [NA] Have you added copyright headers to new files?
* [NA] Have you checked that both Scala and Java APIs are updated?
* [NA] Have you updated the documentation for both Scala and Java sections?
* [NA] Have you added tests for any changed functionality?

## Purpose

Add sbt-svelte to ModuleDirectory.md

## Background Context

It was recommended by mkurz here: https://github.com/orgs/playframework/discussions/11922#discussioncomment-6766739

## References

Are there any relevant issues / PRs / mailing lists discussions?
