### PR TITLE
`shouldRunSequentially` defaults to `false` now

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -41,8 +41,6 @@ trait JavaResultsHandlingSpec
     with ServerIntegrationSpecification
     with ContentTypes {
 
-  protected override def shouldRunSequentially(app: Application): Boolean = false
-
   "Java results handling" should {
     def makeRequest[T](
         controller: MockController,

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -444,8 +444,6 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   // Extend the default spec timeout for CI.
   implicit override def defaultAwaitTimeout: Timeout = 10.seconds
 
-  protected override def shouldRunSequentially(app: Application): Boolean = false
-
   def withServer[A](webSocket: Application => Handler, extraConfig: Map[String, Any] = Map.empty)(
       block: (Application, Int) => A
   ): A = {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -382,6 +382,8 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.http.HttpConfiguration.current"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.inject.guice.GuiceApplicationBuilder.globalApp"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.DefaultTestServerFactory.optionalGlobalLock"),
+      // Rename runSynchronized to maybeRunSynchronized (which is and was private[play] anyway...)
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.Helpers.runSynchronized"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/testkit/play-test/src/main/java/play/test/Helpers.java
+++ b/testkit/play-test/src/main/java/play/test/Helpers.java
@@ -560,7 +560,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
    */
   public static void running(
       TestServer server, WebDriver webDriver, final Consumer<TestBrowser> block) {
-    Helpers$.MODULE$.runSynchronized(
+    Helpers$.MODULE$.maybeRunSynchronized(
         server.application(),
         asScala(
             () -> {


### PR DESCRIPTION
By default test server ports are random since last Play release, also we removed the globa app now, so we can also run the tests in parallel now.

IMHO we can just keep the methods, in case people want to keep running tests sequentially (for whatever reason).

- Replaces #13095
- Fixes #12214