### PR TITLE
Bugfix: Make `play.api.mvc.Result.asJava` to include attributes

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -339,7 +339,8 @@ case class Result(
       body.asJava,
       newSession.map(_.asJava).orNull,
       newFlash.map(_.asJava).orNull,
-      newCookies.map(_.asJava).asJava
+      newCookies.map(_.asJava).asJava,
+      attrs.asJava
     )
 
   /**

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -511,6 +511,10 @@ class ResultsSpec extends Specification {
         req.attrs.get(x) must beNone
         req.attrs.get(y) must beNone
       }
+      "can convert the result into a java result and keep the attributes" in {
+        val x = TypedKey[Int]("x")
+        Results.Ok.addAttr(x, 3).asJava.attrs().get(x.asJava) must_== 3
+      }
     }
   }
 }


### PR DESCRIPTION
This is a bad bad bug which makes you loose information...
Never made it into a (stable) release yet because Result attributes are a 2.9 feature :sweat_smile: 