### PR TITLE
Fix Heroku deprecated toolbelt URL on ProductionHeroku.md

### DIFF
--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -6,7 +6,7 @@
 
 To get started:
 
-1. [Install the Heroku Toolbelt](https://toolbelt.heroku.com)
+1. [Install the Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 2. [Sign up for a Heroku account](https://id.heroku.com/signup)
 
 There are two methods of deployment to Heroku:


### PR DESCRIPTION
This replaces heroku legacy toolbelt URL replaced by Heroku CLI docs URL on play 3.0 documentation.
