### PR TITLE
Fix headers check for Play OpenID module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -492,7 +492,7 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
         --- (baseDirectory.value ** "jquery*js")
         --- (baseDirectory.value ** "target" ** "*")
         --- (baseDirectory.value / "documentation" ** "*")).get ++
-        (baseDirectory.value / "web" / "play-openid" ** "*.html").get ++
+        (baseDirectory.value / "web" / "play-openid" ** "*.html" --- (baseDirectory.value ** "target" ** "*")).get ++
         (baseDirectory.value / "project" ** "*.scala" --- (baseDirectory.value ** "target" ** "*")).get
   )
   .aggregate((userProjects ++ nonUserProjects): _*)


### PR DESCRIPTION
Need to ignore `target` folder the same as for another modules