### PR TITLE
Don't publish `sbt-scripted-tools` to remote repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -250,6 +250,10 @@ lazy val SbtPluginProject = PlaySbtPluginProject("Sbt-Plugin", "dev-mode/sbt-plu
 lazy val SbtScriptedToolsProject = PlaySbtPluginProject("Sbt-Scripted-Tools", "dev-mode/sbt-scripted-tools")
   .enablePlugins(SbtPlugin)
   .dependsOn(SbtPluginProject)
+  .settings(
+    publish / skip      := true,
+    publishLocal / skip := false
+  )
 
 lazy val PlayLogback = PlayCrossBuiltProject("Play-Logback", "core/play-logback")
   .settings(


### PR DESCRIPTION
Following by _The Boy Scout Rule_.
It looks as if `sbt-scripted-tools` needs only locally for scripted tests and we are able to not publish this module into remote repository.