### PR TITLE
Avoid unapply because we mix Scala 3 and Scala 2.13 artifacts when using akka(-http)

### DIFF
--- a/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -50,9 +50,10 @@ object ActorFlow {
           val flowActor = context.watch(context.actorOf(props(outActor), "flowActor"))
 
           def receive = {
-            case Status.Success(_) | Status.Failure(_) => flowActor ! PoisonPill
-            case Terminated(_)                         => context.stop(self)
-            case other                                 => flowActor ! other
+            case _: Status.Success => flowActor ! PoisonPill
+            case _: Status.Failure => flowActor ! PoisonPill
+            case _: Terminated     => context.stop(self)
+            case other             => flowActor ! other
           }
 
           override def supervisorStrategy = OneForOneStrategy() {


### PR DESCRIPTION
Fixes #11928

Same story like in https://github.com/apache/incubator-pekko-http/issues/183 / https://github.com/apache/incubator-pekko-http/pull/184