### PR TITLE
Fix reverse router for  `Optional[Int|Long|Double]` type of query param

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/core/play/src/main/scala/play/api/mvc/Binders.scala
@@ -545,8 +545,9 @@ object QueryStringBindable extends QueryStringBindableMacros {
           .getOrElse(Right(OptionalInt.empty))
       )
     }
-    def unbind(key: String, value: OptionalInt) = value.toScala.getOrElse(0).toString
-    override def javascriptUnbind               = javascriptUnbindOption(super.javascriptUnbind)
+    def unbind(key: String, value: OptionalInt) =
+      value.toScala.map(implicitly[QueryStringBindable[java.lang.Integer]].unbind(key, _)).getOrElse("")
+    override def javascriptUnbind = javascriptUnbindOption(super.javascriptUnbind)
   }
 
   /**
@@ -561,8 +562,9 @@ object QueryStringBindable extends QueryStringBindableMacros {
           .getOrElse(Right(OptionalLong.empty))
       )
     }
-    def unbind(key: String, value: OptionalLong) = value.toScala.getOrElse(0L).toString
-    override def javascriptUnbind                = javascriptUnbindOption(super.javascriptUnbind)
+    def unbind(key: String, value: OptionalLong) =
+      value.toScala.map(implicitly[QueryStringBindable[java.lang.Long]].unbind(key, _)).getOrElse("")
+    override def javascriptUnbind = javascriptUnbindOption(super.javascriptUnbind)
   }
 
   /**
@@ -578,8 +580,9 @@ object QueryStringBindable extends QueryStringBindableMacros {
             .getOrElse(Right(OptionalDouble.empty))
         )
       }
-      def unbind(key: String, value: OptionalDouble) = value.toScala.getOrElse(0.0).toString
-      override def javascriptUnbind                  = javascriptUnbindOption(super.javascriptUnbind)
+      def unbind(key: String, value: OptionalDouble) =
+        value.toScala.map(implicitly[QueryStringBindable[java.lang.Double]].unbind(key, _)).getOrElse("")
+      override def javascriptUnbind = javascriptUnbindOption(super.javascriptUnbind)
     }
 
   private def javascriptUnbindOption(jsUnbindT: String) = "function(k,v){return v!=null?(" + jsUnbindT + ")(k,v):''}"

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
@@ -43,14 +43,20 @@ object RouterSpec extends PlaySpecification {
   "reverse routes containing Optional[Int|Long|Double] parameters" in {
     "the query string" in {
       controllers.routes.Application.takeOptionalInt(java.util.OptionalInt.of(789)).url must equalTo("/take-joptint?x=789")
+      controllers.routes.Application.takeOptionalInt(java.util.OptionalInt.empty()).url must equalTo("/take-joptint")
       controllers.routes.Application.takeOptionalIntWithDefault(java.util.OptionalInt.empty()).url must equalTo("/take-joptint-d")
       controllers.routes.Application.takeOptionalIntWithDefault(java.util.OptionalInt.of(123)).url must equalTo("/take-joptint-d")
+      controllers.routes.Application.takeOptionalIntWithDefault(java.util.OptionalInt.of(987)).url must equalTo("/take-joptint-d?x=987")
       controllers.routes.Application.takeOptionalLong(java.util.OptionalLong.of(789L)).url must equalTo("/take-joptlong?x=789")
+      controllers.routes.Application.takeOptionalLong(java.util.OptionalLong.empty()).url must equalTo("/take-joptlong")
       controllers.routes.Application.takeOptionalLongWithDefault(java.util.OptionalLong.empty()).url must equalTo("/take-joptlong-d")
       controllers.routes.Application.takeOptionalLongWithDefault(java.util.OptionalLong.of(123L)).url must equalTo("/take-joptlong-d")
+      controllers.routes.Application.takeOptionalLongWithDefault(java.util.OptionalLong.of(987)).url must equalTo("/take-joptlong-d?x=987")
       controllers.routes.Application.takeOptionalDouble(java.util.OptionalDouble.of(7.89)).url must equalTo("/take-joptdouble?x=7.89")
+      controllers.routes.Application.takeOptionalDouble(java.util.OptionalDouble.empty()).url must equalTo("/take-joptdouble")
       controllers.routes.Application.takeOptionalDoubleWithDefault(java.util.OptionalDouble.empty()).url must equalTo("/take-joptdouble-d")
       controllers.routes.Application.takeOptionalDoubleWithDefault(java.util.OptionalDouble.of(1.23)).url must equalTo("/take-joptdouble-d")
+      controllers.routes.Application.takeOptionalDoubleWithDefault(java.util.OptionalDouble.of(9.87)).url must equalTo("/take-joptdouble-d?x=9.87")
     }
   }
 

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/tests/RouterSpec.scala
@@ -40,6 +40,20 @@ object RouterSpec extends PlaySpecification {
     }
   }
 
+  "reverse routes containing Optional[Int|Long|Double] parameters" in {
+    "the query string" in {
+      controllers.routes.Application.takeOptionalInt(java.util.OptionalInt.of(789)).url must equalTo("/take-joptint?x=789")
+      controllers.routes.Application.takeOptionalIntWithDefault(java.util.OptionalInt.empty()).url must equalTo("/take-joptint-d")
+      controllers.routes.Application.takeOptionalIntWithDefault(java.util.OptionalInt.of(123)).url must equalTo("/take-joptint-d")
+      controllers.routes.Application.takeOptionalLong(java.util.OptionalLong.of(789L)).url must equalTo("/take-joptlong?x=789")
+      controllers.routes.Application.takeOptionalLongWithDefault(java.util.OptionalLong.empty()).url must equalTo("/take-joptlong-d")
+      controllers.routes.Application.takeOptionalLongWithDefault(java.util.OptionalLong.of(123L)).url must equalTo("/take-joptlong-d")
+      controllers.routes.Application.takeOptionalDouble(java.util.OptionalDouble.of(7.89)).url must equalTo("/take-joptdouble?x=7.89")
+      controllers.routes.Application.takeOptionalDoubleWithDefault(java.util.OptionalDouble.empty()).url must equalTo("/take-joptdouble-d")
+      controllers.routes.Application.takeOptionalDoubleWithDefault(java.util.OptionalDouble.of(1.23)).url must equalTo("/take-joptdouble-d")
+    }
+  }
+
   "bind boolean parameters" in {
     "from the query string" in new WithApplication() {
       override def running() = {


### PR DESCRIPTION
The query parameter name just was missed 🤷‍♂️ 

I caught this just passing by during other work 🧑‍💻
Still following _"The Boy Scout Rule (©Uncle Bob)"_ 🖖
