### PR TITLE
Add generated play.http.secret.key at the end of the application.conf file

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
@@ -59,7 +59,7 @@ object ApplicationSecretGenerator {
         log.warn("Did not find application secret in " + appConfFile.getCanonicalPath)
         log.warn("Adding application secret to start of file")
         val secretConfig = s"""$playHttpSecretKey="$secret""""
-        secretConfig :: lines
+        lines :+ secretConfig
       }
 
       IO.writeLines(appConfFile, newLines)

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
@@ -57,9 +57,14 @@ object ApplicationSecretGenerator {
         getUpdatedSecretLines(secret, lines, config)
       } else {
         log.warn("Did not find application secret in " + appConfFile.getCanonicalPath)
-        log.warn("Adding application secret to start of file")
+        log.warn("Adding application secret to end of file")
         val secretConfig = s"""$playHttpSecretKey="$secret""""
-        lines :+ secretConfig
+        // Append secret at the end of the file and make sure there is an empty line before
+        lines ++ lines.lastOption
+          .map(_.trim)
+          .filter(!_.isEmpty)
+          .map(_ => List("", secretConfig))
+          .getOrElse(List(secretConfig))
       }
 
       IO.writeLines(appConfFile, newLines)


### PR DESCRIPTION
Changed to append the generated play.http.secret.key to the end of file(previously added at the start of the file) so that we do not add the key before comment lines if any.

## Fixes

Fixes #12200 
