### PR TITLE
[2.8.x] Move away from using lightbend tech hub (WIP)

### DIFF
--- a/documentation/manual/gettingStarted/LearningExamples.md
+++ b/documentation/manual/gettingStarted/LearningExamples.md
@@ -1,13 +1,13 @@
 <!--- Copyright (C) Lightbend Inc. <https://www.lightbend.com> -->
 # Learning from Play Examples
 
-[Lightbend Tech Hub](https://developer.lightbend.com/start/?group=play) offers downloadable Play examples for Java and Scala. Play has many features, so rather than pack them all into one project, we've organized many examples that each showcase a Play feature or demonstrate a common use case. The zip files include everything you need to build and run the examples, including a distribution of the sbt and Gradle. Refer to the `README.md` file in the top-level project directory to learn more about the example.
+The [play-samples GitHub repository](https://github.com/playframework/play-samples/tree/2.8.x) offers Play examples for Java and Scala. Play has many features, so rather than pack them all into one project, we've organized many examples that each showcase a Play feature or demonstrate a common use case. Make sure you have verified the [[requirements for running Play|Requirements]]. You can either clone the [play-samples GitHub repository](https://github.com/playframework/play-samples) or download its contents [as zip file](https://github.com/playframework/play-samples/archive/refs/heads/2.8.x.zip). Refer to the `README.md` file within each sample project directory to learn more about the example.
 
-> **Note**: the example projects are not configured for out of the box security.
+> **Note**: The example projects are not configured for out of the box security.
 
 If you are new to Play, we recommend following the Hello World tutorial for Java or Scala first:
 
-1. [Play Java Hello World](https://example.lightbend.com/v1/download/play-samples-play-java-hello-world-tutorial)
-2. [Play Scala Hello World](https://example.lightbend.com/v1/download/play-samples-play-scala-hello-world-tutorial)
+1. [Play Java Hello World](https://github.com/playframework/play-samples/tree/2.8.x/play-java-hello-world-tutorial)
+2. [Play Scala Hello World](https://github.com/playframework/play-samples/tree/2.8.x/play-scala-hello-world-tutorial)
 
-> **Note**: When you run the tutorial application, it displays web pages with the same content and instructions contained in this documentation. The tutorial includes a deliberate mistake and having the [[the documentation|HelloWorldTutorial]] and application pages open in different tabs or browsers allows you to consult the documentation for the fix when you encounter the error. 
+> **Note**: When you run the tutorial application, it displays web pages with the same content and instructions contained in this documentation. The tutorial includes a deliberate mistake and having the [[documentation|HelloWorldTutorial]] and application pages open in different tabs or browsers allows you to consult the documentation for the fix when you encounter the error. 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

The "learning examples" page at
https://www.playframework.com/documentation/2.8.x/LearningExamples points to the Lightbend Tech Hub -- as this is a repackaging of play-samples and is Lightbend specific, it's probably a good idea to move to directly using the samples.

TODO:

* Link to the tutorials: https://www.playframework.com/documentation/2.8.x/Tutorials
* Find and scrub all references to tech hub in documentation
* Make additional PRs for 2.9.x / 3.0.x to match

## Background Context

This changes documentation only, not source code.

