### PR TITLE
fix routes cache directory

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -176,7 +176,7 @@ object RoutesCompiler extends AutoPlugin {
       routesCompilerTasks.value,
       routesGenerator.value,
       (routes / target).value,
-      streams.value.cacheDirectory,
+      streams.value.cacheDirectory / scalaVersion.value,
       log
     )
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-cache/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-cache/build.sbt
@@ -1,0 +1,19 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+enablePlugins(PlayScala)
+
+def Scala3 = "3.7.2"
+
+scalaVersion := Scala3
+
+crossScalaVersions := Seq("2.13.16", Scala3)
+
+TaskKey[Unit]("check") := {
+  val dir = crossTarget.value
+  (Compile / managedSources).value.foreach{ src =>
+    assert(
+      IO.relativize(dir, src).isDefined,
+      s"scalaVersion = ${scalaVersion.value}, file = $src"
+    )
+  }
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-cache/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-cache/conf/routes
@@ -1,0 +1,3 @@
+# Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+GET  /public/*file  controllers.Assets.versioned(path="/public", file: Asset)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-cache/project/plugins.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-cache/project/plugins.sbt
@@ -1,0 +1,3 @@
+// Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+
+addSbtPlugin("org.playframework" % "sbt-plugin" % sys.props("project.version"))

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-cache/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-cache/test
@@ -1,0 +1,2 @@
+> + compile
+> + check


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

fix cache directory location. don't use `target/scala-2.13/routes/` sources if Scala 3.

## Purpose

see scripted test. following error if without this fix

```
[info] [error] java.lang.AssertionError: assertion failed: scalaVersion = 3.7.2, file = /private/var/folders/nz/vb2z3s8j7719gg71zgz9gj_40000gn/T/sbt_c167a6a1/target/scala-2.13/routes/main/controllers/routes.java
[info] [error] 	at scala.Predef$.assert(Predef.scala:223)
[info] [error] 	at $ef7a6fd61184684303de$.$anonfun$$sbtdef$2(/private/var/folders/nz/vb2z3s8j7719gg71zgz9gj_40000gn/T/sbt_c167a6a1/build.sbt:14)
[info] [error] 	at $ef7a6fd61184684303de$.$anonfun$$sbtdef$2$adapted(/private/var/folders/nz/vb2z3s8j7719gg71zgz9gj_40000gn/T/sbt_c167a6a1/build.sbt:13)
[info] [error] 	at scala.collection.immutable.List.foreach(List.scala:431)
[info] [error] 	at $ef7a6fd61184684303de$.$anonfun$$sbtdef$1(/private/var/folders/nz/vb2z3s8j7719gg71zgz9gj_40000gn/T/sbt_c167a6a1/build.sbt:13)
[info] [error] 	at $ef7a6fd61184684303de$.$anonfun$$sbtdef$1$adapted(/private/var/folders/nz/vb2z3s8j7719gg71zgz9gj_40000gn/T/sbt_c167a6a1/build.sbt:11)
```

## Background Context


## References

