### PR TITLE
derby, derbytools 10.16.1.1 (was 10.15.2.0)

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -37,6 +37,9 @@ updates.ignore = [
 ]
 
 updates.pin = [
+  // Apache Derby 10.17.x requires Java 21: https://lists.apache.org/thread/vjl42y0p86c7lh7lsm3bfth6dx83nhb8
+  { groupId = "org.apache.derby", artifactId = "derby", version = "10.16." },
+  { groupId = "org.apache.derby", artifactId = "derbytools", version = "10.16." }
   //{ groupId = "org.apache.pekko", artifactId = "pekko-actor", version = "1.0." },
   //{ groupId = "org.apache.pekko", artifactId = "pekko-http-core", version = "1.0." },
   //{ groupId = "org.hibernate.validator", artifactId = "hibernate-validator", version = "6." },

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
 
   val h2database = "com.h2database" % "h2" % "2.2.224"
 
-  val derbyVersion = "10.15.2.0"
+  val derbyVersion = "10.16.1.1"
   val derbyDatabase = Seq(
     "org.apache.derby" % "derby",
     "org.apache.derby" % "derbytools"


### PR DESCRIPTION
Replaces
- #12130

Can't merge
- #12218

yet because it requires JDK 21 already... pinning in scala steward conf