### PR TITLE
Add suffix to coursier cache key for publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,4 +15,6 @@ jobs:
   publish-artifacts:
     name: Publish / Artifacts
     uses: playframework/.github/.github/workflows/publish.yml@v3
+    with:
+      extra-coursier-cache-key: "publish"
     secrets: inherit


### PR DESCRIPTION
Publish job for protected branches (`main`, `2.9.x`) finishes before check job that why we make a cache entry with not all artifacts that we want.

**Actual** cache size: **780Mb**
**Expected** cache size: **1.2Gb**

For example https://github.com/playframework/playframework/actions/runs/6823204457/job/18556669881