### PR TITLE
Unify `queryMap` methods, fix diffent behaviour and edge cases

### DIFF
--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -335,10 +335,11 @@ public class RequestBuilderTest {
 
   @Test
   public void testQuery_emptyParam() {
-    final Request req = new Http.RequestBuilder().uri("/path?one=&two=a+b&").build();
+    final Request req = new Http.RequestBuilder().uri("/path?one=&two=a+b&=").build();
     assertEquals(Optional.of(""), req.queryString("one"));
     assertEquals(Optional.of("a b"), req.queryString("two"));
     assertEquals(Optional.empty(), req.queryString("three"));
+    assertEquals(Optional.of(""), req.queryString("")); // because last query part is like <empty_string>=<empty_string>
   }
 
   @Test
@@ -347,6 +348,7 @@ public class RequestBuilderTest {
     assertEquals(Optional.of(""), req.queryString("one"));
     assertEquals(Optional.of("a b"), req.queryString("two"));
     assertEquals(Optional.empty(), req.queryString("three"));
+    assertEquals(Optional.of(""), req.queryString("")); // because last query part is like <empty_string> (which needs to be handled the same as e.g. string "one" and gets expanded to <empty_string>=<empty_string>)
   }
 
   @Test
@@ -355,6 +357,14 @@ public class RequestBuilderTest {
     assertEquals(Optional.of(""), req.queryString("one?+"));
     assertEquals(Optional.of(""), req.queryString("two="));
     assertEquals(Optional.empty(), req.queryString("three"));
+    assertEquals(Optional.empty(), req.queryString("")); // correct, because there is no empty & part
+  }
+
+  @Test
+  public void testQuery_multipleEmptyKeyAndValues() {
+    final Request req = new Http.RequestBuilder().uri("/path?&&&&").build();
+    assertEquals(Optional.of(""), req.queryString("")); // expected:<Optional[]> but was:<Optional.empty>, took 0.001 sec
+    assertEquals(5, req.queryString().get("").length); // Cannot read the array length because the return value of "java.util.Map.get(Object)" is null
   }
 
   @Test

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -27,6 +27,7 @@ import play.api.mvc.request.RemoteConnection
 import play.api.mvc.request.RequestTarget
 import play.api.Configuration
 import play.api.Environment
+import play.core.parsers.FormUrlEncodedParser
 import play.i18n
 import play.libs.typedmap.TypedEntry
 import play.libs.typedmap.TypedKey
@@ -117,21 +118,37 @@ trait JavaHelpers {
       override val path: String                       = parsedUri.getRawPath
       override val queryMap: Map[String, Seq[String]] = {
         val query: String = uri.getRawQuery
+        FormUrlEncodedParser.parse(queryString)
+        /*
         if (query == null || query.isEmpty) {
           Map.empty
         } else {
-          query.split("&").foldLeft[Map[String, Seq[String]]](Map.empty) {
+          def updatem = (acc: Map[String, Seq[String]],key: String, value: String) => acc.get(key) match {
+            case None         => acc.updated(key, Seq(value))
+            case Some(values) => acc.updated(key, values :+ value)
+          }
+          println("1: " + query)
+          println("2: " + query.replaceAll("&&", "&=&").replaceAll("&&", "&=&"))
+          val map = query.replaceAll("&&", "&=&").replaceAll("&&", "&=&").split("&").foldLeft[Map[String, Seq[String]]](Map.empty) {
             case (acc, pair) =>
+              println("PAIR:" + pair)
               val idx: Int      = pair.indexOf("=")
-              val key: String   = URLDecoder.decode(if (idx > 0) pair.substring(0, idx) else pair, "UTF-8")
+              val key: String   = if(pair == "=") "" else URLDecoder.decode(if (idx > 0) pair.substring(0, idx) else pair, "UTF-8")
               val value: String =
-                if (idx > 0 && pair.length > idx + 1) URLDecoder.decode(pair.substring(idx + 1), "UTF-8") else ""
-              acc.get(key) match {
-                case None         => acc.updated(key, Seq(value))
-                case Some(values) => acc.updated(key, values :+ value)
-              }
+                if (pair != "=" && idx > 0 && pair.length > idx + 1) URLDecoder.decode(pair.substring(idx + 1), "UTF-8") else ""
+              updatem(acc, key, value)
+          }
+          println("SIZE:" + map.get("").map(_.size))
+          // special case:
+          if(query.startsWith("&") && query.endsWith("&")) {
+            updatem(updatem(map, "", ""), "", "")
+          } else if(query.startsWith("&") || query.endsWith("&")) {
+              updatem(map, "", "")
+          } else {
+            map
           }
         }
+        */
       }
     })
   }

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -199,7 +199,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
         override lazy val uri: URI                           = new URI(uriString)
         override def uriString: String                       = _uri
         override lazy val path                               = uriString.split('?').take(1).mkString
-        override lazy val queryMap: Map[String, Seq[String]] = FormUrlEncodedParser.parse(queryString)
+        override lazy val queryMap: Map[String, Seq[String]] = FormUrlEncodedParser.parse(queryString) // TODO_QUERY
       },
       version,
       headers,

--- a/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -212,7 +212,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
         override lazy val uri: URI                           = new URI(uriString)
         override def uriString: String                       = _uri
         override lazy val path: String                       = uriString.split('?').take(1).mkString
-        override lazy val queryMap: Map[String, Seq[String]] = FormUrlEncodedParser.parse(queryString)
+        override lazy val queryMap: Map[String, Seq[String]] = FormUrlEncodedParser.parse(queryString) // TODO_QUERY
       },
       version,
       headers,

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -34,6 +34,7 @@ import play.api.mvc.request.RequestTarget
 import play.api.routing.Router
 import play.api.ApplicationLoader.Context
 import play.core._
+import play.core.parsers.FormUrlEncodedParser
 import play.routing.{ Router => JRouter }
 
 trait WebSocketable {
@@ -167,7 +168,10 @@ object Server {
       val withoutQueryString = withoutHost.split('?').head
       if (withoutQueryString.isEmpty) "/" else withoutQueryString
     }
+    // TODO_QUERY
     override lazy val queryMap: Map[String, Seq[String]] = {
+      FormUrlEncodedParser.parse(requestUri)
+      /*
       // Very rough parse of query string that doesn't decode
       if (requestUri.contains("?")) {
         requestUri
@@ -186,6 +190,7 @@ object Server {
       } else {
         Map.empty
       }
+      */
     }
   }
 


### PR DESCRIPTION
**...WORK IN PROGRESS...**

I am not working on this right now, I am just pushing things I tried a couple of days ago.
No one complained yet and I think it's not so super important right now because some edge cases are really total edge cases.

- See https://github.com/playframework/playframework/pull/12977#issuecomment-2736821915

Like said in that comment we use a different logic to create the query map and in some cases the methods behave slightly different. Of course it would be better if all methods use the same logic/method.

<details>
  <summary>Test code for sample app to test locally</summary>
  
Java action:
```java
    public Result index(Http.Request request) {
        System.out.println();
        System.out.println("one:" + request.queryString("one"));
        System.out.println("two:" + request.queryString("two"));
        System.out.println("three:" + request.queryString("three"));
        System.out.println("empty:" + request.queryString(""));
        return ok(
        "one:" + request.queryString("one") + "<br>" +
                "one?+" + request.queryString("one?+") + "<br>" +
                "two:" + request.queryString("two") + "<br>" +
                "two=:" + request.queryString("two=") + "<br>" +
                "three:" + request.queryString("three") + "<br>" +
                "empty:" + request.queryString("") + "<br>" +
                "empty_all:" + Arrays.stream(request.queryString().getOrDefault("", new String[]{"<empty>"})).collect(Collectors.joining(","))
        ).as("text/html");
```

Equivalent Scala action:

```scala
  def index() = Action { implicit request: Request[AnyContent] =>
    println()
    println("one:" + request.getQueryString("one"))
    println("two:" + request.getQueryString("two"))
    println("three:" + request.getQueryString("three"))
    println("empty:" + request.getQueryString(""))
    Ok(
        "one:" + request.getQueryString("one") + "<br>" +
        "one?+:" + request.getQueryString("one?+") + "<br>" +
        "two:" + request.getQueryString("two") + "<br>" +
        "two=:" + request.getQueryString("two=") + "<br>" +
        "three:" + request.getQueryString("three") + "<br>" +
        "empty:" + request.getQueryString("") + "<br>" +
         "empty_all:" + request.queryString.get("").map(_.mkString(","))
    ).as("text/html");
  }
```

Testing with:
```
http://localhost:9000/?one=&two=a+b&
http://localhost:9000/?one&two=a+b&
http://localhost:9000/?one=&two=a+b&=
http://localhost:9000/?one&two=a+b
http://localhost:9000/?one?%2B=&two%3D
```

</details>