### PR TITLE
update `.scalafmt.conf`. enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -67,3 +67,10 @@ fileOverride {
     runner.dialect = scala3
   }
 }
+
+rewrite.scala3.convertToNewSyntax = true
+runner.dialectOverride {
+  allowSignificantIndentation = false
+  allowAsForImportRename = false
+  allowStarWildcardImport = false
+}

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheApi.scala
@@ -71,7 +71,7 @@ class CaffeineCacheModule
       }
 
       // bind wrapper classes
-      def wrapperBindings(cacheApiKey: BindingKey[AsyncCacheApi], namedCache: NamedCache): Seq[Binding[_]] = Seq(
+      def wrapperBindings(cacheApiKey: BindingKey[AsyncCacheApi], namedCache: NamedCache): Seq[Binding[?]] = Seq(
         bind[JavaAsyncCacheApi].qualifiedWith(namedCache).to(new NamedJavaAsyncCacheApiProvider(cacheApiKey)),
         bind[Cached].qualifiedWith(namedCache).to(new NamedCachedProvider(cacheApiKey)),
         bind[SyncCacheApi].qualifiedWith(namedCache).to(new NamedSyncCacheApiProvider(cacheApiKey)),

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheManager.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/CaffeineCacheManager.scala
@@ -16,7 +16,7 @@ import play.cache.caffeine.CaffeineParser
 import play.cache.caffeine.NamedCaffeineCache
 
 class CaffeineCacheManager(private val config: Config, private val actorSystem: ActorSystem) {
-  private val cacheMap: ConcurrentMap[String, NamedCaffeineCache[_, _]] =
+  private val cacheMap: ConcurrentMap[String, NamedCaffeineCache[?, ?]] =
     new ConcurrentHashMap(16)
 
   def getCache[K, V](cacheName: String): NamedCaffeineCache[K, V] = {
@@ -27,7 +27,7 @@ class CaffeineCacheManager(private val config: Config, private val actorSystem: 
           val cacheBuilder: Caffeine[K, V] = getCacheBuilder(cacheName).asInstanceOf[Caffeine[K, V]]
           val namedCache =
             new NamedCaffeineCache[K, V](cacheName, cacheBuilder.buildAsync().asInstanceOf[AsyncCache[K, V]])
-          namedCache.asInstanceOf[NamedCaffeineCache[_, _]]
+          namedCache.asInstanceOf[NamedCaffeineCache[?, ?]]
         }
       )
       .asInstanceOf[NamedCaffeineCache[K, V]]
@@ -42,7 +42,7 @@ class CaffeineCacheManager(private val config: Config, private val actorSystem: 
     scala.jdk.CollectionConverters.SetHasAsScala(cacheMap.keySet()).asScala.toSet
   }
 
-  private[caffeine] def getCacheBuilder(cacheName: String): Caffeine[_, _] = {
+  private[caffeine] def getCacheBuilder(cacheName: String): Caffeine[?, ?] = {
     val defaultExpiry: DefaultCaffeineExpiry = new DefaultCaffeineExpiry
     val caches: Config                       = config.getConfig("caches")
     val defaults: Config                     = config.getConfig("defaults")

--- a/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -75,7 +75,7 @@ class EhCacheModule
       }
 
       // bind wrapper classes
-      def wrapperBindings(cacheApiKey: BindingKey[AsyncCacheApi], namedCache: NamedCache): Seq[Binding[_]] = Seq(
+      def wrapperBindings(cacheApiKey: BindingKey[AsyncCacheApi], namedCache: NamedCache): Seq[Binding[?]] = Seq(
         bind[JavaAsyncCacheApi].qualifiedWith(namedCache).to(new NamedJavaAsyncCacheApiProvider(cacheApiKey)),
         bind[Cached].qualifiedWith(namedCache).to(new NamedCachedProvider(cacheApiKey)),
         bind[SyncCacheApi].qualifiedWith(namedCache).to(new NamedSyncCacheApiProvider(cacheApiKey)),

--- a/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -181,9 +181,9 @@ class CachedSpec extends PlaySpecification {
     }
   }
 
-  val dummyAction = Action { (request: Request[_]) => Results.Ok(Random.nextInt().toString) }
+  val dummyAction = Action { (request: Request[?]) => Results.Ok(Random.nextInt().toString) }
 
-  val notFoundAction = Action { (request: Request[_]) => Results.NotFound(Random.nextInt().toString) }
+  val notFoundAction = Action { (request: Request[?]) => Results.NotFound(Random.nextInt().toString) }
 
   "Cached EssentialAction composition" should {
     "cache infinite ok results" in new WithApplication() {

--- a/core/play-configuration/src/main/scala/play/api/Configuration.scala
+++ b/core/play-configuration/src/main/scala/play/api/Configuration.scala
@@ -129,8 +129,8 @@ object Configuration {
    */
   def from(data: Map[String, Any]): Configuration = {
     def toJava(data: Any): Any = data match {
-      case map: Map[_, _]        => map.view.mapValues(toJava).toMap.asJava
-      case iterable: Iterable[_] => iterable.map(toJava).asJava
+      case map: Map[?, ?]        => map.view.mapValues(toJava).toMap.asJava
+      case iterable: Iterable[?] => iterable.map(toJava).asJava
       case v                     => v
     }
 

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -31,7 +31,7 @@ final case class GuiceApplicationBuilder(
     configuration: Configuration = Configuration.empty,
     modules: Seq[GuiceableModule] = Seq.empty,
     overrides: Seq[GuiceableModule] = Seq.empty,
-    disabled: Seq[Class[_]] = Seq.empty,
+    disabled: Seq[Class[?]] = Seq.empty,
     binderOptions: Set[BinderOption] = BinderOption.defaults,
     eagerly: Boolean = false,
     loadConfiguration: Environment => Configuration = Configuration.load,
@@ -183,7 +183,7 @@ final case class GuiceApplicationBuilder(
       configuration: Configuration = configuration,
       modules: Seq[GuiceableModule] = modules,
       overrides: Seq[GuiceableModule] = overrides,
-      disabled: Seq[Class[_]] = disabled,
+      disabled: Seq[Class[?]] = disabled,
       binderOptions: Set[BinderOption] = binderOptions,
       eagerly: Boolean = eagerly,
       loadConfiguration: Environment => Configuration = loadConfiguration,
@@ -209,7 +209,7 @@ final case class GuiceApplicationBuilder(
       configuration: Configuration,
       modules: Seq[GuiceableModule],
       overrides: Seq[GuiceableModule],
-      disabled: Seq[Class[_]],
+      disabled: Seq[Class[?]],
       binderOptions: Set[BinderOption] = binderOptions,
       eagerly: Boolean
   ): GuiceApplicationBuilder =
@@ -233,7 +233,7 @@ final case class GuiceApplicationBuilder(
       values.exists {
         case (_, value: String) if deprecatedValues.contains(value) =>
           true
-        case (_, value: java.util.Map[_, _]) =>
+        case (_, value: java.util.Map[?, ?]) =>
           val v = value.asInstanceOf[java.util.Map[String, AnyRef]]
           hasDeprecatedValue(v.asScala)
         case _ =>
@@ -245,7 +245,7 @@ final case class GuiceApplicationBuilder(
       appConfiguration.underlying.getAnyRef("logger") match {
         case value: String =>
           hasDeprecatedValue(mutable.Map("logger" -> value))
-        case value: java.util.Map[_, _] =>
+        case value: java.util.Map[?, ?] =>
           val v = value.asInstanceOf[java.util.Map[String, AnyRef]]
           hasDeprecatedValue(v.asScala)
         case _ =>

--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/PekkoGuiceSupport.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/PekkoGuiceSupport.scala
@@ -131,7 +131,7 @@ trait PekkoGuiceSupport {
   def bindActorFactory[ActorClass <: Actor: ClassTag, FactoryClass: ClassTag]: Unit = {
     accessBinder.install(
       new FactoryModuleBuilder()
-        .implement(classOf[Actor], implicitly[ClassTag[ActorClass]].runtimeClass.asInstanceOf[Class[_ <: Actor]])
+        .implement(classOf[Actor], implicitly[ClassTag[ActorClass]].runtimeClass.asInstanceOf[Class[? <: Actor]])
         .build(implicitly[ClassTag[FactoryClass]].runtimeClass)
     )
   }

--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/TypedPekko.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/TypedPekko.scala
@@ -28,12 +28,12 @@ private[play] object TypedPekko {
   def behaviorOf[T](cls: Class[T]): TypeLiteral[Behavior[T]] = typeLiteral(cls)
 
   /** Returns the behavior's message type. Requires the class is a nominal subclass. */
-  def messageTypeOf[T](behaviorClass: Class[_ <: Behavior[T]]): Class[T] = {
+  def messageTypeOf[T](behaviorClass: Class[? <: Behavior[T]]): Class[T] = {
     val tpe = behaviorClass.getGenericSuperclass.asInstanceOf[ParameterizedType]
     tpe.getActualTypeArguments()(0).asInstanceOf[Class[T]]
   }
 
-  private def typeLiteral[C[_], T](cls: Class[_])(implicit C: ClassTag[C[Any]]) = {
+  private def typeLiteral[C[_], T](cls: Class[?])(implicit C: ClassTag[C[Any]]) = {
     val parameterizedType = Types.newParameterizedType(C.runtimeClass, cls)
     TypeLiteral.get(parameterizedType).asInstanceOf[TypeLiteral[C[T]]]
   }

--- a/core/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -84,7 +84,7 @@ class GuiceApplicationLoaderSpec extends Specification {
   }
 
   def fakeContext: ApplicationLoader.Context = ApplicationLoader.Context.create(Environment.simple())
-  def fakeContextWithModule(module: Class[_ <: AbstractModule]): ApplicationLoader.Context = {
+  def fakeContextWithModule(module: Class[? <: AbstractModule]): ApplicationLoader.Context = {
     val f                       = fakeContext
     val c                       = f.initialConfiguration
     val newModules: Seq[String] = c.get[Seq[String]]("play.modules.enabled") :+ module.getName

--- a/core/play-guice/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play-guice/src/test/scala/play/core/test/Fakes.scala
@@ -19,7 +19,7 @@ object Fakes {
    * @param bindings The bindings
    * @return The injector
    */
-  def injectorFromBindings(bindings: Seq[Binding[_]]): Injector = {
+  def injectorFromBindings(bindings: Seq[Binding[?]]): Injector = {
     new GuiceInjectorBuilder().bindings(bindings).injector()
   }
 }

--- a/core/play-guice/src/test/scala/play/utils/ReflectSpec.scala
+++ b/core/play-guice/src/test/scala/play/utils/ReflectSpec.scala
@@ -52,7 +52,7 @@ class ReflectSpec extends Specification {
     }
   }
 
-  def bindings(configured: String, defaultClassName: String): Seq[Binding[_]] = {
+  def bindings(configured: String, defaultClassName: String): Seq[Binding[?]] = {
     Reflect.bindingsFromConfiguration[Duck, JavaDuck, JavaDuckAdapter, JavaDuckDelegate, DefaultDuck](
       Environment.simple(),
       Configuration.from(Map("duck" -> configured)),
@@ -61,11 +61,11 @@ class ReflectSpec extends Specification {
     )
   }
 
-  def bindings[Default: ClassTag](configured: String): Seq[Binding[_]] = {
+  def bindings[Default: ClassTag](configured: String): Seq[Binding[?]] = {
     bindings(configured, implicitly[ClassTag[Default]].runtimeClass.getName)
   }
 
-  def doQuack(bindings: Seq[Binding[_]]): String = {
+  def doQuack(bindings: Seq[Binding[?]]): String = {
     val injector = new GuiceInjectorBuilder().bindings(bindings).injector()
     val duck     = injector.instanceOf[Duck]
     val javaDuck = injector.instanceOf[JavaDuck]

--- a/core/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
@@ -28,7 +28,7 @@ class EssentialActionSpec extends PlaySpecification {
 
         val Action = app.injector.instanceOf[DefaultActionBuilder]
 
-        def checkAction(actionCons: (ClassLoader => Unit) => EssentialAction): MatchResult[_] = {
+        def checkAction(actionCons: (ClassLoader => Unit) => EssentialAction): MatchResult[?] = {
           val actionClassLoader = Promise[ClassLoader]()
           val action            = actionCons(cl => actionClassLoader.success(cl))
           call(action, FakeRequest())

--- a/core/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -20,11 +20,11 @@ class SecuritySpec extends PlaySpecification {
   "AuthenticatedBuilder" should {
     "block unauthenticated requests" in withApplication { implicit app =>
       status(
-        TestAction(app) { (req: Security.AuthenticatedRequest[_, String]) => Results.Ok(req.user) }(FakeRequest())
+        TestAction(app) { (req: Security.AuthenticatedRequest[?, String]) => Results.Ok(req.user) }(FakeRequest())
       ) must_== UNAUTHORIZED
     }
     "allow authenticated requests" in withApplication { implicit app =>
-      val result = TestAction(app) { (req: Security.AuthenticatedRequest[_, String]) => Results.Ok(req.user) }(
+      val result = TestAction(app) { (req: Security.AuthenticatedRequest[?, String]) => Results.Ok(req.user) }(
         FakeRequest().withSession("username" -> "john")
       )
       status(result) must_== OK
@@ -32,7 +32,7 @@ class SecuritySpec extends PlaySpecification {
     }
 
     "allow use as an ActionBuilder" in withApplication { implicit app =>
-      val result = Authenticated(app) { (req: AuthenticatedDbRequest[_]) =>
+      val result = Authenticated(app) { (req: AuthenticatedDbRequest[?]) =>
         Results.Ok(s"${req.conn.name}:${req.user.name}")
       }(FakeRequest().withSession("user" -> "Phil"))
       status(result) must_== OK

--- a/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -182,7 +182,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
     }
 
     "preserve the value of headers" in {
-      def headerValueInRequest(headerName: String, headerValue: String): MatchResult[Either[String, _]] = {
+      def headerValueInRequest(headerName: String, headerValue: String): MatchResult[Either[String, ?]] = {
         withServer((Action, _) => Action { rh => Results.Ok(rh.headers.get(headerName).toString) }) { port =>
           val Seq(response) = BasicHttpClient.makeRequests(port)(
             // an empty body implies no parsing is used and no content type is derived from the body.
@@ -204,7 +204,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
     }
 
     "preserve the case of header names" in {
-      def headerNameInRequest(headerName: String, headerValue: String): MatchResult[Either[String, _]] = {
+      def headerNameInRequest(headerName: String, headerValue: String): MatchResult[Either[String, ?]] = {
         withServer((Action, _) =>
           Action { rh => Results.Ok(rh.headers.keys.filter(_.equalsIgnoreCase(headerName)).mkString) }
         ) { port =>
@@ -251,7 +251,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
     }
 
     "maintain uri and path consistency" in {
-      def uriInRequest(uri: String): MatchResult[Either[String, _]] = {
+      def uriInRequest(uri: String): MatchResult[Either[String, ?]] = {
         withServer((Action, _) =>
           Action { rh => Results.Ok((rh.uri.contains(rh.path) && rh.uri.contains(rh.rawQueryString)).toString) }
         ) { port =>

--- a/core/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
@@ -20,7 +20,7 @@ class SecureFlagSpec
 
   /** An ApplicationFactory with a single action that returns the request's `secure` flag. */
   val secureFlagAppFactory: ApplicationFactory = withAction { actionBuilder =>
-    actionBuilder { (request: Request[_]) => Results.Ok(request.secure.toString) }
+    actionBuilder { (request: Request[?]) => Results.Ok(request.secure.toString) }
   }
 
   "Play https server" should {

--- a/core/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/UriHandlingSpec.scala
@@ -28,9 +28,9 @@ class UriHandlingSpec
       import sird.UrlContext
       Router.from {
         case sird.GET(p"/path") =>
-          Action { (request: Request[_]) => Results.Ok(request.queryString) }
+          Action { (request: Request[?]) => Results.Ok(request.queryString) }
         case _ =>
-          Action { (request: Request[_]) => Results.Ok(request.path + queryToString(request.queryString)) }
+          Action { (request: Request[?]) => Results.Ok(request.path + queryToString(request.queryString)) }
       }
     }.withAllOkHttpEndpoints { (okEndpoint: OkHttpEndpoint) =>
       if (

--- a/core/play-integration-test/src/test/scala/play/it/http/parsingdeferred/DeferredBodyParsingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsingdeferred/DeferredBodyParsingSpec.scala
@@ -85,7 +85,7 @@ object DeferredBodyParsingSpec {
     s"Body parsed: $parsedBody, request attribute set: ${request.attrs.contains(Attrs.REQUEST_FLOW.asScala())}, internal request attribute set: ${request.attrs
         .contains(DeferredBodyParsing)}"
 
-  def buildActionCompositionMessage(request: Request[_]) =
+  def buildActionCompositionMessage(request: Request[?]) =
     s"Action composition, body was parsed already: ${(request.body != null)}, internal request attribute set: ${request.attrs
         .contains(DeferredBodyParsing)}"
 }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -53,8 +53,8 @@ trait WebSocketClient {
    * @return A future that will be redeemed when the connection is closed.
    */
   def connect(url: URI, version: WebSocketVersion = WebSocketVersion.V13, subprotocol: Option[String] = None)(
-      onConnect: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, _]) => Unit
-  ): Future[_]
+      onConnect: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
+  ): Future[?]
 
   /**
    * Shutdown the client and release all associated resources.
@@ -117,7 +117,7 @@ object WebSocketClient {
      * Connect to the given URI
      */
     def connect(url: URI, version: WebSocketVersion, subprotocol: Option[String])(
-        onConnected: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, _]) => Unit
+        onConnected: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
     ) = {
       val normalized = url.normalize()
       val tgt = if (normalized.getPath == null || normalized.getPath.trim().isEmpty) {
@@ -155,7 +155,7 @@ object WebSocketClient {
   private class WebSocketSupervisor(
       disconnected: Promise[Unit],
       handshaker: WebSocketClientHandshaker,
-      onConnected: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, _]) => Unit
+      onConnected: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
   ) extends ChannelInboundHandlerAdapter {
     override def channelRead(ctx: ChannelHandlerContext, msg: Object): Unit = {
       msg match {
@@ -187,8 +187,8 @@ object WebSocketClient {
     val serverInitiatedClose = new AtomicBoolean
 
     def webSocketProtocol(
-        clientConnection: Flow[WebSocketFrame, WebSocketFrame, _]
-    ): Flow[ExtendedMessage, ExtendedMessage, _] = {
+        clientConnection: Flow[WebSocketFrame, WebSocketFrame, ?]
+    ): Flow[ExtendedMessage, ExtendedMessage, ?] = {
       val clientInitiatedClose = new AtomicBoolean
 
       val captureClientClose = Flow[WebSocketFrame].via(new GraphStage[FlowShape[WebSocketFrame, WebSocketFrame]] {

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -465,16 +465,16 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
 
   def runWebSocket[A](
       port: Int,
-      handler: Flow[ExtendedMessage, ExtendedMessage, _] => Future[A],
-      handleConnect: Future[_] => Future[_] = c => c
+      handler: Flow[ExtendedMessage, ExtendedMessage, ?] => Future[A],
+      handleConnect: Future[?] => Future[?] = c => c
   ): A =
     runWebSocket(port, handler, subprotocol = None, handleConnect) match { case (result, _) => result }
 
   def runWebSocket[A](
       port: Int,
-      handler: Flow[ExtendedMessage, ExtendedMessage, _] => Future[A],
+      handler: Flow[ExtendedMessage, ExtendedMessage, ?] => Future[A],
       subprotocol: Option[String],
-      handleConnect: Future[_] => Future[_]
+      handleConnect: Future[?] => Future[?]
   ): (A, immutable.Seq[(String, String)]) = {
     WebSocketClient { client =>
       val innerResult     = Promise[A]()
@@ -513,7 +513,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
       future.map(_.reverse)
     }
 
-  def onFramesConsumed[A](onDone: List[A] => Unit): Sink[A, _] = consumeFrames[A].mapMaterializedValue { future =>
+  def onFramesConsumed[A](onDone: List[A] => Unit): Sink[A, ?] = consumeFrames[A].mapMaterializedValue { future =>
     future.foreach {
       case list => onDone(list)
     }

--- a/core/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
@@ -150,7 +150,7 @@ trait JavaWSSpec
     }
 
     "sending a simple multipart form body" in withServer { ws =>
-      val source: Source[_ >: Http.MultipartFormData.Part[javadsl.Source[ByteString, _]], _] = Source
+      val source: Source[? >: Http.MultipartFormData.Part[javadsl.Source[ByteString, ?]], ?] = Source
         .single(new Http.MultipartFormData.DataPart("hello", "world"))
       val res  = ws.url("/post").post(source.asJava)
       val body = res.toCompletableFuture.get().asJson()
@@ -234,7 +234,7 @@ trait JavaWSSpec
   class CustomSigner extends WSSignatureCalculator with play.shaded.ahc.org.asynchttpclient.SignatureCalculator {
     def calculateAndAddSignature(
         request: play.shaded.ahc.org.asynchttpclient.Request,
-        requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[_]
+        requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[?]
     ) = {
       // do nothing
     }

--- a/core/play-integration-test/src/test/scala/play/it/libs/ScalaWSSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/libs/ScalaWSSpec.scala
@@ -70,7 +70,7 @@ trait ScalaWSSpec
 
     "get a streamed response" in withResult(Results.Ok.chunked(Source(List("a", "b", "c")))) { ws =>
       val res: Future[WSResponse]     = ws.url("/get").stream()
-      val body: Source[ByteString, _] = await(res).bodyAsSource
+      val body: Source[ByteString, ?] = await(res).bodyAsSource
 
       val result: MatchResult[Any] = await(body.runWith(foldingSink)).utf8String.aka("streamed response") must_== "abc"
       result
@@ -96,7 +96,7 @@ trait ScalaWSSpec
       val file                                                             = new File(this.getClass.getResource("/testassets/foo.txt").toURI).toPath
       val dp                                                               = MultipartFormData.DataPart("hello", "world")
       val fp                                                               = MultipartFormData.FilePart("upload", "foo.txt", None, FileIO.fromPath(file))
-      val source: Source[MultipartFormData.Part[Source[ByteString, _]], _] = Source(List(dp, fp))
+      val source: Source[MultipartFormData.Part[Source[ByteString, ?]], ?] = Source(List(dp, fp))
       val res                                                              = ws.url("/post").post(source)
       val jsonBody                                                         = await(res).json
 
@@ -178,7 +178,7 @@ trait ScalaWSSpec
         val customCalc = new WSSignatureCalculator with SignatureCalculator {
           def calculateAndAddSignature(
               request: play.shaded.ahc.org.asynchttpclient.Request,
-              requestBuilder: RequestBuilderBase[_]
+              requestBuilder: RequestBuilderBase[?]
           ) = {
             requestBuilder.addHeader(HeaderNames.AUTHORIZATION, "some value")
           }
@@ -229,7 +229,7 @@ trait ScalaWSSpec
     Server.withRouterFromComponents() { components =>
       {
         case _ =>
-          components.defaultActionBuilder(echo) { (req: Request[Source[ByteString, _]]) => Ok.chunked(req.body) }
+          components.defaultActionBuilder(echo) { (req: Request[Source[ByteString, ?]]) => Ok.chunked(req.body) }
       }
     } { implicit port => WsTestClient.withClient(block) }
   }
@@ -258,7 +258,7 @@ trait ScalaWSSpec
   class CustomSigner extends WSSignatureCalculator with SignatureCalculator {
     def calculateAndAddSignature(
         request: play.shaded.ahc.org.asynchttpclient.Request,
-        requestBuilder: RequestBuilderBase[_]
+        requestBuilder: RequestBuilderBase[?]
     ) = {
       // do nothing
     }

--- a/core/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
@@ -257,11 +257,11 @@ private[server] object ServerReloadingSpec {
           Results.Redirect("/getflash").flashing("foo" -> "bar")
         }
       case GET(p"/getflash") =>
-        action { (request: Request[_]) => Results.Ok(request.flash.data.get("foo").toString) }
+        action { (request: Request[?]) => Results.Ok(request.flash.data.get("foo").toString) }
       case GET(p"/getremoteaddress") =>
-        action { (request: Request[_]) => Results.Ok(request.remoteAddress) }
+        action { (request: Request[?]) => Results.Ok(request.remoteAddress) }
       case GET(p"/getserverconfigcachereloads") =>
-        action { (request: Request[_]) =>
+        action { (request: Request[?]) =>
           val reloadCount: Option[Int] = request.attrs.get(ServerDebugInfo.Attr).map(_.serverConfigCacheReloads)
           Results.Ok(reloadCount.toString)
         }

--- a/core/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/test/EndpointIntegrationSpecificationSpec.scala
@@ -33,7 +33,7 @@ class EndpointIntegrationSpecificationSpec
       }
     }
     "respond with the correct server attribute" in withAction { (Action: DefaultActionBuilder) =>
-      Action { (request: Request[_]) => Results.Ok(request.attrs.get(RequestAttrKey.Server).toString) }
+      Action { (request: Request[?]) => Results.Ok(request.attrs.get(RequestAttrKey.Server).toString) }
     }.withAllOkHttpEndpoints { (okHttpEndpoint: OkHttpEndpoint) =>
       val response: Response = okHttpEndpoint.call("/")
       response.body.string must_== okHttpEndpoint.endpoint.serverAttribute.toString

--- a/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -33,7 +33,7 @@ private[routing] class RouterBuilderHelper(
             val actionParameters = request.asJava +: parameters
             val javaResultFuture = route.actionMethod.invoke(route.action, actionParameters: _*) match {
               case result: Result => Future.successful(result)
-              case promise: CompletionStage[_] =>
+              case promise: CompletionStage[?] =>
                 val p = promise.asInstanceOf[CompletionStage[Result]]
                 p.asScala
             }

--- a/core/play-java/src/main/scala/play/routing/RoutingDslModule.scala
+++ b/core/play-java/src/main/scala/play/routing/RoutingDslModule.scala
@@ -17,7 +17,7 @@ import play.mvc.BodyParser.Default
  * A Play binding for the RoutingDsl API.
  */
 class RoutingDslModule extends Module {
-  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
     Seq(
       bind[Default].toSelf, // this bind is here because it is needed by RoutingDsl only
       bind[RoutingDsl].toProvider[JavaRoutingDslProvider]

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -54,7 +54,7 @@ sealed trait Accumulator[-E, +A] {
   /**
    * Return a new accumulator that first feeds the input through the given flow before it goes through this accumulator.
    */
-  def through[F](flow: Flow[F, E, _]): Accumulator[F, A]
+  def through[F](flow: Flow[F, E, ?]): Accumulator[F, A]
 
   /**
    * Right associative operator alias for through.
@@ -67,12 +67,12 @@ sealed trait Accumulator[-E, +A] {
    *   val stringAccumulator = toInt ~>: intAccumulator
    * }}}
    */
-  def ~>:[F](flow: Flow[F, E, _]): Accumulator[F, A] = through(flow)
+  def ~>:[F](flow: Flow[F, E, ?]): Accumulator[F, A] = through(flow)
 
   /**
    * Run this accumulator by feeding in the given source.
    */
-  def run(source: Source[E, _])(implicit materializer: Materializer): Future[A]
+  def run(source: Source[E, ?])(implicit materializer: Materializer): Future[A]
 
   /**
    * Run this accumulator by feeding nothing into it.
@@ -95,7 +95,7 @@ sealed trait Accumulator[-E, +A] {
    *   val intFuture = source ~>: intAccumulator
    * }}}
    */
-  def ~>:(source: Source[E, _])(implicit materializer: Materializer): Future[A] = run(source)
+  def ~>:(source: Source[E, ?])(implicit materializer: Materializer): Future[A] = run(source)
 
   /**
    * Convert this accumulator to a Sink that gets materialised to a Future.
@@ -133,9 +133,9 @@ private class SinkAccumulator[-E, +A](wrappedSink: => Sink[E, Future[A]]) extend
   )(implicit executor: ExecutionContext): Accumulator[E, B] =
     new SinkAccumulator(sink.mapMaterializedValue(_.recoverWith(pf)))
 
-  def through[F](flow: Flow[F, E, _]): Accumulator[F, A] = new SinkAccumulator(flow.toMat(sink)(Keep.right))
+  def through[F](flow: Flow[F, E, ?]): Accumulator[F, A] = new SinkAccumulator(flow.toMat(sink)(Keep.right))
 
-  def run(source: Source[E, _])(implicit materializer: Materializer): Future[A] = source.toMat(sink)(Keep.right).run()
+  def run(source: Source[E, ?])(implicit materializer: Materializer): Future[A] = source.toMat(sink)(Keep.right).run()
   def run()(implicit materializer: Materializer): Future[A]                     = run(Source.empty)
   def run(elem: E)(implicit materializer: Materializer): Future[A]              = run(Source.single(elem))
 
@@ -190,11 +190,11 @@ private class StrictAccumulator[-E, +A](handler: Option[E] => Future[A], val toS
       }
     }
 
-  override def through[F](flow: Flow[F, E, _]): Accumulator[F, A] = {
+  override def through[F](flow: Flow[F, E, ?]): Accumulator[F, A] = {
     new SinkAccumulator(flow.toMat(toSink)(Keep.right))
   }
 
-  override def run(source: Source[E, _])(implicit materializer: Materializer): Future[A] = source.runWith(toSink)
+  override def run(source: Source[E, ?])(implicit materializer: Materializer): Future[A] = source.runWith(toSink)
   override def run()(implicit materializer: Materializer): Future[A]                     = handler(None)
   override def run(elem: E)(implicit materializer: Materializer): Future[A]              = handler(Some(elem))
 
@@ -207,7 +207,7 @@ private class StrictAccumulator[-E, +A](handler: Option[E] => Future[A], val toS
 
 private class FlattenedAccumulator[-E, +A](future: Future[Accumulator[E, A]])(implicit materializer: Materializer)
     extends SinkAccumulator[E, A](Accumulator.futureToSink(future)) {
-  override def run(source: Source[E, _])(implicit materializer: Materializer): Future[A] = {
+  override def run(source: Source[E, ?])(implicit materializer: Materializer): Future[A] = {
     future.flatMap(_.run(source))(materializer.executionContext)
   }
 
@@ -273,7 +273,7 @@ object Accumulator {
    *
    * @return An accumulator that forwards the stream to the produced source.
    */
-  def source[E]: Accumulator[E, Source[E, _]] = {
+  def source[E]: Accumulator[E, Source[E, ?]] = {
     // If Pekko streams ever provides Sink.source(), we should use that instead.
     // https://github.com/akka/akka/issues/18406
     new SinkAccumulator(

--- a/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -38,7 +38,7 @@ object ActorFlow {
       props: ActorRef => Props,
       bufferSize: Int = 16,
       overflowStrategy: OverflowStrategy = OverflowStrategy.fail
-  )(implicit factory: ActorRefFactory, mat: Materializer): Flow[In, Out, _] = {
+  )(implicit factory: ActorRefFactory, mat: Materializer): Flow[In, Out, ?] = {
     val (outActor, publisher) = Source
       .actorRef[Out](bufferSize, overflowStrategy)
       .toMat(Sink.asPublisher(false))(Keep.both)

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Execution.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Execution.scala
@@ -79,7 +79,7 @@ private[play] object Execution {
           runnables.addLast(next)
           runnables.addLast(runnable)
           local.set(runnables)
-        case arrayDeque: ArrayDeque[_] =>
+        case arrayDeque: ArrayDeque[?] =>
           // Add this Runnable to the end of the existing ArrayDeque
           val runnables = arrayDeque.asInstanceOf[ArrayDeque[Runnable]]
           runnables.addLast(runnable)
@@ -104,7 +104,7 @@ private[play] object Execution {
           next.run()
           // Recurse in case more Runnables were added
           executeScheduled()
-        case arrayDeque: ArrayDeque[_] =>
+        case arrayDeque: ArrayDeque[?] =>
           val runnables = arrayDeque.asInstanceOf[ArrayDeque[Runnable]]
           // Rather than recursing, we can use a more efficient
           // while loop. The value of the ThreadLocal will stay as

--- a/core/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
@@ -28,7 +28,7 @@ object GzipFlow {
   def gzip(
       bufferSize: Int = 512,
       compressionLevel: Int = Deflater.DEFAULT_COMPRESSION
-  ): Flow[ByteString, ByteString, _] = {
+  ): Flow[ByteString, ByteString, ?] = {
     Flow[ByteString]
       .via(chunkerIfNeeded(bufferSize))
       .via(Compression.gzip(compressionLevel))

--- a/core/play-streams/src/main/scala/play/api/libs/streams/PekkoStreams.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/PekkoStreams.scala
@@ -22,7 +22,7 @@ object PekkoStreams {
    * If the splitter function returns Left, they will go through the flow.  If it returns Right, they will bypass the
    * flow.
    */
-  def bypassWith[In, FlowIn, Out](splitter: In => Either[FlowIn, Out]): Flow[FlowIn, Out, _] => Flow[In, Out, _] = {
+  def bypassWith[In, FlowIn, Out](splitter: In => Either[FlowIn, Out]): Flow[FlowIn, Out, ?] => Flow[In, Out, ?] = {
     bypassWith(Flow[In].map(splitter))
   }
 
@@ -33,9 +33,9 @@ object PekkoStreams {
    * flow.
    */
   def bypassWith[In, FlowIn, Out](
-      splitter: Flow[In, Either[FlowIn, Out], _],
-      mergeStrategy: Graph[UniformFanInShape[Out, Out], _] = onlyFirstCanFinishMerge[Out](2)
-  ): Flow[FlowIn, Out, _] => Flow[In, Out, _] = { flow =>
+      splitter: Flow[In, Either[FlowIn, Out], ?],
+      mergeStrategy: Graph[UniformFanInShape[Out, Out], ?] = onlyFirstCanFinishMerge[Out](2)
+  ): Flow[FlowIn, Out, ?] => Flow[In, Out, ?] = { flow =>
     val bypasser = Flow.fromGraph(GraphDSL.create[FlowShape[Either[FlowIn, Out], Out]]() { implicit builder =>
       import GraphDSL.Implicits._
 
@@ -80,7 +80,7 @@ object PekkoStreams {
   /**
    * A flow that will ignore upstream finishes.
    */
-  def ignoreAfterFinish[T]: Flow[T, T, _] =
+  def ignoreAfterFinish[T]: Flow[T, T, ?] =
     Flow[T].via(new GraphStage[FlowShape[T, T]] {
       val in  = Inlet[T]("PekkoStreams.in")
       val out = Outlet[T]("PekkoStreams.out")

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Probes.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Probes.scala
@@ -46,7 +46,7 @@ object Probes {
     val probeName = name
     val startTime = System.nanoTime()
 
-    def subscribe(subscriber: Subscriber[_ >: T]) = {
+    def subscribe(subscriber: Subscriber[? >: T]) = {
       log("subscribe", subscriber.toString)(
         publisher.subscribe(subscriberProbe(name, subscriber, messageLogger, startTime))
       )
@@ -55,7 +55,7 @@ object Probes {
 
   def subscriberProbe[T](
       name: String,
-      subscriber: Subscriber[_ >: T],
+      subscriber: Subscriber[? >: T],
       messageLogger: T => String = (t: T) => t.toString,
       start: Long = System.nanoTime()
   ): Subscriber[T] = new Subscriber[T] with Probe {
@@ -93,11 +93,11 @@ object Probes {
       override def onSubscribe(s: Subscription): Unit       = subscriber.onSubscribe(s)
       override def onComplete(): Unit                       = subscriber.onComplete()
       override def onNext(t: In): Unit                      = subscriber.onNext(t)
-      override def subscribe(s: Subscriber[_ >: Out]): Unit = publisher.subscribe(s)
+      override def subscribe(s: Subscriber[? >: Out]): Unit = publisher.subscribe(s)
     }
   }
 
-  def flowProbe[T](name: String, messageLogger: T => String = (t: T) => t.toString): Flow[T, T, _] = {
+  def flowProbe[T](name: String, messageLogger: T => String = (t: T) => t.toString): Flow[T, T, ?] = {
     Flow[T].via(new GraphStage[FlowShape[T, T]] with Probe {
       val in  = Inlet[T]("Probes.in")
       val out = Outlet[T]("Probes.out")

--- a/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/core/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -35,7 +35,7 @@ class AccumulatorSpec extends Specification {
   def await[T](f: Future[T]): T = Await.result(f, 10.seconds)
   def error[T](any: Any): T     = throw sys.error("error")
   def errorSource[T]: Source[T, NotUsed] =
-    Source.fromPublisher((s: Subscriber[_ >: T]) =>
+    Source.fromPublisher((s: Subscriber[? >: T]) =>
       s.onSubscribe(new Subscription {
         def cancel(): Unit         = s.onComplete()
         def request(n: Long): Unit = s.onError(new RuntimeException("error"))

--- a/core/play/src/main/scala/play/api/Application.scala
+++ b/core/play/src/main/scala/play/api/Application.scala
@@ -125,7 +125,7 @@ trait Application {
   /**
    * Stop the application.  The returned future will be redeemed when all stop hooks have been run.
    */
-  def stop(): Future[_]
+  def stop(): Future[?]
 
   /**
    * Get the runtime injector for this application. In a runtime dependency injection based application, this can be
@@ -213,7 +213,7 @@ class DefaultApplication @Inject() (
 
   override def classloader: ClassLoader = environment.classLoader
 
-  override def stop(): Future[_] =
+  override def stop(): Future[?] =
     CoordinatedShutdownSupport.asyncShutdown(actorSystem, ApplicationStoppedReason)
 }
 

--- a/core/play/src/main/scala/play/api/Logger.scala
+++ b/core/play/src/main/scala/play/api/Logger.scala
@@ -316,7 +316,7 @@ object Logger {
    * @param clazz a class whose name will be used as logger name
    * @return a logger
    */
-  def apply(clazz: Class[_]): Logger = new Logger(LoggerFactory.getLogger(clazz.getName.stripSuffix("$")))
+  def apply(clazz: Class[?]): Logger = new Logger(LoggerFactory.getLogger(clazz.getName.stripSuffix("$")))
 }
 
 /**

--- a/core/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/core/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -91,7 +91,7 @@ object LoggerConfigurator {
 
   def apply(loggerConfiguratorClassName: String, classLoader: ClassLoader): Option[LoggerConfigurator] = {
     try {
-      val loggerConfiguratorClass: Class[_] = classLoader.loadClass(loggerConfiguratorClassName)
+      val loggerConfiguratorClass: Class[?] = classLoader.loadClass(loggerConfiguratorClassName)
       Some(loggerConfiguratorClass.getDeclaredConstructor().newInstance().asInstanceOf[LoggerConfigurator])
     } catch {
       case ex: Exception =>

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -43,7 +43,7 @@ import play.utils.Resources
 import play.utils.UriEncoding
 
 class AssetsModule extends Module {
-  override def bindings(environment: Environment, configuration: Configuration): scala.collection.Seq[Binding[_]] = Seq(
+  override def bindings(environment: Environment, configuration: Configuration): scala.collection.Seq[Binding[?]] = Seq(
     bind[Assets].toSelf,
     bind[AssetsMetadata].toProvider[AssetsMetadataProvider],
     bind[AssetsFinder].toProvider[AssetsFinderProvider],

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -107,7 +107,7 @@ object HttpErrorHandler {
   /**
    * Get the bindings for the error handler from the configuration
    */
-  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
     Reflect.bindingsFromConfiguration[
       HttpErrorHandler,
       play.http.HttpErrorHandler,

--- a/core/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/core/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -46,7 +46,7 @@ trait HttpFilters {
 class DefaultHttpFilters @Inject() (val filters: EssentialFilter*) extends HttpFilters
 
 object HttpFilters {
-  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
     Reflect.bindingsFromConfiguration[
       HttpFilters,
       play.http.HttpFilters,

--- a/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -51,7 +51,7 @@ trait HttpRequestHandler {
 }
 
 object HttpRequestHandler {
-  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
     Reflect.bindingsFromConfiguration[
       HttpRequestHandler,
       play.http.HttpRequestHandler,
@@ -66,7 +66,7 @@ object ActionCreator {
   import play.http.ActionCreator
   import play.http.DefaultActionCreator
 
-  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
     Reflect
       .configuredClass[ActionCreator, ActionCreator, DefaultActionCreator](
         environment,
@@ -74,7 +74,7 @@ object ActionCreator {
         "play.http.actionCreator",
         "ActionCreator"
       )
-      .fold(Seq[Binding[_]]()) { either =>
+      .fold(Seq[Binding[?]]()) { either =>
         val impl = either.fold(identity, identity)
         Seq(BindingKey(classOf[ActionCreator]).to(impl))
       }

--- a/core/play/src/main/scala/play/api/i18n/I18nModule.scala
+++ b/core/play/src/main/scala/play/api/i18n/I18nModule.scala
@@ -11,7 +11,7 @@ import play.api.Configuration
 import play.api.Environment
 
 class I18nModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration): scala.collection.Seq[Binding[_]] = {
+  def bindings(environment: Environment, configuration: Configuration): scala.collection.Seq[Binding[?]] = {
     Seq(
       bind[Langs].toProvider[DefaultLangsProvider],
       bind[MessagesApi].toProvider[DefaultMessagesApiProvider],

--- a/core/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/core/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -65,7 +65,7 @@ trait ApplicationLifecycle {
    * The stop hook should redeem the returned future when it is finished shutting down.  It is acceptable to stop
    * immediately and return a successful future.
    */
-  def addStopHook(hook: () => Future[_]): Unit
+  def addStopHook(hook: () => Future[?]): Unit
 
   /**
    * Add a stop hook to be called when the application stops.
@@ -73,7 +73,7 @@ trait ApplicationLifecycle {
    * The stop hook should redeem the returned future when it is finished shutting down.  It is acceptable to stop
    * immediately and return a successful future.
    */
-  def addStopHook(hook: Callable[_ <: CompletionStage[_]]): Unit =
+  def addStopHook(hook: Callable[? <: CompletionStage[?]]): Unit =
     addStopHook(() => { val cs = hook.call(); cs.asScala })
 
   /**
@@ -88,7 +88,7 @@ trait ApplicationLifecycle {
     "Do not invoke stop() directly. Instead, use CoordinatedShutdown.run to stop and release your resources.",
     "2.7.0"
   )
-  def stop(): Future[_]
+  def stop(): Future[?]
 
   /**
    * @return the Java version for this Application Lifecycle.
@@ -102,9 +102,9 @@ trait ApplicationLifecycle {
 @Singleton
 class DefaultApplicationLifecycle @Inject() () extends ApplicationLifecycle {
   private val logger = Logger(getClass)
-  private val hooks  = new ConcurrentLinkedDeque[() => Future[_]]()
+  private val hooks  = new ConcurrentLinkedDeque[() => Future[?]]()
 
-  override def addStopHook(hook: () => Future[_]): Unit = hooks.push(hook)
+  override def addStopHook(hook: () => Future[?]): Unit = hooks.push(hook)
 
   private val stopPromise: Promise[Done] = Promise()
   private val started                    = new AtomicBoolean(false)
@@ -114,7 +114,7 @@ class DefaultApplicationLifecycle @Inject() () extends ApplicationLifecycle {
    *
    * @return A future that will be redeemed once all hooks have executed.
    */
-  override def stop(): Future[_] = {
+  override def stop(): Future[?] = {
     logger.debug(s"Executing ApplicationLifecycle.stop() with ${hooks.size()} stop hook(s) registered")
     // run the code only once and memoize the result of the invocation in a Promise.future so invoking
     // the method many times causes a single run producing the same result in all cases.

--- a/core/play/src/main/scala/play/api/inject/Binding.scala
+++ b/core/play/src/main/scala/play/api/inject/Binding.scala
@@ -36,7 +36,7 @@ import play.inject.SourceProvider
 final case class Binding[T](
     key: BindingKey[T],
     target: Option[BindingTarget[T]],
-    scope: Option[Class[_ <: Annotation]],
+    scope: Option[Class[? <: Annotation]],
     eager: Boolean,
     source: Object
 ) {
@@ -179,7 +179,7 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
    *
    * This class will be instantiated and injected by the injection framework.
    */
-  def to(implementation: Class[_ <: T]): Binding[T] = {
+  def to(implementation: Class[? <: T]): Binding[T] = {
     Binding(
       this,
       Some(ConstructionTarget(validateTargetNonAbstract(implementation))),
@@ -202,7 +202,7 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
    *
    * This provider instance will be invoked to obtain the implementation for the key.
    */
-  def to(provider: Provider[_ <: T]): Binding[T] =
+  def to(provider: Provider[? <: T]): Binding[T] =
     Binding(this, Some(ProviderTarget(provider)), None, false, SourceLocator.source)
 
   /**
@@ -214,7 +214,7 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
   /**
    * Bind this binding key to another binding key.
    */
-  def to(key: BindingKey[_ <: T]): Binding[T] =
+  def to(key: BindingKey[? <: T]): Binding[T] =
     Binding(this, Some(BindingKeyTarget(key)), None, false, SourceLocator.source)
 
   /**
@@ -223,7 +223,7 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
    * The dependency injection framework will instantiate and inject this provider, and then invoke its `get` method
    * whenever an instance of the class is needed.
    */
-  def toProvider[P <: Provider[_ <: T]](provider: Class[P]): Binding[T] =
+  def toProvider[P <: Provider[? <: T]](provider: Class[P]): Binding[T] =
     Binding(
       this,
       Some(ProviderConstructionTarget[T](validateTargetNonAbstract(provider))),
@@ -238,7 +238,7 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
    * The dependency injection framework will instantiate and inject this provider, and then invoke its `get` method
    * whenever an instance of the class is needed.
    */
-  def toProvider[P <: Provider[_ <: T]: ClassTag]: Binding[T] =
+  def toProvider[P <: Provider[? <: T]: ClassTag]: Binding[T] =
     toProvider(implicitly[ClassTag[P]].runtimeClass.asInstanceOf[Class[P]])
 
   /**
@@ -262,7 +262,7 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
       throw new PlayException(
         "Cannot bind abstract target",
         s"""You have attempted to bind $target as a construction target for $this, however, $target is abstract. If you wish to bind this as an alias, bind it to a ${classOf[
-            BindingKey[_]
+            BindingKey[?]
           ]} instead."""
       )
     }
@@ -286,7 +286,7 @@ sealed trait BindingTarget[T] {
  *
  * @see The [[Module]] class for information on how to provide bindings.
  */
-final case class ProviderTarget[T](provider: Provider[_ <: T]) extends BindingTarget[T] {
+final case class ProviderTarget[T](provider: Provider[? <: T]) extends BindingTarget[T] {
   override def asJava: play.inject.ProviderTarget[T] = new play.inject.ProviderTarget[T](this)
 }
 
@@ -295,7 +295,7 @@ final case class ProviderTarget[T](provider: Provider[_ <: T]) extends BindingTa
  *
  * @see The [[Module]] class for information on how to provide bindings.
  */
-final case class ProviderConstructionTarget[T](provider: Class[_ <: Provider[_ <: T]]) extends BindingTarget[T] {
+final case class ProviderConstructionTarget[T](provider: Class[? <: Provider[? <: T]]) extends BindingTarget[T] {
   override def asJava: play.inject.ProviderConstructionTarget[T] = new play.inject.ProviderConstructionTarget[T](this)
 }
 
@@ -304,14 +304,14 @@ final case class ProviderConstructionTarget[T](provider: Class[_ <: Provider[_ <
  *
  * @see The [[play.api.inject.Module]] class for information on how to provide bindings.
  */
-final case class ConstructionTarget[T](implementation: Class[_ <: T]) extends BindingTarget[T] {
+final case class ConstructionTarget[T](implementation: Class[? <: T]) extends BindingTarget[T] {
   override def asJava: play.inject.ConstructionTarget[T] = new play.inject.ConstructionTarget[T](this)
 }
 
 /**
  * A binding target that is provided by another key - essentially an alias.
  */
-final case class BindingKeyTarget[T](key: BindingKey[_ <: T]) extends BindingTarget[T] {
+final case class BindingKeyTarget[T](key: BindingKey[? <: T]) extends BindingTarget[T] {
   override def asJava: play.inject.BindingKeyTarget[T] = new play.inject.BindingKeyTarget[T](this)
 }
 
@@ -347,7 +347,7 @@ final case class QualifierClass[T <: Annotation](clazz: Class[T]) extends Qualif
 
 private object SourceLocator {
   val provider =
-    SourceProvider.DEFAULT_INSTANCE.plusSkippedClasses(this.getClass, classOf[BindingKey[_]], classOf[Binding[_]])
+    SourceProvider.DEFAULT_INSTANCE.plusSkippedClasses(this.getClass, classOf[BindingKey[?]], classOf[Binding[?]])
 
   def source = provider.get()
 }

--- a/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/core/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -41,7 +41,7 @@ import play.libs.concurrent.HttpExecutionContext
  */
 class BuiltinModule
     extends SimpleModule((env, conf) => {
-      def dynamicBindings(factories: ((Environment, Configuration) => Seq[Binding[_]])*) = {
+      def dynamicBindings(factories: ((Environment, Configuration) => Seq[Binding[?]])*) = {
         factories.flatMap(_(env, conf))
       }
 
@@ -131,7 +131,7 @@ class RoutesProvider @Inject() (
 }
 
 object RoutesProvider {
-  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
     val routerClass = Router.load(environment, configuration)
 
     import scala.language.existentials

--- a/core/play/src/main/scala/play/api/inject/Injector.scala
+++ b/core/play/src/main/scala/play/api/inject/Injector.scala
@@ -81,7 +81,7 @@ object NewInstanceInjector extends Injector {
  * @param fallback The injector to fallback to if no component can be found.
  * @param components The components that this injector provides.
  */
-class SimpleInjector(fallback: Injector, components: Map[Class[_], Any] = Map.empty) extends Injector {
+class SimpleInjector(fallback: Injector, components: Map[Class[?], Any] = Map.empty) extends Injector {
 
   /**
    * Get an instance of the given class from the injector.

--- a/core/play/src/main/scala/play/api/inject/Module.scala
+++ b/core/play/src/main/scala/play/api/inject/Module.scala
@@ -58,7 +58,7 @@ abstract class Module {
    * @param configuration The configuration
    * @return A sequence of bindings
    */
-  def bindings(environment: Environment, configuration: Configuration): scala.collection.Seq[Binding[_]]
+  def bindings(environment: Environment, configuration: Configuration): scala.collection.Seq[Binding[?]]
 
   /**
    * Create a binding key for the given class.
@@ -81,19 +81,19 @@ abstract class Module {
    */
   @deprecated("Use play.inject.Module instead if the Module is coded in Java.", "2.7.0")
   @varargs
-  final def seq(bindings: Binding[_]*): scala.collection.Seq[Binding[_]] = bindings
+  final def seq(bindings: Binding[?]*): scala.collection.Seq[Binding[?]] = bindings
 }
 
 /**
  * A simple Play module, which can be configured by passing a function or a list of bindings.
  */
-class SimpleModule(bindingsFunc: (Environment, Configuration) => Seq[Binding[_]]) extends Module {
-  def this(bindings: Binding[_]*) = this((_, _) => bindings)
+class SimpleModule(bindingsFunc: (Environment, Configuration) => Seq[Binding[?]]) extends Module {
+  def this(bindings: Binding[?]*) = this((_, _) => bindings)
 
   final override def bindings(
       environment: Environment,
       configuration: Configuration
-  ): scala.collection.Seq[Binding[_]] =
+  ): scala.collection.Seq[Binding[?]] =
     bindingsFunc(environment, configuration)
 }
 

--- a/core/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/core/play/src/main/scala/play/api/libs/EventSource.scala
@@ -52,7 +52,7 @@ object EventSource {
    *   Ok.chunked(jsonStream via EventSource.flow).as(ContentTypes.EVENT_STREAM)
    * }}}
    */
-  def flow[E: EventDataExtractor: EventNameExtractor: EventIdExtractor]: Flow[E, Event, _] = {
+  def flow[E: EventDataExtractor: EventNameExtractor: EventIdExtractor]: Flow[E, Event, ?] = {
     Flow[E].map(Event(_))
   }
 

--- a/core/play/src/main/scala/play/api/libs/concurrent/Pekko.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Pekko.scala
@@ -168,7 +168,7 @@ class PekkoSchedulerProvider @Inject() (actorSystem: ActorSystem) extends Provid
 }
 
 object ActorSystemProvider {
-  type StopHook = () => Future[_]
+  type StopHook = () => Future[?]
 
   private val logger = LoggerFactory.getLogger(classOf[ActorSystemProvider])
 

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -46,7 +46,7 @@ trait TypedMap {
    * @param key The key to check for.
    * @return True if the value is present, false otherwise.
    */
-  def contains(key: TypedKey[_]): Boolean
+  def contains(key: TypedKey[?]): Boolean
 
   /**
    * Update the map with the given key and value, returning a new instance of the map.
@@ -64,7 +64,7 @@ trait TypedMap {
    * @param e1 The new entry to add to the map.
    * @return A new instance of the map with the new entry added.
    */
-  def updated(e1: TypedEntry[_]): TypedMap
+  def updated(e1: TypedEntry[?]): TypedMap
 
   /**
    * Update the map with two entries, returning a new instance of the map.
@@ -73,7 +73,7 @@ trait TypedMap {
    * @param e2 The second new entry to add to the map.
    * @return A new instance of the map with the new entries added.
    */
-  def updated(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap
+  def updated(e1: TypedEntry[?], e2: TypedEntry[?]): TypedMap
 
   /**
    * Update the map with three entries, returning a new instance of the map.
@@ -83,7 +83,7 @@ trait TypedMap {
    * @param e3 The third new entry to add to the map.
    * @return A new instance of the map with the new entries added.
    */
-  def updated(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap
+  def updated(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): TypedMap
 
   /**
    * Update the map with several entries, returning a new instance of the map.
@@ -91,7 +91,7 @@ trait TypedMap {
    * @param entries The new entries to add to the map.
    * @return A new instance of the map with the new entries added.
    */
-  def updated(entries: TypedEntry[_]*): TypedMap
+  def updated(entries: TypedEntry[?]*): TypedMap
 
   /**
    * Update the map with several entries, returning a new instance of the map.
@@ -100,7 +100,7 @@ trait TypedMap {
    * @return A new instance of the map with the new entries added.
    */
   @deprecated(message = "Use `updated` instead.", since = "2.9.0")
-  def +(entries: TypedEntry[_]*): TypedMap
+  def +(entries: TypedEntry[?]*): TypedMap
 
   /**
    * Removes a key from the map, returning a new instance of the map.
@@ -108,7 +108,7 @@ trait TypedMap {
    * @param e1 The key to remove.
    * @return A new instance of the map with the entry removed.
    */
-  def removed(e1: TypedKey[_]): TypedMap
+  def removed(e1: TypedKey[?]): TypedMap
 
   /**
    * Removes two keys from the map, returning a new instance of the map.
@@ -117,7 +117,7 @@ trait TypedMap {
    * @param e2 The second key to remove.
    * @return A new instance of the map with the entries removed.
    */
-  def removed(e1: TypedKey[_], e2: TypedKey[_]): TypedMap
+  def removed(e1: TypedKey[?], e2: TypedKey[?]): TypedMap
 
   /**
    * Removes three keys from the map, returning a new instance of the map.
@@ -127,7 +127,7 @@ trait TypedMap {
    * @param e3 The third key to remove.
    * @return A new instance of the map with the entries removed.
    */
-  def removed(e1: TypedKey[_], e2: TypedKey[_], e3: TypedKey[_]): TypedMap
+  def removed(e1: TypedKey[?], e2: TypedKey[?], e3: TypedKey[?]): TypedMap
 
   /**
    * Removes keys from the map, returning a new instance of the map.
@@ -135,7 +135,7 @@ trait TypedMap {
    * @param keys The keys to remove.
    * @return A new instance of the map with the entries removed.
    */
-  def removed(keys: TypedKey[_]*): TypedMap
+  def removed(keys: TypedKey[?]*): TypedMap
 
   /**
    * Removes keys from the map, returning a new instance of the map.
@@ -144,7 +144,7 @@ trait TypedMap {
    * @return A new instance of the map with the entries removed.
    */
   @deprecated(message = "Use `removed` instead.", since = "2.9.0")
-  def -(keys: TypedKey[_]*): TypedMap
+  def -(keys: TypedKey[?]*): TypedMap
 
   /**
    * @return The Java version for this map.
@@ -162,22 +162,22 @@ object TypedMap {
   /**
    * Builds a [[TypedMap]] from an entry of key and value.
    */
-  def apply(e1: TypedEntry[_]): TypedMap = TypedMap.empty + e1
+  def apply(e1: TypedEntry[?]): TypedMap = TypedMap.empty + e1
 
   /**
    * Builds a [[TypedMap]] from two entries of keys and values.
    */
-  def apply(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap = TypedMap.empty + (e1, e2)
+  def apply(e1: TypedEntry[?], e2: TypedEntry[?]): TypedMap = TypedMap.empty + (e1, e2)
 
   /**
    * Builds a [[TypedMap]] from three entries of keys and values.
    */
-  def apply(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap = TypedMap.empty + (e1, e2, e3)
+  def apply(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): TypedMap = TypedMap.empty + (e1, e2, e3)
 
   /**
    * Builds a [[TypedMap]] from a list of keys and values.
    */
-  def apply(entries: TypedEntry[_]*): TypedMap = {
+  def apply(entries: TypedEntry[?]*): TypedMap = {
     TypedMap.empty.+(entries: _*)
   }
 }
@@ -185,29 +185,29 @@ object TypedMap {
 /**
  * An implementation of `TypedMap` that wraps a standard Scala [[Map]].
  */
-private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Map[TypedKey[_], Any]) extends TypedMap {
+private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Map[TypedKey[?], Any]) extends TypedMap {
   override def apply[A](key: TypedKey[A]): A                    = m.apply(key).asInstanceOf[A]
   override def get[A](key: TypedKey[A]): Option[A]              = m.get(key).asInstanceOf[Option[A]]
-  override def contains(key: TypedKey[_]): Boolean              = m.contains(key)
+  override def contains(key: TypedKey[?]): Boolean              = m.contains(key)
   override def updated[A](key: TypedKey[A], value: A): TypedMap = new DefaultTypedMap(m.updated(key, value))
-  override def updated(e1: TypedEntry[_]): TypedMap             = new DefaultTypedMap(m.updated(e1.key, e1.value))
-  override def updated(e1: TypedEntry[_], e2: TypedEntry[_]): TypedMap =
+  override def updated(e1: TypedEntry[?]): TypedMap             = new DefaultTypedMap(m.updated(e1.key, e1.value))
+  override def updated(e1: TypedEntry[?], e2: TypedEntry[?]): TypedMap =
     new DefaultTypedMap(m.updated(e1.key, e1.value).updated(e2.key, e2.value))
-  override def updated(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): TypedMap =
+  override def updated(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): TypedMap =
     new DefaultTypedMap(m.updated(e1.key, e1.value).updated(e2.key, e2.value).updated(e3.key, e3.value))
-  override def updated(entries: TypedEntry[_]*): TypedMap = {
+  override def updated(entries: TypedEntry[?]*): TypedMap = {
     val m2 = entries.foldLeft(m) {
       case (m1, e) => m1.updated(e.key, e.value)
     }
     new DefaultTypedMap(m2)
   }
-  override def +(entries: TypedEntry[_]*): TypedMap = updated(entries: _*)
-  override def removed(k1: TypedKey[_]): TypedMap   = new DefaultTypedMap(m - k1)
-  override def removed(k1: TypedKey[_], k2: TypedKey[_]): TypedMap =
+  override def +(entries: TypedEntry[?]*): TypedMap = updated(entries: _*)
+  override def removed(k1: TypedKey[?]): TypedMap   = new DefaultTypedMap(m - k1)
+  override def removed(k1: TypedKey[?], k2: TypedKey[?]): TypedMap =
     new DefaultTypedMap(m - k1 - k2)
-  override def removed(k1: TypedKey[_], k2: TypedKey[_], k3: TypedKey[_]): TypedMap =
+  override def removed(k1: TypedKey[?], k2: TypedKey[?], k3: TypedKey[?]): TypedMap =
     new DefaultTypedMap(m - k1 - k2 - k3)
-  override def removed(keys: TypedKey[_]*): TypedMap = new DefaultTypedMap(m.removedAll(keys))
-  override def -(keys: TypedKey[_]*): TypedMap       = removed(keys: _*)
+  override def removed(keys: TypedKey[?]*): TypedMap = new DefaultTypedMap(m.removedAll(keys))
+  override def -(keys: TypedKey[?]*): TypedMap       = removed(keys: _*)
   override def toString: String                      = m.mkString("{", ", ", "}")
 }

--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -799,7 +799,7 @@ object PathBindable extends PathBindableMacros {
   /**
    * This is used by the Java RouterBuilder DSL.
    */
-  private[play] lazy val pathBindableRegister: Map[Class[_], PathBindable[_]] = {
+  private[play] lazy val pathBindableRegister: Map[Class[?], PathBindable[?]] = {
     import scala.language.existentials
     def register[T](implicit pb: PathBindable[T], ct: ClassTag[T]) = ct.runtimeClass -> pb
     Map(

--- a/core/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/core/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -378,7 +378,7 @@ object RangeResult {
 
   def ofSource(
       entityLength: Long,
-      source: Source[ByteString, _],
+      source: Source[ByteString, ?],
       rangeHeader: Option[String],
       fileName: Option[String],
       contentType: Option[String]
@@ -388,7 +388,7 @@ object RangeResult {
 
   def ofSource(
       entityLength: Option[Long],
-      source: Source[ByteString, _],
+      source: Source[ByteString, ?],
       rangeHeader: Option[String],
       fileName: Option[String],
       contentType: Option[String]
@@ -403,7 +403,7 @@ object RangeResult {
   @ApiMayChange
   def ofSource(
       entityLength: Option[Long],
-      getSource: Long => (Long, Source[ByteString, _]),
+      getSource: Long => (Long, Source[ByteString, ?]),
       rangeHeader: Option[String],
       fileName: Option[String],
       contentType: Option[String]

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -48,7 +48,7 @@ trait Request[+A] extends RequestHeader {
         case rb: play.mvc.Http.RequestBody =>
           rb match {
             // In PlayJava, Optional.empty() is used to represent an empty body
-            case _ if rb.as(classOf[Optional[_]]) != null => !rb.as(classOf[Optional[_]]).isPresent
+            case _ if rb.as(classOf[Optional[?]]) != null => !rb.as(classOf[Optional[?]]).isPresent
             case _                                        => isEmptyBody(rb.as(classOf[AnyRef]))
           }
         case AnyContentAsEmpty | null | ()                      => true
@@ -91,13 +91,13 @@ trait Request[+A] extends RequestHeader {
     new RequestImpl[A](connection, method, target, version, headers, newAttrs, body)
   override def addAttr[B](key: TypedKey[B], value: B): Request[A] =
     withAttrs(attrs.updated(key, value))
-  override def addAttrs(e1: TypedEntry[_]): Request[A]                    = withAttrs(attrs.updated(e1))
-  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Request[A] = withAttrs(attrs.updated(e1, e2))
-  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): Request[A] =
+  override def addAttrs(e1: TypedEntry[?]): Request[A]                    = withAttrs(attrs.updated(e1))
+  override def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?]): Request[A] = withAttrs(attrs.updated(e1, e2))
+  override def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): Request[A] =
     withAttrs(attrs.updated(e1, e2, e3))
-  override def addAttrs(entries: TypedEntry[_]*): Request[A] =
+  override def addAttrs(entries: TypedEntry[?]*): Request[A] =
     withAttrs(attrs.updated(entries: _*))
-  override def removeAttr(key: TypedKey[_]): Request[A] =
+  override def removeAttr(key: TypedKey[?]): Request[A] =
     withAttrs(attrs.removed(key))
   override def withTransientLang(lang: Lang): Request[A] =
     addAttr(Messages.Attrs.CurrentLang, lang)

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -158,7 +158,7 @@ trait RequestHeader {
    * @param e1 The new attribute.
    * @return The new version of this object with the new attribute.
    */
-  def addAttrs(e1: TypedEntry[_]): RequestHeader = withAttrs(attrs.updated(e1))
+  def addAttrs(e1: TypedEntry[?]): RequestHeader = withAttrs(attrs.updated(e1))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -167,7 +167,7 @@ trait RequestHeader {
    * @param e2 The second new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): RequestHeader = withAttrs(attrs.updated(e1, e2))
+  def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?]): RequestHeader = withAttrs(attrs.updated(e1, e2))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -177,7 +177,7 @@ trait RequestHeader {
    * @param e3 The third new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): RequestHeader = withAttrs(
+  def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): RequestHeader = withAttrs(
     attrs.updated(e1, e2, e3)
   )
 
@@ -187,7 +187,7 @@ trait RequestHeader {
    * @param entries The new attributes.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(entries: TypedEntry[_]*): RequestHeader =
+  def addAttrs(entries: TypedEntry[?]*): RequestHeader =
     withAttrs(attrs.updated(entries: _*))
 
   /**
@@ -196,7 +196,7 @@ trait RequestHeader {
    * @param key The key of the attribute to remove.
    * @return The new version of this object with the attribute removed.
    */
-  def removeAttr(key: TypedKey[_]): RequestHeader =
+  def removeAttr(key: TypedKey[?]): RequestHeader =
     withAttrs(attrs.removed(key))
 
   // -- Computed

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -400,7 +400,7 @@ case class Result(
    * @param e1 The new attribute.
    * @return The new version of this object with the new attribute.
    */
-  def addAttrs(e1: TypedEntry[_]): Result = withAttrs(attrs.updated(e1))
+  def addAttrs(e1: TypedEntry[?]): Result = withAttrs(attrs.updated(e1))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -409,7 +409,7 @@ case class Result(
    * @param e2 The second new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): Result = withAttrs(attrs.updated(e1, e2))
+  def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?]): Result = withAttrs(attrs.updated(e1, e2))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -419,7 +419,7 @@ case class Result(
    * @param e3 The third new attribute.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): Result = withAttrs(attrs.updated(e1, e2, e3))
+  def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): Result = withAttrs(attrs.updated(e1, e2, e3))
 
   /**
    * Create a new versions of this object with the given attributes attached to it.
@@ -427,7 +427,7 @@ case class Result(
    * @param entries The new attributes.
    * @return The new version of this object with the new attributes.
    */
-  def addAttrs(entries: TypedEntry[_]*): Result =
+  def addAttrs(entries: TypedEntry[?]*): Result =
     withAttrs(attrs.updated(entries: _*))
 
   /**
@@ -436,7 +436,7 @@ case class Result(
    * @param key The key of the attribute to remove.
    * @return The new version of this object with the attribute removed.
    */
-  def removeAttr(key: TypedKey[_]): Result =
+  def removeAttr(key: TypedKey[?]): Result =
     withAttrs(attrs.removed(key))
 }
 
@@ -592,7 +592,7 @@ trait Results {
       )
     }
 
-    private def streamFile(file: Source[ByteString, _], name: Option[String], length: Option[Long], inline: Boolean)(
+    private def streamFile(file: Source[ByteString, ?], name: Option[String], length: Option[Long], inline: Boolean)(
         implicit fileMimeTypes: FileMimeTypes
     ): Result = {
       Result(
@@ -689,7 +689,7 @@ trait Results {
      * @param content Source providing the content to stream.
      * @param contentType an optional content type.
      */
-    def chunked[C](content: Source[C, _], contentType: Option[String] = None)(
+    def chunked[C](content: Source[C, ?], contentType: Option[String] = None)(
         implicit writeable: Writeable[C]
     ): Result = {
       Result(
@@ -715,7 +715,7 @@ trait Results {
      *      deducing it from this file name if the {@code implicit fileMimeTypes} includes it or fallback to the content-type of the
      *      {@code implicit writeable} if unknown.
      */
-    def chunked[C](content: Source[C, _], inline: Boolean, fileName: Option[String])(
+    def chunked[C](content: Source[C, ?], inline: Boolean, fileName: Option[String])(
         implicit writeable: Writeable[C],
         fileMimeTypes: FileMimeTypes
     ): Result = {
@@ -738,7 +738,7 @@ trait Results {
      * @param contentLength an optional content length.
      * @param contentType an optional content type.
      */
-    def streamed[C](content: Source[C, _], contentLength: Option[Long], contentType: Option[String] = None)(
+    def streamed[C](content: Source[C, ?], contentLength: Option[Long], contentType: Option[String] = None)(
         implicit writeable: Writeable[C]
     ): Result = {
       Result(
@@ -762,7 +762,7 @@ trait Results {
      *      deducing it from this file name if the {@code implicit fileMimeTypes} includes it or fallback to the content-type of the
      *      {@code implicit writeable} if unknown.
      */
-    def streamed[C](content: Source[C, _], contentLength: Option[Long], inline: Boolean, fileName: Option[String])(
+    def streamed[C](content: Source[C, ?], contentLength: Option[Long], inline: Boolean, fileName: Option[String])(
         implicit writeable: Writeable[C],
         fileMimeTypes: FileMimeTypes
     ): Result = {

--- a/core/play/src/main/scala/play/api/routing/HandlerDef.scala
+++ b/core/play/src/main/scala/play/api/routing/HandlerDef.scala
@@ -13,7 +13,7 @@ case class HandlerDef(
     routerPackage: String,
     controller: String,
     method: String,
-    parameterTypes: Seq[Class[_]],
+    parameterTypes: Seq[Class[?]],
     verb: String,
     path: String,
     comments: String = "",

--- a/core/play/src/main/scala/play/api/routing/Router.scala
+++ b/core/play/src/main/scala/play/api/routing/Router.scala
@@ -80,7 +80,7 @@ object Router {
    *
    * @return The router class if configured or if a default one in the root package was detected.
    */
-  def load(env: Environment, configuration: Configuration): Option[Class[_ <: Router]] = {
+  def load(env: Environment, configuration: Configuration): Option[Class[? <: Router]] = {
     val className = configuration.getDeprecated[Option[String]]("play.http.router", "application.router")
 
     try {

--- a/core/play/src/main/scala/play/api/templates/Templates.scala
+++ b/core/play/src/main/scala/play/api/templates/Templates.scala
@@ -43,15 +43,15 @@ object PlayMagic {
     case key: Html         => Html(p.messages(key.toString))
     case Some(key: String) => Some(p.messages(key))
     case Some(key: Html)   => Some(Html(p.messages(key.toString)))
-    case key: Optional[_] =>
+    case key: Optional[?] =>
       key.toScala match {
         case Some(key: String) => Some(p.messages(key)).toJava
         case Some(key: Html)   => Some(Html(p.messages(key.toString))).toJava
         case _                 => arg
       }
-    case keys: Seq[_]            => keys.map(key => translate(key))
-    case keys: java.util.List[_] => keys.asScala.map(key => translate(key)).asJava
-    case keys: Array[_]          => keys.map(key => translate(key))
+    case keys: Seq[?]            => keys.map(key => translate(key))
+    case keys: java.util.List[?] => keys.asScala.map(key => translate(key)).asJava
+    case keys: Array[?]          => keys.map(key => translate(key))
     case _                       => arg
   }
 }

--- a/core/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/core/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -29,9 +29,9 @@ object Multipart {
    * Transforms a `Source[MultipartFormData.Part]` to a `Source[ByteString]`
    */
   def transform(
-      body: Source[MultipartFormData.Part[Source[ByteString, _]], _],
+      body: Source[MultipartFormData.Part[Source[ByteString, ?]], ?],
       boundary: String
-  ): Source[ByteString, _] = {
+  ): Source[ByteString, ?] = {
     body.via(format(boundary, Charset.defaultCharset(), 4096))
   }
 
@@ -42,8 +42,8 @@ object Multipart {
       boundary: String,
       nioCharset: Charset,
       chunkSize: Int
-  ): Flow[MultipartFormData.Part[Source[ByteString, _]], ByteString, NotUsed] = {
-    Flow[MultipartFormData.Part[Source[ByteString, _]]]
+  ): Flow[MultipartFormData.Part[Source[ByteString, ?]], ByteString, NotUsed] = {
+    Flow[MultipartFormData.Part[Source[ByteString, ?]]]
       .via(streamed(boundary, nioCharset, chunkSize))
       .flatMapConcat(identity)
   }
@@ -142,9 +142,9 @@ object Multipart {
       boundary: String,
       nioCharset: Charset,
       chunkSize: Int
-  ): GraphStage[FlowShape[MultipartFormData.Part[Source[ByteString, _]], Source[ByteString, Any]]] =
-    new GraphStage[FlowShape[MultipartFormData.Part[Source[ByteString, _]], Source[ByteString, Any]]] {
-      val in  = Inlet[MultipartFormData.Part[Source[ByteString, _]]]("CustomCharsetByteStringFormatter.in")
+  ): GraphStage[FlowShape[MultipartFormData.Part[Source[ByteString, ?]], Source[ByteString, Any]]] =
+    new GraphStage[FlowShape[MultipartFormData.Part[Source[ByteString, ?]], Source[ByteString, Any]]] {
+      val in  = Inlet[MultipartFormData.Part[Source[ByteString, ?]]]("CustomCharsetByteStringFormatter.in")
       val out = Outlet[Source[ByteString, Any]]("CustomCharsetByteStringFormatter.out")
 
       override def shape = FlowShape.of(in, out)

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -39,11 +39,11 @@ import play.mvc.Http.{ RequestImpl => JRequestImpl }
  * @param method     The method to be evaluated
  */
 class JavaActionAnnotations(
-    val controller: Class[_],
+    val controller: Class[?],
     val method: java.lang.reflect.Method,
     config: ActionCompositionConfiguration
 ) {
-  val parser: Class[_ <: JBodyParser[_]] =
+  val parser: Class[? <: JBodyParser[?]] =
     Seq(
       method.getAnnotation(classOf[play.mvc.BodyParser.Of]),
       controller.getAnnotation(classOf[play.mvc.BodyParser.Of])
@@ -53,13 +53,13 @@ class JavaActionAnnotations(
       .getOrElse(classOf[JBodyParser.Default])
 
   val controllerAnnotations: Seq[(Annotation, AnnotatedElement)] = Seq
-    .unfold[Seq[(Annotation, AnnotatedElement)], Option[Class[_]]](Option(controller)) { clazz =>
+    .unfold[Seq[(Annotation, AnnotatedElement)], Option[Class[?]]](Option(controller)) { clazz =>
       clazz.map(c => (c.getDeclaredAnnotations.map((_, c)).toSeq, Option(c.getSuperclass)))
     }
     .reverse
     .flatten
 
-  val actionMixins: Seq[(Annotation, Class[_ <: JAction[_]], AnnotatedElement)] = {
+  val actionMixins: Seq[(Annotation, Class[? <: JAction[?]], AnnotatedElement)] = {
     val methodAnnotations = ArraySeq.unsafeWrapArray(method.getDeclaredAnnotations.map((_, method)))
     val allDeclaredAnnotations: Seq[(java.lang.annotation.Annotation, AnnotatedElement)] =
       if (config.controllerAnnotationsFirst) {
@@ -104,7 +104,7 @@ class JavaActionAnnotations(
 abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
     extends Action[play.mvc.Http.RequestBody]
     with JavaHelpers {
-  private val logger = Logger(classOf[JAction[_]])
+  private val logger = Logger(classOf[JAction[?]])
 
   private def config: ActionCompositionConfiguration = handlerComponents.httpConfiguration.actionComposition
 
@@ -124,7 +124,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
           .parseBody(
             parser,
             request.asScala(),
-            (r: Request[_]) => invocation(r.asJava).toCompletableFuture.asScala.map(_.asScala())
+            (r: Request[?]) => invocation(r.asJava).toCompletableFuture.asScala.map(_.asScala())
           )(executionContext)
           .map(_.asJava)
           .asJava
@@ -140,7 +140,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
       baseAction
     }
 
-    val firstUserDeclaredAction = annotations.actionMixins.foldLeft[JAction[_ <: Any]](endOfChainAction) {
+    val firstUserDeclaredAction = annotations.actionMixins.foldLeft[JAction[? <: Any]](endOfChainAction) {
       case (delegate, (annotation, actionClass, annotatedElement)) =>
         val action = handlerComponents.getAction(actionClass).asInstanceOf[play.mvc.Action[Object]]
         action.configuration = annotation
@@ -164,7 +164,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
     }
     if (logger.isDebugEnabled) {
       val actionChain = Seq
-        .unfold[JAction[_], Option[JAction[_]]](Option(firstAction)) { action =>
+        .unfold[JAction[?], Option[JAction[?]]](Option(firstAction)) { action =>
           action.map(a => (a, Option(a.delegate)))
         }
       logger.debug("### Start of action order")
@@ -224,8 +224,8 @@ class DefaultJavaContextComponents @Inject() (
 ) extends JavaContextComponents
 
 trait JavaHandlerComponents {
-  def getBodyParser[A <: JBodyParser[_]](parserClass: Class[A]): A
-  def getAction[A <: JAction[_]](actionClass: Class[A]): A
+  def getBodyParser[A <: JBodyParser[?]](parserClass: Class[A]): A
+  def getAction[A <: JAction[?]](actionClass: Class[A]): A
   def actionCreator: play.http.ActionCreator
   def httpConfiguration: HttpConfiguration
   def executionContext: ExecutionContext
@@ -247,6 +247,6 @@ class DefaultJavaHandlerComponents @Inject() (
     @deprecated("Inject MessagesApi, Langs, FileMimeTypes or HttpConfiguration instead", "2.8.0")
     val contextComponents: JavaContextComponents
 ) extends JavaHandlerComponents {
-  def getBodyParser[A <: JBodyParser[_]](parserClass: Class[A]): A = injector.instanceOf(parserClass)
-  def getAction[A <: JAction[_]](actionClass: Class[A]): A         = injector.instanceOf(actionClass)
+  def getBodyParser[A <: JBodyParser[?]](parserClass: Class[A]): A = injector.instanceOf(parserClass)
+  def getAction[A <: JAction[?]](actionClass: Class[A]): A         = injector.instanceOf(actionClass)
 }

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -204,12 +204,12 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def attrs: TypedMap                                                = new TypedMap(header.attrs)
   override def withAttrs(newAttrs: TypedMap): JRequestHeader                  = header.withAttrs(newAttrs.asScala).asJava
   override def addAttr[A](key: TypedKey[A], value: A): JRequestHeader         = withAttrs(attrs.put(key, value))
-  override def addAttrs(e1: TypedEntry[_]): JRequestHeader                    = withAttrs(attrs.putAll(e1))
-  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): JRequestHeader = withAttrs(attrs.putAll(e1, e2))
-  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): JRequestHeader =
+  override def addAttrs(e1: TypedEntry[?]): JRequestHeader                    = withAttrs(attrs.putAll(e1))
+  override def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?]): JRequestHeader = withAttrs(attrs.putAll(e1, e2))
+  override def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): JRequestHeader =
     withAttrs(attrs.putAll(e1, e2, e3))
-  override def addAttrs(entries: util.List[TypedEntry[_]]): JRequestHeader = withAttrs(attrs.putAll(entries))
-  override def removeAttr(key: TypedKey[_]): JRequestHeader                = withAttrs(attrs.remove(key))
+  override def addAttrs(entries: util.List[TypedEntry[?]]): JRequestHeader = withAttrs(attrs.putAll(entries))
+  override def removeAttr(key: TypedKey[?]): JRequestHeader                = withAttrs(attrs.remove(key))
 
   override def withBody(body: RequestBody): JRequest = new JRequestImpl(header.withBody(body))
 
@@ -268,12 +268,12 @@ class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(reque
   override def attrs: TypedMap                                          = new TypedMap(asScala.attrs)
   override def withAttrs(newAttrs: TypedMap): JRequest                  = new JRequestImpl(request.withAttrs(newAttrs.asScala))
   override def addAttr[A](key: TypedKey[A], value: A): JRequest         = withAttrs(attrs.put(key, value))
-  override def addAttrs(e1: TypedEntry[_]): JRequest                    = withAttrs(attrs.putAll(e1))
-  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_]): JRequest = withAttrs(attrs.putAll(e1, e2))
-  override def addAttrs(e1: TypedEntry[_], e2: TypedEntry[_], e3: TypedEntry[_]): JRequest =
+  override def addAttrs(e1: TypedEntry[?]): JRequest                    = withAttrs(attrs.putAll(e1))
+  override def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?]): JRequest = withAttrs(attrs.putAll(e1, e2))
+  override def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): JRequest =
     withAttrs(attrs.putAll(e1, e2, e3))
-  override def addAttrs(entries: util.List[TypedEntry[_]]): JRequest = withAttrs(attrs.putAll(entries))
-  override def removeAttr(key: TypedKey[_]): JRequest                = withAttrs(attrs.remove(key))
+  override def addAttrs(entries: util.List[TypedEntry[?]]): JRequest = withAttrs(attrs.putAll(entries))
+  override def removeAttr(key: TypedKey[?]): JRequest                = withAttrs(attrs.remove(key))
 
   override def body: RequestBody                     = request.body
   override def hasBody: Boolean                      = request.hasBody

--- a/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
+++ b/core/play/src/main/scala/play/core/j/JavaRangeResult.scala
@@ -23,7 +23,7 @@ import play.mvc.Result
  */
 object JavaRangeResult {
   private type OptString   = Optional[String]
-  private type ScalaSource = org.apache.pekko.stream.scaladsl.Source[ByteString, _]
+  private type ScalaSource = org.apache.pekko.stream.scaladsl.Source[ByteString, ?]
 
   def ofStream(stream: InputStream, rangeHeader: OptString, fileName: String, contentType: OptString): Result = {
     RangeResult.ofStream(stream, rangeHeader.toScala, fileName, contentType.toScala).asJava
@@ -57,7 +57,7 @@ object JavaRangeResult {
 
   def ofSource(
       entityLength: Long,
-      source: Source[ByteString, _],
+      source: Source[ByteString, ?],
       rangeHeader: OptString,
       fileName: OptString,
       contentType: OptString
@@ -69,7 +69,7 @@ object JavaRangeResult {
 
   def ofSource(
       entityLength: Optional[Long],
-      source: Source[ByteString, _],
+      source: Source[ByteString, ?],
       rangeHeader: OptString,
       fileName: OptString,
       contentType: OptString

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -458,9 +458,9 @@ a1 <- pa1.value
   }
   // format: on
 
-  def call[T](params: List[Param[_]])(generator: (Seq[_]) => Handler): Handler =
+  def call[T](params: List[Param[?]])(generator: (Seq[?]) => Handler): Handler =
     params
-      .foldLeft[Either[String, Seq[_]]](Right(Seq[T]())) { (seq, param) => seq.flatMap(s => param.value.map(s :+ _)) }
+      .foldLeft[Either[String, Seq[?]]](Right(Seq[T]())) { (seq, param) => seq.flatMap(s => param.value.map(s :+ _)) }
       .fold(badRequest, generator)
   def fakeValue[A]: A = throw new UnsupportedOperationException("Can't get a fake value")
 

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -69,7 +69,7 @@ object HandlerInvokerFactory {
     }
   }
 
-  private def loadJavaControllerClass(handlerDef: HandlerDef): Class[_] = {
+  private def loadJavaControllerClass(handlerDef: HandlerDef): Class[?] = {
     try {
       handlerDef.classLoader.loadClass(handlerDef.controller.stripPrefix("_root_."))
     } catch {
@@ -134,7 +134,7 @@ object HandlerInvokerFactory {
     def resultCall(req: JRequest, call: => A): CompletionStage[JResult]
   }
 
-  private[play] def javaBodyParserToScala(parser: play.mvc.BodyParser[_]): BodyParser[RequestBody] = BodyParser {
+  private[play] def javaBodyParserToScala(parser: play.mvc.BodyParser[?]): BodyParser[RequestBody] = BodyParser {
     request =>
       import scala.language.existentials
       val accumulator = parser.apply(request.asJava).asScala()

--- a/core/play/src/main/scala/play/utils/Reflect.scala
+++ b/core/play/src/main/scala/play/utils/Reflect.scala
@@ -56,7 +56,7 @@ object Reflect {
       javaAdapter: ClassTag[JavaAdapter],
       javaDelegate: ClassTag[JavaDelegate],
       default: ClassTag[Default]
-  ): Seq[Binding[_]] = {
+  ): Seq[Binding[?]] = {
     def bind[T: SubClassOf]: BindingKey[T] = BindingKey(implicitly[SubClassOf[T]].runtimeClass)
 
     configuredClass[ScalaTrait, JavaInterface, Default](environment, config, key, defaultClassName) match {
@@ -115,8 +115,8 @@ object Reflect {
       implicit scalaTrait: SubClassOf[ScalaTrait],
       javaInterface: SubClassOf[JavaInterface],
       default: ClassTag[Default]
-  ): Option[Either[Class[_ <: ScalaTrait], Class[_ <: JavaInterface]]] = {
-    def loadClass(className: String, notFoundFatal: Boolean): Option[Class[_]] = {
+  ): Option[Either[Class[? <: ScalaTrait], Class[? <: JavaInterface]]] = {
+    def loadClass(className: String, notFoundFatal: Boolean): Option[Class[?]] = {
       try {
         Some(environment.classLoader.loadClass(className))
       } catch {
@@ -168,29 +168,29 @@ object Reflect {
     }
   }
 
-  def getClass[T: ClassTag](fqcn: String, classLoader: ClassLoader): Class[_ <: T] = {
-    val c = Class.forName(fqcn, false, classLoader).asInstanceOf[Class[_ <: T]]
+  def getClass[T: ClassTag](fqcn: String, classLoader: ClassLoader): Class[? <: T] = {
+    val c = Class.forName(fqcn, false, classLoader).asInstanceOf[Class[? <: T]]
     val t = implicitly[ClassTag[T]].runtimeClass
     if (t.isAssignableFrom(c)) c
     else throw new ClassCastException(s"$t is not assignable from $c")
   }
 
-  def createInstance[T: ClassTag](clazz: Class[_]): T = {
+  def createInstance[T: ClassTag](clazz: Class[?]): T = {
     val o = clazz.getDeclaredConstructor().newInstance()
     val t = implicitly[ClassTag[T]].runtimeClass
     if (t.isInstance(o)) o.asInstanceOf[T]
     else throw new ClassCastException(clazz.getName + " is not an instance of " + t)
   }
 
-  def simpleName(clazz: Class[_]): String = {
+  def simpleName(clazz: Class[?]): String = {
     val name = clazz.getName
     name.substring(name.lastIndexOf('.') + 1)
   }
 
   class SubClassOf[T](val runtimeClass: Class[T]) {
-    def unapply(clazz: Class[_]): Option[Class[_ <: T]] = {
+    def unapply(clazz: Class[?]): Option[Class[? <: T]] = {
       if (runtimeClass.isAssignableFrom(clazz)) {
-        Some(clazz.asInstanceOf[Class[_ <: T]])
+        Some(clazz.asInstanceOf[Class[? <: T]])
       } else {
         None
       }

--- a/core/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/core/play/src/test/scala/play/api/data/FormSpec.scala
@@ -52,7 +52,7 @@ class FormSpec extends Specification {
         badParts = Seq.empty
       )
 
-      implicit val request: Request[_] = FakeRequest(method = "POST", "/").withMultipartFormDataBody(multipartBody)
+      implicit val request: Request[?] = FakeRequest(method = "POST", "/").withMultipartFormDataBody(multipartBody)
 
       val f1 = ScalaForms.updateForm.bindFromRequest()
       f1.errors must beEmpty
@@ -60,7 +60,7 @@ class FormSpec extends Specification {
     }
 
     "query params ignored when using POST" in {
-      implicit val request: Request[_] = FakeRequest(method = "POST", "/?email=bob%40marley.com&name=john")
+      implicit val request: Request[?] = FakeRequest(method = "POST", "/?email=bob%40marley.com&name=john")
         .withFormUrlEncodedBody("email" -> "michael@jackson.com")
 
       val f1 = ScalaForms.updateForm.bindFromRequest()
@@ -69,7 +69,7 @@ class FormSpec extends Specification {
     }
 
     "query params ignored when using PUT" in {
-      implicit val request: Request[_] = FakeRequest(method = "PUT", "/?email=bob%40marley.com&name=john")
+      implicit val request: Request[?] = FakeRequest(method = "PUT", "/?email=bob%40marley.com&name=john")
         .withFormUrlEncodedBody("email" -> "michael@jackson.com")
 
       val f1 = ScalaForms.updateForm.bindFromRequest()
@@ -78,7 +78,7 @@ class FormSpec extends Specification {
     }
 
     "query params ignored when using PATCH" in {
-      implicit val request: Request[_] = FakeRequest(method = "PATCH", "/?email=bob%40marley.com&name=john")
+      implicit val request: Request[?] = FakeRequest(method = "PATCH", "/?email=bob%40marley.com&name=john")
         .withFormUrlEncodedBody("email" -> "michael@jackson.com")
 
       val f1 = ScalaForms.updateForm.bindFromRequest()
@@ -87,7 +87,7 @@ class FormSpec extends Specification {
     }
 
     "query params NOT ignored when using GET" in {
-      implicit val request: Request[_] = FakeRequest(method = "GET", "/?email=bob%40marley.com&name=john")
+      implicit val request: Request[?] = FakeRequest(method = "GET", "/?email=bob%40marley.com&name=john")
         .withFormUrlEncodedBody("email" -> "michael@jackson.com")
 
       val f1 = ScalaForms.updateForm.bindFromRequest()
@@ -96,7 +96,7 @@ class FormSpec extends Specification {
     }
 
     "query params NOT ignored when using DELETE" in {
-      implicit val request: Request[_] = FakeRequest(method = "DELETE", "/?email=bob%40marley.com&name=john")
+      implicit val request: Request[?] = FakeRequest(method = "DELETE", "/?email=bob%40marley.com&name=john")
         .withFormUrlEncodedBody("email" -> "michael@jackson.com")
 
       val f1 = ScalaForms.updateForm.bindFromRequest()
@@ -105,7 +105,7 @@ class FormSpec extends Specification {
     }
 
     "query params NOT ignored when using HEAD" in {
-      implicit val request: Request[_] = FakeRequest(method = "HEAD", "/?email=bob%40marley.com&name=john")
+      implicit val request: Request[?] = FakeRequest(method = "HEAD", "/?email=bob%40marley.com&name=john")
         .withFormUrlEncodedBody("email" -> "michael@jackson.com")
 
       val f1 = ScalaForms.updateForm.bindFromRequest()
@@ -114,7 +114,7 @@ class FormSpec extends Specification {
     }
 
     "query params NOT ignored when using OPTIONS" in {
-      implicit val request: Request[_] = FakeRequest(method = "OPTIONS", "/?email=bob%40marley.com&name=john")
+      implicit val request: Request[?] = FakeRequest(method = "OPTIONS", "/?email=bob%40marley.com&name=john")
         .withFormUrlEncodedBody("email" -> "michael@jackson.com")
 
       val f1 = ScalaForms.updateForm.bindFromRequest()

--- a/core/play/src/test/scala/play/api/libs/CometSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/CometSpec.scala
@@ -28,7 +28,7 @@ class CometSpec extends Specification {
     // #comet-string
     def cometString = action {
       implicit val m                      = materializer
-      def stringSource: Source[String, _] = Source(List("kiki", "foo", "bar"))
+      def stringSource: Source[String, ?] = Source(List("kiki", "foo", "bar"))
       Ok.chunked(stringSource.via(Comet.string("parent.cometMessage"))).as(ContentTypes.HTML)
     }
     // #comet-string
@@ -36,7 +36,7 @@ class CometSpec extends Specification {
     // #comet-json
     def cometJson = action {
       implicit val m                       = materializer
-      def stringSource: Source[JsValue, _] = Source(List(JsString("jsonString")))
+      def stringSource: Source[JsValue, ?] = Source(List(JsString("jsonString")))
       Ok.chunked(stringSource.via(Comet.json("parent.cometMessage"))).as(ContentTypes.HTML)
     }
     // #comet-json

--- a/core/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
@@ -93,7 +93,7 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
     }
   }
 
-  def enforceMaxLengthEnforced(result: Either[Result, _]) = {
+  def enforceMaxLengthEnforced(result: Either[Result, ?]) = {
     result must beLeft[Result].which { inner => inner.header.status must_== Status.REQUEST_ENTITY_TOO_LARGE }
   }
 

--- a/core/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -398,7 +398,7 @@ class RangeResultSpec extends Specification {
 
     "support a Source function that handles pre-seeking" in {
       val bytes: List[Byte]                             = List[Byte](1, 2, 3, 4, 5, 6)
-      val source: Long => (Long, Source[ByteString, _]) = offsetSupportingGenerator(bytes)
+      val source: Long => (Long, Source[ByteString, ?]) = offsetSupportingGenerator(bytes)
       val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(data, _, _), _, _, _, _) =
         RangeResult.ofSource(Some(bytes.size.toLong), source, Some("bytes=3-4"), None, None)
       implicit val system: ActorSystem        = ActorSystem()
@@ -409,7 +409,7 @@ class RangeResultSpec extends Specification {
 
     "support a Source function that ignores pre-seeking" in {
       val bytes: List[Byte]                             = List[Byte](1, 2, 3, 4, 5, 6)
-      val source: Long => (Long, Source[ByteString, _]) = offsetIgnoringGenerator(bytes)
+      val source: Long => (Long, Source[ByteString, ?]) = offsetIgnoringGenerator(bytes)
       val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(data, _, _), _, _, _, _) =
         RangeResult.ofSource(Some(bytes.size.toLong), source, Some("bytes=3-4"), None, None)
       implicit val system: ActorSystem        = ActorSystem()
@@ -420,7 +420,7 @@ class RangeResultSpec extends Specification {
 
     "throw error when Source function pre-seeks too far" in {
       val bytes: List[Byte]                             = List[Byte](1, 2, 3, 4, 5, 6)
-      val source: Long => (Long, Source[ByteString, _]) = brokenOffsetGenerator(bytes)
+      val source: Long => (Long, Source[ByteString, ?]) = brokenOffsetGenerator(bytes)
       RangeResult.ofSource(Some(bytes.size.toLong), source, Some("bytes=3-4"), None, None) must
         throwAn[IllegalArgumentException](
           "Requested range starts at 3 but the getSource function returned " +
@@ -481,19 +481,19 @@ class RangeResultSpec extends Specification {
     }
   }
 
-  private def collectBytes(data: Source[ByteString, _])(implicit mat: Materializer): Array[Byte] =
+  private def collectBytes(data: Source[ByteString, ?])(implicit mat: Materializer): Array[Byte] =
     Await.result(data.runFold(ByteString.empty)(_ ++ _).map(_.toArray), Duration.Inf)
 
   /** Source-producing function that handles offset */
-  private def offsetSupportingGenerator(data: List[Byte])(offset: Long): (Long, Source[ByteString, _]) =
+  private def offsetSupportingGenerator(data: List[Byte])(offset: Long): (Long, Source[ByteString, ?]) =
     (offset, Source(data.map(ByteString(_))).drop(offset))
 
   /** Source-producing function that seeks beyond the start of the request offset (a bug). */
-  private def brokenOffsetGenerator(data: List[Byte])(offset: Long): (Long, Source[ByteString, _]) =
+  private def brokenOffsetGenerator(data: List[Byte])(offset: Long): (Long, Source[ByteString, ?]) =
     (offset + 1, Source(data.map(ByteString(_))).drop(offset + 1))
 
   /** Source-producing function that ignores offset and returns 0 (expecting RangeResult to handle seeking) */
-  private def offsetIgnoringGenerator(data: List[Byte])(offset: Long): (Long, Source[ByteString, _]) =
+  private def offsetIgnoringGenerator(data: List[Byte])(offset: Long): (Long, Source[ByteString, ?]) =
     (0, Source(data.map(ByteString(_))))
 
   private def createFile(path: Path): File = {

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -58,9 +58,9 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
     new FakeRequest(request.withAttrs(attrs))
   override def addAttr[B](key: TypedKey[B], value: B): FakeRequest[A] =
     withAttrs(attrs.updated(key, value))
-  override def addAttrs(entries: TypedEntry[_]*): FakeRequest[A] =
+  override def addAttrs(entries: TypedEntry[?]*): FakeRequest[A] =
     withAttrs(attrs.updated(entries: _*))
-  override def removeAttr(key: TypedKey[_]): FakeRequest[A] =
+  override def removeAttr(key: TypedKey[?]): FakeRequest[A] =
     withAttrs(attrs.removed(key))
   override def withBody[B](body: B): FakeRequest[B] =
     new FakeRequest(request.withBody(body))

--- a/core/play/src/test/scala/play/mvc/DefaultBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/DefaultBodyParserSpec.scala
@@ -63,7 +63,7 @@ class DefaultBodyParserSpec extends Specification with AfterAll with MustMatcher
         new Http.RequestBuilder().method("POST").body(new RequestBody(body.utf8String), "text/plain").req
       postRequest.hasBody must beFalse
       parse(req(postRequest), body) must beRight[Object].like {
-        case empty: Optional[_] => empty.toScala must beNone
+        case empty: Optional[?] => empty.toScala must beNone
       }
     }
     "handle 'Content-Length: 1' header as non-empty body" in {
@@ -81,7 +81,7 @@ class DefaultBodyParserSpec extends Specification with AfterAll with MustMatcher
         new Http.RequestBuilder().method("POST").body(new RequestBody(null), "text/plain").req
       postRequest.hasBody must beFalse
       parse(req(postRequest), body) must beRight[Object].like {
-        case empty: Optional[_] => empty.toScala must beNone
+        case empty: Optional[?] => empty.toScala must beNone
       }
     }
     "handle missing Content-Length and Transfer-Encoding headers as empty body (containing Optional.empty)" in {
@@ -90,7 +90,7 @@ class DefaultBodyParserSpec extends Specification with AfterAll with MustMatcher
         new Http.RequestBuilder().method("POST").req
       postRequest.hasBody must beFalse
       parse(req(postRequest), body) must beRight[Object].like {
-        case empty: Optional[_] => empty.toScala must beNone
+        case empty: Optional[?] => empty.toScala must beNone
       }
     }
   }

--- a/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/MaxLengthBodyParserSpec.scala
@@ -67,12 +67,12 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll with MustMatch
       .get(5, TimeUnit.SECONDS)
   }
 
-  def maxLengthEnforced(result: F.Either[Result, _]) = {
+  def maxLengthEnforced(result: F.Either[Result, ?]) = {
     result.left.toScala.map(_.status) must beSome(Status.REQUEST_ENTITY_TOO_LARGE)
     result.right.toScala must beNone
   }
 
-  val bodyParsers: Seq[(BodyParser[_], Option[String], ByteString)] = Seq(
+  val bodyParsers: Seq[(BodyParser[?], Option[String], ByteString)] = Seq(
     // Tuple3: (bodyParser with maxLength of 15, Content-Type header, 15 bytes to feed the parser)
     (new BodyParser.Text(15, defaultHttpErrorHandler), Some("text/plain"), Body15),
     (new BodyParser.TolerantText(15, defaultHttpErrorHandler), None, Body15),

--- a/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/core/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -164,7 +164,7 @@ class HelpersSpec extends Specification {
 
   "@repeat" should {
     val form = Form(single("foo" -> Forms.seq(Forms.text)))
-    def renderFoo(form: Form[_], min: Int = 1) =
+    def renderFoo(form: Form[?], min: Int = 1) =
       repeat
         .apply(form("foo"), min) { f => Html(f.name + ":" + f.value.getOrElse("")) }
         .map(_.toString)
@@ -180,7 +180,7 @@ class HelpersSpec extends Specification {
           )
       )
     )
-    def renderComplex(form: Form[_], min: Int = 1) =
+    def renderComplex(form: Form[?], min: Int = 1) =
       repeat
         .apply(form("foo"), min) { f =>
           val a = f("a")

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/org/playframework/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/org/playframework/docs/sbtplugin/PlayDocsPlugin.scala
@@ -248,7 +248,7 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
       classpath.map(_.data.toURI.toURL).toArray,
       null /* important here, don't depend of the sbt classLoader! */
     ) {
-      override def loadClass(name: String): Class[_] = {
+      override def loadClass(name: String): Class[?] = {
         if (play.core.Build.sharedClasses.contains(name)) {
           sbtLoader.loadClass(name)
         } else {
@@ -279,8 +279,8 @@ object PlayDocsPlugin extends AutoPlugin with PlayDocsPluginCompat {
       "start",
       classOf[File],
       classOf[BuildDocHandler],
-      classOf[Callable[_]],
-      classOf[Callable[_]],
+      classOf[Callable[?]],
+      classOf[Callable[?]],
       classOf[java.lang.Integer]
     )
 

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/org/playframework/docs/sbtplugin/PlayDocsValidation.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/org/playframework/docs/sbtplugin/PlayDocsValidation.scala
@@ -383,7 +383,7 @@ object PlayDocsValidation {
 
     var failed = false
 
-    def doAssertion(desc: String, errors: Seq[_])(onFail: => Unit): Unit = {
+    def doAssertion(desc: String, errors: Seq[?])(onFail: => Unit): Unit = {
       if (errors.isEmpty) {
         log.info("[" + Colors.green("pass") + "] " + desc)
       } else {

--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/sbt/internal/PlayDocsPluginCompat.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/sbt/internal/PlayDocsPluginCompat.scala
@@ -17,7 +17,7 @@ trait PlayDocsPluginCompat {
       imports: Seq[String],
       classLoader: ClassLoader,
       eval: () => Eval
-  ): Seq[Def.Setting[_]] = {
+  ): Seq[Def.Setting[?]] = {
     EvaluateConfigurations.evaluateConfiguration(eval(), sbtFile, imports)(classLoader)
   }
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -28,25 +28,25 @@ import play.twirl.sbt.Import.TwirlKeys._
 import play.TemplateImports
 
 object PlaySettings {
-  lazy val minimalJavaSettings = Seq[Setting[_]](
+  lazy val minimalJavaSettings = Seq[Setting[?]](
     templateImports ++= TemplateImports.minimalJavaTemplateImports.asScala,
     routesImport ++= Seq("play.libs.F")
   )
 
-  lazy val defaultJavaSettings = Seq[Setting[_]](
+  lazy val defaultJavaSettings = Seq[Setting[?]](
     templateImports ++= TemplateImports.defaultJavaTemplateImports.asScala,
     routesImport ++= Seq("play.libs.F")
   )
 
-  lazy val defaultScalaSettings = Seq[Setting[_]](
+  lazy val defaultScalaSettings = Seq[Setting[?]](
     templateImports ++= TemplateImports.defaultScalaTemplateImports.asScala
   )
 
-  lazy val serviceGlobalSettings: Seq[Setting[_]] = Seq(
+  lazy val serviceGlobalSettings: Seq[Setting[?]] = Seq(
   )
 
   // Settings for a Play service (not a web project)
-  lazy val serviceSettings: Seq[Setting[_]] = Def.settings(
+  lazy val serviceSettings: Seq[Setting[?]] = Def.settings(
     onLoadMessage := {
       val javaVersion = sys.props("java.specification.version")
       """|  __              __
@@ -218,7 +218,7 @@ object PlaySettings {
   @deprecated("Use serviceSettings for a Play app or service, and add webSettings for a web app", "2.7.0")
   lazy val defaultSettings = serviceSettings ++ webSettings
 
-  lazy val webSettings = Seq[Setting[_]](
+  lazy val webSettings = Seq[Setting[?]](
     constructorAnnotations += "@javax.inject.Inject()",
     playMonitoredFiles ++= (Compile / compileTemplates / sourceDirectories).value,
     routesImport ++= Seq("controllers.Assets.Asset"),
@@ -257,7 +257,7 @@ object PlaySettings {
   /**
    * Settings for creating a jar that excludes externalized resources
    */
-  private def externalizedSettings: Seq[Setting[_]] = Def.settings(
+  private def externalizedSettings: Seq[Setting[?]] = Def.settings(
     Defaults.packageTaskSettings(playJarSansExternalized, playJarSansExternalized / mappings),
     playExternalizedResources := {
       val rdirs = unmanagedResourceDirectories.value

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -126,9 +126,9 @@ object PlayReload {
       }
   }
 
-  def getScopedKey(incomplete: Incomplete): Option[ScopedKey[_]] = incomplete.node.flatMap {
-    case key: ScopedKey[_] => Option(key)
-    case task: Task[_]     => task.info.attributes.get(taskDefinitionKey)
+  def getScopedKey(incomplete: Incomplete): Option[ScopedKey[?]] = incomplete.node.flatMap {
+    case key: ScopedKey[?] => Option(key)
+    case task: Task[?]     => task.info.attributes.get(taskDefinitionKey)
   }
 
   def compile(

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -26,7 +26,7 @@ import play.sbt.run.PlayRun
 object ScriptedTools extends AutoPlugin {
   override def trigger = allRequirements
 
-  override def projectSettings: Seq[Def.Setting[_]] = Def.settings(
+  override def projectSettings: Seq[Def.Setting[?]] = Def.settings(
     resolvers ++= Resolver.sonatypeOssRepos("releases"), // sync BuildSettings.scala
     // This is copy/pasted from PekkoSnapshotRepositories since scripted tests also need
     // the snapshot resolvers in `cron` builds.

--- a/documentation/.scalafmt.conf
+++ b/documentation/.scalafmt.conf
@@ -67,3 +67,10 @@ fileOverride {
     runner.dialect = scala3
   }
 }
+
+rewrite.scala3.convertToNewSyntax = true
+runner.dialectOverride {
+  allowSignificantIndentation = false
+  allowAsForImportRename = false
+  allowStarWildcardImport = false
+}

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -55,7 +55,7 @@ package javaguide.testhelpers {
          method.invoke(this)
        }) match {
         case r: Result             => CompletableFuture.completedFuture(r)
-        case f: CompletionStage[_] => f.asInstanceOf[CompletionStage[Result]]
+        case f: CompletionStage[?] => f.asInstanceOf[CompletionStage[Result]]
       }
     }
   }

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
@@ -80,7 +80,7 @@ class JavaRouting extends Specification {
     }
   }
 
-  def contentOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
+  def contentOf(rh: RequestHeader, router: Class[? <: Router] = classOf[Routes]) = {
     running(_.configure("play.http.router" -> router.getName)) { app =>
       implicit val mat = app.materializer
       contentAsString(app.requestHandler.handlerForRequest(rh)._2 match {
@@ -89,7 +89,7 @@ class JavaRouting extends Specification {
     }
   }
 
-  def statusOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
+  def statusOf(rh: RequestHeader, router: Class[? <: Router] = classOf[Routes]) = {
     running(_.configure("play.http.router" -> router.getName)) { app =>
       implicit val mat = app.materializer
       status(app.requestHandler.handlerForRequest(rh)._2 match {

--- a/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
@@ -40,7 +40,7 @@ class MyCode {
 }
 
 class MyModule extends play.api.inject.Module {
-  def bindings(environment: Environment, configuration: Configuration): Seq[play.api.inject.Binding[_]] = {
+  def bindings(environment: Environment, configuration: Configuration): Seq[play.api.inject.Binding[?]] = {
     Seq(bind[MyCode].toInstance(new MyCode))
   }
 }
@@ -48,7 +48,7 @@ class MyModule extends play.api.inject.Module {
 
 // #builtin-module-definition
 class MyI18nModule extends play.api.inject.Module {
-  def bindings(environment: Environment, configuration: Configuration): Seq[play.api.inject.Binding[_]] = {
+  def bindings(environment: Environment, configuration: Configuration): Seq[play.api.inject.Binding[?]] = {
     Seq(
       bind[Langs].toProvider[DefaultLangsProvider],
       bind[MessagesApi].toProvider[MyMessagesApiProvider]

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
@@ -22,7 +22,7 @@ class MockController(val controllerComponents: ControllerComponents)(implicit ma
   // #comet-string
   def cometString = Action {
     implicit val m                      = materializer
-    def stringSource: Source[String, _] = Source(List("kiki", "foo", "bar"))
+    def stringSource: Source[String, ?] = Source(List("kiki", "foo", "bar"))
     Ok.chunked(stringSource.via(Comet.string("parent.cometMessage"))).as(ContentTypes.HTML)
   }
   // #comet-string
@@ -30,7 +30,7 @@ class MockController(val controllerComponents: ControllerComponents)(implicit ma
   // #comet-json
   def cometJson = Action {
     implicit val m                     = materializer
-    def jsonSource: Source[JsValue, _] = Source(List(JsString("jsonString")))
+    def jsonSource: Source[JsValue, ?] = Source(List(JsString("jsonString")))
     Ok.chunked(jsonSource.via(Comet.json("parent.cometMessage"))).as(ContentTypes.HTML)
   }
   // #comet-json

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -22,7 +22,7 @@ class ScalaWebSockets extends PlaySpecification {
   import play.api.mvc.WebSocket
 
   "Scala WebSockets" should {
-    def runWebSocket[In, Out](webSocket: WebSocket, in: Source[Message, _], expectOut: Int)(
+    def runWebSocket[In, Out](webSocket: WebSocket, in: Source[Message, ?], expectOut: Int)(
         implicit mat: Materializer
     ): Either[Result, List[Message]] = {
       await(webSocket(FakeRequest())).map { flow =>

--- a/documentation/manual/working/scalaGuide/main/async/code/scalaguide/async/scalastream/ScalaStream.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/scalaguide/async/scalastream/ScalaStream.scala
@@ -43,7 +43,7 @@ class ScalaStreamController @Inject() (val controllerComponents: ControllerCompo
     // #create-source-from-file
     val file                          = new java.io.File("/tmp/fileToServe.pdf")
     val path: java.nio.file.Path      = file.toPath
-    val source: Source[ByteString, _] = FileIO.fromPath(path)
+    val source: Source[ByteString, ?] = FileIO.fromPath(path)
     // #create-source-from-file
   }
 
@@ -51,7 +51,7 @@ class ScalaStreamController @Inject() (val controllerComponents: ControllerCompo
   def streamed = Action {
     val file                          = new java.io.File("/tmp/fileToServe.pdf")
     val path: java.nio.file.Path      = file.toPath
-    val source: Source[ByteString, _] = FileIO.fromPath(path)
+    val source: Source[ByteString, ?] = FileIO.fromPath(path)
 
     Result(
       header = ResponseHeader(200, Map.empty),
@@ -64,7 +64,7 @@ class ScalaStreamController @Inject() (val controllerComponents: ControllerCompo
   def streamedWithContentLength = Action {
     val file                          = new java.io.File("/tmp/fileToServe.pdf")
     val path: java.nio.file.Path      = file.toPath
-    val source: Source[ByteString, _] = FileIO.fromPath(path)
+    val source: Source[ByteString, ?] = FileIO.fromPath(path)
 
     val contentLength = Some(Files.size(file.toPath))
 
@@ -104,14 +104,14 @@ class ScalaStreamController @Inject() (val controllerComponents: ControllerCompo
   private def sourceFromInputStream = {
     // #create-source-from-input-stream
     val data                               = getDataStream
-    val dataContent: Source[ByteString, _] = StreamConverters.fromInputStream(() => data)
+    val dataContent: Source[ByteString, ?] = StreamConverters.fromInputStream(() => data)
     // #create-source-from-input-stream
   }
 
   // #chunked-from-input-stream
   def chunked = Action {
     val data                               = getDataStream
-    val dataContent: Source[ByteString, _] = StreamConverters.fromInputStream(() => data)
+    val dataContent: Source[ByteString, ?] = StreamConverters.fromInputStream(() => data)
     Ok.chunked(dataContent)
   }
   // #chunked-from-input-stream

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -149,7 +149,7 @@ package dynamicguicemodule {
       // ClassLoader to load the classes.
       for (l <- languages) {
         val bindingClassName: String = helloConfiguration.get[String](l)
-        val bindingClass: Class[_ <: Hello] =
+        val bindingClass: Class[? <: Hello] =
           environment.classLoader
             .loadClass(bindingClassName)
             .asSubclass(classOf[Hello])
@@ -231,7 +231,7 @@ package playmodule {
   import play.api.Environment
 
   class HelloModule extends Module {
-    def bindings(environment: Environment, configuration: Configuration): Seq[play.api.inject.Binding[_]] = Seq(
+    def bindings(environment: Environment, configuration: Configuration): Seq[play.api.inject.Binding[?]] = Seq(
       bind[Hello].qualifiedWith("en").to[EnglishHello],
       bind[Hello].qualifiedWith("de").to[GermanHello]
     )
@@ -247,7 +247,7 @@ package eagerplaymodule {
   import play.api.Environment
 
   class HelloModule extends Module {
-    def bindings(environment: Environment, configuration: Configuration): Seq[play.api.inject.Binding[_]] = Seq(
+    def bindings(environment: Environment, configuration: Configuration): Seq[play.api.inject.Binding[?]] = Seq(
       bind[Hello].qualifiedWith("en").to[EnglishHello].eagerly(),
       bind[Hello].qualifiedWith("de").to[GermanHello].eagerly()
     )

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrfController.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrfController.scala
@@ -24,7 +24,7 @@ class ScalaCsrfController @Inject() (val controllerComponents: ControllerCompone
     Ok
   }
 
-  def anotherMethod(p: String)(implicit request: Request[_]) = {
+  def anotherMethod(p: String)(implicit request: Request[?]) = {
     // do something that needs access to the request
   }
   // #some-csrf-action-with-more-methods
@@ -35,7 +35,7 @@ class ScalaCsrfController @Inject() (val controllerComponents: ControllerCompone
     Ok("success")
   }
 
-  def accessToken(implicit request: Request[_]) = {
+  def accessToken(implicit request: Request[?]) = {
     val token = CSRF.getToken // request is passed implicitly to CSRF.getToken
   }
   // #implicit-access-to-token

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
@@ -56,7 +56,7 @@ package scalaguide.http.scalaactions {
           Ok("Got request [" + request + "]")
         }
 
-        def anotherMethod(p: String)(implicit request: Request[_]) = {
+        def anotherMethod(p: String)(implicit request: Request[?]) = {
           // do something that needs access to the request
         }
         // #implicit-request-action-with-more-methods

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
@@ -119,7 +119,7 @@ package scalaguide.http.scalaresults {
 
         "with an offset" in {
           class PartialContentController(val controllerComponents: ControllerComponents) extends BaseController {
-            private def sourceFrom(content: String): Source[ByteString, _] =
+            private def sourceFrom(content: String): Source[ByteString, ?] =
               Source(content.getBytes.iterator.map(ByteString(_)).toIndexedSeq)
 
             def index: Action[AnyContent] = Action { request =>

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -160,7 +160,7 @@ object ScalaRoutingSpec extends Specification {
     }
   }
 
-  def contentOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
+  def contentOf(rh: RequestHeader, router: Class[? <: Router] = classOf[Routes]) = {
     running() { app =>
       implicit val mat = app.materializer
       contentAsString {
@@ -173,7 +173,7 @@ object ScalaRoutingSpec extends Specification {
     }
   }
 
-  def statusOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
+  def statusOf(rh: RequestHeader, router: Class[? <: Router] = classOf[Routes]) = {
     running() { app =>
       implicit val mat = app.materializer
       status {

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/Component.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/Component.scala
@@ -25,7 +25,7 @@ import play.api.Configuration
 import play.api.Environment
 
 class ComponentModule extends Module {
-  def bindings(env: Environment, conf: Configuration): Seq[Binding[_]] = Seq(
+  def bindings(env: Environment, conf: Configuration): Seq[Binding[?]] = Seq(
     bind[Component].to[DefaultComponent]
   )
 }

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -96,7 +96,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
    *
    * In this case, 9 chunks, each containing abcdefghij repeated 100 times.
    */
-  val largeSource: Source[ByteString, _] = {
+  val largeSource: Source[ByteString, ?] = {
     val source = Source.single(ByteString("abcdefghij" * 100))
     (1 to 9).foldLeft(source) { (acc, _) => acc ++ source }
   }
@@ -454,7 +454,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         case ("PUT", "/") => Action(Ok(""))
         case other        => Action { NotFound }
       } { ws =>
-        def largeImageFromDB: Source[ByteString, _] = largeSource
+        def largeImageFromDB: Source[ByteString, ?] = largeSource
         // #scalaws-stream-request
         val wsResponse: Future[WSResponse] = ws
           .url(url)

--- a/persistence/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -25,11 +25,11 @@ final class DBModule
         bind[Database].qualifiedWith(new NamedDatabaseImpl(name))
       }
 
-      def namedDatabaseBindings(dbs: Set[String]): Seq[Binding[_]] = dbs.toSeq.map { db =>
+      def namedDatabaseBindings(dbs: Set[String]): Seq[Binding[?]] = dbs.toSeq.map { db =>
         bindNamed(db).to(new NamedDatabaseProvider(db))
       }
 
-      def defaultDatabaseBinding(default: String, dbs: Set[String]): Seq[Binding[_]] = {
+      def defaultDatabaseBinding(default: String, dbs: Set[String]): Seq[Binding[?]] = {
         if (dbs.contains(default)) Seq(bind[Database].to(bindNamed(default))) else Nil
       }
 

--- a/persistence/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/persistence/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -36,7 +36,7 @@ object Databases {
       driver: String,
       url: String,
       name: String = "default",
-      config: Map[String, _ <: Any] = Map.empty
+      config: Map[String, ? <: Any] = Map.empty
   ): Database = {
     val dbConfig = Configuration
       .from(Map("driver" -> driver, "url" -> url) ++ config)
@@ -55,7 +55,7 @@ object Databases {
   def inMemory(
       name: String = "default",
       urlOptions: Map[String, String] = Map.empty,
-      config: Map[String, _ <: Any] = Map.empty
+      config: Map[String, ? <: Any] = Map.empty
   ): Database = {
     val driver   = "org.h2.Driver"
     val urlExtra = if (urlOptions.nonEmpty) urlOptions.map { case (k, v) => k + "=" + v }.mkString(";", ";", "") else ""
@@ -73,7 +73,7 @@ object Databases {
    * @param block The block of code to run
    * @return The result of the block
    */
-  def withDatabase[T](driver: String, url: String, name: String = "default", config: Map[String, _ <: Any] = Map.empty)(
+  def withDatabase[T](driver: String, url: String, name: String = "default", config: Map[String, ? <: Any] = Map.empty)(
       block: Database => T
   ): T = {
     val database = Databases(driver, url, name, config)
@@ -96,7 +96,7 @@ object Databases {
   def withInMemory[T](
       name: String = "default",
       urlOptions: Map[String, String] = Map.empty,
-      config: Map[String, _ <: Any] = Map.empty
+      config: Map[String, ? <: Any] = Map.empty
   )(block: Database => T): T = {
     val database = inMemory(name, urlOptions, config)
     try {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -80,7 +80,7 @@ object BuildSettings {
 
   private val VersionPattern = """^(\d+).(\d+).(\d+)(-.*)?""".r
 
-  def evictionSettings: Seq[Setting[_]] = Seq(
+  def evictionSettings: Seq[Setting[?]] = Seq(
     // This avoids a lot of dependency resolution warnings to be showed.
     (update / evictionWarningOptions) := EvictionWarningOptions.default
       .withWarnTransitiveEvictions(false)
@@ -91,7 +91,7 @@ object BuildSettings {
   val SourcesApplication = config("sources").hide
 
   /** These settings are used by all projects. */
-  def playCommonSettings: Seq[Setting[_]] = Def.settings(
+  def playCommonSettings: Seq[Setting[?]] = Def.settings(
     sonatypeProfileName := "org.playframework",
     fileHeaderSettings,
     ivyLoggingLevel := UpdateLogging.DownloadOnly,
@@ -204,7 +204,7 @@ object BuildSettings {
   /**
    * These settings are used by all projects that are part of the runtime, as opposed to the development mode of Play.
    */
-  def playRuntimeSettings: Seq[Setting[_]] = Def.settings(
+  def playRuntimeSettings: Seq[Setting[?]] = Def.settings(
     playCommonSettings,
     mimaPreviousArtifacts := mimaPreviousVersion.map { version =>
       val cross = if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled
@@ -328,13 +328,13 @@ object BuildSettings {
       .settings(omnidocSettings: _*)
   }
 
-  def omnidocSettings: Seq[Setting[_]] = Def.settings(
+  def omnidocSettings: Seq[Setting[?]] = Def.settings(
     Omnidoc.projectSettings,
     omnidocSnapshotBranch := snapshotBranch,
     omnidocPathPrefix     := ""
   )
 
-  def playScriptedSettings: Seq[Setting[_]] = Seq(
+  def playScriptedSettings: Seq[Setting[?]] = Seq(
     // Don't automatically publish anything.
     // The test-sbt-plugins-* scripts publish before running the scripted tests.
     // When developing the sbt plugins:

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -81,7 +81,7 @@ object Docs {
     }
   )
 
-  def playdocSettings: Seq[Setting[_]] = Def.settings(
+  def playdocSettings: Seq[Setting[?]] = Def.settings(
     Playdoc.projectSettings,
     ivyConfigurations += Webjars,
     extractWebjars := extractWebjarContents.value,

--- a/project/PekkoSnapshotRepositories.scala
+++ b/project/PekkoSnapshotRepositories.scala
@@ -12,7 +12,7 @@ object PekkoSnapshotRepositories extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   // This is also copy/pasted in ScriptedTools for scripted tests to also use the snapshot repositories.
-  override def projectSettings: Seq[Def.Setting[_]] = {
+  override def projectSettings: Seq[Def.Setting[?]] = {
     // If this is a scheduled GitHub Action
     // https://docs.github.com/en/actions/learn-github-actions/environment-variables
     resolvers ++= sys.env

--- a/testkit/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/testkit/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -21,7 +21,7 @@ import play.api.Environment
 import play.api.Mode
 import play.core.server.ServerProvider
 
-abstract class AroundHelper(helperClass: Class[_]) extends Around {
+abstract class AroundHelper(helperClass: Class[?]) extends Around {
 
   private var directlyCallWrap             = false
   private var scala2RunningAlreadyExecuted = false
@@ -188,7 +188,7 @@ abstract class WithBrowser[WEBDRIVER <: WebDriver](
     val webDriver: WebDriver = WebDriverFactory(Helpers.HTMLUNIT),
     val app: Application = GuiceApplicationBuilder().build(),
     var port: Int = Helpers.testServerPort
-) extends AroundHelper(classOf[WithBrowser[_]])
+) extends AroundHelper(classOf[WithBrowser[?]])
     with Scope {
   def this(webDriver: Class[WEBDRIVER], app: Application, port: Int) = this(WebDriverFactory(webDriver), app, port)
 

--- a/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/testkit/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -89,7 +89,7 @@ class FakesSpec extends PlaySpecification {
 
   def contentTypeForFakeRequest(request: FakeRequest[AnyContentAsJson])(implicit mat: Materializer): String = {
     var testContentType: Option[String] = None
-    val action                          = Action { (request: Request[_]) => testContentType = request.headers.get(CONTENT_TYPE); Ok }
+    val action                          = Action { (request: Request[?]) => testContentType = request.headers.get(CONTENT_TYPE); Ok }
     val headers                         = new WrappedRequest(request)
     val execution                       = (new TestActionCaller).call(action, headers, request.body)
     Await.result(execution, Duration(3, TimeUnit.SECONDS))

--- a/testkit/play-test/src/main/scala/play/api/test/ApplicationFactory.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/ApplicationFactory.scala
@@ -47,7 +47,7 @@ import play.api.routing.Router
     }
   }
 
-  final def withAction(createAction: DefaultActionBuilder => Action[_]): ApplicationFactory = withRouter {
+  final def withAction(createAction: DefaultActionBuilder => Action[?]): ApplicationFactory = withRouter {
     (components: BuiltInComponents) =>
       val action = createAction(components.defaultActionBuilder)
       Router.from { case _ => action }

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
@@ -181,8 +181,8 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
    * @deprecated Import WSBodyWritables and use the typeclass in preference to this method, since 2.6.0
    */
   @deprecated("Use patch(bodyWritable)", "2.6.0")
-  override def patch(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
-    patch[Source[MultipartFormData.Part[Source[ByteString, _]], _]](body)
+  override def patch(body: Source[MultipartFormData.Part[Source[ByteString, ?]], ?]): Future[WSResponse] = {
+    patch[Source[MultipartFormData.Part[Source[ByteString, ?]], ?]](body)
   }
 
   // -------------------------------------------------
@@ -210,8 +210,8 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
    * @deprecated Import WSBodyWritables and use the typeclass in preference to this method, since 2.6.0
    */
   @deprecated("Use post(BodyWritable)", "2.6.0")
-  override def post(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
-    post[Source[MultipartFormData.Part[Source[ByteString, _]], _]](body)
+  override def post(body: Source[MultipartFormData.Part[Source[ByteString, ?]], ?]): Future[WSResponse] = {
+    post[Source[MultipartFormData.Part[Source[ByteString, ?]], ?]](body)
   }
 
   // -------------------------------------------------
@@ -240,8 +240,8 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
    * @deprecated Import WSBodyWritables and use the typeclass in preference to this method, since 2.6.0
    */
   @deprecated("Use put(BodyWritable)", "2.6.0")
-  override def put(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
-    put[Source[MultipartFormData.Part[Source[ByteString, _]], _]](body)
+  override def put(body: Source[MultipartFormData.Part[Source[ByteString, ?]], ?]): Future[WSResponse] = {
+    put[Source[MultipartFormData.Part[Source[ByteString, ?]], ?]](body)
   }
 
   override def delete(): Future[Response] = execute("DELETE")

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSResponse.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSResponse.scala
@@ -72,7 +72,7 @@ case class AhcWSResponse(underlying: StandaloneWSResponse) extends WSResponse wi
    */
   override def bodyAsBytes: ByteString = underlying.bodyAsBytes
 
-  override def bodyAsSource: Source[ByteString, _] = underlying.bodyAsSource
+  override def bodyAsSource: Source[ByteString, ?] = underlying.bodyAsSource
 
   /**
    * Return the current headers of the request being constructed

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -127,7 +127,7 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
     val calc = new play.shaded.ahc.org.asynchttpclient.SignatureCalculator with WSSignatureCalculator {
       override def calculateAndAddSignature(
           request: play.shaded.ahc.org.asynchttpclient.Request,
-          requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[_]
+          requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[?]
       ): Unit = {
         called = true
       }

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSBodyWritables.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSBodyWritables.scala
@@ -13,7 +13,7 @@ import play.core.formatters.Multipart
  * JSON, XML and Multipart Form Data Writables used for Play-WS bodies.
  */
 trait WSBodyWritables extends DefaultBodyWritables with JsonBodyWritables with XMLBodyWritables {
-  implicit val bodyWritableOf_Multipart: BodyWritable[Source[MultipartFormData.Part[Source[ByteString, _]], _]] = {
+  implicit val bodyWritableOf_Multipart: BodyWritable[Source[MultipartFormData.Part[Source[ByteString, ?]], ?]] = {
     val boundary    = Multipart.randomBoundary()
     val contentType = s"multipart/form-data; boundary=$boundary"
     BodyWritable(b => SourceBody(Multipart.transform(b, boundary)), contentType)

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSRequest.scala
@@ -192,7 +192,7 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
   /**
    * Perform a POST on the request asynchronously.
    */
-  def post(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[Response]
+  def post(body: Source[MultipartFormData.Part[Source[ByteString, ?]], ?]): Future[Response]
 
   // ------------------------------------------------
   // PATCH
@@ -215,7 +215,7 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
   /**
    * Perform a PATCH on the request asynchronously.
    */
-  def patch(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[Response]
+  def patch(body: Source[MultipartFormData.Part[Source[ByteString, ?]], ?]): Future[Response]
 
   // ------------------------------------------------
   // PUT
@@ -238,7 +238,7 @@ trait WSRequest extends StandaloneWSRequest with WSBodyWritables {
   /**
    * Perform a PUT on the request asynchronously.
    */
-  def put(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[Response]
+  def put(body: Source[MultipartFormData.Part[Source[ByteString, ?]], ?]): Future[Response]
 
   // ------------------------------------------------
   // DELETE, HEAD, OPTIONS

--- a/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSResponse.scala
+++ b/transport/client/play-ws/src/main/scala/play/api/libs/ws/WSResponse.scala
@@ -91,7 +91,7 @@ trait WSResponse extends StandaloneWSResponse with WSBodyReadables {
    */
   override def bodyAsBytes: ByteString
 
-  override def bodyAsSource: Source[ByteString, _]
+  override def bodyAsSource: Source[ByteString, ?]
 
   @deprecated("Use response.headers", "2.6.0")
   def allHeaders: Map[String, scala.collection.Seq[String]]

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -59,7 +59,7 @@ case object Native extends NettyTransport
 class NettyServer(
     config: ServerConfig,
     val applicationProvider: ApplicationProvider,
-    stopHook: () => Future[_],
+    stopHook: () => Future[?],
     val actorSystem: ActorSystem
 )(implicit val materializer: Materializer)
     extends Server {
@@ -167,7 +167,7 @@ class NettyServer(
   /**
    * Bind to the given address, returning the server channel, and a stream of incoming connection channels.
    */
-  private def bind(address: InetSocketAddress): (Channel, Source[Channel, _]) = {
+  private def bind(address: InetSocketAddress): (Channel, Source[Channel, ?]) = {
     val serverChannelEventLoop = eventLoop.next
 
     // Watches for channel events, and pushes them through a reactive streams publisher.
@@ -375,7 +375,7 @@ class NettyServer(
 
     // How to force a class to get initialized:
     // https://docs.oracle.com/javase/specs/jls/se17/html/jls-12.html#jls-12.4.1
-    Seq(classOf[ChannelOption[_]], classOf[UnixChannelOption[_]], classOf[EpollChannelOption[_]]).foreach(clazz => {
+    Seq(classOf[ChannelOption[?]], classOf[UnixChannelOption[?]], classOf[EpollChannelOption[?]]).foreach(clazz => {
       logger.debug(s"Class ${clazz.getName} will be initialized (if it hasn't been initialized already)")
       Class.forName(clazz.getName)
     })

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -254,7 +254,7 @@ private[server] class NettyModelConversion(
 
   /** Create a Netty streamed response. */
   private def createStreamedResponse(
-      stream: Source[ByteString, _],
+      stream: Source[ByteString, ?],
       httpVersion: HttpVersion,
       responseStatus: HttpResponseStatus
   )(implicit mat: Materializer) = {
@@ -264,7 +264,7 @@ private[server] class NettyModelConversion(
 
   /** Create a Netty chunked response. */
   private def createChunkedResponse(
-      chunks: Source[HttpChunk, _],
+      chunks: Source[HttpChunk, ?],
       httpVersion: HttpVersion,
       responseStatus: HttpResponseStatus
   )(implicit mat: Materializer) = {

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/SynchronousMappedStreams.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/SynchronousMappedStreams.scala
@@ -10,7 +10,7 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
 object SynchronousMappedStreams {
-  private class SynchronousContramappedSubscriber[A, B](subscriber: Subscriber[_ >: B], f: A => B)
+  private class SynchronousContramappedSubscriber[A, B](subscriber: Subscriber[? >: B], f: A => B)
       extends Subscriber[A] {
     override def onError(t: Throwable): Unit        = subscriber.onError(t)
     override def onSubscribe(s: Subscription): Unit = subscriber.onSubscribe(s)
@@ -20,7 +20,7 @@ object SynchronousMappedStreams {
   }
 
   private class SynchronousMappedPublisher[A, B](publisher: Publisher[A], f: A => B) extends Publisher[B] {
-    override def subscribe(s: Subscriber[_ >: B]): Unit =
+    override def subscribe(s: Subscriber[? >: B]): Unit =
       publisher.subscribe(new SynchronousContramappedSubscriber[A, B](s, f))
     override def toString = s"SynchronousMappedPublisher($publisher)"
   }
@@ -30,7 +30,7 @@ object SynchronousMappedStreams {
     override def onSubscribe(s: Subscription): Unit     = subscriber.onSubscribe(s)
     override def onComplete(): Unit                     = subscriber.onComplete()
     override def onNext(t: A): Unit                     = subscriber.onNext(t)
-    override def subscribe(s: Subscriber[_ >: B]): Unit = publisher.subscribe(s)
+    override def subscribe(s: Subscriber[? >: B]): Unit = publisher.subscribe(s)
     override def toString                               = s"JoinedProcessor($subscriber, $publisher)"
   }
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -29,7 +29,7 @@ private[server] object WebSocketHandler {
    * compliant manner.
    */
   def messageFlowToFrameProcessor(
-      flow: Flow[Message, Message, _],
+      flow: Flow[Message, Message, ?],
       bufferLimit: Int,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration

--- a/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
@@ -33,13 +33,13 @@ object WebSocketHandler {
    * See https://github.com/playframework/playframework/issues/7895
    */
   @deprecated("Please specify the subprotocol (or be explicit that you specif None)", "2.7.0")
-  def handleWebSocket(upgrade: UpgradeToWebSocket, flow: Flow[Message, Message, _], bufferLimit: Int): HttpResponse =
+  def handleWebSocket(upgrade: UpgradeToWebSocket, flow: Flow[Message, Message, ?], bufferLimit: Int): HttpResponse =
     handleWebSocket(upgrade, flow, bufferLimit, None)
 
   @deprecated("Please specify the keep-alive mode (ping or pong) and max-idle time", "2.8.19")
   def handleWebSocket(
       upgrade: UpgradeToWebSocket,
-      flow: Flow[Message, Message, _],
+      flow: Flow[Message, Message, ?],
       bufferLimit: Int,
       subprotocol: Option[String]
   ): HttpResponse =
@@ -50,7 +50,7 @@ object WebSocketHandler {
    */
   def handleWebSocket(
       upgrade: UpgradeToWebSocket,
-      flow: Flow[Message, Message, _],
+      flow: Flow[Message, Message, ?],
       bufferLimit: Int,
       subprotocol: Option[String],
       wsKeepAliveMode: String,
@@ -69,7 +69,7 @@ object WebSocketHandler {
    * compliant manner.
    */
   @deprecated("Please specify the keep-alive mode (ping or pong) and max-idle time", "2.8.19")
-  def messageFlowToFrameFlow(flow: Flow[Message, Message, _], bufferLimit: Int): Flow[FrameEvent, FrameEvent, _] =
+  def messageFlowToFrameFlow(flow: Flow[Message, Message, ?], bufferLimit: Int): Flow[FrameEvent, FrameEvent, ?] =
     messageFlowToFrameFlow(flow, bufferLimit, "ping", Duration.Inf)
 
   /**
@@ -79,11 +79,11 @@ object WebSocketHandler {
    * compliant manner.
    */
   def messageFlowToFrameFlow(
-      flow: Flow[Message, Message, _],
+      flow: Flow[Message, Message, ?],
       bufferLimit: Int,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration
-  ): Flow[FrameEvent, FrameEvent, _] = {
+  ): Flow[FrameEvent, FrameEvent, ?] = {
     // Each of the stages here transforms frames to an Either[Message, ?], where Message is a close message indicating
     // some sort of protocol failure. The handleProtocolFailures function then ensures that these messages skip the
     // flow that we are wrapping, are sent to the client and the close procedure is implemented.
@@ -210,7 +210,7 @@ object WebSocketHandler {
    * Handles the protocol failures by gracefully closing the connection.
    */
   private def handleProtocolFailures
-      : Flow[WebSocketFlowHandler.RawMessage, Message, _] => Flow[Either[Message, RawMessage], Message, _] = {
+      : Flow[WebSocketFlowHandler.RawMessage, Message, ?] => Flow[Either[Message, RawMessage], Message, ?] = {
     PekkoStreams.bypassWith(
       Flow[Either[Message, RawMessage]]
         .via(new GraphStage[FlowShape[Either[Message, RawMessage], Either[RawMessage, Message]]] {

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -438,7 +438,7 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
       tryApp: Try[Application],
       request: HttpRequest,
       taggedRequestHeader: RequestHeader,
-      requestBodySource: Either[ByteString, Source[ByteString, _]],
+      requestBodySource: Either[ByteString, Source[ByteString, ?]],
       action: EssentialAction,
       errorHandler: HttpErrorHandler,
       deferredBodyParsingAllowed: Boolean = false
@@ -678,7 +678,7 @@ object PekkoHttpServer extends ServerFromRouter {
       appProvider: ApplicationProvider,
       actorSystem: ActorSystem,
       materializer: Materializer,
-      stopHook: () => Future[_]
+      stopHook: () => Future[?]
   )
 
   object Context {
@@ -689,7 +689,7 @@ object PekkoHttpServer extends ServerFromRouter {
     def fromComponents(
         serverConfig: ServerConfig,
         application: Application,
-        stopHook: () => Future[_] = () => Future.successful(())
+        stopHook: () => Future[?] = () => Future.successful(())
     ): Context =
       PekkoHttpServer.Context(
         config = serverConfig,

--- a/transport/server/play-server/src/main/scala/play/core/server/ServerProvider.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ServerProvider.scala
@@ -47,7 +47,7 @@ object ServerProvider {
       appProvider: ApplicationProvider,
       actorSystem: ActorSystem,
       materializer: Materializer,
-      stopHook: () => Future[_]
+      stopHook: () => Future[?]
   )
 
   /**

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
@@ -53,9 +53,9 @@ object ServerSSLEngine {
       serverConfig: ServerConfig,
       applicationProvider: ApplicationProvider
   ): JavaSSLEngineProvider = {
-    var serverConfigProviderArgsConstructor: Constructor[_] = null
-    var providerArgsConstructor: Constructor[_]             = null
-    var noArgsConstructor: Constructor[_]                   = null
+    var serverConfigProviderArgsConstructor: Constructor[?] = null
+    var providerArgsConstructor: Constructor[?]             = null
+    var noArgsConstructor: Constructor[?]                   = null
     for (constructor <- providerClass.getConstructors) {
       val parameterTypes = constructor.getParameterTypes
       if (parameterTypes.isEmpty) {

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -189,7 +189,7 @@ class CSRFAction(
         .prefixAndTail(0)
         .map(_._2)
         .concatSubstreams
-        .toMat(Sink.head[Source[ByteString, _]])(Keep.right)
+        .toMat(Sink.head[Source[ByteString, ?]])(Keep.right)
     ).mapFuture { validatedBodySource =>
       filterLogger.trace(s"[CSRF] running with validated body source")
       action(request).run(validatedBodySource)
@@ -631,8 +631,8 @@ case class CSRFCheck @Inject() (
                   case body: play.api.mvc.AnyContent if body.asFormUrlEncoded.isDefined => body.asFormUrlEncoded.get
                   case body: play.api.mvc.AnyContent if body.asMultipartFormData.isDefined =>
                     body.asMultipartFormData.get.asFormUrlEncoded
-                  case body: Map[_, _]                         => body.asInstanceOf[Map[String, Seq[String]]]
-                  case body: play.api.mvc.MultipartFormData[_] => body.asFormUrlEncoded
+                  case body: Map[?, ?]                         => body.asInstanceOf[Map[String, Seq[String]]]
+                  case body: play.api.mvc.MultipartFormData[?] => body.asFormUrlEncoded
                   case _                                       => Map.empty[String, Seq[String]]
                 }
                 form.get(config.tokenName).flatMap(_.headOption)

--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -303,7 +303,7 @@ object CSRF {
   }
 
   object ErrorHandler {
-    def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+    def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
       Reflect.bindingsFromConfiguration[
         ErrorHandler,
         CSRFErrorHandler,
@@ -319,7 +319,7 @@ object CSRF {
  * The CSRF module.
  */
 class CSRFModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration): scala.collection.Seq[Binding[_]] =
+  def bindings(environment: Environment, configuration: Configuration): scala.collection.Seq[Binding[?]] =
     Seq(
       bind[play.libs.crypto.CSRFTokenSigner].to(classOf[play.libs.crypto.DefaultCSRFTokenSigner]),
       bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],

--- a/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -72,7 +72,7 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
     }
   }
 
-  private def createGzipFlow: Flow[ByteString, ByteString, _] =
+  private def createGzipFlow: Flow[ByteString, ByteString, ?] =
     GzipFlow.gzip(config.bufferSize, config.compressionLevel)
 
   private def handleResult(request: RequestHeader, result: Result): Future[Result] = {

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSActionBuilderSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSActionBuilderSpec.scala
@@ -17,7 +17,7 @@ class CORSActionBuilderSpec extends CORSCommonSpec {
   implicit val materializer: Materializer = Materializer.matFromSystem(system)
   implicit val ec: ExecutionContext       = play.core.Execution.trampoline
 
-  def withApplication[T](conf: Map[String, _ <: Any] = Map.empty)(block: Application => T): T = {
+  def withApplication[T](conf: Map[String, ? <: Any] = Map.empty)(block: Application => T): T = {
     running(_.routes {
       case (_, "/error") =>
         CORSActionBuilder(Configuration.from(conf).withFallback(Configuration.reference)).apply { req =>
@@ -27,7 +27,7 @@ class CORSActionBuilderSpec extends CORSCommonSpec {
     })(block)
   }
 
-  def withApplicationWithPathConfiguredAction[T](configPath: String, conf: Map[String, _ <: Any] = Map.empty)(
+  def withApplicationWithPathConfiguredAction[T](configPath: String, conf: Map[String, ? <: Any] = Map.empty)(
       block: Application => T
   ): T = {
     val action =

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
@@ -12,7 +12,7 @@ import play.api.test.PlaySpecification
 import play.api.Application
 
 trait CORSCommonSpec extends PlaySpecification {
-  def withApplication[T](conf: Map[String, _ <: Any] = Map.empty)(block: Application => T): T
+  def withApplication[T](conf: Map[String, ? <: Any] = Map.empty)(block: Application => T): T
 
   def mustBeNoAccessControlResponseHeaders(result: Future[Result]) = {
     header(ACCESS_CONTROL_ALLOW_CREDENTIALS, result) must beNone

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
@@ -33,7 +33,7 @@ object CORSFilterSpec {
 }
 
 class CORSFilterSpec extends CORSCommonSpec {
-  def withApplication[T](conf: Map[String, _ <: Any] = Map.empty)(block: Application => T): T = {
+  def withApplication[T](conf: Map[String, ? <: Any] = Map.empty)(block: Application => T): T = {
     running(
       _.configure(conf).overrides(
         bind[Router].to[CorsApplicationRouter],

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
@@ -57,8 +57,8 @@ object CORSWithCSRFSpec {
 
 class CORSWithCSRFSpec extends CORSCommonSpec {
   def withApp[T](
-      filters: Class[_ <: HttpFilters] = classOf[CORSWithCSRFSpec.Filters],
-      conf: Map[String, _ <: Any] = Map()
+      filters: Class[? <: HttpFilters] = classOf[CORSWithCSRFSpec.Filters],
+      conf: Map[String, ? <: Any] = Map()
   )(block: Application => T): T = {
     running(
       _.configure(conf).overrides(
@@ -68,7 +68,7 @@ class CORSWithCSRFSpec extends CORSCommonSpec {
     )(block)
   }
 
-  def withApplication[T](conf: Map[String, _] = Map.empty)(block: Application => T) =
+  def withApplication[T](conf: Map[String, ?] = Map.empty)(block: Application => T) =
     withApp(classOf[CORSWithCSRFSpec.Filters], conf)(block)
 
   private def corsRequest =

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPActionSpec.scala
@@ -31,7 +31,7 @@ class JavaCSPActionSpec extends PlaySpecification {
 
   def javaAction[T: ClassTag](method: String, inv: Http.Request => Result)(implicit app: Application): JavaAction =
     new JavaAction(javaHandlerComponents) {
-      val clazz: Class[_] = implicitly[ClassTag[T]].runtimeClass
+      val clazz: Class[?] = implicitly[ClassTag[T]].runtimeClass
       def parser: BodyParser[Http.RequestBody] =
         HandlerInvokerFactory.javaBodyParserToScala(javaHandlerComponents.getBodyParser(annotations.parser))
       def invocation(req: Http.Request): CompletableFuture[Result] = CompletableFuture.completedFuture(inv(req))

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -36,7 +36,7 @@ class JavaCSPReportSpec extends PlaySpecification {
 
   def javaAction[T: ClassTag](method: String, inv: Http.Request => Result)(implicit app: Application): JavaAction =
     new JavaAction(javaHandlerComponents) {
-      val clazz: Class[_] = implicitly[ClassTag[T]].runtimeClass
+      val clazz: Class[?] = implicitly[ClassTag[T]].runtimeClass
       def parser: play.api.mvc.BodyParser[Http.RequestBody] =
         HandlerInvokerFactory.javaBodyParserToScala(javaHandlerComponents.getBodyParser(annotations.parser))
       def invocation(req: Http.Request): CompletableFuture[Result] = CompletableFuture.completedFuture(inv(req))

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -1124,7 +1124,7 @@ trait FormSpec extends CommonFormSpec {
 
       import play.core.j.PlayFormsMagicForJava._
 
-      def render(form: Form[_], min: Int = 1) =
+      def render(form: Form[?], min: Int = 1) =
         views.html.helper.repeat
           .apply(form("foo"), min) { f =>
             val a = f("a")
@@ -1182,7 +1182,7 @@ trait FormSpec extends CommonFormSpec {
 
       import play.core.j.PlayFormsMagicForJava._
 
-      def render(form: Form[_], min: Int = 1) =
+      def render(form: Form[?], min: Int = 1) =
         views.html.helper.repeatWithIndex
           .apply(form("foo"), min) { (f, i) =>
             val a = f("a")
@@ -1254,7 +1254,7 @@ trait FormSpec extends CommonFormSpec {
         "someFileField[92].member8"     -> null,
         "someFileField[96].member9[98]" -> null,
         "someFileField[96].member9[99]" -> null,
-      ).asJava.asInstanceOf[util.Map[String, Http.MultipartFormData.FilePart[_]]]
+      ).asJava.asInstanceOf[util.Map[String, Http.MultipartFormData.FilePart[?]]]
 
       val form: Form[Object] =
         new Form(null, null, dataPart, filePart, null, Optional.empty[Object](), null, null, null, null, null, null)
@@ -1665,7 +1665,7 @@ object FormSpec {
 
   def dummyMultipartRequest(
       dataParts: Map[String, Array[String]] = Map.empty,
-      fileParts: List[FilePart[_]] = List.empty
+      fileParts: List[FilePart[?]] = List.empty
   ): Request = {
     new RequestBuilder()
       .method("POST")
@@ -1675,7 +1675,7 @@ object FormSpec {
   }
 
   def validatorFactory(): ValidatorFactory = {
-    val validationConfig: vConfiguration[_] =
+    val validationConfig: vConfiguration[?] =
       Validation.byDefaultProvider().configure().messageInterpolator(new ParameterMessageInterpolator())
     validationConfig.buildValidatorFactory()
   }

--- a/web/play-openid/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
@@ -261,7 +261,7 @@ class OpenIDSpec extends Specification {
   }
 
   private def setupMockRequest(queryString: Params = openIdResponse) = {
-    val request = mock(classOf[Request[_]])
+    val request = mock(classOf[Request[?]])
     when(request.queryString).thenReturn(queryString)
     request
   }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose


## Background Context

- Scala 3 compiler report warnings since 3.4 https://github.com/lampepfl/dotty/pull/18813
- Scala 2.12 and 2.13 support new syntax without `-Xsource:3` option https://github.com/scala/scala/pull/10005

## References

- https://scalameta.org/scalafmt/docs/configuration.html#rewritescala3converttonewsyntax
