### PR TITLE
Fix typo in docs

### DIFF
--- a/documentation/manual/gettingStarted/LearningExamples.md
+++ b/documentation/manual/gettingStarted/LearningExamples.md
@@ -2,7 +2,7 @@
 
 # Learning from Play Examples
 
-The [play-samples GitHub repository](https://github.com/playframework/play-samples) offers Play examples for Java and Scala. Play has many features, so rather than pack them all into one project, we've organized many examples that each showcase a Play feature or demonstrate a common use case. Make sure you have verified the [[requirements for running Play|Requirements]]. You can either clone the [play-samples GitHub repository](https://github.com/playframework/play-samples) or download its contents [as zip file](https://github.com/playframework/play-samples/archive/refs/heads/3.0.x.zip). Refer to the `README.md` file within each sample project directory to learn more about the example.
+The [play-samples GitHub repository](https://github.com/playframework/play-samples/tree/3.0.x) offers Play examples for Java and Scala. Play has many features, so rather than pack them all into one project, we've organized many examples that each showcase a Play feature or demonstrate a common use case. Make sure you have verified the [[requirements for running Play|Requirements]]. You can either clone the [play-samples GitHub repository](https://github.com/playframework/play-samples) or download its contents [as zip file](https://github.com/playframework/play-samples/archive/refs/heads/3.0.x.zip). Refer to the `README.md` file within each sample project directory to learn more about the example.
 
 > **Note**: The example projects are not configured for out of the box security.
 
@@ -11,4 +11,4 @@ If you are new to Play, we recommend following the Hello World tutorial for Java
 1. [Play Java Hello World](https://github.com/playframework/play-samples/tree/3.0.x/play-java-hello-world-tutorial)
 2. [Play Scala Hello World](https://github.com/playframework/play-samples/tree/3.0.x/play-scala-hello-world-tutorial)
 
-> **Note**: When you run the tutorial application, it displays web pages with the same content and instructions contained in this documentation. The tutorial includes a deliberate mistake and having the [[the documentation|HelloWorldTutorial]] and application pages open in different tabs or browsers allows you to consult the documentation for the fix when you encounter the error. 
+> **Note**: When you run the tutorial application, it displays web pages with the same content and instructions contained in this documentation. The tutorial includes a deliberate mistake and having the [[documentation|HelloWorldTutorial]] and application pages open in different tabs or browsers allows you to consult the documentation for the fix when you encounter the error. 


### PR DESCRIPTION
`the` twice

- backport: #12412