### PR TITLE
Fix Pekko configuration value to match the official documentation

### DIFF
--- a/core/play/src/main/resources/play/reference-overrides.conf
+++ b/core/play/src/main/resources/play/reference-overrides.conf
@@ -13,7 +13,7 @@ pekko {
   # Play applications should exit when Pekko receives a fatal error.
   # If we don't stop the JVM we would have a stale application that
   # can't handle requests since the Pekko system is shutdown only.
-  jvm-exit-on-fatal-error = true
+  jvm-exit-on-fatal-error = on
 
   # Tell pekko to use Slf4jLogger and filter
   loglevel = DEBUG


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

~Fixes #xxxx~

## Purpose

Fix Pekko configuration value to match the official documentation.

## Background Context

`jvm-exit-on-fatal-error` was changed to `true` in #6522. However, according to the official documentation, it seems to be set to either `on` or `off`. So I changed it to `on` to match the documentation.

**Pekko**

https://pekko.apache.org/docs/pekko/current/general/configuration-reference.html

```conf
  # JVM shutdown, System.exit(-1), in case of a fatal error,
  # such as OutOfMemoryError
  jvm-exit-on-fatal-error = on
```

**Akka**

https://doc.akka.io/docs/akka/current/general/configuration-reference.html

```conf
  # JVM shutdown, System.exit(-1), in case of a fatal error,
  # such as OutOfMemoryError
  jvm-exit-on-fatal-error = on
```

## References

- #6522