### PR TITLE
Update ScalaRequestBinders.md

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
@@ -2,7 +2,7 @@
 
 # Custom Routing
 
-Play provides a mechanism to bind types from path or query string parameters. 
+Play provides a mechanism to bind types from path or query string parameters. To use any custom type you should implement either [`PathBindable[A]`](api/scala/play/api/mvc/PathBindable.html)  or [`QueryStringBindable[A]`](api/scala/play/api/mvc/QueryStringBindable.html), make them implicit (or given for scala 3) and import the defined methods to your routes (add `play.sbt.routes.RoutesKeys.routesImport += "controllers.QueryBinders.given"` to your build.sbt file) 
 
 ## PathBindable
 


### PR DESCRIPTION
Adding routesImport section which is essential to use custom routing binders. Without adding it a user wont' be able to use the binders he implements.

## Fixes

Fixes documentation wasn't complete. I have added the missing part 

## Purpose

To make the documentation complete so users don't get confused with error like "No QueryString binder found for type ..."

## Background Context

I faced the same issues when I forgot to import the custom binders but when I checked the docs I didn't find that mentioned so I decided to complete to docs
