### PR TITLE
[2.8.x] Bugfix: Always set `play.server.http.port`, even if disabled

### DIFF
--- a/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/dev-mode/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -201,7 +201,9 @@ object Reloader {
     // but who knows how they will be set in a future change) also set the actual configs they are shortcuts for.
     // So when reading the actual (long) keys from the config (play.server.http...) the values match and are correct.
     val systemPropertiesAddressPorts = Seq("play.server.http.address" -> httpAddress) ++
-      httpPort.map(port => Seq("play.server.http.port" -> port.toString)).getOrElse(Nil) ++
+      httpPort
+        .map(port => Seq("play.server.http.port" -> port.toString))
+        .getOrElse(Seq("play.server.http.port" -> "disabled")) ++
       httpsPort.map(port => Seq("play.server.https.port" -> port.toString)).getOrElse(Nil)
 
     // Properties are combined in this specific order so that command line


### PR DESCRIPTION
When runninng, within sbt:
```
run disabled -Dhttps.port=9001
```
then the play.server.http.port config still is set to 9000, but should "disabled"
