### PR TITLE
[3.0.x] sbt 1.10.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,7 +45,7 @@ jobs:
       cmd: |
         if [ "$CACHE_HIT_COURSIER" = "false" ]; then
           sbt +update                                             # Runs with adoptium:8 (default)
-          # sbt --sbt-version 1.9.9 +update                       # If we run scripted tests with multiple sbt versions, we could init that sbt installs here
+          # sbt --sbt-version 1.10.0 +update                      # If we run scripted tests with multiple sbt versions, we could init that sbt installs here
           sbt +mimaPreviousClassfiles                             # Fetches previous artifacts
           cd documentation && sbt +update && cd ..                # Fetches dependencies of the documentation project
           sbt -java-home `cs java-home --jvm adoptium:11` exit    # Init sbt with new JVM that will be downloaded
@@ -153,7 +153,7 @@ jobs:
       scala: 2.13.x, 3.x
       add-dimensions: >-
         {
-          "sbt": [ "1.9.9" ],
+          "sbt": [ "1.10.0" ],
           "sbt_steps": [ "*1of3", "*2of3", "*3of3" ]
         }
       exclude: >-

--- a/documentation/project/build.properties
+++ b/documentation/project/build.properties
@@ -1,4 +1,4 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # sync with project/build.properties
-sbt.version=1.9.9
+sbt.version=1.10.0

--- a/project/PlaySbtBuildBase.scala
+++ b/project/PlaySbtBuildBase.scala
@@ -13,7 +13,7 @@ object PlaySbtBuildBase extends AutoPlugin {
   override def projectSettings = Seq(
     scalaVersion                  := ScalaVersions.scala212,
     crossScalaVersions            := Seq(ScalaVersions.scala212),
-    pluginCrossBuild / sbtVersion := SbtVersions.sbt19,
+    pluginCrossBuild / sbtVersion := SbtVersions.sbt110,
     compile / javacOptions ++= Seq("--release", "11"),
     doc / javacOptions := Seq("-source", "11")
   )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -9,5 +9,5 @@ object ScalaVersions {
 }
 
 object SbtVersions {
-  val sbt19 = "1.9.9"
+  val sbt110 = "1.10.0"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 # Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 # sync with documentation/project/build.properties
-sbt.version=1.9.9
+sbt.version=1.10.0


### PR DESCRIPTION
I didn't upgrade sbt in the 3.0.x branch before the 3.0.3 release just to keep things safe, in case 1.10.0 would break stuff like it happend [with sbt 1.9.5 once](https://github.com/scala-steward-org/scala-steward/pull/3169).

For next 3.0.x release it should be ok to now upgrade to sbt 1.10.0, given 3.0.4 is a couple of weeks away and if sbt 1.10.0 has major issues I guess they would surface until then. 