### PR TITLE
Eager bindings docs clarification

### DIFF
--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -141,6 +141,16 @@ Eager singletons can be used to start up a service when an application starts. T
 
 @[eager-guice-module](code/javaguide/di/guice/eager/StartModule.java)
 
+It's important to note that the behavior of eager bindings differs between development and production modes:
+
+1. In development mode (`sbt run`):
+    * Eager bindings are created when the application starts, but they are not fully initialized until the first request is made to the application.
+    * This behavior improves development experience by reducing startup time and allowing for quicker code changes.
+2. In production mode (`sbt stage`):
+    * Eager bindings are created and fully initialized immediately when the application starts.
+    * This ensures that all necessary components are ready before the application begins accepting requests.
+
+
 ### Play libraries
 
 If you're implementing a library for Play, then you probably want it to be DI framework agnostic, so that your library will work out of the box regardless of which DI framework is being used in an application.  For this reason, Play provides a lightweight binding API for providing bindings in a DI framework agnostic way.

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
@@ -134,6 +134,16 @@ Eager singletons can be used to start up a service when an application starts. T
 
 @[eager-guice-module-startup](code/RuntimeDependencyInjection.scala)
 
+It's important to note that the behavior of eager bindings differs between development and production modes:
+
+1. In development mode (`sbt run`):
+    * Eager bindings are created when the application starts, but they are not fully initialized until the first request is made to the application.
+    * This behavior improves development experience by reducing startup time and allowing for quicker code changes.
+2. In production mode (`sbt stage`):
+    * Eager bindings are created and fully initialized immediately when the application starts.
+    * This ensures that all necessary components are ready before the application begins accepting requests.
+
+
 ### Play libraries
 
 If you're implementing a library for Play, then you probably want it to be DI framework agnostic, so that your library will work out of the box regardless of which DI framework is being used in an application.  For this reason, Play provides a lightweight binding API for providing bindings in a DI framework agnostic way.


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Resolves https://github.com/playframework/playframework/issues/10469

## Purpose

Adds documentation around differences in eager bindings between development and production modes.

## Background Context

Requested in https://github.com/playframework/playframework/issues/10469. 

I verified the behavior by creating a Hello World Play application and creating a custom binding and logging inside the service like this: 
```
if (environment.mode == Mode.Dev) {
    logger.info("EagerService created in Development mode")
    println("EagerService created in Development mode")
  } else {
    logger.info("EagerService created in Production mode")
    println("EagerService created in Production mode")
  }
```

Then I added a module: 
```
class EagerModule extends AbstractModule {
  override def configure(): Unit = {
    bind(classOf[EagerService]).asEagerSingleton()
    bind(classOf[ApplicationStart]).asEagerSingleton()
  }
}
```

And injected it into the HomeController: 
```
class HomeController @Inject()(val controllerComponents: ControllerComponents, eagerService: EagerService)
  extends BaseController with I18nSupport {
  [...]
```

Then I ran the app in both dev and production modes and verified the behavior is different and documented it.

## References

https://github.com/playframework/playframework/issues/10469
