### PR TITLE
Generate a reasonable `META-INF/MANIFEST.MF` file for each generated jar

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -236,7 +236,9 @@ object PlaySettings {
     assetsPrefix := "public/",
     // Assets for distribution
     Assets / WebKeys.packagePrefix := assetsPrefix.value,
-    playPackageAssets              := (Assets / packageBin).value,
+    // The ...-assets.jar should contain the same META-INF/MANIFEST.MF file like the main app jar
+    Assets / packageBin / packageOptions := (Runtime / packageBin / packageOptions).value,
+    playPackageAssets                    := (Assets / packageBin).value,
     scriptClasspathOrdering := Def.taskDyn {
       val oldValue = scriptClasspathOrdering.value
       // only create a assets-jar if the task is active
@@ -282,5 +284,7 @@ object PlaySettings {
       }
     },
     playJarSansExternalized / artifactClassifier := Option("sans-externalized"),
+    // The ...-sans-externalized.jar should contain the same META-INF/MANIFEST.MF file like the main app jar
+    playJarSansExternalized / packageOptions := (Runtime / packageBin / packageOptions).value,
   )
 }

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -9,6 +9,7 @@ import scala.collection.JavaConverters._
 import sbt._
 import sbt.internal.inc.Analysis
 import sbt.Keys._
+import sbt.Package.MainClass
 import sbt.Path._
 
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
@@ -225,6 +226,12 @@ object PlaySettings {
     constructorAnnotations += "@javax.inject.Inject()",
     playMonitoredFiles ++= (Compile / compileTemplates / sourceDirectories).value,
     routesImport ++= Seq("controllers.Assets.Asset"),
+    // The default packageOptions get set here (and do set the main class by default which we want to avoid):
+    // https://github.com/sbt/sbt/blob/v1.10.0/main/src/main/scala/sbt/Defaults.scala#L1725-L1740
+    Compile / packageBin / packageOptions := (Compile / packageBin / packageOptions).value.filter {
+      case _: MainClass => false // The jar(s) should not contain a main class
+      case _            => true
+    },
     // sbt-web
     Assets / jsFilter         := new PatternFilter("""[^_].*\.js""".r.pattern),
     WebKeys.stagingDirectory  := WebKeys.stagingDirectory.value / "public",

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
@@ -53,26 +53,31 @@ lazy val root = (project in file("."))
       }
     },
     InputKey[Unit]("checkGeneratedJarFiles") := {
-      val libfolder = "target/universal/stage/lib/"
-      val lsOutput = IO.listFiles(new File(libfolder), (file) => file.getName().toLowerCase().contains("asset"))
-                        .map(_.getName).sorted.mkString("\n") + "\n"
+      val args = Def.spaceDelimited("<difffile>").parsed
 
-      val difffile = "expected-jars-in-lib-folder.txt"
-      val difffile_content = IO.readLines(new File(difffile)).mkString("\n") + "\n"
-
-      println(s"\nComparing listing of files of $libfolder (filtered by generated jars only) with contents of $difffile")
-      println(s"### $libfolder")
-      print(lsOutput)
-      println(s"### $difffile")
-      print(difffile_content)
-      println(s"###")
-
-      if (lsOutput != difffile_content) {
-        sys.error(s"File listing in $libfolder does not match expected content!")
+      if (args.length != 1) {
+        sys.error("Usage: checkGeneratedJarFiles <difffile>")
       } else {
-        println(s"File listing of $libfolder as expected.")
+        val libfolder = "target/universal/stage/lib/"
+        val lsOutput = IO.listFiles(new File(libfolder), (file) => file.getName().toLowerCase().contains("asset"))
+          .map(_.getName).sorted.mkString("\n") + "\n"
+        val difffile = args(0)
+        val difffile_content = IO.readLines(new File(difffile)).mkString("\n") + "\n"
+
+        println(s"\nComparing listing of files of $libfolder (filtered by generated jars only) with contents of $difffile")
+        println(s"### $libfolder")
+        print(lsOutput)
+        println(s"### $difffile")
+        print(difffile_content)
+        println(s"###")
+
+        if (lsOutput != difffile_content) {
+          sys.error(s"File listing in $libfolder does not match expected content!")
+        } else {
+          println(s"File listing of $libfolder as expected.")
+        }
+        println()
       }
-      println()
     },
     InputKey[Unit]("checkJarManifest") := {
       val args = Def.spaceDelimited("<zipfile> <difffile>").parsed

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
@@ -74,6 +74,37 @@ lazy val root = (project in file("."))
       }
       println()
     },
+    InputKey[Unit]("checkJarManifest") := {
+      val args = Def.spaceDelimited("<zipfile> <difffile>").parsed
+      val baseDir = (ThisBuild / baseDirectory).value
+
+      if (args.length != 2) {
+        sys.error("Usage: checkJarManifest <zipfile> <difffile>")
+      } else {
+        val zipfile = args(0)
+        val vanilla_difffile = args(1)
+
+        val unzipcmd = s"unzip -p $zipfile META-INF/MANIFEST.MF" // We assume the system has unzip installed...
+        val unzipOutput = Process(unzipcmd, baseDir).!!
+
+        val difffile = vanilla_difffile
+        val difffile_content = IO.readLines(new File(difffile)).mkString("\n") + "\n"
+
+        println(s"\nComparing unzip listing of file $zipfile with contents of $difffile")
+        println(s"### $zipfile")
+        print(unzipOutput)
+        println(s"### $difffile")
+        print(difffile_content)
+        println(s"###")
+
+        if (unzipOutput != difffile_content) {
+          sys.error(s"Unzip listing ('$unzipcmd') does not match expected content!")
+        } else {
+          println(s"Listing of $zipfile as expected.")
+        }
+        println()
+      }
+    },
   )
   .dependsOn(subproj)
   .aggregate(subproj)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
@@ -83,9 +83,12 @@ lazy val subproj = (project in file("subproj"))
   .settings(common: _*)
   .settings(
     name := "asset-changes-sub",
+    version := "1.1-SNAPSHOT",
   )
 
 def common: Seq[Setting[?]] = Seq(
+  organizationName := "Nice Org Inc.",
+  organization := "com.nice.org",
   version := "1.0-SNAPSHOT",
   PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
   scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-       25  2010-01-01 00:00   META-INF/MANIFEST.MF
+      344  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   public/
         0  2010-01-01 00:00   public/lib/
         0  2010-01-01 00:00   public/lib/asset-changes-sub/
@@ -11,4 +11,4 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHO
       183  2010-01-01 00:00   public/lib/asset-changes-sub/stylesheets/main.less
       183  2010-01-01 00:00   public/lib/asset-changes-sub/stylesheets/main.less.new
 ---------                     -------
-      673                     9 files
+      992                     9 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      344  2010-01-01 00:00   META-INF/MANIFEST.MF
+      298  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   public/
         0  2010-01-01 00:00   public/lib/
         0  2010-01-01 00:00   public/lib/asset-changes-sub/
@@ -11,4 +11,4 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHO
       183  2010-01-01 00:00   public/lib/asset-changes-sub/stylesheets/main.less
       183  2010-01-01 00:00   public/lib/asset-changes-sub/stylesheets/main.less.new
 ---------                     -------
-      992                     9 files
+      946                     9 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
@@ -1,4 +1,4 @@
-Archive:  target/universal/stage/lib/asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar
+Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
        25  2010-01-01 00:00   META-INF/MANIFEST.MF

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala2.jar.txt
@@ -1,4 +1,4 @@
-Archive:  target/universal/stage/lib/asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
+Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
        25  2010-01-01 00:00   META-INF/MANIFEST.MF

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala2.jar.txt
@@ -1,11 +1,11 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      344  2010-01-01 00:00   META-INF/MANIFEST.MF
+      298  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   router/
      2266  2010-01-01 00:00   router/Routes$$anonfun$routes$1.class
      6391  2010-01-01 00:00   router/Routes.class
      2075  2010-01-01 00:00   router/RoutesPrefix$.class
      1126  2010-01-01 00:00   router/RoutesPrefix.class
 ---------                     -------
-    12202                     6 files
+    12156                     6 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala2.jar.txt
@@ -1,11 +1,11 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-       25  2010-01-01 00:00   META-INF/MANIFEST.MF
+      344  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   router/
      2266  2010-01-01 00:00   router/Routes$$anonfun$routes$1.class
      6391  2010-01-01 00:00   router/Routes.class
      2075  2010-01-01 00:00   router/RoutesPrefix$.class
      1126  2010-01-01 00:00   router/RoutesPrefix.class
 ---------                     -------
-    11883                     6 files
+    12202                     6 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala3.jar.txt
@@ -1,4 +1,4 @@
-Archive:  target/universal/stage/lib/asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
+Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
        25  2010-01-01 00:00   META-INF/MANIFEST.MF

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala3.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-       25  2010-01-01 00:00   META-INF/MANIFEST.MF
+      344  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   router/
      2040  2010-01-01 00:00   router/Routes$$anon$1.class
      5341  2010-01-01 00:00   router/Routes.class
@@ -10,4 +10,4 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHO
       540  2010-01-01 00:00   router/RoutesPrefix.class
       789  2010-01-01 00:00   router/RoutesPrefix.tasty
 ---------                     -------
-    13744                     8 files
+    14063                     8 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.scala3.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      344  2010-01-01 00:00   META-INF/MANIFEST.MF
+      298  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   router/
      2040  2010-01-01 00:00   router/Routes$$anon$1.class
      5341  2010-01-01 00:00   router/Routes.class
@@ -10,4 +10,4 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHO
       540  2010-01-01 00:00   router/RoutesPrefix.class
       789  2010-01-01 00:00   router/RoutesPrefix.tasty
 ---------                     -------
-    14063                     8 files
+    14017                     8 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT.scala2.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      344  2010-01-01 00:00   META-INF/MANIFEST.MF
+      298  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   router/
        88  2010-01-01 00:00   application.conf
      2266  2010-01-01 00:00   router/Routes$$anonfun$routes$1.class
@@ -10,4 +10,4 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHO
      1126  2010-01-01 00:00   router/RoutesPrefix.class
       173  2010-01-01 00:00   routes
 ---------                     -------
-    12463                     8 files
+    12417                     8 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT.scala2.jar.txt
@@ -1,0 +1,13 @@
+Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+      344  2010-01-01 00:00   META-INF/MANIFEST.MF
+        0  2010-01-01 00:00   router/
+       88  2010-01-01 00:00   application.conf
+     2266  2010-01-01 00:00   router/Routes$$anonfun$routes$1.class
+     6391  2010-01-01 00:00   router/Routes.class
+     2075  2010-01-01 00:00   router/RoutesPrefix$.class
+     1126  2010-01-01 00:00   router/RoutesPrefix.class
+      173  2010-01-01 00:00   routes
+---------                     -------
+    12463                     8 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT.scala3.jar.txt
@@ -1,0 +1,15 @@
+Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+      344  2010-01-01 00:00   META-INF/MANIFEST.MF
+        0  2010-01-01 00:00   router/
+       88  2010-01-01 00:00   application.conf
+     2040  2010-01-01 00:00   router/Routes$$anon$1.class
+     5341  2010-01-01 00:00   router/Routes.class
+     2974  2010-01-01 00:00   router/Routes.tasty
+     2035  2010-01-01 00:00   router/RoutesPrefix$.class
+      540  2010-01-01 00:00   router/RoutesPrefix.class
+      789  2010-01-01 00:00   router/RoutesPrefix.tasty
+      173  2010-01-01 00:00   routes
+---------                     -------
+    14324                     10 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT.scala3.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      344  2010-01-01 00:00   META-INF/MANIFEST.MF
+      298  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   router/
        88  2010-01-01 00:00   application.conf
      2040  2010-01-01 00:00   router/Routes$$anon$1.class
@@ -12,4 +12,4 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHO
       789  2010-01-01 00:00   router/RoutesPrefix.tasty
       173  2010-01-01 00:00   routes
 ---------                     -------
-    14324                     10 files
+    14278                     10 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala2.jar.txt
@@ -1,7 +1,7 @@
-Archive:  target/universal/stage/lib/asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.jar
+Archive:  target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      355  2010-01-01 00:00   META-INF/MANIFEST.MF
+      342  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   controllers/
         0  2010-01-01 00:00   controllers/javascript/
         0  2010-01-01 00:00   subproj/
@@ -15,4 +15,4 @@ Archive:  target/universal/stage/lib/asset-changes-sub.asset-changes-sub-1.0-SNA
      2077  2010-01-01 00:00   subproj/RoutesPrefix$.class
      1130  2010-01-01 00:00   subproj/RoutesPrefix.class
 ---------                     -------
-    25947                     13 files
+    25934                     13 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala2.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      342  2010-01-01 00:00   META-INF/MANIFEST.MF
+      296  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   controllers/
         0  2010-01-01 00:00   controllers/javascript/
         0  2010-01-01 00:00   subproj/
@@ -15,4 +15,4 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT
      2077  2010-01-01 00:00   subproj/RoutesPrefix$.class
      1130  2010-01-01 00:00   subproj/RoutesPrefix.class
 ---------                     -------
-    25934                     13 files
+    25888                     13 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala3.jar.txt
@@ -1,7 +1,7 @@
-Archive:  target/universal/stage/lib/asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.jar
+Archive:  target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      355  2010-01-01 00:00   META-INF/MANIFEST.MF
+      342  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   controllers/
         0  2010-01-01 00:00   controllers/javascript/
         0  2010-01-01 00:00   subproj/
@@ -19,4 +19,4 @@ Archive:  target/universal/stage/lib/asset-changes-sub.asset-changes-sub-1.0-SNA
       543  2010-01-01 00:00   subproj/RoutesPrefix.class
       800  2010-01-01 00:00   subproj/RoutesPrefix.tasty
 ---------                     -------
-    33515                     17 files
+    33502                     17 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala3.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-      342  2010-01-01 00:00   META-INF/MANIFEST.MF
+      296  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   controllers/
         0  2010-01-01 00:00   controllers/javascript/
         0  2010-01-01 00:00   subproj/
@@ -19,4 +19,4 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT
       543  2010-01-01 00:00   subproj/RoutesPrefix.class
       800  2010-01-01 00:00   subproj/RoutesPrefix.tasty
 ---------                     -------
-    33502                     17 files
+    33456                     17 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest-sub.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest-sub.txt
@@ -6,5 +6,4 @@ Implementation-Title: asset-changes-sub
 Implementation-Version: 1.1-SNAPSHOT
 Implementation-Vendor: Nice Org Inc.
 Implementation-Vendor-Id: com.nice.org
-Main-Class: play.core.server.ProdServerStart
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest-sub.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest-sub.txt
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Specification-Title: asset-changes-sub
+Specification-Version: 1.1-SNAPSHOT
+Specification-Vendor: Nice Org Inc.
+Implementation-Title: asset-changes-sub
+Implementation-Version: 1.1-SNAPSHOT
+Implementation-Vendor: Nice Org Inc.
+Implementation-Vendor-Id: com.nice.org
+Main-Class: play.core.server.ProdServerStart
+

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest.txt
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest.txt
@@ -1,2 +1,10 @@
 Manifest-Version: 1.0
+Specification-Title: asset-changes-main
+Specification-Version: 1.0-SNAPSHOT
+Specification-Vendor: Nice Org Inc.
+Implementation-Title: asset-changes-main
+Implementation-Version: 1.0-SNAPSHOT
+Implementation-Vendor: Nice Org Inc.
+Implementation-Vendor-Id: com.nice.org
+Main-Class: play.core.server.ProdServerStart
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jar-manifest.txt
@@ -6,5 +6,4 @@ Implementation-Title: asset-changes-main
 Implementation-Version: 1.0-SNAPSHOT
 Implementation-Vendor: Nice Org Inc.
 Implementation-Vendor-Id: com.nice.org
-Main-Class: play.core.server.ProdServerStart
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jars-in-lib-folder-sans-externalized.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jars-in-lib-folder-sans-externalized.txt
@@ -1,3 +1,3 @@
 com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar
-com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar
+com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
 com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jars-in-lib-folder.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-jars-in-lib-folder.txt
@@ -1,3 +1,3 @@
-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar
-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.jar
+com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar
+com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar
+com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/test
@@ -36,5 +36,5 @@ $ copy-file subproj/app/assets/stylesheets/main.less.new subproj/app/assets/styl
 #> checkGeneratedJarFiles
 # Again, check the META-INF/MANIFEST.MF of each jar file
 > checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar expected-jar-manifest.txt
--> checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar expected-jar-manifest.txt
+> checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar expected-jar-manifest.txt
 > checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar expected-jar-manifest-sub.txt

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/test
@@ -12,9 +12,9 @@ $ copy-file subproj/app/assets/stylesheets/main.less.new subproj/app/assets/styl
 
 # Bonus: Also let's check if the assets are correctly packaged into the jar files
 # runProd above runs `stage` already
-> checkUnzipListing target/universal/stage/lib/asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
-> checkUnzipListing target/universal/stage/lib/asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized
-> checkUnzipListing target/universal/stage/lib/asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.jar expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT
+> checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
+> checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-sans-externalized
+> checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT
 
 # Even more, lets check if there are exact 3 generated (sub)project jar files (in addition to the dependencies)
 > checkGeneratedJarFiles

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/test
@@ -17,7 +17,7 @@ $ copy-file subproj/app/assets/stylesheets/main.less.new subproj/app/assets/styl
 > checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT
 
 # Even more, lets check if there are exact 3 generated (sub)project jar files (in addition to the dependencies)
-> checkGeneratedJarFiles
+> checkGeneratedJarFiles expected-jars-in-lib-folder-sans-externalized.txt
 
 # Now let's also see if the META-INF/MANIFEST.MF file is generated correctly for each jar file
 > checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar expected-jar-manifest.txt
@@ -33,7 +33,7 @@ $ copy-file subproj/app/assets/stylesheets/main.less.new subproj/app/assets/styl
 > checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT
 > checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT
 # Three jar files once more expected, but again, the "-sans-externalized[.jar]" suffix got removed now
-#> checkGeneratedJarFiles
+> checkGeneratedJarFiles expected-jars-in-lib-folder.txt
 # Again, check the META-INF/MANIFEST.MF of each jar file
 > checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar expected-jar-manifest.txt
 > checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar expected-jar-manifest.txt

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/test
@@ -18,3 +18,23 @@ $ copy-file subproj/app/assets/stylesheets/main.less.new subproj/app/assets/styl
 
 # Even more, lets check if there are exact 3 generated (sub)project jar files (in addition to the dependencies)
 > checkGeneratedJarFiles
+
+# Now let's also see if the META-INF/MANIFEST.MF file is generated correctly for each jar file
+> checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar expected-jar-manifest.txt
+> checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-sans-externalized.jar expected-jar-manifest.txt
+> checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar expected-jar-manifest-sub.txt
+
+# Now let's do the same again, but with externalize resources set to false, meaning the conf/ folder gets packaged within the jar file
+> clean
+> set PlayKeys.externalizeResources := false
+> stage
+# First check the jar contents again
+> checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT-assets.jar.txt
+> checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar expected-asset-changes-main.asset-changes-main-1.0-SNAPSHOT
+> checkUnzipListing target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT
+# Three jar files once more expected, but again, the "-sans-externalized[.jar]" suffix got removed now
+#> checkGeneratedJarFiles
+# Again, check the META-INF/MANIFEST.MF of each jar file
+> checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT-assets.jar expected-jar-manifest.txt
+-> checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-main-1.0-SNAPSHOT.jar expected-jar-manifest.txt
+> checkJarManifest target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT.jar expected-jar-manifest-sub.txt

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/assets-pipeline/expected-assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-assets.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/assets-pipeline/expected-assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-assets.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-assets.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-       25  2010-01-01 00:00   META-INF/MANIFEST.MF
+      303  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   public/
         0  2010-01-01 00:00   public/coffeescripts/
         0  2010-01-01 00:00   public/images/
@@ -14,4 +14,4 @@ Archive:  target/universal/stage/lib/assets-pipeline.assets-pipeline-0.1.0-SNAPS
     95957  2010-01-01 00:00   public/javascripts/jquery-1.11.3.min.js
         0  2010-01-01 00:00   public/stylesheets/main.css
 ---------                     -------
-    99284                     12 files
+    99562                     12 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/assets-pipeline/expected-assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-sans-externalized.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/assets-pipeline/expected-assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-sans-externalized.scala2.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-sans-externalized.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-       25  2010-01-01 00:00   META-INF/MANIFEST.MF
+      303  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   controllers/
         0  2010-01-01 00:00   controllers/javascript/
         0  2010-01-01 00:00   router/
@@ -15,4 +15,4 @@ Archive:  target/universal/stage/lib/assets-pipeline.assets-pipeline-0.1.0-SNAPS
      2075  2010-01-01 00:00   router/RoutesPrefix$.class
      1126  2010-01-01 00:00   router/RoutesPrefix.class
 ---------                     -------
-    21296                     13 files
+    21574                     13 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/assets-pipeline/expected-assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-sans-externalized.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/assets-pipeline/expected-assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-sans-externalized.scala3.jar.txt
@@ -1,7 +1,7 @@
 Archive:  target/universal/stage/lib/assets-pipeline.assets-pipeline-0.1.0-SNAPSHOT-sans-externalized.jar
   Length      Date    Time    Name
 ---------  ---------- -----   ----
-       25  2010-01-01 00:00   META-INF/MANIFEST.MF
+      303  2010-01-01 00:00   META-INF/MANIFEST.MF
         0  2010-01-01 00:00   controllers/
         0  2010-01-01 00:00   controllers/javascript/
         0  2010-01-01 00:00   router/
@@ -19,4 +19,4 @@ Archive:  target/universal/stage/lib/assets-pipeline.assets-pipeline-0.1.0-SNAPS
       540  2010-01-01 00:00   router/RoutesPrefix.class
       789  2010-01-01 00:00   router/RoutesPrefix.tasty
 ---------                     -------
-    26903                     17 files
+    27181                     17 files


### PR DESCRIPTION
- Fixes #7010

Make sure that each generated jar file, no matter if `PlayKeys.externalizeResources` is set to `true` or `false`, contains a meaninful manifest file (including the assets jar).
Also removed the `Main-Class` attribute from the manifest files, because these jar files themselves can not be run via `java -jar`, and even worse, the value of that attribute `play.core.server.ProdServerStart` is a class that does not even exists in one of the generated jar files (it is inside the `org.playframework.play-server_....jar` file).

I split the PR into meaningful commits so you can follow, also I tested the scripted test I added for each commit locally, but I will just now push all commits at once, instead of pushing each commit one-by-one to run the scripted test on CI again and again. I leave this put to you if you want to test this :wink: 