### PR TITLE
Pin Netty to 4.1.x

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -51,6 +51,8 @@ updates.pin = [
   { groupId = "org.springframework", artifactId = "spring-core", version = "5." },
   // persistence-api 3.2 requires Java 17 and also it wouldn't be a good idea to upgrade anyway
   { groupId = "jakarta.persistence", artifactId = "jakarta.persistence-api", version = "3.1." },
+  // We stay on Netty 4.1.x as long it receives bug and security fixes: https://netty.io/news/2025/04/03/4-2-0.html
+  { groupId = "io.netty", version = "4.1." },
   // We do not upgrade beyond these versions anymore in Play 2.9:
   { groupId = "com.typesafe.play", artifactId = "play-ws-standalone", version = "2.2." },
   { groupId = "com.typesafe.play", artifactId = "play-ws-standalone-xml", version = "2.2." },


### PR DESCRIPTION
We stay on Netty 4.1.x as long it receives bug and security fixes: https://netty.io/news/2025/04/03/4-2-0.html

> With the release of netty 4.2.0.Final we will also start to only merge bug-fixes into 4.1, new features will only be merged to 4.2 and main branches. While 4.1.x releases will only receive bug-fixes we **will still support it 4.1.x for the time beeing**, so projects can take their time to upgrade to 4.2.0.Final. T