### PR TITLE
[3.0.x] Pin caffeine

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -80,7 +80,9 @@ updates.pin = [
   { groupId = "com.zaxxer", artifactId = "HikariCP", version = "5.0." },
   { groupId = "net.logstash.logback", artifactId = "logstash-logback-encoder", version = "7.3." },
   { groupId = "org.specs2", version = "4.20." },
-  { groupId = "org.scalacheck", artifactId = "scalacheck", version = "1.17.0." }
+  { groupId = "org.scalacheck", artifactId = "scalacheck", version = "1.17.0." },
+  { groupId = "com.github.ben-manes", artifactId = "caffeine", version = "3.1." },
+  { groupId = "com.github.ben-manes", artifactId = "jcache", version = "3.1." }
 ]
 
 updatePullRequests = never


### PR DESCRIPTION
As long as there are no CVE's there is not reason to upgrade to 3.2 which might break.

- #13321
- #13305