### PR TITLE
[Gradle] Fix `playRun` classpath when project depends on a pure java project

### DIFF
--- a/dev-mode/gradle-plugin/src/test/java/play/gradle/PlayRunPluginTest.java
+++ b/dev-mode/gradle-plugin/src/test/java/play/gradle/PlayRunPluginTest.java
@@ -60,8 +60,7 @@ class PlayRunPluginTest {
     scalaLib.getPluginManager().apply("scala");
 
     project.getRepositories().add(project.getRepositories().mavenCentral());
-    // TODO: Uncomment in https://github.com/playframework/playframework/pull/12531
-    // project.getDependencies().add("implementation", javaLib);
+    project.getDependencies().add("implementation", javaLib);
     project.getDependencies().add("implementation", scalaLib);
 
     ((DefaultProject) project).evaluate();
@@ -71,10 +70,8 @@ class PlayRunPluginTest {
             project.getLayout().getBuildDirectory().file("classes/scala/main").get().getAsFile(),
             project.getLayout().getBuildDirectory().file("classes/java/main").get().getAsFile(),
             project.getLayout().getBuildDirectory().file("resources/main").get().getAsFile(),
-            // TODO: Uncomment in https://github.com/playframework/playframework/pull/12531
-            // javaLib.getLayout().getBuildDirectory().file("classes/scala/main").get().getAsFile(),
-            // javaLib.getLayout().getBuildDirectory().file("classes/java/main").get().getAsFile(),
-            // javaLib.getLayout().getBuildDirectory().file("resources/main").get().getAsFile()
+            javaLib.getLayout().getBuildDirectory().file("classes/java/main").get().getAsFile(),
+            javaLib.getLayout().getBuildDirectory().file("resources/main").get().getAsFile(),
             scalaLib.getLayout().getBuildDirectory().file("classes/scala/main").get().getAsFile(),
             scalaLib.getLayout().getBuildDirectory().file("classes/java/main").get().getAsFile(),
             scalaLib.getLayout().getBuildDirectory().file("resources/main").get().getAsFile());


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

Copy of #12531 
Original author is @vincent-raman 

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [/] Have you checked that both Scala and Java APIs are updated?
* [/] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes playframework/playframework#12530

## Purpose

Avoid relying on the fixed existence of `compileJava`, `compileScala` or even `processResources` in any of the gradle projects when computing the classpath for `playRun`

## Background Context

The computation of the classpath for the `playRun` takes the output folders of the current Play project and any of the subprojects it depends on. It supposes that `compileJava`, `compileScala` and `processResources` tasks exist for any of these projects without any check. If one of them doesn't exist, it fails creating `playRun`.

I chose the approach of mapping directories only if the task existed. I used the Java stream API as it seemed the easiest one to filter and map tasks in one go.

I added a unit test checking that the required output folder were present in the class path and that the `test` output folder were not included

## References

https://github.com/playframework/playframework/issues/12530
