### PR TITLE
Fix comments for Pekko configurations

### DIFF
--- a/core/play/src/main/resources/play/reference-overrides.conf
+++ b/core/play/src/main/resources/play/reference-overrides.conf
@@ -20,13 +20,13 @@ pekko {
   loggers = ["org.apache.pekko.event.slf4j.Slf4jLogger"]
   logging-filter = "org.apache.pekko.event.slf4j.Slf4jLoggingFilter"
 
-  # Since Pekko 2.5.8 there's a setting to disable all Pekko-provided JVM shutdown
-  # hooks. Play provides the shutdown hooks and runs the appropriate tasks already.
-  # Pekko's shutdown hooks are therefore not necessary.
+  # Pekko installs JVM shutdown hooks by default, e.g. in CoordinatedShutdown
+  # and Artery. Play provides the shutdown hooks and runs the appropriate tasks
+  # already. Pekko's shutdown hooks are therefore not necessary.
   jvm-shutdown-hooks = off
 
-  # CoordinatedShutdown is an extension introduced in Pekko 2.5 that will
-  # perform registered tasks in the order that is defined by the phases.
+  # CoordinatedShutdown is an extension that will perform registered
+  # tasks in the order that is defined by the phases.
   coordinated-shutdown {
 
     # Terminate the ActorSystem in the last phase actor-system-terminate.


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

~Fixes #xxxx~

## Purpose

Fix comments for Pekko configurations.

## Background Context

As a result of replacing `Akka` with `Pekko` in #11847, some comments became incorrect, such as "Pekko 2.5". So I fixed them by referring to the official documentation.

- https://pekko.apache.org/docs/pekko/current/general/configuration-reference.html

```conf
  # Pekko installs JVM shutdown hooks by default, e.g. in CoordinatedShutdown and Artery. This property will
  # not disable user-provided hooks registered using `CoordinatedShutdown#addCancellableJvmShutdownHook`.
  # This property is related to `pekko.coordinated-shutdown.run-by-jvm-shutdown-hook` below.
  # This property makes it possible to disable all such hooks if the application itself
  # or a higher level framework such as Play prefers to install the JVM shutdown hook and
  # terminate the ActorSystem itself, with or without using CoordinatedShutdown.
  jvm-shutdown-hooks = on
```

```conf
  # CoordinatedShutdown is an extension that will perform registered
  # tasks in the order that is defined by the phases. It is started
  # by calling CoordinatedShutdown(system).run(). This can be triggered
  # by different things, for example:
  # - JVM shutdown hook will by default run CoordinatedShutdown
  # - Cluster node will automatically run CoordinatedShutdown when it
  #   sees itself as Exiting
  # - A management console or other application specific command can
  #   run CoordinatedShutdown
  coordinated-shutdown {
```

## References

- #11847
- https://github.com/playframework/playframework/commit/5e9cf5c2beb089a2fab80cb0b83f440391bcd7d0#diff-d776d373f69270606271642831c30e051e2d4cf32de3376c9261700dfb9f277b