### PR TITLE
Pronoun change in IDE.md for gender neutrality

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -66,7 +66,7 @@ If you make any important changes to your application, such as changing the clas
 > /.settings
 > ```
 
-The generated configuration files contain absolute references to your framework installation. These are specific to your own installation. When you work in a team, each developer must keep his Eclipse configuration files private.
+The generated configuration files contain absolute references to your framework installation. These are specific to your own installation. When you work in a team, each developer must keep their Eclipse configuration files private.
 
 ## IntelliJ IDEA
 


### PR DESCRIPTION


<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?

# Helpful things

## Fixes
This replaces the gendered term "his" in the sentence of IDE.md, `each developer must keep his Eclipse configuration files private`, with the neutral "their". 

## Purpose
This change has been made to ensure that Play's documentation is gender neutral as per the guidelines: [https://www.playframework.com/documentation/2.8.x/Documentation#Gender-neutral-language-and-names](https://www.playframework.com/documentation/2.8.x/Documentation#Gender-neutral-language-and-names)

## References
[Play Documentation Guidelines](https://www.playframework.com/documentation/2.8.x/Documentation#Gender-neutral-language-and-names)
