### PR TITLE
A call to `onClientError` from the server backend was missing the `HttpErrorInfo` attr

### DIFF
--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -182,7 +182,7 @@ private[play] final class ServerResultUtils(
         // Call the HttpErrorHandler to generate an alternative error
         val futureErrorResult = if (isInvalidHeaderCharacter) {
           errorHandler.onClientError(
-            requestHeader,
+            requestHeader.addAttr(HttpErrorHandler.Attrs.HttpErrorInfo, HttpErrorInfo("server-backend")),
             400,
             s"Invalid header: ${conversionError.getMessage()}"
           )


### PR DESCRIPTION
The changed code is part of the [`resultConversionWithErrorHandling` method](https://github.com/playframework/playframework/blob/3.0.8/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala#L159-L163). Obviously that code lives in `transport/server/` and is part of the backend servers and only gets called by 
- the [Netty backend's `NettyModelConversion`](https://github.com/playframework/playframework/blob/3.0.8/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala#L168)
- the [Pekko HTTP's `PekkoModelConversion`](https://github.com/playframework/playframework/blob/3.0.8/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala#L179)

When calling `onServerError` from one of the backends we alway add a `"server-backend"` `HttpErrorInfo` attr:
https://github.com/playframework/playframework/blob/6a4473c5632c4b736be86a7d7990d2bc31bc2e18/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala#L118
https://github.com/playframework/playframework/blob/6a4473c5632c4b736be86a7d7990d2bc31bc2e18/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala#L342
https://github.com/playframework/playframework/blob/6a4473c5632c4b736be86a7d7990d2bc31bc2e18/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala#L477

Seems like I missed this one :cry: 

Introduced in
- #10270