### PR TITLE
Fix Gradle Publishing to Central Portal

### DIFF
--- a/dev-mode/gradle-plugin/build.gradle.kts
+++ b/dev-mode/gradle-plugin/build.gradle.kts
@@ -90,7 +90,10 @@ nexusPublishing {
     packageGroup.set(project.group.toString())
     clientTimeout.set(Duration.ofMinutes(60))
     this.repositories {
-        sonatype()
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
     }
 }
 


### PR DESCRIPTION
Without this I get 401 locally, when applying this it seems to work...

From https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/