### PR TITLE
Sbt2 compatibility cleanup

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -16,6 +16,9 @@ import xsbti.FileConverter
 object PluginCompat {
   type MainClass = sbt.Package.MainClass
   type FileRef   = File
+  type MainClass     = sbt.Package.MainClass
+  type FileRef       = File
+  type PathFinderRef = Seq[File]
 
   def toFileRef(file: java.io.File)(implicit fileConverter: FileConverter): FileRef     = file
   def toFileRef(path: NioPath)(implicit fileConverter: FileConverter): FileRef          = path.toFile
@@ -26,4 +29,5 @@ object PluginCompat {
   def createLazyProjectRef(p: Project): LazyProjectReference                            = new LazyProjectReference(p)
   def getAttributeMap(t: Task[?]): AttributeMap                                         = t.info.attributes
   def toKey(settingKey: SettingKey[String]): AttributeKey[String]                       = settingKey.key
+  def toFinder(s: Seq[FileRef])(implicit fc: FileConverter): PathFinderRef   = s
 }

--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -29,5 +29,15 @@ object PluginCompat {
   def createLazyProjectRef(p: Project): LazyProjectReference                            = new LazyProjectReference(p)
   def getAttributeMap(t: Task[?]): AttributeMap                                         = t.info.attributes
   def toKey(settingKey: SettingKey[String]): AttributeKey[String]                       = settingKey.key
+  def toFileRef(file: java.io.File)(implicit fc: FileConverter): FileRef     = file
+  def toFileRef(path: NioPath)(implicit fc: FileConverter): FileRef          = path.toFile
+  def toFileRefs(files: Seq[File])(implicit fc: FileConverter): Seq[FileRef] = files.map(toFileRef)
+  def fileName(file: FileRef): String                                        = file.getName
+  def toNioPath(f: File)(implicit conv: FileConverter): NioPath              = f.toPath
+  def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]        = c.files
+  def createLazyProjectRef(p: Project): LazyProjectReference                 = new LazyProjectReference(p)
+  def getAttributeMap(t: Task[?]): AttributeMap                              = t.info.attributes
+  def toKey(settingKey: SettingKey[String]): AttributeKey[String]            = settingKey.key
   def toFinder(s: Seq[FileRef])(implicit fc: FileConverter): PathFinderRef   = s
+  def uncached[T](value: T): T                                               = value
 }

--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -14,21 +14,10 @@ import play.sbt.routes.RoutesKeys.LazyProjectReference
 import xsbti.FileConverter
 
 object PluginCompat {
-  type MainClass = sbt.Package.MainClass
-  type FileRef   = File
   type MainClass     = sbt.Package.MainClass
   type FileRef       = File
   type PathFinderRef = Seq[File]
 
-  def toFileRef(file: java.io.File)(implicit fileConverter: FileConverter): FileRef     = file
-  def toFileRef(path: NioPath)(implicit fileConverter: FileConverter): FileRef          = path.toFile
-  def toFileRefs(files: Seq[File])(implicit fileConverter: FileConverter): Seq[FileRef] = files.map(toFileRef)
-  def fileName(file: FileRef): String                                                   = file.getName
-  def toNioPath(f: File)(implicit conv: FileConverter): NioPath                         = f.toPath
-  def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]                   = c.files
-  def createLazyProjectRef(p: Project): LazyProjectReference                            = new LazyProjectReference(p)
-  def getAttributeMap(t: Task[?]): AttributeMap                                         = t.info.attributes
-  def toKey(settingKey: SettingKey[String]): AttributeKey[String]                       = settingKey.key
   def toFileRef(file: java.io.File)(implicit fc: FileConverter): FileRef     = file
   def toFileRef(path: NioPath)(implicit fc: FileConverter): FileRef          = path.toFile
   def toFileRefs(files: Seq[File])(implicit fc: FileConverter): Seq[FileRef] = files.map(toFileRef)

--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -21,8 +21,9 @@ import xsbti.HashedVirtualFileRef
 import xsbti.VirtualFileRef
 
 object PluginCompat:
-  type MainClass    = sbt.PackageOption.MainClass
-  type FileRef      = xsbti.HashedVirtualFileRef
+  type MainClass     = sbt.PackageOption.MainClass
+  type FileRef       = xsbti.HashedVirtualFileRef
+  type PathFinderRef = sbt.io.PathFinder
 
   inline def toFileRef(file: File)(using conv: FileConverter): FileRef = conv.toVirtualFile(file.toPath)
   inline def toFileRef(path: NioPath)(using conv: FileConverter): FileRef = conv.toVirtualFile(path)
@@ -37,4 +38,5 @@ object PluginCompat:
   def createLazyProjectRef(p: Project): LazyProjectReference                    = new LazyProjectReference(p)
   def getAttributeMap(t: Task[?]): AttributeMap                                 = t.attributes
   inline def toKey(settingKey: SettingKey[String]): StringAttributeKey          = StringAttributeKey(settingKey.key.label)
+  def toFinder(s: Seq[FileRef])(using conv: FileConverter): PathFinderRef       = PathFinder(s.map(toNioPath(_).toFile))
 end PluginCompat

--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -21,6 +21,8 @@ import xsbti.HashedVirtualFileRef
 import xsbti.VirtualFileRef
 
 object PluginCompat:
+  export sbt.Def.uncached
+
   type MainClass     = sbt.PackageOption.MainClass
   type FileRef       = xsbti.HashedVirtualFileRef
   type PathFinderRef = sbt.io.PathFinder

--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -27,10 +27,6 @@ object PluginCompat:
   type FileRef       = xsbti.HashedVirtualFileRef
   type PathFinderRef = sbt.io.PathFinder
 
-  inline def toFileRef(file: File)(using conv: FileConverter): FileRef = conv.toVirtualFile(file.toPath)
-  inline def toFileRef(path: NioPath)(using conv: FileConverter): FileRef = conv.toVirtualFile(path)
-  def toFileRefs(files: Seq[File])(using conv: FileConverter): Seq[FileRef] = files.map(toFileRef)
-  inline def fileName(file: FileRef): String = file.name
   inline def toFileRef(file: File)(using conv: FileConverter): FileRef          = conv.toVirtualFile(file.toPath)
   inline def toFileRef(path: NioPath)(using conv: FileConverter): FileRef       = conv.toVirtualFile(path)
   def toFileRefs(files: Seq[File])(using conv: FileConverter): Seq[FileRef]     = files.map(toFileRef)

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -114,7 +114,7 @@ object PlaySettings {
     Compile / Keys.run             := PlayRun.playDefaultRunTask.evaluated,
     Compile / Keys.run / mainClass := Some("play.core.server.DevServerStart"),
     Compile / Keys.bgRun           := PlayRun.playDefaultBgRunTask.evaluated,
-    PlayInternalKeys.playStop      := {
+    PlayInternalKeys.playStop      := uncached {
       playInteractionMode.value match {
         case x: PlayNonBlockingInteractionMode => x.stop()
         case _                                 => sys.error("Play interaction mode must be non blocking to stop it")
@@ -122,16 +122,18 @@ object PlaySettings {
     },
     shellPrompt := PlayCommands.playPrompt,
     // all dependencies from outside the project (all dependency jars)
-    playDependencyClasspath := (Runtime / externalDependencyClasspath).value,
+    playDependencyClasspath := uncached((Runtime / externalDependencyClasspath).value),
     // all user classes, in this project and any other subprojects that it depends on
-    playReloaderClasspath := Classpaths
-      .concatDistinct(Runtime / exportedProducts, Runtime / internalDependencyClasspath)
-      .value,
+    playReloaderClasspath := uncached {
+      Classpaths
+        .concatDistinct(Runtime / exportedProducts, Runtime / internalDependencyClasspath)
+        .value
+    },
     // filter out asset directories from the classpath (supports sbt-web 1.0 and 1.1)
     playReloaderClasspath ~= { _.filter(_.get(toKey(WebKeys.webModulesLib)).isEmpty) },
-    playCommonClassloader := PlayCommands.playCommonClassloaderTask.value,
-    playCompileEverything := PlayCommands.playCompileEverythingTask.value.asInstanceOf[Seq[Analysis]],
-    playReload            := PlayCommands.playReloadTask.value,
+    playCommonClassloader := uncached { PlayCommands.playCommonClassloaderTask.value },
+    playCompileEverything := uncached { PlayCommands.playCompileEverythingTask.value.asInstanceOf[Seq[Analysis]] },
+    playReload            := uncached { PlayCommands.playReloadTask.value },
     ivyLoggingLevel       := UpdateLogging.DownloadOnly,
     playMonitoredFiles    := PlayCommands.playMonitoredFilesTask.value,
     fileWatchService      := {
@@ -140,7 +142,7 @@ object PlaySettings {
     playDefaultPort    := 9000,
     playDefaultAddress := "0.0.0.0",
     // Default hooks
-    playRunHooks        := Nil,
+    playRunHooks        := uncached { Nil },
     playInteractionMode := PlayConsoleInteractionMode,
     // Settings
     devSettings := Nil,
@@ -241,8 +243,8 @@ object PlaySettings {
     // sbt-web
     Assets / jsFilter         := new PatternFilter("""[^_].*\.js""".r.pattern),
     WebKeys.stagingDirectory  := WebKeys.stagingDirectory.value / "public",
-    playAssetsWithCompilation := (Compile / compile).value.asInstanceOf[Analysis],
-    playAssetsWithCompilation := playAssetsWithCompilation.dependsOn((Assets / assets).?).value,
+    playAssetsWithCompilation := uncached { (Compile / compile).value.asInstanceOf[Analysis] },
+    playAssetsWithCompilation := uncached { playAssetsWithCompilation.dependsOn((Assets / assets).?).value },
     // Assets for run mode
     PlayRun.playPrefixAndAssetsSetting,
     PlayRun.playAllAssetsSetting,
@@ -251,7 +253,7 @@ object PlaySettings {
     Assets / WebKeys.packagePrefix := assetsPrefix.value,
     // The ...-assets.jar should contain the same META-INF/MANIFEST.MF file like the main app jar
     Assets / packageBin / packageOptions := (Runtime / packageBin / packageOptions).value,
-    playPackageAssets                    := (Assets / packageBin).value,
+    playPackageAssets                    := uncached { (Assets / packageBin).value },
     scriptClasspathOrdering              := Def.taskDyn {
       val oldValue = scriptClasspathOrdering.value
       // only create a assets-jar if the task is active
@@ -269,10 +271,12 @@ object PlaySettings {
     }.value,
     // Assets for testing
     TestAssets / public := (TestAssets / public).value / assetsPrefix.value,
-    Test / fullClasspath += Def.taskDyn {
-      implicit val fc: FileConverter = fileConverter.value
-      Def.task(Attributed.blank(toFileRef((TestAssets / assets).value.getParentFile)))
-    }.value
+    Test / fullClasspath += uncached {
+      Def.taskDyn {
+        implicit val fc: FileConverter = fileConverter.value
+        Def.task(Attributed.blank(toFileRef((TestAssets / assets).value.getParentFile)))
+      }.value
+    }
   )
 
   /**
@@ -280,7 +284,7 @@ object PlaySettings {
    */
   private def externalizedSettings: Seq[Setting[?]] = Def.settings(
     Defaults.packageTaskSettings(playJarSansExternalized, playJarSansExternalized / mappings),
-    playExternalizedResources := {
+    playExternalizedResources := uncached {
       implicit val fc: FileConverter = fileConverter.value
       val rdirs                      = unmanagedResourceDirectories.value
       (unmanagedResources.value --- rdirs --- toFinder(externalizeResourcesExcludes.value))

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -281,9 +281,11 @@ object PlaySettings {
   private def externalizedSettings: Seq[Setting[?]] = Def.settings(
     Defaults.packageTaskSettings(playJarSansExternalized, playJarSansExternalized / mappings),
     playExternalizedResources := {
-      val rdirs = unmanagedResourceDirectories.value
-      (unmanagedResources.value --- rdirs --- externalizeResourcesExcludes.value)
+      implicit val fc: FileConverter = fileConverter.value
+      val rdirs                      = unmanagedResourceDirectories.value
+      (unmanagedResources.value --- rdirs --- toFinder(externalizeResourcesExcludes.value))
         .pair(relativeTo(rdirs) | flat)
+        .map(mapping => (toFileRef(mapping._1), mapping._2))
     },
     playJarSansExternalized / mappings := {
       implicit val fc: FileConverter = fileConverter.value

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -248,13 +248,13 @@ object PlayReload {
   }
 
   private class PositionImpl(fileName: String, lineNo: Int, pos: Option[Int]) extends Position {
-    def line         = Optional.ofNullable(lineNo)
-    def lineContent  = ""
-    def offset       = Optional.empty[Integer]
-    def pointer      = o2jo(pos.map(_ - 1))
-    def pointerSpace = Optional.empty[String]
-    def sourcePath   = Optional.ofNullable(fileName)
-    def sourceFile   = Optional.ofNullable(file(fileName))
+    def line: java.util.Optional[java.lang.Integer]    = Optional.ofNullable(lineNo)
+    def lineContent                                    = ""
+    def offset                                         = Optional.empty[Integer]
+    def pointer: java.util.Optional[java.lang.Integer] = o2jo(pos.map(_ - 1))
+    def pointerSpace                                   = Optional.empty[String]
+    def sourcePath                                     = Optional.ofNullable(fileName)
+    def sourceFile                                     = Optional.ofNullable(file(fileName))
   }
 
   private class ProblemImpl(msg: String, pos: Position) extends Problem {

--- a/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
@@ -54,8 +54,9 @@ object PlayRun {
 
   val generatedSourceHandlers = SbtTwirl.defaultFormats.map { case (k, _) => s"scala.$k" -> twirlSourceHandler }
 
-  val playDefaultRunTask =
-    playRunTask(playRunHooks, playDependencyClasspath, playReloaderClasspath, playAssetsClassLoader)
+  val playDefaultRunTask = {
+    playRunTask(playRunHooks, playDependencyClasspath, playReloaderClasspath, playAssetsClassLoader).map(_ => ())
+  }
 
   private val playDefaultRunTaskNonBlocking =
     playRunTask(


### PR DESCRIPTION
# Helpful things

## Fixes

Towards #13319 

## Purpose

Lots of type compatibility issues/fixes. Notably:
* Adds uncached to several keys
* Maps `playDefaultRunTask` to Unit, because SBT's `run` is more strict on types. This one concerns me a bit.
* Removes some legacy console reader code for SBT < 1.3, the compilation errors weren't worth the trouble.
* Type conversions via shims

This is stacked on top of #13549, can safely rebase after that is merged.
