### PR TITLE
replace deprecated `Resolver.sonatypeRepo`

### DIFF
--- a/documentation/manual/hacking/Repositories.md
+++ b/documentation/manual/hacking/Repositories.md
@@ -13,5 +13,5 @@ This repository is enabled by default in your project, so you don't need to manu
 Nightly snapshots are published to the Sonatype snapshots repository. You can [browse the play directory to find the version of the sbt-plugin you'd like to use](https://oss.sonatype.org/content/repositories/snapshots/org/playframework/sbt-plugin_2.12_1.0/) in your `plugins.sbt`. To enable the snapshots repo in your build, you must add a resolver (typically in `plugins.sbt`):
 
 ```scala
-resolvers += Resolver.sonatypeRepo("snapshots")
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 ```

--- a/documentation/manual/working/commonGuide/build/code/dependencies.sbt
+++ b/documentation/manual/working/commonGuide/build/code/dependencies.sbt
@@ -24,7 +24,7 @@ libraryDependencies += "org.scala-stm" %% "scala-stm" % "0.9.1"
 //#auto-scala-version-dep
 
 //#resolver
-resolvers += Resolver.sonatypeRepo("snapshots")
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 //#resolver
 
 //#local-maven-repos


### PR DESCRIPTION

<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose

fix warnings

## Background Context

- https://github.com/sbt/librarymanagement/commit/e15f0c149ae940575d2314cf044b4347fc67b12a
- https://github.com/sbt/librarymanagement/blob/54011d5e74335bab229bc3f6532b6a1ca6d0d5cd/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala#L159-L163

## References
