### PR TITLE
Fix pattern match exhaustivity warning in PekkoRequestTimeoutSpec

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/PekkoRequestTimeoutSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/PekkoRequestTimeoutSpec.scala
@@ -26,8 +26,8 @@ class PekkoRequestTimeoutSpec extends PlaySpecification with PekkoHttpIntegratio
   "play.server.pekko.requestTimeout configuration" should {
     def withServer[T](httpTimeout: Duration)(action: EssentialAction)(block: Port => T) = {
       def getTimeout(d: Duration) = d match {
-        case Duration.Inf   => "null"
-        case Duration(t, u) => s"${u.toMillis(t)}ms"
+        case _: Duration.Infinite => "null"
+        case fd: FiniteDuration   => s"${fd.toMillis}ms"
       }
       val props = new Properties(System.getProperties)
       (props: java.util.Map[Object, Object]).putAll(


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
## Fixes

Fix pattern match exhaustivity warning in PekkoRequestTimeoutSpec

## Purpose

I fixed the following warning

```scala
[warn] /Users/toshi/work/github.com/playframework/playframework/core/play-integration-test/src/test/scala/play/it/http/PekkoRequestTimeoutSpec.scala:28:37: match may not be exhaustive.
[warn] It would fail on the following inputs: (_ : scala.concurrent.duration.Duration.Infinite#<local child>), FiniteDuration()
[warn]       def getTimeout(d: Duration) = d match {
[warn]                                     ^
[warn] one warning found
```
