### PR TITLE
[2.9.x] Backports that are not specific to Play 3

### DIFF
--- a/core/play/src/test/java/play/mvc/CallTest.java
+++ b/core/play/src/test/java/play/mvc/CallTest.java
@@ -48,7 +48,7 @@ public class CallTest {
   public void absoluteURLWithHostAndSecureParameterIsFalseShouldHaveHTTPScheme() {
     final TestCall call = new TestCall("/url", "GET");
 
-    assertEquals("http://typesafe.com/url", call.absoluteURL(false, "typesafe.com"));
+    assertEquals("http://foobar.com/url", call.absoluteURL(false, "foobar.com"));
   }
 
   @Test
@@ -73,7 +73,7 @@ public class CallTest {
   public void absoluteURLWithHostAndSecureParameterIsTrueShouldHaveHTTPSScheme() {
     final TestCall call = new TestCall("/url", "GET");
 
-    assertEquals("https://typesafe.com/url", call.absoluteURL(true, "typesafe.com"));
+    assertEquals("https://foobar.com/url", call.absoluteURL(true, "foobar.com"));
   }
 
   @Test
@@ -98,7 +98,7 @@ public class CallTest {
   public void webSocketURLWithHostAndSecureParameterIsFalseShouldHaveHTTPScheme() {
     final TestCall call = new TestCall("/url", "GET");
 
-    assertEquals("ws://typesafe.com/url", call.webSocketURL(false, "typesafe.com"));
+    assertEquals("ws://foobar.com/url", call.webSocketURL(false, "foobar.com"));
   }
 
   @Test
@@ -123,7 +123,7 @@ public class CallTest {
   public void webSocketURLWithHostAndSecureParameterIsTrueShouldHaveHTTPSScheme() {
     final TestCall call = new TestCall("/url", "GET");
 
-    assertEquals("wss://typesafe.com/url", call.webSocketURL(true, "typesafe.com"));
+    assertEquals("wss://foobar.com/url", call.webSocketURL(true, "foobar.com"));
   }
 
   @Test

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -44,7 +44,7 @@ For more information, please see the [Play documentation guidelines](https://www
 
 ## IDE integration
 
-There is no out of the box integration, but you can use IntelliJ IDEA's [Scala plugin](https://blog.jetbrains.com/scala/) or the [Eclipse](https://github.com/typesafehub/sbteclipse) plugin to generate a project for you.  If you are using IntelliJ IDEA, the [Markdown Support](https://www.jetbrains.com/help/idea/markdown.html) plugin will make editing documentation much easier.
+There is no out of the box integration, but you can use IntelliJ IDEA's [Scala plugin](https://blog.jetbrains.com/scala/) or the [Eclipse](https://github.com/sbt/sbt-eclipse) plugin to generate a project for you.  If you are using IntelliJ IDEA, the [Markdown Support](https://www.jetbrains.com/help/idea/markdown.html) plugin will make editing documentation much easier.
 
 ## Testing
 

--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -8,9 +8,9 @@ However, using a modern Java or Scala IDE provides cool productivity features li
 
 ## Eclipse
 
-### Setup sbteclipse
+### Setup sbt-eclipse
 
-Integration with Eclipse requires [sbteclipse](https://github.com/typesafehub/sbteclipse). Make sure to always use the [most recent available version](https://github.com/typesafehub/sbteclipse/releases) in your project/plugins.sbt file or follow [sbteclipse docs](https://github.com/typesafehub/sbteclipse#for-sbt-013-and-up) to install globally.
+Integration with Eclipse requires [sbt-eclipse](https://github.com/sbt/sbt-eclipse). Make sure to always use the [most recent available version](https://github.com/sbt/sbt-eclipse/releases) in your project/plugins.sbt file or follow [sbt-eclipse docs](https://github.com/sbt/sbt-eclipse#for-sbt-013-and-up) to install globally.
 
 @[add-sbt-eclipse-plugin](code/ide.sbt)
 

--- a/documentation/style/main.css
+++ b/documentation/style/main.css
@@ -107,8 +107,6 @@ footer .links dl{width:33%;box-sizing:border-box;-webkit-box-sizing:border-box;-
 footer .links dt{color:#80c846;font-weight:bold;}
 footer .links a{color:#aaa;text-decoration:none;}footer .links a:hover{color:#888;}
 footer .licence{width:960px;margin:0 auto;box-sizing:border-box;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;margin:20px auto 0;padding-top:20px;border-top:2px solid #ddd;font-size:12px;}footer .licence:after{content:" ";display:block;clear:both;}
-footer .licence .typesafe,footer .licence .zenexity{float:right;}
-footer .licence .typesafe{position:relative;top:-3px;margin-left:10px;}
 footer .licence a{color:#999;}
 div.coreteam{position:relative;min-height:80px;border-bottom:1px solid #eee;}div.coreteam img{width:50px;position:absolute;left:0;top:0;padding:2px;border:1px solid #ddd;}
 div.coreteam a{color:inherit;text-decoration:none;}

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -115,7 +115,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
   "the allowed hosts filter" should {
     "disallow non-local hosts with default config" in withApplication(okWithHost, "") { app =>
       status(request(app, "localhost")) must_== OK
-      statusBadRequest(app, "typesafe.com")
+      statusBadRequest(app, "example.com")
       statusBadRequest(app, "")
     }
 


### PR DESCRIPTION
These (cherry-picked) commits have nothing to do with Pekko or with the `org.playframework` switch, so I backport them 2.9.x so we keep that branches "synced". With that, the main branch only contains pekko and `org.playframework` commits now.