### PR TITLE
[Gradle] Template imports for Java project should be minimal

### DIFF
--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayPlugin.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayPlugin.java
@@ -74,7 +74,7 @@ public class PlayPlugin implements Plugin<Project> {
         imports.addAll(
             () -> {
               if (isPlayJava(project)) {
-                return TemplateImports.defaultJavaTemplateImports.iterator();
+                return TemplateImports.minimalJavaTemplateImports.iterator();
               }
               return TemplateImports.defaultScalaTemplateImports.iterator();
             });


### PR DESCRIPTION
Fix the first case in https://github.com/playframework/playframework/issues/12720

I agree with @Nezisi, that `java-forms` should be optional dependency. If someone need them, they can configure that explicitly and very easy (`build.gradle.kts`):

```kotlin
import play.TemplateImports

dependencies {
  implementation("org.playframework:play-java-forms_$scalaVersion")
}

sourceSets {
    main {
        twirl {
            templateImports.set(TemplateImports.defaultJavaTemplateImports)
        }
    }
}
```