### PR TITLE
simplify PartialFunction compose

### DIFF
--- a/core/play/src/main/scala/play/api/routing/Router.scala
+++ b/core/play/src/main/scala/play/api/routing/Router.scala
@@ -174,7 +174,7 @@ trait SimpleRouter extends Router { self =>
           rh.withTarget(rh.target.withPath(newPath))
       }
       new Router {
-        def routes                = Function.unlift(prefixed.lift.andThen(_.flatMap(self.routes.lift)))
+        def routes                = prefixed.andThen(self.routes)
         def withPrefix(p: String) = self.withPrefix(Router.concatPrefix(p, prefix))
         def documentation         = self.documentation
       }


### PR DESCRIPTION

# Helpful things

## Purpose

Simplify  `PartialFunction` compose

## Background Context
No need to `lift` to `Function`, there are `PartialFunction.andThen(xxx: PartialFunction)`
https://github.com/scala/scala/blob/0d8f4caa713977983c53828f87d50fbadc7dd7ab/src/library/scala/PartialFunction.scala#L164

