### PR TITLE
add `-Xsource:3` options for Scala 2.12 projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,6 @@ lazy val PlayRunSupportProject = PlayNonCrossBuiltProject("Play-Run-Support", "d
 lazy val PlayRoutesCompilerProject = PlayDevelopmentProject("Play-Routes-Compiler", "dev-mode/play-routes-compiler")
   .enablePlugins(SbtTwirl)
   .settings(
-    scalacOptions -= "-Xsource:3", // Since this is actually a sbt plugin and the codebase is 2.12, this flag causes problems when cross compiling
     scalacOptions ++= Seq("-release", "11"),
     libraryDependencies ++= routesCompilerDependencies(scalaVersion.value),
     TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")

--- a/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -244,7 +244,7 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
   def path: Parser[PathPattern] =
     "/" ~ ((positioned(singleComponentPathPart) | positioned(multipleComponentsPathPart) | positioned(
       regexComponentPathPart
-    ) | staticPathPart) *) ^^ {
+    ) | staticPathPart).*) ^^ {
       case _ ~ parts => PathPattern(parts)
     }
 
@@ -342,7 +342,7 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
         "HTTP Verb (GET, POST, ...), include (->), comment (#), or modifier line (+) expected"
       ) <~ ignoreWhiteSpace <~ (newLine | EOF)
 
-  def parser: Parser[List[Rule]] = phrase((blankLine | sentence *) <~ end) ^^ {
+  def parser: Parser[List[Rule]] = phrase((blankLine | sentence).* <~ end) ^^ {
     case routes =>
       routes.reverse
         .foldLeft(List[(Option[Rule], List[Comment], List[Modifier])]()) {

--- a/project/PlayBuildBase.scala
+++ b/project/PlayBuildBase.scala
@@ -56,8 +56,8 @@ object PlayBuildBase extends AutoPlugin {
     licenses             := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8") ++
       (CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 13)) => Seq("-Xsource:3")
-        case _             => Seq.empty
+        case Some((2, _)) => Seq("-Xsource:3")
+        case _            => Seq.empty
       }),
     javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
     resolvers ++= {


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose

prepare better Scala 3 cross build

https://docs.scala-lang.org/scala3/guides/migration/tooling-scala2-xsource3.html

## Background Context


## References

