### PR TITLE
use new sbt slash syntax in doc

### DIFF
--- a/documentation/manual/working/commonGuide/build/sbtDebugging.md
+++ b/documentation/manual/working/commonGuide/build/sbtDebugging.md
@@ -37,7 +37,7 @@ The output above has been formatted to ensure it fits cleanly on the screen, you
 You can also specify a task a particular scope, eg `Test/sources` or `Compile/sources`, or for a particular project, `my-project/Compile/sources`, and in some cases, where tasks are scoped by another task, you can specify that scope too, for example, to see everything that will be packaged into your projects jar file, you want to show the `mappings` task, scoped to the `packageBin` task:
 
 ```
-[my-first-app] $ show compile:packageBin::mappings
+[my-first-app] $ show Compile / packageBin / mappings
 [info] List(
   (my-first-app/target/scala-2.13/classes/application.conf,application.conf),
   (my-first-app/target/scala-2.13/classes/controllers/Application.class,controllers/Application.class),

--- a/documentation/manual/working/commonGuide/production/Deploying.md
+++ b/documentation/manual/working/commonGuide/production/Deploying.md
@@ -75,10 +75,10 @@ For a full description of usage invoke the start script with a `-h` option.
 > $ chmod +x /path/to/bin/<project-name>
 > ```
 >
-> Alternatively a tar.gz file can be produced instead. Tar files retain permissions. Invoke the `universal:packageZipTarball` task instead of the `dist` task:
+> Alternatively a tar.gz file can be produced instead. Tar files retain permissions. Invoke the `Universal / packageZipTarball` task instead of the `dist` task:
 >
 > ```bash
-> sbt universal:packageZipTarball
+> sbt Universal / packageZipTarball
 > ```
 
 By default, the `dist` task will include the API documentation in the generated package. If this is not necessary, add these lines in `build.sbt`:
@@ -92,7 +92,7 @@ For builds with sub-projects, the statement above has to be applied to all sub-p
 Play uses the [sbt Native Packager plugin](https://sbt-native-packager.readthedocs.io/en/stable/). The native packager plugin declares the `dist` task to create a zip file. Invoking the `dist` task is directly equivalent to invoking the following:
 
 ```bash
-[my-first-app] $ universal:packageBin
+[my-first-app] $ Universal / packageBin
 ```
 
 Many other types of archive can be generated including:
@@ -124,7 +124,7 @@ Add the following settings to your build:
 Then build your package with:
 
 ```bash
-[my-first-app] $ debian:packageBin
+[my-first-app] $ Debian / packageBin
 ```
 
 #### Minimal RPM settings
@@ -136,7 +136,7 @@ Add the following settings to your build:
 Then build your package with:
 
 ```bash
-[my-first-app] $ rpm:packageBin
+[my-first-app] $ Rpm / packageBin
 ```
 
 > There will be some error logging. This is because rpm logs to stderr instead of stdout.


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose



## Background Context

```
[my-first-app] $ compile:packageBin::mappings
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: Compile / packageBin / mappings
```

```
[my-first-app] $ universal:packageZipTarball
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: Universal / packageZipTarball
```

```
[my-first-app] $ universal:packageBin
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: Universal / packageBin
```

```
[my-first-app] $ debian:packageBin
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: Debian / packageBin
```

```
[my-first-app] $ rpm:packageBin
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: Rpm / packageBin
```



## References

- https://github.com/sbt/sbt/blob/3e205d04b830136775dec6fc7daf41b5491b0230/main/src/main/scala/sbt/internal/Act.scala#L483
- https://github.com/sbt/sbt/commit/2305abd81ead3533920c960fa5e20384a6541c3d