### PR TITLE
remove usage of deprecated play.api.Configuration ++

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -459,9 +459,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
     val testServer = TestServer(testServerPort, app)
     val configuredTestServer =
       testServer.copy(config =
-        testServer.config.copy(configuration =
-          Configuration(config.underlying.withFallback(testServer.config.configuration.underlying))
-        )
+        testServer.config.copy(configuration = config.withFallback(testServer.config.configuration))
       )
     runningWithPort(configuredTestServer)(port => block(app, port))
   }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -458,7 +458,11 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
     currentApp.set(app)
     val testServer = TestServer(testServerPort, app)
     val configuredTestServer =
-      testServer.copy(config = testServer.config.copy(configuration = testServer.config.configuration ++ config))
+      testServer.copy(config =
+        testServer.config.copy(configuration =
+          Configuration(config.underlying.withFallback(testServer.config.configuration.underlying))
+        )
+      )
     runningWithPort(configuredTestServer)(port => block(app, port))
   }
 


### PR DESCRIPTION
one less warning.

`play.api.Configuration.++` was marked as deprecated on 24/09/2019 and since v2.8.0. 
Should it be removed for the 2.9.x series ?
