### PR TITLE
Adds support for Guice's Scopes.NO_SCOPE

### DIFF
--- a/core/play-guice/src/main/java/play/inject/guice/NoScope.java
+++ b/core/play-guice/src/main/java/play/inject/guice/NoScope.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.inject.guice;
+
+import javax.inject.Scope;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom scope annotation to represent the absence of any specific scope.
+ *
+ * This annotation is created because Play Framework's GuiceInjectorBuilder
+ * requires a scope to be defined with an annotation. Since Guice's NO_SCOPE
+ * is not bound to an annotation by default, we define @NoScope to represent
+ * a "no-scope" condition. It will be detected by the builder to apply the
+ * desired behavior for unscoped bindings.
+ */
+@Scope
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoScope {}

--- a/core/play-guice/src/main/java/play/inject/guice/NoScope.java
+++ b/core/play-guice/src/main/java/play/inject/guice/NoScope.java
@@ -4,20 +4,19 @@
 
 package play.inject.guice;
 
-import javax.inject.Scope;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.inject.Scope;
 
 /**
  * Custom scope annotation to represent the absence of any specific scope.
  *
- * This annotation is created because Play Framework's GuiceInjectorBuilder
- * requires a scope to be defined with an annotation. Since Guice's NO_SCOPE
- * is not bound to an annotation by default, we define @NoScope to represent
- * a "no-scope" condition. It will be detected by the builder to apply the
- * desired behavior for unscoped bindings.
+ * <p>This annotation is created because Play Framework's GuiceInjectorBuilder requires a scope to
+ * be defined with an annotation. Since Guice's NO_SCOPE is not bound to an annotation by default,
+ * we define @NoScope to represent a "no-scope" condition. It will be detected by the builder to
+ * apply the desired behavior for unscoped bindings.
  */
 @Scope
 @Target({ElementType.TYPE, ElementType.METHOD})

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -8,14 +8,21 @@ package guice
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Provider
-import scala.jdk.CollectionConverters.*
+
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
-import com.google.inject.{Binder, CreationException, Guice, Scopes, Stage, Module as GuiceModule}
-import com.google.inject.util.Modules as GuiceModules
-import com.google.inject.util.Providers as GuiceProviders
-import play.api.inject.Binding as PlayBinding
-import play.api.inject.Injector as PlayInjector
-import play.api.inject.Module as PlayModule
+
+import com.google.inject.{ Module => GuiceModule }
+import com.google.inject.util.{ Modules => GuiceModules }
+import com.google.inject.util.{ Providers => GuiceProviders }
+import com.google.inject.Binder
+import com.google.inject.CreationException
+import com.google.inject.Guice
+import com.google.inject.Scopes
+import com.google.inject.Stage
+import play.api.inject.{ Binding => PlayBinding }
+import play.api.inject.{ Injector => PlayInjector }
+import play.api.inject.{ Module => PlayModule }
 import play.api.Configuration
 import play.api.Environment
 import play.api.Mode
@@ -376,7 +383,7 @@ trait GuiceableModuleConversions {
             case (Some(scope), false) =>
               if (scope.getName.equals(classOf[NoScope].getName)) builder.in(Scopes.NO_SCOPE)
               else builder.in(scope)
-            case (None, true)         => builder.asEagerSingleton()
+            case (None, true) => builder.asEagerSingleton()
             case (Some(scope), true) =>
               throw new GuiceLoadException("A binding must either declare a scope or be eager: " + binding)
             case _ => // do nothing

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -8,20 +8,14 @@ package guice
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Provider
-
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.reflect.ClassTag
-
-import com.google.inject.{ Module => GuiceModule }
-import com.google.inject.util.{ Modules => GuiceModules }
-import com.google.inject.util.{ Providers => GuiceProviders }
-import com.google.inject.Binder
-import com.google.inject.CreationException
-import com.google.inject.Guice
-import com.google.inject.Stage
-import play.api.inject.{ Binding => PlayBinding }
-import play.api.inject.{ Injector => PlayInjector }
-import play.api.inject.{ Module => PlayModule }
+import com.google.inject.{Binder, CreationException, Guice, Scopes, Stage, Module as GuiceModule}
+import com.google.inject.util.Modules as GuiceModules
+import com.google.inject.util.Providers as GuiceProviders
+import play.api.inject.Binding as PlayBinding
+import play.api.inject.Injector as PlayInjector
+import play.api.inject.Module as PlayModule
 import play.api.Configuration
 import play.api.Environment
 import play.api.Mode
@@ -379,7 +373,9 @@ trait GuiceableModuleConversions {
             case BindingKeyTarget(key)                => builder.to(GuiceKey(key))
           }
           (binding.scope, binding.eager) match {
-            case (Some(scope), false) => builder.in(scope)
+            case (Some(scope), false) =>
+              if (scope.getName.equals(classOf[NoScope].getName)) builder.in(Scopes.NO_SCOPE)
+              else builder.in(scope)
             case (None, true)         => builder.asEagerSingleton()
             case (Some(scope), true) =>
               throw new GuiceLoadException("A binding must either declare a scope or be eager: " + binding)

--- a/core/play-guice/src/main/scala/play/api/inject/guice/NoScope.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/NoScope.scala
@@ -4,7 +4,11 @@
 
 package play.api.inject.guice
 
-import java.lang.annotation.{Annotation, ElementType, Retention, RetentionPolicy, Target}
+import java.lang.annotation.Annotation
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
 import javax.inject.Scope
 
 /**
@@ -20,5 +24,5 @@ import javax.inject.Scope
 @Retention(RetentionPolicy.RUNTIME)
 @Target(Array(ElementType.TYPE, ElementType.METHOD, ElementType.FIELD))
 class NoScope extends Annotation {
-  override def annotationType(): Class[_ <: Annotation] = classOf[NoScope]
+  override def annotationType(): Class[? <: Annotation] = classOf[NoScope]
 }

--- a/core/play-guice/src/main/scala/play/api/inject/guice/NoScope.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/NoScope.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.inject.guice
+
+import javax.inject.Scope
+import scala.annotation.StaticAnnotation
+
+/**
+ * Custom scope annotation to represent the absence of any specific scope.
+ *
+ * This annotation is created because Play Framework's GuiceInjectorBuilder
+ * requires a scope to be defined with an annotation. Since Guice's NO_SCOPE
+ * is not bound to an annotation by default, we define @NoScope to represent
+ * a "no-scope" condition. It will be detected by the builder to apply the
+ * desired behavior for unscoped bindings.
+ */
+@Scope
+class NoScope extends StaticAnnotation

--- a/core/play-guice/src/main/scala/play/api/inject/guice/NoScope.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/NoScope.scala
@@ -4,8 +4,8 @@
 
 package play.api.inject.guice
 
+import java.lang.annotation.{Annotation, ElementType, Retention, RetentionPolicy, Target}
 import javax.inject.Scope
-import scala.annotation.StaticAnnotation
 
 /**
  * Custom scope annotation to represent the absence of any specific scope.
@@ -17,4 +17,8 @@ import scala.annotation.StaticAnnotation
  * desired behavior for unscoped bindings.
  */
 @Scope
-class NoScope extends StaticAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target(Array(ElementType.TYPE, ElementType.METHOD, ElementType.FIELD))
+class NoScope extends Annotation {
+  override def annotationType(): Class[_ <: Annotation] = classOf[NoScope]
+}

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
@@ -10,6 +10,7 @@ import static play.inject.Bindings.bind;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.ConfigurationException;
+import com.google.inject.Scopes;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.io.File;
@@ -257,6 +258,7 @@ public class GuiceInjectorBuilderTest {
   public static class NoScopeModule extends com.google.inject.AbstractModule {
     @Override
     protected void configure() {
+      bindScope(NoScope.class, Scopes.NO_SCOPE);
       bind(A.class).to(A1.class).in(NoScope.class);
       bind(B.class).to(B1.class).in(javax.inject.Singleton.class);
     }

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
@@ -167,9 +167,7 @@ public class GuiceInjectorBuilderTest {
 
   @Test
   public void testNoScopeAnnotation() {
-    Injector injector = new GuiceInjectorBuilder()
-            .bindings(new NoScopeModule())
-            .injector();
+    Injector injector = new GuiceInjectorBuilder().bindings(new NoScopeModule()).injector();
 
     A noScopeInstance1 = injector.instanceOf(A.class);
     A noScopeInstance2 = injector.instanceOf(A.class);
@@ -263,5 +261,4 @@ public class GuiceInjectorBuilderTest {
       bind(B.class).to(B1.class).in(javax.inject.Singleton.class);
     }
   }
-
 }

--- a/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
+++ b/core/play-guice/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
@@ -164,6 +164,21 @@ public class GuiceInjectorBuilderTest {
     assertThrows(ConfigurationException.class, () -> injector.instanceOf(A.class));
   }
 
+  @Test
+  public void testNoScopeAnnotation() {
+    Injector injector = new GuiceInjectorBuilder()
+            .bindings(new NoScopeModule())
+            .injector();
+
+    A noScopeInstance1 = injector.instanceOf(A.class);
+    A noScopeInstance2 = injector.instanceOf(A.class);
+    B singletonInstance1 = injector.instanceOf(B.class);
+    B singletonInstance2 = injector.instanceOf(B.class);
+
+    assertThat(noScopeInstance1).isNotSameAs(noScopeInstance2);
+    assertThat(singletonInstance1).isSameAs(singletonInstance2);
+  }
+
   public static class EnvironmentModule extends play.api.inject.Module {
     @Override
     public Seq<play.api.inject.Binding<?>> bindings(
@@ -238,4 +253,13 @@ public class GuiceInjectorBuilderTest {
   public interface D {}
 
   public static class D1 implements D {}
+
+  public static class NoScopeModule extends com.google.inject.AbstractModule {
+    @Override
+    protected void configure() {
+      bind(A.class).to(A1.class).in(NoScope.class);
+      bind(B.class).to(B1.class).in(javax.inject.Singleton.class);
+    }
+  }
+
 }

--- a/core/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -225,8 +225,8 @@ class GuiceInjectorBuilderSpec extends Specification {
         )
         .injector()
 
-      val noScopeInstance1 = injector.instanceOf[GuiceInjectorBuilderSpec.A]
-      val noScopeInstance2 = injector.instanceOf[GuiceInjectorBuilderSpec.A]
+      val noScopeInstance1   = injector.instanceOf[GuiceInjectorBuilderSpec.A]
+      val noScopeInstance2   = injector.instanceOf[GuiceInjectorBuilderSpec.A]
       val singletonInstance1 = injector.instanceOf[GuiceInjectorBuilderSpec.B]
       val singletonInstance2 = injector.instanceOf[GuiceInjectorBuilderSpec.B]
 

--- a/core/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/core/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -216,6 +216,24 @@ class GuiceInjectorBuilderSpec extends Specification {
       injector.instanceOf[GuiceInjectorBuilderSpec.B1] must throwA[com.google.inject.ConfigurationException]
       injector.instanceOf[GuiceInjectorBuilderSpec.C1] must throwA[com.google.inject.ConfigurationException]
     }
+
+    "support NoScope and Singleton annotations" in {
+      val injector = new GuiceInjectorBuilder()
+        .bindings(
+          bind[GuiceInjectorBuilderSpec.A].to[GuiceInjectorBuilderSpec.A1].in[NoScope],
+          bind[GuiceInjectorBuilderSpec.B].to[GuiceInjectorBuilderSpec.B1].in[javax.inject.Singleton]
+        )
+        .injector()
+
+      val noScopeInstance1 = injector.instanceOf[GuiceInjectorBuilderSpec.A]
+      val noScopeInstance2 = injector.instanceOf[GuiceInjectorBuilderSpec.A]
+      val singletonInstance1 = injector.instanceOf[GuiceInjectorBuilderSpec.B]
+      val singletonInstance2 = injector.instanceOf[GuiceInjectorBuilderSpec.B]
+
+      noScopeInstance1 must not(beTheSameAs(noScopeInstance2))
+      singletonInstance1 must beTheSameAs(singletonInstance2)
+    }
+
   }
 }
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Resolves https://github.com/playframework/playframework/issues/10893

## Purpose

This PR adds support for Guice's [Scopes.NO_SCOPE](https://google.github.io/guice/api-docs/5.0.1/javadoc/com/google/inject/Scopes.html#NO_SCOPE).

We do this by creating a new `@NoScopes` annotation, and in `GuiceInjectorBuilder`, we detect this annotation and forward it along as such:  
```scala
def guice(bindings: Seq[PlayBinding[?]], binderOptions: Set[BinderOption]): GuiceModule = {
  [...]
  (binding.scope, binding.eager) match {
            case (Some(scope), false) =>
              if (scope.getName.equals(classOf[NoScope].getName)) builder.in(Scopes.NO_SCOPE)
              else builder.in(scope)
  [...]
}
```

## Background Context

Approach suggested by @mkurz in https://github.com/playframework/playframework/issues/10893.  
Initial attempt was made in https://github.com/playframework/playframework/pull/11451, however, PR was abandoned.  

## References

https://github.com/playframework/playframework/issues/10893
https://github.com/orgs/playframework/discussions/12891