### PR TITLE
No need for actions/setup-java to submit deps

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -21,10 +21,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
       - uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v3 # for root project
       - uses: scalacenter/sbt-dependency-submission@v3


### PR DESCRIPTION
In no other Play repo we call this action in this workflow. Not even in this repo's 2.9.x and 3.0.x branch.

Also, removing this exact call does not make any difference in reality, because using `temurin` and `17` will not download anything but just use the java the GitHub action image [provides already](https://github.com/actions/runner-images/blob/ubuntu24/20250223.1/images/ubuntu/Ubuntu2404-Readme.md#java) (see [here](https://github.com/actions/setup-java/blob/799ee7c97e9721ef38d1a7e8486c39753b9d6102/src/distributions/base-installer.ts#L49-L51) which [ends up here](https://github.com/actions/setup-java/blob/799ee7c97e9721ef38d1a7e8486c39753b9d6102/src/util.ts#L76-L80)).

Since Temurin Java 17 is the default for the Ubuntu 24.04 image we are fine.
In future we might want to nail down the Java version, but to be honest even if they change the default to 21 I would not care.