### PR TITLE
Update scalafmt dialect

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,7 +4,7 @@
 # Version https://scalameta.org/scalafmt/docs/configuration.html#version
 version = 3.9.3
 # Dialect https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects
-runner.dialect = scala213
+runner.dialect = scala213source3
 
 # Top-level preset https://scalameta.org/scalafmt/docs/configuration.html#top-level-presets
 preset = default

--- a/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
@@ -235,7 +235,7 @@ class ConfigurationSpec extends Specification {
     }
 
     "be accessible as an entry set" in {
-      val map = Map(exampleConfig.entrySet.toList: _*)
+      val map = Map(exampleConfig.entrySet.toList*)
       map.keySet must contain(
         allOf("foo.bar1", "foo.bar2", "blah.0", "blah.1", "blah.2", "blah.3", "blah.4", "blah2.blah3.blah4")
       )

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -111,7 +111,7 @@ final case class GuiceApplicationBuilder(
     val loadedModules = loadModules(environment, appConfiguration)
 
     copy(configuration = appConfiguration)
-      .bindings(loadedModules: _*)
+      .bindings(loadedModules*)
       .bindings(
         bind[ILoggerFactory] to loggerFactory,
         bind[OptionalDevContext] to new OptionalDevContext(None),

--- a/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/core/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -29,7 +29,7 @@ class GuiceApplicationLoader(protected val initialBuilder: GuiceApplicationBuild
       .disableCircularProxies()
       .in(context.environment)
       .loadConfig(context.initialConfiguration)
-      .overrides(overrides(context): _*)
+      .overrides(overrides(context)*)
   }
 
   /**

--- a/core/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -130,7 +130,7 @@ trait HeadActionSpec
     val attrAction = ActionBuilder.ignoringBody { (rh: RequestHeader) =>
       val attrComment = rh.attrs.get(CustomAttr)
       val headers     = rh.attrs.get(CustomAttr).map("CustomAttr" -> _).toSeq
-      Results.Ok.withHeaders(headers: _*)
+      Results.Ok.withHeaders(headers*)
     }
 
     "modify request with DefaultHttpRequestHandler" in serverWithHandler(

--- a/core/play-integration-test/src/test/scala/play/it/api/SecretConfigurationParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/api/SecretConfigurationParserSpec.scala
@@ -20,7 +20,7 @@ class SecretConfigurationParserSpec extends PlaySpecification {
   def parseSecret(mode: Mode)(extraConfig: (String, String)*): (Option[String], Seq[ILoggingEvent]) = {
     Try {
       val app = GuiceApplicationBuilder(environment = Environment.simple(mode = mode))
-        .configure(extraConfig: _*)
+        .configure(extraConfig*)
         .build()
       val (secret, events) = LogTester.recordLogEvents {
         app.httpConfiguration.secret.secret

--- a/core/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -205,7 +205,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
           parsed :: readHeaders
         }
       }
-      val headers = TreeMap(readHeaders: _*)(CaseInsensitiveOrdered)
+      val headers = TreeMap(readHeaders*)(CaseInsensitiveOrdered)
 
       def readCompletely(length: Int): String = {
         if (length == 0) {

--- a/core/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -32,7 +32,7 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
     def withServerAndConfig[T](
         configuration: (String, Any)*
     )(action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
-      val config = Configuration(configuration: _*)
+      val config = Configuration(configuration*)
       val serverConfig: ServerConfig = {
         val c = ServerConfig(port = Some(testServerPort), mode = Mode.Test)
         c.copy(configuration = config.withFallback(c.configuration))

--- a/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -66,7 +66,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
   )(action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T): T = {
     val serverConfig: ServerConfig = {
       val c = ServerConfig(port = Some(testServerPort), mode = Mode.Test)
-      c.copy(configuration = Configuration(configuration: _*).withFallback(c.configuration))
+      c.copy(configuration = Configuration(configuration*).withFallback(c.configuration))
     }
     runningWithPort(
       play.api.test.TestServer(

--- a/core/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -116,7 +116,7 @@ class ScalaResultsSpec extends PlaySpecification {
 
   def withApplication[T](config: (String, Any)*)(block: Application => T): T =
     running(
-      _.configure(Map(config: _*) + ("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
+      _.configure(Map(config*) + ("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
     )(block)
 
   def withFooDomain[T](block: Application => T) = withApplication("play.http.session.domain" -> ".foo.com")(block)

--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
@@ -17,7 +17,7 @@ class AnyContentBodyParserSpec extends PlaySpecification {
     ): Either[Result, AnyContent] = {
       implicit val mat = app.materializer
       val parsers      = app.injector.instanceOf[PlayBodyParsers]
-      val request      = FakeRequest(method, "/x").withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
+      val request      = FakeRequest(method, "/x").withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq*)
       await(parsers.anyContent(maxLength).apply(request).run(Source.single(body)))
     }
 

--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
@@ -23,7 +23,7 @@ class EmptyBodyParserSpec extends PlaySpecification {
     ) = {
       await(
         bodyParser(
-          FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
+          FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq*)
         ).run(Source.single(bytes))
       )
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
@@ -35,7 +35,7 @@ class FormBodyParserSpec extends PlaySpecification {
         bodyParser: BodyParser[A]
     )(implicit writeable: Writeable[B], mat: Materializer): Either[Result, A] = {
       await(
-        bodyParser(FakeRequest().withHeaders(writeable.contentType.map(CONTENT_TYPE -> _).toSeq: _*))
+        bodyParser(FakeRequest().withHeaders(writeable.contentType.map(CONTENT_TYPE -> _).toSeq*))
           .run(Source.single(writeable.transform(body)))
       )
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
@@ -17,7 +17,7 @@ class IgnoreBodyParserSpec extends PlaySpecification {
     ) = {
       await(
         BodyParsers.utils
-          .ignore(value)(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
+          .ignore(value)(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq*))
           .run(Source.single(bytes))
       )
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
@@ -32,7 +32,7 @@ class JsonBodyParserSpec extends PlaySpecification {
         bodyParser: BodyParser[A]
     ) = {
       await(
-        bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
+        bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq*))
           .run(Source.single(ByteString(json.getBytes(encoding))))
       )
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
@@ -22,7 +22,7 @@ class TextBodyParserSpec extends PlaySpecification {
         bodyParser: BodyParser[String]
     ) = {
       await(
-        bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
+        bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq*))
           .run(Source.single(ByteString(text, encoding)))
       )
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -30,7 +30,7 @@ class XmlBodyParserSpec extends PlaySpecification {
         bodyParser: BodyParser[NodeSeq]
     ) = {
       await(
-        bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
+        bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq*))
           .run(Source.single(ByteString(xml, encoding)))
       )
     }

--- a/core/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
@@ -199,7 +199,7 @@ trait ServerReloadingSpec extends PlaySpecification with WsTestClient with Serve
         def appWithConfig(conf: (String, Any)*): Success[Application] = {
           Success(
             GuiceApplicationBuilder()
-              .configure(conf: _*)
+              .configure(conf*)
               .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
               .build()
           )

--- a/core/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/core/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -131,7 +131,7 @@ object HttpBinApplication {
 
   def responseHeaders(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/response-header") =>
-      Action { request => Ok("").withHeaders(request.queryString.view.mapValues(_.mkString(",")).toSeq: _*) }
+      Action { request => Ok("").withHeaders(request.queryString.view.mapValues(_.mkString(",")).toSeq*) }
   }
 
   def redirect(implicit Action: DefaultActionBuilder): Routes = {
@@ -169,14 +169,14 @@ object HttpBinApplication {
       Action { request =>
         Redirect("/cookies").withCookies(request.queryString.view.mapValues(_.head).toSeq.map {
           case (k, v) => Cookie(k, v)
-        }: _*)
+        }*)
       }
   }
 
   def cookiesDelete(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/cookies/delete") =>
       Action { request =>
-        Redirect("/cookies").discardingCookies(request.queryString.keys.toSeq.map(DiscardingCookie(_)): _*)
+        Redirect("/cookies").discardingCookies(request.queryString.keys.toSeq.map(DiscardingCookie(_))*)
       }
   }
 

--- a/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -31,7 +31,7 @@ private[routing] class RouterBuilderHelper(
               implicit executionContext: ExecutionContext
           ) = {
             val actionParameters = request.asJava +: parameters
-            val javaResultFuture = route.actionMethod.invoke(route.action, actionParameters: _*) match {
+            val javaResultFuture = route.actionMethod.invoke(route.action, actionParameters*) match {
               case result: Result => Future.successful(result)
               case promise: CompletionStage[?] =>
                 val p = promise.asInstanceOf[CompletionStage[Result]]

--- a/core/play-logback/src/test/scala/play/api/ModeSpecificLoggerSpec.scala
+++ b/core/play-logback/src/test/scala/play/api/ModeSpecificLoggerSpec.scala
@@ -11,7 +11,7 @@ class ModeSpecificLoggerSpec extends Specification {
   sequential
 
   case class ModeLoggerTest(mode: Mode*) {
-    private val logger = Logger(getClass).forMode(mode: _*)
+    private val logger = Logger(getClass).forMode(mode*)
 
     logger.info("This is info")
     logger.debug("This is debug")

--- a/core/play-streams/src/main/scala/play/api/libs/streams/PekkoStreams.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/PekkoStreams.scala
@@ -74,7 +74,7 @@ object PekkoStreams {
 
     val inlets = Seq(merge.in(0)) ++ blockFinishes
 
-    UniformFanInShape(merge.out, inlets: _*)
+    UniformFanInShape(merge.out, inlets*)
   }
 
   /**

--- a/core/play/src/main/scala/play/api/data/Form.scala
+++ b/core/play/src/main/scala/play/api/data/Form.scala
@@ -268,7 +268,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
     val map = errors
       .groupBy(_.key)
       .view
-      .mapValues(_.map(e => messages(e.message, e.args.map(translate): _*)))
+      .mapValues(_.map(e => messages(e.message, e.args.map(translate)*)))
     Json.toJson(map)
   }
 
@@ -559,7 +559,7 @@ case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
   /**
    * Displays the formatted message, for use in a template.
    */
-  def format(implicit messages: Messages): String = messages.apply(message, args: _*)
+  def format(implicit messages: Messages): String = messages.apply(message, args*)
 }
 
 object FormError {

--- a/core/play/src/main/scala/play/api/data/validation/Validation.scala
+++ b/core/play/src/main/scala/play/api/data/validation/Validation.scala
@@ -245,7 +245,7 @@ object Invalid {
    * @param args the validation error message arguments
    * @return an `Invalid` value
    */
-  def apply(error: String, args: Any*): Invalid = Invalid(Seq(ValidationError(error, args: _*)))
+  def apply(error: String, args: Any*): Invalid = Invalid(Seq(ValidationError(error, args*)))
 }
 
 object ParameterValidator {
@@ -282,8 +282,8 @@ object ValidationError {
    * Conversion from a JsonValidationError to a Play ValidationError.
    */
   def fromJsonValidationError(jve: JsonValidationError): ValidationError = {
-    ValidationError(jve.message, jve.args: _*)
+    ValidationError(jve.message, jve.args*)
   }
 
-  def apply(message: String, args: Any*) = new ValidationError(Seq(message), args: _*)
+  def apply(message: String, args: Any*) = new ValidationError(Seq(message), args*)
 }

--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -99,7 +99,7 @@ class PreferredMediaTypeHttpErrorHandler(val handlers: (String, HttpErrorHandler
 }
 
 object PreferredMediaTypeHttpErrorHandler {
-  def apply(handlers: (String, HttpErrorHandler)*) = new PreferredMediaTypeHttpErrorHandler(handlers: _*)
+  def apply(handlers: (String, HttpErrorHandler)*) = new PreferredMediaTypeHttpErrorHandler(handlers*)
 }
 
 object HttpErrorHandler {

--- a/core/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/core/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -140,7 +140,7 @@ object NoHttpFilters extends NoHttpFilters
  * Adapter from the Java HttpFilters to the Scala HttpFilters interface.
  */
 class JavaHttpFiltersAdapter @Inject() (underlying: play.http.HttpFilters)
-    extends DefaultHttpFilters(underlying.getFilters.asScala.toSeq: _*)
+    extends DefaultHttpFilters(underlying.getFilters.asScala.toSeq*)
 
 class JavaHttpFiltersDelegate @Inject() (delegate: HttpFilters)
     extends play.http.DefaultHttpFilters(delegate.filters.asJava)

--- a/core/play/src/main/scala/play/api/http/Writeable.scala
+++ b/core/play/src/main/scala/play/api/http/Writeable.scala
@@ -184,7 +184,7 @@ trait DefaultWriteables extends LowPriorityWriteables {
       transform = { (form: MultipartFormData[A]) =>
         formatDataParts(form.dataParts) ++ ByteString(form.files.flatMap { file =>
           filePartHeader(file) ++ file.transformRefToBytes() ++ codec.encode("\r\n")
-        }: _*) ++ codec.encode(s"--$resolvedBoundary--")
+        }*) ++ codec.encode(s"--$resolvedBoundary--")
       },
       contentType = Some(s"multipart/form-data; boundary=$resolvedBoundary")
     )

--- a/core/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/core/play/src/main/scala/play/api/i18n/Messages.scala
@@ -56,7 +56,7 @@ object Messages extends MessagesImplicits {
    * @return the formatted message or a default rendering if the key wasn’t defined
    */
   def apply(key: String, args: Any*)(implicit provider: MessagesProvider): String = {
-    provider.messages(key, args: _*)
+    provider.messages(key, args*)
   }
 
   /**
@@ -69,7 +69,7 @@ object Messages extends MessagesImplicits {
    * @return the formatted message or a default rendering if the key wasn’t defined
    */
   def apply(keys: Seq[String], args: Any*)(implicit provider: MessagesProvider): String = {
-    provider.messages(keys, args: _*)
+    provider.messages(keys, args*)
   }
 
   /**
@@ -196,7 +196,7 @@ case class MessagesImpl(lang: Lang, messagesApi: MessagesApi) extends Messages {
    * @return the formatted message or a default rendering if the key wasn’t defined
    */
   override def apply(key: String, args: Any*): String = {
-    messagesApi(key, args: _*)(lang)
+    messagesApi(key, args*)(lang)
   }
 
   /**
@@ -209,7 +209,7 @@ case class MessagesImpl(lang: Lang, messagesApi: MessagesApi) extends Messages {
    * @return the formatted message or a default rendering if the key wasn’t defined
    */
   override def apply(keys: Seq[String], args: Any*): String = {
-    messagesApi(keys, args: _*)(lang)
+    messagesApi(keys, args*)(lang)
   }
 
   /**

--- a/core/play/src/main/scala/play/api/inject/Module.scala
+++ b/core/play/src/main/scala/play/api/inject/Module.scala
@@ -156,12 +156,12 @@ object Modules {
         val constructor: Option[Constructor[T]] =
           try {
             val argTypes = args.map(_.getClass)
-            Option(ConstructorUtils.getMatchingAccessibleConstructor(moduleClass, argTypes: _*))
+            Option(ConstructorUtils.getMatchingAccessibleConstructor(moduleClass, argTypes*))
           } catch {
             case _: NoSuchMethodException => None
             case _: SecurityException     => None
           }
-        constructor.map(_.newInstance(args: _*))
+        constructor.map(_.newInstance(args*))
       }
 
       {

--- a/core/play/src/main/scala/play/api/libs/concurrent/Pekko.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Pekko.scala
@@ -129,7 +129,7 @@ trait PekkoTypedComponents {
 @Singleton
 class ActorSystemProvider @Inject() (environment: Environment, configuration: Configuration)
     extends Provider[ActorSystem] {
-  lazy val get: ActorSystem = ActorSystemProvider.start(environment.classLoader, configuration, Nil: _*)
+  lazy val get: ActorSystem = ActorSystemProvider.start(environment.classLoader, configuration, Nil*)
 }
 
 /**
@@ -180,7 +180,7 @@ object ActorSystemProvider {
    */
   @deprecated("Use start(ClassLoader, Configuration, Setup*) instead", "2.8.0")
   protected[ActorSystemProvider] def start(classLoader: ClassLoader, config: Configuration): ActorSystem = {
-    start(classLoader, config, Nil: _*)
+    start(classLoader, config, Nil*)
   }
 
   /**
@@ -194,7 +194,7 @@ object ActorSystemProvider {
       config: Configuration,
       additionalSetup: Setup
   ): ActorSystem = {
-    start(classLoader, config, Seq(additionalSetup): _*)
+    start(classLoader, config, Seq(additionalSetup)*)
   }
 
   /**

--- a/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/core/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -178,7 +178,7 @@ object TypedMap {
    * Builds a [[TypedMap]] from a list of keys and values.
    */
   def apply(entries: TypedEntry[?]*): TypedMap = {
-    TypedMap.empty.+(entries: _*)
+    TypedMap.empty.+(entries*)
   }
 }
 
@@ -201,13 +201,13 @@ private[typedmap] final class DefaultTypedMap private[typedmap] (m: immutable.Ma
     }
     new DefaultTypedMap(m2)
   }
-  override def +(entries: TypedEntry[?]*): TypedMap = updated(entries: _*)
+  override def +(entries: TypedEntry[?]*): TypedMap = updated(entries*)
   override def removed(k1: TypedKey[?]): TypedMap   = new DefaultTypedMap(m - k1)
   override def removed(k1: TypedKey[?], k2: TypedKey[?]): TypedMap =
     new DefaultTypedMap(m - k1 - k2)
   override def removed(k1: TypedKey[?], k2: TypedKey[?], k3: TypedKey[?]): TypedMap =
     new DefaultTypedMap(m - k1 - k2 - k3)
   override def removed(keys: TypedKey[?]*): TypedMap = new DefaultTypedMap(m.removedAll(keys))
-  override def -(keys: TypedKey[?]*): TypedMap       = removed(keys: _*)
+  override def -(keys: TypedKey[?]*): TypedMap       = removed(keys*)
   override def toString: String                      = m.mkString("{", ", ", "}")
 }

--- a/core/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/core/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -404,7 +404,7 @@ object CookieHeaderMerging {
    */
   private def mergeOn[A, B](input: Iterable[A], f: A => B): Seq[A] = {
     val withMergeValue: Seq[(B, A)] = input.toSeq.map(el => (f(el), el))
-    ListMap(withMergeValue: _*).values.toSeq
+    ListMap(withMergeValue*).values.toSeq
   }
 
   /**

--- a/core/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/core/play/src/main/scala/play/api/mvc/Headers.scala
@@ -74,14 +74,14 @@ class Headers(protected var _headers: Seq[(String, String)]) {
    * Remove any headers with the given keys
    */
   def remove(keys: String*): Headers = {
-    val keySet = TreeSet(keys: _*)(CaseInsensitiveOrdered)
+    val keySet = TreeSet(keys*)(CaseInsensitiveOrdered)
     new Headers(headers.filterNot { case (name, _) => keySet(name) })
   }
 
   /**
    * Append the given headers, replacing any existing headers having the same keys
    */
-  def replace(headers: (String, String)*): Headers = remove(headers.map(_._1): _*).add(headers: _*)
+  def replace(headers: (String, String)*): Headers = remove(headers.map(_._1)*).add(headers*)
 
   /**
    * Transform the Headers to a Map

--- a/core/play/src/main/scala/play/api/mvc/Render.scala
+++ b/core/play/src/main/scala/play/api/mvc/Render.scala
@@ -32,7 +32,7 @@ trait Rendering {
     def apply(f: PartialFunction[MediaRange, Result])(implicit request: RequestHeader): Result = {
       def _render(ms: Seq[MediaRange]): Result = ms match {
         case Nil => NotAcceptable
-        case Seq(m, ms @ _*) =>
+        case Seq(m, ms*) =>
           f.applyOrElse(m, (m: MediaRange) => _render(ms))
       }
 
@@ -63,7 +63,7 @@ trait Rendering {
     def async(f: PartialFunction[MediaRange, Future[Result]])(implicit request: RequestHeader): Future[Result] = {
       def _render(ms: Seq[MediaRange]): Future[Result] = ms match {
         case Nil => Future.successful(NotAcceptable)
-        case Seq(m, ms @ _*) =>
+        case Seq(m, ms*) =>
           f.applyOrElse(m, (m: MediaRange) => _render(ms))
       }
 

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -96,7 +96,7 @@ trait Request[+A] extends RequestHeader {
   override def addAttrs(e1: TypedEntry[?], e2: TypedEntry[?], e3: TypedEntry[?]): Request[A] =
     withAttrs(attrs.updated(e1, e2, e3))
   override def addAttrs(entries: TypedEntry[?]*): Request[A] =
-    withAttrs(attrs.updated(entries: _*))
+    withAttrs(attrs.updated(entries*))
   override def removeAttr(key: TypedKey[?]): Request[A] =
     withAttrs(attrs.removed(key))
   override def withTransientLang(lang: Lang): Request[A] =

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -188,7 +188,7 @@ trait RequestHeader {
    * @return The new version of this object with the new attributes.
    */
   def addAttrs(entries: TypedEntry[?]*): RequestHeader =
-    withAttrs(attrs.updated(entries: _*))
+    withAttrs(attrs.updated(entries*))
 
   /**
    * Create a new versions of this object with the given attribute removed.

--- a/core/play/src/main/scala/play/api/mvc/Results.scala
+++ b/core/play/src/main/scala/play/api/mvc/Results.scala
@@ -213,7 +213,7 @@ case class Result(
    * @return the new result
    */
   def discardingCookies(cookies: DiscardingCookie*): Result = {
-    withCookies(cookies.map(_.toCookie): _*)
+    withCookies(cookies.map(_.toCookie)*)
   }
 
   /**
@@ -428,7 +428,7 @@ case class Result(
    * @return The new version of this object with the new attributes.
    */
   def addAttrs(entries: TypedEntry[?]*): Result =
-    withAttrs(attrs.updated(entries: _*))
+    withAttrs(attrs.updated(entries*))
 
   /**
    * Create a new versions of this object with the given attribute removed.

--- a/core/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
+++ b/core/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
@@ -38,7 +38,7 @@ object JavaScriptReverseRouter {
   def apply(name: String = "Router", ajaxMethod: Option[String] = Some("jQuery.ajax"))(
       routes: JavaScriptReverseRoute*
   )(implicit request: RequestHeader): JavaScript = {
-    apply(name, ajaxMethod, request.host, routes: _*)
+    apply(name, ajaxMethod, request.host, routes*)
   }
 
   def apply(name: String, ajaxMethod: Option[String], host: String, routes: JavaScriptReverseRoute*): JavaScript =

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -97,7 +97,7 @@ object HandlerInvokerFactory {
     if (annotations == null) {
       val controller = loadJavaControllerClass(handlerDef)
       val method =
-        MethodUtils.getMatchingAccessibleMethod(controller, handlerDef.method, handlerDef.parameterTypes: _*)
+        MethodUtils.getMatchingAccessibleMethod(controller, handlerDef.method, handlerDef.parameterTypes*)
       new JavaActionAnnotations(controller, method, config)
     } else {
       annotations

--- a/core/play/src/main/scala/play/utils/Conversions.scala
+++ b/core/play/src/main/scala/play/utils/Conversions.scala
@@ -8,5 +8,5 @@ package play.utils
  * provides conversion helpers
  */
 object Conversions {
-  def newMap[A, B](data: (A, B)*) = Map(data: _*)
+  def newMap[A, B](data: (A, B)*) = Map(data*)
 }

--- a/core/play/src/main/scala/views/helper/Helpers.scala
+++ b/core/play/src/main/scala/views/helper/Helpers.scala
@@ -25,8 +25,8 @@ package views.html.helper {
             case _           => true
           }
         ) {
-          field.constraints.map(c => p.messages(c._1, c._2.map(a => translate(a)(p)): _*)) ++
-            field.format.map(f => p.messages(f._1, f._2.map(a => translate(a)(p)): _*))
+          field.constraints.map(c => p.messages(c._1, c._2.map(a => translate(a)(p))*)) ++
+            field.format.map(f => p.messages(f._1, f._2.map(a => translate(a)(p))*))
         } else Nil
       }
     }
@@ -34,9 +34,9 @@ package views.html.helper {
     def errors: Seq[Any] = {
       (args.get(Symbol("_error")) match {
         case Some(Some(FormError(_, message, args))) =>
-          Some(p.messages(message, args.map(a => translate(a)(p)): _*))
+          Some(p.messages(message, args.map(a => translate(a)(p))*))
         case Some(FormError(_, message, args)) =>
-          Some(p.messages(message, args.map(a => translate(a)(p)): _*))
+          Some(p.messages(message, args.map(a => translate(a)(p))*))
         case Some(None)  => None
         case Some(value) => Some(translate(value)(p))
         case _           => None
@@ -47,7 +47,7 @@ package views.html.helper {
             case _           => true
           }
         ) {
-          field.errors.map(e => p.messages(e.message, e.args.map(a => translate(a)(p)): _*))
+          field.errors.map(e => p.messages(e.message, e.args.map(a => translate(a)(p))*))
         } else Nil
       }
     }

--- a/core/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
+++ b/core/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
@@ -292,7 +292,7 @@ class ValidationSpec extends Specification {
       val values      = Seq(Some(9), Some(0), Some(5))
       val expected    = Invalid(List(ValidationError("error.min", 1)))
 
-      ParameterValidator(constraints, values: _*) must equalTo(expected)
+      ParameterValidator(constraints, values*) must equalTo(expected)
     }
 
     "validate multiple string values and multiple validation errors" in {
@@ -300,7 +300,7 @@ class ValidationSpec extends Specification {
       val values      = Seq(Some(""), Some("12345678910"), Some("valid"))
       val expected    = Invalid(List(ValidationError("error.minLength", 1), ValidationError("error.maxLength", 10)))
 
-      ParameterValidator(constraints, values: _*) must equalTo(expected)
+      ParameterValidator(constraints, values*) must equalTo(expected)
     }
 
     "ValidationError" should {

--- a/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -155,7 +155,7 @@ class ResultsSpec extends Specification {
 
     "provide convenience method for setting cookie header" in withApplication {
       def testWithCookies(cookies1: List[Cookie], cookies2: List[Cookie], expected: Option[Set[Cookie]]) = {
-        val result = bake { Ok("hello").withCookies(cookies1: _*).withCookies(cookies2: _*) }
+        val result = bake { Ok("hello").withCookies(cookies1*).withCookies(cookies2*) }
         result.header.headers
           .get("Set-Cookie")
           .map(cookieHeaderEncoding.decodeSetCookieHeader(_).toSet) must_== expected

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -59,7 +59,7 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
   override def addAttr[B](key: TypedKey[B], value: B): FakeRequest[A] =
     withAttrs(attrs.updated(key, value))
   override def addAttrs(entries: TypedEntry[?]*): FakeRequest[A] =
-    withAttrs(attrs.updated(entries: _*))
+    withAttrs(attrs.updated(entries*))
   override def removeAttr(key: TypedKey[?]): FakeRequest[A] =
     withAttrs(attrs.removed(key))
   override def withBody[B](body: B): FakeRequest[B] =
@@ -69,7 +69,7 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
    * Constructs a new request with additional headers. Any existing headers of the same name will be replaced.
    */
   def withHeaders(newHeaders: (String, String)*): FakeRequest[A] = {
-    withHeaders(headers.replace(newHeaders: _*))
+    withHeaders(headers.replace(newHeaders*))
   }
 
   /**

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -24,7 +24,7 @@ class RequestHeaderSpec extends Specification {
       method = "GET",
       target = RequestTarget("/", "", Map.empty),
       version = "",
-      headers = Headers(headers: _*),
+      headers = Headers(headers*),
       attrs = TypedMap.empty
     )
   }

--- a/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -272,7 +272,7 @@ package object templates {
       val parameters           = reverseMatchParameters(params, annotateUnchecked = false)
       val parameterConstraints = reverseParameterConstraints(route, localNames)
       (parameters -> parameterConstraints) -> block(route, parameters, parameterConstraints, localNames)
-    }: _*).values.toSeq.reverse
+    }*).values.toSeq.reverse
   }
 
   /**

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -175,7 +175,7 @@ object PlayReload {
             val path =
               if (names.head.startsWith("${")) { // check for ${BASE} or similar (in case it changes)
                 // It's an relative path, skip the first element (which usually is "${BASE}")
-                Paths.get(names.drop(1).head, names.drop(2): _*)
+                Paths.get(names.drop(1).head, names.drop(2)*)
               } else {
                 // It's an absolute path, sbt uses them e.g. for subprojects located outside of the base project
                 val id = vf.getClass.getMethod("id").invoke(vf).asInstanceOf[String]

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -96,7 +96,7 @@ object ScriptedTools extends AutoPlugin {
       if (ssl) setupSsl()
       val loc = if (ssl) url(s"https://localhost:9443$path") else url(s"http://localhost:9000$path")
 
-      val (requestStatus, contents) = callUrlImpl(loc, headers: _*)
+      val (requestStatus, contents) = callUrlImpl(loc, headers*)
 
       if (status == requestStatus) messages += s"Resource at $path returned $status as expected"
       else throw new RuntimeException(s"Resource at $path returned $requestStatus instead of $status")
@@ -125,7 +125,7 @@ object ScriptedTools extends AutoPlugin {
   }
 
   def callUrl(path: String, headers: (String, String)*): (Int, String) = {
-    callUrlImpl(url(s"http://localhost:9000$path"), headers: _*)
+    callUrlImpl(url(s"http://localhost:9000$path"), headers*)
   }
 
   private def callUrlImpl(url: URL, headers: (String, String)*): (Int, String) = {

--- a/documentation/.scalafmt.conf
+++ b/documentation/.scalafmt.conf
@@ -5,7 +5,7 @@
 # Version https://scalameta.org/scalafmt/docs/configuration.html#version
 version = 3.9.3
 # Dialect https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects
-runner.dialect = scala213
+runner.dialect = scala213source3
 
 # Top-level preset https://scalameta.org/scalafmt/docs/configuration.html#top-level-presets
 preset = default

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -16,8 +16,8 @@ lazy val main = Project("Play-Documentation", file("."))
     // Avoid the use of deprecated APIs in the docs
     scalacOptions ++= Seq("-deprecation") ++
       (CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 13)) => Seq("-Xsource:3")
-        case _             => Seq.empty
+        case Some((2, _)) => Seq("-Xsource:3")
+        case _            => Seq.empty
       }),
     javacOptions ++= Seq(
       "-encoding",

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -272,7 +272,7 @@ package customapplicationloader {
       initialBuilder
         .in(context.environment)
         .loadConfig(context.initialConfiguration.withFallback(extra))
-        .overrides(overrides(context): _*)
+        .overrides(overrides(context)*)
     }
   }
 //#custom-application-loader

--- a/persistence/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
+++ b/persistence/play-jdbc/src/test/scala/play/api/db/DBApiSpec.scala
@@ -22,7 +22,7 @@ class ProdDBApiSpec extends DBApiSpec(Mode.Prod)
 abstract class DBApiSpec(mode: Mode) extends Specification {
   def app(conf: (String, Any)*): Application = {
     GuiceApplicationBuilder(environment = Environment.simple(mode = mode))
-      .configure(conf: _*)
+      .configure(conf*)
       .build()
   }
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -104,7 +104,7 @@ object BuildSettings {
     (Compile / doc / scalacOptions) := {
       // disable the new scaladoc feature for scala 2.12+ (https://github.com/scala/scala-dev/issues/249 and https://github.com/scala/bug/issues/11340)
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, v)) if v >= 12 => Seq("-no-java-comments")
+        case Some((2, v)) if v >= 12 => Seq("-no-java-comments", "-Xsource:3")
         case _                       => Seq() // Not available/needed in Scala 3 according to https://github.com/lampepfl/dotty/issues/11907
       }
     },
@@ -468,8 +468,8 @@ object BuildSettings {
   def PlayNonCrossBuiltProject(name: String, dir: String): Project = {
     Project(name, file(dir))
       .enablePlugins(PlaySbtLibrary, AutomateHeaderPlugin, MimaPlugin)
-      .settings(playRuntimeSettings: _*)
-      .settings(omnidocSettings: _*)
+      .settings(playRuntimeSettings*)
+      .settings(omnidocSettings*)
       .settings(
         autoScalaLibrary := false,
         crossPaths       := false,
@@ -494,8 +494,8 @@ object BuildSettings {
   def PlayCrossBuiltProject(name: String, dir: String): Project = {
     Project(name, file(dir))
       .enablePlugins(PlayLibrary, AutomateHeaderPlugin, PekkoSnapshotRepositories, MimaPlugin)
-      .settings(playRuntimeSettings: _*)
-      .settings(omnidocSettings: _*)
+      .settings(playRuntimeSettings*)
+      .settings(omnidocSettings*)
   }
 
   def omnidocSettings: Seq[Setting[?]] = Def.settings(

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -138,7 +138,8 @@ object Docs {
       (ThisBuild / baseDirectory).value.getAbsolutePath,
       "-doc-source-url",
       s"https://github.com/playframework/playframework/tree/${commitish}€{FILE_PATH}.scala",
-      s"-doc-external-doc:$externalDoc"
+      s"-doc-external-doc:$externalDoc",
+      "-Xsource:3"
     )
 
     val cache  = apiDocsCache("scalaapidocs.cache").value

--- a/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -61,7 +61,7 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
    * Constructs a new request with additional headers. Any existing headers of the same name will be replaced.
    */
   def withHeaders(newHeaders: (String, String)*): FakeRequest[A] = {
-    withHeaders(headers.replace(newHeaders: _*))
+    withHeaders(headers.replace(newHeaders*))
   }
 
   /**

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
@@ -94,15 +94,15 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
   }
 
   override def withCookies(cookies: WSCookie*): Self = toWSRequest {
-    underlying.withCookies(cookies: _*)
+    underlying.withCookies(cookies*)
   }
 
   override def addCookies(cookies: WSCookie*): Self = toWSRequest {
-    underlying.addCookies(cookies: _*)
+    underlying.addCookies(cookies*)
   }
 
   override def withQueryStringParameters(parameters: (String, String)*): Self = toWSRequest {
-    underlying.withQueryStringParameters(parameters: _*)
+    underlying.withQueryStringParameters(parameters*)
   }
 
   override def withAuth(username: String, password: String, scheme: WSAuthScheme): Self = toWSRequest {
@@ -111,16 +111,16 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
 
   @deprecated("Use addHttpHeaders or withHttpHeaders", "2.6.0")
   override def withHeaders(hdrs: (String, String)*): Self = toWSRequest {
-    underlying.addHttpHeaders(hdrs: _*)
+    underlying.addHttpHeaders(hdrs*)
   }
 
   override def withHttpHeaders(headers: (String, String)*): Self = toWSRequest {
-    underlying.withHttpHeaders(headers: _*)
+    underlying.withHttpHeaders(headers*)
   }
 
   @deprecated("Use addQueryStringParameters or withQueryStringParameters", "2.6.0")
   override def withQueryString(parameters: (String, String)*): Self = toWSRequest {
-    underlying.addQueryStringParameters(parameters: _*)
+    underlying.addQueryStringParameters(parameters*)
   }
 
   override def withFollowRedirects(follow: Boolean): Self = toWSRequest {

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -395,7 +395,7 @@ final case class PekkoHeadersWrapper(
   }
 
   override def replace(headers: (String, String)*): Headers =
-    remove(headers.map(_._1): _*).add(headers: _*)
+    remove(headers.map(_._1)*).add(headers*)
 
   override def equals(other: Any): Boolean =
     other match {

--- a/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -162,7 +162,7 @@ private[cors] trait AbstractCORSPolicy {
       headerBuilder += ACCESS_CONTROL_EXPOSE_HEADERS -> corsConfig.exposedHeaders.mkString(",")
     }
 
-    result.withHeaders(headerBuilder.result(): _*)
+    result.withHeaders(headerBuilder.result()*)
   }
 
   private def handlePreFlightCORSRequest(request: RequestHeader): Accumulator[ByteString, Result] = {
@@ -282,7 +282,7 @@ private[cors] trait AbstractCORSPolicy {
                   headerBuilder += ACCESS_CONTROL_ALLOW_HEADERS -> accessControlRequestHeaders.mkString(",")
                 }
 
-                Accumulator.done(Results.Ok.withHeaders(headerBuilder.result(): _*))
+                Accumulator.done(Results.Ok.withHeaders(headerBuilder.result()*))
               }
             }
         }

--- a/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/csp/CSPResultProcessor.scala
@@ -44,7 +44,7 @@ class DefaultCSPResultProcessor @Inject() (cspProcessor: CSPProcessor) extends C
           .map { nonce => request.addAttr(RequestAttrKey.CSPNonce, nonce) }
           .getOrElse(request)
 
-        next(maybeNonceRequest).map { result => result.withHeaders(generateHeaders(cspResult): _*) }(
+        next(maybeNonceRequest).map { result => result.withHeaders(generateHeaders(cspResult)*) }(
           play.core.Execution.trampoline
         )
       }

--- a/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -171,7 +171,7 @@ class SecurityHeadersFilter @Inject() (config: SecurityHeadersConfig) extends Es
    */
   def apply(next: EssentialAction) = EssentialAction { req =>
     import play.core.Execution.Implicits.trampoline
-    next(req).map(result => result.withHeaders(headers(req, result): _*))
+    next(req).map(result => result.withHeaders(headers(req, result)*))
   }
 }
 

--- a/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -53,7 +53,7 @@ class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration) extends
     import play.api.libs.streams.Accumulator
     import play.core.Execution.Implicits.trampoline
     if (isSecure(req)) {
-      next(req).map(_.withHeaders(stsHeaders: _*))
+      next(req).map(_.withHeaders(stsHeaders*))
     } else if (isExcluded(req)) {
       logger.debug(s"Not redirecting to HTTPS because the path is included in exclude paths")
       next(req)

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPActionSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPActionSpec.scala
@@ -45,7 +45,7 @@ class JavaCSPActionSpec extends PlaySpecification {
 
   def withActionServer[T](config: (String, String)*)(block: Application => T): T = {
     val app = GuiceApplicationBuilder()
-      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
+      .configure(Map(config*) ++ Map("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
       .appRoutes(implicit app => { case _ => javaAction[JavaCSPActionSpec.MyAction]("index", myAction.index) })
       .build()
     block(app)

--- a/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csp/JavaCSPReportSpec.scala
@@ -51,7 +51,7 @@ class JavaCSPReportSpec extends PlaySpecification {
   def withActionServer[T](config: (String, String)*)(block: Application => T): T = {
     val app = GuiceApplicationBuilder()
       .configure(
-        Map(config: _*) ++ Map(
+        Map(config*) ++ Map(
           "play.http.secret.key"   -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b",
           "play.http.errorHandler" -> "play.http.JsonHttpErrorHandler"
         )

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -429,10 +429,10 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       request.withCookies(sessionCookieBaker.COOKIE_NAME -> sessionCookieBaker.encode(session.toMap))
     }
     def withCookies(cookies: (String, String)*): WSRequest = {
-      request.addCookies(cookies.map(c => DefaultWSCookie(c._1, c._2)): _*)
+      request.addCookies(cookies.map(c => DefaultWSCookie(c._1, c._2))*)
     }
     def addCookie(cookies: (String, String)*): WSRequest = {
-      request.addCookies(cookies.map(c => DefaultWSCookie(c._1, c._2)): _*)
+      request.addCookies(cookies.map(c => DefaultWSCookie(c._1, c._2))*)
     }
   }
 
@@ -443,7 +443,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       config: Seq[(String, String)]
   )(router: PartialFunction[(String, String), Handler])(block: (WSClient, Int) => T) = {
     implicit val app: Application = GuiceApplicationBuilder()
-      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
+      .configure(Map(config*) ++ Map("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
       .routes(router)
       .build()
     val ws = inject[WSClient]
@@ -454,7 +454,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       config: Seq[(String, Any)]
   )(router: Application => PartialFunction[(String, String), Handler])(block: (WSClient, Int) => T) = {
     implicit val app: Application = GuiceApplicationBuilder()
-      .configure(Map(config: _*) ++ Map("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
+      .configure(Map(config*) ++ Map("play.http.secret.key" -> "ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"))
       .appRoutes(app => router(app))
       .build()
     val ws = inject[WSClient]

--- a/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -523,7 +523,7 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
         case _ =>
           val Action = inject[DefaultActionBuilder]
           Action { implicit request: RequestHeader =>
-            Results.Ok(CSRF.getToken.fold("")(_.value)).withHeaders(responseHeaders: _*)
+            Results.Ok(CSRF.getToken.fold("")(_.value)).withHeaders(responseHeaders*)
           }
       }) { (ws, port) => handleResponse(await(makeRequest(ws.url("http://localhost:" + port)))) }
     }

--- a/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -58,7 +58,7 @@ class AllowedHostsFilterSpec extends PlaySpecification {
       headers: Seq[(String, String)] = Seq()
   ) = {
     val req = FakeRequest(method = "GET", path = uri)
-      .withHeaders(headers: _*)
+      .withHeaders(headers*)
       .withHeaders(HOST -> hostHeader)
     route(app, req).get
   }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose

use `scala213source3` for new varargs splice syntax. old varargs syntax deprecated in latest Scala 3.x

```
Welcome to Scala 3.6.4 (21.0.6, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> List(Nil : _*)
1 warning found
-- Warning: --------------------------------------------------------------------
1 |List(Nil : _*)
  |           ^
  |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
val res0: List[Nothing] = List()
                                                                                                                                             
scala> List(Nil *)
val res1: List[Nothing] = List()
```

## Background Context


## References

https://scalameta.org/scalafmt/docs/configuration.html#scala-2-with--xsource3