### PR TITLE
Make it easier to work with Play's WebSocket `Message` objects in Java

### DIFF
--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -30,6 +30,11 @@ public abstract class WebSocket {
   public abstract CompletionStage<F.Either<Result, Flow<Message, Message, ?>>> apply(
       Http.RequestHeader request);
 
+  /** Acceptor for WebSockets to directly handle Play's Message objects. */
+  public static final MappedWebSocketAcceptor<Message, Message> Message =
+      new WebSocket.MappedWebSocketAcceptor<>(
+          Scala.partialFunction(message -> F.Either.Left(message)), Function.identity());
+
   /** Acceptor for text WebSockets. */
   public static final MappedWebSocketAcceptor<String, String> Text =
       new MappedWebSocketAcceptor<>(


### PR DESCRIPTION
The WebSocket specs [defines various frame types](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5).
In Play we handle them as `Message` ([scala](https://github.com/playframework/playframework/blob/3.0.x/core/play/src/main/scala/play/api/http/websocket/Message.scala), [java](https://github.com/playframework/playframework/blob/3.0.x/core/play/src/main/java/play/http/websocket/Message.java)).

Using Play Scala, it's easy to directly work with `Message` objects, so one can easily receive and send and mix Messages. (Like receive a text message, answer with a binary, etc.). For example:
```scala
  def websocket: WebSocket = WebSocket.accept[Message, Message](rh =>
    Flow.fromSinkAndSource(
      Sink.foreach(_ match {
        case TextMessage(data)           => ...
        case BinaryMessage(data)         => ...
        case CloseMessage(statusCode, _) => ...
        case _                           => ...
      }),
      Source.maybe[Message] // Keep connection open, or you can with a source send any kind of Message to the client
    ) 
  )
```

In Play Java however, we currently allow users to only work with either Text, Binary or Json and there is no way to work directly with Message objects:
```java
WebSocket.Text.acceptOrResult(...)
WebSocket.Binary.acceptOrResult(...)
WebSocket.Json.acceptOrResult(...)
WebSocket.json(Foo.class).acceptOrResult(...)
```

So if Java users want to have a bit more sophisticated WebSocket handling its not possible out of the box, they can however work around this by:

```java
public WebSocket websocket() {

        final WebSocket.MappedWebSocketAcceptor<Message, Message> Message =
                new WebSocket.MappedWebSocketAcceptor<>(
                        Scala.partialFunction(message -> F.Either.Left(message)),
                        message -> message);

        return Message.acceptOrResult(request -> CompletableFuture
                .completedStage(F.Either.<Result, Flow<Message, Message, ?>>Right(
                        Flow.fromSinkAndSource(someSink, someSource)
                )));
}
```

So instead of having to write the very simple `MappedWebSocketAcceptor` to handle `Message`s as a workaround I propose to just include it to Play to make devs life easier.