### PR TITLE
Gradle Plugin should be compatible with JDK 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,9 @@ ThisBuild / dynver := {
 }
 
 lazy val PlayBuildLinkProject = PlayNonCrossBuiltProject("Play-Build-Link", "dev-mode/play-build-link")
+  .settings(
+    compile / javacOptions ++= Seq("--release", "11"),
+  )
   .dependsOn(PlayExceptionsProject)
 
 // play-run-support project is only compiled against sbt scala version
@@ -41,6 +44,7 @@ lazy val PlayRunSupportProject = PlayNonCrossBuiltProject("Play-Run-Support", "d
   .settings(
     target := target.value / "play-run-support",
     libraryDependencies ++= runSupportDeps,
+    compile / javacOptions ++= Seq("--release", "11"),
     mimaPreviousArtifacts := Set.empty, // TODO: Remove later
     // Or:
     // MimaKeys.mimaPreviousArtifacts := Set("org.playframework" % "play-run-support_2.12" % "3.0.0"),
@@ -53,6 +57,7 @@ lazy val PlayRoutesCompilerProject = PlayDevelopmentProject("Play-Routes-Compile
   .enablePlugins(SbtTwirl)
   .settings(
     scalacOptions -= "-Xsource:3", // Since this is actually a sbt plugin and the codebase is 2.12, this flag causes problems when cross compiling
+    scalacOptions ++= Seq("-release", "11"),
     libraryDependencies ++= routesCompilerDependencies(scalaVersion.value),
     TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")
   )
@@ -69,6 +74,9 @@ lazy val PlayStreamsProject = PlayCrossBuiltProject("Play-Streams", "core/play-s
   .settings(libraryDependencies ++= streamsDependencies)
 
 lazy val PlayExceptionsProject = PlayNonCrossBuiltProject("Play-Exceptions", "core/play-exceptions")
+  .settings(
+    compile / javacOptions ++= Seq("--release", "11"),
+  )
 
 lazy val PlayBillOfMaterials = PlayCrossBuiltProject("Play-Bom", "dev-mode/play-bill-of-materials")
   .enablePlugins(BillOfMaterialsPlugin)

--- a/dev-mode/gradle-plugin/build.gradle.kts
+++ b/dev-mode/gradle-plugin/build.gradle.kts
@@ -46,6 +46,10 @@ dependencies {
     testImplementation(libs.kotlin.plugin)
 }
 
+tasks.compileJava {
+    options.release = 11
+}
+
 tasks.jar {
     manifest {
         attributes("Implementation-Version" to version)

--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayRunPlugin.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayRunPlugin.java
@@ -19,6 +19,7 @@ import static play.gradle.plugin.PlayAssetsPlugin.PUBLIC_SOURCE_NAME;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
@@ -75,7 +76,7 @@ public class PlayRunPlugin implements Plugin<Project> {
             .map(source -> ((SourceDirectorySet) mainSourceSet.getExtensions().findByName(source)))
             .filter(Objects::nonNull)
             .map(SourceDirectorySet::getClassesDirectory)
-            .toList());
+            .collect(Collectors.toList()));
   }
 
   private List<DirectoryProperty> findAssetsDirectories(@Nullable Project project) {


### PR DESCRIPTION
I think it's a very low-cost option to provide a Gradle plugin for users who are still using Akka and Play 2.9.x. 

We just need to build for JDK 11 the next modules:
* Play-Exceptions
* Play-Build-Link
* Play-Run-Support
* Play-Routes-Compiler
* Play Gradle Plugin