### PR TITLE
Migrate from Hamcrest/FEST-Assert to AssertJ (test sources)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,6 +169,7 @@ lazy val PlayJdbcEvolutionsProject = PlayCrossBuiltProject("Play-JDBC-Evolutions
   .dependsOn(PlayJavaJdbcProject % "test")
 
 lazy val PlayJavaJdbcProject = PlayCrossBuiltProject("Play-Java-JDBC", "persistence/play-java-jdbc")
+  .settings(libraryDependencies += assertj % Test)
   .dependsOn(PlayJdbcProject % "compile->compile;test->test", PlayJavaProject)
   .dependsOn(PlaySpecs2Project % "test", PlayGuiceProject % "test")
 
@@ -180,7 +181,7 @@ lazy val PlayJpaProject = PlayCrossBuiltProject("Play-Java-JPA", "persistence/pl
 
 lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "testkit/play-test")
   .settings(
-    libraryDependencies ++= testDependencies ++ Seq(h2database % "test"),
+    libraryDependencies ++= testDependencies ++ Seq(h2database, assertj).map(_ % "test"),
     (Test / parallelExecution) := false
   )
   .dependsOn(
@@ -224,7 +225,7 @@ lazy val PlayDocsProject = PlayCrossBuiltProject("Play-Docs", "dev-mode/play-doc
   .dependsOn(PlayNettyServerProject)
 
 lazy val PlayGuiceProject = PlayCrossBuiltProject("Play-Guice", "core/play-guice")
-  .settings(libraryDependencies ++= guiceDeps ++ specs2Deps.map(_ % "test"))
+  .settings(libraryDependencies ++= guiceDeps ++ (specs2Deps ++ Seq(assertj)).map(_ % "test"))
   .dependsOn(
     PlayProject % "compile;test->test"
   )

--- a/cache/play-caffeine-cache/src/test/java/play/cache/caffeine/NamedCaffeineCacheSpec.java
+++ b/cache/play-caffeine-cache/src/test/java/play/cache/caffeine/NamedCaffeineCacheSpec.java
@@ -4,8 +4,7 @@
 
 package play.cache.caffeine;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.util.*;
@@ -37,7 +36,7 @@ public class NamedCaffeineCacheSpec {
     expectedMap.put(key1, value1);
     expectedMap.put(key2, value2);
 
-    assertThat(resultMap, equalTo(expectedMap));
+    assertThat(resultMap).isEqualTo(expectedMap);
   }
 
   @Test
@@ -59,7 +58,7 @@ public class NamedCaffeineCacheSpec {
     expectedMap.put(key1, value1);
     expectedMap.put(key2, value2);
 
-    assertThat(resultMap, equalTo(expectedMap));
+    assertThat(resultMap).isEqualTo(expectedMap);
   }
 
   @Test
@@ -82,7 +81,7 @@ public class NamedCaffeineCacheSpec {
     expectedMap.put(key1, value1);
     expectedMap.put(key2, value2);
 
-    assertThat(resultMap, equalTo(expectedMap));
+    assertThat(resultMap).isEqualTo(expectedMap);
   }
 
   @Test()
@@ -94,6 +93,6 @@ public class NamedCaffeineCacheSpec {
     future.completeExceptionally(testException);
     CompletableFuture<Map<String, String>> resultFuture =
         cache.getAll(new HashSet<>(Arrays.asList("key1")), (missingKeys, executor) -> future);
-    assertThat(resultFuture.isCompletedExceptionally(), equalTo(true));
+    assertThat(resultFuture).isCompletedExceptionally();
   }
 }

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -4,9 +4,7 @@
 
 package play.inject.guice;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static play.inject.Bindings.bind;
 
@@ -33,8 +31,8 @@ public class GuiceApplicationBuilderTest {
             .bindings(bind(B.class).to(B1.class))
             .injector();
 
-    assertThat(injector.instanceOf(A.class), instanceOf(A1.class));
-    assertThat(injector.instanceOf(B.class), instanceOf(B1.class));
+    assertThat(injector.instanceOf(A.class)).isInstanceOf(A1.class);
+    assertThat(injector.instanceOf(B.class)).isInstanceOf(B1.class);
   }
 
   @Test
@@ -56,9 +54,9 @@ public class GuiceApplicationBuilderTest {
             .injector()
             .instanceOf(Application.class);
 
-    assertThat(app.config().getInt("a"), is(1));
-    assertThat(app.config().getInt("b"), is(2));
-    assertThat(app.injector().instanceOf(A.class), instanceOf(A2.class));
+    assertThat(app.config().getInt("a")).isEqualTo(1);
+    assertThat(app.config().getInt("b")).isEqualTo(2);
+    assertThat(app.injector().instanceOf(A.class)).isInstanceOf(A2.class);
   }
 
   @Test
@@ -76,7 +74,7 @@ public class GuiceApplicationBuilderTest {
             .withConfigLoader(env -> extra.withFallback(ConfigFactory.load(env.classLoader())))
             .build();
 
-    assertThat(app.config().getInt("a"), is(1));
+    assertThat(app.config().getInt("a")).isEqualTo(1);
   }
 
   @Test
@@ -93,7 +91,7 @@ public class GuiceApplicationBuilderTest {
                         Guiceable.bindings(bind(A.class).to(A1.class))))
             .injector();
 
-    assertThat(injector.instanceOf(A.class), instanceOf(A1.class));
+    assertThat(injector.instanceOf(A.class)).isInstanceOf(A1.class);
   }
 
   @Test
@@ -108,7 +106,7 @@ public class GuiceApplicationBuilderTest {
                 Guiceable.bindings(bind(A.class).to(A1.class)))
             .injector();
 
-    assertThat(injector.instanceOf(A.class), instanceOf(A1.class));
+    assertThat(injector.instanceOf(A.class)).isInstanceOf(A1.class);
   }
 
   public static interface A {}

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
@@ -4,10 +4,7 @@
 
 package play.inject.guice;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static play.inject.Bindings.bind;
 
 import com.typesafe.config.Config;
@@ -31,8 +28,8 @@ public class GuiceApplicationLoaderTest {
     ApplicationLoader loader = new GuiceApplicationLoader(builder);
     Application app = loader.load(fakeContext());
 
-    assertThat(app.injector().instanceOf(A.class), instanceOf(A1.class));
-    assertThat(app.injector().instanceOf(B.class), instanceOf(B1.class));
+    assertThat(app.injector().instanceOf(A.class)).isInstanceOf(A1.class);
+    assertThat(app.injector().instanceOf(B.class)).isInstanceOf(B1.class);
   }
 
   @Test
@@ -50,7 +47,7 @@ public class GuiceApplicationLoaderTest {
         };
     Application app = loader.load(fakeContext());
 
-    assertThat(app.config().getInt("a"), is(1));
+    assertThat(app.config().getInt("a")).isEqualTo(1);
   }
 
   @Test
@@ -67,7 +64,7 @@ public class GuiceApplicationLoaderTest {
         ApplicationLoader.create(Environment.simple()).withConfig(config);
     Application app = loader.load(context);
 
-    assertThat(app.asScala().httpConfiguration().context(), equalTo("/tests"));
+    assertThat(app.asScala().httpConfiguration().context()).isEqualTo("/tests");
   }
 
   public interface A {}

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
@@ -4,8 +4,7 @@
 
 package play.inject.guice;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static play.inject.Bindings.bind;
 
@@ -47,9 +46,9 @@ public class GuiceInjectorBuilderTest {
             .injector()
             .instanceOf(Environment.class);
 
-    assertThat(env.rootPath(), equalTo(new File("test")));
-    assertThat(env.mode(), equalTo(Mode.DEV));
-    assertThat(env.classLoader(), sameInstance(classLoader));
+    assertThat(env.rootPath()).isEqualTo(new File("test"));
+    assertThat(env.mode()).isEqualTo(Mode.DEV);
+    assertThat(env.classLoader()).isSameAs(classLoader);
   }
 
   @Test
@@ -73,9 +72,9 @@ public class GuiceInjectorBuilderTest {
             .injector()
             .instanceOf(Environment.class);
 
-    assertThat(env.rootPath(), equalTo(new File("test")));
-    assertThat(env.mode(), equalTo(Mode.DEV));
-    assertThat(env.classLoader(), sameInstance(classLoader));
+    assertThat(env.rootPath()).isEqualTo(new File("test"));
+    assertThat(env.mode()).isEqualTo(Mode.DEV);
+    assertThat(env.classLoader()).isSameAs(classLoader);
   }
 
   @Test
@@ -100,14 +99,14 @@ public class GuiceInjectorBuilderTest {
             .injector()
             .instanceOf(Config.class);
 
-    assertThat(conf.root().keySet().size(), is(4));
-    assertThat(conf.root().keySet(), hasItems("a", "b", "c", "d"));
+    assertThat(conf.root().keySet()).hasSize(4);
+    assertThat(conf.root().keySet()).contains("a", "b", "c", "d");
 
-    assertThat(conf.getInt("a"), is(1));
-    assertThat(conf.getInt("b"), is(2));
-    assertThat(conf.getInt("c"), is(3));
-    assertThat(conf.getInt("d.1"), is(4));
-    assertThat(conf.getInt("d.2"), is(5));
+    assertThat(conf.getInt("a")).isEqualTo(1);
+    assertThat(conf.getInt("b")).isEqualTo(2);
+    assertThat(conf.getInt("c")).isEqualTo(3);
+    assertThat(conf.getInt("d.1")).isEqualTo(4);
+    assertThat(conf.getInt("d.2")).isEqualTo(5);
   }
 
   @Test
@@ -129,12 +128,12 @@ public class GuiceInjectorBuilderTest {
             .bindings(bind(C.class).to(C1.class), bind(D.class).toInstance(new D1()))
             .injector();
 
-    assertThat(injector.instanceOf(Environment.class), instanceOf(Environment.class));
-    assertThat(injector.instanceOf(Config.class), instanceOf(Config.class));
-    assertThat(injector.instanceOf(A.class), instanceOf(A1.class));
-    assertThat(injector.instanceOf(B.class), instanceOf(B1.class));
-    assertThat(injector.instanceOf(C.class), instanceOf(C1.class));
-    assertThat(injector.instanceOf(D.class), instanceOf(D1.class));
+    assertThat(injector.instanceOf(Environment.class)).isInstanceOf(Environment.class);
+    assertThat(injector.instanceOf(Config.class)).isInstanceOf(Config.class);
+    assertThat(injector.instanceOf(A.class)).isInstanceOf(A1.class);
+    assertThat(injector.instanceOf(B.class)).isInstanceOf(B1.class);
+    assertThat(injector.instanceOf(C.class)).isInstanceOf(C1.class);
+    assertThat(injector.instanceOf(D.class)).isInstanceOf(D1.class);
   }
 
   @Test
@@ -147,8 +146,8 @@ public class GuiceInjectorBuilderTest {
             .overrides(bind(B.class).to(B2.class))
             .injector();
 
-    assertThat(injector.instanceOf(A.class), instanceOf(A2.class));
-    assertThat(injector.instanceOf(B.class), instanceOf(B2.class));
+    assertThat(injector.instanceOf(A.class)).isInstanceOf(A2.class);
+    assertThat(injector.instanceOf(B.class)).isInstanceOf(B2.class);
   }
 
   @Test
@@ -160,8 +159,8 @@ public class GuiceInjectorBuilderTest {
             .disable(AModule.class, CModule.class) // C won't be disabled
             .injector();
 
-    assertThat(injector.instanceOf(B.class), instanceOf(B1.class));
-    assertThat(injector.instanceOf(C.class), instanceOf(C1.class));
+    assertThat(injector.instanceOf(B.class)).isInstanceOf(B1.class);
+    assertThat(injector.instanceOf(C.class)).isInstanceOf(C1.class);
     assertThrows(ConfigurationException.class, () -> injector.instanceOf(A.class));
   }
 

--- a/core/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
+++ b/core/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
@@ -4,8 +4,7 @@
 
 package play;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -60,154 +59,146 @@ public class BuiltInComponentsFromContextTest {
         () -> {
           Http.RequestBuilder request = Helpers.fakeRequest(Helpers.GET, "/");
           Result result = Helpers.route(application, request);
-          assertThat(result.status(), equalTo(Helpers.OK));
+          assertThat(result.status()).isEqualTo(Helpers.OK);
         });
   }
 
   @Test
   public void shouldProvideDefaultFilters() {
-    assertThat(this.componentsFromContext.httpFilters().isEmpty(), is(false));
+    assertThat(this.componentsFromContext.httpFilters()).isNotEmpty();
   }
 
   @Test
   public void shouldProvideRouter() {
     Router router = this.componentsFromContext.router();
-    assertThat(router, notNullValue());
+    assertThat(router).isNotNull();
 
     Http.RequestHeader ok = Helpers.fakeRequest(Helpers.GET, "/").build();
-    assertThat(router.route(ok).isPresent(), is(true));
+    assertThat(router.route(ok)).isPresent();
 
     Http.RequestHeader notFound = Helpers.fakeRequest(Helpers.GET, "/404").build();
-    assertThat(router.route(notFound).isPresent(), is(false));
+    assertThat(router.route(notFound)).isNotPresent();
   }
 
   @Test
   public void shouldProvideHttpConfiguration() {
     HttpConfiguration httpConfiguration = this.componentsFromContext.httpConfiguration();
-    assertThat(httpConfiguration.context(), equalTo("/"));
-    assertThat(httpConfiguration, notNullValue());
+    assertThat(httpConfiguration.context()).isEqualTo("/");
+    assertThat(httpConfiguration).isNotNull();
   }
 
   // The tests below just ensure that the we are able to instantiate the components
 
   @Test
   public void shouldProvideApplicationLifecycle() {
-    assertThat(this.componentsFromContext.applicationLifecycle(), notNullValue());
+    assertThat(this.componentsFromContext.applicationLifecycle()).isNotNull();
   }
 
   @Test
   public void shouldProvideActionCreator() {
-    assertThat(this.componentsFromContext.actionCreator(), notNullValue());
+    assertThat(this.componentsFromContext.actionCreator()).isNotNull();
   }
 
   @Test
   public void shouldProvidePekkoActorSystem() {
-    assertThat(this.componentsFromContext.actorSystem(), notNullValue());
+    assertThat(this.componentsFromContext.actorSystem()).isNotNull();
   }
 
   @Test
   public void shouldProvidePekkoMaterializer() {
-    assertThat(this.componentsFromContext.materializer(), notNullValue());
+    assertThat(this.componentsFromContext.materializer()).isNotNull();
   }
 
   @Test
   public void shouldProvideExecutionContext() {
-    assertThat(this.componentsFromContext.executionContext(), notNullValue());
+    assertThat(this.componentsFromContext.executionContext()).isNotNull();
   }
 
   @Test
   public void shouldProvideCookieSigner() {
-    assertThat(this.componentsFromContext.cookieSigner(), notNullValue());
+    assertThat(this.componentsFromContext.cookieSigner()).isNotNull();
   }
 
   @Test
   public void shouldProvideCSRFTokenSigner() {
-    assertThat(this.componentsFromContext.csrfTokenSigner(), notNullValue());
+    assertThat(this.componentsFromContext.csrfTokenSigner()).isNotNull();
   }
 
   @Test
   public void shouldProvideFileMimeTypes() {
-    assertThat(this.componentsFromContext.fileMimeTypes(), notNullValue());
+    assertThat(this.componentsFromContext.fileMimeTypes()).isNotNull();
   }
 
   @Test
   public void shouldProvideHttpErrorHandler() {
-    assertThat(this.componentsFromContext.httpErrorHandler(), notNullValue());
+    assertThat(this.componentsFromContext.httpErrorHandler()).isNotNull();
   }
 
   @Test
   public void shouldProvideHttpRequestHandler() {
-    assertThat(this.componentsFromContext.httpRequestHandler(), notNullValue());
+    assertThat(this.componentsFromContext.httpRequestHandler()).isNotNull();
   }
 
   @Test
   public void shouldProvideLangs() {
-    assertThat(this.componentsFromContext.langs(), notNullValue());
+    assertThat(this.componentsFromContext.langs()).isNotNull();
   }
 
   @Test
   public void shouldProvideMessagesApi() {
-    assertThat(this.componentsFromContext.messagesApi(), notNullValue());
+    assertThat(this.componentsFromContext.messagesApi()).isNotNull();
   }
 
   @Test
   public void shouldProvideTempFileCreator() {
-    assertThat(this.componentsFromContext.tempFileCreator(), notNullValue());
+    assertThat(this.componentsFromContext.tempFileCreator()).isNotNull();
   }
 
   @Test
   public void actorSystemMustBeASingleton() {
-    assertThat(
-        this.componentsFromContext.actorSystem(),
-        sameInstance(this.componentsFromContext.actorSystem()));
+    assertThat(this.componentsFromContext.actorSystem())
+        .isSameAs(this.componentsFromContext.actorSystem());
   }
 
   @Test
   public void applicationMustBeASingleton() {
-    assertThat(
-        this.componentsFromContext.application(),
-        sameInstance(this.componentsFromContext.application()));
+    assertThat(this.componentsFromContext.application())
+        .isSameAs(this.componentsFromContext.application());
   }
 
   @Test
   public void langsMustBeASingleton() {
-    assertThat(
-        this.componentsFromContext.langs(), sameInstance(this.componentsFromContext.langs()));
+    assertThat(this.componentsFromContext.langs()).isSameAs(this.componentsFromContext.langs());
   }
 
   @Test
   public void fileMimeTypesMustBeASingleton() {
-    assertThat(
-        this.componentsFromContext.fileMimeTypes(),
-        sameInstance(this.componentsFromContext.fileMimeTypes()));
+    assertThat(this.componentsFromContext.fileMimeTypes())
+        .isSameAs(this.componentsFromContext.fileMimeTypes());
   }
 
   @Test
   public void httpRequestHandlerMustBeASingleton() {
-    assertThat(
-        this.componentsFromContext.httpRequestHandler(),
-        sameInstance(this.componentsFromContext.httpRequestHandler()));
+    assertThat(this.componentsFromContext.httpRequestHandler())
+        .isSameAs(this.componentsFromContext.httpRequestHandler());
   }
 
   @Test
   public void cookieSignerMustBeASingleton() {
-    assertThat(
-        this.componentsFromContext.cookieSigner(),
-        sameInstance(this.componentsFromContext.cookieSigner()));
+    assertThat(this.componentsFromContext.cookieSigner())
+        .isSameAs(this.componentsFromContext.cookieSigner());
   }
 
   @Test
   public void csrfTokenSignerMustBeASingleton() {
-    assertThat(
-        this.componentsFromContext.csrfTokenSigner(),
-        sameInstance(this.componentsFromContext.csrfTokenSigner()));
+    assertThat(this.componentsFromContext.csrfTokenSigner())
+        .isSameAs(this.componentsFromContext.csrfTokenSigner());
   }
 
   @Test
   public void temporaryFileCreatorMustBeASingleton() {
-    assertThat(
-        this.componentsFromContext.tempFileCreator(),
-        sameInstance(this.componentsFromContext.tempFileCreator()));
+    assertThat(this.componentsFromContext.tempFileCreator())
+        .isSameAs(this.componentsFromContext.tempFileCreator());
   }
 
   @Test

--- a/core/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
+++ b/core/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
@@ -5,8 +5,7 @@
 package play.routing;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 import static play.mvc.Results.internalServerError;
 import static play.mvc.Results.ok;
@@ -58,7 +57,7 @@ public abstract class AbstractRoutingDslTest {
 
     String result =
         makeRequest(router, "GET", "/with-request", rb -> rb.header("X-Test", "Header value"));
-    assertThat(result, equalTo("Header value"));
+    assertThat(result).isEqualTo("Header value");
   }
 
   @Test
@@ -78,7 +77,7 @@ public abstract class AbstractRoutingDslTest {
 
     String result =
         makeRequest(router, "GET", "/with-request/10", rb -> rb.header("X-Test", "Header value"));
-    assertThat(result, equalTo("Header value - 10"));
+    assertThat(result).isEqualTo("Header value - 10");
   }
 
   @Test
@@ -99,7 +98,7 @@ public abstract class AbstractRoutingDslTest {
     String result =
         makeRequest(
             router, "GET", "/with-request/10/20", rb -> rb.header("X-Test", "Header value"));
-    assertThat(result, equalTo("Header value - 10 - 20"));
+    assertThat(result).isEqualTo("Header value - 10 - 20");
   }
 
   @Test
@@ -122,7 +121,7 @@ public abstract class AbstractRoutingDslTest {
     String result =
         makeRequest(
             router, "GET", "/with-request/10/20/30", rb -> rb.header("X-Test", "Header value"));
-    assertThat(result, equalTo("Header value - 10 - 20 - 30"));
+    assertThat(result).isEqualTo("Header value - 10 - 20 - 30");
   }
 
   @Test
@@ -143,7 +142,7 @@ public abstract class AbstractRoutingDslTest {
 
     String result =
         makeRequest(router, "GET", "/with-request", rb -> rb.header("X-Test", "Header value"));
-    assertThat(result, equalTo("Header value"));
+    assertThat(result).isEqualTo("Header value");
   }
 
   @Test
@@ -164,7 +163,7 @@ public abstract class AbstractRoutingDslTest {
 
     String result =
         makeRequest(router, "GET", "/with-request/10", rb -> rb.header("X-Test", "Header value"));
-    assertThat(result, equalTo("Header value - 10"));
+    assertThat(result).isEqualTo("Header value - 10");
   }
 
   @Test
@@ -186,7 +185,7 @@ public abstract class AbstractRoutingDslTest {
     String result =
         makeRequest(
             router, "GET", "/with-request/10/20", rb -> rb.header("X-Test", "Header value"));
-    assertThat(result, equalTo("Header value - 10 - 20"));
+    assertThat(result).isEqualTo("Header value - 10 - 20");
   }
 
   @Test
@@ -211,7 +210,7 @@ public abstract class AbstractRoutingDslTest {
     String result =
         makeRequest(
             router, "GET", "/with-request/10/20/30", rb -> rb.header("X-Test", "Header value"));
-    assertThat(result, equalTo("Header value - 10 - 20 - 30"));
+    assertThat(result).isEqualTo("Header value - 10 - 20 - 30");
   }
 
   @Test
@@ -225,7 +224,7 @@ public abstract class AbstractRoutingDslTest {
                     .build());
 
     String result = makeRequest(router, "POST", "/with-body", rb -> rb.bodyText("The Body"));
-    assertThat(result, equalTo("The Body"));
+    assertThat(result).isEqualTo("The Body");
   }
 
   @Test
@@ -244,7 +243,7 @@ public abstract class AbstractRoutingDslTest {
             "POST",
             "/with-body",
             requestBuilder -> requestBuilder.bodyJson(Json.parse("{ \"a\": \"b\" }")));
-    assertThat(result, equalTo("{\"a\":\"b\"}"));
+    assertThat(result).isEqualTo("{\"a\":\"b\"}");
   }
 
   @Test
@@ -265,7 +264,7 @@ public abstract class AbstractRoutingDslTest {
             requestBuilder ->
                 requestBuilder.bodyXml(
                     XML.fromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>")));
-    assertThat(result, equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>"));
+    assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>");
   }
 
   @Test
@@ -284,7 +283,7 @@ public abstract class AbstractRoutingDslTest {
             "POST",
             "/with-body",
             requestBuilder -> requestBuilder.bodyRaw(ByteString.fromString("The Raw Body")));
-    assertThat(result, equalTo("The Raw Body"));
+    assertThat(result).isEqualTo("The Raw Body");
   }
 
   @Test
@@ -335,13 +334,12 @@ public abstract class AbstractRoutingDslTest {
                     List.of(
                         new Http.MultipartFormData.FilePart<>(
                             "document", "jabberwocky.txt", "text/plain", tempFile))));
-    assertThat(
-        result,
-        equalTo(
+    assertThat(result)
+        .isEqualTo(
             "author: Lewis Carrol\n"
                 + "filename: jabberwocky.txt\n"
                 + "contentType: text/plain\n"
-                + "contents: Twas brillig and the slithy Toves...\n"));
+                + "contents: Twas brillig and the slithy Toves...\n");
   }
 
   @Test
@@ -352,7 +350,7 @@ public abstract class AbstractRoutingDslTest {
                 routingDsl.POST("/with-body").routingTo(req -> ok(req.body().asText())).build());
 
     String result = makeRequest(router, "POST", "/with-body", rb -> rb.bodyText("The Body"));
-    assertThat(result, equalTo("The Body"));
+    assertThat(result).isEqualTo("The Body");
   }
 
   @Test
@@ -368,7 +366,7 @@ public abstract class AbstractRoutingDslTest {
             "POST",
             "/with-body",
             requestBuilder -> requestBuilder.bodyJson(Json.parse("{ \"a\": \"b\" }")));
-    assertThat(result, equalTo("{\"a\":\"b\"}"));
+    assertThat(result).isEqualTo("{\"a\":\"b\"}");
   }
 
   @Test
@@ -389,7 +387,7 @@ public abstract class AbstractRoutingDslTest {
             requestBuilder ->
                 requestBuilder.bodyXml(
                     XML.fromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>")));
-    assertThat(result, equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>"));
+    assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>b</a>");
   }
 
   @Test
@@ -408,7 +406,7 @@ public abstract class AbstractRoutingDslTest {
             "POST",
             "/with-body",
             requestBuilder -> requestBuilder.bodyRaw(ByteString.fromString("The Raw Body")));
-    assertThat(result, equalTo("The Raw Body"));
+    assertThat(result).isEqualTo("The Raw Body");
   }
 
   @Test
@@ -418,7 +416,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.GET("/hello/world").routingTo(req -> ok("Hello world")).build());
 
-    assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "GET", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "GET", "/foo/bar"));
   }
 
@@ -429,7 +427,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.GET("/hello/:to").routingTo((req, to) -> ok("Hello " + to)).build());
 
-    assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "GET", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "GET", "/foo/bar"));
   }
 
@@ -443,7 +441,7 @@ public abstract class AbstractRoutingDslTest {
                     .routingTo((req, say, to) -> ok(say + " " + to))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/Hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "GET", "/Hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "GET", "/foo"));
   }
 
@@ -457,7 +455,7 @@ public abstract class AbstractRoutingDslTest {
                     .routingTo((req, say, to, extra) -> ok(say + " " + to + extra))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/Hello/world/!"), equalTo("Hello world!"));
+    assertThat(makeRequest(router, "GET", "/Hello/world/!")).isEqualTo("Hello world!");
     assertNull(makeRequest(router, "GET", "/foo/bar"));
   }
 
@@ -471,7 +469,7 @@ public abstract class AbstractRoutingDslTest {
                     .routingAsync(req -> completedFuture(ok("Hello world")))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "GET", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "GET", "/foo/bar"));
   }
 
@@ -485,7 +483,7 @@ public abstract class AbstractRoutingDslTest {
                     .routingAsync((req, to) -> completedFuture(ok("Hello " + to)))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "GET", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "GET", "/foo/bar"));
   }
 
@@ -499,7 +497,7 @@ public abstract class AbstractRoutingDslTest {
                     .routingAsync((req, say, to) -> completedFuture(ok(say + " " + to)))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/Hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "GET", "/Hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "GET", "/foo"));
   }
 
@@ -514,7 +512,7 @@ public abstract class AbstractRoutingDslTest {
                         (req, say, to, extra) -> completedFuture(ok(say + " " + to + extra)))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/Hello/world/!"), equalTo("Hello world!"));
+    assertThat(makeRequest(router, "GET", "/Hello/world/!")).isEqualTo("Hello world!");
     assertNull(makeRequest(router, "GET", "/foo/bar"));
   }
 
@@ -525,7 +523,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.GET("/hello/world").routingTo(req -> ok("Hello world")).build());
 
-    assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "GET", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "POST", "/hello/world"));
   }
 
@@ -536,7 +534,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.HEAD("/hello/world").routingTo(req -> ok("Hello world")).build());
 
-    assertThat(makeRequest(router, "HEAD", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "HEAD", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "POST", "/hello/world"));
   }
 
@@ -547,7 +545,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.POST("/hello/world").routingTo(req -> ok("Hello world")).build());
 
-    assertThat(makeRequest(router, "POST", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "POST", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "GET", "/hello/world"));
   }
 
@@ -558,7 +556,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.PUT("/hello/world").routingTo(req -> ok("Hello world")).build());
 
-    assertThat(makeRequest(router, "PUT", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "PUT", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "POST", "/hello/world"));
   }
 
@@ -569,7 +567,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.DELETE("/hello/world").routingTo(req -> ok("Hello world")).build());
 
-    assertThat(makeRequest(router, "DELETE", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "DELETE", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "POST", "/hello/world"));
   }
 
@@ -580,7 +578,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.PATCH("/hello/world").routingTo(req -> ok("Hello world")).build());
 
-    assertThat(makeRequest(router, "PATCH", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "PATCH", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "POST", "/hello/world"));
   }
 
@@ -591,7 +589,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.OPTIONS("/hello/world").routingTo(req -> ok("Hello world")).build());
 
-    assertThat(makeRequest(router, "OPTIONS", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "OPTIONS", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "POST", "/hello/world"));
   }
 
@@ -610,8 +608,8 @@ public abstract class AbstractRoutingDslTest {
                     .build());
 
     Result result = routeAndCall(application(), router, fakeRequest("GET", "/hello/world"));
-    assertThat(result.session().get("foo"), equalTo(Optional.of("bar")));
-    assertThat(result.headers().get("Foo"), equalTo("Bar"));
+    assertThat(result.session().get("foo")).isEqualTo(Optional.of("bar"));
+    assertThat(result.headers().get("Foo")).isEqualTo("Bar");
   }
 
   @Test
@@ -621,7 +619,7 @@ public abstract class AbstractRoutingDslTest {
             routingDsl ->
                 routingDsl.GET("/hello/*to").routingTo((req, to) -> ok("Hello " + to)).build());
 
-    assertThat(makeRequest(router, "GET", "/hello/blah/world"), equalTo("Hello blah/world"));
+    assertThat(makeRequest(router, "GET", "/hello/blah/world")).isEqualTo("Hello blah/world");
     assertNull(makeRequest(router, "GET", "/foo/bar"));
   }
 
@@ -635,7 +633,7 @@ public abstract class AbstractRoutingDslTest {
                     .routingTo((req, to) -> ok("Hello " + to))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
+    assertThat(makeRequest(router, "GET", "/hello/world")).isEqualTo("Hello world");
     assertNull(makeRequest(router, "GET", "/hello/10"));
   }
 
@@ -655,10 +653,10 @@ public abstract class AbstractRoutingDslTest {
                     .routingTo((req, path) -> ok("Path " + path))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
-    assertThat(makeRequest(router, "GET", "/foo/bar"), equalTo("foo bar"));
-    assertThat(makeRequest(router, "POST", "/hello/world"), equalTo("Post world"));
-    assertThat(makeRequest(router, "GET", "/something/else"), equalTo("Path something/else"));
+    assertThat(makeRequest(router, "GET", "/hello/world")).isEqualTo("Hello world");
+    assertThat(makeRequest(router, "GET", "/foo/bar")).isEqualTo("foo bar");
+    assertThat(makeRequest(router, "POST", "/hello/world")).isEqualTo("Post world");
+    assertThat(makeRequest(router, "GET", "/something/else")).isEqualTo("Path something/else");
   }
 
   @Test
@@ -675,9 +673,9 @@ public abstract class AbstractRoutingDslTest {
                     .routingTo((req, to) -> ok("Regex " + to))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/simple/dollar%24"), equalTo("Simple dollar$"));
-    assertThat(makeRequest(router, "GET", "/path/dollar%24"), equalTo("Path dollar%24"));
-    assertThat(makeRequest(router, "GET", "/regex/dollar%24"), equalTo("Regex dollar%24"));
+    assertThat(makeRequest(router, "GET", "/simple/dollar%24")).isEqualTo("Simple dollar$");
+    assertThat(makeRequest(router, "GET", "/path/dollar%24")).isEqualTo("Path dollar%24");
+    assertThat(makeRequest(router, "GET", "/regex/dollar%24")).isEqualTo("Regex dollar%24");
   }
 
   @Test
@@ -692,8 +690,8 @@ public abstract class AbstractRoutingDslTest {
                             ok("int " + a + " boolean " + b + " string " + c))
                     .build());
 
-    assertThat(
-        makeRequest(router, "GET", "/20/true/foo"), equalTo("int 20 boolean true string foo"));
+    assertThat(makeRequest(router, "GET", "/20/true/foo"))
+        .isEqualTo("int 20 boolean true string foo");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -716,9 +714,8 @@ public abstract class AbstractRoutingDslTest {
                     .routingTo((Http.Request req, Integer a) -> ok("int " + a))
                     .build());
 
-    assertThat(
-        makeRequest(router, "GET", "/foo"),
-        equalTo("Cannot parse parameter a as Int: For input string: \"foo\""));
+    assertThat(makeRequest(router, "GET", "/foo"))
+        .isEqualTo("Cannot parse parameter a as Int: For input string: \"foo\"");
   }
 
   @Test
@@ -731,7 +728,7 @@ public abstract class AbstractRoutingDslTest {
                     .routingTo((Http.Request req, MyString myString) -> ok(myString.value))
                     .build());
 
-    assertThat(makeRequest(router, "GET", "/foo"), equalTo("a:foo"));
+    assertThat(makeRequest(router, "GET", "/foo")).isEqualTo("a:foo");
   }
 
   public static class MyString implements PathBindable<MyString> {

--- a/core/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/core/play-java/src/test/java/play/mvc/HttpTest.java
@@ -4,7 +4,7 @@
 
 package play.mvc;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.HeaderNames.ACCEPT_LANGUAGE;
 
 import com.typesafe.config.Config;

--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -4,7 +4,7 @@
 
 package play.mvc;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
 import java.io.File;
@@ -21,7 +21,6 @@ import java.util.concurrent.ExecutionException;
 import org.apache.pekko.stream.javadsl.FileIO;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import play.api.Application;
 import play.api.Play;
@@ -423,13 +422,10 @@ public class RequestBuilderTest {
 
     String body =
         request.body().asBytes().utf8String(); // Let's get the text representation of the bytes
-    assertThat(
-        body,
-        CoreMatchers.containsString("Content-Disposition: form-data; name=\"f%0Ai%0De%22l%0Ad1\""));
-    assertThat(
-        body,
-        CoreMatchers.containsString(
-            "Content-Disposition: form-data; name=\"f%22i%0Dl%0Aef%22ie%0Ald%0D1\"; filename=\"f%0Dir%22s%0Atf%0Dil%22e%0A.txt\""));
+    assertThat(body)
+        .contains("Content-Disposition: form-data; name=\"f%0Ai%0De%22l%0Ad1\"")
+        .contains(
+            "Content-Disposition: form-data; name=\"f%22i%0Dl%0Aef%22ie%0Ald%0D1\"; filename=\"f%0Dir%22s%0Atf%0Dil%22e%0A.txt\"");
 
     Play.stop(app);
   }

--- a/core/play/src/test/java/play/i18n/MessagesTest.java
+++ b/core/play/src/test/java/play/i18n/MessagesTest.java
@@ -4,7 +4,7 @@
 
 package play.i18n;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;

--- a/core/play/src/test/java/play/libs/concurrent/FuturesTest.java
+++ b/core/play/src/test/java/play/libs/concurrent/FuturesTest.java
@@ -6,8 +6,7 @@ package play.libs.concurrent;
 
 import static java.text.MessageFormat.*;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
@@ -43,7 +42,7 @@ public class FuturesTest {
     final Double actual =
         new MyClass().callWithTimeout().toCompletableFuture().get(1, TimeUnit.SECONDS);
     final Double expected = Math.PI;
-    assertThat(actual, equalTo(expected));
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -60,7 +59,7 @@ public class FuturesTest {
             .exceptionally(e -> 100d)
             .get(1, TimeUnit.SECONDS);
     final Double expected = 100d;
-    assertThat(actual, equalTo(expected));
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test

--- a/persistence/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/persistence/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -4,8 +4,7 @@
 
 package play.db;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -22,16 +21,16 @@ public class DatabaseTest {
   @Test
   public void createDatabase() {
     Database db = Databases.createFrom("test", "org.h2.Driver", "jdbc:h2:mem:test");
-    assertThat(db.getName(), equalTo("test"));
-    assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test"));
+    assertThat(db.getName()).isEqualTo("test");
+    assertThat(db.getUrl()).isEqualTo("jdbc:h2:mem:test");
     db.shutdown();
   }
 
   @Test
   public void createDefaultDatabase() {
     Database db = Databases.createFrom("org.h2.Driver", "jdbc:h2:mem:default");
-    assertThat(db.getName(), equalTo("default"));
-    assertThat(db.getUrl(), equalTo("jdbc:h2:mem:default"));
+    assertThat(db.getName()).isEqualTo("default");
+    assertThat(db.getUrl()).isEqualTo("jdbc:h2:mem:default");
     db.shutdown();
   }
 
@@ -39,29 +38,29 @@ public class DatabaseTest {
   public void createConfiguredDatabase() throws Exception {
     Map<String, String> config = ImmutableMap.of("jndiName", "DefaultDS");
     Database db = Databases.createFrom("test", "org.h2.Driver", "jdbc:h2:mem:test", config);
-    assertThat(db.getName(), equalTo("test"));
-    assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test"));
+    assertThat(db.getName()).isEqualTo("test");
+    assertThat(db.getUrl()).isEqualTo("jdbc:h2:mem:test");
 
     // Forces the data source initialization, and then JNDI registration.
     db.getDataSource();
 
-    assertThat(JNDI.initialContext().lookup("DefaultDS"), equalTo(db.getDataSource()));
+    assertThat(JNDI.initialContext().lookup("DefaultDS")).isEqualTo(db.getDataSource());
     db.shutdown();
   }
 
   @Test
   public void createDefaultInMemoryDatabase() {
     Database db = Databases.inMemory();
-    assertThat(db.getName(), equalTo("default"));
-    assertThat(db.getUrl(), equalTo("jdbc:h2:mem:default"));
+    assertThat(db.getName()).isEqualTo("default");
+    assertThat(db.getUrl()).isEqualTo("jdbc:h2:mem:default");
     db.shutdown();
   }
 
   @Test
   public void createNamedInMemoryDatabase() {
     Database db = Databases.inMemory("test");
-    assertThat(db.getName(), equalTo("test"));
-    assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test"));
+    assertThat(db.getName()).isEqualTo("test");
+    assertThat(db.getUrl()).isEqualTo("jdbc:h2:mem:test");
     db.shutdown();
   }
 
@@ -71,8 +70,8 @@ public class DatabaseTest {
     Map<String, Object> config = ImmutableMap.of();
     Database db = Databases.inMemory("test", options, config);
 
-    assertThat(db.getName(), equalTo("test"));
-    assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test;MODE=MySQL"));
+    assertThat(db.getName()).isEqualTo("test");
+    assertThat(db.getUrl()).isEqualTo("jdbc:h2:mem:test;MODE=MySQL");
 
     db.shutdown();
   }
@@ -80,13 +79,13 @@ public class DatabaseTest {
   @Test
   public void createConfiguredInMemoryDatabase() throws Exception {
     Database db = Databases.inMemoryWith("jndiName", "DefaultDS");
-    assertThat(db.getName(), equalTo("default"));
-    assertThat(db.getUrl(), equalTo("jdbc:h2:mem:default"));
+    assertThat(db.getName()).isEqualTo("default");
+    assertThat(db.getUrl()).isEqualTo("jdbc:h2:mem:default");
 
     // Forces the data source initialization, and then JNDI registration.
     db.getDataSource();
 
-    assertThat(JNDI.initialContext().lookup("DefaultDS"), equalTo(db.getDataSource()));
+    assertThat(JNDI.initialContext().lookup("DefaultDS")).isEqualTo(db.getDataSource());
     db.shutdown();
   }
 
@@ -112,8 +111,8 @@ public class DatabaseTest {
       c1.createStatement().execute("create table test (id bigint not null, name varchar(255))");
       c1.createStatement().execute("insert into test (id, name) values (1, 'alice')");
       ResultSet results = c2.createStatement().executeQuery("select * from test");
-      assertThat(results.next(), is(true));
-      assertThat(results.next(), is(false));
+      assertThat(results.next()).isTrue();
+      assertThat(results.next()).isFalse();
     }
 
     db.shutdown();
@@ -133,12 +132,12 @@ public class DatabaseTest {
         db.withConnection(
             c -> {
               ResultSet results = c.createStatement().executeQuery("select * from test");
-              assertThat(results.next(), is(true));
-              assertThat(results.next(), is(false));
+              assertThat(results.next()).isTrue();
+              assertThat(results.next()).isFalse();
               return true;
             });
 
-    assertThat(result, is(true));
+    assertThat(result).isTrue();
 
     db.shutdown();
   }
@@ -158,11 +157,11 @@ public class DatabaseTest {
         db.withConnection(
             c -> {
               ResultSet results = c.createStatement().executeQuery("select * from test");
-              assertThat(results.next(), is(false));
+              assertThat(results.next()).isFalse();
               return true;
             });
 
-    assertThat(result, is(true));
+    assertThat(result).isTrue();
 
     db.shutdown();
   }
@@ -180,13 +179,13 @@ public class DatabaseTest {
               return true;
             });
 
-    assertThat(created, is(true));
+    assertThat(created).isTrue();
 
     db.withConnection(
         c -> {
           ResultSet results = c.createStatement().executeQuery("select * from test");
-          assertThat(results.next(), is(true));
-          assertThat(results.next(), is(false));
+          assertThat(results.next()).isTrue();
+          assertThat(results.next()).isFalse();
         });
 
     try {
@@ -196,14 +195,14 @@ public class DatabaseTest {
             throw new RuntimeException("boom");
           });
     } catch (Exception e) {
-      assertThat(e.getMessage(), equalTo("boom"));
+      assertThat(e.getMessage()).isEqualTo("boom");
     }
 
     db.withConnection(
         c -> {
           ResultSet results = c.createStatement().executeQuery("select * from test");
-          assertThat(results.next(), is(true));
-          assertThat(results.next(), is(false));
+          assertThat(results.next()).isTrue();
+          assertThat(results.next()).isFalse();
         });
 
     db.shutdown();
@@ -215,16 +214,16 @@ public class DatabaseTest {
     db.getConnection().close();
     db.shutdown();
     SQLException sqlException = assertThrows(SQLException.class, () -> db.getConnection().close());
-    assertThat(sqlException.getMessage(), endsWith("has been closed."));
+    assertThat(sqlException.getMessage()).endsWith("has been closed.");
   }
 
   @Test
   public void useConnectionPoolDataSourceProxyWhenLogSqlIsTrue() throws Exception {
     Map<String, String> config = ImmutableMap.of("jndiName", "DefaultDS", "logSql", "true");
     Database db = Databases.createFrom("test", "org.h2.Driver", "jdbc:h2:mem:test", config);
-    assertThat(db.getDataSource(), instanceOf(ConnectionPoolDataSourceProxy.class));
-    assertThat(
-        JNDI.initialContext().lookup("DefaultDS"), instanceOf(ConnectionPoolDataSourceProxy.class));
+    assertThat(db.getDataSource()).isInstanceOf(ConnectionPoolDataSourceProxy.class);
+    assertThat(JNDI.initialContext().lookup("DefaultDS"))
+        .isInstanceOf(ConnectionPoolDataSourceProxy.class);
     db.shutdown();
   }
 
@@ -242,13 +241,13 @@ public class DatabaseTest {
               return true;
             });
 
-    assertThat(created, is(true));
+    assertThat(created).isTrue();
 
     db.withConnection(
         c -> {
           ResultSet results = c.createStatement().executeQuery("select * from test");
-          assertThat(results.next(), is(true));
-          assertThat(results.next(), is(false));
+          assertThat(results.next()).isTrue();
+          assertThat(results.next()).isFalse();
         });
 
     db.shutdown();

--- a/persistence/play-java-jdbc/src/test/java/play/db/NamedDatabaseTest.java
+++ b/persistence/play-java-jdbc/src/test/java/play/db/NamedDatabaseTest.java
@@ -4,8 +4,7 @@
 
 package play.db;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Guice;
@@ -33,13 +32,12 @@ public class NamedDatabaseTest {
             "db.other.driver", "org.h2.Driver",
             "db.other.url", "jdbc:h2:mem:other");
     Injector injector = createInjector(config);
-    assertThat(
-        injector.getInstance(DefaultComponent.class).db.getUrl(), equalTo("jdbc:h2:mem:default"));
-    assertThat(
-        injector.getInstance(NamedDefaultComponent.class).db.getUrl(),
-        equalTo("jdbc:h2:mem:default"));
-    assertThat(
-        injector.getInstance(NamedOtherComponent.class).db.getUrl(), equalTo("jdbc:h2:mem:other"));
+    assertThat(injector.getInstance(DefaultComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:default");
+    assertThat(injector.getInstance(NamedDefaultComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:default");
+    assertThat(injector.getInstance(NamedOtherComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:other");
   }
 
   @Test
@@ -49,8 +47,8 @@ public class NamedDatabaseTest {
             "db.other.driver", "org.h2.Driver",
             "db.other.url", "jdbc:h2:mem:other");
     Injector injector = createInjector(config);
-    assertThat(
-        injector.getInstance(NamedOtherComponent.class).db.getUrl(), equalTo("jdbc:h2:mem:other"));
+    assertThat(injector.getInstance(NamedOtherComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:other");
     exception.expect(com.google.inject.ConfigurationException.class);
     injector.getInstance(DefaultComponent.class);
   }
@@ -62,8 +60,8 @@ public class NamedDatabaseTest {
             "db.other.driver", "org.h2.Driver",
             "db.other.url", "jdbc:h2:mem:other");
     Injector injector = createInjector(config);
-    assertThat(
-        injector.getInstance(NamedOtherComponent.class).db.getUrl(), equalTo("jdbc:h2:mem:other"));
+    assertThat(injector.getInstance(NamedOtherComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:other");
     exception.expect(com.google.inject.ConfigurationException.class);
     injector.getInstance(NamedDefaultComponent.class);
   }
@@ -76,10 +74,10 @@ public class NamedDatabaseTest {
             "db.other.driver", "org.h2.Driver",
             "db.other.url", "jdbc:h2:mem:other");
     Injector injector = createInjector(config);
-    assertThat(
-        injector.getInstance(DefaultComponent.class).db.getUrl(), equalTo("jdbc:h2:mem:other"));
-    assertThat(
-        injector.getInstance(NamedOtherComponent.class).db.getUrl(), equalTo("jdbc:h2:mem:other"));
+    assertThat(injector.getInstance(DefaultComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:other");
+    assertThat(injector.getInstance(NamedOtherComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:other");
     exception.expect(com.google.inject.ConfigurationException.class);
     injector.getInstance(NamedDefaultComponent.class);
   }
@@ -92,11 +90,10 @@ public class NamedDatabaseTest {
             "databases.default.driver", "org.h2.Driver",
             "databases.default.url", "jdbc:h2:mem:default");
     Injector injector = createInjector(config);
-    assertThat(
-        injector.getInstance(DefaultComponent.class).db.getUrl(), equalTo("jdbc:h2:mem:default"));
-    assertThat(
-        injector.getInstance(NamedDefaultComponent.class).db.getUrl(),
-        equalTo("jdbc:h2:mem:default"));
+    assertThat(injector.getInstance(DefaultComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:default");
+    assertThat(injector.getInstance(NamedDefaultComponent.class).db.getUrl())
+        .isEqualTo("jdbc:h2:mem:default");
   }
 
   private Injector createInjector(Map<String, Object> config) {

--- a/persistence/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
+++ b/persistence/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
@@ -4,15 +4,11 @@
 
 package play.db.jpa;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import jakarta.persistence.EntityManager;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Rule;
@@ -37,29 +33,28 @@ public class JPAApiTest {
   public void shouldWorkWithEmptyConfiguration() {
     String configString = "";
     Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
-    assertThat(unitNames, equalTo(Collections.emptySet()));
+    assertThat(unitNames).isEmpty();
   }
 
   @Test
   public void shouldWorkWithSingleValue() {
     String configString = "jpa.default = defaultPersistenceUnit";
     Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
-    assertThat(unitNames, equalTo(new HashSet<>(Arrays.asList("defaultPersistenceUnit"))));
+    assertThat(unitNames).containsOnly("defaultPersistenceUnit");
   }
 
   @Test
   public void shouldWorkWithMultipleValues() {
     String configString = "jpa.default = defaultPersistenceUnit\n" + "jpa.number2 = number2Unit";
     Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
-    assertThat(
-        unitNames, equalTo(new HashSet<>(Arrays.asList("defaultPersistenceUnit", "number2Unit"))));
+    assertThat(unitNames).containsOnly("defaultPersistenceUnit", "number2Unit");
   }
 
   @Test
   public void shouldWorkWithEmptyConfigurationAtConfiguredLocation() {
     String configString = "play.jpa.config = myconfig.jpa";
     Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
-    assertThat(unitNames, equalTo(Collections.emptySet()));
+    assertThat(unitNames).isEmpty();
   }
 
   @Test
@@ -67,7 +62,7 @@ public class JPAApiTest {
     String configString =
         "play.jpa.config = myconfig.jpa\n" + "myconfig.jpa.default = defaultPersistenceUnit";
     Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
-    assertThat(unitNames, equalTo(new HashSet<>(Arrays.asList("defaultPersistenceUnit"))));
+    assertThat(unitNames).containsOnly("defaultPersistenceUnit");
   }
 
   @Test
@@ -77,14 +72,13 @@ public class JPAApiTest {
             + "myconfig.jpa.default = defaultPersistenceUnit\n"
             + "myconfig.jpa.number2 = number2Unit";
     Set<String> unitNames = getConfiguredPersistenceUnitNames(configString);
-    assertThat(
-        unitNames, equalTo(new HashSet<>(Arrays.asList("defaultPersistenceUnit", "number2Unit"))));
+    assertThat(unitNames).containsOnly("defaultPersistenceUnit", "number2Unit");
   }
 
   @Test
   public void shouldBeAbleToGetAnEntityManagerWithAGivenName() {
     EntityManager em = db.jpa.em("default");
-    assertThat(em, notNullValue());
+    assertThat(em).isNotNull();
   }
 
   @Test
@@ -99,7 +93,7 @@ public class JPAApiTest {
     db.jpa.withTransaction(
         entityManager -> {
           TestEntity entity = TestEntity.find(1L, entityManager);
-          assertThat(entity.name, equalTo("alice"));
+          assertThat(entity.name).isEqualTo("alice");
         });
   }
 
@@ -116,7 +110,7 @@ public class JPAApiTest {
     db.jpa.withTransaction(
         entityManager -> {
           TestEntity entity = TestEntity.find(1L, entityManager);
-          assertThat(entity.name, equalTo("alice"));
+          assertThat(entity.name).isEqualTo("alice");
         });
   }
 
@@ -134,7 +128,7 @@ public class JPAApiTest {
     db.jpa.withTransaction(
         entityManager -> {
           TestEntity entity = TestEntity.find(1L, entityManager);
-          assertThat(entity, nullValue());
+          assertThat(entity).isNull();
         });
   }
 
@@ -160,7 +154,7 @@ public class JPAApiTest {
     db.jpa.withTransaction(
         entityManager -> {
           TestEntity entity = TestEntity.find(1L, entityManager);
-          assertThat(entity.name, equalTo("alice"));
+          assertThat(entity.name).isEqualTo("alice");
         });
   }
 
@@ -176,12 +170,12 @@ public class JPAApiTest {
           db.jpa.withTransaction(
               entityManagerInner -> {
                 TestEntity entity2 = TestEntity.find(2L, entityManagerInner);
-                assertThat(entity2, nullValue());
+                assertThat(entity2).isNull();
               });
 
           // Verify that we can still access the EntityManager
           TestEntity entity3 = TestEntity.find(2L, entityManager);
-          assertThat(entity3, equalTo(entity));
+          assertThat(entity3).isEqualTo(entity);
         });
   }
 
@@ -204,16 +198,16 @@ public class JPAApiTest {
 
           // Verify that we can still access the EntityManager
           TestEntity entity3 = TestEntity.find(2L, entityManager);
-          assertThat(entity3, equalTo(entity));
+          assertThat(entity3).isEqualTo(entity);
         });
 
     db.jpa.withTransaction(
         entityManager -> {
           TestEntity entity = TestEntity.find(3L, entityManager);
-          assertThat(entity, nullValue());
+          assertThat(entity).isNull();
 
           TestEntity entity2 = TestEntity.find(2L, entityManager);
-          assertThat(entity2.name, equalTo("alice"));
+          assertThat(entity2.name).isEqualTo("alice");
         });
   }
 
@@ -234,7 +228,7 @@ public class JPAApiTest {
 
           // Verify that we can still access the EntityManager
           TestEntity entity3 = TestEntity.find(2L, entityManager);
-          assertThat(entity3, equalTo(entity));
+          assertThat(entity3).isEqualTo(entity);
 
           entityManager.getTransaction().setRollbackOnly();
         });
@@ -242,10 +236,10 @@ public class JPAApiTest {
     db.jpa.withTransaction(
         entityManager -> {
           TestEntity entity = TestEntity.find(3L, entityManager);
-          assertThat(entity.name, equalTo("alice"));
+          assertThat(entity.name).isEqualTo("alice");
 
           TestEntity entity2 = TestEntity.find(2L, entityManager);
-          assertThat(entity2, nullValue());
+          assertThat(entity2).isNull();
         });
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -137,10 +137,12 @@ object Dependencies {
   val junitInterface = "com.github.sbt" % "junit-interface" % "0.13.3"
   val junit          = "junit"          % "junit"           % "4.13.2"
 
+  val assertj = "org.assertj" % "assertj-core" % "3.24.2"
+
   val javaTestDeps = Seq(
     junit,
     junitInterface,
-    "org.easytesting" % "fest-assert" % "1.4",
+    assertj,
     mockitoAll,
     logback
   ).map(_ % Test)
@@ -289,7 +291,7 @@ object Dependencies {
   val playCaffeineDeps = Seq(
     "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion,
     "com.github.ben-manes.caffeine" % "jcache"   % caffeineVersion
-  ) ++ jcacheApi
+  ) ++ jcacheApi ++ Seq(assertj % Test)
 
   val playWsStandaloneVersion = "3.0.1"
   val playWsDeps = Seq(

--- a/testkit/play-test/src/test/java/play/test/HelpersTest.java
+++ b/testkit/play-test/src/test/java/play/test/HelpersTest.java
@@ -4,8 +4,7 @@
 
 package play.test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static play.test.Helpers.POST;
 
 import java.util.Collections;
@@ -15,7 +14,6 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.Terminated;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.util.ByteString;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import play.Application;
 import play.mvc.Http;
@@ -32,35 +30,35 @@ public class HelpersTest {
   @Test
   public void shouldCreateASimpleFakeRequest() {
     Http.RequestImpl request = Helpers.fakeRequest().build();
-    assertThat(request.method(), equalTo("GET"));
-    assertThat(request.path(), equalTo("/"));
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.path()).isEqualTo("/");
   }
 
   @Test
   public void shouldCreateAFakeRequestWithMethodAndUri() {
     Http.RequestImpl request = Helpers.fakeRequest("POST", "/my-uri").build();
-    assertThat(request.method(), equalTo("POST"));
-    assertThat(request.path(), equalTo("/my-uri"));
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.path()).isEqualTo("/my-uri");
   }
 
   @Test
   public void shouldAddHostHeaderToFakeRequests() {
     Http.RequestImpl request = Helpers.fakeRequest().build();
-    assertThat(request.host(), equalTo("localhost"));
+    assertThat(request.host()).isEqualTo("localhost");
   }
 
   @Test
   public void shouldCreateFakeApplicationsWithAnInMemoryDatabase() {
     Application application = Helpers.fakeApplication(Helpers.inMemoryDatabase());
-    assertThat(application.config().getString("db.default.driver"), CoreMatchers.notNullValue());
-    assertThat(application.config().getString("db.default.url"), CoreMatchers.notNullValue());
+    assertThat(application.config().getString("db.default.driver")).isNotNull();
+    assertThat(application.config().getString("db.default.url")).isNotNull();
   }
 
   @Test
   public void shouldCreateFakeApplicationsWithAnNamedInMemoryDatabase() {
     Application application = Helpers.fakeApplication(Helpers.inMemoryDatabase("testDb"));
-    assertThat(application.config().getString("db.testDb.driver"), CoreMatchers.notNullValue());
-    assertThat(application.config().getString("db.testDb.url"), CoreMatchers.notNullValue());
+    assertThat(application.config().getString("db.testDb.driver")).isNotNull();
+    assertThat(application.config().getString("db.testDb.url")).isNotNull();
   }
 
   @Test
@@ -70,18 +68,17 @@ public class HelpersTest {
     options.put("ttl", "10");
 
     Application application = Helpers.fakeApplication(Helpers.inMemoryDatabase("testDb", options));
-    assertThat(application.config().getString("db.testDb.driver"), CoreMatchers.notNullValue());
-    assertThat(application.config().getString("db.testDb.url"), CoreMatchers.notNullValue());
-    assertThat(
-        application.config().getString("db.testDb.url"), CoreMatchers.containsString("username"));
-    assertThat(application.config().getString("db.testDb.url"), CoreMatchers.containsString("ttl"));
+    assertThat(application.config().getString("db.testDb.driver")).isNotNull();
+    assertThat(application.config().getString("db.testDb.url")).isNotNull();
+    assertThat(application.config().getString("db.testDb.url")).contains("username");
+    assertThat(application.config().getString("db.testDb.url")).contains("ttl");
   }
 
   @Test
   public void shouldExtractContentAsBytesFromAResult() {
     Result result = Results.ok("Test content");
     ByteString contentAsBytes = Helpers.contentAsBytes(result);
-    assertThat(contentAsBytes, equalTo(ByteString.fromString("Test content")));
+    assertThat(contentAsBytes).isEqualTo(ByteString.fromString("Test content"));
   }
 
   @Test
@@ -93,7 +90,7 @@ public class HelpersTest {
 
       Result result = Results.ok("Test content");
       ByteString contentAsBytes = Helpers.contentAsBytes(result, mat);
-      assertThat(contentAsBytes, equalTo(ByteString.fromString("Test content")));
+      assertThat(contentAsBytes).isEqualTo(ByteString.fromString("Test content"));
     } finally {
       Future<Terminated> future = actorSystem.terminate();
       Await.result(future, Duration.create("5s"));
@@ -104,21 +101,21 @@ public class HelpersTest {
   public void shouldExtractContentAsBytesFromTwirlContent() {
     Content content = Html.apply("Test content");
     ByteString contentAsBytes = Helpers.contentAsBytes(content);
-    assertThat(contentAsBytes, equalTo(ByteString.fromString("Test content")));
+    assertThat(contentAsBytes).isEqualTo(ByteString.fromString("Test content"));
   }
 
   @Test
   public void shouldExtractContentAsStringFromTwirlContent() {
     Content content = Html.apply("Test content");
     String contentAsString = Helpers.contentAsString(content);
-    assertThat(contentAsString, equalTo("Test content"));
+    assertThat(contentAsString).isEqualTo("Test content");
   }
 
   @Test
   public void shouldExtractContentAsStringFromAResult() {
     Result result = Results.ok("Test content");
     String contentAsString = Helpers.contentAsString(result);
-    assertThat(contentAsString, equalTo("Test content"));
+    assertThat(contentAsString).isEqualTo("Test content");
   }
 
   @Test
@@ -130,7 +127,7 @@ public class HelpersTest {
 
       Result result = Results.ok("Test content");
       String contentAsString = Helpers.contentAsString(result, mat);
-      assertThat(contentAsString, equalTo("Test content"));
+      assertThat(contentAsString).isEqualTo("Test content");
     } finally {
       Future<Terminated> future = actorSystem.terminate();
       Await.result(future, Duration.create("5s"));
@@ -143,7 +140,7 @@ public class HelpersTest {
     Application app = Helpers.fakeApplication();
 
     Result result = Helpers.route(app, request);
-    assertThat(result.status(), equalTo(404));
+    assertThat(result.status()).isEqualTo(404);
   }
 
   @Test
@@ -154,14 +151,14 @@ public class HelpersTest {
     Http.RequestBuilder request =
         new Http.RequestBuilder().method(POST).bodyMultipart(postParams, Collections.emptyList());
     Result result = Helpers.route(app, request);
-    assertThat(result.status(), equalTo(404));
+    assertThat(result.status()).isEqualTo(404);
   }
 
   @Test
   public void shouldReturnProperHasBodyValueForFakeRequest() {
     // Does not set a Content-Length and also not a Transfer-Encoding header, sets null as body
     Http.Request request = Helpers.fakeRequest("POST", "/uri").build();
-    assertThat(request.hasBody(), equalTo(false));
+    assertThat(request.hasBody()).isFalse();
   }
 
   @Test
@@ -169,7 +166,7 @@ public class HelpersTest {
     // Does set a Content-Length header
     Http.Request request =
         Helpers.fakeRequest("POST", "/uri").bodyRaw(ByteString.emptyByteString()).build();
-    assertThat(request.hasBody(), equalTo(false));
+    assertThat(request.hasBody()).isFalse();
   }
 
   @Test
@@ -177,6 +174,6 @@ public class HelpersTest {
     // Does set a Content-Length header
     Http.Request request =
         Helpers.fakeRequest("POST", "/uri").bodyRaw(ByteString.fromString("a")).build();
-    assertThat(request.hasBody(), equalTo(true));
+    assertThat(request.hasBody()).isTrue();
   }
 }

--- a/testkit/play-test/src/test/java/play/test/WithApplicationOverrideTest.java
+++ b/testkit/play-test/src/test/java/play/test/WithApplicationOverrideTest.java
@@ -4,8 +4,7 @@
 
 package play.test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
@@ -32,6 +31,6 @@ public class WithApplicationOverrideTest extends WithApplication {
 
   @Test
   public void shouldHaveExtraConfiguration() {
-    assertThat(app.config().getString("extraConfig"), equalTo("valueForExtraConfig"));
+    assertThat(app.config().getString("extraConfig")).isEqualTo("valueForExtraConfig");
   }
 }

--- a/testkit/play-test/src/test/java/play/test/WithBrowserTest.java
+++ b/testkit/play-test/src/test/java/play/test/WithBrowserTest.java
@@ -4,8 +4,7 @@
 
 package play.test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
@@ -15,6 +14,6 @@ public class WithBrowserTest extends WithBrowser {
   public void withBrowserShouldProvideABrowser() {
     assertNotNull(browser);
     browser.goTo("/");
-    assertThat(browser.pageSource(), containsString("Action Not Found"));
+    assertThat(browser.pageSource()).contains("Action Not Found");
   }
 }

--- a/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -4,7 +4,7 @@
 
 package play.mvc;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;


### PR DESCRIPTION
It's a first small step for
- #11839

I'm still thinking we should migrate to AssertJ firstly instead of rewrite assertion expressions twice (Hamcrest -> JUnit5 -> AssertJ).

In this part I remove using Hamcrest in sources. The second part will be related to documentation.