### PR TITLE
Fix deprecated notice in WSResponse#getBodyAsStream

### DIFF
--- a/transport/client/play-ws/src/main/java/play/libs/ws/WSResponse.java
+++ b/transport/client/play-ws/src/main/java/play/libs/ws/WSResponse.java
@@ -93,7 +93,7 @@ public interface WSResponse extends StandaloneWSResponse {
   /**
    * Gets the body as a stream.
    *
-   * @deprecated use {@link #getBody(BodyReadable)} with {@code WSBodyWritables.inputStream()}.
+   * @deprecated use {@link #getBody(BodyReadable)} with {@link WSBodyReadables#inputStream()}.
    */
   @Deprecated
   InputStream getBodyAsStream();


### PR DESCRIPTION
This PR fixes a minor documentation mistake introduced in Play 2.6 via #7413. The `@deprecated` notice in `getBodyAsStream()` from `WSResponse` was suggesting to combine `getBody(BodyReadable)` with `WSBodyWritables#inputStream()`, but it should have suggested `WSBodyReadables#inputStream()` instead. 
