### PR TITLE
Upgrade sbt-web plugins (to avoid repo.scala-sbt.org)

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-less"           % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-less"           % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-less"           % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-less"           % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-less"           % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-less"           % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-less"           % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-less"           % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/plugins.sbt
@@ -3,3 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt"    % "sbt-less"           % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation-with-request-passed/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-mocha"          % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-mocha"          % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-mocha"          % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-mocha"          % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-namespace-reverse-router/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-mocha"          % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-mocha"          % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-no-package-declaration-in-routes-file/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-mocha"          % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-mocha"          % "2.0.1")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/project/plugins.sbt
@@ -3,4 +3,4 @@
 updateOptions                   := updateOptions.value.withLatestSnapshots(false)
 addSbtPlugin("org.playframework" % "sbt-plugin"         % sys.props("project.version"))
 addSbtPlugin("org.playframework" % "sbt-scripted-tools" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.sbt"  % "sbt-mocha"          % "1.1.2")
+addSbtPlugin("com.github.sbt"    % "sbt-mocha"          % "2.0.1")

--- a/documentation/manual/working/commonGuide/assets/AssetsCoffeeScript.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsCoffeeScript.md
@@ -34,7 +34,7 @@ You can use the following syntax to use the compiled JavaScript file in your tem
 CoffeeScript compilation is enabled by simply adding the plugin to your plugins.sbt file when using the `PlayJava` or `PlayScala` plugins:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-coffeescript" % "2.0.1")
 ```
 
 The plugin's default configuration is normally sufficient. However please refer to the [plugin's documentation](https://github.com/sbt/sbt-coffeescript#sbt-coffeescript) for information on how it may be configured.

--- a/documentation/manual/working/commonGuide/assets/AssetsJSHint.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsJSHint.md
@@ -17,7 +17,7 @@ JavaScript code is compiled during the `assets` command as well as when the brow
 JSHint processing is enabled by simply adding the plugin to your plugins.sbt file when using the `PlayJava` or `PlayScala` plugins:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-jshint" % "1.0.6")
+addSbtPlugin("com.github.sbt" % "sbt-jshint" % "2.0.1")
 ```
 
 The plugin's default configuration is normally sufficient. However please refer to the [plugin's documentation](https://github.com/sbt/sbt-jshint#sbt-jshint) for information on how it may be configured.

--- a/documentation/manual/working/commonGuide/assets/AssetsLess.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsLess.md
@@ -85,7 +85,7 @@ h1 {
 LESS compilation is enabled by simply adding the plugin to your plugins.sbt file when using the `PlayJava` or `PlayScala` plugins:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
+addSbtPlugin("com.github.sbt" % "sbt-less" % "2.0.1")
 ```
 
 The plugin's default configuration is normally sufficient. However please refer to the [plugin's documentation](https://github.com/sbt/sbt-less#sbt-less) for information on how it may be configured.

--- a/documentation/manual/working/commonGuide/assets/RequireJS-support.md
+++ b/documentation/manual/working/commonGuide/assets/RequireJS-support.md
@@ -21,7 +21,7 @@ If you're using WebJars with your build then the RequireJS optimizer plugin will
 RequireJS optimization is enabled by simply adding the plugin to your plugins.sbt file when using the `PlayJava` or `PlayScala` plugins:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.9")
+addSbtPlugin("com.github.sbt" % "sbt-rjs" % "2.0.0")
 ```
 
 To add the plugin to the asset pipeline you can declare it as follows (assuming just the one plugin for the pipeline - add others into the sequence such as digest and gzip as required):


### PR DESCRIPTION
- https://github.com/sbt/sbt-less/releases/tag/2.0.0
- https://github.com/sbt/sbt-digest/releases/tag/2.0.0
- https://github.com/sbt/sbt-gzip/releases/tag/2.0.0
- https://github.com/sbt/sbt-coffeescript/releases/tag/2.0.0
- https://github.com/sbt/sbt-jshint/releases/tag/2.0.0

TODO:
- [x] https://github.com/sbt/sbt-mocha/releases/tag/2.0.0
- [x] https://github.com/sbt/sbt-rjs/releases/tag/2.0.0

They all uses latest sbt-web 1.5 / sbt-js-engine 1.3.x now, but most importantly are now hosted on maven central intead of deprecated https://repo.scala-sbt.org/ (see https://github.com/sbt/sbt/issues/7202).

Only relevant for documentation and scripted tests (meaning if repo.scala-sbt.org goes down we can still successfully run our tests :wink:)