### PR TITLE
Add `addDependencyTreePlugin`

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,8 @@
 
 enablePlugins(BuildInfoPlugin)
 
+addDependencyTreePlugin
+
 // when updating sbtNativePackager version, be sure to also update the documentation links in
 // documentation/manual/working/commonGuide/production/Deploying.md
 val sbtNativePackager  = "1.9.16"


### PR DESCRIPTION
Doesn't hurt but gives us more commands to inspect dependencies:
* https://www.scala-sbt.org/1.x/docs/sbt-1.4-Release-Notes.html#sbt-dependency-graph+is+in-sourced
* https://github.com/sbt/sbt-dependency-graph#main-tasks