### PR TITLE
Avoid `app.injector` in tests using compile time DI

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/action/FormActionSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/action/FormActionSpec.scala
@@ -45,7 +45,7 @@ class FormActionSpec extends PlaySpecification with WsTestClient {
     )(User.apply)(User.unapply)
   )
 
-  def application: Application = {
+  private def builtInComponents: BuiltInComponentsFromContext = {
     val context = ApplicationLoader.Context.create(Environment.simple())
     new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
       import play.api.routing.sird.{ POST => SirdPost, _ }
@@ -87,8 +87,10 @@ class FormActionSpec extends PlaySpecification with WsTestClient {
             }
           }
       }
-    }.application
+    }
   }
+
+  def application: Application = builtInComponents.application
 
   "Form Actions" should {
     "When POSTing" in {
@@ -125,7 +127,7 @@ class FormActionSpec extends PlaySpecification with WsTestClient {
 
       "keep TemporaryFiles of multipart request while processing" in new WithApplication(application) {
         override def running(): Unit = {
-          val tempFileCreator = app.injector.instanceOf[TemporaryFileCreator]
+          val tempFileCreator = builtInComponents.tempFileCreator
           val tempFile        = tempFileCreator.create()
           Files.writeString(tempFile.path, "Hello")
 

--- a/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/core/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -412,18 +412,19 @@ class TemporaryFileCreatorSpec extends Specification {
       val context = ApplicationLoader.Context.create(
         new Environment(new File("."), ApplicationLoader.getClass.getClassLoader, Mode.Test)
       )
+      val builtInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+        lazy val router = Router.empty
+      }
       val appLoader = new ApplicationLoader {
         def load(context: Context) = {
-          new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
-            lazy val router = Router.empty
-          }.application
+          builtInComponents.application
         }
       }
       val app = appLoader.load(context)
       Play.start(app)
       val tempFile =
         try {
-          val tempFileCreator = app.injector.instanceOf[TemporaryFileCreator]
+          val tempFileCreator = builtInComponents.tempFileCreator
           val tempFile        = tempFileCreator.create()
           tempFile.exists must beTrue
           tempFile

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -171,8 +171,10 @@ class ResultsSpec extends Specification {
     }
 
     "support clearing a language cookie using withoutLang" in withApplication { (app: Application) =>
-      implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
-      val cookie                            = cookieHeaderEncoding.decodeSetCookieHeader(bake(Ok.clearingLang).header.headers("Set-Cookie")).head
+      val langs: Langs = new DefaultLangsProvider(app.configuration).get
+      implicit val messagesApi: MessagesApi =
+        new DefaultMessagesApiProvider(app.environment, app.configuration, langs, app.httpConfiguration).get
+      val cookie = cookieHeaderEncoding.decodeSetCookieHeader(bake(Ok.clearingLang).header.headers("Set-Cookie")).head
       cookie.name must_== Play.langCookieName
       cookie.value must_== ""
     }


### PR DESCRIPTION
This PR just refactors three tests which relied on `tempFileCreator` and `messagesApi` to be available via `SimpleInjector` from this code:
https://github.com/playframework/playframework/blob/3a8154e29130ae3f8c02574f6e835ef8f601d095/core/play/src/main/scala/play/api/Application.scala#L247-L255

The code above is just a workaround to make some components available via `app.injector` for compile time DI while the whole DI support in Play was in development. _In theory_ the above code could now be removed.

This PR makes
- #13093 

work now.