### PR TITLE
Fix broken link

### DIFF
--- a/documentation/manual/tutorial/Tutorials.md
+++ b/documentation/manual/tutorial/Tutorials.md
@@ -175,7 +175,7 @@ Marius Soutier has an excellent series on setting up a Javascript interface usin
 
 #### React JS
 
-* [ReactJS Tutorial with Play, Scala and WebJars](http://ticofab.io/react-js-tutorial-with-play_scala_webjars/) by Fabio Tiriticco.
+* [ReactJS Tutorial with Play, Scala and WebJars](http://ticofab.io/blog/react-js-tutorial-with-play_scala_webjars/) by Fabio Tiriticco.
 * [A basic example to render UI using ReactJS with Play 2.4.x, Scala and Anorm](https://blog.knoldus.com/2015/07/19/playing-reactjs/) by Knoldus / [activator template](https://github.com/knoldus/playing-reactjs#master).
 
 ### 2.3.x


### PR DESCRIPTION
As a Play user
I want the links in the Play documentation to take me to the correct webpage
So that I am not frustrated by a 404 error