### PR TITLE
Module: Accept constructor with (com.typesafe.config.Config)

### DIFF
--- a/core/play/src/main/scala/play/api/inject/Module.scala
+++ b/core/play/src/main/scala/play/api/inject/Module.scala
@@ -169,6 +169,8 @@ object Modules {
       }.orElse {
         tryConstruct(new JavaEnvironment(environment), configuration.underlying)
       }.orElse {
+        tryConstruct(configuration.underlying)
+      }.orElse {
         tryConstruct()
       }.getOrElse {
         throw new PlayException(
@@ -177,7 +179,8 @@ object Modules {
             "Expected one of:\n" +
             "()\n" +
             "(play.api.Environment, play.api.Configuration)\n" +
-            "(play.Environment, com.typesafe.config.Config)"
+            "(play.Environment, com.typesafe.config.Config)\n" +
+            "(com.typesafe.config.Config)"
         )
       }
     } catch {


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

This allows modules to use Typesafe Config without Play dependencies, which is useful when building Modules in sbt projects separated from Play.

## Background Context

## References

https://discord.com/channels/931647755942776882/931955815479402546/1327130375373455391