### PR TITLE
Group Scala Steward patch updates into single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,10 @@
 pullRequests.frequency = "@monthly"
+
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] }
+]
 
 buildRoots = [ ".", "documentation" ]
 


### PR DESCRIPTION
Patch updates are likey to not break anything so we can just put them into one PR.
Would have saved us 9 pull request last time Scala Steward visited this repo 3 days ago.
Makes administration a bit easier hopefully.