### PR TITLE
scala-parser-combinators 2.4.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -102,7 +102,7 @@ object Dependencies {
     Seq("org.scala-lang.modules" %% "scala-parser-combinators" % {
       CrossVersion.partialVersion(scalaVersion) match {
         case Some((2, _)) => "1.1.2"
-        case _            => "2.3.0"
+        case _            => "2.4.0"
       }
     })
 


### PR DESCRIPTION
scala-steward is unable to bump this version automatically because of the `match`/`case`:

```
2024-05-02 15:01:01,371 INFO  Process update org.scala-lang.modules:(scala-parser-combinators, scala-parser-combinators_3) : 2.3.0 -> 2.4.0
2024-05-02 15:01:01,658 WARN  Unable to bump version for update org.scala-lang.modules:(scala-parser-combinators, scala-parser-combinators_3) : 2.3.0 -> 2.4.0
2024-05-02 15:01:01,658 WARN  No commits created
```