### PR TITLE
`--add-opens` not needed anymore

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -114,7 +114,7 @@ jobs:
         ]
       cmd: >-
         if [ "$MATRIX_JAVA" = 17 ]; then
-          export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.ssl=ALL-UNNAMED";
+          export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED";
         fi;
         if [ "$MATRIX_SCALA" = "3.x" ]; then
           export PLAY_SCALA3_TESTS="-Dscala3Tests=true"


### PR DESCRIPTION
I do think that was necessary for older ssl-config version, but not now anymore (?). `--add-exports` should be sufficient. We will see if tests pass.