### PR TITLE
Make use of Unix Domain Sockets in Netty (using the NIO transport)

### DIFF
--- a/core/play-logback/src/main/resources/logback-play-dev.xml
+++ b/core/play-logback/src/main/resources/logback-play-dev.xml
@@ -19,6 +19,8 @@
   <logger name="play" level="INFO"/>
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF"/>
 
+  <logger name="io.netty" level="DEBUG"/>
+
   <root level="WARN">
     <appender-ref ref="STDOUT"/>
   </root>

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -28,6 +28,7 @@ import io.netty.channel.kqueue.KQueueChannelOption
 import io.netty.channel.kqueue.KQueueIoHandler
 import io.netty.channel.kqueue.KQueueServerSocketChannel
 import io.netty.channel.nio.NioIoHandler
+import io.netty.channel.socket.nio.NioServerDomainSocketChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.channel.unix.UnixChannelOption
 import io.netty.channel.uring.IoUringChannelOption
@@ -213,7 +214,7 @@ class NettyServer(
       case Native if isBSDDerivative => classOf[KQueueServerSocketChannel]
       case Native                    => classOf[EpollServerSocketChannel]
       case IOUring                   => classOf[IoUringServerSocketChannel]
-      case Jdk                       => classOf[NioServerSocketChannel]
+      case Jdk                       => classOf[NioServerDomainSocketChannel]
     }
 
     val bootstrap = new Bootstrap()

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -5,6 +5,7 @@
 package play.core.server
 
 import java.net.InetSocketAddress
+import java.net.UnixDomainSocketAddress
 import java.util.concurrent.TimeUnit
 import java.util.Locale
 
@@ -226,7 +227,15 @@ class NettyServer(
 
     setOptions(bootstrap.option, bootstrapOption, true)
 
-    val channel = bootstrap.bind.await().channel()
+    val cf: ChannelFuture = bootstrap.bind.await()
+    if (cf.cause() != null) {
+      // UnixDomainSocketAddress.of()
+      // new UnixDomainSocketAddress()
+      // new io.netty.channel.unix.DomainSocketAddress()
+      println(cf.cause())
+    }
+    println(cf.getClass.getCanonicalName)
+    val channel = cf.channel()
     allChannels.add(channel)
 
     (channel, Source.fromPublisher(channelPublisher))
@@ -313,6 +322,11 @@ class NettyServer(
     val protocolName                   = if (secure) "HTTPS" else "HTTP"
     val address                        = new InetSocketAddress(config.address, port)
     val (serverChannel, channelSource) = bind(address)
+    println("serverChannel.class: " + serverChannel.getClass.getCanonicalName)
+    println("isopen: " + serverChannel.isOpen)
+    println("isActive: " + serverChannel.isActive)
+    println("isWritable: " + serverChannel.isWritable)
+    println("isRegistered: " + serverChannel.isRegistered)
     channelSource.runWith(channelSink(port = port, secure = secure))
     val boundAddress = serverChannel.localAddress()
     if (boundAddress == null) {


### PR DESCRIPTION
- Fixes #12703

Low priority, just pushing what I was playing around with.

Currently this is not working, because we run into an `java.nio.channels.UnsupportedAddressTypeException`.
That is because we use the `NioServerDomainSocketChannel` which expects we are working with sockets (= file path), but we pass an inet address (host:port).