### PR TITLE
Migrate to `jakarta.inject.*` in gradle plugin (requires `jakarta.inject-api` dependency)

### DIFF
--- a/dev-mode/gradle-plugin/build.gradle.kts
+++ b/dev-mode/gradle-plugin/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     compileOnly("org.playframework:play-routes-compiler_2.13:$playVersion")
     compileOnly("org.playframework.twirl:gradle-twirl:${libs.versions.twirl.get()}")
     implementation("org.playframework:play-run-support:$playVersion")
+    implementation("jakarta.inject:jakarta.inject-api:2.0.1")
     testImplementation(libs.assertj)
     testImplementation(libs.commons.io)
     testImplementation(libs.freemarker)

--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/internal/PlayRunHandle.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/internal/PlayRunHandle.java
@@ -3,12 +3,12 @@
  */
 package play.gradle.internal;
 
+import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
-import javax.inject.Inject;
 import org.gradle.deployment.internal.Deployment;
 import org.gradle.deployment.internal.DeploymentHandle;
 import org.jetbrains.annotations.NotNull;

--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayAssetsPlugin.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayAssetsPlugin.java
@@ -10,7 +10,7 @@ import static play.gradle.internal.Utils.mainSourceSet;
 import static play.gradle.internal.Utils.playExtension;
 import static play.gradle.plugin.PlayRunPlugin.PLAY_RUN_TASK_NAME;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayPlugin.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayPlugin.java
@@ -10,8 +10,8 @@ import static play.gradle.internal.Utils.playExtension;
 import static play.gradle.internal.Utils.scalaSourceDirectorySet;
 import static play.gradle.internal.Utils.testSourceSet;
 
+import jakarta.inject.Inject;
 import java.util.List;
-import javax.inject.Inject;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -80,7 +80,7 @@ public class PlayPlugin implements Plugin<Project> {
             });
       }
       var annotations = ((TwirlSourceDirectorySet) twirlSource).getConstructorAnnotations();
-      if (annotations != null) annotations.add("@javax.inject.Inject()");
+      if (annotations != null) annotations.add("@jakarta.inject.Inject()");
     }
   }
 

--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayRoutesPlugin.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayRoutesPlugin.java
@@ -14,9 +14,9 @@ import static play.gradle.internal.Utils.scalaSourceDirectorySet;
 import static play.gradle.plugin.PlayPlugin.DEFAULT_SCALA_VERSION;
 import static play.gradle.plugin.PlayPlugin.PLAY_GROUP_ID;
 
+import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
-import javax.inject.Inject;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/task/PlayRun.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/task/PlayRun.java
@@ -3,8 +3,8 @@
  */
 package play.gradle.task;
 
+import jakarta.inject.Inject;
 import java.util.ArrayList;
-import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;

--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/task/RoutesCompile.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/task/RoutesCompile.java
@@ -3,7 +3,7 @@
  */
 package play.gradle.task;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;


### PR DESCRIPTION
For Play itself not really relevant, this is just about the gradle plugin.

Currently gradle only supports `javax.inject`, which [is hardcoded](https://github.com/gradle/gradle/blob/v8.12.1/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/InjectUtil.java#L43-L58).

So we need to wait for:
- https://github.com/gradle/gradle/issues/20183
- https://github.com/gradle/gradle/issues/31135