### PR TITLE
Inject (CSRF)errorHandler in CSRFCheck

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -279,6 +279,11 @@ object BuildSettings {
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "play.data.validation.Constraints#PlayConstraintValidatorWithPayload.isValid"
       ),
+      // Inject (CSRF)errorHandler in CSRFCheck
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.csrf.CSRFCheck.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.csrf.CSRFCheck.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.csrf.CSRFCheck.this"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.filters.csrf.CSRFCheck$"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/web/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
+++ b/web/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
@@ -53,7 +53,8 @@ public interface CSRFComponents
   }
 
   default CSRFCheck csrfCheck() {
-    return new CSRFCheck(csrfConfig(), csrfTokenSigner().asScala(), sessionConfiguration());
+    return new CSRFCheck(
+        csrfConfig(), csrfTokenSigner(), sessionConfiguration(), csrfErrorHandler());
   }
 
   default CSRFAddToken csrfAddToken() {


### PR DESCRIPTION
- Fixes #8971

Makes sure `play.filters.csrf.errorHandler` will be used by default. More details in the referenced issue.
