### PR TITLE
Jackson 2.15.4 (was 2.14.3)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
     "org.scalacheck" %% "scalacheck"        % "1.17.0"      % Test
   )
 
-  val jacksonVersion  = "2.14.3"
+  val jacksonVersion  = "2.15.4"
   val jacksonDatabind = Seq("com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion)
   val jacksons = Seq(
     "com.fasterxml.jackson.core"     % "jackson-core",


### PR DESCRIPTION
Step by step.

Akka bumped already, seems everything went smoothly:
- https://github.com/akka/akka/pull/32086
- Pekko main branch already on 2.16, planned to have that in Pekko 1.1.0: https://github.com/apache/incubator-pekko/pull/564
  - Need to take a closer look what changed here, if we need to do something

Upgrade to 2.16 will be done in:
- #12296