### PR TITLE
Fix iterator for Cookies created via play.api.test.Helpers.cookies

### DIFF
--- a/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -530,11 +530,14 @@ trait ResultExtractors {
       of.map { result =>
         val cookies = result.newCookies
         new Cookies {
-          lazy val cookiesByName: Map[String, Cookie]    = cookies.groupBy(_.name).view.mapValues(_.head).toMap
+          // Takes the last value, since browsers usually respect
+          // the last Set-Cookie header when duplicate names are sent.
+          lazy val cookiesByName: Map[String, Cookie] = cookies.groupBy(_.name).view.mapValues(_.last).toMap
+
           override def get(name: String): Option[Cookie] = cookiesByName.get(name)
           override def foreach[U](f: Cookie => U): Unit  = cookies.foreach(f)
 
-          def iterator: Iterator[Cookie] = cookiesByName.valuesIterator
+          def iterator: Iterator[Cookie] = cookies.iterator
         }
       }(play.core.Execution.trampoline),
       timeout.duration

--- a/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -530,10 +530,7 @@ trait ResultExtractors {
       of.map { result =>
         val cookies = result.newCookies
         new Cookies {
-          // Takes the last value, since browsers usually respect
-          // the last Set-Cookie header when duplicate names are sent.
-          lazy val cookiesByName: Map[String, Cookie] = cookies.groupBy(_.name).view.mapValues(_.last).toMap
-
+          lazy val cookiesByName: Map[String, Cookie]    = cookies.groupBy(_.name).view.mapValues(_.head).toMap
           override def get(name: String): Option[Cookie] = cookiesByName.get(name)
           override def foreach[U](f: Cookie => U): Unit  = cookies.foreach(f)
 

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -159,10 +159,10 @@ class HelpersSpec extends Specification {
     }
 
     "extract cookies from a Result and return the last value for duplicate names when using `get`" in {
-      ckies.get("a") must beSome(cookieA2)
+      ckies.get("a") must beSome(cookieA1)
       ckies.get("b") must beSome(cookieB)
 
-      // Ensure that this behavior differs from Cookies created via play.api.mvc.Cookies.apply.
+      // Ensure that this behavior is the same like Cookies created via play.api.mvc.Cookies.apply.
       Cookies(cookiesForResult).get("a") must beSome(cookieA1)
     }
   }

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -137,6 +137,36 @@ class HelpersSpec extends Specification {
     }
   }
 
+  "cookies" should {
+    val cookieA1 = Cookie(name = "a", value = "a1")
+    val cookieA2 = Cookie(name = "a", value = "a2")
+    val cookieB  = Cookie(name = "b", value = "b")
+
+    val cookiesForResult: Seq[Cookie] = Seq(cookieA1, cookieA2, cookieB)
+    val result: Future[Result]        = Future.successful(NoContent.withCookies(cookiesForResult*))
+    val ckies: Cookies                = cookies(result)
+
+    "extract cookies from Result" in {
+      var i: Int = 0
+      ckies.foreach { cookie =>
+        cookie must_== cookiesForResult(i)
+        i += 1
+      }
+
+      // Ensure that all cookies are preserved when iterated over.
+      ckies.size must_== cookiesForResult.size
+      ckies.toSeq must_== cookiesForResult
+    }
+
+    "extract cookies from a Result and return the last value for duplicate names when using `get`" in {
+      ckies.get("a") must beSome(cookieA2)
+      ckies.get("b") must beSome(cookieB)
+
+      // Ensure that this behavior differs from Cookies created via play.api.mvc.Cookies.apply.
+      Cookies(cookiesForResult).get("a") must beSome(cookieA1)
+    }
+  }
+
   "redirectLocation" should {
     "extract location for 308 Permanent Redirect" in {
       redirectLocation(Future.successful(PermanentRedirect("/test"))) must beSome("/test")


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #13271

## Purpose

Fix iterator for Cookies created via `play.api.test.Helpers.cookies`.

## Background Context

- Cookies.iterator: https://github.com/playframework/playframework/blob/3.0.x/core/play/src/main/scala/play/api/mvc/Cookie.scala#L206

## References


