### PR TITLE
[3.0.x] Declare Java 25 LTS officially supported

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -78,9 +78,9 @@ object PlaySettings {
             |https://www.playframework.com/sponsors
             |
             |""".stripMargin +
-        (if (javaVersion != "11" && javaVersion != "17" && javaVersion != "21")
+        (if (javaVersion != "11" && javaVersion != "17" && javaVersion != "21" && javaVersion != "25")
            s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-              |  Java version is ${sys.props("java.specification.version")}. Play supports only Java 11, 17 and 21.
+              |  Java version is ${sys.props("java.specification.version")}. Play supports only Java 11, 17, 21 and 25.
               |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
               |
               |""".stripMargin


### PR DESCRIPTION
_All_ tests pass with Java 25 final release candiate:
- #13490
- #13495

IMHO there is no reason why not declare it as supported.

History shows that the final RC of a Java release usually becomes the final release:
- [Java 21 final RC becomes final release](https://mail.openjdk.org/pipermail/jdk-dev/2023-September/008267.html)
- [Java 22 final RC becomes final release](https://mail.openjdk.org/pipermail/jdk-dev/2024-March/008827.html)
- [Java 23 final RC becomes final release](https://mail.openjdk.org/pipermail/jdk-dev/2024-September/009395.html)
- [Java 24 final RC becomes final release](https://mail.openjdk.org/pipermail/jdk-dev/2025-March/009843.html)

There are not P1 bugs reported yet: https://bugs.openjdk.org/issues/?filter=33410

Therefore it's very very likely to say nothing relevant will change anymore that would influence Play's support for Java 25 until its final release in 2 weeks from today.

Regarding Scala:
They will upgrad ASM in all of their next releases so they officially declarse Java 25 support as well:
- Scala 3.3.7: https://github.com/scala/scala3/commit/9ebb8c4062148dec314f55c86c9d139741da5eb6
- 2.12.21 and 2.13.17: https://github.com/scala/scala/commit/edac1eb162d8599d3df16c41e3b08c42bdf91c3e

For Play this is not relevant as it seems, but end users likely want to upgrade to that latest Scala versions when they are out.