### PR TITLE
avoid deprecated `scala.Symbol` literal in `CspFilter.md`

### DIFF
--- a/documentation/manual/working/commonGuide/filters/CspFilter.md
+++ b/documentation/manual/working/commonGuide/filters/CspFilter.md
@@ -237,7 +237,7 @@ And is used in pages like this:
 ```twirl
 @()(implicit request: RequestHeader)
 
-@views.html.helper.style('type -> "text/css") {
+@views.html.helper.style(Symbol("type") -> "text/css") {
     html, body, pre {
         margin: 0;
         padding: 0;
@@ -260,7 +260,7 @@ and is used as follows:
 ```twirl
 @()(implicit request: RequestHeader)
 
-@views.html.helper.script(args = 'type -> "text/javascript") {
+@views.html.helper.script(args = Symbol("type") -> "text/javascript") {
   alert("hello world");
 }
 ```


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose


## Background Context

- https://github.com/scala/scala/commit/f46fc7e49058352ff2ac5e843c343e24d0ee6e3c

## References

