### PR TITLE
Explicitly submit the root project's dependency

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -26,8 +26,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: sbt/setup-sbt@v1
+      - uses: scalacenter/sbt-dependency-submission@v3 # for root project
       - uses: scalacenter/sbt-dependency-submission@v3
         with:
-          # We submit ./documentation/build.sbt because the documentation project depends on the root project(s)
-          # anyway. In the end, all projects will be checked (including the dependencies of the documentation project).
           working-directory: './documentation/'


### PR DESCRIPTION
I think it's confusing that all the alerts look like they come from the documentation project, which is not true. The documentation projects depends on the root project. By checking the root project explicitly, we should also see the alerts for `build.sbt`.

I just want to make sure that no one mistakenly thinks "oh ok it's just the docs, we are fine".

![image](https://github.com/user-attachments/assets/cabd9dfb-0c07-4579-bb3e-d3bd97e37b51)
