### PR TITLE
fix warnings with Scala 3.4. avoid `private[this]`

### DIFF
--- a/dev-mode/play-routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/play-routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -35,7 +35,7 @@ class Routes(
     new Routes(errorHandler, @for(dep <- deps){@dep.ident, }prefix)
   @cb
 
-  private[this] val defaultPrefix: String = @ob
+  private val defaultPrefix: String = @ob
     if (this.prefix.endsWith("/")) "" else "/"
   @cb
 
@@ -54,10 +54,10 @@ class Routes(
 @for((dep, index) <- rules.zipWithIndex){@dep.rule match {
 case route @ Route(verb, path, call, comments, modifiers) => {
   @markLines(route)
-  private[this] lazy val @routeIdentifier(route, index) = Route("@verb.value",
+  private lazy val @routeIdentifier(route, index) = Route("@verb.value",
     PathPattern(List(StaticPart(this.prefix)@if(path.parts.nonEmpty) {, StaticPart(this.defaultPrefix), }@path.parts.map(_.toString).mkString(", ")))
   )
-  private[this] lazy val @invokerIdentifier(route, index) = createInvoker(
+  private lazy val @invokerIdentifier(route, index) = createInvoker(
     @if(route.call.passJavaRequest){
     (req:play.mvc.Http.Request) =>
       }@injectedControllerMethodCall(route, dep.ident, p => s"fakeValue[${p.typeNameReal}]"),
@@ -75,7 +75,7 @@ case route @ Route(verb, path, call, comments, modifiers) => {
 }
 case include @ Include(path, router) => {
   @markLines(include)
-  private[this] val prefixed_@(dep.ident)_@(index) = Include(@(dep.ident).withPrefix(this.prefix + (if (this.prefix.endsWith("/")) "" else "/") + "@include.prefix"))
+  private val prefixed_@(dep.ident)_@(index) = Include(@(dep.ident).withPrefix(this.prefix + (if (this.prefix.endsWith("/")) "" else "/") + "@include.prefix"))
 }}}
 
   def routes: PartialFunction[RequestHeader, Handler] = @ob


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose

fix warnings. use `private` instead of `private[this]` in routes-compiler generate code.

## Background Context

- https://github.com/lampepfl/dotty/pull/18819
- https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html

## References
