### PR TITLE
Performance: use ByteString toArrayUnsafe

### DIFF
--- a/cache/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
@@ -104,7 +104,7 @@ private[play] final class SerializableResult(constructorResult: Result) extends 
         case other                      => throw new IllegalStateException("Non strict body cannot be materialized")
       }
       out.writeInt(body.length)
-      out.write(body.toArray)
+      out.write(body.toArrayUnsafe())
     }
   }
 }

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -263,12 +263,12 @@ case class RawBuffer(
     if (inMemory != null) {
       if (chunk.length + inMemory.size > memoryThreshold) {
         backToTemporaryFile()
-        outStream.write(chunk.toArray)
+        outStream.write(chunk.toArrayUnsafe())
       } else {
         inMemory = inMemory ++ chunk
       }
     } else {
-      outStream.write(chunk.toArray)
+      outStream.write(chunk.toArrayUnsafe())
     }
   }
 
@@ -277,7 +277,7 @@ case class RawBuffer(
   private[play] def backToTemporaryFile(): Unit = {
     backedByTemporaryFile = temporaryFileCreator.create("requestBody", "asRaw")
     outStream = Files.newOutputStream(backedByTemporaryFile)
-    outStream.write(inMemory.toArray)
+    outStream.write(inMemory.toArrayUnsafe())
     inMemory = null
   }
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

With ByteString.toArray, you need to clone the underlying byte data in the ByteString. ByteString.toArrayUnsafe() avoids the array copy - saving time and memory. The risk is that the code that calls toArrayUnsafe() then modifies the data in the array. If you know that your code just reads the byte array and doesn't change it then it is safe to use ByteString.toArrayUnsafe().