### PR TITLE
Fix generated router with param `req`

### DIFF
--- a/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -188,7 +188,8 @@ package object templates {
     "with",
     "yield",
     // Not scala keywords, but are used in the router
-    "queryString"
+    "queryString",
+    "req"
   )
 
   /**

--- a/dev-mode/play-routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/play-routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -91,7 +91,7 @@ case include @ Include(path, router) => {
     case @(routeIdentifier(route, index))(params@@_) =>
       call@(routeBinding(route)) @ob @localNames(route)
         @(invokerIdentifier(route, index)).call(@if(route.call.passJavaRequest){
-          req => }@injectedControllerMethodCall(route, dep.ident, x => safeKeyword(x.nameClean)))
+          req => }@injectedControllerMethodCall(route, dep.ident, x => if (x.isJavaRequest) "req" else safeKeyword(x.nameClean)))
       @cb
   }
   }}}@cb

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/app/controllers/Application.scala
@@ -259,6 +259,9 @@ class Application @Inject() (c: ControllerComponents) extends AbstractController
   def route(parameter: String) = Action {
     Ok(parameter)
   }
+  def javaRoute(request: play.mvc.Http.Request, parameter: String): play.mvc.Result = {
+    play.mvc.Results.ok(parameter)
+  }
   def routetest(parameter: String) = Action {
     Ok(parameter)
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/conf/routes
@@ -108,6 +108,7 @@ GET         /routes                 controllers.Application.route(type)
 GET         /routes                 controllers.Application.route(val)
 GET         /routes                 controllers.Application.route(var)
 GET         /routes                 controllers.Application.route(while)
+GET         /routes                 controllers.Application.javaRoute(request: Request, req)
 GET         /routestest             controllers.Application.routetest(with)
 GET         /routestest             controllers.Application.routetest(yield)
 


### PR DESCRIPTION
I caught this just passing by during other work 🧑‍💻
Still following _"The Boy Scout Rule (©Uncle Bob)"_ 🖖

PS: As a workaround in current version is possible to use next hack:
```
GET         /routes                 controllers.Application.javaRoute(request: Request, `req`)
```