### PR TITLE
Workaround for GitHub API to retrieve dependabot alerts per branch

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -22,7 +22,29 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
       - uses: sbt/setup-sbt@v1
+      - name: Set current timestamp (to the minute)
+        run: echo "TIMESTAMP_MINUTE=$(date +'%Y-%m-%d %H-%M')" >> $GITHUB_ENV
       - uses: scalacenter/sbt-dependency-submission@v3 # for root project
-      - uses: scalacenter/sbt-dependency-submission@v3
+        id: submit-root-build
         with:
+          correlator: '${{ github.workflow }}_${{ github.job }}_${{ github.action }}-branch_${{ github.ref_name }}'
+          manifest-override: '${{ env.TIMESTAMP_MINUTE }} [${{ github.ref_name}}] build.sbt'
+          # By hardcoding the sha and ref, we ensure that all branches update the same snapshots, differing only by their correlator.
+          sha-override: '90f6d1fc243dfaeff4657cb8ea586f1b3d74292b'
+          ref-override: 'refs/heads/main' # 2025-02-27: GitHub ignores it, but to be future-proof, let's hardcode it (not using github.event.repository.default_branch)
+          # mkurz: It does not make sense to ignore some configs or modules currently. (Only for SBOM we don't need them)
+          #configs-ignore: provided optional compile-internal test-internal runtime-internal scala-tool scala-doc-tool scripted-sbt scripted-sbt-launch jmh webjars
+          #modules-ignore: play-framework_2.13 play-framework_3 play-bom_2.13 play-bom_3 play-documentation_2.13 play-documentation_3 play-integration-test_2.13 play-integration-test_3 play-microbenchmark_2.13 play-microbenchmark_3
+      - name: Log dependency snapshot for build.sbt
+        run: cat ${{ steps.submit-root-build.outputs.snapshot-json-path }} | jq
+      - uses: scalacenter/sbt-dependency-submission@v3
+        id: submit-documentation-build
+        with:
+          # The comments above also apply here! (regarding sha, ref and ignore's)
           working-directory: './documentation/'
+          correlator: '${{ github.workflow }}_${{ github.job }}_${{ github.action }}-branch_${{ github.ref_name }}'
+          manifest-override: '${{ env.TIMESTAMP_MINUTE }} [${{ github.ref_name}}] documentation/build.sbt'
+          sha-override: '90f6d1fc243dfaeff4657cb8ea586f1b3d74292b'
+          ref-override: 'refs/heads/main'
+      - name: Log dependency snapshot for documentation/build.sbt
+        run: cat ${{ steps.submit-documentation-build.outputs.snapshot-json-path }} | jq


### PR DESCRIPTION
I think knowing which vulnerabilities we have/ship in our dependencies in our stable branches is _very_ important. But currently GitHub does not support non-default branches with their Dependabot alerts.

So, time to make the impossible possible ;)

---

- This PR is waiting for https://github.com/scalacenter/sbt-dependency-submission/pull/249

If you have a repo that hosts a [package ecosystem that is supported by GitHub's dependency graph api](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/dependency-graph-supported-package-ecosystems) (like node or maven), GitHub (can) automatically scan a repos' manifest file(s) and create a dependency tree and dependabot alerts from that.
The current problem is, only the default branch of a repo is currently supported. There is no way to make GitHub scan a non-default branch (e.g. in our case that would be the stable 3.0.x and 2.9.x branch).

Further, GitHub does not support Scala (sbt) project's out of the box, so that's why sbt-dependency-submission exists.
We have workflows setup up with that action in the 2.9.x and 3.0.x branch. However, currently, they are useless. They do not submit anything to GitHub, GitHub just ignores the JSON it generates.
That means, the alerts we see at https://github.com/playframework/playframework/security/dependabot **only** cover the main branch.

However, how do we see if there is a vulnerability in a dependency in the 3.0.x branch? And how could we distinguish the branches in the "Dependabot alerts" page referenced above? After a _lot_ of research how the GitHub dependency submission API works I am pretty sure  It's possible to make GitHub api do what we want. Please take a look at https://github.com/scalacenter/sbt-dependency-submission/pull/249 where I also posted a screenshot.