### PR TITLE
Keep attrs when modifying result

### DIFF
--- a/core/play/src/main/java/play/mvc/Result.java
+++ b/core/play/src/main/java/play/mvc/Result.java
@@ -265,7 +265,7 @@ public class Result {
    */
   public Result withFlash(Flash flash) {
     play.api.mvc.Result.warnFlashingIfNotRedirect(flash.asScala(), header.asScala());
-    return new Result(header, body, session, flash, cookies);
+    return new Result(header, body, session, flash, cookies, attrs);
   }
 
   /**
@@ -356,7 +356,7 @@ public class Result {
    * @return the new result
    */
   public Result withSession(Session session) {
-    return new Result(header, body, session, flash, cookies);
+    return new Result(header, body, session, flash, cookies, attrs);
   }
 
   /**
@@ -471,7 +471,7 @@ public class Result {
                         }),
                 Stream.of(newCookies))
             .collect(Collectors.toList());
-    return new Result(header, body, session, flash, finalCookies);
+    return new Result(header, body, session, flash, finalCookies, attrs);
   }
 
   /**
@@ -546,7 +546,7 @@ public class Result {
    * @return the transformed copy
    */
   public Result withHeader(String name, String value) {
-    return new Result(header.withHeader(name, value), body, session, flash, cookies);
+    return new Result(header.withHeader(name, value), body, session, flash, cookies, attrs);
   }
 
   /**
@@ -560,7 +560,7 @@ public class Result {
    */
   public Result withHeaders(String... nameValues) {
     return new Result(
-        JavaResultExtractor.withHeader(header, nameValues), body, session, flash, cookies);
+        JavaResultExtractor.withHeader(header, nameValues), body, session, flash, cookies, attrs);
   }
 
   /**
@@ -570,7 +570,7 @@ public class Result {
    * @return the transformed copy
    */
   public Result withoutHeader(String name) {
-    return new Result(header.withoutHeader(name), body, session, flash, cookies);
+    return new Result(header.withoutHeader(name), body, session, flash, cookies, attrs);
   }
 
   /**
@@ -580,7 +580,7 @@ public class Result {
    * @return the transformed copy
    */
   public Result as(String contentType) {
-    return new Result(header, body.as(contentType), session, flash, cookies);
+    return new Result(header, body.as(contentType), session, flash, cookies, attrs);
   }
 
   /**

--- a/core/play/src/test/java/play/mvc/ResultsTest.java
+++ b/core/play/src/test/java/play/mvc/ResultsTest.java
@@ -19,6 +19,9 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.junit.*;
+import play.libs.typedmap.TypedEntry;
+import play.libs.typedmap.TypedKey;
+import play.libs.typedmap.TypedMap;
 import play.mvc.Http.HeaderNames;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
@@ -407,4 +410,59 @@ public class ResultsTest {
     assertTrue(result.redirectLocation().get().contains(expectedParam1));
     assertTrue(result.redirectLocation().get().contains(expectedParam2));
   }
+
+  @Test
+  public void canAddAttributes() {
+    TypedKey<String> x = TypedKey.create("x");
+    TypedMap attrs = TypedMap.create(new TypedEntry<>(x, "y"));
+    Result result = Results.ok().withAttrs(attrs);
+    assertTrue(result.attrs().containsKey(x));
+    assertEquals("y", result.attrs().get(x));
+  }
+
+  @Test
+  public void keepAttributesWhenModifyingHeader() {
+    TypedKey<String> x = TypedKey.create("x");
+    TypedMap attrs = TypedMap.create(new TypedEntry<>(x, "y"));
+
+    Result a = Results.ok().withAttrs(attrs).withHeader("foo", "bar");
+    assertTrue(a.attrs().containsKey(x));
+    assertEquals("y", a.attrs().get(x));
+
+    Result b = Results.ok().withAttrs(attrs).withHeaders("foo", "bar");
+    assertTrue(b.attrs().containsKey(x));
+    assertEquals("y", b.attrs().get(x));
+
+    Result c = Results.ok().withAttrs(attrs).withoutHeader("foo");
+    assertTrue(c.attrs().containsKey(x));
+    assertEquals("y", c.attrs().get(x));
+  }
+
+  @Test
+  public void keepAttributesWhenModifyingFlash() {
+    TypedKey<String> x = TypedKey.create("x");
+    TypedMap attrs = TypedMap.create(new TypedEntry<>(x, "y"));
+    Result result = Results.redirect("/").withAttrs(attrs).withFlash(new Http.Flash(Map.of("foo", "bar")));
+    assertTrue(result.attrs().containsKey(x));
+    assertEquals("y", result.attrs().get(x));
+  }
+
+  @Test
+  public void keepAttributesWhenModifyingSession() {
+    TypedKey<String> x = TypedKey.create("x");
+    TypedMap attrs = TypedMap.create(new TypedEntry<>(x, "y"));
+    Result result = Results.ok().withAttrs(attrs).withSession(new Http.Session(Map.of("foo", "bar")));
+    assertTrue(result.attrs().containsKey(x));
+    assertEquals("y", result.attrs().get(x));
+  }
+
+  @Test
+  public void keepAttributesWhenModifyingContentType() {
+    TypedKey<String> x = TypedKey.create("x");
+    TypedMap attrs = TypedMap.create(new TypedEntry<>(x, "y"));
+    Result result = Results.ok().withAttrs(attrs).as(Http.MimeTypes.TEXT);
+    assertTrue(result.attrs().containsKey(x));
+    assertEquals("y", result.attrs().get(x));
+  }
+
 }

--- a/core/play/src/test/java/play/mvc/ResultsTest.java
+++ b/core/play/src/test/java/play/mvc/ResultsTest.java
@@ -442,7 +442,8 @@ public class ResultsTest {
   public void keepAttributesWhenModifyingFlash() {
     TypedKey<String> x = TypedKey.create("x");
     TypedMap attrs = TypedMap.create(new TypedEntry<>(x, "y"));
-    Result result = Results.redirect("/").withAttrs(attrs).withFlash(new Http.Flash(Map.of("foo", "bar")));
+    Result result =
+        Results.redirect("/").withAttrs(attrs).withFlash(new Http.Flash(Map.of("foo", "bar")));
     assertTrue(result.attrs().containsKey(x));
     assertEquals("y", result.attrs().get(x));
   }
@@ -451,7 +452,8 @@ public class ResultsTest {
   public void keepAttributesWhenModifyingSession() {
     TypedKey<String> x = TypedKey.create("x");
     TypedMap attrs = TypedMap.create(new TypedEntry<>(x, "y"));
-    Result result = Results.ok().withAttrs(attrs).withSession(new Http.Session(Map.of("foo", "bar")));
+    Result result =
+        Results.ok().withAttrs(attrs).withSession(new Http.Session(Map.of("foo", "bar")));
     assertTrue(result.attrs().containsKey(x));
     assertEquals("y", result.attrs().get(x));
   }
@@ -464,5 +466,4 @@ public class ResultsTest {
     assertTrue(result.attrs().containsKey(x));
     assertEquals("y", result.attrs().get(x));
   }
-
 }

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -515,6 +515,23 @@ class ResultsSpec extends Specification {
         val x = TypedKey[Int]("x")
         Results.Ok.addAttr(x, 3).asJava.attrs().get(x.asJava) must_== 3
       }
+      "keep current attributes when modifying result session" in {
+        val x = TypedKey[Int]("x")
+        Results.Ok.addAttr(x, 3).withSession("Foo" -> "Bar").attrs.get(x) must beSome(3)
+      }
+      "keep current attributes when modifying result headers" in {
+        val x = TypedKey[Int]("x")
+        Results.Ok.addAttr(x, 3).withHeaders("Foo" -> "Bar").attrs.get(x) must beSome(3)
+        Results.Ok.addAttr(x, 3).discardingHeader("Foo").attrs.get(x) must beSome(3)
+      }
+      "keep current attributes when modifying result flash" in {
+        val x = TypedKey[Int]("x")
+        Results.Ok.addAttr(x, 3).flashing("Foo" -> "Bar").attrs.get(x) must beSome(3)
+      }
+      "keep current attributes when modifying result content type" in {
+        val x = TypedKey[Int]("x")
+        Results.Ok.addAttr(x, 3).as(ContentTypes.TEXT).attrs.get(x) must beSome(3)
+      }
     }
   }
 }


### PR DESCRIPTION
## Fixes

Fixes #12333 

## Purpose

Currently, when modifying a `Result` in Java, the result's `attrs` are lost due to them not being copied. This PR fixes this by also copying the `attrs` to the new `Result` when modifying flash, session, content type, or headers.

The issue only existed in the Java API. Tests have been added to check for the bug in both Java and Scala.

