### PR TITLE
remove eta-expansion

### DIFF
--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -415,7 +415,7 @@ class DefaultAssetsMetadata(
 ) extends AssetsMetadata {
   @Inject
   def this(env: Environment, config: AssetsConfiguration, fileMimeTypes: FileMimeTypes) =
-    this(config, env.resource _, fileMimeTypes)
+    this(config, env.resource, fileMimeTypes)
 
   lazy val finder: AssetsFinder = new AssetsFinder {
     val assetsBasePath  = config.path

--- a/core/play/src/test/scala/play/api/data/format/FormatSpec.scala
+++ b/core/play/src/test/scala/play/api/data/format/FormatSpec.scala
@@ -257,7 +257,7 @@ class FormatSpec extends Specification {
   "String parsing utility function" should {
     val errorMessage = "error.parsing"
 
-    def parsingFunction[T](fu: String => T) = Formats.parsing(fu, errorMessage, Nil) _
+    def parsingFunction[T](fu: String => T) = Formats.parsing(fu, errorMessage, Nil)
 
     val intParse: String => Int = Integer.parseInt
 

--- a/core/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
@@ -62,7 +62,7 @@ class RawBodyParserSpec extends Specification with AfterAll {
       val body = ByteString("lorem ipsum")
 
       "successfully" in {
-        parse(body)(javaParser _) must beRight[RawBuffer].like {
+        parse(body)(javaParser) must beRight[RawBuffer].like {
           case rawBuffer =>
             rawBuffer.asBytes() must beSome[ByteString].like {
               case outBytes => outBytes mustEqual body
@@ -96,7 +96,7 @@ class RawBodyParserSpec extends Specification with AfterAll {
 
       "close the raw buffer after parsing the body" in {
         val body = ByteString("lorem ipsum")
-        parse(body, memoryThreshold = 1)(javaParser _) must beRight[RawBuffer].like {
+        parse(body, memoryThreshold = 1)(javaParser) must beRight[RawBuffer].like {
           case rawBuffer =>
             rawBuffer.push(ByteString("This fails because the stream was closed!")) must throwA[IOException]
         }
@@ -104,7 +104,7 @@ class RawBodyParserSpec extends Specification with AfterAll {
 
       "fail to parse longer than allowed body" in {
         val msg = ByteString("lorem ipsum")
-        parse(msg, maxLength = 1)(javaParser _) must beLeft
+        parse(msg, maxLength = 1)(javaParser) must beLeft
       }
     }
   }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -327,7 +327,7 @@ private[play] class PlayRequestHandler(
       Server.routeModifierDefersBodyParsing(deferBodyParsingGlobal, requestHeader)
     // Execute the action on the Play default execution context
     val actionFuture = Future(action(if (deferBodyParsing) {
-      requestHeader.addAttr(RequestAttrKey.DeferredBodyParsing, invokeAction _)
+      requestHeader.addAttr(RequestAttrKey.DeferredBodyParsing, invokeAction)
     } else {
       requestHeader
     }))(mat.executionContext)

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -485,7 +485,7 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
     val deferBodyParsing = deferredBodyParsingAllowed &&
       Server.routeModifierDefersBodyParsing(serverConfig.underlying.getBoolean("deferBodyParsing"), taggedRequestHeader)
     val futureAcc: Future[Accumulator[ByteString, Result]] = Future(action(if (deferBodyParsing) {
-      taggedRequestHeader.addAttr(RequestAttrKey.DeferredBodyParsing, invokeAction _)
+      taggedRequestHeader.addAttr(RequestAttrKey.DeferredBodyParsing, invokeAction)
     } else {
       taggedRequestHeader
     }))

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -166,14 +166,14 @@ object CORSConfig {
         .get[Option[Seq[String]]]("allowedHttpMethods")
         .map { methods =>
           val s = methods.toSet
-          s.contains _
+          s.contains
         }
         .getOrElse(_ => true),
       isHttpHeaderAllowed = config
         .get[Option[Seq[String]]]("allowedHttpHeaders")
         .map { headers =>
           val s = headers.map(_.toLowerCase(java.util.Locale.ENGLISH)).toSet
-          s.contains _
+          s.contains
         }
         .getOrElse(_ => true),
       exposedHeaders = config.get[Seq[String]]("exposedHeaders"),

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPReportActionBuilder.scala
@@ -234,7 +234,7 @@ object ScalaCSPReport {
       .and((__ \ "status-code").readNullable[Int])
       .and((__ \ "source-file").readNullable[String])
       .and((__ \ "line-number").readNullable[Long](longOrStringToLongRead))
-      .and((__ \ "column-number").readNullable[Long](longOrStringToLongRead))(ScalaCSPReport.apply _)
+      .and((__ \ "column-number").readNullable[Long](longOrStringToLongRead))(ScalaCSPReport.apply)
 }
 
 import java.util.Optional

--- a/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/web/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -289,7 +289,7 @@ private[openid] object Discovery {
     def resolve(response: WSResponse) =
       for {
         _ <- response.header(HeaderNames.CONTENT_TYPE).filter(_.contains("application/xrds+xml"))
-        findInXml = findUriWithType(response.xml) _
+        findInXml = findUriWithType(response.xml)
         (typeId, uri) <- serviceTypeId.flatMap(findInXml(_)).headOption
       } yield OpenIDServer(typeId, uri, None)
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose

remove `_`

## Background Context

https://docs.scala-lang.org/scala3/reference/changed-features/eta-expansion.html

this syntax deprecated since Scala 3.4.x.
Scala 2.13.x support this syntax if `-Xsource:3`

```
Welcome to Scala 3.4.1 (17.0.11, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                                                                                              
scala> def f(x: Int): Int = x
def f(x: Int): Int
                                                                                                                                                                                                                                              
scala> f _
1 warning found
-- Warning: --------------------------------------------------------------------
1 |f _
  |^^^
  |The syntax `<function> _` is no longer supported;
  |you can simply leave out the trailing ` _`
val res0: Int => Int = Lambda$1431/0x000000040150c000@4cc89246
```


## References
