### PR TITLE
Fix encoding a value of `Char` query param for reverse router

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -394,7 +394,7 @@ object QueryStringBindable extends QueryStringBindableMacros {
         }
       }
     def unbind(key: String, value: Char) =
-      s"${_urlEncode(key)}=$value"
+      s"${_urlEncode(key)}=${_urlEncode(value.toString)}"
   }
 
   /**

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
@@ -22,6 +22,13 @@ object RouterSpec extends PlaySpecification {
     }
   }
 
+  "reverse routes containing char parameters" in {
+    "the query string" in {
+      controllers.routes.Application.takeChar('z').url must equalTo("/take-char?x=z")
+      controllers.routes.Application.takeChar('π').url must equalTo("/take-char?x=%CF%80")
+    }
+  }
+
   "reverse routes containing custom parameters" in {
     "the query string" in {
       controllers.routes.Application.queryUser(UserId("foo")).url must equalTo("/query-user?userId=foo")


### PR DESCRIPTION
I caught this just passing by during other work 🧑‍💻
Still following _"The Boy Scout Rule (©Uncle Bob)"_ 🖖