### PR TITLE
Improve getTestServerIfRunning

### DIFF
--- a/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -22,13 +22,7 @@ case class TestServer(config: ServerConfig, application: Application, serverProv
   private var testServerProcess: TestServerProcess = _
   private[test] var server: Server                 = _
 
-  private def getTestServerIfRunning: Server = {
-    val s = server
-    if (s == null) {
-      throw new IllegalStateException("Test server not running")
-    }
-    s
-  }
+  private def getTestServer: Option[Server] = Option(server)
 
   /**
    * Starts this server.
@@ -71,17 +65,23 @@ case class TestServer(config: ServerConfig, application: Application, serverProv
   /**
    * The address that the server is running on.
    */
-  def runningAddress: String = getTestServerIfRunning.mainAddress.getAddress.getHostAddress
+  def runningAddress: String = {
+    val server = getTestServer.getOrElse {
+      throw new IllegalStateException("Test server not running")
+    }
+
+    server.mainAddress.getAddress.getHostAddress
+  }
 
   /**
    * The HTTP port that the server is running on.
    */
-  def runningHttpPort: Option[Int] = getTestServerIfRunning.httpPort
+  def runningHttpPort: Option[Int] = getTestServer.flatMap(_.httpPort)
 
   /**
    * The HTTPS port that the server is running on.
    */
-  def runningHttpsPort: Option[Int] = getTestServerIfRunning.httpsPort
+  def runningHttpsPort: Option[Int] = getTestServer.flatMap(_.httpsPort)
 
   /**
    * True if the server is running either on HTTP or HTTPS port.


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes https://github.com/playframework/playframework/issues/12331

## Purpose

Improve the interface of TestServer. Currently, if a TestServer doesn't exist, a few functions raise an exception.

Those functions should have return `None` (e.g. `def runningHttpPort: Option[Int]`) or `false` (e.g. `def isRunning: Boolean`) instead of raising an exception.

