### PR TITLE
remove `"-Xmigration"` from main scalacOptions. add explicit type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,6 +86,13 @@ lazy val PlayJodaFormsProject = PlayCrossBuiltProject("Play-Joda-Forms", "web/pl
 lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
   .enablePlugins(SbtTwirl)
   .settings(
+    Compile / scalacOptions ++= {
+      if (scalaBinaryVersion.value == "2.13") {
+        Seq("-Wconf:msg=package object inheritance is deprecated:warning")
+      } else {
+        Nil
+      }
+    },
     libraryDependencies ++= runtime(scalaVersion.value) ++ scalacheckDependencies ++ cookieEncodingDependencies :+
       jimfs % Test,
     (Compile / sourceGenerators) += Def
@@ -280,6 +287,13 @@ lazy val PlayConfiguration = PlayCrossBuiltProject("Play-Configuration", "core/p
 lazy val PlayWsProject = PlayCrossBuiltProject("Play-WS", "transport/client/play-ws")
   .settings(
     libraryDependencies ++= playWsDeps,
+    Compile / scalacOptions ++= {
+      if (scalaBinaryVersion.value == "2.13") {
+        Seq("-Wconf:msg=package object inheritance is deprecated:warning")
+      } else {
+        Nil
+      }
+    },
     (Test / parallelExecution) := false,
     // quieten deprecation warnings in tests
     (Test / scalacOptions) := (Test / scalacOptions).value.diff(Seq("-deprecation"))

--- a/build.sbt
+++ b/build.sbt
@@ -86,13 +86,6 @@ lazy val PlayJodaFormsProject = PlayCrossBuiltProject("Play-Joda-Forms", "web/pl
 lazy val PlayProject = PlayCrossBuiltProject("Play", "core/play")
   .enablePlugins(SbtTwirl)
   .settings(
-    Compile / scalacOptions ++= {
-      if (scalaBinaryVersion.value == "2.13") {
-        Seq("-Wconf:msg=package object inheritance is deprecated:warning")
-      } else {
-        Nil
-      }
-    },
     libraryDependencies ++= runtime(scalaVersion.value) ++ scalacheckDependencies ++ cookieEncodingDependencies :+
       jimfs % Test,
     (Compile / sourceGenerators) += Def
@@ -287,13 +280,6 @@ lazy val PlayConfiguration = PlayCrossBuiltProject("Play-Configuration", "core/p
 lazy val PlayWsProject = PlayCrossBuiltProject("Play-WS", "transport/client/play-ws")
   .settings(
     libraryDependencies ++= playWsDeps,
-    Compile / scalacOptions ++= {
-      if (scalaBinaryVersion.value == "2.13") {
-        Seq("-Wconf:msg=package object inheritance is deprecated:warning")
-      } else {
-        Nil
-      }
-    },
     (Test / parallelExecution) := false,
     // quieten deprecation warnings in tests
     (Test / scalacOptions) := (Test / scalacOptions).value.diff(Seq("-deprecation"))

--- a/core/play-configuration/src/main/scala/play/api/Configuration.scala
+++ b/core/play-configuration/src/main/scala/play/api/Configuration.scala
@@ -158,7 +158,7 @@ object Configuration {
         val originUrlOpt     = Option(o.url)
         new PlayException.ExceptionSource("Configuration error", message, e.orNull) {
           def line              = originLine
-          def position          = null
+          def position: Integer = null
           def input             = originUrlOpt.map(url => new String(readStream(url.openStream()), codec.name)).orNull
           def sourceName        = originSourceName
           override def toString = "Configuration error: " + getMessage

--- a/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
@@ -466,7 +466,7 @@ object ConfigurationSpec {
   }
 
   final class BytesUrlConnection(url: URL, bytes: Array[Byte]) extends URLConnection(url) {
-    def connect()               = ()
-    override def getInputStream = new ByteArrayInputStream(bytes)
+    def connect()                            = ()
+    override def getInputStream: InputStream = new ByteArrayInputStream(bytes)
   }
 }

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -274,7 +274,7 @@ private class FakeRoutes(injected: => PartialFunction[(String, String), Handler]
       fallback.routes.applyOrElse(rh, default)
     def isDefinedAt(x: RequestHeader) = fallback.routes.isDefinedAt(x)
   })
-  def withPrefix(prefix: String) = {
+  def withPrefix(prefix: String): Router = {
     new FakeRoutes(injected, fallback.withPrefix(prefix))
   }
 }

--- a/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -56,7 +56,7 @@ object ActorFlow {
             case other             => flowActor ! other
           }
 
-          override def supervisorStrategy = OneForOneStrategy() {
+          override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() {
             case _ => SupervisorStrategy.Stop
           }
         })),

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -704,7 +704,7 @@ object Assets {
 
     // This uses StaticAssetsMetadata to obtain the full path to the asset.
     implicit def assetPathBindable(implicit rrc: ReverseRouteContext): PathBindable[Asset] = new PathBindable[Asset] {
-      def bind(key: String, value: String) = Right(new Asset(value))
+      def bind(key: String, value: String): Either[String, Asset] = Right(new Asset(value))
 
       def unbind(key: String, value: Asset): String = {
         val base = pathFromParams(rrc)

--- a/core/play/src/main/scala/play/api/data/format/Format.scala
+++ b/core/play/src/main/scala/play/api/data/format/Format.scala
@@ -53,8 +53,8 @@ object Formats {
    * @param value As we ignore this parameter in binding/unbinding we have to provide a default value.
    */
   def ignoredFormat[A](value: A): Formatter[A] = new Formatter[A] {
-    def bind(key: String, data: Map[String, String]) = Right(value)
-    def unbind(key: String, value: A)                = Map.empty
+    def bind(key: String, data: Map[String, String]): Either[Seq[FormError], A] = Right(value)
+    def unbind(key: String, value: A): Map[String, String]                      = Map.empty
   }
 
   /**
@@ -103,7 +103,7 @@ object Formats {
   private def numberFormatter[T](convert: String => T, real: Boolean = false): Formatter[T] = {
     val (formatString, errorString) = if (real) ("format.real", "error.real") else ("format.numeric", "error.number")
     new Formatter[T] {
-      override val format = Some(formatString -> Nil)
+      override val format: Option[(String, Seq[Any])] = Some(formatString -> Nil)
       def bind(key: String, data: Map[String, String]) =
         parsing(convert, errorString, Nil)(key, data)
       def unbind(key: String, value: T) = Map(key -> value.toString)
@@ -144,7 +144,7 @@ object Formats {
    * Default formatter for the `BigDecimal` type.
    */
   def bigDecimalFormat(precision: Option[(Int, Int)]): Formatter[BigDecimal] = new Formatter[BigDecimal] {
-    override val format = Some(("format.real", Nil))
+    override val format: Option[(String, Seq[Any])] = Some(("format.real", Nil))
 
     def bind(key: String, data: Map[String, String]) = {
       Formats.stringFormat.bind(key, data).flatMap { s =>
@@ -192,7 +192,7 @@ object Formats {
    * Default formatter for the `Boolean` type.
    */
   implicit def booleanFormat: Formatter[Boolean] = new Formatter[Boolean] {
-    override val format = Some(("format.boolean", Nil))
+    override val format: Option[(String, Seq[Any])] = Some(("format.boolean", Nil))
 
     def bind(key: String, data: Map[String, String]) = {
       Right(data.getOrElse(key, "false")).flatMap {
@@ -223,7 +223,7 @@ object Formats {
       Date.from(instant.withZoneSameLocal(javaTimeZone).toInstant)
     }
 
-    override val format = Some(("format.date", Seq(pattern)))
+    override val format: Option[(String, Seq[Any])] = Some(("format.date", Seq(pattern)))
 
     def bind(key: String, data: Map[String, String]) = parsing(dateParse, "error.date", Nil)(key, data)
 
@@ -243,7 +243,7 @@ object Formats {
   def sqlDateFormat(pattern: String): Formatter[java.sql.Date] = new Formatter[java.sql.Date] {
     private val dateFormatter: Formatter[LocalDate] = localDateFormat(pattern)
 
-    override val format = Some(("format.date", Seq(pattern)))
+    override val format: Option[(String, Seq[Any])] = Some(("format.date", Seq(pattern)))
 
     def bind(key: String, data: Map[String, String]) = {
       dateFormatter.bind(key, data).map(d => java.sql.Date.valueOf(d))
@@ -270,7 +270,7 @@ object Formats {
       private val formatter                    = java.time.format.DateTimeFormatter.ofPattern(pattern).withZone(timeZone.toZoneId)
       private def timestampParse(data: String) = java.sql.Timestamp.valueOf(LocalDateTime.parse(data, formatter))
 
-      override val format = Some(("format.timestamp", Seq(pattern)))
+      override val format: Option[(String, Seq[Any])] = Some(("format.timestamp", Seq(pattern)))
 
       override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Timestamp] =
         parsing(timestampParse, "error.timestamp", Nil)(key, data)
@@ -294,7 +294,7 @@ object Formats {
     val formatter                    = java.time.format.DateTimeFormatter.ofPattern(pattern)
     def localDateParse(data: String) = LocalDate.parse(data, formatter)
 
-    override val format = Some(("format.date", Seq(pattern)))
+    override val format: Option[(String, Seq[Any])] = Some(("format.date", Seq(pattern)))
 
     def bind(key: String, data: Map[String, String]) = parsing(localDateParse, "error.date", Nil)(key, data)
 
@@ -321,7 +321,7 @@ object Formats {
     val formatter                        = java.time.format.DateTimeFormatter.ofPattern(pattern).withZone(zoneId)
     def localDateTimeParse(data: String) = LocalDateTime.parse(data, formatter)
 
-    override val format = Some(("format.localDateTime", Seq(pattern)))
+    override val format: Option[(String, Seq[Any])] = Some(("format.localDateTime", Seq(pattern)))
 
     def bind(key: String, data: Map[String, String]) =
       parsing(localDateTimeParse, "error.localDateTime", Nil)(key, data)
@@ -345,7 +345,7 @@ object Formats {
     val formatter                    = java.time.format.DateTimeFormatter.ofPattern(pattern)
     def localTimeParse(data: String) = LocalTime.parse(data, formatter)
 
-    override val format = Some(("format.localTime", Seq(pattern)))
+    override val format: Option[(String, Seq[Any])] = Some(("format.localTime", Seq(pattern)))
 
     def bind(key: String, data: Map[String, String]) = parsing(localTimeParse, "error.localTime", Nil)(key, data)
 
@@ -361,7 +361,7 @@ object Formats {
    * Default formatter for the `java.util.UUID` type.
    */
   implicit def uuidFormat: Formatter[UUID] = new Formatter[UUID] {
-    override val format = Some(("format.uuid", Nil))
+    override val format: Option[(String, Seq[Any])] = Some(("format.uuid", Nil))
 
     override def bind(key: String, data: Map[String, String]) = parsing(UUID.fromString, "error.uuid", Nil)(key, data)
 

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -398,10 +398,10 @@ object HttpErrorHandlerExceptions {
       .map {
         case (file, lineOpt) =>
           new PlayException.ExceptionSource("Execution exception", desc, throwable) {
-            def line       = lineOpt.map(_.asInstanceOf[java.lang.Integer]).orNull
-            def position   = null
-            def input      = PlayIO.readFileAsString(file.toPath)
-            def sourceName = file.getAbsolutePath
+            def line              = lineOpt.map(_.asInstanceOf[java.lang.Integer]).orNull
+            def position: Integer = null
+            def input             = PlayIO.readFileAsString(file.toPath)
+            def sourceName        = file.getAbsolutePath
           }
       }
       .getOrElse(new PlayException("Execution exception", desc, throwable))

--- a/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -85,7 +85,7 @@ object ActionCreator {
  * Implementation of a [HttpRequestHandler] that always returns NotImplemented results
  */
 object NotImplementedHttpRequestHandler extends HttpRequestHandler {
-  def handlerForRequest(request: RequestHeader) =
+  def handlerForRequest(request: RequestHeader): (RequestHeader, Handler) =
     request -> EssentialAction(_ => Accumulator.done(Results.NotImplemented))
 }
 

--- a/core/play/src/main/scala/play/api/mvc/Action.scala
+++ b/core/play/src/main/scala/play/api/mvc/Action.scala
@@ -542,7 +542,7 @@ trait ActionTransformer[-R[_], +P[_]] extends ActionRefiner[R, P] {
    */
   protected def transform[A](request: R[A]): Future[P[A]]
 
-  final def refine[A](request: R[A]) = transform(request).map(Right(_))(executionContext)
+  final def refine[A](request: R[A]): Future[Either[Result, P[A]]] = transform(request).map(Right(_))(executionContext)
 }
 
 /**

--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -332,7 +332,7 @@ object QueryStringBindable extends QueryStringBindableMacros {
    * QueryString binder for String.
    */
   implicit def bindableString: QueryStringBindable[String] = new QueryStringBindable[String] {
-    def bind(key: String, params: Map[String, Seq[String]]) =
+    def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, String]] =
       params.get(key).flatMap(_.headOption).map(Right(_))
     // No need to URL decode from query string since netty already does that
 
@@ -461,7 +461,7 @@ object QueryStringBindable extends QueryStringBindableMacros {
    */
   implicit def bindableOption[T: QueryStringBindable]: QueryStringBindable[Option[T]] =
     new QueryStringBindable[Option[T]] {
-      def bind(key: String, params: Map[String, Seq[String]]) = {
+      def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, Option[T]]] = {
         Some(
           implicitly[QueryStringBindable[T]]
             .bind(key, params)
@@ -479,7 +479,7 @@ object QueryStringBindable extends QueryStringBindableMacros {
    */
   implicit def bindableJavaOption[T: QueryStringBindable]: QueryStringBindable[Optional[T]] =
     new QueryStringBindable[Optional[T]] {
-      def bind(key: String, params: Map[String, Seq[String]]) = {
+      def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, Optional[T]]] = {
         Some(
           implicitly[QueryStringBindable[T]]
             .bind(key, params)
@@ -497,7 +497,7 @@ object QueryStringBindable extends QueryStringBindableMacros {
    * QueryString binder for Java OptionalInt.
    */
   implicit def bindableJavaOptionalInt: QueryStringBindable[OptionalInt] = new QueryStringBindable[OptionalInt] {
-    def bind(key: String, params: Map[String, Seq[String]]) = {
+    def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, OptionalInt]] = {
       Some(
         bindableInt
           .bind(key, params)
@@ -513,7 +513,7 @@ object QueryStringBindable extends QueryStringBindableMacros {
    * QueryString binder for Java OptionalLong.
    */
   implicit def bindableJavaOptionalLong: QueryStringBindable[OptionalLong] = new QueryStringBindable[OptionalLong] {
-    def bind(key: String, params: Map[String, Seq[String]]) = {
+    def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, OptionalLong]] = {
       Some(
         bindableLong
           .bind(key, params)
@@ -530,7 +530,7 @@ object QueryStringBindable extends QueryStringBindableMacros {
    */
   implicit def bindableJavaOptionalDouble: QueryStringBindable[OptionalDouble] =
     new QueryStringBindable[OptionalDouble] {
-      def bind(key: String, params: Map[String, Seq[String]]) = {
+      def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, OptionalDouble]] = {
         Some(
           bindableDouble
             .bind(key, params)

--- a/core/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/core/play/src/main/scala/play/api/mvc/Filters.scala
@@ -93,7 +93,7 @@ object Filter {
   def apply(
       filter: (RequestHeader => Future[Result], RequestHeader) => Future[Result]
   )(implicit m: Materializer): Filter = new Filter {
-    implicit def mat                                                                 = m
+    implicit def mat: Materializer                                                   = m
     def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = filter(f, rh)
   }
 }

--- a/core/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/core/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -87,7 +87,7 @@ private[mvc] trait Range extends Ordered[Range] {
 
 private[mvc] case class WithEntityLengthRange(entityLength: Long, start: Option[Long], end: Option[Long])
     extends Range {
-  override def getEntityLength = Some(entityLength)
+  override def getEntityLength: Option[Long] = Some(entityLength)
 
   // Rules according to RFC 7233:
   // 1. If the last-byte-pos value is absent, or if the value is greater

--- a/core/play/src/main/scala/play/api/routing/Router.scala
+++ b/core/play/src/main/scala/play/api/routing/Router.scala
@@ -140,9 +140,9 @@ object Router {
    * Never returns an handler from the routes function.
    */
   val empty: Router = new Router {
-    def documentation              = Nil
-    def withPrefix(prefix: String) = this
-    def routes                     = PartialFunction.empty
+    def documentation: Seq[(String, String, String)] = Nil
+    def withPrefix(prefix: String): Router           = this
+    def routes: Routes                               = PartialFunction.empty
   }
 
   /**

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -48,7 +48,7 @@ trait JavaHelpers {
     cookies.asScala.toSeq.map(_.asScala())
   }
 
-  def cookiesToJavaCookies(cookies: Cookies) = {
+  def cookiesToJavaCookies(cookies: Cookies): JCookies = {
     new JCookies {
       override def get(name: String): Optional[JCookie] = Optional.ofNullable(cookies.get(name).map(_.asJava).orNull)
 
@@ -235,7 +235,7 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   override def queryString(key: String): Optional[String] = header.getQueryString(key).toJava
 
-  override def cookie(name: String): Optional[JCookie] = cookies().get(name)
+  override def cookie(name: String) = cookies().get(name)
 
   @deprecated override def getCookie(name: String): Optional[JCookie] = cookie(name)
 

--- a/core/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
@@ -16,8 +16,8 @@ import play.routing.Router.RouteDocumentation
  * Adapts the Scala router to the Java Router API
  */
 class JavaRouterAdapter @Inject() (underlying: play.api.routing.Router) extends play.routing.Router {
-  def route(requestHeader: RequestHeader) = underlying.handlerFor(requestHeader.asScala()).toJava
-  def withPrefix(prefix: String)          = new JavaRouterAdapter(asScala.withPrefix(prefix))
+  def route(requestHeader: RequestHeader)             = underlying.handlerFor(requestHeader.asScala()).toJava
+  def withPrefix(prefix: String): play.routing.Router = new JavaRouterAdapter(asScala.withPrefix(prefix))
   def documentation() =
     asScala.documentation.map {
       case (httpMethod, pathPattern, controllerMethodInvocation) =>

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -20,6 +20,7 @@ import play.api.Environment
 import play.api.Logger
 import play.api.Mode
 import play.core.DefaultWebCommands
+import play.core.WebCommands
 import play.utils.PlayIO
 
 /**
@@ -367,7 +368,7 @@ object OfflineEvolutions {
       lazy val configuration                              = Configuration.load(environment)
       lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
       lazy val dbApi: DBApi                               = _dbApi
-      lazy val webCommands                                = new DefaultWebCommands
+      lazy val webCommands: WebCommands                   = new DefaultWebCommands
     }
   }
 

--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -850,7 +850,7 @@ object ThisClassLoaderEvolutionsReader
  * Simple map based implementation of the evolutions reader.
  */
 class SimpleEvolutionsReader(evolutionsMap: Map[String, Seq[Evolution]]) extends EvolutionsReader {
-  def evolutions(db: String) = evolutionsMap.getOrElse(db, Nil)
+  def evolutions(db: String): collection.Seq[Evolution] = evolutionsMap.getOrElse(db, Nil)
 }
 
 /**

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -279,7 +279,6 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "play.data.validation.Constraints#PlayConstraintValidatorWithPayload.isValid"
       ),
-      ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.inject.Module.bindings"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -279,6 +279,7 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "play.data.validation.Constraints#PlayConstraintValidatorWithPayload.isValid"
       ),
+      ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.inject.Module.bindings"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/PlayBuildBase.scala
+++ b/project/PlayBuildBase.scala
@@ -56,9 +56,17 @@ object PlayBuildBase extends AutoPlugin {
     licenses             := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8") ++
       (CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 13)) => Seq("-Xsource:3", "-Xmigration")
+        case Some((2, 13)) => Seq("-Xsource:3")
         case _             => Seq.empty
       }),
+    Test / scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 13)) =>
+          Seq("-Xmigration:2.13")
+        case _ =>
+          Seq.empty
+      }
+    },
     javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
     resolvers ++= {
       if (isSnapshot.value) {

--- a/testkit/play-test/src/main/scala/play/api/test/NoMaterializer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/NoMaterializer.scala
@@ -9,9 +9,11 @@ package org.apache.pekko.stream.testkit
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.ExecutionContextExecutor
 
+import org.apache.pekko.actor.ActorRef
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.actor.Cancellable
 import org.apache.pekko.actor.Props
+import org.apache.pekko.event.LoggingAdapter
 import org.apache.pekko.stream.ActorMaterializerSettings
 import org.apache.pekko.stream.Attributes
 import org.apache.pekko.stream.ClosedShape
@@ -60,12 +62,14 @@ object NoMaterializer extends Materializer {
 
   override def system: ActorSystem = throw new UnsupportedOperationException("NoMaterializer does not provide system")
 
-  private[pekko] override def logger = throw new UnsupportedOperationException("NoMaterializer does not provide logger")
+  private[pekko] override def logger: LoggingAdapter = throw new UnsupportedOperationException(
+    "NoMaterializer does not provide logger"
+  )
 
-  private[pekko] override def supervisor =
+  private[pekko] override def supervisor: ActorRef =
     throw new UnsupportedOperationException("NoMaterializer does not provide supervisor")
 
-  private[pekko] override def actorOf(context: MaterializationContext, props: Props) =
+  private[pekko] override def actorOf(context: MaterializationContext, props: Props): ActorRef =
     throw new UnsupportedOperationException("NoMaterializer does not provide actorOf")
 
   override def settings: ActorMaterializerSettings =

--- a/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ServerEndpointRecipe.scala
@@ -141,7 +141,7 @@ import play.core.server.ServerProvider
     )
   }
 
-  def withDescription(newDescription: String) =
+  def withDescription(newDescription: String): ServerEndpointRecipe =
     new HttpsServerEndpointRecipe(
       newDescription,
       serverProvider,
@@ -150,7 +150,7 @@ import play.core.server.ServerProvider
       expectedServerAttr
     )
 
-  def withServerProvider(newProvider: ServerProvider) =
+  def withServerProvider(newProvider: ServerProvider): ServerEndpointRecipe =
     new HttpsServerEndpointRecipe(
       description,
       newProvider,

--- a/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -135,10 +135,10 @@ private[play] class TestServerProcess extends ServerProcess {
     for (h <- hooks) h.apply()
   }
 
-  override def classLoader = getClass.getClassLoader
-  override def args        = Seq()
-  override def properties  = System.getProperties
-  override def pid         = None
+  override def classLoader         = getClass.getClassLoader
+  override def args: Seq[String]   = Seq()
+  override def properties          = System.getProperties
+  override def pid: Option[String] = None
 
   override def exit(message: String, cause: Option[Throwable] = None, returnCode: Int = -1): Nothing = {
     throw new TestServerExitException(message, cause, returnCode)

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -420,7 +420,7 @@ class NettyServer(
  * The Netty server provider
  */
 class NettyServerProvider extends ServerProvider {
-  def createServer(context: ServerProvider.Context) =
+  def createServer(context: ServerProvider.Context): Server =
     new NettyServer(
       context.config,
       context.appProvider,

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -255,8 +255,8 @@ private[play] final class ServerResultUtils(
    * force an HTTP 1.0 connection to remain open.
    */
   case object SendKeepAlive extends ConnectionHeader {
-    override def willClose = false
-    override def header    = Some(KEEP_ALIVE)
+    override def willClose              = false
+    override def header: Option[String] = Some(KEEP_ALIVE)
   }
 
   /**
@@ -264,8 +264,8 @@ private[play] final class ServerResultUtils(
    * force an HTTP 1.1 connection to close.
    */
   case object SendClose extends ConnectionHeader {
-    override def willClose = true
-    override def header    = Some(CLOSE)
+    override def willClose              = true
+    override def header: Option[String] = Some(CLOSE)
   }
 
   /**
@@ -274,8 +274,8 @@ private[play] final class ServerResultUtils(
    * or when the response already has a Connection: close header.
    */
   case object DefaultClose extends ConnectionHeader {
-    override def willClose = true
-    override def header    = None
+    override def willClose              = true
+    override def header: Option[String] = None
   }
 
   /**
@@ -284,8 +284,8 @@ private[play] final class ServerResultUtils(
    * open.
    */
   case object DefaultKeepAlive extends ConnectionHeader {
-    override def willClose = false
-    override def header    = None
+    override def willClose              = false
+    override def header: Option[String] = None
   }
 
   // Values for the Connection header

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -86,7 +86,8 @@ object CORSActionBuilder {
   )(implicit materializer: Materializer, ec: ExecutionContext): CORSActionBuilder = {
     val eh = errorHandler
     new CORSActionBuilder {
-      override lazy val parser                                  = new BodyParsers.Default(tempFileCreator, eh, parserConfig)(materializer)
+      override lazy val parser: BodyParser[AnyContent] =
+        new BodyParsers.Default(tempFileCreator, eh, parserConfig)(materializer)
       protected override def mat: Materializer                  = materializer
       protected override def executionContext: ExecutionContext = ec
       protected override def corsConfig: CORSConfig = {
@@ -112,7 +113,8 @@ object CORSActionBuilder {
   )(implicit materializer: Materializer, ec: ExecutionContext): CORSActionBuilder = {
     val eh = errorHandler
     new CORSActionBuilder {
-      override lazy val parser                                  = new BodyParsers.Default(tempFileCreator, eh, parserConfig)(materializer)
+      override lazy val parser: BodyParser[AnyContent] =
+        new BodyParsers.Default(tempFileCreator, eh, parserConfig)(materializer)
       protected override def mat: Materializer                  = materializer
       protected override val executionContext: ExecutionContext = ec
       protected override val corsConfig: CORSConfig             = config

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -14,6 +14,7 @@ import play.api.libs.streams.Accumulator
 import play.api.libs.typedmap.TypedKey
 import play.api.mvc._
 import play.api.Logger
+import play.api.LoggerLike
 import play.core.j.JavaContextComponents
 import play.core.j.JavaHttpErrorHandlerAdapter
 
@@ -74,7 +75,7 @@ class CORSFilter(
     )
   }
 
-  protected override val logger = Logger(classOf[CORSFilter])
+  protected override val logger: LoggerLike = Logger(classOf[CORSFilter])
 
   override def apply(next: EssentialAction): EssentialAction = new EssentialAction {
     override def apply(request: RequestHeader): Accumulator[ByteString, Result] = {

--- a/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -60,8 +60,9 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
   )(implicit mat: Materializer) =
     this(GzipFilterConfig(bufferSize, chunkedThreshold, threshold, shouldGzip, compressionLevel))
 
-  def apply(next: EssentialAction) = new EssentialAction {
+  def apply(next: EssentialAction): EssentialAction = new EssentialAction {
     implicit val ec: ExecutionContext = mat.executionContext
+
     def apply(request: RequestHeader) = {
       if (mayCompress(request)) {
         next(request).mapFuture(result => handleResult(request, result))

--- a/web/play-joda-forms/src/main/scala/play/api/data/format/JodaFormats.scala
+++ b/web/play-joda-forms/src/main/scala/play/api/data/format/JodaFormats.scala
@@ -40,7 +40,7 @@ object JodaFormats {
   ): Formatter[org.joda.time.DateTime] = new Formatter[org.joda.time.DateTime] {
     val formatter = org.joda.time.format.DateTimeFormat.forPattern(pattern).withZone(timeZone)
 
-    override val format = Some(("format.date", Seq(pattern)))
+    override val format: Option[(String, Seq[Any])] = Some(("format.date", Seq(pattern)))
 
     def bind(key: String, data: Map[String, String]) = parsing(formatter.parseDateTime, "error.date", Nil)(key, data)
 
@@ -64,7 +64,7 @@ object JodaFormats {
       val formatter                        = org.joda.time.format.DateTimeFormat.forPattern(pattern)
       def jodaLocalDateParse(data: String) = LocalDate.parse(data, formatter)
 
-      override val format = Some(("format.date", Seq(pattern)))
+      override val format: Option[(String, Seq[Any])] = Some(("format.date", Seq(pattern)))
 
       def bind(key: String, data: Map[String, String]) = parsing(jodaLocalDateParse, "error.date", Nil)(key, data)
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose

remove `"-Xmigration"` from main code and add explicit types. for avoid different return types Scala 2 and 3.

## Background Context

`"-Xmigration"` suppress some warnings. But I think this is **not** good idea.

please see following example and `scala/scala` pull request.

- https://github.com/scala/scala/pull/10439

#### Scala 3

```scala
Welcome to Scala 3.3.1 (11.0.20.1, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> trait A { def x: Any } ; class B extends A { def x = "x" }
// defined trait A
// defined class B
                                                                                                                                             
scala> new B().x // not String !. different type with Scala 2.13
val res0: Any = x

```

#### no option


```scala
Welcome to Scala 2.13.12 (OpenJDK 64-Bit Server VM, Java 11.0.20.1).
Type in expressions for evaluation. Or try :help.

scala> trait A { def x: Any } ; class B extends A { def x = "x" }
trait A
class B

scala> new B().x
val res0: String = x
```

#### `-Xsource:3`

```scala
$ scala -Xsource:3
Welcome to Scala 2.13.12 (OpenJDK 64-Bit Server VM, Java 11.0.20.1).
Type in expressions for evaluation. Or try :help.

scala> trait A { def x: Any } ; class B extends A { def x = "x" }
                                                        ^
       error: under -Xsource:3, inferred Any instead of String [quickfixable]
       Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
       Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=B.x

scala> trait A { def x: Any } ; class B extends A { def x: String = "x" }
trait A
class B
```


#### `-Xsource:3` and `-Xmigration`

```scala
$ scala -Xsource:3 -Xmigration
Welcome to Scala 2.13.12 (OpenJDK 64-Bit Server VM, Java 11.0.20.1).
Type in expressions for evaluation. Or try :help.

scala> trait A { def x: Any } ; class B extends A { def x = "x" }
                                                        ^
       warning: under -Xsource:3, inferred Any instead of String [quickfixable]
trait A
class B

scala> def f: Seq[Int] = Nil // unnecessary migration message!!!
              ^
       warning: type Seq in package scala has changed semantics in version 2.13.0:
       scala.Seq is now scala.collection.immutable.Seq instead of scala.collection.Seq
def f: Seq[Int]
```


## References

