### PR TITLE
Remove `javax.annotation`

### DIFF
--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineDefaultExpiry.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/CaffeineDefaultExpiry.java
@@ -5,7 +5,6 @@
 package play.cache.caffeine;
 
 import com.github.benmanes.caffeine.cache.Expiry;
-import javax.annotation.Nonnull;
 
 /**
  * @deprecated Deprecated as of 2.8.0. This is an implementation detail and it was not supposed to
@@ -14,19 +13,17 @@ import javax.annotation.Nonnull;
 @Deprecated
 public final class CaffeineDefaultExpiry implements Expiry<Object, Object> {
   @Override
-  public long expireAfterCreate(@Nonnull Object key, @Nonnull Object value, long currentTime) {
+  public long expireAfterCreate(Object key, Object value, long currentTime) {
     return Long.MAX_VALUE;
   }
 
   @Override
-  public long expireAfterUpdate(
-      @Nonnull Object key, @Nonnull Object value, long currentTime, long currentDuration) {
+  public long expireAfterUpdate(Object key, Object value, long currentTime, long currentDuration) {
     return currentDuration;
   }
 
   @Override
-  public long expireAfterRead(
-      @Nonnull Object key, @Nonnull Object value, long currentTime, long currentDuration) {
+  public long expireAfterRead(Object key, Object value, long currentTime, long currentDuration) {
     return currentDuration;
   }
 }

--- a/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/NamedCaffeineCache.java
+++ b/cache/play-caffeine-cache/src/main/java/play/cache/caffeine/NamedCaffeineCache.java
@@ -10,8 +10,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 
 public class NamedCaffeineCache<K, V> implements AsyncCache<K, V> {
 
@@ -27,55 +25,47 @@ public class NamedCaffeineCache<K, V> implements AsyncCache<K, V> {
     return name;
   }
 
-  @CheckForNull
   @Override
-  public CompletableFuture<V> getIfPresent(@Nonnull K key) {
+  public CompletableFuture<V> getIfPresent(K key) {
     return cache.getIfPresent(key);
   }
 
-  @CheckForNull
+  @Override
+  public CompletableFuture<V> get(K key, Function<? super K, ? extends V> mappingFunction) {
+    return cache.get(key, mappingFunction);
+  }
+
   @Override
   public CompletableFuture<V> get(
-      @Nonnull K key, @Nonnull Function<? super K, ? extends V> mappingFunction) {
+      K key,
+      BiFunction<? super K, ? super Executor, ? extends CompletableFuture<? extends V>>
+          mappingFunction) {
     return cache.get(key, mappingFunction);
   }
 
   @Override
-  public @Nonnull CompletableFuture<V> get(
-      @Nonnull K key,
-      @Nonnull
-          BiFunction<? super K, ? super Executor, ? extends CompletableFuture<? extends V>>
-              mappingFunction) {
-    return cache.get(key, mappingFunction);
-  }
-
-  @Override
-  public @Nonnull CompletableFuture<Map<K, V>> getAll(
-      @Nonnull Iterable<? extends K> keys,
-      @Nonnull
-          Function<? super Set<? extends K>, ? extends Map<? extends K, ? extends V>>
-              mappingFunction) {
+  public CompletableFuture<Map<K, V>> getAll(
+      Iterable<? extends K> keys,
+      Function<? super Set<? extends K>, ? extends Map<? extends K, ? extends V>> mappingFunction) {
     return cache.getAll(keys, mappingFunction);
   }
 
   @Override
-  public @Nonnull CompletableFuture<Map<K, V>> getAll(
-      @Nonnull Iterable<? extends K> keys,
-      @Nonnull
-          BiFunction<
-                  ? super Set<? extends K>,
-                  ? super Executor,
-                  ? extends CompletableFuture<? extends Map<? extends K, ? extends V>>>
-              mappingFunction) {
+  public CompletableFuture<Map<K, V>> getAll(
+      Iterable<? extends K> keys,
+      BiFunction<
+              ? super Set<? extends K>,
+              ? super Executor,
+              ? extends CompletableFuture<? extends Map<? extends K, ? extends V>>>
+          mappingFunction) {
     return cache.getAll(keys, mappingFunction);
   }
 
   @Override
-  public void put(@Nonnull K key, @Nonnull CompletableFuture<? extends V> value) {
+  public void put(K key, CompletableFuture<? extends V> value) {
     cache.put(key, value);
   }
 
-  @Nonnull
   @Override
   public ConcurrentMap<K, CompletableFuture<V>> asMap() {
     return cache.asMap();


### PR DESCRIPTION
Next guice version will drop the findbugs jsr305 dependency.
- https://github.com/google/guava/commit/04bf0300b8736ec7297a34da40a6efb21231c5da
- https://github.com/google/guava/issues/2960

I can confirm with latest guice snapshot those annotation are gone and compilation fails.