### PR TITLE
Scala 2.13.14 / Add explicit types and remove `-Xmigration` flag in tests

### DIFF
--- a/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -5,6 +5,7 @@
 package play.api.http
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
@@ -254,15 +255,15 @@ object HttpErrorHandlerSpec {
 }
 
 class CustomScalaErrorHandler extends HttpErrorHandler {
-  def onClientError(request: RequestHeader, statusCode: Int, message: String) =
+  def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] =
     Future.successful(Results.Ok)
-  def onServerError(request: RequestHeader, exception: Throwable) =
+  def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
     Future.successful(Results.Ok)
 }
 
 class CustomJavaErrorHandler extends play.http.HttpErrorHandler {
-  def onClientError(req: play.mvc.Http.RequestHeader, status: Int, msg: String) =
+  def onClientError(req: play.mvc.Http.RequestHeader, status: Int, msg: String): CompletionStage[play.mvc.Result] =
     CompletableFuture.completedFuture(play.mvc.Results.ok())
-  def onServerError(req: play.mvc.Http.RequestHeader, exception: Throwable) =
+  def onServerError(req: play.mvc.Http.RequestHeader, exception: Throwable): CompletionStage[play.mvc.Result] =
     CompletableFuture.completedFuture(play.mvc.Results.ok())
 }

--- a/core/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -14,12 +14,12 @@ import play.api.test._
 class NettyServerIntegrationSpecificationSpec
     extends ServerIntegrationSpecificationSpec
     with NettyIntegrationSpecification {
-  override def expectedServerTag = Some("netty")
+  override def expectedServerTag: Option[String] = Some("netty")
 }
 class PekkoHttpServerIntegrationSpecificationSpec
     extends ServerIntegrationSpecificationSpec
     with PekkoHttpIntegrationSpecification {
-  override def expectedServerTag = None
+  override def expectedServerTag: Option[String] = None
 }
 
 /**

--- a/core/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -60,14 +60,14 @@ class SecuritySpec extends PlaySpecification {
 
   def getUserInfoFromRequest(req: RequestHeader) = req.session.get("username")
 
-  def getUserFromRequest(req: RequestHeader) = req.session.get("user").map(User)
+  def getUserFromRequest(req: RequestHeader) = req.session.get("user").map(User.apply)
 
   class AuthenticatedDbRequest[A](val user: User, val conn: Connection, request: Request[A])
       extends WrappedRequest[A](request)
 
   def Authenticated(implicit app: Application) = new ActionBuilder[AuthenticatedDbRequest, AnyContent] {
-    lazy val executionContext = app.materializer.executionContext
-    lazy val parser           = app.injector.instanceOf[PlayBodyParsers].default
+    lazy val executionContext: ExecutionContext = app.materializer.executionContext
+    lazy val parser                             = app.injector.instanceOf[PlayBodyParsers].default
     def invokeBlock[A](request: Request[A], block: (AuthenticatedDbRequest[A]) => Future[Result]) = {
       val builder = AuthenticatedBuilder(req => getUserFromRequest(req), parser)(executionContext)
       builder.authenticate(
@@ -100,7 +100,7 @@ class AuthMessagesRequest[A](val user: User, messagesApi: MessagesApi, request: 
     extends MessagesRequest[A](request, messagesApi)
 
 class UserAuthenticatedBuilder(parser: BodyParser[AnyContent])(implicit ec: ExecutionContext)
-    extends AuthenticatedBuilder[User]({ (req: RequestHeader) => req.session.get("user").map(User) }, parser) {
+    extends AuthenticatedBuilder[User]({ (req: RequestHeader) => req.session.get("user").map(User.apply) }, parser) {
   @Inject()
   def this(parser: BodyParsers.Default)(implicit ec: ExecutionContext) = {
     this(parser: BodyParser[AnyContent])

--- a/core/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -74,7 +74,7 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
     "allow accessing the raw unparsed path from an error handler" in withServer(new HttpErrorHandler() {
       def onClientError(request: RequestHeader, statusCode: Int, message: String) =
         Future.successful(Results.BadRequest("Bad path: " + request.path + " message: " + message))
-      def onServerError(request: RequestHeader, exception: Throwable) = Future.successful(Results.Ok)
+      def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = Future.successful(Results.Ok)
     }) { port =>
       val response = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/[", "HTTP/1.1", Map(), "")

--- a/core/play-integration-test/src/test/scala/play/it/http/HttpErrorHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/HttpErrorHandlingSpec.scala
@@ -73,7 +73,7 @@ class HttpErrorHandlingSpec
       webCommandHandler = None,
       filters = Seq(
         new EssentialFilter {
-          def apply(next: EssentialAction) = {
+          def apply(next: EssentialAction): EssentialAction = {
             throw new RuntimeException("filter exception!")
           }
         }
@@ -129,7 +129,7 @@ class HttpErrorHandlingSpec
         webCommandHandler = None,
         filters = Seq(
           new EssentialFilter {
-            def apply(next: EssentialAction) = {
+            def apply(next: EssentialAction): EssentialAction = {
               throw new RuntimeException("filter exception!")
             }
           }

--- a/core/play-integration-test/src/test/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/JavaHttpErrorHandlingSpec.scala
@@ -112,7 +112,7 @@ class JavaHttpErrorHandlingSpec
       webCommandHandler = None,
       filters = Seq(
         new EssentialFilter {
-          def apply(next: EssentialAction) = {
+          def apply(next: EssentialAction): EssentialAction = {
             throw new RuntimeException("filter exception!")
           }
         }
@@ -176,7 +176,7 @@ class JavaHttpErrorHandlingSpec
         webCommandHandler = None,
         filters = Seq(
           new EssentialFilter {
-            def apply(next: EssentialAction) = {
+            def apply(next: EssentialAction): EssentialAction = {
               throw new RuntimeException("filter exception!")
             }
           }

--- a/core/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -85,7 +85,7 @@ trait JavaResultsHandlingSpec
     }) { response => response.header(DATE) must beSome }
 
     "work with non-standard HTTP response codes" in makeRequest(new MockController {
-      def action(request: Http.Request) = {
+      def action(request: Http.Request): Result = {
         Results.status(498)
       }
     }) { response => response.status must beEqualTo(498) }

--- a/core/play-integration-test/src/test/scala/play/it/http/PekkoHttpCustomServerProviderSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/PekkoHttpCustomServerProviderSpec.scala
@@ -18,6 +18,7 @@ import play.api.test.ApplicationFactory
 import play.api.test.PlaySpecification
 import play.api.test.ServerEndpointRecipe
 import play.core.server.PekkoHttpServer
+import play.core.server.Server
 import play.core.server.ServerProvider
 import play.it.test._
 
@@ -73,7 +74,7 @@ class PekkoHttpCustomServerProviderSpec
     val customPekkoHttpEndpoint: ServerEndpointRecipe = PekkoHttp11Plaintext
       .withDescription("Pekko HTTP HTTP/1.1 (plaintext, supports FOO)")
       .withServerProvider(new ServerProvider {
-        def createServer(context: ServerProvider.Context) =
+        def createServer(context: ServerProvider.Context): Server =
           new PekkoHttpServer(PekkoHttpServer.Context.fromServerProviderContext(context)) {
             protected override def createParserSettings(): ParserSettings = {
               super.createParserSettings().withCustomMethods(HttpMethod.custom("FOO"))
@@ -95,7 +96,7 @@ class PekkoHttpCustomServerProviderSpec
     val customPekkoHttpEndpoint: ServerEndpointRecipe = PekkoHttp11Plaintext
       .withDescription("Pekko HTTP HTTP/1.1 (plaintext, long headers)")
       .withServerProvider(new ServerProvider {
-        def createServer(context: ServerProvider.Context) =
+        def createServer(context: ServerProvider.Context): Server =
           new PekkoHttpServer(PekkoHttpServer.Context.fromServerProviderContext(context)) {
             protected override def createParserSettings(): ParserSettings = {
               super.createParserSettings().withMaxHeaderNameLength(100)

--- a/core/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -164,6 +164,6 @@ class CustomErrorHandler extends HttpErrorHandler {
           .getOrElse("<not set>") + " / " + message
       )
     )
-  def onServerError(request: RequestHeader, exception: Throwable) =
+  def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
     Future.successful(Results.BadRequest)
 }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -118,7 +118,7 @@ object WebSocketClient {
      */
     def connect(url: URI, version: WebSocketVersion, subprotocol: Option[String])(
         onConnected: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
-    ) = {
+    ): Future[?] = {
       val normalized = url.normalize()
       val tgt = if (normalized.getPath == null || normalized.getPath.trim().isEmpty) {
         new URI(normalized.getScheme, normalized.getAuthority, "/", normalized.getQuery, normalized.getFragment)

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -20,6 +20,7 @@ import org.apache.pekko.actor.Props
 import org.apache.pekko.actor.Status
 import org.apache.pekko.stream.scaladsl._
 import org.apache.pekko.util.ByteString
+import org.apache.pekko.util.Timeout
 import org.specs2.execute.AsResult
 import org.specs2.execute.EventuallyResults
 import org.specs2.matcher.Matcher
@@ -343,7 +344,7 @@ trait WebSocketSpec
             Props(new Actor() {
               messages.foreach { msg => out ! msg }
               out ! Status.Success(())
-              def receive = PartialFunction.empty
+              def receive: Actor.Receive = PartialFunction.empty
             })
           }
         }
@@ -356,7 +357,7 @@ trait WebSocketSpec
           ActorFlow.actorRef { out =>
             Props(new Actor() {
               system.scheduler.scheduleOnce(10.millis, out, Status.Success(()))
-              def receive = PartialFunction.empty
+              def receive: Actor.Receive = PartialFunction.empty
             })
           }
         }
@@ -382,7 +383,7 @@ trait WebSocketSpec
         WebSocket.accept[String, String] { req =>
           ActorFlow.actorRef { out =>
             Props(new Actor() {
-              def receive = PartialFunction.empty
+              def receive: Actor.Receive = PartialFunction.empty
               override def postStop() = {
                 cleanedUp.success(true)
               }
@@ -441,7 +442,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   import scala.jdk.CollectionConverters._
 
   // Extend the default spec timeout for CI.
-  implicit override def defaultAwaitTimeout = 10.seconds
+  implicit override def defaultAwaitTimeout: Timeout = 10.seconds
 
   protected override def shouldRunSequentially(app: Application): Boolean = false
 

--- a/core/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -276,7 +276,8 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
       def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
         Future.successful(Results.NotFound(request.headers.get(filterAddedHeaderKey).getOrElse("undefined header")))
       }
-      def onServerError(request: RequestHeader, exception: Throwable) = Future.successful(Results.InternalServerError)
+      def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
+        Future.successful(Results.InternalServerError)
     }
 
     "requests not matching a route should receive a RequestHeader modified by upstream filters" in withServer(

--- a/core/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/core/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -325,7 +325,7 @@ object HttpBinApplication {
     new BuiltInComponentsFromContext(ApplicationLoader.Context.create(Environment.simple()))
       with AhcWSComponents
       with NoHttpFiltersComponents {
-      implicit override lazy val Action = defaultActionBuilder
+      implicit override lazy val Action: DefaultActionBuilder = defaultActionBuilder
       override def router = SimpleRouter(
         PartialFunction.empty
           .orElse(getIp)

--- a/core/play/src/test/scala/play/mvc/StatusHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/StatusHeaderSpec.scala
@@ -36,7 +36,7 @@ class StatusHeaderSpec extends TestKit(ActorSystem("StatusHeaderSpec")) with Spe
       val materializer = Materializer.matFromSystem
 
       Json.mapper.getFactory.setCharacterEscapes(new CharacterEscapes {
-        override def getEscapeSequence(ch: Int) = new SerializedString(f"\\u$ch%04x")
+        override def getEscapeSequence(ch: Int): SerializedString = new SerializedString(f"\\u$ch%04x")
 
         override def getEscapeCodesForAscii: Array[Int] =
           CharacterEscapes.standardAsciiEscapesForJSON.zipWithIndex.map {

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -77,8 +77,8 @@ lazy val main = Project("Play-Documentation", file("."))
     Test / unmanagedResourceDirectories ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
     // Don't include sbt files in the resources
     Test / unmanagedResources / excludeFilter := (Test / unmanagedResources / excludeFilter).value || "*.sbt",
-    crossScalaVersions                        := Seq("2.13.13", "3.3.3"),
-    scalaVersion                              := "2.13.13",
+    crossScalaVersions                        := Seq("2.13.14", "3.3.3"),
+    scalaVersion                              := "2.13.14",
     Test / fork                               := true,
     Test / javaOptions ++= Seq("-Xmx512m", "-Xms128m"),
     headerLicense := Some(

--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -39,7 +39,7 @@ This will build and publish Play for the default Scala version. If you want to p
 Or to publish for a specific Scala version:
 
 ```bash
-> ++ 2.13.13 publishLocal
+> ++ 2.13.14 publishLocal
 ```
 
 ## Build the documentation

--- a/documentation/manual/releases/release27/Highlights27.md
+++ b/documentation/manual/releases/release27/Highlights27.md
@@ -25,7 +25,7 @@ scalaVersion := "2.11.12"
 For Scala 2.13:
 
 ```scala
-scalaVersion := "2.13.13"
+scalaVersion := "2.13.14"
 ```
 
 ## Lifecycle managed by Akka's Coordinated Shutdown

--- a/documentation/manual/releases/release28/migration28/Migration28.md
+++ b/documentation/manual/releases/release28/migration28/Migration28.md
@@ -47,14 +47,14 @@ Play 2.8 support Scala 2.12 and 2.13, but not 2.11, which has reached its end of
 To set the Scala version in sbt, simply set the `scalaVersion` key, for example:
 
 ```scala
-scalaVersion := "2.13.13"
+scalaVersion := "2.13.14"
 ```
 
 If you have a single project build, then this setting can just be placed on its own line in `build.sbt`.  However, if you have a multi-project build, then the scala version setting must be set on each project.  Typically, in a multi-project build, you will have some common settings shared by every project, this is the best place to put the setting, for example:
 
 ```scala
 def commonSettings = Seq(
-  scalaVersion := "2.13.13"
+  scalaVersion := "2.13.14"
 )
 
 val projectA = (project in file("projectA"))

--- a/documentation/manual/releases/release29/migration29/Migration29.md
+++ b/documentation/manual/releases/release29/migration29/Migration29.md
@@ -62,7 +62,7 @@ Play 2.9 supports Scala 2.13 and Scala 3.3, but not 2.12 anymore. Scala 3 requir
 To set the Scala version in sbt, simply set the `scalaVersion` key, for example:
 
 ```scala
-scalaVersion := "2.13.13"
+scalaVersion := "2.13.14"
 ```
 
 Play 2.9 also supports Scala 3:
@@ -77,7 +77,7 @@ If you have a single project build, then this setting can just be placed on its 
 
 ```scala
 def commonSettings = Seq(
-  scalaVersion := "2.13.13"
+  scalaVersion := "2.13.14"
 )
 
 val projectA = (project in file("projectA"))

--- a/documentation/manual/working/commonGuide/build/sbtDependencies.md
+++ b/documentation/manual/working/commonGuide/build/sbtDependencies.md
@@ -38,7 +38,7 @@ If you use `groupID %% artifactID % revision` rather than `groupID % artifactID 
 
 @[explicit-scala-version-dep](code/dependencies.sbt)
 
-Assuming the `scalaVersion` for your build is `2.13.13`, the following is identical (note the double `%%` after `"org.scala-tools"`):
+Assuming the `scalaVersion` for your build is `2.13.14`, the following is identical (note the double `%%` after `"org.scala-tools"`):
 
 @[auto-scala-version-dep](code/dependencies.sbt)
 

--- a/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsSpec.scala
+++ b/persistence/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsSpec.scala
@@ -194,7 +194,7 @@ class EvolutionsSpec extends Specification {
       connection.createStatement.execute(sql)
     }.get
 
-    def after = {
+    def after: Any = {
       database.shutdown()
     }
   }

--- a/project/PlayBuildBase.scala
+++ b/project/PlayBuildBase.scala
@@ -59,14 +59,6 @@ object PlayBuildBase extends AutoPlugin {
         case Some((2, 13)) => Seq("-Xsource:3")
         case _             => Seq.empty
       }),
-    Test / scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 13)) =>
-          Seq("-Xmigration:2.13")
-        case _ =>
-          Seq.empty
-      }
-    },
     javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
     resolvers ++= {
       if (isSnapshot.value) {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -4,7 +4,7 @@
 
 object ScalaVersions {
   val scala212 = "2.12.19"
-  val scala213 = "2.13.13"
+  val scala213 = "2.13.14"
   val scala3   = "3.3.3"
 }
 

--- a/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
@@ -78,11 +78,11 @@ class FakeServer(context: ServerProvider.Context) extends Server with Reloadable
 }
 
 class FakeServerProvider extends ServerProvider {
-  override def createServer(context: ServerProvider.Context) = new FakeServer(context)
+  override def createServer(context: ServerProvider.Context): Server = new FakeServer(context)
 }
 
 class StartupErrorServerProvider extends ServerProvider {
-  override def createServer(context: ServerProvider.Context) = throw new Exception("server fails to start")
+  override def createServer(context: ServerProvider.Context): Server = throw new Exception("server fails to start")
 }
 
 class ProdServerStartSpec extends Specification {

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
@@ -9,6 +9,7 @@ import javax.inject.Inject
 import play.api.http.HttpFilters
 import play.api.inject.bind
 import play.api.mvc.DefaultActionBuilder
+import play.api.mvc.EssentialFilter
 import play.api.mvc.Results
 import play.api.routing.sird._
 import play.api.routing.Router
@@ -19,7 +20,7 @@ import play.mvc.Http.HeaderNames._
 
 object CORSFilterSpec {
   class Filters @Inject() (corsFilter: CORSFilter) extends HttpFilters {
-    def filters = Seq(corsFilter)
+    def filters: Seq[EssentialFilter] = Seq(corsFilter)
   }
 
   class CorsApplicationRouter @Inject() (action: DefaultActionBuilder)

--- a/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
@@ -17,6 +17,7 @@ import play.api.inject.bind
 import play.api.libs.crypto.DefaultCSRFTokenSigner
 import play.api.libs.crypto.DefaultCookieSigner
 import play.api.mvc.DefaultActionBuilder
+import play.api.mvc.EssentialFilter
 import play.api.mvc.Results
 import play.api.routing.sird._
 import play.api.routing.Router
@@ -30,7 +31,7 @@ object CORSWithCSRFSpec {
   }
 
   class FiltersWithoutCors @Inject() (csrfFilter: CSRFFilter) extends HttpFilters {
-    def filters = Seq(csrfFilter)
+    def filters: Seq[EssentialFilter] = Seq(csrfFilter)
   }
 
   class CORSWithCSRFRouter @Inject() (action: DefaultActionBuilder) extends Router {
@@ -50,8 +51,8 @@ object CORSWithCSRFSpec {
         val csrfCheck = CSRFCheck(play.filters.csrf.CSRFConfig(), signer, sessionConfiguration)
         csrfCheck(action(Results.Ok), CSRF.DefaultErrorHandler)
     }
-    override def withPrefix(prefix: String) = this
-    override def documentation              = Seq.empty
+    override def withPrefix(prefix: String): Router           = this
+    override def documentation: Seq[(String, String, String)] = Seq.empty
   }
 }
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/CSPFilterSpec.scala
@@ -25,7 +25,7 @@ import play.api.Configuration
 import play.api.Environment
 
 class Filters @Inject() (cspFilter: CSPFilter) extends HttpFilters {
-  def filters = Seq(cspFilter)
+  def filters: Seq[EssentialFilter] = Seq(cspFilter)
 }
 
 class CSPFilterSpec extends PlaySpecification {

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -5,6 +5,7 @@
 package play.filters.csrf
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 import javax.inject.Inject
 
 import scala.concurrent.Future
@@ -543,7 +544,7 @@ class CustomErrorHandler extends CSRF.ErrorHandler {
 }
 
 class JavaErrorHandler extends CSRFErrorHandler {
-  def handle(req: Http.RequestHeader, msg: String) =
+  def handle(req: Http.RequestHeader, msg: String): CompletionStage[play.mvc.Result] =
     CompletableFuture.completedFuture(
       play.mvc.Results.unauthorized(
         "Origin: " + req.attrs
@@ -556,5 +557,5 @@ class JavaErrorHandler extends CSRFErrorHandler {
 }
 
 class CsrfFilters @Inject() (filter: CSRFFilter) extends HttpFilters {
-  def filters = Seq(filter)
+  def filters: Seq[EssentialFilter] = Seq(filter)
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -5,6 +5,7 @@
 package play.filters.csrf
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
 import scala.jdk.OptionConverters._
@@ -32,9 +33,9 @@ class JavaCSRFActionSpec extends CSRFCommonSpecs {
 
   def javaAction[T: ClassTag](method: String, inv: JRequest => Result)(implicit app: Application) =
     new JavaAction(javaHandlerComponents) {
-      val clazz                     = implicitly[ClassTag[T]].runtimeClass
-      def parser                    = HandlerInvokerFactory.javaBodyParserToScala(javaHandlerComponents.getBodyParser(annotations.parser))
-      def invocation(req: JRequest) = CompletableFuture.completedFuture(inv(req))
+      val clazz                                              = implicitly[ClassTag[T]].runtimeClass
+      def parser                                             = HandlerInvokerFactory.javaBodyParserToScala(javaHandlerComponents.getBodyParser(annotations.parser))
+      def invocation(req: JRequest): CompletionStage[Result] = CompletableFuture.completedFuture(inv(req))
       val annotations =
         new JavaActionAnnotations(
           clazz,
@@ -139,7 +140,7 @@ object JavaCSRFActionSpec {
   }
 
   class CustomErrorHandler extends CSRFErrorHandler {
-    def handle(req: RequestHeader, msg: String) = {
+    def handle(req: RequestHeader, msg: String): CompletionStage[Result] = {
       CompletableFuture.completedFuture(
         Results.unauthorized(
           "Origin: " + req

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -28,6 +28,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.AnyContentAsEmpty
 import play.api.mvc.Cookie
 import play.api.mvc.DefaultActionBuilder
+import play.api.mvc.EssentialFilter
 import play.api.mvc.Result
 import play.api.mvc.Results._
 import play.api.routing.Router
@@ -40,7 +41,7 @@ object GzipFilterSpec {
       extends SimpleRouterImpl({ case _ => action(result) })
 
   class Filters @Inject() (gzipFilter: GzipFilter) extends HttpFilters {
-    def filters = Seq(gzipFilter)
+    def filters: Seq[EssentialFilter] = Seq(gzipFilter)
   }
 }
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -11,6 +11,7 @@ import play.api.http.HttpFilters
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.DefaultActionBuilder
+import play.api.mvc.EssentialFilter
 import play.api.mvc.Result
 import play.api.mvc.Results._
 import play.api.routing.Router
@@ -22,7 +23,7 @@ import play.api.Application
 import play.api.Configuration
 
 class Filters @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends HttpFilters {
-  def filters = Seq(securityHeadersFilter)
+  def filters: Seq[EssentialFilter] = Seq(securityHeadersFilter)
 }
 
 object SecurityHeadersFilterSpec {

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -35,7 +35,7 @@ import play.api.Environment
 
 object AllowedHostsFilterSpec {
   class Filters @Inject() (allowedHostsFilter: AllowedHostsFilter) extends HttpFilters {
-    def filters = Seq(allowedHostsFilter)
+    def filters: Seq[EssentialFilter] = Seq(allowedHostsFilter)
   }
 
   case class ActionHandler(result: RequestHeader => Result) extends (RequestHeader => Result) {
@@ -369,6 +369,6 @@ class CustomErrorHandler extends HttpErrorHandler {
           .getOrElse("<not set>") + " / " + message
       )
     )
-  def onServerError(request: RequestHeader, exception: Throwable) =
+  def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
     Future.successful(Results.BadRequest)
 }


### PR DESCRIPTION
~Waiting for official announcement~:
- https://github.com/scala/scala/releases/tag/v2.13.14
- https://contributors.scala-lang.org/t/scala-2-13-14-release-planning/6581/13
- https://github.com/SethTisue/scala-dev/blob/scala-2.13.14/releases/2.13.14.md
  - from https://github.com/scala/scala-dev/pull/869