### PR TITLE
[3.0.x] Fix `ClassCastException` when using `@With` Java annotation

### DIFF
--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -151,7 +151,11 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
     val firstUserDeclaredAction = annotations.actionMixins.foldLeft[JAction[_ <: Any]](endOfChainAction) {
       case (delegate, (annotation, actionClass, annotatedElement)) =>
         val action = handlerComponents.getAction(actionClass).asInstanceOf[play.mvc.Action[Object]]
-        action.configuration = annotation
+        action.configuration = annotation match {
+          case _: play.mvc.With =>
+            action.configuration // This will always be null anyway, but avoids a ClassCastException, see #13281
+          case _ => annotation
+        }
         delegate.precursor = action
         action.delegate = delegate
         action.annotatedElement = annotatedElement

--- a/core/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/core/play/src/main/scala/play/core/j/JavaAction.scala
@@ -152,9 +152,8 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
       case (delegate, (annotation, actionClass, annotatedElement)) =>
         val action = handlerComponents.getAction(actionClass).asInstanceOf[play.mvc.Action[Object]]
         action.configuration = annotation match {
-          case _: play.mvc.With =>
-            action.configuration // This will always be null anyway, but avoids a ClassCastException, see #13281
-          case _ => annotation
+          case _: play.mvc.With => null // avoids a ClassCastException, see #13281
+          case _                => annotation
         }
         delegate.precursor = action
         action.delegate = delegate


### PR DESCRIPTION
See 
- #13281

This does not fix the problem but at least avoids the `ClassCastException`

When using `@With` directly on an action method, there simply is no configuration.
Even the "Simple Action" that is used [in the docs](https://www.playframework.com/documentation/3.0.x/JavaActionsComposition#Composing-actions) when using `@With` make that clear and uses `Void`
https://github.com/playframework/playframework/blob/cf19f573ee76356a6e62ab6bca1b8cac0a3326c2/core/play/src/main/java/play/mvc/Action.java#L50-L51

However, what the author in #13281 tries, even fails with a `ClassCastException` when using `Action.Simple` because also `Void` can not be cast to the desired type.