### PR TITLE
[2.8.x] Upgrade typesafe config to 1.4.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -203,7 +203,7 @@ object Dependencies {
     )
   }
 
-  val typesafeConfig = "com.typesafe" % "config" % "1.4.2"
+  val typesafeConfig = "com.typesafe" % "config" % "1.4.3"
 
   def sbtDependencies(sbtVersion: String, scalaVersion: String) = {
     def sbtDep(moduleId: ModuleID) = sbtPluginDep(moduleId, sbtVersion, scalaVersion)


### PR DESCRIPTION
No other updates for the 2.8.x branch as far as I can see.