### PR TITLE
Remove `jakarta.transaction-api`, seems it was of no use...

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -181,7 +181,6 @@ object Dependencies {
       Seq(
         playJson,
         guava,
-        "jakarta.transaction" % "jakarta.transaction-api" % "2.0.1",
         javaxInject,
         sslConfig
       ) ++ scalaParserCombinators(scalaVersion).map(_.forScala3TestsUse2_13()) ++ specs2Deps.map(


### PR DESCRIPTION
It was added long time ago [here](https://github.com/playframework/playframework/commit/d1e0b691f9f673bd1c4f05f3ddeb2e4b5c02e33e#diff-ec261f75c247d15b297e3af41ce5cce377993dd908d940589aad865c47637058R201) (when it was still under the `javax.transaction` namespace) but even then it was not used. Could be it was a mistake and until now no one cared? I mean it's not even in the jdbc dependencies but gets imported in every application. Why?
If the build is green I do not see any reason to keep this dependencies, it just doesn't make sense.
Will mention it in the migration guide though.