### PR TITLE
Update play-json scaladoc url

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
@@ -37,7 +37,7 @@ The default body parser produces a body of type [`AnyContent`](api/scala/play/ap
 The following is a mapping of types supported by the default body parser:
 
 - **text/plain**: `String`, accessible via `asText`.
-- **application/json**: [`JsValue`](https://static.javadoc.io/org.playframework/play-json_2.13/2.6.9/play/api/libs/json/JsValue.html), accessible via `asJson`.
+- **application/json**: [`JsValue`](https://www.javadoc.io/doc/org.playframework/play-json_2.13/3.0.0/play/api/libs/json/JsValue.html), accessible via `asJson`.
 - **application/xml**, **text/xml** or **application/XXX+xml**: `scala.xml.NodeSeq`, accessible via `asXml`.
 - **application/x-www-form-urlencoded**: `Map[String, Seq[String]]`, accessible via `asFormUrlEncoded`.
 - **multipart/form-data**: [`MultipartFormData`](api/scala/play/api/mvc/MultipartFormData.html), accessible via `asMultipartFormData`.

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -178,11 +178,11 @@ The WSResponse extends [`play.api.libs.ws.WSBodyReadables`](api/scala/play/api/l
 
 ### Processing a response as JSON
 
-You can process the response as a [JSON object](https://static.javadoc.io/org.playframework/play-json_2.13/2.9.2/play/api/libs/json/JsValue.html) by calling `response.json`.
+You can process the response as a [JSON object](https://www.javadoc.io/doc/org.playframework/play-json_2.13/3.0.0/play/api/libs/json/JsValue.html) by calling `response.json`.
 
 @[scalaws-process-json](code/ScalaWSSpec.scala)
 
-The JSON library has a [[useful feature|ScalaJsonCombinators]] that will map an implicit [`Reads[T]`](https://static.javadoc.io/org.playframework/play-json_2.13/2.9.2/play/api/libs/json/Reads.html) directly to a class:
+The JSON library has a [[useful feature|ScalaJsonCombinators]] that will map an implicit [`Reads[T]`](https://www.javadoc.io/doc/org.playframework/play-json_2.13/3.0.0/play/api/libs/json/Reads.html) directly to a class:
 
 @[scalaws-process-json-with-implicit](code/ScalaWSSpec.scala)
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes


## Purpose

fix url

## Background Context

play-json 2.x does not exists with new groupId( `org.playframework` ).
playframework 3.x depends on play-json 3.x.

## References
