### PR TITLE
[Gradle] Use `processIsolation` instead of `classLoaderIsolation`

### DIFF
--- a/dev-mode/gradle-plugin/build.gradle.kts
+++ b/dev-mode/gradle-plugin/build.gradle.kts
@@ -110,7 +110,7 @@ spotless {
         licenseHeader(headerLicenseJava)
     }
     kotlinGradle {
-        licenseHeader(headerLicenseJava, "[^/*]")
+        licenseHeader(headerLicenseJava, "(import|rootProject)")
     }
     format("properties") {
         target("**/*.properties")

--- a/dev-mode/gradle-plugin/settings.gradle.kts
+++ b/dev-mode/gradle-plugin/settings.gradle.kts
@@ -1,5 +1,4 @@
 /*
  * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
-
 rootProject.name = "gradle-plugin"

--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/task/RoutesCompile.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/task/RoutesCompile.java
@@ -75,7 +75,7 @@ public abstract class RoutesCompile extends DefaultTask {
       if (change.getFileType() == FileType.DIRECTORY) continue;
       var workQueue =
           getWorkerExecutor()
-              .classLoaderIsolation(spec -> spec.getClasspath().from(getRoutesCompilerClasspath()));
+              .processIsolation(spec -> spec.getClasspath().from(getRoutesCompilerClasspath()));
 
       workQueue.submit(
           RoutesCompileAction.class,
@@ -97,7 +97,7 @@ public abstract class RoutesCompile extends DefaultTask {
       if (change.getFileType() == FileType.DIRECTORY) continue;
       var workQueue =
           getWorkerExecutor()
-              .classLoaderIsolation(spec -> spec.getClasspath().from(getRoutesCompilerClasspath()));
+              .processIsolation(spec -> spec.getClasspath().from(getRoutesCompilerClasspath()));
 
       workQueue.submit(
           RoutesCompileAction.class,


### PR DESCRIPTION
It's a WA for https://github.com/gradle/gradle/issues/18313 
We've already fixed the same problem for Twirl plugin https://github.com/playframework/twirl/pull/746