### PR TITLE
If WebSocket close frame does not send status code it defaults to 1005

### DIFF
--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -410,7 +410,7 @@ object WebSocketFlowHandler {
     } else if (data.length == 1) {
       invalid("close code must be length 2 but was 1")
     } else {
-      CloseMessage()
+      CloseMessage(CloseCodes.NoStatus)
     }
   }
 }


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1

> 1005 is a reserved value and MUST NOT be set as a status code in a Close control frame by an endpoint.  It is designated for use in applications expecting a status code to indicate that no status code was actually present.

Currently, when the close frame gets send by the client without status code, we set the status code to regular/1000 (the one the app receives):

https://github.com/playframework/playframework/blob/0dcea10a40661926e3b0fb3c107d3ae25b8d9c6b/core/play/src/main/scala/play/api/http/websocket/Message.scala#L38

This is wrong according to the specs the app needs to receive 1005.