### PR TITLE
[2.9.x] `sbt-akka-version-check` now hosted on maven central

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,7 +33,7 @@ addSbtPlugin("de.heikoseeberger"  % "sbt-header"            % sbtHeader)
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"          % scalafmt)
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release"        % "1.5.12")
 
-addSbtPlugin("com.lightbend.akka" % "sbt-akka-version-check" % "0.1")
+addSbtPlugin("com.markatta" % "sbt-akka-version-check" % "0.2")
 
 libraryDependencies ++= Seq(
   "org.webjars" % "webjars-locator-core" % webjarsLocatorCore


### PR DESCRIPTION
Finally, all our dependencies for Play 2.9 and Play 3.0 are now hosted on Maven Central. Bye bye custom repos like https://repo.scala-sbt.org/ (cough cough https://github.com/sbt/sbt/issues/7202)

* https://github.com/johanandren/sbt-akka-version-check/pull/2
* https://github.com/johanandren/sbt-akka-version-check/releases/tag/v0.2
* https://github.com/johanandren/sbt-akka-version-check/commit/623017edb047435b3a587e2db8b5a9c2682d69d9
* https://repo1.maven.org/maven2/com/markatta/sbt-akka-version-check_2.12_1.0/0.2/sbt-akka-version-check-0.2.pom