### PR TITLE
add parentheses for `PathFinder.get`

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -96,7 +96,7 @@ object PlaySettings {
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "--ignore-runners=org.specs2.runner.JUnitRunner"),
     // Adds app directory's source files to continuous hot reloading
     watchSources ++= {
-      ((Compile / sourceDirectory).value ** "*" --- (Assets / sourceDirectory).value ** "*").get
+      ((Compile / sourceDirectory).value ** "*" --- (Assets / sourceDirectory).value ** "*").get()
     },
     commands ++= {
       import PlayCommands._
@@ -186,7 +186,7 @@ object PlaySettings {
           val docDirectory    = (Compile / doc).value
           val docDirectoryLen = docDirectory.getCanonicalPath.length
           val pathFinder      = docDirectory ** "*"
-          pathFinder.get.map { (docFile: File) =>
+          pathFinder.get().map { (docFile: File) =>
             docFile -> ("share/doc/api/" + docFile.getCanonicalPath.substring(docDirectoryLen))
           }
         }
@@ -198,7 +198,7 @@ object PlaySettings {
     }.value,
     Universal / mappings ++= {
       val pathFinder = baseDirectory.value * "README*"
-      pathFinder.get.map { (readmeFile: File) => readmeFile -> readmeFile.getName }
+      pathFinder.get().map { (readmeFile: File) => readmeFile -> readmeFile.getName }
     },
     // Adds the Play application directory to the command line args passed to Play
     bashScriptExtraDefines += "addJava \"-Duser.dir=$(realpath \"$(cd \"${app_home}/..\"; pwd -P)\"  $(is_cygwin && echo \"fix\"))\"\n",
@@ -207,7 +207,7 @@ object PlaySettings {
     // by default, compile any routes files in the root named "routes" or "*.routes"
     Compile / RoutesKeys.routes / sources ++= {
       val dirs = (Compile / unmanagedResourceDirectories).value
-      (dirs * "routes").get ++ (dirs * "*.routes").get
+      (dirs * "routes").get() ++ (dirs * "*.routes").get()
     },
     inConfig(Compile)(externalizedSettings),
     // Avoid duplicated asset files in dist packages, see https://github.com/playframework/playframework/issues/5765


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose

prepare sbt 2.x build

```
[error] 210 |      (dirs * "routes").get ++ (dirs * "*.routes").get
[error]     |                               ^^^^^^^^^^^^^^^^^^^^^^^
[error]     |        method get in class PathFinder must be called with () argument
[error]     |
[error]     | longer explanation available when compiling with `-explain`
```

https://github.com/sbt/io/blob/514d9dad8f7ddf4529a276f2d6a8f211697d900c/io/src/main/scala/sbt/io/Path.scala#L448

## Background Context


## References

