### PR TITLE
Apply recommendations from Pekko 1.1.x Migration guide

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -185,6 +185,7 @@ class CSRFAction(
           )
         )
         .splitWhen(_ => false)
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
         // TODO rewrite BodyHandler such that it emits sub-source then we can avoid all these dancing around
         .prefixAndTail(0)
         .map(_._2)


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

This PR applies the recommendations from the Pekko migration guide from 1.0.x to 1.1.x. The Pekko sub stream cancellation strategy was defaulted to `SubstreamCancelStrategy.drain` in the 1.0.x branches. It now defaults to `Supervision.stop` which is an equivalent of `SubstreamCancelStrategy.propagate`. It causes the MultipartFormData parser to fail after the first `form-data` item encountered when using Pekko 1.1.x dependencies in user land.

## Background Context

The change doesn't affect Play 3.0.4 users using the Pekko 1.0.x dependencies included with the framework it self. But it gets the framework ready for when the Pekko 1.1.x release is ready. It has the added benefit of making the usage of the "cancel on purpose as an early sub-stream exit" pattern more obvious. 

## References

[Migration from Apache Pekko 1.0.x to 1.1.x](https://pekko.apache.org/docs/pekko/1.1.0-M1/migration/migration-guide-1.0.x-1.1.x.html)
[A PR from @pjfanning trying the Pekko 1.1.0-M1 release in Play 3 bringing those changes as well](https://github.com/playframework/playframework/pull/12662)
