### PR TITLE
[3.0.x] Nicer warning for unsupported Java versions

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -60,7 +60,10 @@ object PlaySettings {
   // Settings for a Play service (not a web project)
   lazy val serviceSettings: Seq[Setting[_]] = Def.settings(
     onLoadMessage := {
-      val javaVersion = sys.props("java.specification.version")
+      val javaVersion            = sys.props("java.specification.version")
+      val unsupportedJavaWarning =
+        s"Java version is ${sys.props("java.specification.version")}. Play supports only Java 11, 17, 21 and 25."
+      val exclamationMarksWarning = "!".repeat(unsupportedJavaWarning.length + 4)
       """|  __              __
          |  \ \     ____   / /____ _ __  __
          |   \ \   / __ \ / // __ `// / / /
@@ -79,9 +82,9 @@ object PlaySettings {
             |
             |""".stripMargin +
         (if (javaVersion != "11" && javaVersion != "17" && javaVersion != "21" && javaVersion != "25")
-           s"""!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-              |  Java version is ${sys.props("java.specification.version")}. Play supports only Java 11, 17, 21 and 25.
-              |!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+           s"""${Colors.red(exclamationMarksWarning)}
+              |  ${Colors.red(unsupportedJavaWarning)}
+              |${Colors.red(exclamationMarksWarning)}
               |
               |""".stripMargin
          else "")


### PR DESCRIPTION
Just cosmetics. Make the exclamation marks fit the message length.

Also made the message red to it stands out.

Tested locally.

Before:

<img width="1522" height="120" alt="image" src="https://github.com/user-attachments/assets/a8390619-4afb-42aa-9822-2dbd18c7309b" />

After:
<img width="1520" height="120" alt="image" src="https://github.com/user-attachments/assets/6980760d-94ed-4e19-89c0-fd5431160155" />
