### PR TITLE
Temporary remove `~run` from docs because it's broken since long time

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -54,8 +54,6 @@ You then need to import the application into your Workspace with the **File/Impo
 
 To debug, start your application with `sbt -jvm-debug 9999 run` and in Eclipse right-click on the project and select **Debug As**, **Debug Configurations**. In the **Debug Configurations** dialog, right-click on **Remote Java Application** and select **New**. Change **Port** to 9999 and click **Apply**. From now on you can click on **Debug** to connect to the running application. Stopping the debugging session will not stop the server.
 
-> **Tip**: You can run your application using `~run` to enable direct compilation on file change. This way scala template files are auto discovered when you create a new template in `view` and auto compiled when the file changes. If you use normal `run` then you have to hit `Refresh` on your browser each time.
-
 If you make any important changes to your application, such as changing the classpath, use `eclipse` again to regenerate the configuration files.
 
 > **Tip**: Do not commit Eclipse configuration files when you work in a team. To make that easier, add the following lines to your `.gitignore` file:

--- a/documentation/manual/gettingStarted/PlayConsole.md
+++ b/documentation/manual/gettingStarted/PlayConsole.md
@@ -171,14 +171,6 @@ For example, using `~ compile`:
 
 The compilation will be triggered each time you change a source file.
 
-If you are using `~ run`:
-
-```bash
-[my-first-app] $ ~ run
-```
-
-The triggered compilation will be enabled while a development server is running.
-
 You can also do the same for `~ test`, to continuously test your project each time you modify a source file:
 
 ```bash
@@ -212,12 +204,6 @@ $ sbt run
 The application starts directly. When you quit the server using `Ctrl+D` or `Enter`, you will come back to your OS prompt.
 
 By default, the server runs on port 9000. A custom port (e.g. 8080) can be specified: `sbt 'run 8080'`
-
-Of course, the **triggered execution** is available here as well:
-
-```bash
-$ sbt ~run
-```
 
 ## Getting help
 


### PR DESCRIPTION
- See #9983 

`~run` does not work anymore. IMHO we should not advertise it in the documentation until fixed. Makes Play look bad.