### PR TITLE
Netty 4.2.0 and adding io_uring native transport

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/conf/application.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/conf/application.conf
@@ -5,6 +5,7 @@ play.server {
       "io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT" = true
       "io.netty.channel.epoll.EpollChannelOption#TCP_CORK" = true
       "io.netty.channel.kqueue.KQueueChannelOption#TCP_NOPUSH" = true
+      "io.netty.channel.uring.IoUringChannelOption#TCP_KEEPIDLE" = true
       foo = "abc"
       child {
         SO_KEEPALIVE = true

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/expected-application-log.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/expected-application-log.txt
@@ -2,12 +2,14 @@
 [DEBUG] play.core.server.NettyServer - Class io.netty.channel.unix.UnixChannelOption will be initialized (if it hasn't been initialized already)
 [DEBUG] play.core.server.NettyServer - Class io.netty.channel.epoll.EpollChannelOption will be initialized (if it hasn't been initialized already)
 [DEBUG] play.core.server.NettyServer - Class io.netty.channel.kqueue.KQueueChannelOption will be initialized (if it hasn't been initialized already)
+[DEBUG] play.core.server.NettyServer - Class io.netty.channel.uring.IoUringChannelOption will be initialized (if it hasn't been initialized already)
 [WARN] play.core.server.NettyServer - Ignoring unknown Netty channel option: foo
 [WARN] play.core.server.NettyServer - Valid values can be found at https://netty.io/4.2/api/io/netty/channel/ChannelOption.html
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to true at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_BACKLOG to 256 at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_CORK to true at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.kqueue.KQueueChannelOption#TCP_NOPUSH to true at bootstrapping
+[DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.uring.IoUringChannelOption#TCP_KEEPIDLE to true at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_FASTOPEN_CONNECT to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_NODELAY to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_KEEPALIVE to true

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/expected-application-log.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/expected-application-log.txt
@@ -3,7 +3,7 @@
 [DEBUG] play.core.server.NettyServer - Class io.netty.channel.epoll.EpollChannelOption will be initialized (if it hasn't been initialized already)
 [DEBUG] play.core.server.NettyServer - Class io.netty.channel.kqueue.KQueueChannelOption will be initialized (if it hasn't been initialized already)
 [WARN] play.core.server.NettyServer - Ignoring unknown Netty channel option: foo
-[WARN] play.core.server.NettyServer - Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html
+[WARN] play.core.server.NettyServer - Valid values can be found at https://netty.io/4.2/api/io/netty/channel/ChannelOption.html
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to true at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_BACKLOG to 256 at bootstrapping
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.epoll.EpollChannelOption#TCP_CORK to true at bootstrapping
@@ -12,6 +12,6 @@
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option TCP_NODELAY to true
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option SO_KEEPALIVE to true
 [WARN] play.core.server.NettyServer - Ignoring unknown Netty channel option: bar
-[WARN] play.core.server.NettyServer - Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html
+[WARN] play.core.server.NettyServer - Valid values can be found at https://netty.io/4.2/api/io/netty/channel/ChannelOption.html
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.ChannelOption#TCP_FASTOPEN to 3
 [DEBUG] play.core.server.NettyServer - Setting Netty channel option io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT to false

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
@@ -59,7 +59,7 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
           // Immediately after opening the connection we close it again.
           //
           // According to netty, close status code 2000 is invalid:
-          // https://github.com/netty/netty/blob/netty-4.1.84.Final/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java#L286-L291
+          // https://github.com/netty/netty/blob/netty-4.2.0.Final/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java#L286-L291
           // That's kind of true, because it's reserved for the protocol itself, not for users: https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2
           // However, the pekko-http backend does not care and pushes all status code down to the application,
           // so the netty backend should do the same.

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-pekko-http/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-pekko-http/src/test/scala/controllers/IntegrationTest.scala
@@ -59,7 +59,7 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
           // Immediately after opening the connection we close it again.
           //
           // According to netty, close status code 2000 is invalid:
-          // https://github.com/netty/netty/blob/netty-4.1.84.Final/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java#L286-L291
+          // https://github.com/netty/netty/blob/netty-4.2.0.Final/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java#L286-L291
           // That's kind of true, because it's reserved for the protocol itself, not for users: https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2
           // However, the pekko-http backend does not care and pushes all status code down to the application,
           // so the netty backend should do the same.

--- a/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
@@ -18,7 +18,7 @@ The configurations above are specific to Netty server backend, but other more ge
 
 ## Configuring transport socket
 
-Native socket transport has higher performance and produces less garbage and is available on Linux, macOS, FreeBSD and OpenBSD. You can configure the transport socket type in `application.conf`:
+[Native socket transport](https://netty.io/wiki/native-transports.html) has higher performance and produces less garbage and is available on Linux, macOS, FreeBSD and OpenBSD. You can configure the transport socket type in `application.conf`:
 
 ```properties
 play.server {
@@ -28,9 +28,11 @@ play.server {
 }
 ```
 
-When set to `native`, Play will automatically detect the operating system it is running on and load the appropriate native transport library.
+In addition to `native`, you can set transport to `io_uring` to make use of [Netty's io_uring native transport](https://github.com/netty/netty/tree/4.2/transport-native-io_uring). Be aware `io_uring` is available on Linux only.
 
-> **Note**: On Windows, if the transport configuration is set to `native`, Play will ignore it and automatically fall back to Java NIO transport - just like when using the default `jdk` config.
+When set to `native` or `io_uring`, Play will automatically detect the operating system it is running on and load the appropriate native transport library.
+
+> **Note**: On Windows, if the transport configuration is set to `native` or `io_uring`, Play will ignore it and automatically fall back to Java NIO transport - just like when using the default `jdk` config. A similiar fallback mechanism kicks in on macOS: If transport is set to `io_uring`, Play will fall back to `native` instead, because the `io_uring` native transport is not available on macOS - but on Linux only (using Kernel 5.14 or newer compiled with [`CONFIG_IO_URING=y`](https://github.com/torvalds/linux/blob/v6.14/init/Kconfig#L1739-L1746) - which is the default anyway).
 
 ## Configuring channel options
 
@@ -39,4 +41,5 @@ The available options are defined in the [Netty channel option documentation](ht
 If you are using the native socket transport, you can set the following additional options:
 
 - For Linux: [UnixChannelOption](https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html) and [EpollChannelOption](https://netty.io/4.2/api/io/netty/channel/epoll/EpollChannelOption.html)
+    - When using `io_uring`: [IoUringChannelOption](https://netty.io/4.2/api/io/netty/channel/uring/IoUringChannelOption.html) (instead of `EpollChannelOption`)
 - For macOS/BSD: [UnixChannelOption](https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html) and [KQueueChannelOption](https://netty.io/4.2/api/io/netty/channel/kqueue/KQueueChannelOption.html)

--- a/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
@@ -34,9 +34,9 @@ When set to `native`, Play will automatically detect the operating system it is 
 
 ## Configuring channel options
 
-The available options are defined in the [Netty channel option documentation](https://netty.io/4.1/api/io/netty/channel/ChannelOption.html).
+The available options are defined in the [Netty channel option documentation](https://netty.io/4.2/api/io/netty/channel/ChannelOption.html).
 
 If you are using the native socket transport, you can set the following additional options:
 
-- For Linux: [UnixChannelOption](https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html) and [EpollChannelOption](https://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html)
-- For macOS/BSD: [UnixChannelOption](https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html) and [KQueueChannelOption](https://netty.io/4.1/api/io/netty/channel/kqueue/KQueueChannelOption.html)
+- For Linux: [UnixChannelOption](https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html) and [EpollChannelOption](https://netty.io/4.2/api/io/netty/channel/epoll/EpollChannelOption.html)
+- For macOS/BSD: [UnixChannelOption](https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html) and [KQueueChannelOption](https://netty.io/4.2/api/io/netty/channel/kqueue/KQueueChannelOption.html)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -174,15 +174,18 @@ object Dependencies {
     "org.playframework.netty" % "netty-reactive-streams-http" % "3.0.4",
     "io.netty"                % "netty-codec-http"            % nettyVersion, // increases transitive Netty dependency version ...
     "io.netty"                % "netty-handler"               % nettyVersion, // ... pulled in by netty-reactive-streams-http
+  ) ++
     // Provide Netty's Linux and macOS/BSD native transport dependencies. Netty automatically loads the correct native library
     // depending on the architecture; the ones that don't match are simply ignored.
-    // Of course this all works only when enabled in the config via: play.server.netty.transport = "native"
-    ("io.netty" % "netty-transport-native-epoll"  % nettyVersion).classifier("linux-x86_64"),
-    ("io.netty" % "netty-transport-native-epoll"  % nettyVersion).classifier("linux-aarch_64"),
-    ("io.netty" % "netty-transport-native-epoll"  % nettyVersion).classifier("linux-riscv64"),
-    ("io.netty" % "netty-transport-native-kqueue" % nettyVersion).classifier("osx-x86_64"),
-    ("io.netty" % "netty-transport-native-kqueue" % nettyVersion).classifier("osx-aarch_64"),
-  ) ++ specs2Deps.map(_ % Test)
+    // Of course this all works only when enabled in the config via: play.server.netty.transport = "native" (or "io_uring")
+    Seq("x86_64", "aarch_64", "riscv64").flatMap(arch =>
+      Seq(
+        ("io.netty" % "netty-transport-native-epoll"    % nettyVersion).classifier(s"linux-${arch}"),
+        ("io.netty" % "netty-transport-native-io_uring" % nettyVersion).classifier(s"linux-${arch}")
+      )
+    ) ++ Seq("x86_64", "aarch_64").map(arch =>
+      ("io.netty" % "netty-transport-native-kqueue" % nettyVersion).classifier(s"osx-${arch}")
+    ) ++ specs2Deps.map(_ % Test)
 
   val pekkoHttp = "org.apache.pekko" %% "pekko-http-core" % pekkoHttpVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -168,7 +168,7 @@ object Dependencies {
       ) ++ scalaParserCombinators(scalaVersion) ++ specs2Deps.map(_ % Test) ++ javaTestDeps ++
       scalaReflect(scalaVersion)
 
-  val nettyVersion = "4.1.119.Final"
+  val nettyVersion = "4.2.0.Final"
 
   val netty = Seq(
     "org.playframework.netty" % "netty-reactive-streams-http" % "3.0.4",

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -42,8 +42,11 @@ play.server {
     # Whether the Netty wire should be logged
     log.wire = false
 
-    # The transport to use, either jdk or native.
+    # The transport to use, either `jdk`, `native` or `io_uring`.
     # Native socket transport has higher performance and produces less garbage and are available on Linux, macOS, FreeBSD and OpenBSD.
+    # When set to `native` or `io_uring`, Play will automatically detect the operating system it is running on and load the appropriate native transport library.
+    # On Windows, if set to `native` or `io_uring`, Play will ignore it and automatically fall back to Java NIO transport - just like when using the default `jdk` config.
+    # On macOS, if set to `io_uring`, Play will fall back to `native` instead, because the `io_uring` transport is only available on Linux (using Kernel 5.14 or newer compiled with `CONFIG_IO_URING=y`).
     transport = "jdk"
 
     # Netty options. Possible keys here are defined by:
@@ -53,6 +56,8 @@ play.server {
     # https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html
     # For Linux native socket transport only:
     # https://netty.io/4.2/api/io/netty/channel/epoll/EpollChannelOption.html
+    # When using `io_uring` native socket transport on Linux only:
+    # https://netty.io/4.2/api/io/netty/channel/uring/IoUringChannelOption.html
     # For macOS/BSD native socket transport only:
     # https://netty.io/4.2/api/io/netty/channel/kqueue/KQueueChannelOption.html
     #
@@ -77,6 +82,8 @@ play.server {
         # "io.netty.channel.unix.UnixChannelOption#SO_REUSEPORT" = true
         # E.g. Linux only:
         # "io.netty.channel.epoll.EpollChannelOption#IP_BIND_ADDRESS_NO_PORT" = true
+        # E.g. on Linux only when using the `io_uring` transport:
+        # "io.netty.channel.uring.IoUringChannelOption#TCP_KEEPIDLE" = true
         # E.g. macOS/BSD only:
         # "io.netty.channel.kqueue.KQueueChannelOption#TCP_NOPUSH" = true
       }

--- a/transport/server/play-netty-server/src/main/resources/reference.conf
+++ b/transport/server/play-netty-server/src/main/resources/reference.conf
@@ -20,10 +20,10 @@ play.server {
     # If a task is submitted during the quiet period, it is guaranteed to be accepted and the quiet period will start over.
     #
     # For more details see:
-    # https://netty.io/4.1/api/io/netty/util/concurrent/EventExecutorGroup.html#shutdownGracefully-long-long-java.util.concurrent.TimeUnit-
+    # https://netty.io/4.2/api/io/netty/util/concurrent/EventExecutorGroup.html#shutdownGracefully-long-long-java.util.concurrent.TimeUnit-
     #
     # Play keeps using Netty's default of 2 seconds:
-    # https://github.com/netty/netty/blob/netty-4.1.92.Final/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java#L40
+    # https://github.com/netty/netty/blob/netty-4.2.0.Final/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java#L39
     shutdownQuietPeriod = 2 seconds
 
     # The maximum length of the initial line. This effectively restricts the maximum length of a URL that the server will
@@ -48,13 +48,13 @@ play.server {
 
     # Netty options. Possible keys here are defined by:
     #
-    # https://netty.io/4.1/api/io/netty/channel/ChannelOption.html
+    # https://netty.io/4.2/api/io/netty/channel/ChannelOption.html
     # For both Linux and macOS/BSD:
-    # https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html
+    # https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html
     # For Linux native socket transport only:
-    # https://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html
+    # https://netty.io/4.2/api/io/netty/channel/epoll/EpollChannelOption.html
     # For macOS/BSD native socket transport only:
-    # https://netty.io/4.1/api/io/netty/channel/kqueue/KQueueChannelOption.html
+    # https://netty.io/4.2/api/io/netty/channel/kqueue/KQueueChannelOption.html
     #
     # Options that pertain to the listening server socket are defined at the top level, options for the sockets associated
     # with received client connections are prefixed with child.*

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -169,18 +169,18 @@ class NettyServer(
         transport match {
           case Native if isBSDDerivative =>
             logger.warn(
-              "Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html, " +
-                "https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html and " +
-                "https://netty.io/4.1/api/io/netty/channel/kqueue/KQueueChannelOption.html"
+              "Valid values can be found at https://netty.io/4.2/api/io/netty/channel/ChannelOption.html, " +
+                "https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html and " +
+                "https://netty.io/4.2/api/io/netty/channel/kqueue/KQueueChannelOption.html"
             )
           case Native =>
             logger.warn(
-              "Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html, " +
-                "https://netty.io/4.1/api/io/netty/channel/unix/UnixChannelOption.html and " +
-                "http://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html"
+              "Valid values can be found at https://netty.io/4.2/api/io/netty/channel/ChannelOption.html, " +
+                "https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html and " +
+                "https://netty.io/4.2/api/io/netty/channel/epoll/EpollChannelOption.html"
             )
           case Jdk =>
-            logger.warn("Valid values can be found at http://netty.io/4.1/api/io/netty/channel/ChannelOption.html")
+            logger.warn("Valid values can be found at https://netty.io/4.2/api/io/netty/channel/ChannelOption.html")
         }
       }
     }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -6,6 +6,7 @@ package play.core.server
 
 import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
+import java.util.Locale
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
@@ -29,6 +30,9 @@ import io.netty.channel.kqueue.KQueueServerSocketChannel
 import io.netty.channel.nio.NioIoHandler
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.channel.unix.UnixChannelOption
+import io.netty.channel.uring.IoUringChannelOption
+import io.netty.channel.uring.IoUringIoHandler
+import io.netty.channel.uring.IoUringServerSocketChannel
 import io.netty.handler.codec.http._
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
@@ -53,8 +57,9 @@ import play.core.server.Server.ServerStoppedReason
 import play.server.SSLEngineProvider
 
 sealed trait NettyTransport
-case object Jdk    extends NettyTransport
-case object Native extends NettyTransport
+case object Jdk     extends NettyTransport
+case object Native  extends NettyTransport
+case object IOUring extends NettyTransport
 
 /**
  * creates a Server implementation based Netty
@@ -92,7 +97,7 @@ class NettyServer(
   private val wsKeepAliveMaxIdle  = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
   private val deferBodyParsing    = serverConfig.underlying.getBoolean("deferBodyParsing")
 
-  private lazy val osName             = sys.props("os.name").toLowerCase(java.util.Locale.ENGLISH)
+  private lazy val osName             = sys.props("os.name").toLowerCase(Locale.ENGLISH)
   private lazy val isWindows: Boolean = osName.contains("windows")
   private lazy val isMac: Boolean     = osName.contains("mac")
   private lazy val isBSDDerivative: Boolean = // NetBSD currently not supported by Netty: netty/netty#10809
@@ -100,16 +105,17 @@ class NettyServer(
 
   import NettyServer._
 
-  private lazy val transport = nettyConfig.get[String]("transport") match {
-    case "native" =>
-      if (isWindows) {
-        logger.warn("Netty native transport not available on Windows. Falling back to Java NIO transport.")
-        Jdk
-      } else {
-        Native
-      }
-    case "jdk" => Jdk
-    case _     => throw ServerStartException("Netty transport configuration value should be either jdk or native")
+  private lazy val transport = nettyConfig.get[String]("transport").toLowerCase(Locale.ENGLISH) match {
+    case "native" | "io_uring" if isWindows =>
+      logger.warn("No Netty native transport available on Windows. Falling back to Java NIO transport.")
+      Jdk
+    case "io_uring" if isBSDDerivative =>
+      logger.warn("Netty io_uring native transport not available on macOS/BSD. Falling back to native transport.")
+      Native
+    case "native"   => Native
+    case "io_uring" => IOUring
+    case "jdk"      => Jdk
+    case _          => throw ServerStartException("Netty transport configuration value should be jdk, native or io_uring")
   }
 
   // The shutdown tasks depend on above configs, so we can only register them after the configs got initialized
@@ -125,8 +131,9 @@ class NettyServer(
     transport match {
       case Native if isBSDDerivative =>
         new MultiThreadIoEventLoopGroup(threadCount, threadFactory, KQueueIoHandler.newFactory())
-      case Native => new MultiThreadIoEventLoopGroup(threadCount, threadFactory, EpollIoHandler.newFactory())
-      case Jdk    => new MultiThreadIoEventLoopGroup(threadCount, threadFactory, NioIoHandler.newFactory())
+      case Native  => new MultiThreadIoEventLoopGroup(threadCount, threadFactory, EpollIoHandler.newFactory())
+      case IOUring => new MultiThreadIoEventLoopGroup(threadCount, threadFactory, IoUringIoHandler.newFactory())
+      case Jdk     => new MultiThreadIoEventLoopGroup(threadCount, threadFactory, NioIoHandler.newFactory())
     }
   }
 
@@ -180,6 +187,12 @@ class NettyServer(
                 "https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html and " +
                 "https://netty.io/4.2/api/io/netty/channel/epoll/EpollChannelOption.html"
             )
+          case IOUring =>
+            logger.warn(
+              "Valid values can be found at https://netty.io/4.2/api/io/netty/channel/ChannelOption.html, " +
+                "https://netty.io/4.2/api/io/netty/channel/unix/UnixChannelOption.html and " +
+                "https://netty.io/4.2/api/io/netty/channel/uring/IoUringChannelOption.html"
+            )
           case Jdk =>
             logger.warn("Valid values can be found at https://netty.io/4.2/api/io/netty/channel/ChannelOption.html")
         }
@@ -199,6 +212,7 @@ class NettyServer(
     val channelClass = transport match {
       case Native if isBSDDerivative => classOf[KQueueServerSocketChannel]
       case Native                    => classOf[EpollServerSocketChannel]
+      case IOUring                   => classOf[IoUringServerSocketChannel]
       case Jdk                       => classOf[NioServerSocketChannel]
     }
 
@@ -403,7 +417,8 @@ class NettyServer(
       classOf[ChannelOption[?]],
       classOf[UnixChannelOption[?]],
       classOf[EpollChannelOption[?]],
-      classOf[KQueueChannelOption[?]]
+      classOf[KQueueChannelOption[?]],
+      classOf[IoUringChannelOption[?]]
     ).foreach(clazz => {
       logger.debug(s"Class ${clazz.getName} will be initialized (if it hasn't been initialized already)")
       Class.forName(clazz.getName)


### PR DESCRIPTION
> _"Everyone using netty 4.1.x should be able to upgrade to 4.2.0.RC4 without any API breakage. The only new requirement is JDK8 or later."_

- [x] Replace `.../netty-4.2.0.RC4/..` with correct release in the URLs this PR
- [x] https://repo1.maven.org/maven2/io/netty/netty-transport-native-io_uring/
  - [x] Done in this PR
- [x] https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/ (for macos/bsd)
  - [x] Done in #13219<br>
<br>

- https://netty.io/news/2024/06/12/4-2-0-Alpha1.html
- https://netty.io/news/2024/07/03/4-2-0-Alpha2.html
- https://netty.io/news/2024/08/26/4-2-0-Alpha3.html
- https://netty.io/news/2024/09/05/4-2-0-Alpha4.html
- https://netty.io/news/2024/11/04/4-2-0-Beta1.html
- https://netty.io/news/2024/12/11/4-2-0-RC1.html
- https://netty.io/news/2025/01/20/4-2-0-RC2.html
- https://netty.io/news/2025/02/11/4-2-0-RC3.html
- https://netty.io/news/2025/03/07/4-2-0-RC4.html
- https://netty.io/news/2025/04/03/4-2-0.html
  - https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide