### PR TITLE
Generate and set the request-id as early as possible

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
@@ -84,7 +84,7 @@ object RequestFactory {
 /**
  * The default [[RequestFactory]] used by a Play application. This
  * `RequestFactory` adds the following typed attributes to requests:
- * - request id
+ * - request id (if not existing yet)
  * - cookie
  * - session cookie
  * - flash cookie
@@ -108,7 +108,8 @@ class DefaultRequestFactory @Inject() (
       headers: Headers,
       attrs: TypedMap
   ): RequestHeader = {
-    val requestId: Long = RequestIdProvider.freshId()
+    // Generate a new request ID only if one has not already been generated at an earlier stage
+    val requestId: Long = attrs.get(RequestAttrKey.Id).getOrElse(RequestIdProvider.freshId())
     val cookieCell      = new LazyCell[Cookies] {
       protected override def emptyMarker: Cookies = null
       protected override def create: Cookies      =

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -16,6 +16,7 @@ import play.api.libs.typedmap.TypedKey
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.request.DefaultRequestFactory
 import play.api.mvc.request.RemoteConnection
+import play.api.mvc.request.RequestAttrKey
 import play.api.mvc.request.RequestTarget
 
 class RequestHeaderSpec extends Specification {
@@ -206,6 +207,19 @@ class RequestHeaderSpec extends Specification {
         accept("en-US;q=0.7, es") must contain(exactly(Lang("es"), Lang("en-US")).inOrder)
       }
     }
+
+    "have request id" in {
+      "generated if it does not exist yet" in {
+        val rh = dummyRequestHeader()
+        // The request id will likely be somewhere from 1 to 10000 in the tests
+        rh.id must beBetween(1L, 10000L)
+        rh.attrs(RequestAttrKey.Id) must beBetween(1L, 10000L)
+      }
+
+      "not generated if one exists in the attrs already" in {
+        dummyRequestHeader(attrs = TypedMap(RequestAttrKey.Id -> 987656789)).id must_== 987656789
+      }
+    }
   }
 
   private def accept(value: String) =
@@ -216,7 +230,8 @@ class RequestHeaderSpec extends Specification {
   private def dummyRequestHeader(
       requestMethod: String = "GET",
       requestUri: String = "/",
-      headers: Headers = Headers()
+      headers: Headers = Headers(),
+      attrs: TypedMap = TypedMap.empty
   ): RequestHeader = {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
       connection = RemoteConnection("", false, None),
@@ -224,7 +239,7 @@ class RequestHeaderSpec extends Specification {
       target = RequestTarget(requestUri, "", Map.empty),
       version = "",
       headers = headers,
-      attrs = TypedMap.empty
+      attrs = attrs
     )
   }
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -42,6 +42,7 @@ import play.api.Logger
 import play.core.server.common.ForwardedHeaderHandler
 import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
+import play.core.system.RequestIdProvider
 
 private[server] class NettyModelConversion(
     resultUtils: ServerResultUtils,
@@ -127,10 +128,14 @@ private[server] class NettyModelConversion(
       target,
       request.protocolVersion.text(),
       headers,
-      // Send an attribute so our tests can tell which kind of server we're using.
-      // We only do this for the "non-default" engine, so we used to tag
-      // pekko-http explicitly, so that benchmarking isn't affected by this.
-      TypedMap(RequestAttrKey.Server -> "netty")
+      TypedMap(
+        // Send an attribute so our tests can tell which kind of server we're using.
+        // We only do this for the "non-default" engine, so we used to tag
+        // pekko-http explicitly, so that benchmarking isn't affected by this.
+        RequestAttrKey.Server -> "netty",
+        // This is the earliest stage of a Play request at which we can set an id.
+        RequestAttrKey.Id -> RequestIdProvider.freshId(),
+      )
     )
   }
 

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -29,11 +29,13 @@ import play.api.http.HttpErrorHandler
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
 import play.api.mvc.request.RemoteConnection
+import play.api.mvc.request.RequestAttrKey
 import play.api.mvc.request.RequestTarget
 import play.api.Logger
 import play.core.server.common.ForwardedHeaderHandler
 import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
+import play.core.system.RequestIdProvider
 import play.mvc.Http.HeaderNames
 
 /**
@@ -109,7 +111,10 @@ private[server] class PekkoModelConversion(
       requestTarget,
       request.protocol.value,
       headers,
-      TypedMap.empty
+      TypedMap(
+        // This is the earliest stage of a Play request at which we can set an id.
+        RequestAttrKey.Id -> RequestIdProvider.freshId(),
+      )
     )
   }
 


### PR DESCRIPTION
Improvement thanks to
- #13406

Makes sure that calling `attrs(RequestAttrKey.Id)` always returns an id, even if the request was rejected by the server backend (before Play parses any headers to set the cookies, etc.)

https://github.com/playframework/playframework/blob/6a4473c5632c4b736be86a7d7990d2bc31bc2e18/core/play/src/main/scala/play/api/mvc/RequestHeader.scala#L40

Also in the light of 
- #13204

it makes a lot of sense to generate and set the request id as early as possible as #13204 will include a timestamp in the id.

