### PR TITLE
Make sure Java's Session and Flash always exists even if empty req attrs

### DIFF
--- a/core/play-java/src/test/java/play/mvc/AttributesTest.java
+++ b/core/play-java/src/test/java/play/mvc/AttributesTest.java
@@ -5,6 +5,7 @@
 package play.mvc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -16,6 +17,7 @@ import org.junit.runners.Parameterized.Parameters;
 import play.core.j.RequestHeaderImpl;
 import play.libs.typedmap.TypedEntry;
 import play.libs.typedmap.TypedKey;
+import play.libs.typedmap.TypedMap;
 
 @RunWith(Parameterized.class)
 public final class AttributesTest {
@@ -117,5 +119,25 @@ public final class AttributesTest {
     assertTrue(newRequestHeader.attrs().containsKey(color));
     assertEquals(((Long) 5L), newRequestHeader.attrs().get(number));
     assertEquals("white", newRequestHeader.attrs().get(color));
+  }
+
+  @Test
+  public void testRequestHeader_emptyAttributesCookies() {
+    Http.RequestHeader newRequestHeader = requestHeader.withAttrs(TypedMap.empty());
+    assertFalse(newRequestHeader.cookies().iterator().hasNext());
+  }
+
+  @Test
+  public void testRequestHeader_emptyAttributesSession() {
+    Http.RequestHeader newRequestHeader = requestHeader.withAttrs(TypedMap.empty());
+    assertTrue(newRequestHeader.session().data().isEmpty());
+    assertTrue(newRequestHeader.session().asScala().isEmpty());
+  }
+
+  @Test
+  public void testRequestHeader_emptyAttributesFlash() {
+    Http.RequestHeader newRequestHeader = requestHeader.withAttrs(TypedMap.empty());
+    assertTrue(newRequestHeader.flash().data().isEmpty());
+    assertTrue(newRequestHeader.flash().asScala().isEmpty());
   }
 }

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -373,7 +373,10 @@ public class Http {
      * {@link Cell} to store the session cookie, to allow it to be evaluated on-demand.
      */
     default Session session() {
-      return attrs().get(RequestAttrKey.Session().asJava()).value().asJava();
+      return attrs()
+          .getOptional(RequestAttrKey.Session().asJava())
+          .map(cell -> cell.value().asJava())
+          .orElseGet(() -> new Session());
     }
 
     /**
@@ -382,7 +385,10 @@ public class Http {
      * store the flash, to allow it to be evaluated on-demand.
      */
     default Flash flash() {
-      return attrs().get(RequestAttrKey.Flash().asJava()).value().asJava();
+      return attrs()
+          .getOptional(RequestAttrKey.Flash().asJava())
+          .map(cell -> cell.value().asJava())
+          .orElseGet(() -> new Flash());
     }
 
     /**


### PR DESCRIPTION
Same as 

- #13407

but for the Java API.

I thought Java's RequestHeader just passes through to the underlying Scala rh methods, but it turns out only for cookies, but not for Flash and Session.

The tests in the first commit I push should fail with:

```
[info] Test run play.mvc.AttributesTest started
[info] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesSession[0] started
[error] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesSession[0] failed: java.util.NoSuchElementException: key not found: Session, took 0.002 sec
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:243)
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:239)
[error]     at play.api.libs.typedmap.DefaultTypedMap.apply(TypedMap.scala:189)
[error]     at play.libs.typedmap.TypedMap.get(TypedMap.java:47)
[error]     at play.mvc.Http$RequestHeader.session(Http.java:376)
[error]     at play.core.j.RequestHeaderImpl.session(JavaHelpers.scala:195)
[error]     at play.mvc.AttributesTest.testRequestHeader_emptyAttributesSession(AttributesTest.java:133)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[error]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:569)
[error]     ...
[info] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesFlash[0] started
[error] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesFlash[0] failed: java.util.NoSuchElementException: key not found: Flash, took 0.0 sec
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:243)
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:239)
[error]     at play.api.libs.typedmap.DefaultTypedMap.apply(TypedMap.scala:189)
[error]     at play.libs.typedmap.TypedMap.get(TypedMap.java:47)
[error]     at play.mvc.Http$RequestHeader.flash(Http.java:385)
[error]     at play.core.j.RequestHeaderImpl.flash(JavaHelpers.scala:195)
[error]     at play.mvc.AttributesTest.testRequestHeader_emptyAttributesFlash(AttributesTest.java:140)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[error]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:569)
[error]     ...
[info] Test play.mvc.AttributesTest.testRequestHeader_KeepCurrentAttributesWhenAddingMultipleOnes[0] started
[info] Test play.mvc.AttributesTest.testRequestHeader_OverrideExistingValueWhenAddingMultipleAttributes[0] started
[info] Test play.mvc.AttributesTest.testRequestHeader_OverrideExistingValue[0] started
[info] Test play.mvc.AttributesTest.testRequestHeader_addMultipleAttributes[0] started
[info] Test play.mvc.AttributesTest.testRequestHeader_addSingleAttribute[0] started
[info] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesCookies[0] started
[error] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesCookies[0] failed: java.util.NoSuchElementException: key not found: Cookies, took 0.0 sec
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:243)
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:239)
[error]     at play.api.libs.typedmap.DefaultTypedMap.apply(TypedMap.scala:189)
[error]     at play.api.mvc.RequestHeader.cookies(RequestHeader.scala:269)
[error]     at play.api.mvc.RequestHeader.cookies$(RequestHeader.scala:269)
[error]     at play.api.mvc.RequestImpl.cookies(Request.scala:145)
[error]     at play.core.j.RequestHeaderImpl.cookies(JavaHelpers.scala:227)
[error]     at play.mvc.AttributesTest.testRequestHeader_emptyAttributesCookies(AttributesTest.java:127)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[error]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:569)
[error]     ...
[info] Test play.mvc.AttributesTest.testRequestHeader_KeepCurrentAttributesWhenAddingANewOne[0] started
[info] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesSession[1] started
[error] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesSession[1] failed: java.util.NoSuchElementException: key not found: Session, took 0.0 sec
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:243)
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:239)
[error]     at play.api.libs.typedmap.DefaultTypedMap.apply(TypedMap.scala:189)
[error]     at play.libs.typedmap.TypedMap.get(TypedMap.java:47)
[error]     at play.mvc.Http$RequestHeader.session(Http.java:376)
[error]     at play.core.j.RequestHeaderImpl.session(JavaHelpers.scala:195)
[error]     at play.mvc.AttributesTest.testRequestHeader_emptyAttributesSession(AttributesTest.java:133)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[error]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:569)
[error]     ...
[info] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesFlash[1] started
[error] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesFlash[1] failed: java.util.NoSuchElementException: key not found: Flash, took 0.001 sec
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:243)
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:239)
[error]     at play.api.libs.typedmap.DefaultTypedMap.apply(TypedMap.scala:189)
[error]     at play.libs.typedmap.TypedMap.get(TypedMap.java:47)
[error]     at play.mvc.Http$RequestHeader.flash(Http.java:385)
[error]     at play.core.j.RequestHeaderImpl.flash(JavaHelpers.scala:195)
[error]     at play.mvc.AttributesTest.testRequestHeader_emptyAttributesFlash(AttributesTest.java:140)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[error]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:569)
[error]     ...
[info] Test play.mvc.AttributesTest.testRequestHeader_KeepCurrentAttributesWhenAddingMultipleOnes[1] started
[info] Test play.mvc.AttributesTest.testRequestHeader_OverrideExistingValueWhenAddingMultipleAttributes[1] started
[info] Test play.mvc.AttributesTest.testRequestHeader_OverrideExistingValue[1] started
[info] Test play.mvc.AttributesTest.testRequestHeader_addMultipleAttributes[1] started
[info] Test play.mvc.AttributesTest.testRequestHeader_addSingleAttribute[1] started
[info] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesCookies[1] started
[error] Test play.mvc.AttributesTest.testRequestHeader_emptyAttributesCookies[1] failed: java.util.NoSuchElementException: key not found: Cookies, took 0.0 sec
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:243)
[error]     at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:239)
[error]     at play.api.libs.typedmap.DefaultTypedMap.apply(TypedMap.scala:189)
[error]     at play.api.mvc.RequestHeader.cookies(RequestHeader.scala:269)
[error]     at play.api.mvc.RequestHeader.cookies$(RequestHeader.scala:269)
[error]     at play.api.mvc.RequestImpl.cookies(Request.scala:145)
[error]     at play.core.j.RequestHeaderImpl.cookies(JavaHelpers.scala:227)
[error]     at play.mvc.AttributesTest.testRequestHeader_emptyAttributesCookies(AttributesTest.java:127)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[error]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:569)
[error]     ...
[info] Test play.mvc.AttributesTest.testRequestHeader_KeepCurrentAttributesWhenAddingANewOne[1] started
[info] Test run play.mvc.AttributesTest finished: 6 failed, 0 ignored, 18 total, 0.01s
```