### PR TITLE
Prevent TemporaryFile to be deleted before returning a response

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Action.scala
+++ b/core/play/src/main/scala/play/api/mvc/Action.scala
@@ -432,6 +432,12 @@ trait ActionBuilder[+R[_], B] extends ActionFunction[Request, R] {
       def apply(request: Request[A]) =
         try {
           invokeBlock(request, block)
+            .andThen { _ =>
+              // This andThen block is used to keep a reference to the request until invokeBlock() is completed.
+              // If the request contains TemporaryFiles, they will be deleted when they are garbage collected.
+              // By keeping a reference to the request, it prevents the TemporaryFiles from becoming GC targets.
+              request
+            }(self.executionContext)
         } catch {
           // NotImplementedError is not caught by NonFatal, wrap it
           case e: NotImplementedError => throw new RuntimeException(e)

--- a/core/play/src/main/scala/play/api/mvc/Action.scala
+++ b/core/play/src/main/scala/play/api/mvc/Action.scala
@@ -437,7 +437,7 @@ trait ActionBuilder[+R[_], B] extends ActionFunction[Request, R] {
               // If the request contains TemporaryFiles, they will be deleted when they are garbage collected.
               // By keeping a reference to the request, it prevents the TemporaryFiles from becoming GC targets.
               request
-            }(self.executionContext)
+            }(Execution.trampoline)
         } catch {
           // NotImplementedError is not caught by NonFatal, wrap it
           case e: NotImplementedError => throw new RuntimeException(e)

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -124,7 +124,15 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
           .parseBody(
             parser,
             request.asScala(),
-            (r: Request[?]) => invocation(r.asJava).toCompletableFuture.asScala.map(_.asScala())
+            (r: Request[?]) =>
+              invocation(r.asJava).toCompletableFuture.asScala
+                .map(_.asScala())
+                .andThen { _ =>
+                  // This andThen block is used to keep a reference to the request until invocation() is completed.
+                  // If the request contains TemporaryFiles, they will be deleted when they are garbage collected.
+                  // By keeping a reference to the request, it prevents the TemporaryFiles from becoming GC targets.
+                  r
+                }(trampoline)
           )(executionContext)
           .map(_.asJava)
           .asJava

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/java/controller/HomeController.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/java/controller/HomeController.java
@@ -42,6 +42,8 @@ public class HomeController extends Controller {
                         + "\n");
     }
 
+    private java.nio.file.Path tmpPath = null; // not best practice, but for testing it's good enough
+
     public CompletionStage<Result> multipartFormUploadTmpFileExists(Http.Request request) throws IOException {
         return CompletableFuture.supplyAsync(() -> request
                         .body()
@@ -50,6 +52,7 @@ public class HomeController extends Controller {
                 .thenApplyAsync(
                         path -> {
                             System.gc();
+                            tmpPath = path;
                             return path;
                         })
                 .thenApplyAsync(
@@ -71,4 +74,22 @@ public class HomeController extends Controller {
                         });
     }
 
+    public Result gc(Http.Request request) {
+        System.gc();
+        try {
+            // Give garbage collector some time
+            TimeUnit.MILLISECONDS.sleep(100);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return ok();
+    }
+
+    public Result checkTmpFileStillExists(Http.Request request) {
+        if (java.nio.file.Files.exists(tmpPath)) {
+            return ok("exists");
+        } else {
+            return ok("not exists");
+        }
+    }
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/resources/routes
@@ -2,3 +2,4 @@
 
 POST     /multipart-form-data-no-files             controllers.HomeController.multipartFormUploadNoFiles(request: Request)
 POST     /multipart-form-data                      controllers.HomeController.multipartFormUpload(request: Request)
+POST     /multipart-form-data-tmpfileexists        controllers.HomeController.multipartFormUploadTmpFileExists(request: Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/resources/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/main/resources/routes
@@ -3,3 +3,5 @@
 POST     /multipart-form-data-no-files             controllers.HomeController.multipartFormUploadNoFiles(request: Request)
 POST     /multipart-form-data                      controllers.HomeController.multipartFormUpload(request: Request)
 POST     /multipart-form-data-tmpfileexists        controllers.HomeController.multipartFormUploadTmpFileExists(request: Request)
+GET      /gc                                       controllers.HomeController.gc(request: Request)
+GET      /check-tmp-file-still-exists              controllers.HomeController.checkTmpFileStillExists(request: Request)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/test/java/controllers/HomeControllerTest.java
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/java-test-helpers/src/test/java/controllers/HomeControllerTest.java
@@ -88,6 +88,22 @@ public class HomeControllerTest extends WithApplication {
         testTemporaryFile(List.of(new Http.MultipartFormData.FilePart<>("document", "jabberwocky.txt", "text/plain", tempFile.path())));
     }
 
+    @Test
+    public void testTmpFileExists() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        play.api.libs.Files.TemporaryFile tempFile = play.api.libs.Files.SingletonTemporaryFileCreator$.MODULE$.create("temp", "txt");
+        write(tempFile.path(), "Hello".getBytes());
+
+        Http.RequestBuilder request = new Http.RequestBuilder()
+                .method(POST)
+                .bodyMultipart(Map.of(), List.of(new Http.MultipartFormData.FilePart<>("file", "file.txt", "text/plain", tempFile.path())))
+                .uri("/multipart-form-data-tmpfileexists");
+
+        Result result = route(app, request);
+        String content = result.body().consumeData(mat).thenApply(bs -> bs.utf8String()).toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertEquals(OK, result.status());
+        assertEquals("exists", content);
+    }
+
     private void testTemporaryFile(final List<Http.MultipartFormData.FilePart> files) throws ExecutionException, InterruptedException, TimeoutException {
         final Map<String, String[]> data = new HashMap<>();
         data.put("author", new String[]{"Lewis Carrol"});


### PR DESCRIPTION

<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #12770

## Purpose

If the Path of a temporary file is retrieved and processed, the TemporaryFile may be deleted before the response is finished (#12770). This pull request will prevent TemporaryFile from being deleted until the response is finished.


cc/ @mkurz 

