### PR TITLE
Introduce sbt-pekko-version-check plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -515,9 +515,9 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
   )
   .aggregate((userProjects ++ nonUserProjects): _*)
 
-//val _ = sys.props += ("sbt_validateCode" -> List(
-//  "+checkPekkoModuleVersions", // TODO: See https://github.com/playframework/playframework/issues/11986
-//).mkString(";"))
+val _ = sys.props += ("sbt_validateCode" -> List(
+  "+pekkoVersionCheck",
+).mkString(";"))
 
 lazy val savePlayVersion = taskKey[Unit]("Save Play version")
 savePlayVersion := {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -22,6 +22,7 @@ import de.heikoseeberger.sbtheader.FileType
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern.commentBetween
 import de.heikoseeberger.sbtheader.LineCommentCreator
+import nl.gn0s1s.pekko.versioncheck.PekkoVersionCheckPlugin.autoImport._
 import xerial.sbt.Sonatype.autoImport.sonatypeProfileName
 import Omnidoc.autoImport.omnidocPathPrefix
 import Omnidoc.autoImport.omnidocSnapshotBranch
@@ -120,6 +121,7 @@ object BuildSettings {
         sys.props.get("pekko.version").map("-pekko-" + _).getOrElse("") +
         sys.props.get("pekko.http.version").map("-pekko-http-" + _).getOrElse("")
     },
+    pekkoVersionCheckFailBuildOnNonMatchingVersions := true,
     apiURL := {
       val v = version.value
       if (isSnapshot.value) {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,7 +33,7 @@ addSbtPlugin("de.heikoseeberger"       % "sbt-header"            % sbtHeader)
 addSbtPlugin("org.scalameta"           % "sbt-scalafmt"          % scalafmt)
 addSbtPlugin("com.github.sbt"          % "sbt-ci-release"        % "1.5.12")
 
-//addSbtPlugin("org.playframework" % "sbt-pekko-version-check" % "0.1")
+addSbtPlugin("nl.gn0s1s" % "sbt-pekko-version-check" % "0.0.3")
 
 libraryDependencies ++= Seq(
   "org.webjars" % "webjars-locator-core" % webjarsLocatorCore


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?

# Helpful things

## Fixes

Fixes #11986

## Purpose

Introduce sbt-pekko-version-check plugin, to make sure versions across Pekko modules are the same in the project.

## Background Context

We had the akka-equivalent of this plugin before.