### PR TITLE
[3.0.x] Fix jjwt 0.12 compatibility for `setExpiration` method

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/core/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -791,7 +791,14 @@ object JWTCookieDataCodec {
       // https://tools.ietf.org/html/rfc7519#section-4.1.4
       jwtConfiguration.expiresAfter.map { duration =>
         val expirationDate = new Date(now.getTime + duration.toMillis)
-        builder.setExpiration(expirationDate)
+        try {
+          builder.setExpiration(expirationDate)
+        } catch {
+          case _: NoSuchMethodError => // In case users upgrade to jjwt 0.12+
+            classOf[JwtBuilder]
+              .getDeclaredMethod("expiration", classOf[java.util.Date])
+              .invoke(builder, expirationDate)
+        }
       }
 
       try {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/jjwt-compatibility/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/jjwt-compatibility/conf/application.conf
@@ -2,3 +2,4 @@
 # https://www.playframework.com/documentation/latest/ConfigFile
 
 play.http.secret.key="<Lt>v_F:bfRC=/YN8riEbEUAM1C:wT^1a92ywJ8>PI6Vb5c8Brq?b@y1HgzU2qgA"
+play.http.session.maxAge="30 minutes"


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #12817

## Purpose

Fix for `JwtBuilder.setExpiration` method which become `expiration` in 0.12+

## References

#12817, #12624, #12626

