### PR TITLE
upgrade jjwt to 0.12.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val acolyteVersion = "1.2.9"
   val acolyte        = "org.eu.acolyte" % "jdbc-driver" % acolyteVersion
 
-  val jjwtVersion = "0.11.5"
+  val jjwtVersion = "0.12.5"
   val jjwts = Seq(
     "io.jsonwebtoken" % "jjwt-api",
     "io.jsonwebtoken" % "jjwt-impl"


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

## Fixes

This PR makes #12033 obsolete

## Purpose

This PR upgrades the [jjwt](https://github.com/jwtk/jjwt) dependency from `0.11.5` to `0.12.3`.

The `0.12.0` of `jjwt` adds a lot of new features that were highly anticipated by a lot of `jjwt` users. For example, the support to marshal and parse JWKs and the support for encrypted JWTs (JWE).

## Notes

The version bump includes breaking changes for a few `jjwt` exposed methods (see [CHANGELOG](https://github.com/jwtk/jjwt/blob/0.12.0/CHANGELOG.md)), while other methods were just deprecated.

Where possible, the deprecated method calls have been replaced with their latest counterpart. A few deprecated classes and methods are still being used in this PR. In particular, anything relating to `io.jsonwebtoken.SignatureAlgorithm`, which has been deprecated as a whole. Replacing those is unfortunately not as straightforward, and some additional effort has to be put into the upgrade if different types of algorithms should be supported by Play (ie. not just `HMAC` signatures, but also `RSA`, `ECDSA`, etc.). 

It would be sensible to open an issue for the deprecations regarding the signature algorithm usage and address it at a later time.

## References

- https://github.com/playframework/playframework/pull/12033#issuecomment-1809961474
- https://github.com/jwtk/jjwt/blob/0.12.0/CHANGELOG.md
