### PR TITLE
avoid `scala.collection.breakOut`

### DIFF
--- a/dev-mode/play-docs-sbt-plugin/src/main/scala/org/playframework/docs/sbtplugin/PlayDocsValidation.scala
+++ b/dev-mode/play-docs-sbt-plugin/src/main/scala/org/playframework/docs/sbtplugin/PlayDocsValidation.scala
@@ -12,7 +12,6 @@ import java.net.URI
 import java.util.concurrent.Executors
 import java.util.jar.JarFile
 
-import scala.collection.breakOut
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.Duration
@@ -61,7 +60,7 @@ object PlayDocsValidation {
    */
   case class CodeSamplesReport(files: Seq[FileWithCodeSamples]) {
     lazy val byFile: Map[String, FileWithCodeSamples] =
-      files.map(f => f.name -> f)(breakOut)
+      files.map(f => f.name -> f).toMap
 
     lazy val byName: Map[String, FileWithCodeSamples] = files.collect {
       case file if !file.name.endsWith("_Sidebar.md") =>
@@ -69,7 +68,7 @@ object PlayDocsValidation {
         val name     = filename.takeRight(filename.length - filename.lastIndexOf('/'))
 
         name -> file
-    }(breakOut)
+    }.toMap
   }
   case class FileWithCodeSamples(name: String, source: String, codeSamples: Seq[CodeSample])
   case class CodeSample(source: String, segment: String, sourcePosition: Int, segmentPosition: Int)
@@ -379,7 +378,7 @@ object PlayDocsValidation {
     val pageIndex = PageIndex.parseFrom(combinedRepo, "", None)
 
     val pages: Map[String, File] =
-      report.markdownFiles.map(f => f.getName.dropRight(3) -> f)(breakOut)
+      report.markdownFiles.map(f => f.getName.dropRight(3) -> f).toMap
 
     var failed = false
 

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -201,7 +201,7 @@ object RoutesCompiler extends AutoPlugin {
             errs ++= details
             op -> OpFailure
         }
-      }(scala.collection.breakOut)
+      }.toMap
 
       opResults -> errs.result()
     }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -179,7 +179,7 @@ object BuildSettings {
             None
         }
         url <- urlOption
-      } yield fullyFile -> url)(collection.breakOut(Map.canBuildFrom))
+      } yield fullyFile -> url).toMap
     }
   )
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes


## Purpose

prepare sbt 2.x build. `scala.collection.breakOut` removed since Scala 2.13

## Background Context


## References

