### PR TITLE
use new intersection type syntax

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/test/WSEndpointSupport.scala
+++ b/core/play-integration-test/src/test/scala/play/it/test/WSEndpointSupport.scala
@@ -37,7 +37,7 @@ import play.core.server.ServerEndpoint
  * arbitrary scheme and port.
  */
 trait WSEndpointSupport {
-  self: EndpointIntegrationSpecification with FutureAwaits with DefaultAwaitTimeout =>
+  self: EndpointIntegrationSpecification & FutureAwaits & DefaultAwaitTimeout =>
 
   /** Describes a [[WSClient]] that is bound to a particular [[ServerEndpoint]]. */
   @implicitNotFound("Use withAllWSEndpoints { implicit wsEndpoint: WSEndpoint => ... } to get a value")

--- a/core/play/src/main/scala/play/api/mvc/Action.scala
+++ b/core/play/src/main/scala/play/api/mvc/Action.scala
@@ -98,7 +98,7 @@ trait Action[A] extends EssentialAction {
  */
 trait BodyParser[+A] extends (RequestHeader => Accumulator[ByteString, Either[Result, A]]) {
   // "with Any" because we need to prevent 2.12 SAM inference here
-  self: BodyParser[A] with Any =>
+  self: BodyParser[A] & Any =>
 
   /**
    * Uses the provided function to transform the BodyParser's computed result

--- a/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -419,7 +419,7 @@ trait RouteInvokers extends EssentialActionCaller {
 }
 
 trait ResultExtractors {
-  self: HeaderNames with Status =>
+  self: HeaderNames & Status =>
 
   /**
    * Extracts the Content-Type of this Content value.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -519,7 +519,7 @@ object NettyServer extends ServerFromRouter {
 
   protected override def createServerFromRouter(
       serverConf: ServerConfig
-  )(routes: ServerComponents with BuiltInComponents => Router): Server = {
+  )(routes: ServerComponents & BuiltInComponents => Router): Server = {
     new NettyServerComponents with BuiltInComponents with NoHttpFiltersComponents {
       override lazy val serverConfig: ServerConfig = serverConf
       override def router: Router                  = routes(this)

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -726,7 +726,7 @@ object PekkoHttpServer extends ServerFromRouter {
 
   protected override def createServerFromRouter(
       serverConf: ServerConfig = ServerConfig()
-  )(routes: ServerComponents with BuiltInComponents => Router): Server = {
+  )(routes: ServerComponents & BuiltInComponents => Router): Server = {
     new PekkoHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
       override lazy val serverConfig: ServerConfig = serverConf
       override def router: Router                  = routes(this)

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -375,7 +375,7 @@ trait ServerComponents {
  */
 private[server] trait ServerFromRouter {
   protected def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(
-      routes: ServerComponents with BuiltInComponents => Router
+      routes: ServerComponents & BuiltInComponents => Router
   ): Server
 
   /**


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes



## Purpose

old `with` syntax is deprecated in latest Scala 3

## Background Context

https://docs.scala-lang.org/scala3/book/types-intersection.html

## References

