### PR TITLE
refactor routes-parser

### DIFF
--- a/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
+++ b/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
@@ -11,7 +11,7 @@ import scala.util.parsing.input.Positional
 /**
  * A routing rule
  */
-sealed trait Rule extends Positional
+sealed trait Rule extends Positional with Sentence
 
 /**
  * A route
@@ -103,15 +103,19 @@ case class Parameter(name: String, typeName: String, fixed: Option[String], defa
     name + ":" + typeName + fixed.map(" = " + _).getOrElse("") + default.map(" ?= " + _).getOrElse("")
 }
 
+sealed trait Sentence
+
+case class ModifiersWithComment(modifiers: List[Modifier], commant: Option[Comment]) extends Sentence
+
 /**
  * A comment from the routes file.
  */
-case class Comment(comment: String)
+case class Comment(comment: String) extends Sentence
 
 /**
  * A modifier tag in the routes file
  */
-case class Modifier(value: String)
+case class Modifier(value: String) extends Sentence
 
 /**
  * A part of the path


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose

fix warnings and avoid `scala.Product` type.

```
[warn] /home/runner/work/playframework/playframework/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala:354:58: non-variable type argument play.routes.compiler.Modifier in type pattern List[play.routes.compiler.Modifier] (the underlying of List[play.routes.compiler.Modifier]) is unchecked since it is eliminated by erasure
[warn]           case ((r, comments, modifiers) :: others, (ms: List[Modifier], c: Option[Comment])) =>
[warn]                                                          ^
[warn] /home/runner/work/playframework/playframework/dev-mode/play-routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala:354:77: non-variable type argument play.routes.compiler.Comment in type pattern Option[play.routes.compiler.Comment] is unchecked since it is eliminated by erasure
[warn]           case ((r, comments, modifiers) :: others, (ms: List[Modifier], c: Option[Comment])) =>
[warn]                                                                             ^
```

## Background Context


## References

