### PR TITLE
`TestServer.isRunning` should not throw exception but return `false`

### DIFF
--- a/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -87,7 +87,7 @@ case class TestServer(config: ServerConfig, application: Application, serverProv
    * True if the server is running either on HTTP or HTTPS port.
    */
   @ApiMayChange
-  def isRunning: Boolean = runningHttpPort.nonEmpty || runningHttpsPort.nonEmpty
+  def isRunning: Boolean = server != null && (runningHttpPort.nonEmpty || runningHttpsPort.nonEmpty)
 }
 
 object TestServer {


### PR DESCRIPTION
- Fixes #12331

This is an alternative, less intervening PR to
- #12352