### PR TITLE
Update ActorModule documentation

### DIFF
--- a/core/play-guice/src/main/scala/play/api/libs/concurrent/ActorModule.scala
+++ b/core/play-guice/src/main/scala/play/api/libs/concurrent/ActorModule.scala
@@ -31,7 +31,7 @@ import org.apache.pekko.annotation.ApiMayChange
  *
  *   final class AppModule extends AbstractModule with PekkoGuiceSupport {
  *     override def configure() = {
- *       bindTypedActor(classOf[ConfiguredActor], "configured-actor")
+ *       bindTypedActor(ConfiguredActor, "configured-actor")
  *     }
  *   }
  * }}}


### PR DESCRIPTION
The example provided does not compile as `ConfiguredActor` is an object, not a class, thus cannot be instanciated.