### PR TITLE
Make clear the evolutions page shows a button

### DIFF
--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -635,6 +635,6 @@ case class InvalidDatabaseRevision(db: String, script: String)
 
   def htmlDescription = {
     <span>An SQL script will be run on your database -</span>
-    <input name="evolution-button" type="button" value="Apply this script now!" onclick={javascript}/>
+    <input name="evolution-button" type="button" value="Click here to apply this script now!" onclick={javascript}/>
   }.mkString
 }


### PR DESCRIPTION
It seems in

* https://github.com/playframework/play-samples/pull/451

the author had a problem figuring out this actually is a button you can click so I want to make sure this is bullet proof for newcomers and add "_Click here..._" to the button's label:

**Old:**
![Screenshot_20240110_120038](https://github.com/playframework/playframework/assets/644927/abaedd4f-dc4e-49af-9a4c-5fe44528a1ed)

**New:**
![Screenshot_20240110_120010](https://github.com/playframework/playframework/assets/644927/dc00f515-93f9-4903-8533-de1b515a2216)
