### PR TITLE
Fix encoding a key of `Boolean` query param for JavaScript reverse router

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -477,7 +477,7 @@ object QueryStringBindable extends QueryStringBindableMacros {
         _.toString,
         (s, _) => s"Cannot parse parameter $s as Boolean: should be true, false, 0 or 1"
       ) {
-    override def javascriptUnbind = """function(k,v){return k+'='+(!!v)}"""
+    override def javascriptUnbind = """function(k,v){return encodeURIComponent(k)+'='+(!!v)}"""
   }
 
   /**

--- a/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -275,7 +275,9 @@ class BindersSpec extends Specification {
       )
     }
     "JavaScript Unbind Pferd as String which is a Boolean and uses special js unbind" in {
-      implicitly[QueryStringBindable[Pferd]].javascriptUnbind must equalTo("""function(k,v){return k+'='+(!!v)}""")
+      implicitly[QueryStringBindable[Pferd]].javascriptUnbind must equalTo(
+        """function(k,v){return encodeURIComponent(k)+'='+(!!v)}"""
+      )
     }
     "Unbind with keys and values needing encode (String)" in {
       val boundValue = implicitly[QueryStringBindable[Hase]].unbind("ke=y", Hase("Kre=mlin"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/routes
@@ -11,7 +11,7 @@ GET         /query-user                     controllers.Application.queryUser(us
 
 GET         /escapes/$i<\d+>                controllers.Application.takeIntEscapes(i: Int)
 
-GET         /take-bool                      controllers.Application.takeBool(b: Boolean)
+GET         /take-bool                      controllers.Application.takeBool(`b=`: Boolean)
 GET         /take-bool-2/:b                 controllers.Application.takeBool2(b: Boolean)
 
 GET         /take-str                       controllers.Application.takeString(x: String)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
@@ -13,8 +13,8 @@ object RouterSpec extends PlaySpecification {
 
   "reverse routes containing boolean parameters" in {
     "the query string" in {
-      controllers.routes.Application.takeBool(true).url must equalTo("/take-bool?b=true")
-      controllers.routes.Application.takeBool(false).url must equalTo("/take-bool?b=false")
+      controllers.routes.Application.takeBool(true).url must equalTo("/take-bool?b%3D=true")
+      controllers.routes.Application.takeBool(false).url must equalTo("/take-bool?b%3D=false")
     }
     "the path" in {
       controllers.routes.Application.takeBool2(true).url must equalTo("/take-bool-2/true")
@@ -70,13 +70,13 @@ object RouterSpec extends PlaySpecification {
   "bind boolean parameters" in {
     "from the query string" in new WithApplication() {
       override def running() = {
-        val result = route(implicitApp, FakeRequest(GET, "/take-bool?b=true")).get
+        val result = route(implicitApp, FakeRequest(GET, "/take-bool?b%3D=true")).get
         contentAsString(result) must equalTo("true")
-        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b=false")).get
+        val result2 = route(implicitApp, FakeRequest(GET, "/take-bool?b%3D=false")).get
         contentAsString(result2) must equalTo("false")
         // Bind boolean values from 1 and 0 integers too
-        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo("true")
-        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo("false")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b%3D=1")).get) must equalTo("true")
+        contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b%3D=0")).get) must equalTo("false")
       }
     }
     "from the path" in new WithApplication() {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/assets/JavaScriptRouterSpec.js
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/assets/JavaScriptRouterSpec.js
@@ -24,7 +24,7 @@ describe("The JavaScript router", function() {
     });
     it("should add parameters to the query string", function() {
         var data = jsRoutes.controllers.Application.takeBool(true);
-        assert.equal("/take-bool?b=true", data.url);
+        assert.equal("/take-bool?b%3D=true", data.url);
     });
     it("should add parameters to the query string when they are default", function() {
         var data = jsRoutes.controllers.Application.takeOptionalIntWithDefault(123);


### PR DESCRIPTION
I caught this just passing by during other work 🧑‍💻
Still following _"The Boy Scout Rule (©Uncle Bob)"_ 🖖