### PR TITLE
Fix pattern match exhaustivity warning in IdleTimeoutSpec

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -28,8 +28,8 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
 
   def timeouts(httpTimeout: Duration, httpsTimeout: Duration): Map[String, String] = {
     def getTimeout(d: Duration) = d match {
-      case Duration.Inf   => "null"
-      case Duration(t, u) => s"${u.toMillis(t)}ms"
+      case _: Duration.Infinite => "null"
+      case fd: FiniteDuration   => s"${fd.toMillis}ms"
     }
 
     Map(


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->
## Fixes

Fix pattern match exhaustivity warning in IdleTimeoutSpec.

Related https://github.com/playframework/playframework/pull/13335

## Purpose

I fixed the following warning

```scala
[warn] /Users/toshi/work/github.com/playframework/playframework/core/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala:30:35: match may not be exhaustive.
[warn] It would fail on the following inputs: (_ : scala.concurrent.duration.Duration.Infinite#<local child>), FiniteDuration()
[warn]     def getTimeout(d: Duration) = d match {
[warn]                                   ^
[warn] 8 warnings found
```
