### PR TITLE
Display soft warning about EOL when starting sbt

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -89,6 +89,11 @@ object PlaySettings extends PlaySettingsCompat {
            )}
             |https://www.playframework.com/sponsors
             |
+            |
+            |${Colors.blue(Colors.bold("Play 2.9 and 3.0 released! Play 2.8 will be end-of-life (EOL) at May 31st, 2024."))}
+            |Please upgrade, see https://www.playframework.com/documentation/2.9.x/Highlights29
+            |
+            |
             |""".stripMargin +
         (if (javaVersion == "17")
            s"""Running Play on Java ${sys.props("java.specification.version")} is experimental. Tweaks are necessary:


### PR DESCRIPTION
To be released with 2.8.21 after 2.9 and 3.0 are out.

![image](https://github.com/playframework/playframework/assets/644927/44bdefb5-639b-400c-b842-4ae52124b2b2)

