### PR TITLE
Remove `runSynchronized` / `shouldRunSequentially`

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -41,8 +41,6 @@ trait JavaResultsHandlingSpec
     with ServerIntegrationSpecification
     with ContentTypes {
 
-  protected override def shouldRunSequentially(app: Application): Boolean = false
-
   "Java results handling" should {
     def makeRequest[T](
         controller: MockController,

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -444,8 +444,6 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   // Extend the default spec timeout for CI.
   implicit override def defaultAwaitTimeout: Timeout = 10.seconds
 
-  protected override def shouldRunSequentially(app: Application): Boolean = false
-
   def withServer[A](webSocket: Application => Handler, extraConfig: Map[String, Any] = Map.empty)(
       block: (Application, Int) => A
   ): A = {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -382,6 +382,12 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.HttpConfiguration.current"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.inject.guice.GuiceApplicationBuilder.globalApp"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.DefaultTestServerFactory.optionalGlobalLock"),
+      // Remove runSynchronized / shouldRunSequentially
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.runSynchronized"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.shouldRunSequentially"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.PlayRunners.mutex"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.PlayRunners.shouldRunSequentially"),
+      ProblemFilters.exclude[MissingClassProblem]("play.api.test.PlayRunners$"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/testkit/play-test/src/main/java/play/test/Helpers.java
+++ b/testkit/play-test/src/main/java/play/test/Helpers.java
@@ -560,27 +560,21 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
    */
   public static void running(
       TestServer server, WebDriver webDriver, final Consumer<TestBrowser> block) {
-    Helpers$.MODULE$.runSynchronized(
-        server.application(),
-        asScala(
-            () -> {
-              TestBrowser browser = null;
-              TestServer startedServer = null;
-              try {
-                start(server);
-                startedServer = server;
-                browser = testBrowser(webDriver, server.getRunningHttpPort().getAsInt());
-                block.accept(browser);
-              } finally {
-                if (browser != null) {
-                  browser.quit();
-                }
-                if (startedServer != null) {
-                  stop(startedServer);
-                }
-              }
-              return null;
-            }));
+    TestBrowser browser = null;
+    TestServer startedServer = null;
+    try {
+      start(server);
+      startedServer = server;
+      browser = testBrowser(webDriver, server.getRunningHttpPort().getAsInt());
+      block.accept(browser);
+    } finally {
+      if (browser != null) {
+        browser.quit();
+      }
+      if (startedServer != null) {
+        stop(startedServer);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
We probably want to set `shouldRunSequentially` to `false` first and deprecated all the stuff before removing it, however I want to see if all tests pass...

- See #12214