### PR TITLE
If WebSocket closes abnormally send status code 1006 to app

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -182,6 +182,82 @@ trait WebSocketSpec
         WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source(messages)) }
       }
 
+      "notify the application when the connection closes without a close frame" in {
+        val consumed = Promise[List[Message]]()
+        withServer(app =>
+          WebSocket.accept[Message, Message] { req =>
+            Flow.fromSinkAndSource(onFramesConsumed[Message](consumed.success(_)), Source.maybe[Message])
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val result = runWebSocket(
+            port,
+            { flow =>
+              Source.empty[ExtendedMessage].via(flow).runWith(Sink.ignore)
+              consumed.future
+            }
+          )
+          result must contain(exactly(closeMessage(1006)))
+        }
+      }
+
+      "not notify the application with 1006 when the client sends a close frame" in {
+        val consumed = Promise[List[Message]]()
+        withServer(app =>
+          WebSocket.accept[Message, Message] { req =>
+            Flow.fromSinkAndSource(onFramesConsumed[Message](consumed.success(_)), Source.maybe[Message])
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val result = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(CloseMessage(1000)).via(flow).runWith(Sink.ignore)
+              consumed.future
+            }
+          )
+          result must contain(exactly(closeMessage(1000)))
+        }
+      }
+
+      "not expose 1006 as a typed WebSocket message" in {
+        val consumed = Promise[List[String]]()
+        withServer(app =>
+          WebSocket.accept[String, String] { req =>
+            Flow.fromSinkAndSource(onFramesConsumed[String](consumed.success(_)), Source.maybe[String])
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val result = runWebSocket(
+            port,
+            { flow =>
+              Source.empty[ExtendedMessage].via(flow).runWith(Sink.ignore)
+              consumed.future
+            }
+          )
+          result must beEmpty
+        }
+      }
+
+      "not notify the application with 1006 when the application sends a close frame" in {
+        val consumed = Promise[List[Message]]()
+        withServer(app =>
+          WebSocket.accept[Message, Message] { req =>
+            Flow.fromSinkAndSource(onFramesConsumed[Message](consumed.success(_)), Source.single(CloseMessage(1000)))
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val result = runWebSocket(
+            port,
+            { flow =>
+              Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames)
+              consumed.future
+            }
+          )
+          result must beEmpty
+        }
+      }
+
       "close when the consumer is done" in closeWhenTheConsumerIsDone { _ =>
         WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.cancelled, Source.maybe[String]) }
       }
@@ -572,6 +648,10 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
     case SimpleMessage(CloseMessage(statusCode, _), _) => statusCode must beSome(status)
   }
 
+  def closeMessage(status: Int): Matcher[Message] = beLike {
+    case CloseMessage(statusCode, _) => statusCode must beSome(status)
+  }
+
   def consumeFrames[A]: Sink[A, Future[List[A]]] =
     Sink.fold[List[A], A](Nil)((result, next) => next :: result).mapMaterializedValue { future =>
       future.map(_.reverse)
@@ -695,7 +775,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
     withServer(
       app =>
         WebSocket.accept[String, String] { req =>
-          Flow.fromSinkAndSource(onFramesConsumed[String](consumed.success(_)), Source.maybe)
+          Flow.fromSinkAndSource(onFramesConsumed[String](consumed.trySuccess(_)), Source.maybe)
         },
       Map(
         "play.server.pekko.http2.enabled" -> pekkoHttp2enabled,
@@ -715,7 +795,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
             .via(
               flow.recover(t =>
                 // recover from "java.io.IOException: Connection reset by peer"
-                consumed.success(List.empty)
+                consumed.trySuccess(List.empty)
               )
             )
             .runWith(consumeFrames)

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -34,3 +34,11 @@ WebSocket.Text.acceptWithOptions(request ->
 This is useful for protocols where the client and server need to agree on an application-level WebSocket protocol during the opening handshake. Existing `accept` and `acceptOrResult` handlers keep their previous behavior.
 
 For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Selecting-a-WebSocket-subprotocol]] and [[Java WebSocket documentation|JavaWebSockets#Selecting-a-WebSocket-subprotocol]].
+
+### WebSocket Abnormal Closure Status
+
+Play now reports abnormal WebSocket connection loss to raw WebSocket handlers with close status `1006`.
+
+Previously, if the underlying connection disappeared without a WebSocket Close frame, for example because the network connection was lost or an idle timeout closed the transport, raw `WebSocket.accept[Message, Message]` handlers could see the stream complete without a close message. Play now emits a `CloseMessage` with status code `1006` to application code before completing the stream.
+
+The `1006` status is never sent to the remote peer as a WebSocket Close frame. It is only used as the application-visible status for a connection that closed abnormally without receiving a Close frame. This behavior follows [RFC 6455 section 7.1.5](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.5) and the reserved close code definition in [section 7.4.1](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1).

--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -48,3 +48,13 @@ Plain `URI` values are still parsed as URI values. For example, a `classpath:` U
 This does not affect normal file uploads. Play file uploads use multipart form handling and `Http.MultipartFormData.FilePart`, not string-to-`File` form binding. See [[Handling file upload|JavaFileUpload]] for the Java file upload API.
 
 If your application intentionally needs one of the removed bindings, register an explicit formatter or converter for that type in your application. See [[Register a custom DataBinder|JavaForms#Register-a-custom-DataBinder]] for the Java form formatter setup. If you think a removed binding should be supported by Play by default, please open an issue in the [Play issue tracker](https://github.com/playframework/playframework/issues).
+
+### Raw WebSocket handlers now receive status 1006 for abnormal connection loss
+
+Raw WebSocket handlers that consume `play.api.http.websocket.Message` values now receive `CloseMessage(Some(1006), ...)` when the underlying connection closes or fails without Play receiving a WebSocket Close frame.
+
+This can happen when the network connection is interrupted, the client disconnects without completing the WebSocket close handshake, or the server idle timeout closes the transport. The status code `1006` is not sent on the wire; it is only delivered to application code to report that the connection was closed abnormally. This is the behavior defined by [RFC 6455 section 7.1.5](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.5) and the reserved close code definition in [section 7.4.1](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1).
+
+Because abnormal WebSocket termination is now reported as a `CloseMessage` before the stream completes, raw `Message` handlers that previously relied on `watchTermination` seeing a failed stream for transport loss should instead inspect `CloseMessage(Some(1006), ...)`.
+
+Handlers using typed APIs such as `WebSocket.accept[String, String]` still do not receive close control frames as typed messages. Use a raw `Message` flow if your application needs to inspect WebSocket close status codes directly.

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -78,6 +78,8 @@ object WebSocketFlowHandler {
         var pingToSend: Message    = null
         var pongToSend: Message    = null
         var messageToSend: Message = null
+        var closeForwardedToApp    = false
+        var appInitiatedClose      = false
 
         var currentPartialMessage: RawMessage = null
 
@@ -186,6 +188,25 @@ object WebSocketFlowHandler {
           }
         }
 
+        def completeAfterForwardingCloseToApp(close: CloseMessage): Unit = {
+          if (!isClosed(appOut)) {
+            closeForwardedToApp = true
+            emit(appOut, close, () => completeStage())
+          } else {
+            completeStage()
+          }
+        }
+
+        def completeRemoteInputAbnormally(): Unit = {
+          if (!closeForwardedToApp && !appInitiatedClose) {
+            completeAfterForwardingCloseToApp(
+              CloseMessage(CloseCodes.ConnectionAbort, "Connection closed abnormally")
+            )
+          } else {
+            completeStage()
+          }
+        }
+
         setHandler(
           appOut,
           new OutHandler {
@@ -199,6 +220,7 @@ object WebSocketFlowHandler {
 
             override def onDownstreamFinish(cause: Throwable): Unit = {
               if (state == Open) {
+                appInitiatedClose = true
                 serverInitiatedClose(CloseMessage(Some(CloseCodes.Regular)))
               }
             }
@@ -208,21 +230,30 @@ object WebSocketFlowHandler {
         setHandler(
           remoteIn,
           new InHandler {
+            override def onUpstreamFinish(): Unit = {
+              completeRemoteInputAbnormally()
+            }
+
             override def onUpstreamFailure(ex: Throwable): Unit = {
               // This happens e.g. when using the Netty backend and a client sends an invalid close status code
               // that is not defined in https://tools.ietf.org/html/rfc6455#section-7.4
-              if (state == Open) {
+              val closeFromFailure = if (state == Open) {
                 val statusCode = """(\d+)""".r
                 ex.getMessage match {
                   case s"Invalid close frame getStatus code: ${statusCode(code)}" => // Parse Netty error message
-                    push(appOut, CloseMessage(code.toInt)) // Forward down to app
-                  case _                                                          => // Don't log the whole exception to not overwhelm the logs in case failures occur often
+                    Some(CloseMessage(code.toInt))
+                  case _ => // Don't log the whole exception to not overwhelm the logs in case failures occur often
                     logger.warn(s"WebSocket communication problem: ${ex.getMessage}")
+                    None
                 }
               } else {
                 logger.debug("WebSocket communication problem after the WebSocket was closed", ex)
+                None
               }
-              super.onUpstreamFailure(ex)
+              closeFromFailure match {
+                case Some(close) => completeAfterForwardingCloseToApp(close)
+                case None        => completeRemoteInputAbnormally()
+              }
             }
 
             override def onPush() = {
@@ -264,6 +295,7 @@ object WebSocketFlowHandler {
                       case close: CloseMessage =>
                         // Forward down to app
                         push(appOut, close)
+                        closeForwardedToApp = true
                         // And complete both app out and app in
                         complete(appOut)
                         cancel(appIn)
@@ -301,6 +333,7 @@ object WebSocketFlowHandler {
               if (state == Open) {
                 grab(appIn) match {
                   case close: CloseMessage =>
+                    appInitiatedClose = true
                     serverInitiatedClose(close)
                     cancel(appIn)
                   case other =>
@@ -317,12 +350,14 @@ object WebSocketFlowHandler {
 
             override def onUpstreamFinish() = {
               if (state == Open) {
+                appInitiatedClose = true
                 serverInitiatedClose(CloseMessage(Some(CloseCodes.Regular)))
               }
             }
 
             override def onUpstreamFailure(ex: Throwable) = {
               if (state == Open) {
+                appInitiatedClose = true
                 serverInitiatedClose(CloseMessage(Some(CloseCodes.UnexpectedCondition)))
                 logger.error("WebSocket flow threw exception", ex)
               } else {

--- a/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
+import org.apache.pekko.Done
+import org.specs2.matcher.Matcher
+import org.specs2.mutable.Specification
+import play.api.http.websocket.CloseCodes
+import play.api.http.websocket.CloseMessage
+import play.api.http.websocket.Message
+
+class WebSocketFlowHandlerSpec extends Specification {
+  "WebSocketFlowHandler" should {
+    "send 1006 to the application when remote input fails without a close frame" in withActorSystem {
+      implicit materializer =>
+        val messages = runFailedRemoteInput(new RuntimeException("connection failed"))
+
+        messages must contain(exactly(closeMessage(CloseCodes.ConnectionAbort)))
+    }
+
+    "forward an invalid close status code reported by the backend failure" in withActorSystem { implicit materializer =>
+      val messages = runFailedRemoteInput(new RuntimeException("Invalid close frame getStatus code: 1006"))
+
+      messages must contain(exactly(closeMessage(CloseCodes.ConnectionAbort)))
+    }
+
+    "not send 1006 when the application initiated close and remote input then fails" in withActorSystem {
+      implicit materializer =>
+        val messages = runAppInitiatedCloseThenFailedRemoteInput()
+
+        messages must beEmpty
+    }
+
+    "forward a remote close code without sending 1006" in withActorSystem { implicit materializer =>
+      val messages = runRemoteInput(rawClose(CloseCodes.GoingAway))
+
+      messages must contain(exactly(closeMessage(CloseCodes.GoingAway)))
+    }
+
+    "send 1006 after remote input completes even when the application has no immediate demand" in withActorSystem {
+      implicit materializer =>
+        val messages = runCompletedRemoteInputWithoutInitialAppDemand()
+
+        messages must contain(exactly(closeMessage(CloseCodes.ConnectionAbort)))
+    }
+  }
+
+  private def runFailedRemoteInput(ex: Throwable)(implicit materializer: Materializer): Seq[Message] = {
+    runRemoteInput(Source.failed[WebSocketFlowHandler.RawMessage](ex))
+  }
+
+  private def runRemoteInput(messages: WebSocketFlowHandler.RawMessage*)(
+      implicit materializer: Materializer
+  ): Seq[Message] = {
+    runRemoteInput(Source(messages.toList))
+  }
+
+  private def runRemoteInput(
+      remoteIn: Source[WebSocketFlowHandler.RawMessage, ?]
+  )(implicit materializer: Materializer): Seq[Message] = {
+    runRemoteInputWithAppSource(remoteIn, Source.maybe[Message])
+  }
+
+  private def runRemoteInputWithAppSource(
+      remoteIn: Source[WebSocketFlowHandler.RawMessage, ?],
+      appIn: Source[Message, ?]
+  )(implicit materializer: Materializer): Seq[Message] = {
+    val appFlow = Flow.fromSinkAndSourceMat(Sink.seq[Message], appIn)(Keep.left)
+    val flow    = protocol.joinMat(appFlow)(Keep.right)
+
+    val (appMessages, remoteOutDone) = remoteIn.viaMat(flow)(Keep.right).toMat(Sink.ignore)(Keep.both).run()
+
+    awaitRemoteOut(remoteOutDone)
+    Await.result(appMessages, 5.seconds)
+  }
+
+  private def runAppInitiatedCloseThenFailedRemoteInput()(implicit materializer: Materializer): Seq[Message] = {
+    val appFlow = Flow.fromSinkAndSourceMat(
+      Sink.seq[Message],
+      Source.single(CloseMessage(CloseCodes.Regular))
+    )(Keep.left)
+    val flow      = protocol.joinMat(appFlow)(Keep.right)
+    val closeSent = Promise[Message]()
+
+    val ((remoteIn, appMessages), remoteOutDone) =
+      Source
+        .queue[WebSocketFlowHandler.RawMessage](1)
+        .viaMat(flow)(Keep.both)
+        .toMat(Sink.foreach[Message](message => closeSent.trySuccess(message)))(Keep.both)
+        .run()
+
+    Await.result(closeSent.future, 5.seconds) must beLike { case CloseMessage(Some(CloseCodes.Regular), _) => ok }
+    remoteIn.fail(new RuntimeException("connection failed"))
+    awaitRemoteOut(remoteOutDone)
+    Await.result(appMessages, 5.seconds)
+  }
+
+  private def runCompletedRemoteInputWithoutInitialAppDemand()(
+      implicit materializer: Materializer
+  ): Seq[Message] = {
+    val appFlow = Flow.fromSinkAndSourceMat(Sink.asPublisher[Message](fanout = false), Source.maybe[Message])(Keep.left)
+    val flow    = protocol.joinMat(appFlow)(Keep.right)
+
+    val (appPublisher, remoteOutDone) =
+      Source.empty[WebSocketFlowHandler.RawMessage].viaMat(flow)(Keep.right).toMat(Sink.ignore)(Keep.both).run()
+
+    val appMessages = Source.fromPublisher(appPublisher).runWith(Sink.seq)
+
+    awaitRemoteOut(remoteOutDone)
+    Await.result(appMessages, 5.seconds)
+  }
+
+  private def protocol =
+    WebSocketFlowHandler.webSocketProtocol(
+      bufferLimit = 65536,
+      wsKeepAliveMode = "ping",
+      wsKeepAliveMaxIdle = Duration.Inf
+    )
+
+  private def rawClose(statusCode: Int): WebSocketFlowHandler.RawMessage = {
+    WebSocketFlowHandler.RawMessage(
+      WebSocketFlowHandler.MessageType.Close,
+      ByteString((statusCode >> 8).toByte, statusCode.toByte),
+      isFinal = true
+    )
+  }
+
+  private def awaitRemoteOut(done: Future[Done]): Unit = {
+    Await.result(done.recover { case _ => Done }(scala.concurrent.ExecutionContext.parasitic), 5.seconds)
+  }
+
+  private def closeMessage(status: Int): Matcher[Message] = beLike {
+    case CloseMessage(statusCode, _) => statusCode must beSome(status)
+  }
+
+  private def withActorSystem[T](block: Materializer => T): T = {
+    implicit val system: ActorSystem        = ActorSystem("web-socket-flow-handler-spec")
+    implicit val materializer: Materializer = Materializer.matFromSystem
+    try {
+      block(materializer)
+    } finally {
+      Await.result(system.terminate(), 5.seconds)
+    }
+  }
+}


### PR DESCRIPTION
See [WebSocket specs 7.4.1](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1)

>  1006 is a reserved value and MUST NOT be set as a status code in a Close control frame by an endpoint.  It is designated for use in applications expecting a status code to indicate that the connection was closed abnormally, e.g., without sending or receiving a Close control frame.

Also [7.1.5](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.5)
> If _The WebSocket Connection is Closed_ and no Close control frame was received by the endpoint (such as could occur if the underlying transport connection is lost), _The WebSocket Connection Close Code_ is considered to be 1006.

And [11.7](https://datatracker.ietf.org/doc/html/rfc6455#section-11.7)
```
-+------------+-----------------+---------------+------------------------------------------------------------|
 | 1006       | Abnormal Closure| hybi@ietf.org | [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455)  |
-+------------+-----------------+---------------+------------------------------------------------------------|
```

The problem is right now the app only gets a status code if the connection gets closed correctly, triggered by the client. (If user code triggers closing, no status code will be send to the app which is OK).

However, if a WebSocket connection is lost / abnormaly closed, for whatever reason (network is down, cable unplugged, ...), currently the app does not receive a close message, but according to the specs this is what 1006 is for.

Currently, one can only detect if a connection is closed via watchTermination on a flow like (java code):
```java
Flow.fromSinkAndSource(someSink, someSource).watchTermination((prevMatValue, completionStage) -> {
    // This function will be run when the stream terminates
    // the CompletionStage provided as a second parameter indicates whether
    // the stream completed successfully or failed
    completionStage.whenComplete((done, exc) -> {
      if (done != null) {
        // For Play WebSockets, we -->always<-- enter this if condition, even when the connection was closed abnormally
        System.out.println("The stream materialized successfully " + prevMatValue.toString());
      } else {
        System.out.println(exc.getMessage());
      }
    });
    return prevMatValue;
});
```

As you see from this code, the watchtermination is always called in a way so that done is set, no matter what the reason is that a connections got closed: you can not determine the connection was closed cleanly (triggered by user code or by the client) or if the connection was closed abnormally. There is only one work around I can think of currently, which would be to capture the close status code of a close message, if one is received, and check in the watch termination if there was a close message before, and if so one knows if the connection was closed clean or not (also the user needs to save if the connection was closed by user code of course to make the distinction).

With this PR I always make the WebSocket send a close status code to the user code with status 1006 if the connection is not closed cleanly by user code nor by the client.