### PR TITLE
use ByteString.fromArrayUnsafe for performance reasons

### DIFF
--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -146,6 +146,14 @@ trait DefaultWriteables extends LowPriorityWriteables {
   }
 
   /**
+   * explicit `Writeable` for `Array[Byte]` that uses `ByteString.fromArrayUnsafe` to avoid copying the array for performance reasons.
+   *
+   * This should only be used in cases where the array being supplied is not to be modified.
+   */
+  def createWriteableFromArrayUnsafe: Writeable[Array[Byte]] =
+    Writeable(array => ByteString.fromArrayUnsafe(array))
+
+  /**
    * `Writeable` for `MultipartFormData`.
    *
    * If you pass a boundary, it will be used to separate the data/file parts of the multipart/form-data body.


### PR DESCRIPTION
create a new explicit writeable function for arrays to be used in cases where the caller wants to avoid copying of arrays as opposed to the default implementation that results in an array copy
 
 Relates to https://github.com/playframework/playframework/pull/12843 and https://github.com/playframework/playframework/pull/12795
 
 See discussion [here](https://github.com/orgs/playframework/discussions/12856)

<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
