### PR TITLE
Introduce `play.http.actionComposition.includeWebSocketActions`

### DIFF
--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -118,6 +118,10 @@ play {
 
       # If the action returned by the action creator should be executed before the action composition ones
       executeActionCreatorActionFirst = false
+
+      # If WebSocket actions should be included in action composition.
+      # This config is only relevant for Play Java and will not have an effect in Play Scala.
+      includeWebSocketActions = false
     }
 
     # Cookies configuration

--- a/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/core/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -154,10 +154,12 @@ case class ParserConfiguration(
  * @param controllerAnnotationsFirst      If annotations put on controllers should be executed before the ones put on actions.
  * @param executeActionCreatorActionFirst If the action returned by the action creator should be
  *                                        executed before the action composition ones.
+ * @param includeWebSocketActions         If WebSocket actions should be included in action composition.
  */
 case class ActionCompositionConfiguration(
     controllerAnnotationsFirst: Boolean = false,
-    executeActionCreatorActionFirst: Boolean = false
+    executeActionCreatorActionFirst: Boolean = false,
+    includeWebSocketActions: Boolean = false,
 )
 
 /**
@@ -235,7 +237,8 @@ object HttpConfiguration {
       actionComposition = ActionCompositionConfiguration(
         controllerAnnotationsFirst = config.get[Boolean]("play.http.actionComposition.controllerAnnotationsFirst"),
         executeActionCreatorActionFirst =
-          config.get[Boolean]("play.http.actionComposition.executeActionCreatorActionFirst")
+          config.get[Boolean]("play.http.actionComposition.executeActionCreatorActionFirst"),
+        includeWebSocketActions = config.get[Boolean]("play.http.actionComposition.includeWebSocketActions"),
       ),
       cookies = CookiesConfiguration(
         strict = config.get[Boolean]("play.http.cookies.strict")

--- a/core/play/src/main/scala/play/api/mvc/Action.scala
+++ b/core/play/src/main/scala/play/api/mvc/Action.scala
@@ -237,7 +237,7 @@ object BodyParser {
         )
       })
       .getOrElse {
-        logger.trace("Not parsing body, was parsed before already for request: " + request)
+        logger.trace("Not parsing body, it's a WebSocket or it was parsed before already for request: " + request)
         next(request)
       }
   }

--- a/core/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/core/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -30,6 +30,7 @@ class HttpConfigurationSpec extends Specification {
         "play.http.parser.allowEmptyFiles"                            -> "true",
         "play.http.actionComposition.controllerAnnotationsFirst"      -> "true",
         "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+        "play.http.actionComposition.includeWebSocketActions"         -> "true",
         "play.http.cookies.strict"                                    -> "true",
         "play.http.session.cookieName"                                -> "PLAY_SESSION",
         "play.http.session.secure"                                    -> "true",
@@ -192,6 +193,11 @@ class HttpConfigurationSpec extends Specification {
       "execute request handler action first" in {
         val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration, environment).get
         httpConfiguration.actionComposition.executeActionCreatorActionFirst must beTrue
+      }
+
+      "include WebSocket actions" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration, environment).get
+        httpConfiguration.actionComposition.includeWebSocketActions must beTrue
       }
     }
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -458,6 +458,11 @@ object BuildSettings {
       ),
       // Added isEmpty method to MultipartFormData
       ProblemFilters.exclude[ReversedMissingMethodProblem]("play.mvc.Http#MultipartFormData.isEmpty"),
+      // play.http.actionComposition.includeWebSocketActions
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.ActionCompositionConfiguration.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.ActionCompositionConfiguration.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.ActionCompositionConfiguration.this"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.api.http.ActionCompositionConfiguration$"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Woke up early today to implement #11921 before continuing migration guide.
PR works, I am 99,99% sure, however tests and docs come later because I want to cut M7 which, if no problems occur in the play-samples tests, will become RC1.