### PR TITLE
jgit upgrade to support git worktree

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,9 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
   s
 }
 
+// TODO
+ThisBuild / com.github.sbt.git.SbtGit.GitKeys.useConsoleForROGit := false
+
 // Makes sure to increase the version and remove the distance
 ThisBuild / version := dynverGitDescribeOutput.value
   .mkVersion(out => versionFmt(out, dynverSonatypeSnapshots.value), fallbackVersion(dynverCurrentDate.value))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -32,6 +32,12 @@ addSbtPlugin("pl.project13.scala"      % "sbt-jmh"               % sbtJmh)
 addSbtPlugin("com.github.sbt"          % "sbt-header"            % sbtHeader)
 addSbtPlugin("org.scalameta"           % "sbt-scalafmt"          % scalafmt)
 addSbtPlugin("com.github.sbt"          % "sbt-ci-release"        % "1.11.2")
+// sbt-ci-release relies on sbt-git, which in turn depends on jgit. Unfortunately, sbt-git is still using jgit v5
+// to maintain support for Java 8, while jgit v6 requires Java 11, and jgit v7 requires Java 17. Since jgit v7
+// finally introduces (read-only) support for git worktree and Play already requires Java 17, we can upgrade jgit
+// ourselves to enhance the developer experience for Play contributors, especially if they want to use git worktree.
+// See https://github.com/sbt/sbt-git/issues/213 and https://github.com/sbt/sbt-git/pull/243#issuecomment-2397762074
+libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "7.7.0.202606012155-r"
 
 addSbtPlugin("nl.gn0s1s" % "sbt-pekko-version-check" % "0.0.9")
 

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,3 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+addDependencyTreePlugin


### PR DESCRIPTION
The comment in the diff explains everything.

See 
- https://github.com/sbt/sbt-git/issues/213
- https://github.com/sbt/sbt-git/pull/243#issuecomment-2397762074

Personally I make use of git worktree, I checked out the 3.0.x and and 2.9.x in separate folders. Until now I had to make a workaround by setting `ThisBuild / com.github.sbt.git.SbtGit.GitKeys.gitUncommittedChanges := false` otherwise sbt wont start up the project and you run into following exception:

<details>
  <summary>Exception with jgit 5 (and 6) (click to expand)</summary>
  
```
$ sbt
[info] welcome to sbt 1.10.2 (Eclipse Adoptium Java 17.0.12)
[info] loading global plugins from /home/mkurz/.sbt/1.0/plugins
...
org.eclipse.jgit.errors.NoWorkTreeException: Bare Repository has neither a working tree, nor an index
        at org.eclipse.jgit.lib.Repository.getWorkTree(Repository.java:1570)
        at org.eclipse.jgit.treewalk.FileTreeIterator.<init>(FileTreeIterator.java:87)
        at org.eclipse.jgit.treewalk.FileTreeIterator.<init>(FileTreeIterator.java:73)
        at org.eclipse.jgit.api.StatusCommand.call(StatusCommand.java:113)
        at com.github.sbt.git.JGit.hasUncommittedChanges(JGit.scala:94)
        at com.github.sbt.git.SbtGit$.$anonfun$buildSettings$22(GitPlugin.scala:126)
        at com.github.sbt.git.SbtGit$.$anonfun$buildSettings$22$adapted(GitPlugin.scala:126)
        at com.github.sbt.git.DefaultReadableGit.withGit(ReadableGit.scala:44)
        at com.github.sbt.git.SbtGit$.$anonfun$buildSettings$21(GitPlugin.scala:126)
        at com.github.sbt.git.SbtGit$.$anonfun$buildSettings$21$adapted(GitPlugin.scala:126)
        at scala.Function1.$anonfun$compose$1(Function1.scala:49)
        at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:229)
        at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:171)
        at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:88)
        at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:100)
        at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:95)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
[error] org.eclipse.jgit.errors.NoWorkTreeException: Bare Repository has neither a working tree, nor an index
[error] Use 'last' for the full log.
```
</details>

sbt-git introduced a setting (`useReadableConsoleGit`) to avoid using jgit and fall back to command line git:
- https://github.com/sbt/sbt-git?tab=readme-ov-file#jgit
- https://github.com/sbt/sbt-git/pull/168
- https://github.com/sbt/sbt-git/pull/230

Also they want to soon detect if a project is checked out in a linked worktree or not and only disable jgit if you are:
- https://github.com/sbt/sbt-git/pull/243

However, if we just ugprade to jgit 7+ we can avoid all of that because it supports git worktree out of the box.
One of those small things that makes development just smoother out of the box...