### PR TITLE
[2.8.x] scala-steward: pin dependencies

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -46,7 +46,36 @@ updates.pin = [
   // See https://github.com/playframework/playframework/pull/10616#issuecomment-758273638
   { groupId = "org.hibernate.validator", artifactId = "hibernate-validator", version = "6." },
   // Spring 6 requires Java 17
-  { groupId = "org.springframework", artifactId = "spring-core", version = "5." }
+  { groupId = "org.springframework", artifactId = "spring-core", version = "5.2." },
+  // We don't upgrade following libraries anymore in Play 2.8
+  { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.2." },
+  { groupId = "com.typesafe.netty", artifactId = "netty-reactive-streams-http", version = "2.0." },
+  { groupId = "com.typesafe.play", artifactId = "play-json", version = "2.8." },
+  { groupId = "com.typesafe.sbt", artifactId = "sbt-web", version = "1.4." },
+  { groupId = "io.jsonwebtoken", artifactId = "jjwt", version = "0.9." },
+  { groupId = "joda-time", artifactId = "joda-time", version = "2.10." },
+  { groupId = "org.seleniumhq.selenium", artifactId = "selenium-api", version = "3.141." },
+  { groupId = "org.slf4j", artifactId = "jcl-over-slf4j", version = "1.7." },
+  { groupId = "org.slf4j", artifactId = "jul-to-slf4j", version = "1.7." },
+  { groupId = "org.slf4j", artifactId = "slf4j-api", version = "1.7." },
+  { groupId = "org.slf4j", artifactId = "slf4j-simple", version = "1.7." },
+  { groupId = "org.specs2", artifactId = "specs2-core", version = "4.8." },
+  { groupId = "org.specs2", artifactId = "specs2-junit", version = "4.8." },
+  { groupId = "org.specs2", artifactId = "specs2-matcher-extra", version = "4.8." },
+  { groupId = "org.specs2", artifactId = "specs2-mock", version = "4.8." },
+  { groupId = "org.specs2", artifactId = "specs2-scalacheck", version = "4.8." },
+  { groupId = "pl.project13.scala", artifactId = "sbt-jmh", version = "0.3." },
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1.3." },
+  { groupId = "com.typesafe.sbteclipse", artifactId = "sbteclipse-plugin", version = "5.2." },
+  { groupId = "com.google.guava", artifactId = "guava", version = "30.1." },
+  { groupId = "com.typesafe.play", artifactId = "shaded-asynchttpclient", version = "2.1." },
+  { groupId = "com.typesafe.play", artifactId = "shaded-oauth", version = "2.1." },
+  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.11." },
+  { groupId = "org.webjars", artifactId = "webjars-locator-core", version = "0.43" },
+  { groupId = "org.apache.derby", artifactId = "derby", version = "10.13.1." },
+  { groupId = "com.zaxxer", artifactId = "HikariCP", version = "3.4." },
+  { groupId = "com.lightbend.sbt", artifactId = "sbt-javaagent", version = "0.1." },
+  { groupId = "com.typesafe.sbt", artifactId = "sbt-js-engine", version = "1.2." }
 ]
 
 updatePullRequests = never


### PR DESCRIPTION
In 2.8 we only allow patch upgrades anymore.
If something important we can do it by hand.