### PR TITLE
Fix #8184 Evolutions Fail With a Small Pool

### DIFF
--- a/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/persistence/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -333,10 +333,10 @@ class DatabaseEvolutions(
    * Read evolutions from the database.
    */
   def databaseEvolutions(): Seq[Evolution] = {
+    checkEvolutionsState()
     implicit val connection = database.getConnection(autocommit = true)
 
     try {
-      checkEvolutionsState()
       executeQuery(
         "select id, hash, apply_script, revert_script from ${schema}${evolutions_table} order by id"
       ) { rs =>
@@ -405,11 +405,10 @@ class DatabaseEvolutions(
       }
     }
 
-    implicit val connection = database.getConnection(autocommit = autocommit)
     checkEvolutionsState()
-
-    var applying           = -1
-    var lastScript: Script = null
+    implicit val connection = database.getConnection(autocommit = autocommit)
+    var applying            = -1
+    var lastScript: Script  = null
 
     try {
       scripts.foreach { script =>


### PR DESCRIPTION
Fixes #8184

Check evolution state before acquiring the connection to actually perform the evolution operation. Previously, the connection to perform the actual operation was acquired before checking, requiring 2 simultaneous connections. This approach requires only a single connection.

Alternatively, `checkEvolutionsState` could be modified to take a current connection, but this would require more code changes to make sure autocommit is handled, and not all callsites have an open connection to use. Practically, Hikari will just reuse the same connection for both, so calling getConnection twice should not be expensive.

I modified the test suite to default to a single connection to make sure this was tested. Unfortunately, this required tweaking many checks, as the test suite itself  opened a connection without closing it, causing a deadlock from the test code.
