### PR TITLE
Revert "Temporary mention the RC2 release in the migration docs"

### DIFF
--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -13,10 +13,11 @@ Before starting `sbt`, make sure to make the following upgrades.
 Update the Play version number in `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-RC2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.x")
 ```
 
-Make sure to check the release notes for new Play [releases](https://github.com/playframework/playframework/releases).
+Where the "x" in `2.9.x` is the minor version of Play you want to use, for instance `2.9.0`.
+Check the release notes for Play's minor version [releases](https://github.com/playframework/playframework/releases).
 
 ### sbt upgrade
 


### PR DESCRIPTION
After the 2.9 final release