### PR TITLE
use ByteString.fromArrayUnsafe for perf reasons

### DIFF
--- a/cache/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
+++ b/cache/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
@@ -74,7 +74,7 @@ private[play] final class SerializableResult(constructorResult: Result) extends 
         }
       }
       readBytes(0, sizeOfBody)
-      HttpEntity.Strict(ByteString(buffer), contentType)
+      HttpEntity.Strict(ByteString.fromArrayUnsafe(buffer), contentType)
     }
 
     cachedResult = Result(

--- a/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/core/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -301,7 +301,7 @@ case class RawBuffer(
    */
   def asBytes(maxLength: Long = memoryThreshold): Option[ByteString] = {
     if (size <= maxLength) {
-      Some(if (inMemory != null) inMemory else ByteString(PlayIO.readFile(backedByTemporaryFile.path)))
+      Some(if (inMemory != null) inMemory else ByteString.fromArrayUnsafe(PlayIO.readFile(backedByTemporaryFile.path)))
     } else {
       None
     }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

`ByteString(Array[Byte])` assumes that later code could change the array data - `fromArrayUnsafe` is faster because it trusts that array is not going to be changed.

- Relates to #12795

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
