### PR TITLE
Add route modifiers on RedirectHttpsFilter. Resolves #12776

### DIFF
--- a/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
@@ -14,6 +14,10 @@ play.filters.enabled += play.filters.https.RedirectHttpsFilter
 
 By default, the redirect only happens in Prod mode. To override this, set `play.filters.https.redirectEnabled = true`.
 
+It is possible to disable the HTTPS filter for a specific route in the routes file. To do this, add the nohttps modifier tag before your route:
+
+@[nohttps](code/commonguide.http.routing.routes)
+
 ## Determining Secure Requests
 
 The filter evaluates a request to be secure if `request.secure` is true.

--- a/documentation/manual/working/commonGuide/filters/code/CommonRouting.scala
+++ b/documentation/manual/working/commonGuide/filters/code/CommonRouting.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package commonguide.http.routing
+
+import org.specs2.mutable.Specification
+import play.api.mvc._
+import play.api.routing.Router
+import play.api.test._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+package controllers {
+  import javax.inject.Inject
+
+  import play.api.libs.json.JsValue
+
+  class Api @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
+    def newThing: Action[JsValue] = Action(parse.json) { request => Ok(request.body) }
+  }
+}

--- a/documentation/manual/working/commonGuide/filters/code/commonguide.http.routing.routes
+++ b/documentation/manual/working/commonGuide/filters/code/commonguide.http.routing.routes
@@ -1,0 +1,6 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+# #nohttps
++ nohttps
+POST  /api/new              controllers.Api.newThing
+# #nohttps

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -292,6 +292,11 @@ object BuildSettings {
         "play.api.libs.crypto.DefaultCSRFTokenSigner.constantTimeEquals"
       ),
       ProblemFilters.exclude[MissingClassProblem]("play.api.libs.crypto.CSRFTokenSigner$"),
+      // Add routeModifierExcluded to RedirectHttpsConfiguration to implement route modifier black/whitelist
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.this"),
+      ProblemFilters.exclude[MissingTypesProblem]("play.filters.https.RedirectHttpsConfiguration$"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -327,12 +327,10 @@ play.filters {
     port = ${?play.server.https.port} # default to same HTTPS port as play server
 
     routeModifiers {
-      # If non empty, then requests will be checked if the route does not have this modifier. This is how we enable the
-      # nohttps modifier, but you may choose to use a different modifier (such as "api") if you plan to check the
-      # modifier in your code for other purposes.
+      # If non empty, then requests will be redirected if the route does not have this modifier.
       whiteList = ["nohttps"]
 
-      # If non empty, then requests will be checked if the route contains this modifier
+      # If non empty, then requests will be redirected if the route contains this modifier.
       # The black list is used only if the white list is empty
       blackList = []
     }

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -325,6 +325,17 @@ play.filters {
     # e.g. port = 9443 results in https://playframework.com:9443/some/url
     port = null
     port = ${?play.server.https.port} # default to same HTTPS port as play server
+
+    routeModifiers {
+      # If non empty, then requests will be checked if the route does not have this modifier. This is how we enable the
+      # nohttps modifier, but you may choose to use a different modifier (such as "api") if you plan to check the
+      # modifier in your code for other purposes.
+      whiteList = ["nohttps"]
+
+      # If non empty, then requests will be checked if the route contains this modifier
+      # The black list is used only if the white list is empty
+      blackList = []
+    }
   }
 
   # IP filter configuration

--- a/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -150,7 +150,7 @@ class RedirectHttpsConfigurationProvider @Inject() (c: Configuration, e: Environ
     @inline def checkRouteModifiers(rh: RequestHeader): Boolean = {
       import play.api.routing.Router.RequestImplicits._
       if (whitelistModifiers.isEmpty) {
-        !blacklistModifiers.exists(rh.hasRouteModifier)
+        !blacklistModifiers.isEmpty && !blacklistModifiers.exists(rh.hasRouteModifier)
       } else {
         whitelistModifiers.exists(rh.hasRouteModifier)
       }

--- a/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -58,6 +58,9 @@ class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration) extends
     } else if (isExcluded(req)) {
       logger.debug(s"Not redirecting to HTTPS because the path is included in exclude paths")
       next(req)
+    } else if (routeModifierExcluded(req)) {
+      logger.debug(s"Not redirecting to HTTPS because the path is excluded through route modifiers")
+      next(req)
     } else {
       val redirect = shouldRedirect(req)
       if (redirectEnabled && redirect) {
@@ -98,7 +101,8 @@ case class RedirectHttpsConfiguration(
     sslPort: Option[Int] = None, // should match up to ServerConfig.sslPort
     redirectEnabled: Boolean = true,
     xForwardedProtoEnabled: Boolean = false,
-    excludePaths: Seq[String] = Seq()
+    excludePaths: Seq[String] = Seq(),
+    routeModifierExcluded: RequestHeader => Boolean = _ => false
 ) {
   @deprecated("Use redirectEnabled && strictTransportSecurity.isDefined", "2.7.0")
   def hstsEnabled: Boolean = redirectEnabled && strictTransportSecurity.isDefined
@@ -111,6 +115,8 @@ private object RedirectHttpsKeys {
   val redirectEnabledPath   = "play.filters.https.redirectEnabled"
   val forwardedProtoEnabled = "play.filters.https.xForwardedProtoEnabled"
   val excludePaths          = "play.filters.https.excludePaths"
+  val whitelistModifier     = "play.filters.https.routeModifiers.whiteList"
+  val blacklistModifier     = "play.filters.https.routeModifiers.blackList"
 }
 
 @Singleton
@@ -139,13 +145,27 @@ class RedirectHttpsConfigurationProvider @Inject() (c: Configuration, e: Environ
     val xProtoEnabled = c.get[Boolean](forwardedProtoEnabled)
     val excludePaths  = c.get[Seq[String]](RedirectHttpsKeys.excludePaths)
 
+    val whitelistModifiers = c.get[Seq[String]](whitelistModifier)
+    val blacklistModifiers = c.get[Seq[String]](blacklistModifier)
+    @inline def checkRouteModifiers(rh: RequestHeader): Boolean = {
+      import play.api.routing.Router.RequestImplicits._
+      if (whitelistModifiers.isEmpty) {
+        !blacklistModifiers.exists(rh.hasRouteModifier)
+      } else {
+        whitelistModifiers.exists(rh.hasRouteModifier)
+      }
+    }
+
+    val isRouteExcluded: RequestHeader => Boolean = rh => checkRouteModifiers(rh)
+
     RedirectHttpsConfiguration(
       strictTransportSecurity,
       redirectStatusCode,
       port,
       redirectEnabled,
       xProtoEnabled,
-      excludePaths
+      excludePaths,
+      isRouteExcluded
     )
   }
 }

--- a/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -6,6 +6,8 @@ package play.filters.https
 
 import javax.inject.Inject
 
+import scala.reflect.ClassTag
+
 import com.typesafe.config.ConfigFactory
 import play.api._
 import play.api.http.HttpFilters
@@ -13,7 +15,10 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.mvc.request.RemoteConnection
+import play.api.mvc.Handler.Stage
 import play.api.mvc.Results._
+import play.api.routing.HandlerDef
+import play.api.routing.Router
 import play.api.test._
 import play.api.test.WithApplication
 import play.api.Configuration
@@ -268,12 +273,90 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         status(result) must_== OK
       }
     }
+
+    "not redirect when route has whitelisted modifier" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.filters.https.routeModifiers.whiteList = [ "nohttps" ]
+        """.stripMargin,
+        mode = Mode.Test
+      )
+    ) {
+      override def running() = {
+        val insecure =
+          RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request("/modifiers").withConnection(insecure)).get
+
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== OK
+      }
+    }
+
+    "redirect when route does not have whitelisted modifier" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.filters.https.routeModifiers.whiteList = [ "other" ]
+        """.stripMargin,
+        mode = Mode.Test
+      )
+    ) {
+      override def running() = {
+        val insecure =
+          RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request("/modifiers").withConnection(insecure)).get
+
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== PERMANENT_REDIRECT
+      }
+    }
+
+    "redirect when route has blacklisted modifier" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.filters.https.routeModifiers.whiteList = []
+          |play.filters.https.routeModifiers.blackList = [ "api" ]
+        """.stripMargin,
+        mode = Mode.Test
+      )
+    ) {
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request("/modifiers").withConnection(secure)).get
+
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== PERMANENT_REDIRECT
+      }
+    }
+
+    "not redirect when route does not have blacklisted modifier" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.filters.https.routeModifiers.whiteList = []
+          |play.filters.https.routeModifiers.blackList = [ "other" ]
+        """.stripMargin,
+        mode = Mode.Test
+      )
+    ) {
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request("/modifiers").withConnection(secure)).get
+
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== OK
+      }
+    }
   }
 
   private def request(path: String = "/", queryParams: Option[String] = None) = {
     FakeRequest(method = "GET", path = path + queryParams.map("?" + _).getOrElse(""))
       .withHeaders(HOST -> "playframework.com")
   }
+
+  def inject[T: ClassTag](implicit app: Application) = app.injector.instanceOf[T]
 
   private def buildApp(config: String = "", mode: Mode = Mode.Test) =
     GuiceApplicationBuilder(Environment.simple(mode = mode))
@@ -284,13 +367,37 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         new play.api.i18n.I18nModule,
         new play.filters.https.RedirectHttpsModule
       )
-      .appRoutes(app => {
+      .appRoutes(implicit app => {
         case ("GET", "/") =>
-          val action = app.injector.instanceOf[DefaultActionBuilder]
+          val action = inject[DefaultActionBuilder]
           action(Ok(""))
         case ("GET", "/skip") =>
-          val action = app.injector.instanceOf[DefaultActionBuilder]
+          val action = inject[DefaultActionBuilder]
           action(Ok(""))
+        case ("GET", "/modifiers") =>
+          val env    = inject[Environment]
+          val action = inject[DefaultActionBuilder]
+          new Stage {
+            override def apply(requestHeader: RequestHeader): (RequestHeader, Handler) = {
+              (
+                requestHeader.addAttr(
+                  Router.Attrs.HandlerDef,
+                  HandlerDef(
+                    env.classLoader,
+                    "routes",
+                    "FooController",
+                    "foo",
+                    Seq.empty,
+                    "POST",
+                    "/modifiers",
+                    "comments",
+                    Seq("NOHTTPS", "api")
+                  )
+                ),
+                action(Ok(""))
+              )
+            }
+          }
       })
       .overrides(
         bind[HttpFilters].to[TestFilters]

--- a/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -349,6 +349,25 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         status(result) must_== OK
       }
     }
+
+    "redirect when black and white lists are empty" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.filters.https.routeModifiers.whiteList = []
+          |play.filters.https.routeModifiers.blackList = []
+        """.stripMargin,
+        mode = Mode.Test
+      )
+    ) {
+      override def running() = {
+        val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request("/modifiers").withConnection(secure)).get
+
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        status(result) must_== PERMANENT_REDIRECT
+      }
+    }
   }
 
   private def request(path: String = "/", queryParams: Option[String] = None) = {


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

As discussed on #12776 , the way to exclude paths for https redirection was very limited. The goal of this PR is to make it much more flexible, taking inspiration from existing whitelist/blacklist route modifiers in the framework (CSRFFilter for example)


