### PR TITLE
Remove deprecated `constantTimeEquals` methods from `CSRFTokenSigner`

### DIFF
--- a/core/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
+++ b/core/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
@@ -54,20 +54,6 @@ trait CSRFTokenSigner {
    * Compare two signed tokens
    */
   def compareSignedTokens(tokenA: String, tokenB: String): Boolean
-
-  /**
-   * Constant time equals method.
-   *
-   * Given a length that both Strings are equal to, this method will always
-   * run in constant time.  This prevents timing attacks.
-   *
-   * @deprecated Please use `java.security.MessageDigest.isEqual(a.getBytes("utf-8"), b.getBytes("utf-8"))` over this method.
-   */
-  @deprecated(
-    "Please use java.security.MessageDigest.isEqual(a.getBytes(\"utf-8\"), b.getBytes(\"utf-8\")) over this method.",
-    "2.6.0"
-  )
-  def constantTimeEquals(a: String, b: String): Boolean
 }
 
 /**
@@ -92,7 +78,7 @@ class DefaultCSRFTokenSigner @Inject() (signer: CookieSigner, clock: Clock) exte
    */
   def signToken(token: String): String = {
     val nonce  = clock.millis()
-    val joined = s"${nonce}-${token}"
+    val joined = s"$nonce-$token"
     signer.sign(joined) + "-" + joined
   }
 
@@ -133,21 +119,7 @@ class DefaultCSRFTokenSigner @Inject() (signer: CookieSigner, clock: Clock) exte
     } yield isEqual(rawA, rawB)).getOrElse(false)
   }
 
-  override def constantTimeEquals(a: String, b: String): Boolean = isEqual(a, b)
-
   private def isEqual(a: String, b: String): Boolean = {
-    MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8))
-  }
-}
-
-@deprecated("CSRFTokenSigner's singleton object can be replaced by MessageDigest.isEqual", "2.6.0")
-object CSRFTokenSigner {
-
-  /**
-   * @deprecated Please use [[java.security.MessageDigest.isEqual]] over this method.
-   */
-  @deprecated("Consider java.security.MessageDigest.isEqual", "2.6.0")
-  def constantTimeEquals(a: String, b: String): Boolean = {
     MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8))
   }
 }


### PR DESCRIPTION
## Purpose

This PR removes deprecated `constantTimeEquals()` methods on the Scala implementation of `CSRFTokenSigner` - these methods were deprecated with https://github.com/playframework/playframework/pull/6429 back in August 2016 with Play v2.6.

This PR does break binary compatibility (hence the failing test), because it's removing deprecated methods/objects.

There are no `constantTimeEquals()` or deprecated methods on the Java `play.libs.crypto.CSRFTokenSigner` implementation, so no methods changes are occurring there.

## Background Context

I encountered these deprecated methods while addressing https://github.com/guardian/play-secret-rotation/issues/445 and thought they may as well be removed.

I also opened this PR to see how receptive you'd be to PRs that break binary compatibility, because I'm interested in https://github.com/playframework/playframework/issues/12520!
