### PR TITLE
Change access modifier to package private for  `RoutingDsl.{Route,RouteParam}`

### DIFF
--- a/core/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/core/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -294,7 +294,7 @@ public class RoutingDsl {
     return PathBindable$.MODULE$.<A>javaPathBindable(ClassTag$.MODULE$.apply(clazz));
   }
 
-  private static class Route {
+  static class Route {
     final String method;
     final Pattern pathPattern;
     final List<RouteParam> params;
@@ -315,7 +315,7 @@ public class RoutingDsl {
     }
   }
 
-  private static class RouteParam {
+  static class RouteParam {
     final String name;
     final Boolean decode;
     final PathBindable<?> pathBindable;


### PR DESCRIPTION
The `static private` modifier for these 2 classes was incorrect. In the previous versions of Scala it compiled due to existence of a bug in the compiler. 
The mentioned bug was minimized and discussed in https://github.com/scala/scala3/issues/21599 and was discovered after merging a fix https://github.com/scala/scala3/pull/21362 
Problem was discovered by Scala 3 Open Community Build in: 
- `playframework/playframework` - [build logs](https://github.com/VirtusLab/community-build3/actions/runs/12091465203/job/33720349509#step:3:6049) 
- `playframework/omnidoc` - [build logs](https://github.com/VirtusLab/community-build3/actions/runs/12091465203/job/33720345526#step:3:1835)



<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

