### PR TITLE
Add crossbuild support

### DIFF
--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.8.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.5")
 
 // Required for Tutorial
-addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.1.0-M4") // sync with project/plugins.sbt
+addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.1.0-M5") // sync with project/plugins.sbt
 
 // Required for IDE docs
 addSbtPlugin("com.github.sbt" % "sbt-eclipse" % "6.2.0")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -225,8 +225,8 @@ object Dependencies {
       playFileWatch,
       sbtDep("org.playframework.twirl" % "sbt-twirl"           % BuildInfo.sbtTwirlVersion),
       sbtDep("com.github.sbt"          % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
-      sbtDep("com.github.sbt"          % "sbt-web"             % "1.5.8"),
-      sbtDep("com.github.sbt"          % "sbt-js-engine"       % "1.3.9"),
+      sbtDep("com.github.sbt"          % "sbt-web"             % "1.6.0-M1"),
+      sbtDep("com.github.sbt"          % "sbt-js-engine"       % "1.4.0-M1"),
       logback % Test
     ) ++ specs2Deps.map(_ % Test) ++ scalaReflect(scalaVersion)
   }

--- a/project/PlaySbtBuildBase.scala
+++ b/project/PlaySbtBuildBase.scala
@@ -12,8 +12,16 @@ object PlaySbtBuildBase extends AutoPlugin {
 
   override def projectSettings = Seq(
     scalaVersion                  := ScalaVersions.scala212,
-    crossScalaVersions            := Seq(ScalaVersions.scala212),
-    pluginCrossBuild / sbtVersion := SbtVersions.sbt111,
+    crossScalaVersions            := Seq(ScalaVersions.scala212, ScalaVersions.scala3),
+    pluginCrossBuild / sbtVersion := {
+      //SbtVersions.sbt110
+      scalaBinaryVersion.value match {
+        case "2.12" =>
+          SbtVersions.sbt111
+        case _ =>
+          SbtVersions.sbt2
+      }
+    },
     compile / javacOptions ++= Seq("--release", "17"),
     doc / javacOptions := Seq("-source", "17")
   )

--- a/project/PlaySbtBuildBase.scala
+++ b/project/PlaySbtBuildBase.scala
@@ -14,7 +14,6 @@ object PlaySbtBuildBase extends AutoPlugin {
     scalaVersion                  := ScalaVersions.scala212,
     crossScalaVersions            := Seq(ScalaVersions.scala212, ScalaVersions.scala3),
     pluginCrossBuild / sbtVersion := {
-      //SbtVersions.sbt110
       scalaBinaryVersion.value match {
         case ScalaVersions.scala212 =>
           SbtVersions.sbt111

--- a/project/PlaySbtBuildBase.scala
+++ b/project/PlaySbtBuildBase.scala
@@ -16,7 +16,7 @@ object PlaySbtBuildBase extends AutoPlugin {
     pluginCrossBuild / sbtVersion := {
       //SbtVersions.sbt110
       scalaBinaryVersion.value match {
-        case "2.12" =>
+        case ScalaVersions.scala212 =>
           SbtVersions.sbt111
         case _ =>
           SbtVersions.sbt2

--- a/project/PlaySbtBuildBase.scala
+++ b/project/PlaySbtBuildBase.scala
@@ -15,7 +15,7 @@ object PlaySbtBuildBase extends AutoPlugin {
     crossScalaVersions            := Seq(ScalaVersions.scala212, ScalaVersions.scala3),
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
-        case ScalaVersions.scala212 =>
+        case "2.12" =>
           SbtVersions.sbt111
         case _ =>
           SbtVersions.sbt2

--- a/project/PlaySbtBuildBase.scala
+++ b/project/PlaySbtBuildBase.scala
@@ -12,7 +12,7 @@ object PlaySbtBuildBase extends AutoPlugin {
 
   override def projectSettings = Seq(
     scalaVersion                  := ScalaVersions.scala212,
-    crossScalaVersions            := Seq(ScalaVersions.scala212, ScalaVersions.scala3),
+    crossScalaVersions            := Seq(ScalaVersions.scala212),
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
         case "2.12" =>

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,9 +5,10 @@
 object ScalaVersions {
   val scala212 = "2.12.20"
   val scala213 = "2.13.16"
-  val scala3   = "3.3.6"
+  val scala3   = "3.7.2"
 }
 
 object SbtVersions {
   val sbt111 = "1.11.4"
+  val sbt2   = "2.0.0-RC3"
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@
 object ScalaVersions {
   val scala212 = "2.12.20"
   val scala213 = "2.13.16"
-  val scala3   = "3.7.2"
+  val scala3   = "3.3.6"
 }
 
 object SbtVersions {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ val sbtJmh             = "0.4.7"
 val webjarsLocatorCore = "0.59"
 val sbtHeader          = "5.8.0"
 val scalafmt           = "2.4.6"
-val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "2.1.0-M4") // sync with documentation/project/plugins.sbt
+val sbtTwirl: String   = sys.props.getOrElse("twirl.version", "2.1.0-M5") // sync with documentation/project/plugins.sbt
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackager,


### PR DESCRIPTION
Adds the ability to crossbuild plugins (without actually doing it in CI, explicitly)

Related to #12897.

* Updates to `sbt-twirl` % `2.1.0-M5` (which has crossbuild support)
* Adds sbt2 crossbuilds to default `PlaySbtBuildBase`
* Adds `sbt2` to sbt versions

Needs crossbuilds of the following plugins:
- [x] com.github.sbt:sbt-web_sbt2.0.0-M2_3
  - [x] https://github.com/sbt/sbt-web/issues/255
- [x] com.github.sbt:sbt-native-packager_sbt2.0.0-M2_3
  - [x] https://github.com/sbt/sbt-native-packager/issues/1638
- [x] com.github.sbt:sbt-js-engine_sbt2.0.0-M2_3
  - [x] https://github.com/sbt/sbt-js-engine/issues/139
  
  Edit: `+mimaReportBinaryIssues` fails with Scala3 in the crossbuild, so removing. Will follow up with a PR to fix Scala3 compile/format issues.