### PR TITLE
Enable scripted test now that Scala 3 scaladoc handles `-Werror`

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/test
@@ -2,7 +2,4 @@
 > stage
 $ absent target/universal/stage/share
 
-# TODO: The next line is not working currently in Scala 3. Enable as soon as one of following gets resolved:
-# https://github.com/lampepfl/dotty/pull/17022
-# https://github.com/lampepfl/dotty/pull/17023
-#-> compile:doc
+-> compile:doc


### PR DESCRIPTION
Depends on 

- https://github.com/lampepfl/dotty/pull/17023

which finally is being worked on.

Was disabled in
- #11703 originally.

Reminder to myself: Also take a look at

- https://github.com/playframework/playframework/issues/9422
- https://github.com/playframework/play-webgoat/pull/95