### PR TITLE
Depend on scala-parser-combinators v1 only when using Scala 2.12 (sbt-plugins)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -101,8 +101,8 @@ object Dependencies {
   def scalaParserCombinators(scalaVersion: String) =
     Seq("org.scala-lang.modules" %% "scala-parser-combinators" % {
       CrossVersion.partialVersion(scalaVersion) match {
-        case Some((2, _)) => "1.1.2"
-        case _            => "2.4.0"
+        case Some((2, 12)) => "1.1.2"
+        case _             => "2.4.0"
       }
     })
 


### PR DESCRIPTION
- See #13179