### PR TITLE
Scala3 compat pt2

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -14,6 +14,7 @@ import sbt.State
 import sbt.TaskKey
 import sbt.Value
 
+import play.sbt.routes.RoutesKeys.LazyProjectReference
 import xsbti.FileConverter
 
 object PluginCompat {
@@ -26,4 +27,5 @@ object PluginCompat {
   def fileName(file: FileRef): String                                                   = file.getName
   def toNioPath(f: File)(implicit conv: FileConverter): NioPath                         = f.toPath
   def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]                   = c.files
+  def createLazyProjectRef(p: Project): LazyProjectReference                            = new LazyProjectReference(p)
 }

--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -7,14 +7,8 @@ package play.sbt
 import java.io.File
 import java.nio.file.{ Path => NioPath }
 
-import sbt.AttributeMap
+import sbt.*
 import sbt.Def.Classpath
-import sbt.Project
-import sbt.Result
-import sbt.State
-import sbt.Task
-import sbt.TaskKey
-import sbt.Value
 
 import play.sbt.routes.RoutesKeys.LazyProjectReference
 import xsbti.FileConverter
@@ -31,4 +25,5 @@ object PluginCompat {
   def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]                   = c.files
   def createLazyProjectRef(p: Project): LazyProjectReference                            = new LazyProjectReference(p)
   def getAttributeMap(t: Task[?]): AttributeMap                                         = t.info.attributes
+  def toKey(settingKey: SettingKey[String]): AttributeKey[String]                       = settingKey.key
 }

--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -7,10 +7,12 @@ package play.sbt
 import java.io.File
 import java.nio.file.{ Path => NioPath }
 
+import sbt.AttributeMap
 import sbt.Def.Classpath
 import sbt.Project
 import sbt.Result
 import sbt.State
+import sbt.Task
 import sbt.TaskKey
 import sbt.Value
 
@@ -28,4 +30,5 @@ object PluginCompat {
   def toNioPath(f: File)(implicit conv: FileConverter): NioPath                         = f.toPath
   def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]                   = c.files
   def createLazyProjectRef(p: Project): LazyProjectReference                            = new LazyProjectReference(p)
+  def getAttributeMap(t: Task[?]): AttributeMap                                         = t.info.attributes
 }

--- a/dev-mode/sbt-plugin/src/main/scala-2.12/sbt/LoggerCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/sbt/LoggerCompat.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package sbt
+
+import sbt.util.LoggerContext
+
+object LoggerCompat {
+  def createLoggerContext(state: State): LoggerContext =
+    LoggerContext(useLog4J = state.get(Keys.useLog4J.key).getOrElse(false))
+}

--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -11,7 +11,11 @@ import sbt.{ ScopedKey, Task, Project, State, Result, TaskKey }
 import sbt.Def.Classpath
 import sbt.Defaults.files
 import sbt.ProjectExtra.extract
+import sbt.ProjectExtra.projectToLocalProject
 
+import scala.language.implicitConversions
+
+import play.sbt.routes.RoutesKeys.LazyProjectReference
 import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFileRef }
 
 object PluginCompat:
@@ -24,4 +28,5 @@ object PluginCompat:
   inline def fileName(file: FileRef): String = file.name
   inline def toNioPath(hvf: VirtualFileRef)(using conv: FileConverter): NioPath = conv.toPath(hvf)
   def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File] = c.files.map(_.toFile)
+  def createLazyProjectRef(p: Project): LazyProjectReference = new LazyProjectReference(p)
 end PluginCompat

--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -7,16 +7,24 @@ package play.sbt
 import java.io.File
 import java.nio.file.Path as NioPath
 
-import sbt.{ ScopedKey, Task, Project, State, Result, TaskKey }
-import sbt.Def.Classpath
-import sbt.Defaults.files
-import sbt.ProjectExtra.extract
-import sbt.ProjectExtra.projectToLocalProject
-
 import scala.language.implicitConversions
 
+import sbt.AttributeMap
+import sbt.Def.Classpath
+import sbt.Defaults.files
+import sbt.Project
+import sbt.ProjectExtra.extract
+import sbt.ProjectExtra.projectToLocalProject
+import sbt.Result
+import sbt.ScopedKey
+import sbt.State
+import sbt.Task
+import sbt.TaskKey
+
 import play.sbt.routes.RoutesKeys.LazyProjectReference
-import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFileRef }
+import xsbti.FileConverter
+import xsbti.HashedVirtualFileRef
+import xsbti.VirtualFileRef
 
 object PluginCompat:
   type MainClass    = sbt.PackageOption.MainClass
@@ -26,7 +34,12 @@ object PluginCompat:
   inline def toFileRef(path: NioPath)(using conv: FileConverter): FileRef = conv.toVirtualFile(path)
   def toFileRefs(files: Seq[File])(using conv: FileConverter): Seq[FileRef] = files.map(toFileRef)
   inline def fileName(file: FileRef): String = file.name
+  inline def toFileRef(file: File)(using conv: FileConverter): FileRef          = conv.toVirtualFile(file.toPath)
+  inline def toFileRef(path: NioPath)(using conv: FileConverter): FileRef       = conv.toVirtualFile(path)
+  def toFileRefs(files: Seq[File])(using conv: FileConverter): Seq[FileRef]     = files.map(toFileRef)
+  inline def fileName(file: FileRef): String                                    = file.name
   inline def toNioPath(hvf: VirtualFileRef)(using conv: FileConverter): NioPath = conv.toPath(hvf)
-  def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File] = c.files.map(_.toFile)
-  def createLazyProjectRef(p: Project): LazyProjectReference = new LazyProjectReference(p)
+  def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]           = c.files.map(_.toFile)
+  def createLazyProjectRef(p: Project): LazyProjectReference                    = new LazyProjectReference(p)
+  def getAttributeMap(t: Task[?]): AttributeMap                                 = t.attributes
 end PluginCompat

--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -9,17 +9,11 @@ import java.nio.file.Path as NioPath
 
 import scala.language.implicitConversions
 
-import sbt.AttributeMap
+import sbt.*
 import sbt.Def.Classpath
 import sbt.Defaults.files
-import sbt.Project
 import sbt.ProjectExtra.extract
 import sbt.ProjectExtra.projectToLocalProject
-import sbt.Result
-import sbt.ScopedKey
-import sbt.State
-import sbt.Task
-import sbt.TaskKey
 
 import play.sbt.routes.RoutesKeys.LazyProjectReference
 import xsbti.FileConverter
@@ -42,4 +36,5 @@ object PluginCompat:
   def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]           = c.files.map(_.toFile)
   def createLazyProjectRef(p: Project): LazyProjectReference                    = new LazyProjectReference(p)
   def getAttributeMap(t: Task[?]): AttributeMap                                 = t.attributes
+  inline def toKey(settingKey: SettingKey[String]): StringAttributeKey          = StringAttributeKey(settingKey.key.label)
 end PluginCompat

--- a/dev-mode/sbt-plugin/src/main/scala-3/sbt/LoggerCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/sbt/LoggerCompat.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package sbt
+
+import sbt.util.LoggerContext
+
+object LoggerCompat:
+  def createLoggerContext(state: State): LoggerContext =
+    LoggerContext()
+end LoggerCompat

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -128,7 +128,7 @@ object PlaySettings {
       .concatDistinct(Runtime / exportedProducts, Runtime / internalDependencyClasspath)
       .value,
     // filter out asset directories from the classpath (supports sbt-web 1.0 and 1.1)
-    playReloaderClasspath ~= { _.filter(_.get(WebKeys.webModulesLib.key).isEmpty) },
+    playReloaderClasspath ~= { _.filter(_.get(toKey(WebKeys.webModulesLib)).isEmpty) },
     playCommonClassloader := PlayCommands.playCommonClassloaderTask.value,
     playCompileEverything := PlayCommands.playCompileEverythingTask.value.asInstanceOf[Seq[Analysis]],
     playReload            := PlayCommands.playReloadTask.value,

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -107,7 +107,7 @@ object RoutesCompiler extends AutoPlugin {
           thisProjectTasks ++ reverseRouterTasks
         }
     }.value,
-    Defaults.ConfigGlobal / watchSources ++= (routes / sources).value,
+    Defaults.ConfigZero / watchSources ++= (routes / sources).value,
     routes / target := crossTarget.value / "routes" / Defaults.nameForSrc(configuration.value.name),
     routes          := compileRoutesFiles.value,
     sourceGenerators += Def.task(routes.value).taskValue,

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -18,6 +18,7 @@ import play.routes.compiler.RoutesCompilationError
 import play.routes.compiler.RoutesCompiler.GeneratedSource
 import play.routes.compiler.RoutesCompiler.RoutesCompilerTask
 import play.routes.compiler.RoutesGenerator
+import play.sbt.PluginCompat.createLazyProjectRef
 import xsbti.Position
 
 object RoutesKeys {
@@ -49,7 +50,7 @@ object RoutesKeys {
   object LazyProjectReference {
     import scala.language.implicitConversions
     implicit def fromProjectReference(ref: => ProjectReference): LazyProjectReference = new LazyProjectReference(ref)
-    implicit def fromProject(project: => Project): LazyProjectReference               = new LazyProjectReference(project)
+    implicit def fromProject(project: => Project): LazyProjectReference               = createLazyProjectRef(project)
   }
 
   val aggregateReverseRoutes = SettingKey[Seq[LazyProjectReference]](

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -131,7 +131,7 @@ object PlayReload {
 
   def getScopedKey(incomplete: Incomplete): Option[ScopedKey[?]] = incomplete.node.flatMap {
     case key: ScopedKey[?] => Option(key)
-    case task: Task[?]     => task.info.attributes.get(taskDefinitionKey)
+    case task: Task[?]     => getAttributeMap(task).get(taskDefinitionKey)
   }
 
   def compile(

--- a/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
@@ -16,6 +16,7 @@ import sbt.*
 import sbt.internal.io.PlaySource
 import sbt.util.LoggerContext
 import sbt.Keys.*
+import sbt.LoggerCompat.*
 
 import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.*
 import com.typesafe.sbt.packager.Keys.executableScriptName
@@ -96,7 +97,7 @@ object PlayRun {
       try {
         val newState = interaction match {
           case _: PlayNonBlockingInteractionMode =>
-            loggerContext = LoggerContext(useLog4J = state.get(Keys.useLog4J.key).getOrElse(false))
+            loggerContext = createLoggerContext(state)
             state.put(Keys.loggerContext, loggerContext)
           case _ => state
         }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Towards #13319

## Purpose

Lots more compatibility shims for moves in sbt2
* Logger removed the `log4J` param, so shimmed for the collision.
* StringAttributeKey vs. AttributeKey[String]
* `ConfigGlobal` is just an alias for `ConfigZero` and is gone in sbt2, so moved entirely
* `LazyProjectReference` moved, so created a shim for the constructor.
* `Task.info` isn't there, so shimmed to get access to attributes.
