### PR TITLE
Added Filepath.getSanitizedFilename, deprecated getFilename

### DIFF
--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -15,6 +15,9 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.InvalidPathException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.*;
@@ -1499,7 +1502,31 @@ public class Http {
         return key;
       }
 
-      /** @return the file name */
+      /** @return the sanitized version of the file name (i.e. only the filename, no path components) */
+      public String getSanitizedFilename() {
+        try {
+          // Will throw InvalidPathException on invalid filepaths
+          Path name = Paths.get(filename).normalize().getFileName();
+
+          // This can occur if the filepath is empty when fully resolved
+          if (name == null || name.toString().isEmpty() || name.toString().equals("..")) {
+            throw new InvalidPathException(filename, "");
+          }
+          return name.toString();
+
+        } catch (InvalidPathException e) {
+          throw new RuntimeException(
+                        "Unable to sanitize the filename given to MultipartFormData.FilePart: \""
+                            + e.getInput()
+                            + "\"");
+        }
+      }
+
+      /** 
+       * @deprecated Use {@link #getSanitizedFilename()} instead.
+       * @return the raw file name
+       */
+      @Deprecated
       public String getFilename() {
         return filename;
       }

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -15,9 +15,9 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.InvalidPathException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.*;
@@ -1502,7 +1502,9 @@ public class Http {
         return key;
       }
 
-      /** @return the sanitized version of the file name (i.e. only the filename, no path components) */
+      /**
+       * @return the sanitized version of the file name (i.e. only the filename, no path components)
+       */
       public String getSanitizedFilename() {
         try {
           // Will throw InvalidPathException on invalid filepaths
@@ -1516,13 +1518,13 @@ public class Http {
 
         } catch (InvalidPathException e) {
           throw new RuntimeException(
-                        "Unable to sanitize the filename given to MultipartFormData.FilePart: \""
-                            + e.getInput()
-                            + "\"");
+              "Unable to sanitize the filename given to MultipartFormData.FilePart: \""
+                  + e.getInput()
+                  + "\"");
         }
       }
 
-      /** 
+      /**
        * @deprecated Use {@link #getSanitizedFilename()} instead.
        * @return the raw file name
        */

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -15,6 +15,9 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.*;
@@ -1575,9 +1578,31 @@ public class Http {
         return key;
       }
 
+      /** @return the sanitized version of the file name (i.e. only the filename, no path components) */
+      public String getSanitizedFilename() {
+        try {
+          // Will throw InvalidPathException on invalid filepaths
+          Path name = Paths.get(filename).normalize().getFileName();
+
+          // This can occur if the filepath is empty when fully resolved
+          if (name == null || name.toString().isEmpty() || name.toString().equals("..")) {
+            throw new InvalidPathException(filename, "");
+          }
+          return name.toString();
+
+        } catch (InvalidPathException e) {
+          throw new RuntimeException(
+              "Unable to sanitize the filename given to MultipartFormData.FilePart: \""
+                  + e.getInput()
+                  + "\"");
+        }
+      }
+
       /**
-       * @return the file name
+       * @deprecated Use {@link #getSanitizedFilename()} instead.
+       * @return the raw file name
        */
+      @Deprecated
       public String getFilename() {
         return filename;
       }

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -1578,7 +1578,9 @@ public class Http {
         return key;
       }
 
-      /** @return the sanitized version of the file name (i.e. only the filename, no path components) */
+      /**
+       * @return the sanitized version of the file name (i.e. only the filename, no path components)
+       */
       public String getSanitizedFilename() {
         try {
           // Will throw InvalidPathException on invalid filepaths

--- a/core/play/src/test/java/play/mvc/SanitizedFilenameTest.java
+++ b/core/play/src/test/java/play/mvc/SanitizedFilenameTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) from 2023 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.mvc;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import play.mvc.Http.MultipartFormData;
+
+public class SanitizedFilenameTest {
+  @Test
+  public void sanitizeSingleComponent() {
+    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "abc", null, null);
+    assertEquals("abc", p.getSanitizedFilename());
+  }
+
+  @Test
+  public void sanitizeMultipleComponents() {
+    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "abc/def/xyz", null, null);
+    assertEquals("xyz", p.getSanitizedFilename());
+  }
+
+  @Test
+  public void sanitizeWithTrailingDots() {
+    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "a/b/c/././", null, null);
+    assertEquals("c", p.getSanitizedFilename());
+  }
+
+  @Test
+  public void sanitizeWithLeadingDoubleDots() {
+    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "../../../a", null, null);
+    assertEquals("a", p.getSanitizedFilename());
+  }
+
+  @Test
+  public void sanitizeWithNameAfterDoubleDots() {
+    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "../../../a/../b", null, null);
+    assertEquals("b", p.getSanitizedFilename());
+  }
+
+  @Test
+  public void sanitizeWithTrailingDoubleDots() {
+    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "a/b/c/../..", null, null);
+    assertEquals("a", p.getSanitizedFilename());
+  }
+
+  @Test
+  public void sanitizeWithRedundantSlashesAndDots() {
+    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "///a//b/c/.././d/././/", null, null);
+    assertEquals("d", p.getSanitizedFilename());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void sanitizeThrowsOnEmptyPath() {
+    (new MultipartFormData.FilePart<Object>(null, "", null, null)).getSanitizedFilename();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void sanitizeThrowsOnCurrentDirectory() {
+    (new MultipartFormData.FilePart<Object>(null, ".", null, null)).getSanitizedFilename();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void sanitizeThrowsOnDoubleDots() {
+    (new MultipartFormData.FilePart<Object>(null, "..", null, null)).getSanitizedFilename();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void sanitizeThrowsPastRoot() {
+    (new MultipartFormData.FilePart<Object>(null, "a/b/../../..", null, null)).getSanitizedFilename();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void sanitizeThrowsOnParentAfterResolving() {
+    (new MultipartFormData.FilePart<Object>(null, "../a/..", null, null)).getSanitizedFilename();
+  }
+}

--- a/core/play/src/test/java/play/mvc/SanitizedFilenameTest.java
+++ b/core/play/src/test/java/play/mvc/SanitizedFilenameTest.java
@@ -12,43 +12,50 @@ import play.mvc.Http.MultipartFormData;
 public class SanitizedFilenameTest {
   @Test
   public void sanitizeSingleComponent() {
-    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "abc", null, null);
+    MultipartFormData.FilePart<Object> p =
+        new MultipartFormData.FilePart<Object>(null, "abc", null, null);
     assertEquals("abc", p.getSanitizedFilename());
   }
 
   @Test
   public void sanitizeMultipleComponents() {
-    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "abc/def/xyz", null, null);
+    MultipartFormData.FilePart<Object> p =
+        new MultipartFormData.FilePart<Object>(null, "abc/def/xyz", null, null);
     assertEquals("xyz", p.getSanitizedFilename());
   }
 
   @Test
   public void sanitizeWithTrailingDots() {
-    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "a/b/c/././", null, null);
+    MultipartFormData.FilePart<Object> p =
+        new MultipartFormData.FilePart<Object>(null, "a/b/c/././", null, null);
     assertEquals("c", p.getSanitizedFilename());
   }
 
   @Test
   public void sanitizeWithLeadingDoubleDots() {
-    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "../../../a", null, null);
+    MultipartFormData.FilePart<Object> p =
+        new MultipartFormData.FilePart<Object>(null, "../../../a", null, null);
     assertEquals("a", p.getSanitizedFilename());
   }
 
   @Test
   public void sanitizeWithNameAfterDoubleDots() {
-    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "../../../a/../b", null, null);
+    MultipartFormData.FilePart<Object> p =
+        new MultipartFormData.FilePart<Object>(null, "../../../a/../b", null, null);
     assertEquals("b", p.getSanitizedFilename());
   }
 
   @Test
   public void sanitizeWithTrailingDoubleDots() {
-    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "a/b/c/../..", null, null);
+    MultipartFormData.FilePart<Object> p =
+        new MultipartFormData.FilePart<Object>(null, "a/b/c/../..", null, null);
     assertEquals("a", p.getSanitizedFilename());
   }
 
   @Test
   public void sanitizeWithRedundantSlashesAndDots() {
-    MultipartFormData.FilePart<Object> p = new MultipartFormData.FilePart<Object>(null, "///a//b/c/.././d/././/", null, null);
+    MultipartFormData.FilePart<Object> p =
+        new MultipartFormData.FilePart<Object>(null, "///a//b/c/.././d/././/", null, null);
     assertEquals("d", p.getSanitizedFilename());
   }
 
@@ -69,7 +76,8 @@ public class SanitizedFilenameTest {
 
   @Test(expected = RuntimeException.class)
   public void sanitizeThrowsPastRoot() {
-    (new MultipartFormData.FilePart<Object>(null, "a/b/../../..", null, null)).getSanitizedFilename();
+    (new MultipartFormData.FilePart<Object>(null, "a/b/../../..", null, null))
+        .getSanitizedFilename();
   }
 
   @Test(expected = RuntimeException.class)

--- a/core/play/src/test/java/play/mvc/SanitizedFilenameTest.java
+++ b/core/play/src/test/java/play/mvc/SanitizedFilenameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) from 2023 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package play.mvc;


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [X] Have you added copyright headers to new files?
* [X] Have you checked that both Scala and Java APIs are updated?
* [X] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #8008 

## Purpose

Provides a new way of getting sanitized filepaths from a `FilePart`, via the `getSanitizedFilename` method, as discussed in #8007 and #8008. Also deprecates the old `getFilename` method that returns the raw path.

## Background Context

In #8000, it was found that Play used a raw filepath in an insecure way. This particular case was fixed in #8007, but @gmethvin suggested a reusable method should be added for doing this, instead of just once-off fixes.

This change uses the builtin Java functionality in `Path.normalize` to do most of the processing, as suggested by @wsargent. It then uses `getFileName` to return the last part of the path.

Also checks for empty filepaths and unresolvable `..` paths and throws a runtime error - there is no good way to sanitize these into a valid filepath.

Tests have also been written in `SanitizedFilenameTest.java` to check that it works correctly.

## References

#8007 and #8008