### PR TITLE
Explicitly depend on `netty-reactive-streams-http` transitive dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -172,6 +172,8 @@ object Dependencies {
 
   val netty = Seq(
     "org.playframework.netty" % "netty-reactive-streams-http"  % "3.0.2",
+    "io.netty"                % "netty-codec-http"             % nettyVersion, // increases transitive Netty dependency version ...
+    "io.netty"                % "netty-handler"                % nettyVersion, // ... pulled in by netty-reactive-streams-http
     ("io.netty"               % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
   ) ++ specs2Deps.map(_ % Test)
 


### PR DESCRIPTION
This avoids that we have to cut a new `netty-reactive-streams[-http]` release each time we upgrade netty... which is a bit annoying... Also this approach here is a bit safer IMHO, in case we forget to cut a new `netty-reactive-streams[-http]` release but upgrade netty in the dependencies only and ship mixed dependencies.

* `netty-reactive-streams-http` depends on `netty-reactive-streams`: https://github.com/playframework/netty-reactive-streams/blob/netty-reactive-streams-parent-3.0.2/netty-reactive-streams-http/pom.xml#L17-L21
* `netty-reactive-streams-http` pulls in `netty-codec-http`: https://github.com/playframework/netty-reactive-streams/blob/netty-reactive-streams-parent-3.0.2/netty-reactive-streams-http/pom.xml#L22-L25
* `netty-reactive-streams` pulls in `netty-handler`: https://github.com/playframework/netty-reactive-streams/blob/netty-reactive-streams-parent-3.0.2/netty-reactive-streams/pom.xml#L17-L20

I also checked locally running `show runtime:fullClasspath` in sbt.