### PR TITLE
Fix `packageTimestamp` setting for static assets

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -251,6 +251,7 @@ object PlaySettings {
     assetsPrefix := "public/",
     // Assets for distribution
     Assets / WebKeys.packagePrefix := assetsPrefix.value,
+    Assets / packageOptions += Package.setFixedTimestamp((Assets / packageTimestamp).value),
     // The ...-assets.jar should contain the same META-INF/MANIFEST.MF file like the main app jar
     Assets / packageBin / packageOptions := (Runtime / packageBin / packageOptions).value,
     playPackageAssets                    := uncached { (Assets / packageBin).value },


### PR DESCRIPTION
sbt 1.5.0 added a [`ThisBuild / packageTimestamp` setting](https://eed3si9n.com/sbt-1.5.0#thisbuild--packagetimestamp-setting) to fix Play's last-modified header. The problem is, it doesn't work. Setting `ThisBuild / packageTimestamp` has no effect on Play's packaged assets.

This PR fixes the settings to respect `ThisBuild / packageTimestamp` for Play assets. Additionally, there is an `Assets / packageTimestamp` setting which can set asset timestamps differently from other packaging.

For example, this configuration is valid:
```sbt
// use the git HEAD commit timestamp as the last-modified header for assets
Assets / packageTimestamp := Package.gitCommitDateTimestamp

// use 2010 timestamp for other packaging (e.g. class files in jars)
ThisBuild / packageTimestamp := Package.fixed2010Timestamp
```

I updated the docs to recommend setting `packageTimestamp` instead of `packageOptions`.

Fixes #10572


<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?
