### PR TITLE
[2.9.x] Fix link to typesafe config

### DIFF
--- a/documentation/manual/working/javaGuide/main/config/JavaConfig.md
+++ b/documentation/manual/working/javaGuide/main/config/JavaConfig.md
@@ -12,4 +12,4 @@ Typically, you'll obtain a `Config` object through [[Dependency Injection|JavaDe
 
 ## API documentation
 
-Since Play just uses `Config` object, you can [see the javadoc for the class](https://static.javadoc.io/com.typesafe/config/1.3.1/com/typesafe/config/Config.html) to see what you can do and how to access configuration data.
+Since Play just uses `Config` object, you can [see the javadoc for the class](https://lightbend.github.io/config/latest/api/com/typesafe/config/Config.html) to see what you can do and how to access configuration data.


### PR DESCRIPTION
This was part of 3f0e09fd78b in main branch already.