### PR TITLE
Fix `JavaHelpers.updateRequestWithUri`

### DIFF
--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -334,17 +334,27 @@ public class RequestBuilderTest {
   }
 
   @Test
-  public void testGetQuery_emptyParam() {
+  public void testQuery_emptyParam() {
     final Request req = new Http.RequestBuilder().uri("/path?one=&two=a+b&").build();
-    assertEquals(Optional.empty(), req.queryString("one"));
+    assertEquals(Optional.of(""), req.queryString("one"));
     assertEquals(Optional.of("a b"), req.queryString("two"));
+    assertEquals(Optional.empty(), req.queryString("three"));
   }
 
   @Test
-  public void testQuery_emptyParam() {
-    final Request req = new Http.RequestBuilder().uri("/path?one=&two=a+b&").build();
-    assertEquals(Optional.empty(), req.queryString("one"));
+  public void testQuery_noValueParam() {
+    final Request req = new Http.RequestBuilder().uri("/path?one&two=a+b&").build();
+    assertEquals(Optional.of(""), req.queryString("one"));
     assertEquals(Optional.of("a b"), req.queryString("two"));
+    assertEquals(Optional.empty(), req.queryString("three"));
+  }
+
+  @Test
+  public void testQuery_keyDecoding() {
+    final Request req = new Http.RequestBuilder().uri("/path?one?%2B=&two%3D").build();
+    assertEquals(Optional.of(""), req.queryString("one?+"));
+    assertEquals(Optional.of(""), req.queryString("two="));
+    assertEquals(Optional.empty(), req.queryString("three"));
   }
 
   @Test

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -117,15 +117,15 @@ trait JavaHelpers {
       override val path: String      = parsedUri.getRawPath
       override val queryMap: Map[String, Seq[String]] = {
         val query: String = uri.getRawQuery
-        if (query == null || query.length == 0) {
+        if (query == null || query.isEmpty) {
           Map.empty
         } else {
           query.split("&").foldLeft[Map[String, Seq[String]]](Map.empty) {
             case (acc, pair) =>
               val idx: Int    = pair.indexOf("=")
-              val key: String = if (idx > 0) URLDecoder.decode(pair.substring(0, idx), "UTF-8") else pair
+              val key: String = URLDecoder.decode(if (idx > 0) pair.substring(0, idx) else pair, "UTF-8")
               val value: String =
-                if (idx > 0 && pair.length > idx + 1) URLDecoder.decode(pair.substring(idx + 1), "UTF-8") else null
+                if (idx > 0 && pair.length > idx + 1) URLDecoder.decode(pair.substring(idx + 1), "UTF-8") else ""
               acc.get(key) match {
                 case None         => acc.updated(key, Seq(value))
                 case Some(values) => acc.updated(key, values :+ value)


### PR DESCRIPTION
I got this issue when working on another pull request 😞 
The problem is related to parsing query params from URI that contains a parameter with empty or no value.
**URI:** 
`/path?param=` or `/path?param`
**Expected result:**
`Map("param" -> List(""))`
**Actual result:**
`Map("param" -> List(null))`

In our codebase we already have a function that implement this parsing (`FormUrlEncodedParser.parse`) and also have a test for this cases https://github.com/playframework/playframework/blob/b295dc85da8deec73a2161707e69ca1a472390f4/core/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala#L31-L36