### PR TITLE
sbt 1.9.6 + rebuild libs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,7 +46,7 @@ jobs:
       cmd: |
         if [ "$CACHE_HIT_COURSIER" = "false" ]; then
           sbt +update                                             # Runs with adoptium:8 (default)
-          # sbt --sbt-version 1.9.5 +update                       # If we run scripted tests with multiple sbt versions, we could init that sbt installs here
+          # sbt --sbt-version 1.9.6 +update                       # If we run scripted tests with multiple sbt versions, we could init that sbt installs here
           sbt +mimaPreviousClassfiles                             # Fetches previous artifacts
           cd documentation && sbt +update && cd ..                # Fetches dependencies of the documentation project
           sbt -java-home `cs java-home --jvm adoptium:11` exit    # Init sbt with new JVM that will be downloaded
@@ -153,7 +153,7 @@ jobs:
       scala: 2.13.x, 3.x
       add-dimensions: >-
         {
-          "sbt": [ "1.9.5" ],
+          "sbt": [ "1.9.6" ],
           "sbt_steps": [ "*1of3", "*2of3", "*3of3" ]
         }
       exclude: >-

--- a/documentation/manual/hacking/Translations.md
+++ b/documentation/manual/hacking/Translations.md
@@ -40,7 +40,7 @@ translation-project
 `build.properties` should contain the sbt version, ie:
 
 ```
-sbt.version=1.9.5
+sbt.version=1.9.6
 ```
 
 `plugins.sbt` should include the Play docs sbt plugin, ie:

--- a/documentation/manual/releases/release29/Highlights29.md
+++ b/documentation/manual/releases/release29/Highlights29.md
@@ -40,7 +40,7 @@ Play, its standalone modules, samples, and seed projects are all rigorously test
 
 ## Scala 2.12, sbt 0.13 and Java 8 Support discontinued
 
-Alongside Scala 2.12, we have opted to discontinue support for Java 8 in this release. This decision was necessitated by the growing number of libraries that Play depends on, which have ceased providing Java 8 artifacts. Additionally, Play 2.9 has finally bid farewell to support for sbt 0.13. While Play is likely to remain compatible with various sbt 1.x versions, our official support is extended to sbt version 1.9.5 or newer. Consequently, we strongly advise maintaining your setup with the [latest available sbt version](https://github.com/sbt/sbt/releases).
+Alongside Scala 2.12, we have opted to discontinue support for Java 8 in this release. This decision was necessitated by the growing number of libraries that Play depends on, which have ceased providing Java 8 artifacts. Additionally, Play 2.9 has finally bid farewell to support for sbt 0.13. While Play is likely to remain compatible with various sbt 1.x versions, our official support is extended to sbt version 1.9.6 or newer. Consequently, we strongly advise maintaining your setup with the [latest available sbt version](https://github.com/sbt/sbt/releases).
 
 ## Akka HTTP 10.2
 

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -24,10 +24,10 @@ Check the release notes for Play's minor version [releases](https://github.com/p
 Play 2.9 only supports sbt 1.9 or newer. To update, change your `project/build.properties` so that it reads:
 
 ```properties
-sbt.version=1.9.5
+sbt.version=1.9.6
 ```
 
-At the time of this writing `1.9.5` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for sbt's [releases](https://github.com/sbt/sbt/releases) for details.
+At the time of this writing `1.9.6` is the latest version in the sbt 1.x family, you may be able to use newer versions too. Check the release notes for sbt's [releases](https://github.com/sbt/sbt/releases) for details.
 
 ### Minimum required Java and sbt version
 

--- a/documentation/project/build.properties
+++ b/documentation/project/build.properties
@@ -1,4 +1,4 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # sync with project/build.properties
-sbt.version=1.9.5
+sbt.version=1.9.6

--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.8.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.2")
 
 // Required for Tutorial
-addSbtPlugin("com.typesafe.play" % "sbt-twirl" % "1.6.0") // sync with project/plugins.sbt
+addSbtPlugin("com.typesafe.play" % "sbt-twirl" % "1.6.1") // sync with project/plugins.sbt
 
 // Required for IDE docs
 addSbtPlugin("com.github.sbt" % "sbt-eclipse" % "6.0.0")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   val sslConfigCoreVersion = "0.6.1"
   val sslConfig            = "com.typesafe" %% "ssl-config-core" % sslConfigCoreVersion
 
-  val playJsonVersion = "2.10.0"
+  val playJsonVersion = "2.10.1"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.11"
 
@@ -219,7 +219,7 @@ object Dependencies {
     )
   }
 
-  val playFileWatch = "com.typesafe.play" %% "play-file-watch" % "1.2.0"
+  val playFileWatch = "com.typesafe.play" %% "play-file-watch" % "1.2.1"
 
   def runSupportDependencies(sbtVersion: String): Seq[ModuleID] = {
     Seq(playFileWatch, logback % Test) ++ specs2Deps.map(_ % Test)
@@ -236,8 +236,8 @@ object Dependencies {
       playFileWatch,
       sbtDep("com.typesafe.play" % "sbt-twirl"           % BuildInfo.sbtTwirlVersion),
       sbtDep("com.github.sbt"    % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
-      sbtDep("com.github.sbt"    % "sbt-web"             % "1.5.0"),
-      sbtDep("com.github.sbt"    % "sbt-js-engine"       % "1.3.0"),
+      sbtDep("com.github.sbt"    % "sbt-web"             % "1.5.1"),
+      sbtDep("com.github.sbt"    % "sbt-js-engine"       % "1.3.1"),
       logback % Test
     ) ++ specs2Deps.map(_ % Test) ++ scalaReflect(scalaVersion)
   }
@@ -247,7 +247,7 @@ object Dependencies {
     "org.webjars" % "prettify" % "4-Mar-2013-1" % "webjars"
   )
 
-  val playDocVersion = "2.2.0"
+  val playDocVersion = "2.2.1"
   val playDocsDependencies = Seq(
     "com.typesafe.play" %% "play-doc" % playDocVersion
   ) ++ playdocWebjarDependencies
@@ -310,7 +310,7 @@ object Dependencies {
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
   ) ++ jcacheApi
 
-  val playWsStandaloneVersion = "2.2.0"
+  val playWsStandaloneVersion = "2.2.1"
   val playWsDeps = Seq(
     ("com.typesafe.play" %% "play-ws-standalone"      % playWsStandaloneVersion).forScala3TestsExcludeAkkaOrganization(),
     ("com.typesafe.play" %% "play-ws-standalone-xml"  % playWsStandaloneVersion).forScala3TestsExcludeAkkaOrganization(),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # sync with documentation/project/build.properties
-sbt.version=1.9.5
+sbt.version=1.9.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ val sbtJmh             = "0.4.6"
 val webjarsLocatorCore = "0.53"
 val sbtHeader          = "5.8.0"
 val scalafmt           = "2.4.6"
-val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.6.0") // sync with documentation/project/plugins.sbt
+val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.6.1") // sync with documentation/project/plugins.sbt
 val interplay: String  = sys.props.getOrElse("interplay.version", "3.1.7")
 
 buildInfoKeys := Seq[BuildInfoKey](

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ val webjarsLocatorCore = "0.53"
 val sbtHeader          = "5.8.0"
 val scalafmt           = "2.4.6"
 val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "1.6.0") // sync with documentation/project/plugins.sbt
-val interplay: String  = sys.props.getOrElse("interplay.version", "3.1.6")
+val interplay: String  = sys.props.getOrElse("interplay.version", "3.1.7")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackager,


### PR DESCRIPTION
sbt 1.9.5 introduced a compiler bug.

https://github.com/sbt/sbt/releases/tag/v1.9.5
> Update: ⚠️ sbt 1.9.5 is broken, because it causes Scala compiler to generate wrong class names for anonymous class on lambda. While we investigate please refrain from publishing libraries with it.
scala/bug#12868 (comment)
