### PR TITLE
Add timeout to scripted tests to fix failing it locally

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/test
@@ -37,5 +37,6 @@ $ sleep 2000
 > playUpdateSecret
 # Should fail to start when there are evolutions and `autoApply=false`
 -> runProd
+$ sleep 4000
 # And since it fail to start, there should be no pid file
 -$ exists target/universal/stage/RUNNING_PID


### PR DESCRIPTION
Seems GitHub actions runner are slower so this does not occure there.
