### PR TITLE
Enable Websocket compression for Netty

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -27,6 +27,7 @@ import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.channel.socket.SocketChannel
 import io.netty.handler.codec.http._
 import io.netty.handler.codec.http.websocketx._
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler
 import io.netty.util.ReferenceCountUtil
 import org.apache.pekko.stream.scaladsl._
 import org.apache.pekko.stream.stage._
@@ -52,7 +53,12 @@ trait WebSocketClient {
    *
    * @return A future that will be redeemed when the connection is closed.
    */
-  def connect(url: URI, version: WebSocketVersion = WebSocketVersion.V13, subprotocol: Option[String] = None)(
+  def connect(
+      url: URI,
+      version: WebSocketVersion = WebSocketVersion.V13,
+      subprotocol: Option[String] = None,
+      compressionMode: WebSocketClient.CompressionMode = WebSocketClient.CompressionMode.Disabled
+  )(
       onConnect: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
   ): Future[?]
 
@@ -73,6 +79,15 @@ object WebSocketClient {
   }
   case class SimpleMessage(message: Message, finalFragment: Boolean)       extends ExtendedMessage
   case class ContinuationMessage(data: ByteString, finalFragment: Boolean) extends ExtendedMessage
+  case class RawWebSocketFrame(frameType: String, data: ByteString, rsv: Int, finalFragment: Boolean)
+      extends ExtendedMessage
+
+  sealed trait CompressionMode
+  object CompressionMode {
+    case object Disabled                           extends CompressionMode
+    case class Enabled(maxAllocation: Int = 65536) extends CompressionMode
+    case object RequestOnly                        extends CompressionMode
+  }
 
   def create(): WebSocketClient = new DefaultWebSocketClient
 
@@ -116,7 +131,7 @@ object WebSocketClient {
     /**
      * Connect to the given URI
      */
-    def connect(url: URI, version: WebSocketVersion, subprotocol: Option[String])(
+    def connect(url: URI, version: WebSocketVersion, subprotocol: Option[String], compressionMode: CompressionMode)(
         onConnected: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
     ): Future[?] = {
       val normalized = url.normalize()
@@ -130,12 +145,23 @@ object WebSocketClient {
         .connect(tgt.getHost, tgt.getPort)
         .toScala
         .map { channel =>
+          compressionMode match {
+            case CompressionMode.Enabled(maxAllocation) =>
+              channel.pipeline().addLast("ws-compressor", new WebSocketClientCompressionHandler(maxAllocation))
+            case CompressionMode.Disabled | CompressionMode.RequestOnly =>
+          }
+
+          val headers = new DefaultHttpHeaders()
+          if (compressionMode == CompressionMode.RequestOnly) {
+            headers.add(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, "permessage-deflate")
+          }
+
           val handshaker = WebSocketClientHandshakerFactory.newHandshaker(
             tgt,
             version,
             subprotocol.orNull,
-            false,
-            new DefaultHttpHeaders()
+            compressionMode != CompressionMode.Disabled,
+            headers
           )
           channel.pipeline().addLast("supervisor", new WebSocketSupervisor(disconnected, handshaker, onConnected))
           handshaker.handshake(channel)
@@ -233,6 +259,17 @@ object WebSocketClient {
 
       val framesToMessages = Flow[WebSocketFrame].map { frame =>
         val message = frame match {
+          case text: TextWebSocketFrame if text.rsv() != 0 =>
+            RawWebSocketFrame("text", toByteString(text), text.rsv(), text.isFinalFragment)
+          case binary: BinaryWebSocketFrame if binary.rsv() != 0 =>
+            RawWebSocketFrame("binary", toByteString(binary), binary.rsv(), binary.isFinalFragment)
+          case continuation: ContinuationWebSocketFrame if continuation.rsv() != 0 =>
+            RawWebSocketFrame(
+              "continuation",
+              toByteString(continuation),
+              continuation.rsv(),
+              continuation.isFinalFragment
+            )
           case text: TextWebSocketFrame     => SimpleMessage(TextMessage(text.text()), text.isFinalFragment)
           case binary: BinaryWebSocketFrame =>
             SimpleMessage(BinaryMessage(toByteString(binary)), binary.isFinalFragment)

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -84,9 +84,9 @@ object WebSocketClient {
 
   sealed trait CompressionMode
   object CompressionMode {
-    case object Disabled                           extends CompressionMode
-    case class Enabled(maxAllocation: Int = 65536) extends CompressionMode
-    case object RequestOnly                        extends CompressionMode
+    case object Disabled                                              extends CompressionMode
+    case class Enabled(maxAllocation: Int = 65536)                    extends CompressionMode
+    case class RequestOnly(extensions: String = "permessage-deflate") extends CompressionMode
   }
 
   def create(): WebSocketClient = new DefaultWebSocketClient
@@ -148,12 +148,14 @@ object WebSocketClient {
           compressionMode match {
             case CompressionMode.Enabled(maxAllocation) =>
               channel.pipeline().addLast("ws-compressor", new WebSocketClientCompressionHandler(maxAllocation))
-            case CompressionMode.Disabled | CompressionMode.RequestOnly =>
+            case CompressionMode.Disabled | _: CompressionMode.RequestOnly =>
           }
 
           val headers = new DefaultHttpHeaders()
-          if (compressionMode == CompressionMode.RequestOnly) {
-            headers.add(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, "permessage-deflate")
+          compressionMode match {
+            case CompressionMode.RequestOnly(extensions) =>
+              headers.add(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, extensions)
+            case CompressionMode.Disabled | _: CompressionMode.Enabled =>
           }
 
           val handshaker = WebSocketClientHandshakerFactory.newHandshaker(

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -40,11 +40,83 @@ import play.api.test._
 import play.api.Application
 import play.api.Configuration
 import play.it._
+import play.it.http.websocket.WebSocketClient.CompressionMode
 import play.it.http.websocket.WebSocketClient.ContinuationMessage
 import play.it.http.websocket.WebSocketClient.ExtendedMessage
+import play.it.http.websocket.WebSocketClient.RawWebSocketFrame
 import play.it.http.websocket.WebSocketClient.SimpleMessage
 
-class NettyWebSocketSpec     extends WebSocketSpec with NettyIntegrationSpecification
+class NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecification {
+  "Plays WebSockets using netty backend with compression" should {
+    "negotiate permessage-deflate" in {
+      withServer(app =>
+        WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) }
+      ) { (app, port) =>
+        import app.materializer
+        val (_, headers) = runWebSocket(
+          port,
+          { flow =>
+            Source.empty[ExtendedMessage].via(flow).runWith(Sink.ignore)
+            Future.successful(())
+          },
+          subprotocol = None,
+          handleConnect = c => c,
+          compressionMode = CompressionMode.Enabled()
+        )
+
+        headers.collectFirst {
+          case (name, value) if name.equalsIgnoreCase("Sec-WebSocket-Extensions") => value
+        } must beSome(contain("permessage-deflate"))
+      }
+    }
+
+    "decompress inbound permessage-deflate frames before passing them to the application" in {
+      val consumed = Promise[List[String]]()
+      withServer(app =>
+        WebSocket.accept[String, String] { req =>
+          Flow.fromSinkAndSource(onFramesConsumed[String](consumed.success(_)), Source.maybe[String])
+        }
+      ) { (app, port) =>
+        import app.materializer
+        val result = runWebSocket(
+          port,
+          { flow =>
+            sendFrames(
+              TextMessage("compressed client message"),
+              CloseMessage(1000)
+            ).via(flow).runWith(Sink.ignore)
+            consumed.future
+          },
+          compressionMode = CompressionMode.Enabled()
+        )
+
+        result must_== Seq("compressed client message")
+      }
+    }
+
+    "compress outbound permessage-deflate frames sent by the application" in {
+      withServer(app =>
+        WebSocket.accept[String, String] { req =>
+          Flow.fromSinkAndSource(Sink.ignore, Source.single("compressed server message"))
+        }
+      ) { (app, port) =>
+        import app.materializer
+        val frames = runWebSocket(
+          port,
+          { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+          compressionMode = CompressionMode.RequestOnly
+        )
+
+        frames.collectFirst {
+          case RawWebSocketFrame("text", data, rsv, true) => (data, rsv)
+        } must beSome[(ByteString, Int)].which {
+          case (data, rsv) =>
+            data.nonEmpty && (rsv & 4) == 4
+        }
+      }
+    }
+  }
+}
 class PekkoHttpWebSocketSpec extends WebSocketSpec with PekkoHttpIntegrationSpecification {
   "Plays WebSockets using pekko-http backend with HTTP2 enabled" should {
     "time out after play.server.http.idleTimeout" in delayedSend(
@@ -391,7 +463,8 @@ trait WebSocketSpec
               sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
             },
             Some("my_crazy_subprotocol"),
-            c => c
+            c => c,
+            CompressionMode.Disabled
           )
           (headers
             .map { case (key, value) => (key.toLowerCase, value) }
@@ -411,7 +484,8 @@ trait WebSocketSpec
               sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
             },
             Some("first-protocol, second-protocol, third-protocol"),
-            c => c
+            c => c,
+            CompressionMode.Disabled
           )
           (headers
             .map { case (key, value) => (key.toLowerCase, value) }
@@ -436,7 +510,8 @@ trait WebSocketSpec
               sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
             },
             Some("graphql-ws, graphql-transport-ws"),
-            c => c
+            c => c,
+            CompressionMode.Disabled
           )
           (headers
             .map { case (key, value) => (key.toLowerCase, value) }
@@ -666,7 +741,8 @@ trait WebSocketSpec
               sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
             },
             Some("graphql-ws, graphql-transport-ws"),
-            c => c
+            c => c,
+            CompressionMode.Disabled
           )
           (headers
             .map { case (key, value) => (key.toLowerCase, value) }
@@ -784,25 +860,30 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   def runWebSocket[A](
       port: Int,
       handler: Flow[ExtendedMessage, ExtendedMessage, ?] => Future[A],
-      handleConnect: Future[?] => Future[?] = c => c
+      handleConnect: Future[?] => Future[?] = c => c,
+      compressionMode: CompressionMode = CompressionMode.Disabled
   ): A =
-    runWebSocket(port, handler, subprotocol = None, handleConnect) match { case (result, _) => result }
+    runWebSocket(port, handler, subprotocol = None, handleConnect, compressionMode) match { case (result, _) => result }
 
   def runWebSocket[A](
       port: Int,
       handler: Flow[ExtendedMessage, ExtendedMessage, ?] => Future[A],
       subprotocol: Option[String],
-      handleConnect: Future[?] => Future[?]
+      handleConnect: Future[?] => Future[?],
+      compressionMode: CompressionMode
   ): (A, immutable.Seq[(String, String)]) = {
     WebSocketClient { client =>
       val innerResult     = Promise[A]()
       val responseHeaders = Promise[immutable.Seq[(String, String)]]()
       await(
         handleConnect(
-          client.connect(URI.create("ws://localhost:" + port + "/stream"), subprotocol = subprotocol) {
-            (headers, flow) =>
-              innerResult.completeWith(handler(flow))
-              responseHeaders.success(headers)
+          client.connect(
+            URI.create("ws://localhost:" + port + "/stream"),
+            subprotocol = subprotocol,
+            compressionMode = compressionMode
+          ) { (headers, flow) =>
+            innerResult.completeWith(handler(flow))
+            responseHeaders.success(headers)
           }
         )
       )

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -4,8 +4,10 @@
 
 package play.it.http.websocket
 
+import java.io.ByteArrayOutputStream
 import java.net.URI
 import java.util.concurrent.atomic.AtomicReference
+import java.util.zip.Inflater
 
 import scala.collection.immutable
 import scala.concurrent.duration._
@@ -104,17 +106,99 @@ class NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecificatio
         val frames = runWebSocket(
           port,
           { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
-          compressionMode = CompressionMode.RequestOnly
+          compressionMode = CompressionMode.RequestOnly()
         )
 
         frames.collectFirst {
           case RawWebSocketFrame("text", data, rsv, true) => (data, rsv)
         } must beSome[(ByteString, Int)].which {
           case (data, rsv) =>
-            data.nonEmpty && (rsv & 4) == 4
+            data.nonEmpty &&
+            (rsv & 4) == 4 &&
+            data != ByteString("compressed server message") &&
+            inflatePerMessageDeflate(data).utf8String == "compressed server message"
         }
       }
     }
+
+    "not negotiate compression when websocket compression is disabled" in {
+      withServer(
+        app => WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) },
+        Map("play.server.websocket.compression.enabled" -> false)
+      ) { (app, port) =>
+        import app.materializer
+        val (_, headers) = runWebSocket(
+          port,
+          { flow =>
+            Source.empty[ExtendedMessage].via(flow).runWith(Sink.ignore)
+            Future.successful(())
+          },
+          subprotocol = None,
+          handleConnect = c => c,
+          compressionMode = CompressionMode.RequestOnly()
+        )
+
+        headers.collectFirst {
+          case (name, value) if name.equalsIgnoreCase("Sec-WebSocket-Extensions") => value
+        } must beNone
+      }
+    }
+
+    "use configured Netty permessage-deflate negotiation settings" in {
+      withServer(
+        app => WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) },
+        Map(
+          "play.server.netty.websocket.compression.perMessageDeflate.allowServerWindowSize"     -> true,
+          "play.server.netty.websocket.compression.perMessageDeflate.serverWindowSize"          -> 12,
+          "play.server.netty.websocket.compression.perMessageDeflate.memLevel"                  -> 7,
+          "play.server.netty.websocket.compression.perMessageDeflate.preferredClientWindowSize" -> 11,
+          "play.server.netty.websocket.compression.perMessageDeflate.allowServerNoContext"      -> true,
+          "play.server.netty.websocket.compression.perMessageDeflate.preferredClientNoContext"  -> true,
+          "play.server.netty.websocket.compression.perMessageDeflate.compressionLevel"          -> 5
+        )
+      ) { (app, port) =>
+        import app.materializer
+        val (_, headers) = runWebSocket(
+          port,
+          { flow =>
+            Source.empty[ExtendedMessage].via(flow).runWith(Sink.ignore)
+            Future.successful(())
+          },
+          subprotocol = None,
+          handleConnect = c => c,
+          compressionMode = CompressionMode.RequestOnly(
+            "permessage-deflate; client_max_window_bits; server_max_window_bits=15; " +
+              "client_no_context_takeover; server_no_context_takeover"
+          )
+        )
+
+        val extension = headers.collectFirst {
+          case (name, value) if name.equalsIgnoreCase("Sec-WebSocket-Extensions") => value
+        }
+
+        extension must beSome[String].which { value =>
+          value.contains("permessage-deflate") &&
+          value.contains("server_max_window_bits=12") &&
+          value.contains("client_max_window_bits=11") &&
+          value.contains("server_no_context_takeover") &&
+          value.contains("client_no_context_takeover")
+        }
+      }
+    }
+
+    "fail clearly when Netty websocket compression maxAllocation exceeds Netty's integer limit" in {
+      withServer(
+        app => WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) },
+        Map("play.server.netty.websocket.compression.maxAllocation" -> "3g")
+      ) { (_, _) =>
+        ()
+      } must throwA[RuntimeException].like {
+        case exception =>
+          (exception.getCause must beAnInstanceOf[play.core.server.ServerStartException])
+            .and(exception.getMessage must contain("play.server.netty.websocket.compression.maxAllocation"))
+      }
+    }
+
   }
 }
 class PekkoHttpWebSocketSpec extends WebSocketSpec with PekkoHttpIntegrationSpecification {
@@ -888,6 +972,23 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
         )
       )
       (await(innerResult.future), await(responseHeaders.future))
+    }
+  }
+
+  def inflatePerMessageDeflate(data: ByteString): ByteString = {
+    val inflater = new Inflater(true)
+    try {
+      inflater.setInput((data ++ ByteString(0x00, 0x00, 0xff.toByte, 0xff.toByte)).toArray)
+      val output = new ByteArrayOutputStream()
+      val buffer = new Array[Byte](256)
+      var count  = inflater.inflate(buffer)
+      while (count > 0) {
+        output.write(buffer, 0, count)
+        count = inflater.inflate(buffer)
+      }
+      ByteString.fromArray(output.toByteArray)
+    } finally {
+      inflater.end()
     }
   }
 

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -6,6 +6,20 @@ This section highlights the new features of Play 3.1. If you want to learn about
 
 ## Other Additions
 
+### Netty WebSocket Compression
+
+The Play Netty server backend now supports WebSocket compression using the RFC 7692 `permessage-deflate` extension.
+
+Compression is enabled by default and is negotiated during the WebSocket handshake when the client offers `permessage-deflate` in the `Sec-WebSocket-Extensions` header. Applications can disable WebSocket compression for all server backends with:
+
+```hocon
+play.server.websocket.compression.enabled = false
+```
+
+The Netty backend also exposes Netty-specific tuning options under `play.server.netty.websocket.compression`, including the compression level, server and client window-size behavior, memory level, context-takeover behavior, and the decompression allocation limit. By default, the allocation limit follows `play.server.websocket.frame.maxLength`.
+
+For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Configuring-WebSocket-compression]] and [[Java WebSocket documentation|JavaWebSockets#Configuring-WebSocket-compression]].
+
 ### WebSocket Subprotocol Selection
 
 Play now lets applications explicitly select the WebSocket subprotocol that is sent back in the successful `101 Switching Protocols` response.

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -120,6 +120,20 @@ This configuration gives you more control of WebSocket frame length and can be a
 
 The configuration above applies to WebSocket data frames. WebSocket Close frames, on the other hand, are control frames and have a smaller payload limit defined by [RFC 6455 section 5.5](https://www.rfc-editor.org/rfc/rfc6455#section-5.5). If a Close frame includes a status code, the status code uses 2 bytes, leaving at most 123 UTF-8 bytes for the close reason. Play truncates longer close reasons before sending them. Status codes `1005`, `1006`, and `1015` are reserved by [RFC 6455 section 7.4.1](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1) and should not be sent by application code as WebSocket Close frame status codes.
 
+## Configuring WebSocket compression
+
+The Netty server backend supports WebSocket compression using the RFC 7692 `permessage-deflate` extension. Compression is enabled by default and is negotiated during the WebSocket handshake when the client offers `permessage-deflate` in the `Sec-WebSocket-Extensions` header.
+
+You can disable WebSocket compression for all server backends with:
+
+```
+play.server.websocket.compression.enabled = false
+```
+
+When using the Netty backend, Netty-specific compression settings are available under `play.server.netty.websocket.compression`. These settings include the compression level, server and client window-size behavior, memory level, context-takeover behavior, and the maximum decompression allocation. By default, `play.server.netty.websocket.compression.maxAllocation` uses `play.server.websocket.frame.maxLength`, so the same limit applies to decompressed WebSocket messages.
+
+> **Note:** WebSocket compression can increase CPU and memory usage. If messages include secrets alongside attacker-controlled data, consider whether compression is appropriate for that endpoint. Under the `play.server.netty.websocket` config parent, Netty's default context-takeover settings are `compression.perMessageDeflate.allowServerNoContext = false` and `compression.perMessageDeflate.preferredClientNoContext = false`. For a more conservative setup, set them to `true` so the server may accept `server_no_context_takeover` when the client requests it, and so Netty requests `client_no_context_takeover` when the client supports it.
+
 ## Configuring keep-alive Frames
 
 First of all, if a client sends a `ping` Frame to the Play backend server, it automatically answers with a `pong` frame. This is a requirement according to [RFC 6455 Section 5.5.2](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2), therefore this is hardcoded within Play, you don't need to set up or configure anything.

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -122,6 +122,20 @@ This configuration gives you more control of WebSocket frame length and can be a
 
 The configuration above applies to WebSocket data frames. WebSocket Close frames, on the other hand, are control frames and have a smaller payload limit defined by [RFC 6455 section 5.5](https://www.rfc-editor.org/rfc/rfc6455#section-5.5). If a Close frame includes a status code, the status code uses 2 bytes, leaving at most 123 UTF-8 bytes for the close reason. Play truncates longer close reasons before sending them. Status codes `1005`, `1006`, and `1015` are reserved by [RFC 6455 section 7.4.1](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1) and should not be sent by application code as WebSocket Close frame status codes.
 
+## Configuring WebSocket compression
+
+The Netty server backend supports WebSocket compression using the RFC 7692 `permessage-deflate` extension. Compression is enabled by default and is negotiated during the WebSocket handshake when the client offers `permessage-deflate` in the `Sec-WebSocket-Extensions` header.
+
+You can disable WebSocket compression for all server backends with:
+
+```
+play.server.websocket.compression.enabled = false
+```
+
+When using the Netty backend, Netty-specific compression settings are available under `play.server.netty.websocket.compression`. These settings include the compression level, server and client window-size behavior, memory level, context-takeover behavior, and the maximum decompression allocation. By default, `play.server.netty.websocket.compression.maxAllocation` uses `play.server.websocket.frame.maxLength`, so the same limit applies to decompressed WebSocket messages.
+
+> **Note:** WebSocket compression can increase CPU and memory usage. If messages include secrets alongside attacker-controlled data, consider whether compression is appropriate for that endpoint. Under the `play.server.netty.websocket` config parent, Netty's default context-takeover settings are `compression.perMessageDeflate.allowServerNoContext = false` and `compression.perMessageDeflate.preferredClientNoContext = false`. For a more conservative setup, set them to `true` so the server may accept `server_no_context_takeover` when the client requests it, and so Netty requests `client_no_context_takeover` when the client supports it.
+
 ## Configuring keep-alive Frames
 
 First of all, if a client sends a `ping` Frame to the Play backend server, it automatically answers with a `pong` frame. This is a requirement according to [RFC 6455 Section 5.5.2](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2), therefore this is hardcoded within Play, you don't need to set up or configure anything.

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -42,6 +42,52 @@ play.server {
     # Whether the Netty wire should be logged
     log.wire = false
 
+    websocket {
+      compression {
+        # Maximum size of Netty's WebSocket decompression buffer. If this value is
+        # exceeded while inflating a compressed WebSocket frame, Netty fails
+        # decompression. By default this follows Play's WebSocket frame limit.
+        maxAllocation = ${play.server.websocket.frame.maxLength}
+
+        perMessageDeflate {
+          # DEFLATE compression level used for server-to-client frames. Valid
+          # values are 0-9, where 0 disables compression and 9 favors compression
+          # ratio over CPU usage.
+          compressionLevel = 6
+
+          # Whether a client may request server_max_window_bits. Valid values are
+          # true, false, and auto. auto preserves Netty's default and enables this
+          # only when the active zlib codec supports custom window size and memory
+          # level.
+          allowServerWindowSize = auto
+
+          # The server_max_window_bits value Netty should use for server-to-client
+          # messages. When allowServerWindowSize is true and the client requests
+          # server_max_window_bits=N, Netty negotiates min(N, serverWindowSize).
+          # Netty also advertises server_max_window_bits unilaterally when this is
+          # less than 15. Valid values are 8-15.
+          serverWindowSize = 15
+
+          # DEFLATE memory level used for server-to-client frames. Valid values
+          # are 1-9, where higher values may improve compression ratio at the cost
+          # of memory usage.
+          memLevel = 8
+
+          # The client_max_window_bits value Netty should prefer when the client
+          # sends client_max_window_bits without an explicit value. Valid values
+          # are 8-15.
+          preferredClientWindowSize = 15
+
+          # Whether a client may request server_no_context_takeover.
+          allowServerNoContext = false
+
+          # Whether Netty should request client_no_context_takeover when the client
+          # indicates that it supports this parameter.
+          preferredClientNoContext = false
+        }
+      }
+    }
+
     # The transport to use, either `jdk`, `native` or `io_uring`.
     # Native socket transport has higher performance and produces less garbage and are available on Linux, macOS, FreeBSD and OpenBSD.
     # When set to `native` or `io_uring`, Play will automatically detect the operating system it is running on and load the appropriate native transport library.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -34,6 +34,7 @@ import io.netty.channel.uring.IoUringChannelOption
 import io.netty.channel.uring.IoUringIoHandler
 import io.netty.channel.uring.IoUringServerSocketChannel
 import io.netty.handler.codec.http._
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.handler.ssl.SslHandler
@@ -274,6 +275,7 @@ class NettyServer(
       pipeline.addLast("decoder", new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize))
       pipeline.addLast("encoder", new PlayHttpResponseEncoder())
       pipeline.addLast("decompressor", new HttpContentDecompressor())
+      pipeline.addLast("ws-compressor", new WebSocketServerCompressionHandler(wsBufferLimit))
       if (logWire) {
         pipeline.addLast("logging", new LoggingHandler(LogLevel.DEBUG))
       }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -33,8 +33,10 @@ import io.netty.channel.unix.UnixChannelOption
 import io.netty.channel.uring.IoUringChannelOption
 import io.netty.channel.uring.IoUringIoHandler
 import io.netty.channel.uring.IoUringServerSocketChannel
+import io.netty.handler.codec.compression.ZlibCodecFactory
 import io.netty.handler.codec.http._
-import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler
+import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.handler.ssl.SslHandler
@@ -80,23 +82,39 @@ class NettyServer(
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize        =
     serverConfig.getDeprecated[ConfigMemorySize]("max-header-size", "netty.maxHeaderSize").toBytes.toInt
-  private val maxContentLength    = Server.getPossiblyInfiniteBytes(serverConfig.underlying, "max-content-length")
-  private val maxChunkSize        = nettyConfig.get[Int]("maxChunkSize")
-  private val threadCount         = nettyConfig.get[Int]("eventLoopThreads")
-  private val logWire             = nettyConfig.get[Boolean]("log.wire")
-  private val bootstrapOption     = nettyConfig.get[Config]("option")
-  private val channelOption       = nettyConfig.get[Config]("option.child")
-  private val httpsWantClientAuth = serverConfig.get[Boolean]("https.wantClientAuth")
-  private val httpsNeedClientAuth = serverConfig.get[Boolean]("https.needClientAuth")
-  private val httpIdleTimeout     = serverConfig.get[Duration]("http.idleTimeout")
-  private val httpsIdleTimeout    = serverConfig.get[Duration]("https.idleTimeout")
-  private val shutdownQuietPeriod = nettyConfig.get[FiniteDuration]("shutdownQuietPeriod")
-  private val terminationDelay    = serverConfig.get[FiniteDuration]("waitBeforeTermination")
-  private val terminationTimeout  = serverConfig.getOptional[FiniteDuration]("terminationTimeout")
-  private val wsBufferLimit       = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
-  private val wsKeepAliveMode     = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
-  private val wsKeepAliveMaxIdle  = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
-  private val deferBodyParsing    = serverConfig.underlying.getBoolean("deferBodyParsing")
+  private val maxContentLength           = Server.getPossiblyInfiniteBytes(serverConfig.underlying, "max-content-length")
+  private val maxChunkSize               = nettyConfig.get[Int]("maxChunkSize")
+  private val threadCount                = nettyConfig.get[Int]("eventLoopThreads")
+  private val logWire                    = nettyConfig.get[Boolean]("log.wire")
+  private val bootstrapOption            = nettyConfig.get[Config]("option")
+  private val channelOption              = nettyConfig.get[Config]("option.child")
+  private val httpsWantClientAuth        = serverConfig.get[Boolean]("https.wantClientAuth")
+  private val httpsNeedClientAuth        = serverConfig.get[Boolean]("https.needClientAuth")
+  private val httpIdleTimeout            = serverConfig.get[Duration]("http.idleTimeout")
+  private val httpsIdleTimeout           = serverConfig.get[Duration]("https.idleTimeout")
+  private val shutdownQuietPeriod        = nettyConfig.get[FiniteDuration]("shutdownQuietPeriod")
+  private val terminationDelay           = serverConfig.get[FiniteDuration]("waitBeforeTermination")
+  private val terminationTimeout         = serverConfig.getOptional[FiniteDuration]("terminationTimeout")
+  private val wsBufferLimit              = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
+  private val wsKeepAliveMode            = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
+  private val wsKeepAliveMaxIdle         = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
+  private val wsCompression              = serverConfig.get[Boolean]("websocket.compression.enabled")
+  private val wsCompressionConfig        = nettyConfig.get[Configuration]("websocket.compression")
+  private val wsCompressionMaxAllocation =
+    if (wsCompression) {
+      Some(
+        getMemorySizeAsInt(
+          wsCompressionConfig,
+          "maxAllocation",
+          "play.server.netty.websocket.compression.maxAllocation"
+        )
+      )
+    } else {
+      None
+    }
+  private val wsCompressionPerMessageDeflateConfig =
+    if (wsCompression) Some(wsCompressionConfig.get[Configuration]("perMessageDeflate")) else None
+  private val deferBodyParsing = serverConfig.underlying.getBoolean("deferBodyParsing")
 
   private lazy val osName                   = sys.props("os.name").toLowerCase(Locale.ENGLISH)
   private lazy val isWindows: Boolean       = osName.contains("windows")
@@ -246,6 +264,57 @@ class NettyServer(
       deferBodyParsing
     )
 
+  private def getAutoBoolean(config: Configuration, path: String, auto: => Boolean): Boolean = {
+    config.underlying.getValue(path).unwrapped() match {
+      case value: java.lang.Boolean                         => value.booleanValue()
+      case value: String if value.equalsIgnoreCase("auto")  => auto
+      case value: String if value.equalsIgnoreCase("true")  => true
+      case value: String if value.equalsIgnoreCase("false") => false
+      case value                                            =>
+        throw ServerStartException(
+          s"Netty WebSocket compression configuration value $path should be true, false or auto, but was $value"
+        )
+    }
+  }
+
+  private def getMemorySizeAsInt(config: Configuration, path: String, displayPath: String): Int = {
+    val bytes = config.get[ConfigMemorySize](path).toBytes
+    if (bytes > Int.MaxValue) {
+      throw ServerStartException(
+        s"Netty WebSocket compression configuration value $displayPath must be <= ${Int.MaxValue} bytes, but was $bytes bytes"
+      )
+    }
+    bytes.toInt
+  }
+
+  private def newWebSocketCompressionHandler(): Option[ChannelHandler] = {
+    if (!wsCompression) {
+      None
+    } else {
+      val maxAllocation           = wsCompressionMaxAllocation.get
+      val perMessageDeflateConfig = wsCompressionPerMessageDeflateConfig.get
+
+      Some(
+        new WebSocketServerExtensionHandler(
+          new PerMessageDeflateServerExtensionHandshaker(
+            perMessageDeflateConfig.get[Int]("compressionLevel"),
+            getAutoBoolean(
+              perMessageDeflateConfig,
+              "allowServerWindowSize",
+              ZlibCodecFactory.isSupportingWindowSizeAndMemLevel()
+            ),
+            perMessageDeflateConfig.get[Int]("preferredClientWindowSize"),
+            perMessageDeflateConfig.get[Boolean]("allowServerNoContext"),
+            perMessageDeflateConfig.get[Boolean]("preferredClientNoContext"),
+            perMessageDeflateConfig.get[Int]("serverWindowSize"),
+            perMessageDeflateConfig.get[Int]("memLevel"),
+            maxAllocation
+          )
+        )
+      )
+    }
+  }
+
   /**
    * Create a sink for the incoming connection channels.
    */
@@ -275,7 +344,7 @@ class NettyServer(
       pipeline.addLast("decoder", new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize))
       pipeline.addLast("encoder", new PlayHttpResponseEncoder())
       pipeline.addLast("decompressor", new HttpContentDecompressor())
-      pipeline.addLast("ws-compressor", new WebSocketServerCompressionHandler(wsBufferLimit))
+      newWebSocketCompressionHandler().foreach(pipeline.addLast("ws-compressor", _))
       if (logWire) {
         pipeline.addLast("logging", new LoggingHandler(LogLevel.DEBUG))
       }

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -93,11 +93,12 @@ play {
     websocket {
       # Maximum allowable frame payload length. Setting this value to your application's
       # requirement may reduce denial of service attacks using long data frames.
-      # This configuration applies to WebSocket data frames. WebSocket Close frames,
-      # on the other hand, are control frames and are still limited by RFC 6455 to
-      # 125 bytes. If a Close frame includes a status code, the status code uses 2
-      # bytes, leaving at most 123 UTF-8 bytes for the close reason. Play truncates
-      # longer close reasons before sending them.
+      # For compressed WebSocket frames, this also limits the decompression buffer
+      # used before Play handles the frame. WebSocket Close frames, on the other hand,
+      # are control frames and are still limited by RFC 6455 to 125 bytes. If a Close
+      # frame includes a status code, the status code uses 2 bytes, leaving at most
+      # 123 UTF-8 bytes for the close reason. Play truncates longer close reasons
+      # before sending them.
       frame.maxLength = 64k
       frame.maxLength = ${?websocket.frame.maxLength}
 

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -91,6 +91,15 @@ play {
     pidfile.path = ${?pidfile.path}
 
     websocket {
+      compression {
+        # Whether WebSocket compression support should be enabled.
+        # WebSocket compression is negotiated during the WebSocket handshake and is
+        # only used when the client requests a supported WebSocket compression
+        # extension. Backend-specific compression tuning can be configured in the
+        # corresponding backend reference.conf.
+        enabled = true
+      }
+
       # Maximum allowable frame payload length. Setting this value to your application's
       # requirement may reduce denial of service attacks using long data frames.
       # For compressed WebSocket frames, this also limits the decompression buffer


### PR DESCRIPTION
## TODO: Netty permessage-deflate tuning after Netty upgrade

- [x] Upgrade to (unreleased) Netty 4.2.16.Final that includes netty/netty commit https://github.com/netty/netty/commit/7bae566a93 / https://github.com/netty/netty/pull/16809 
- [x] Wire Netty's new `PerMessageDeflateServerExtensionHandshaker` constructor parameters for `serverWindowSize` and `memLevel`.
- [x] Decide whether Play should expose `serverWindowSize` and `memLevel` as Netty-specific config keys under `play.server.netty.websocket.compression.perMessageDeflate`.
- [x] Add tests for configured `serverWindowSize` negotiation once the newer Netty API is available.
- [x] Document any newly exposed `serverWindowSize` / `memLevel` settings in `transport/server/play-netty-server/src/main/resources/reference.conf` and the WebSocket docs.

This replaces
- #11169 

Not sure why #11169 got closed by GitHub, I just wanted to rebase... Maybe because the original pull request branch was called `main`...?

/cc @TheAntimist 