### PR TITLE
Docs: Use example with idle timout larger than request timeout

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -17,11 +17,13 @@ You can read more about the configuration settings in the [Akka HTTP documentati
 > **Note:** Akka HTTP has a number of [timeouts configurations](https://doc.akka.io/docs/akka-http/10.2/common/timeouts.html?language=scala#server-timeouts) that you can use to protect your application from attacks or programming mistakes. The Akka HTTP Server in Play will automatically recognize all these Akka configurations. For example, if you have `idle-timeout` and `request-timeout` configurations like below:
 >
 > ```
-> akka.http.server.idle-timeout = 20s
-> akka.http.server.request-timeout = 30s
+> akka.http.server.idle-timeout = 30s
+> akka.http.server.request-timeout = 20s
 > ```
 >
 > They will be automatically recognized. Keep in mind that Play configurations listed above will override the Akka ones.
+>
+>  When setting the request-timeout, make sure it is smaller than the idle-timeout. Otherwise the idle-timeout will kick in first and reset the TCP connection without a response.
 
 There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have [[enabled the `AkkaHttp2Support` plugin|AkkaHttpServer#HTTP/2-support-(incubating)]]:
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

According to the Akka docs, the request-timeout should be smaller than the idle-timeout.
Cf. https://doc.akka.io/docs/akka-http/current/configuration.html

It would probably also be a good idea to either show a warning when, when the request-timeout is larger than the idle-timeout, or even set the actual idle-timeout always as the larger of the two.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?
