### PR TITLE
Unable to map snake_case JSON to Play Form with camelCase fields (Java)

### DIFF
--- a/web/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/web/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -4,6 +4,8 @@
 
 package play.data;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.typesafe.config.Config;
 import jakarta.validation.ValidatorFactory;
@@ -485,6 +487,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     }
 
     /** @return the data. */
+    @JsonAnyGetter
     public Map<String, Object> getData() {
       return data;
     }
@@ -496,6 +499,17 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public void setData(Map<String, Object> data) {
       this.data = data;
+    }
+
+    /**
+     * Put data property.
+     *
+     * @param key the property key.
+     * @param value the property value.
+     */
+    @JsonAnySetter
+    public void putData(String key, Object value) {
+      data.put(key, value);
     }
 
     public String toString() {

--- a/web/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/web/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -4,6 +4,8 @@
 
 package play.data;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.typesafe.config.Config;
 import jakarta.validation.ValidatorFactory;
@@ -505,6 +507,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     /**
      * @return the data.
      */
+    @JsonAnyGetter
     public Map<String, Object> getData() {
       return data;
     }
@@ -516,6 +519,17 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public void setData(Map<String, Object> data) {
       this.data = data;
+    }
+
+    /**
+     * Put data property.
+     *
+     * @param key the property key.
+     * @param value the property value.
+     */
+    @JsonAnySetter
+    public void putData(String key, Object value) {
+      data.put(key, value);
     }
 
     public String toString() {

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -9,7 +9,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static play.api.templates.PlayMagic.translate;
 import static play.libs.F.Tuple;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import jakarta.validation.ConstraintViolation;
@@ -31,11 +38,13 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -755,12 +764,7 @@ public class Form<T> {
 
     Map<String, String> jsonData = new HashMap<>();
     if (request.body().asJson() != null) {
-      jsonData =
-          play.libs.Scala.asJava(
-              play.api.data.FormUtils.fromJson(
-                  play.api.libs.json.Json.parse(play.libs.Json.stringify(request.body().asJson())),
-                  maxJsonChars(),
-                  maxJsonDepth()));
+      jsonData = convertJsonToFormData(request.body().asJson(), maxJsonChars(), maxJsonDepth());
     }
 
     Map<String, String> data = new HashMap<>();
@@ -937,15 +941,7 @@ public class Form<T> {
    */
   public Form<T> bind(
       Lang lang, TypedMap attrs, JsonNode data, long maxChars, String... allowedFields) {
-    return bind(
-        lang,
-        attrs,
-        play.libs.Scala.asJava(
-            play.api.data.FormUtils.fromJson(
-                play.api.libs.json.Json.parse(play.libs.Json.stringify(data)),
-                maxChars,
-                maxJsonDepth())),
-        allowedFields);
+    return bind(lang, attrs, data, maxChars, maxJsonDepth(), allowedFields);
   }
 
   /**
@@ -971,13 +967,23 @@ public class Form<T> {
       long maxChars,
       int maxDepth,
       String... allowedFields) {
-    return bind(
-        lang,
-        attrs,
-        play.libs.Scala.asJava(
-            play.api.data.FormUtils.fromJson(
-                play.api.libs.json.Json.parse(play.libs.Json.stringify(data)), maxChars, maxDepth)),
-        allowedFields);
+    return bind(lang, attrs, convertJsonToFormData(data, maxChars, maxDepth), allowedFields);
+  }
+
+  private Map<String, String> convertJsonToFormData(JsonNode json, long maxChars, int maxDepth) {
+    ObjectMapper noAnnotationsMapper =
+        JsonMapper.builder().configure(MapperFeature.USE_ANNOTATIONS, false).build();
+
+    // ignore Jackson annotations so that property naming strategy
+    // isn't applied when converting value to JsonNode
+    JsonNode formData =
+        Optional.of(play.libs.Json.fromJson(json, backedType))
+            .map(t -> (JsonNode) noAnnotationsMapper.valueToTree(t))
+            .orElse(json);
+
+    return play.libs.Scala.asJava(
+        play.api.data.FormUtils.fromJson(
+            play.api.libs.json.Json.parse(play.libs.Json.stringify(formData)), maxChars, maxDepth));
   }
 
   private static final Set<String> internalAnnotationAttributes = new HashSet<>(3);
@@ -1460,6 +1466,7 @@ public class Form<T> {
    * @return the JSON node containing the errors.
    */
   public JsonNode errorsAsJson(Lang lang) {
+    Map<String, String> keyMapping = !errors.isEmpty() ? getJsonKeyMapping() : null;
     Map<String, List<String>> allMessages = new HashMap<>();
     errors.forEach(
         error -> {
@@ -1476,10 +1483,66 @@ public class Form<T> {
             } else {
               messages.add(error.message());
             }
-            allMessages.put(error.key(), messages);
+            allMessages.put(keyMapping.get(error.key()), messages);
           }
         });
     return play.libs.Json.toJson(allMessages);
+  }
+
+  private Map<String, String> getJsonKeyMapping() {
+    ObjectMapper mapper = play.libs.Json.mapper();
+    JavaType type = mapper.getTypeFactory().constructType(backedType);
+    List<BeanPropertyDefinition> properties =
+        mapper.getSerializationConfig().introspect(type).findProperties();
+    Map<String, List<BeanPropertyDefinition>> groupedProperties =
+        properties.stream()
+            .map(prop -> Tuple(prop.getInternalName(), prop))
+            .collect(
+                Collectors.groupingBy(
+                    t -> t._1, Collectors.mapping(t -> t._2, Collectors.toList())));
+
+    List<Predicate<BeanPropertyDefinition>> predicates =
+        List.of(
+            prop ->
+                Optional.of(prop)
+                    .map(p -> p.getField())
+                    .map(f -> f.getAnnotation(JsonProperty.class))
+                    .isPresent(),
+            prop ->
+                Optional.of(prop)
+                    .map(p -> p.getSetter())
+                    .map(s -> s.getAnnotation(JsonSetter.class))
+                    .isPresent(),
+            prop ->
+                Optional.of(prop)
+                    .map(p -> p.getSetter())
+                    .map(s -> s.getAnnotation(JsonProperty.class))
+                    .isPresent(),
+            prop -> true);
+    Map<String, String> keyMapping = new HashMap<>();
+    groupedProperties.forEach(
+        (internalName, props) -> {
+          if (props.size() == 1) {
+            keyMapping.put(internalName, props.get(0).getName());
+          } else {
+            predicates.stream()
+                .map(predicate -> findJsonPropertyName(props, predicate))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .ifPresent(name -> keyMapping.put(internalName, name));
+          }
+        });
+
+    return keyMapping;
+  }
+
+  private String findJsonPropertyName(
+      List<BeanPropertyDefinition> properties, Predicate<BeanPropertyDefinition> predicate) {
+    return properties.stream()
+        .filter(predicate)
+        .findFirst()
+        .map(prop -> prop.getName())
+        .orElse(null);
   }
 
   /**

--- a/web/play-java-forms/src/test/java/play/data/JacksonJsonGetterSetterForm.java
+++ b/web/play-java-forms/src/test/java/play/data/JacksonJsonGetterSetterForm.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.data;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import play.data.validation.Constraints;
+
+public class JacksonJsonGetterSetterForm {
+
+  @Constraints.Required private String authorName;
+
+  @Constraints.Required private String bookName;
+
+  @JsonGetter("author")
+  public String getAuthorName() {
+    return authorName;
+  }
+
+  @JsonSetter("AUTHOR-NAME")
+  public void setAuthorName(String authorName) {
+    this.authorName = authorName;
+  }
+
+  @JsonProperty("book_name")
+  public String getBookName() {
+    return bookName;
+  }
+
+  @JsonProperty("title")
+  public void setBookName(String bookName) {
+    this.bookName = bookName;
+  }
+}

--- a/web/play-java-forms/src/test/java/play/data/JacksonJsonNamingForm.java
+++ b/web/play-java-forms/src/test/java/play/data/JacksonJsonNamingForm.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.data;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import play.data.validation.Constraints;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public class JacksonJsonNamingForm {
+
+  @Constraints.Required private String authorName;
+
+  public String getAuthorName() {
+    return authorName;
+  }
+
+  public void setAuthorName(String authorName) {
+    this.authorName = authorName;
+  }
+}

--- a/web/play-java-forms/src/test/java/play/data/JacksonJsonPropertyForm.java
+++ b/web/play-java-forms/src/test/java/play/data/JacksonJsonPropertyForm.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import play.data.validation.Constraints;
+
+public class JacksonJsonPropertyForm {
+
+  @Constraints.Required
+  @JsonProperty("AuthorName")
+  private String authorName;
+
+  public String getAuthorName() {
+    return authorName;
+  }
+
+  public void setAuthorName(String authorName) {
+    this.authorName = authorName;
+  }
+}

--- a/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -228,7 +228,7 @@ public class HttpFormsTest {
           List<Object> args = new ArrayList<>();
           args.add("error.customarg");
           List<ValidationError> errors = new ArrayList<>();
-          errors.add(new ValidationError("foo", msgs, args));
+          errors.add(new ValidationError("amount", msgs, args));
 
           Form<Money> form =
               new Form<>(
@@ -244,7 +244,7 @@ public class HttpFormsTest {
                   config,
                   lang);
 
-          assertThat(form.errorsAsJson().get("foo").toString())
+          assertThat(form.errorsAsJson().get("amount").toString())
               .isEqualTo("[\"It looks like something was not correct\"]");
         });
   }

--- a/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -225,7 +225,7 @@ public class HttpFormsTest {
           List<Object> args = new ArrayList<>();
           args.add("error.customarg");
           List<ValidationError> errors = new ArrayList<>();
-          errors.add(new ValidationError("foo", msgs, args));
+          errors.add(new ValidationError("amount", msgs, args));
 
           Form<Money> form =
               new Form<>(
@@ -242,7 +242,7 @@ public class HttpFormsTest {
                   config,
                   lang);
 
-          assertThat(form.errorsAsJson().get("foo").toString())
+          assertThat(form.errorsAsJson().get("amount").toString())
               .isEqualTo("[\"It looks like something was not correct\"]");
         });
   }

--- a/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -7,8 +7,6 @@ package play.data
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
-import com.fasterxml.jackson.databind.node.TextNode
-import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.config.ConfigFactory
 import play.api.data.FormJsonExpansionTooLarge
 import play.api.i18n.DefaultMessagesApi
@@ -16,6 +14,7 @@ import play.api.i18n.Messages
 import play.core.j.PlayFormsMagicForJava.javaFieldtoScalaField
 import play.data.format.Formatters
 import play.libs.Files.SingletonTemporaryFileCreator
+import play.libs.Json
 import play.mvc.Http.RequestBuilder
 import views.html.helper.inputText
 import views.html.helper.FieldConstructor.defaultField
@@ -263,21 +262,22 @@ class DynamicFormSpec extends CommonFormSpec {
       sField.errors must_== Nil
     }
 
-    "fail with exception when the json paylod is bigger than default maxBufferSize" in {
+    "fail with exception when the json payload is bigger than default maxBufferSize" in {
       val cfg = ConfigFactory
         .parseString("""
                        |play.http.parser.maxMemoryBuffer = 32
                        |""".stripMargin)
         .withFallback(config)
       val form       = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, cfg)
-      val longString =
-        "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
-      val textNode: JsonNode = new TextNode(longString)
-      val req                = new RequestBuilder()
+      val longString = "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+      val json       = Json.mapper.createObjectNode
+      json.put("foo", longString)
+
+      val req = new RequestBuilder()
         .method("POST")
         .uri("http://localhost/test")
         .header("Content-type", "application/json")
-        .bodyJson(textNode)
+        .bodyJson(json)
         .build()
 
       form.bindFromRequest(req) must throwA[FormJsonExpansionTooLarge].like {

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -15,6 +15,7 @@ import java.util.Optional
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import jakarta.validation.{ Configuration => vConfiguration }
@@ -36,6 +37,7 @@ import play.libs.typedmap.TypedMap
 import play.libs.F
 import play.libs.Files.TemporaryFile
 import play.libs.Files.TemporaryFileCreator
+import play.libs.Json
 import play.mvc.EssentialFilter
 import play.mvc.Http
 import play.mvc.Http.MultipartFormData.FilePart
@@ -1707,6 +1709,147 @@ trait FormSpec extends CommonFormSpec {
         myFormFr.errors("note").get(0).message() must beEqualTo("Größe muss zwischen 10 und 100 sein")
       }
     }
+
+    "support Jackson naming annotations" in {
+      "that maps author_name to authorName when @JsonNaming(SnakeCaseStrategy.class) is used" in {
+        val json = Json.mapper.readTree("{\"author_name\": \"foo\"}");
+        "when using bind" in {
+          val form = formFactory
+            .form(classOf[JacksonJsonNamingForm])
+            .bind(Lang.defaultLang(), TypedMap.empty(), json, 1024)
+
+          form.hasErrors must beEqualTo(false)
+          form.field("authorName").value.get must beEqualTo("foo")
+        }
+        "when using bindFromRequest" in {
+          val request = FormSpec.dummyJsonRequest(json)
+          val form    = formFactory
+            .form(classOf[JacksonJsonNamingForm])
+            .bindFromRequest(request)
+
+          form.hasErrors must beEqualTo(false)
+          form.field("authorName").value.get must beEqualTo("foo")
+        }
+        "when NOT supplying author_name the form should have an error" in {
+          val json = Json.mapper.readTree("{\"authorName\": \"foo\"}");
+          "when using bind" in {
+            val form = formFactory
+              .form(classOf[JacksonJsonNamingForm])
+              .bind(Lang.defaultLang(), TypedMap.empty(), json, 1024)
+
+            form.hasErrors must beEqualTo(true)
+            form.errors("authorName").get(0).message must beEqualTo("error.required")
+            val errorsJson = form.errorsAsJson();
+            errorsJson.get("author_name").get(0).asText must beEqualTo("This field is required")
+          }
+          "when using bindFromRequest" in {
+            val request = FormSpec.dummyJsonRequest(json)
+            val form    = formFactory
+              .form(classOf[JacksonJsonNamingForm])
+              .bindFromRequest(request)
+
+            form.hasErrors must beEqualTo(true)
+            form.errors("authorName").get(0).message must beEqualTo("error.required")
+            val errorsJson = form.errorsAsJson();
+            errorsJson.get("author_name").get(0).asText must beEqualTo("This field is required")
+          }
+        }
+      }
+      "that maps AuthorName to authorName when @JsonProperty(\"AuthorName\") is used" in {
+        val json = Json.mapper.readTree("{\"AuthorName\": \"foo\"}");
+        "when using bind" in {
+          val form = formFactory
+            .form(classOf[JacksonJsonPropertyForm])
+            .bind(Lang.defaultLang(), TypedMap.empty(), json, 1024)
+
+          form.hasErrors must beEqualTo(false)
+          form.field("authorName").value.get must beEqualTo("foo")
+        }
+        "when using bindFromRequest" in {
+          val request = FormSpec.dummyJsonRequest(json)
+          val form    = formFactory
+            .form(classOf[JacksonJsonPropertyForm])
+            .bindFromRequest(request)
+
+          form.hasErrors must beEqualTo(false)
+          form.field("authorName").value.get must beEqualTo("foo")
+        }
+        "when NOT supplying AuthorName the form should have an error" in {
+          val json = Json.mapper.readTree("{\"author_name\": \"foo\"}");
+          "when using bind" in {
+            val form = formFactory
+              .form(classOf[JacksonJsonPropertyForm])
+              .bind(Lang.defaultLang(), TypedMap.empty(), json, 1024)
+
+            form.hasErrors must beEqualTo(true)
+            form.errors("authorName").get(0).message must beEqualTo("error.required")
+            val errorsJson = form.errorsAsJson();
+            errorsJson.get("AuthorName").get(0).asText must beEqualTo("This field is required")
+          }
+          "when using bindFromRequest" in {
+            val request = FormSpec.dummyJsonRequest(json)
+            val form    = formFactory
+              .form(classOf[JacksonJsonPropertyForm])
+              .bindFromRequest(request)
+
+            form.hasErrors must beEqualTo(true)
+            form.errors("authorName").get(0).message must beEqualTo("error.required")
+            val errorsJson = form.errorsAsJson();
+            errorsJson.get("AuthorName").get(0).asText must beEqualTo("This field is required")
+          }
+        }
+      }
+      "that maps AUTHOR-NAME to authorName when @JsonSetter(\"AUTHOR-NAME\") is used" in {
+        val json = Json.mapper.readTree("{\"AUTHOR-NAME\": \"foo\",\"title\": \"bar\"}");
+        "when using bind" in {
+          val form = formFactory
+            .form(classOf[JacksonJsonGetterSetterForm])
+            .bind(Lang.defaultLang(), TypedMap.empty(), json, 1024)
+
+          form.hasErrors must beEqualTo(false)
+          form.field("authorName").value.get must beEqualTo("foo")
+          form.field("bookName").value.get must beEqualTo("bar")
+        }
+        "when using bindFromRequest" in {
+          val request = FormSpec.dummyJsonRequest(json)
+          val form    = formFactory
+            .form(classOf[JacksonJsonGetterSetterForm])
+            .bindFromRequest(request)
+
+          form.hasErrors must beEqualTo(false)
+          form.field("authorName").value.get must beEqualTo("foo")
+          form.field("bookName").value.get must beEqualTo("bar")
+        }
+        "when NOT supplying AUTHOR-NAME the form should have an error" in {
+          val json = Json.mapper.readTree("{\"authorName\": \"foo\",\"bookName\": \"bar\"}");
+          "when using bind" in {
+            val form = formFactory
+              .form(classOf[JacksonJsonGetterSetterForm])
+              .bind(Lang.defaultLang(), TypedMap.empty(), json, 1024)
+
+            form.hasErrors must beEqualTo(true)
+            form.errors("authorName").get(0).message must beEqualTo("error.required")
+            form.errors("bookName").get(0).message must beEqualTo("error.required")
+            val errorsJson = form.errorsAsJson();
+            errorsJson.get("AUTHOR-NAME").get(0).asText must beEqualTo("This field is required")
+            errorsJson.get("title").get(0).asText must beEqualTo("This field is required")
+          }
+          "when using bindFromRequest" in {
+            val request = FormSpec.dummyJsonRequest(json)
+            val form    = formFactory
+              .form(classOf[JacksonJsonGetterSetterForm])
+              .bindFromRequest(request)
+
+            form.hasErrors must beEqualTo(true)
+            form.errors("authorName").get(0).message must beEqualTo("error.required")
+            form.errors("bookName").get(0).message must beEqualTo("error.required")
+            val errorsJson = form.errorsAsJson();
+            errorsJson.get("AUTHOR-NAME").get(0).asText must beEqualTo("This field is required")
+            errorsJson.get("title").get(0).asText must beEqualTo("This field is required")
+          }
+        }
+      }
+    }
   }
 }
 
@@ -1716,6 +1859,14 @@ object FormSpec {
       .method(method)
       .uri("http://localhost/test" + query)
       .bodyFormArrayValues(data.asJava)
+      .build()
+  }
+
+  def dummyJsonRequest(data: JsonNode, method: String = "POST", query: String = ""): Request = {
+    new RequestBuilder()
+      .method(method)
+      .uri("http://localhost/test" + query)
+      .bodyJson(data)
       .build()
   }
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #11171

## Purpose

What does this PR do?

- It maps the form data from a generic `JsonNode` to the form's backing type. After mapping, the data is converted back to a generic `JsonNode`. This time annotations are ignored.
- When the `errorsAsJson` method is called, it maps internal form field names (`authorName`) back to the corresponding JSON data field names (`author_name`).

- It fixes `testLangErrorsAsJson()` in `HttpFormsTest` by changing `foo` to `amount`. This was needed because the `Money` form doesn't have a field called `foo`.
- It fixes the `fail with exception when the json payload is bigger than default maxBufferSize` test scenario in `DynamicFormSpec`. A `TextNode` can't be mapped to a `DynamicForm.Dynamic` while a `JsonObject` can.

## Background Context

Why did you take this approach?

The form data is converted to the form's backing type, so that Jackson naming annotations like `@JsonNaming`, `@JsonProperty`, `@JsonSetter` are applied to the form fields (e.g. from `author_name` to `authorName`). When mapping back, annotations are ignored to preserve the field names obtained from the previous mapping step (`authorName` stays `authorName`).

I needed to fix the tests, because JSON form binding has become stricter due to the mapping from generic `JsonNode` to the form's backing type. 

## References

Are there any relevant issues / PRs / mailing lists discussions?
