### PR TITLE
Some libs moved to `org.playframework`

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -18,8 +18,6 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.language.implicitConversions
 
-import com.typesafe.netty.HandlerPublisher
-import com.typesafe.netty.HandlerSubscriber
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.ByteBufHolder
 import io.netty.buffer.Unpooled
@@ -37,6 +35,8 @@ import org.apache.pekko.stream.FlowShape
 import org.apache.pekko.stream.Inlet
 import org.apache.pekko.stream.Outlet
 import org.apache.pekko.util.ByteString
+import org.playframework.netty.HandlerPublisher
+import org.playframework.netty.HandlerSubscriber
 import play.api.http.websocket._
 import play.api.Logger
 import play.it.http.websocket.WebSocketClient.ExtendedMessage

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
 
   val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.6.1"
 
-  val playJsonVersion = "2.10.1"
+  val playJsonVersion = "3.0.0-M1"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.11"
 
@@ -49,7 +49,7 @@ object Dependencies {
     "com.fasterxml.jackson.module"    %% "jackson-module-scala",
   ).map(_ % jacksonVersion)
 
-  val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
+  val playJson = "org.playframework" %% "play-json" % playJsonVersion
 
   val slf4jVersion = "2.0.9"
   val slf4j        = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % slf4jVersion)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -171,8 +171,8 @@ object Dependencies {
   val nettyVersion = "4.1.99.Final"
 
   val netty = Seq(
-    "com.typesafe.netty" % "netty-reactive-streams-http"  % "2.0.9",
-    ("io.netty"          % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
+    "org.playframework.netty" % "netty-reactive-streams-http"  % "3.0.0-M1",
+    ("io.netty"               % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
   ) ++ specs2Deps.map(_ % Test)
 
   val pekkoHttp = "org.apache.pekko" %% "pekko-http-core" % pekkoHttpVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -197,7 +197,7 @@ object Dependencies {
     )
   }
 
-  val playFileWatch = "com.typesafe.play" %% "play-file-watch" % "1.2.1"
+  val playFileWatch = "org.playframework" %% "play-file-watch" % "2.0.0"
 
   def runSupportDependencies(sbtVersion: String): Seq[ModuleID] = {
     Seq(playFileWatch, logback % Test) ++ specs2Deps.map(_ % Test)

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -16,8 +16,6 @@ import scala.util.control.NonFatal
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigMemorySize
 import com.typesafe.config.ConfigValue
-import com.typesafe.netty.http.HttpStreamsServerHandler
-import com.typesafe.netty.HandlerPublisher
 import io.netty.bootstrap.Bootstrap
 import io.netty.channel._
 import io.netty.channel.epoll.EpollChannelOption
@@ -39,6 +37,8 @@ import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.Done
+import org.playframework.netty.http.HttpStreamsServerHandler
+import org.playframework.netty.HandlerPublisher
 import play.api._
 import play.api.http.HttpProtocol
 import play.api.internal.libs.concurrent.CoordinatedShutdownSupport

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -17,8 +17,6 @@ import scala.util.control.NonFatal
 import scala.util.Failure
 import scala.util.Try
 
-import com.typesafe.netty.http.DefaultStreamedHttpResponse
-import com.typesafe.netty.http.StreamedHttpRequest
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.Channel
@@ -29,6 +27,8 @@ import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.util.ByteString
+import org.playframework.netty.http.DefaultStreamedHttpResponse
+import org.playframework.netty.http.StreamedHttpRequest
 import play.api.http.HeaderNames._
 import play.api.http.HttpChunk
 import play.api.http.HttpEntity

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -14,13 +14,13 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import com.typesafe.netty.http.DefaultWebSocketHttpResponse
 import io.netty.channel._
 import io.netty.handler.codec.http._
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory
 import io.netty.handler.codec.TooLongFrameException
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.util.ByteString
+import org.playframework.netty.http.DefaultWebSocketHttpResponse
 import play.api.http._
 import play.api.libs.streams.Accumulator
 import play.api.mvc._


### PR DESCRIPTION
Not done yet, but I need a published Play 3 milestone with netty-reactive-streams moved to org.playframework to fix https://github.com/playframework/play-ws/pull/806 because it's shading the "wrong" package currently.