### PR TITLE
Bump ehcache to version 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -316,7 +316,8 @@ lazy val PlayAhcWsProject = PlayCrossBuiltProject("Play-AHC-WS", "transport/clie
     // quieten deprecation warnings in tests
     (Test / scalacOptions) := (Test / scalacOptions).value.diff(Seq("-deprecation"))
   )
-  .dependsOn(PlayWsProject, PlayCaffeineCacheProject % "test")
+  .dependsOn(PlayWsProject)
+  .dependsOn(PlayCaffeineCacheProject % "test")
   .dependsOn(PlaySpecs2Project % "test")
   .dependsOn(PlayTestProject % "test->test")
   .dependsOn(PlayPekkoHttpServerProject % "test") // Because we need a server provider when running the tests

--- a/cache/play-cache/src/main/scala/play/api/cache/ExpirableCacheValue.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/ExpirableCacheValue.scala
@@ -2,11 +2,11 @@
  * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package play.api.cache.caffeine
+package play.api.cache
 
 import scala.concurrent.duration.Duration
 
 import org.apache.pekko.annotation.InternalApi
 
 @InternalApi
-private[caffeine] case class ExpirableCacheValue[V](value: V, durationMaybe: Option[Duration] = None)
+case class ExpirableCacheValue[V](value: V, durationMaybe: Option[Duration] = None)

--- a/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
+++ b/cache/play-caffeine-cache/src/main/scala/play/api/cache/caffeine/DefaultCaffeineExpiry.scala
@@ -9,6 +9,7 @@ import scala.concurrent.duration.Duration
 
 import com.github.benmanes.caffeine.cache.Expiry
 import org.apache.pekko.annotation.InternalApi
+import play.api.cache.ExpirableCacheValue
 
 @InternalApi
 private[caffeine] class DefaultCaffeineExpiry extends Expiry[String, ExpirableCacheValue[Any]] {

--- a/cache/play-ehcache/src/main/java/play/cache/ehcache/EhCacheComponents.java
+++ b/cache/play-ehcache/src/main/java/play/cache/ehcache/EhCacheComponents.java
@@ -4,7 +4,7 @@
 
 package play.cache.ehcache;
 
-import net.sf.ehcache.CacheManager;
+import org.ehcache.CacheManager;
 import play.Environment;
 import play.api.cache.ehcache.CacheManagerProvider;
 import play.api.cache.ehcache.EhCacheApi;

--- a/cache/play-ehcache/src/main/resources/ehcache-default.xml
+++ b/cache/play-ehcache/src/main/resources/ehcache-default.xml
@@ -2,18 +2,19 @@
    Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
-<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../config/ehcache.xsd" updateCheck="false">
+<config
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns='http://www.ehcache.org/v3'
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core.xsd">
 
-    <defaultCache
-            maxElementsInMemory="10000"
-            eternal="false"
-            timeToIdleSeconds="120"
-            timeToLiveSeconds="120"
-            overflowToDisk="false"
-            maxElementsOnDisk="10000000"
-            diskPersistent="false"
-            diskExpiryThreadIntervalSeconds="120"
-            memoryStoreEvictionPolicy="LRU"
-    /> 
-    
-</ehcache>
+        <cache-template name="default">
+            <key-type>java.lang.String</key-type>
+            <value-type>play.api.cache.ehcache.EhCacheApi.CacheValue</value-type>
+            <expiry>
+                <ttl unit="seconds">120</ttl>
+            </expiry>
+            <resources>
+                <heap unit="entries">10000</heap>
+            </resources>
+        </cache-template>
+</config>

--- a/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/cache/play-ehcache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -4,6 +4,10 @@
 
 package play.api.cache.ehcache
 
+import java.time
+import java.util.function.Supplier
+
+import scala.concurrent.duration
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.ExecutionContext
@@ -14,14 +18,21 @@ import com.google.common.primitives.Primitives
 import jakarta.inject.Inject
 import jakarta.inject.Provider
 import jakarta.inject.Singleton
-import net.sf.ehcache.CacheManager
-import net.sf.ehcache.Ehcache
-import net.sf.ehcache.Element
-import net.sf.ehcache.ObjectExistsException
 import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.annotation.InternalApi
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.Done
+import org.ehcache.config.builders.CacheConfigurationBuilder
+import org.ehcache.config.builders.CacheManagerBuilder
+import org.ehcache.config.builders.ResourcePoolsBuilder
+import org.ehcache.expiry.ExpiryPolicy
+import org.ehcache.xml.XmlConfiguration
+import org.ehcache.Cache
+import org.ehcache.CacheManager
 import play.api.cache._
+import play.api.cache.ehcache.EhCacheApi.EhExpirableCacheValue
+import play.api.cache.ehcache.EhCacheApi.PlayEhCache
+import play.api.cache.ExpirableCacheValue
 import play.api.inject._
 import play.api.Configuration
 import play.api.Environment
@@ -84,7 +95,7 @@ class EhCacheModule
       // bind a cache with the given name
       def bindCache(name: String) = {
         val namedCache  = named(name)
-        val ehcacheKey  = bind[Ehcache].qualifiedWith(namedCache)
+        val ehcacheKey  = bind[PlayEhCache].qualifiedWith(namedCache)
         val cacheApiKey = bind[AsyncCacheApi].qualifiedWith(namedCache)
         Seq(
           ehcacheKey.to(new NamedEhCacheProvider(name, createBoundCaches)),
@@ -112,26 +123,64 @@ class CacheManagerProvider @Inject() (env: Environment, config: Configuration, l
   lazy val get: CacheManager = {
     val resourceName   = config.underlying.getString("play.cache.configResource")
     val configResource = env.resource(resourceName).getOrElse(env.classLoader.getResource("ehcache-default.xml"))
-    val manager        = CacheManager.create(configResource)
-    lifecycle.addStopHook(() => Future.successful(manager.shutdown()))
+    val configuration  = new XmlConfiguration(configResource)
+    val manager        = CacheManagerBuilder.newCacheManager(configuration)
+    manager.init()
+    lifecycle.addStopHook(() => Future.successful(manager.close()))
     manager
   }
 }
 
-private[play] class NamedEhCacheProvider(name: String, create: Boolean) extends Provider[Ehcache] {
+private[play] class NamedEhCacheProvider(name: String, create: Boolean) extends Provider[PlayEhCache] {
   @Inject private var manager: CacheManager = _
-  lazy val get: Ehcache                     = NamedEhCacheProvider.getNamedCache(name, manager, create)
+  lazy val get: PlayEhCache                 = NamedEhCacheProvider.getNamedCache(name, manager, create)
 }
 
 private[play] object NamedEhCacheProvider {
-  def getNamedCache(name: String, manager: CacheManager, create: Boolean): Ehcache =
+
+  private val expiryPolicy = new ExpiryPolicy[String, EhExpirableCacheValue]() {
+    def getExpiryForCreation(key: String, value: EhExpirableCacheValue): time.Duration = value.durationMaybe match {
+      case Some(finite: FiniteDuration) =>
+        val seconds = finite.toSeconds
+        if (seconds <= 0) {
+          time.Duration.ZERO
+        } else if (seconds > Int.MaxValue) {
+          ExpiryPolicy.INFINITE
+        } else {
+          time.Duration.ofSeconds(seconds.toInt)
+        }
+      case _ => ExpiryPolicy.INFINITE
+    }
+
+    def getExpiryForAccess(key: String, value: Supplier[? <: EhExpirableCacheValue]): time.Duration = null
+
+    def getExpiryForUpdate(
+        key: String,
+        oldValue: Supplier[? <: EhExpirableCacheValue],
+        newValue: EhExpirableCacheValue
+    ): time.Duration = null
+  }
+
+  private def cacheConfigurationBuilder(manager: CacheManager) = {
+    val builder = manager.getRuntimeConfiguration match {
+      case configuration: XmlConfiguration =>
+        configuration
+          .newCacheConfigurationBuilderFromTemplate("default", classOf[String], classOf[EhExpirableCacheValue])
+      case _ =>
+        CacheConfigurationBuilder
+          .newCacheConfigurationBuilder(classOf[String], classOf[EhExpirableCacheValue], ResourcePoolsBuilder.heap(100))
+    }
+    builder.withExpiry(expiryPolicy)
+  }
+
+  def getNamedCache(name: String, manager: CacheManager, create: Boolean): PlayEhCache =
     try {
       if (create) {
-        manager.addCache(name)
+        manager.createCache(name, cacheConfigurationBuilder(manager))
       }
-      manager.getEhcache(name)
+      manager.getCache(name, classOf[String], classOf[EhExpirableCacheValue])
     } catch {
-      case e: ObjectExistsException =>
+      case e: IllegalArgumentException =>
         throw EhCacheExistsException(
           s"""An EhCache instance with name '$name' already exists.
              |
@@ -142,7 +191,7 @@ private[play] object NamedEhCacheProvider {
     }
 }
 
-private[play] class NamedAsyncCacheApiProvider(key: BindingKey[Ehcache]) extends Provider[AsyncCacheApi] {
+private[play] class NamedAsyncCacheApiProvider(key: BindingKey[PlayEhCache]) extends Provider[AsyncCacheApi] {
   @Inject private var injector: Injector          = _
   @Inject private var defaultEc: ExecutionContext = _
   @Inject private var config: Configuration       = _
@@ -184,23 +233,10 @@ private[play] class NamedCachedProvider(key: BindingKey[AsyncCacheApi]) extends 
 
 private[play] case class EhCacheExistsException(msg: String, cause: Throwable) extends RuntimeException(msg, cause)
 
-class SyncEhCacheApi @Inject() (private[ehcache] val cache: Ehcache) extends SyncCacheApi {
+class SyncEhCacheApi @Inject() (private[ehcache] val cache: PlayEhCache) extends SyncCacheApi {
   override def set(key: String, value: Any, expiration: Duration): Unit = {
-    val element = new Element(key, value)
-    expiration match {
-      case infinite: Duration.Infinite => element.setEternal(true)
-      case finite: FiniteDuration      =>
-        val seconds = finite.toSeconds
-        if (seconds <= 0) {
-          element.setTimeToLive(1)
-        } else if (seconds > Int.MaxValue) {
-          element.setTimeToLive(Int.MaxValue)
-        } else {
-          element.setTimeToLive(seconds.toInt)
-        }
-    }
-    cache.put(element)
-    Done
+    cache.put(key, ExpirableCacheValue[Any](value, Some(expiration)))
+    ()
   }
 
   override def remove(key: String): Unit = cache.remove(key)
@@ -217,7 +253,7 @@ class SyncEhCacheApi @Inject() (private[ehcache] val cache: Ehcache) extends Syn
 
   override def get[T](key: String)(implicit ct: ClassTag[T]): Option[T] = {
     Option(cache.get(key))
-      .map(_.getObjectValue)
+      .map(_.value)
       .filter { v =>
         Primitives.wrap(ct.runtimeClass).isInstance(v) ||
         ct == ClassTag.Nothing || (ct == ClassTag.Unit && v == ((): Unit).asInstanceOf[Any])
@@ -229,7 +265,7 @@ class SyncEhCacheApi @Inject() (private[ehcache] val cache: Ehcache) extends Syn
 /**
  * Ehcache implementation of [[AsyncCacheApi]]. Since Ehcache is synchronous by default, this uses [[SyncEhCacheApi]].
  */
-class EhCacheApi @Inject() (private[ehcache] val cache: Ehcache)(implicit context: ExecutionContext)
+class EhCacheApi @Inject() (private[ehcache] val cache: PlayEhCache)(implicit context: ExecutionContext)
     extends AsyncCacheApi {
   override lazy val sync: SyncEhCacheApi = new SyncEhCacheApi(cache)
 
@@ -255,7 +291,12 @@ class EhCacheApi @Inject() (private[ehcache] val cache: Ehcache)(implicit contex
   }
 
   def removeAll(): Future[Done] = Future {
-    cache.removeAll()
+    cache.clear()
     Done
   }
+}
+
+object EhCacheApi {
+  type EhExpirableCacheValue = ExpirableCacheValue[Any]
+  type PlayEhCache           = Cache[String, EhExpirableCacheValue]
 }

--- a/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -4,18 +4,35 @@
 
 package play.api.cache
 
+import java.nio.file.Files
+import java.time.{ Duration => JDurarion }
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.duration._
+import scala.concurrent.Future
 import scala.util.Random
 
 import jakarta.inject._
+import org.ehcache.config.builders.CacheConfigurationBuilder
+import org.ehcache.config.builders.CacheManagerBuilder
+import org.ehcache.config.builders.ConfigurationBuilder
+import org.ehcache.config.builders.ExpiryPolicyBuilder
+import org.ehcache.config.builders.ResourcePoolsBuilder
+import org.ehcache.config.units.MemoryUnit
+import org.ehcache.impl.config.persistence.DefaultPersistenceConfiguration
+import org.ehcache.CacheManager
 import play.api.cache.ehcache.EhCacheApi
+import play.api.cache.ehcache.EhCacheApi.EhExpirableCacheValue
+import play.api.cache.ehcache.EhCacheApi.PlayEhCache
 import play.api.http
+import play.api.inject
+import play.api.inject.ApplicationLifecycle
 import play.api.mvc._
 import play.api.test._
 import play.api.Application
+import play.api.Configuration
+import play.api.Environment
 
 class CachedSpec extends PlaySpecification {
   sequential
@@ -66,24 +83,31 @@ class CachedSpec extends PlaySpecification {
       }
     }
 
-    "cache values to disk using injected CachedApi" in new WithApplication() {
+    "cache values to disk using injected CachedApi" in new WithApplication(
+      // default implementation does not do disk caching, so inject a custom one
+      _.overrides(inject.bind[CacheManager].toProvider[PersistentCacheManagerProvider])
+    ) {
       override def running() = {
-        import net.sf.ehcache._
-        import net.sf.ehcache.config._
-        import net.sf.ehcache.store.MemoryStoreEvictionPolicy
+        import org.ehcache._
         // FIXME: Do this properly
         val cacheManager = app.injector.instanceOf[CacheManager]
-        val diskEhcache  = new Cache(
-          new CacheConfiguration("disk", 30)
-            .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LFU)
-            .eternal(false)
-            .timeToLiveSeconds(60)
-            .timeToIdleSeconds(30)
-            .diskExpiryThreadIntervalSeconds(0)
-            .persistence(new PersistenceConfiguration().strategy(PersistenceConfiguration.Strategy.LOCALTEMPSWAP))
+
+        cacheManager.createCache(
+          "disk",
+          CacheConfigurationBuilder
+            .newCacheConfigurationBuilder(
+              classOf[String],
+              classOf[EhExpirableCacheValue],
+              ResourcePoolsBuilder
+                .newResourcePoolsBuilder()
+                .disk(1, MemoryUnit.MB)
+            )
+            .withExpiry(
+              ExpiryPolicyBuilder.timeToIdleExpiration(JDurarion.ofSeconds(30))
+            )
         )
-        cacheManager.addCache(diskEhcache)
-        val diskEhcache2 = cacheManager.getCache("disk")
+
+        val diskEhcache2: PlayEhCache = cacheManager.getCache("disk", classOf[String], classOf[EhExpirableCacheValue])
         assert(diskEhcache2 != null)
         val diskCache  = new EhCacheApi(diskEhcache2)(using app.materializer.executionContext)
         val diskCached = new Cached(diskCache)
@@ -398,4 +422,24 @@ class NamedCachedController @Inject() (
   val invoked                        = new AtomicInteger()
   val action                         = cached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
   def isCached(key: String): Boolean = cache.sync.get[String](key).isDefined
+}
+
+class PersistentCacheManagerProvider @Inject() (
+    env: Environment,
+    config: Configuration,
+    lifecycle: ApplicationLifecycle
+) extends Provider[CacheManager] {
+
+  lazy val tempDir = Files.createTempDirectory("cache").toFile()
+
+  lazy val get: CacheManager = {
+    val configuration = ConfigurationBuilder
+      .newConfigurationBuilder()
+      .withService(new DefaultPersistenceConfiguration(tempDir))
+      .build()
+    val manager = CacheManagerBuilder.newCacheManager(configuration)
+    manager.init()
+    lifecycle.addStopHook(() => Future.successful(manager.close()))
+    manager
+  }
 }

--- a/cache/play-ehcache/src/test/scala/play/api/cache/ehcache/EhCacheApiSpec.scala
+++ b/cache/play-ehcache/src/test/scala/play/api/cache/ehcache/EhCacheApiSpec.scala
@@ -13,7 +13,10 @@ import scala.concurrent.Future
 
 import jakarta.inject.Inject
 import jakarta.inject.Provider
-import net.sf.ehcache.CacheManager
+import org.ehcache.config.builders.CacheConfigurationBuilder
+import org.ehcache.config.builders.ResourcePoolsBuilder
+import org.ehcache.CacheManager
+import play.api.cache.ehcache.EhCacheApi.EhExpirableCacheValue
 import play.api.cache.AsyncCacheApi
 import play.api.cache.SyncCacheApi
 import play.api.inject._
@@ -33,12 +36,13 @@ class EhCacheApiSpec extends PlaySpecification {
       override def running() = {
         val controller    = app.injector.instanceOf[NamedCacheController]
         val syncCacheName =
-          controller.cache.asInstanceOf[SyncEhCacheApi].cache.getName
+          controller.cache.asInstanceOf[SyncEhCacheApi].cache
         val asyncCacheName =
-          controller.asyncCache.asInstanceOf[EhCacheApi].cache.getName
+          controller.asyncCache.asInstanceOf[EhCacheApi].cache
 
-        syncCacheName must_== "custom"
-        asyncCacheName must_== "custom"
+        // no way to get cache name anymore, so doing most basic test
+        syncCacheName.getClass.getSimpleName must_== "Ehcache"
+        asyncCacheName.getClass.getSimpleName must_== "Ehcache"
       }
     }
     "bind already created named caches" in new WithApplication(
@@ -102,8 +106,18 @@ class EhCacheApiSpec extends PlaySpecification {
 class CustomCacheManagerProvider @Inject() (cacheManagerProvider: CacheManagerProvider) extends Provider[CacheManager] {
   lazy val get = {
     val mgr = cacheManagerProvider.get
-    mgr.removeAllCaches()
-    mgr.addCache("custom")
+    mgr.close()
+    mgr.init()
+    mgr.removeCache("custom") // cache config is not cleared upon `close()` and causes auto-creation of cache on init()
+    mgr.createCache(
+      "custom",
+      CacheConfigurationBuilder.newCacheConfigurationBuilder(
+        classOf[String],
+        classOf[EhExpirableCacheValue],
+        ResourcePoolsBuilder.heap(100)
+      )
+    )
+    mgr.getCache("custom", classOf[String], classOf[EhExpirableCacheValue])
     mgr
   }
 }

--- a/documentation/manual/working/commonGuide/configuration/WsCache.md
+++ b/documentation/manual/working/commonGuide/configuration/WsCache.md
@@ -45,17 +45,22 @@ play.ws.cache.cacheManagerResource="ehcache-play-ws-cache.xml"
 and then adding a cache such as following into the `conf` directory:
 
 ```xml
-<ehcache
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://ehcache.org/ehcache.xsd"
-        name="play-ws-cache"
-        updateCheck="false"
-        >
+<config
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns='http://www.ehcache.org/v3'
+  xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core.xsd">
 
-	<cache name="play-ws-cache" maxEntriesLocalHeap="10000" eternal="false"
-		timeToIdleSeconds="360" timeToLiveSeconds="1000" overflowToDisk="false" />
-
-</ehcache>
+  <cache alias="play-ws-cache">
+    <key-type>java.lang.String</key-type>
+    <value-type>play.api.cache.ExpirableCacheValue</value-type>
+    <expiry>
+      <tti unit="seconds">360</tti>
+    </expiry>
+    <resources>
+      <heap unit="entries">10000</heap>
+    </resources>
+  </cache>
+</config>
 ```
 
 > **NOTE**: `play.ws.cache.cacheManagerURI` is deprecated, use `play.ws.cache.cacheManagerResource` with a path on the classpath instead.

--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -8,7 +8,7 @@ Caching data is a typical optimization in modern applications, and so Play provi
 
 For any data stored in the cache, a regeneration strategy needs to be put in place in case the data goes missing. This philosophy is one of the fundamentals behind Play, and is different from Java EE, where the session is expected to retain values throughout its lifetime.
 
-Play provides a CacheApi implementation based on [Caffeine](https://github.com/ben-manes/caffeine/) and a legacy implementation based on [Ehcache 2.x](http://www.ehcache.org). For in-process caching Caffeine is typically the best choice. If you need distributed caching, there are third-party plugins for [memcached](https://github.com/mumoshu/play2-memcached) and [redis](https://github.com/KarelCemus/play-redis).
+Play provides a CacheApi implementation based on [Caffeine](https://github.com/ben-manes/caffeine/) and a legacy implementation based on [Ehcache 3.x](http://www.ehcache.org). For in-process caching Caffeine is typically the best choice. If you need distributed caching, there are third-party plugins for [memcached](https://github.com/mumoshu/play2-memcached) and [redis](https://github.com/KarelCemus/play-redis).
 
 ## Importing the Cache API
 

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -8,7 +8,7 @@ Caching data is a typical optimization in modern applications, and so Play provi
 
 For any data stored in the cache, a regeneration strategy needs to be put in place in case the data goes missing. This philosophy is one of the fundamentals behind Play, and is different from Java EE, where the session is expected to retain values throughout its lifetime.
 
-Play provides a CacheApi implementation based on [Caffeine](https://github.com/ben-manes/caffeine/) and a legacy implementation based on [Ehcache 2.x](http://www.ehcache.org). For in-process caching Caffeine is typically the best choice. If you need distributed caching, there are third-party plugins for [memcached](https://github.com/mumoshu/play2-memcached) and [redis](https://github.com/KarelCemus/play-redis).
+Play provides a CacheApi implementation based on [Caffeine](https://github.com/ben-manes/caffeine/) and a legacy implementation based on [Ehcache 3.x](http://www.ehcache.org). For in-process caching Caffeine is typically the best choice. If you need distributed caching, there are third-party plugins for [memcached](https://github.com/mumoshu/play2-memcached) and [redis](https://github.com/KarelCemus/play-redis).
 
 ## Importing the Cache API
 
@@ -121,7 +121,7 @@ By default, Play will try to create caches with names from `play.cache.bindCache
 ## Setting the execution context
 
 By default, Caffeine and EhCache store elements in memory. Therefore reads from and writes to the cache should be very fast, because there is hardly any blocking I/O.
-However, depending on how a cache was configured (e.g. by using [EhCache's `DiskStore`](http://www.ehcache.org/generated/2.10.4/html/ehc-all/#page/Ehcache_Documentation_Set%2Fco-store_storage_tiers.html)), there might be blocking I/O which can become too costly, because even the async implementations will block threads in the default execution context.
+However, depending on how a cache was configured (e.g. by using [EhCache's `DiskStore`](https://www.ehcache.org/documentation/3.10/tiering.html#disk-tier)), there might be blocking I/O which can become too costly, because even the async implementations will block threads in the default execution context.
 
 For such a case you can configure a different [Pekko dispatcher](https://pekko.apache.org/docs/pekko/1.0/dispatchers.html?language=scala#looking-up-a-dispatcher) and set it via `play.cache.dispatcher` so the cache plugin makes use of it:
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -553,6 +553,17 @@ object BuildSettings {
       // Make Java's Formatters.print(TypeDescriptor desc, ...) package private to hide spring implementation
       // (It leaks the now internal play.data.internal.binding.core.convert.TypeDescriptor)
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.data.format.Formatters.print"),
+      // EhCache3 upgrade
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.cache.ehcache.CacheManagerProvider.get"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.cache.ehcache.EhCacheApi.<init>"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.cache.ehcache.EhCacheComponents.ehCacheManager"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.cache.ehcache.EhCacheApi.this"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.cache.ehcache.SyncEhCacheApi.this"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.cache.ehcache.EhCacheComponents.ehCacheManager"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.cache.ehcache.EhCacheApi.cache"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.cache.ehcache.SyncEhCacheApi.cache"),
+      ProblemFilters.exclude[MissingClassProblem]("play.api.cache.caffeine.ExpirableCacheValue"),
+      ProblemFilters.exclude[MissingClassProblem]("play.api.cache.caffeine.ExpirableCacheValue$")
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -274,10 +274,9 @@ object Dependencies {
     "javax.cache" % "cache-api" % "1.1.1"
   )
 
-  val ehcacheVersion  = "2.10.9.2"
+  val ehcacheVersion  = "3.10.8"
   val playEhcacheDeps = Seq(
-    "net.sf.ehcache" % "ehcache" % ehcacheVersion,
-    "org.ehcache"    % "jcache"  % "1.0.1"
+    ("org.ehcache" % "ehcache" % ehcacheVersion).classifier("jakarta")
   ) ++ jcacheApi
 
   val caffeineVersion  = "3.2.4"
@@ -301,8 +300,7 @@ object Dependencies {
     "org.playframework"             % "shaded-asynchttpclient" % playWsStandaloneVersion,
     "org.playframework"             % "shaded-oauth"           % playWsStandaloneVersion,
     "com.github.ben-manes.caffeine" % "jcache"                 % caffeineVersion % Test,
-    "net.sf.ehcache"                % "ehcache"                % ehcacheVersion  % Test,
-    "org.ehcache"                   % "jcache"                 % "1.0.1"         % Test
+    ("org.ehcache"                  % "ehcache"                % ehcacheVersion  % Test).classifier("jakarta")
   ) ++ jcacheApi
 
   val playDocsSbtPluginDependencies = Seq(

--- a/transport/client/play-ahc-ws/src/test/resources/ehcache-play-ws-cache.xml
+++ b/transport/client/play-ahc-ws/src/test/resources/ehcache-play-ws-cache.xml
@@ -2,14 +2,19 @@
    Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 -->
 
-<ehcache
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://ehcache.org/ehcache.xsd"
-        name="play-ws-cache"
-        updateCheck="false"
->
+<config
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns='http://www.ehcache.org/v3'
+  xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core.xsd">
 
-  <cache name="play-ws-cache" maxEntriesLocalHeap="10000" eternal="false"
-         timeToIdleSeconds="360" timeToLiveSeconds="1000" overflowToDisk="false" />
-
-</ehcache>
+  <cache alias="play-ws-cache">
+    <key-type>java.lang.String</key-type>
+    <value-type>play.api.cache.ExpirableCacheValue</value-type>
+    <expiry>
+      <tti unit="seconds">360</tti>
+    </expiry>
+    <resources>
+      <heap unit="entries">10000</heap>
+    </resources>
+  </cache>
+</config>

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/OptionalAhcHttpCacheProviderSpec.scala
@@ -5,7 +5,7 @@
 package play.api.libs.ws.ahc
 
 import com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider
-import org.ehcache.jcache.JCacheCachingProvider
+import org.ehcache.jsr107.EhcacheCachingProvider
 import org.specs2.concurrent.ExecutionEnv
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.inject.DefaultApplicationLifecycle
@@ -31,8 +31,9 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
     "work with a cache defined using ehcache through jcache" in new WithApplication(
       GuiceApplicationBuilder(loadConfiguration = { (env: Environment) =>
         val settings = Map(
+          "play.http.secret.key"               -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b",
           "play.ws.cache.enabled"              -> "true",
-          "play.ws.cache.cachingProviderName"  -> classOf[JCacheCachingProvider].getName,
+          "play.ws.cache.cachingProviderName"  -> classOf[EhcacheCachingProvider].getName,
           "play.ws.cache.cacheManagerResource" -> "ehcache-play-ws-cache.xml"
         )
         Configuration.load(env, settings)
@@ -47,6 +48,7 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
     "work with a cache defined using caffeine through jcache" in new WithApplication(
       GuiceApplicationBuilder(loadConfiguration = { (env: Environment) =>
         val settings = Map(
+          "play.http.secret.key"               -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b",
           "play.ws.cache.enabled"              -> "true",
           "play.ws.cache.cachingProviderName"  -> classOf[CaffeineCachingProvider].getName,
           "play.ws.cache.cacheManagerResource" -> "caffeine.conf"
@@ -54,7 +56,7 @@ class OptionalAhcHttpCacheProviderSpec(implicit ee: ExecutionEnv) extends PlaySp
         Configuration.load(env, settings)
       }).build()
     ) {
-      override def running() = {
+      override def running(): Unit = {
         val provider = app.injector.instanceOf[OptionalAhcHttpCacheProvider]
         provider.get must beSome[AhcHttpCache].which { cache => cache.isShared must beFalse }
       }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Upgrades Ehcache to version 3 (version 2 contains security vulnerabilities).

## Background Context

This is a bit 'naive' implementation but it does not break the Play API which I think is more important. One big disadvantage is the ehcahce xml configuration which force use of Play API as cache item.
