### PR TITLE
[2.9.x] Pin persistence-api in scala-steward conf

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -49,6 +49,8 @@ updates.pin = [
   { groupId = "org.hibernate.validator", artifactId = "hibernate-validator", version = "6." },
   // Spring 6 requires Java 17
   { groupId = "org.springframework", artifactId = "spring-core", version = "5." },
+  // persistence-api 3.2 requires Java 17 and also it wouldn't be a good idea to upgrade anyway
+  { groupId = "jakarta.persistence", artifactId = "jakarta.persistence-api", version = "3.1." },
   // We do not upgrade beyond these versions anymore in Play 2.9:
   { groupId = "com.typesafe.play", artifactId = "play-ws-standalone", version = "2.2." },
   { groupId = "com.typesafe.play", artifactId = "play-ws-standalone-xml", version = "2.2." },


### PR DESCRIPTION
jakarta.persistence-api 3.2.0 requires Java 17: https://jakarta.ee/specifications/persistence/3.2/
- See #12651 