### PR TITLE
sbt 2 runTask compatibility

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -18,6 +18,11 @@ object PluginCompat {
   type FileRef       = File
   type PathFinderRef = Seq[File]
 
+  def execValue[T](t: T) = Value(t)
+
+  def runTask[T](taskKey: TaskKey[T], state: State): Option[(State, Result[T])] =
+    Project.runTask(taskKey, state)
+
   def toFileRef(file: java.io.File)(implicit fc: FileConverter): FileRef     = file
   def toFileRef(path: NioPath)(implicit fc: FileConverter): FileRef          = path.toFile
   def toFileRefs(files: Seq[File])(implicit fc: FileConverter): Seq[FileRef] = files.map(toFileRef)

--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -18,8 +18,6 @@ object PluginCompat {
   type FileRef       = File
   type PathFinderRef = Seq[File]
 
-  def execValue[T](t: T) = Value(t)
-
   def runTask[T](taskKey: TaskKey[T], state: State): Option[(State, Result[T])] =
     Project.runTask(taskKey, state)
 

--- a/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-2.12/play/sbt/PluginCompat.scala
@@ -21,15 +21,17 @@ object PluginCompat {
   def runTask[T](taskKey: TaskKey[T], state: State): Option[(State, Result[T])] =
     Project.runTask(taskKey, state)
 
-  def toFileRef(file: java.io.File)(implicit fc: FileConverter): FileRef     = file
-  def toFileRef(path: NioPath)(implicit fc: FileConverter): FileRef          = path.toFile
-  def toFileRefs(files: Seq[File])(implicit fc: FileConverter): Seq[FileRef] = files.map(toFileRef)
-  def fileName(file: FileRef): String                                        = file.getName
-  def toNioPath(f: File)(implicit conv: FileConverter): NioPath              = f.toPath
-  def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]        = c.files
-  def createLazyProjectRef(p: Project): LazyProjectReference                 = new LazyProjectReference(p)
-  def getAttributeMap(t: Task[?]): AttributeMap                              = t.info.attributes
-  def toKey(settingKey: SettingKey[String]): AttributeKey[String]            = settingKey.key
-  def toFinder(s: Seq[FileRef])(implicit fc: FileConverter): PathFinderRef   = s
-  def uncached[T](value: T): T                                               = value
+  // File converter shims
+  def toFileRef(file: java.io.File)(implicit fc: FileConverter): FileRef   = file
+  def toFileRef(path: NioPath)(implicit fc: FileConverter): FileRef        = path.toFile
+  def toNioPath(f: File)(implicit conv: FileConverter): NioPath            = f.toPath
+  def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]      = c.files
+  def toFinder(s: Seq[FileRef])(implicit fc: FileConverter): PathFinderRef = s
+
+  def fileName(file: FileRef): String                             = file.getName
+  def createLazyProjectRef(p: Project): LazyProjectReference      = new LazyProjectReference(p)
+  def getAttributeMap(t: Task[?]): AttributeMap                   = t.info.attributes
+  def toKey(settingKey: SettingKey[String]): AttributeKey[String] = settingKey.key
+
+  def uncached[T](value: T): T = value
 }

--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -27,7 +27,17 @@ object PluginCompat:
   type FileRef       = xsbti.HashedVirtualFileRef
   type PathFinderRef = sbt.io.PathFinder
 
-  def execValue[T](t: T)                                                        = sbt.Result.Value(t)
+  val Inc   = sbt.Result.Inc
+  val Value = sbt.Result.Value
+
+  private def execValue[T](t: T) = sbt.Result.Value(t)
+
+  /**
+   * Shim for runTask. Project.runTask is removed in sbt 2.0.
+   *
+   * This will be replaced when Extracted.runTask with the same signature
+   * is supported in sbt 2.0.
+   */
   def runTask[T](taskKey: TaskKey[T], state: State): Option[(State, Result[T])] =
     Some(
       Project.extract(state).runTask(taskKey, state) match {

--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -44,14 +44,16 @@ object PluginCompat:
         case (state, t) => (state, execValue(t))
       }
     )
-  inline def toFileRef(file: File)(using conv: FileConverter): FileRef          = conv.toVirtualFile(file.toPath)
-  inline def toFileRef(path: NioPath)(using conv: FileConverter): FileRef       = conv.toVirtualFile(path)
-  def toFileRefs(files: Seq[File])(using conv: FileConverter): Seq[FileRef]     = files.map(toFileRef)
-  inline def fileName(file: FileRef): String                                    = file.name
-  inline def toNioPath(hvf: VirtualFileRef)(using conv: FileConverter): NioPath = conv.toPath(hvf)
-  inline def getFiles(c: Classpath)(implicit conv: FileConverter): Seq[File]    = c.files.map(_.toFile)
-  inline def createLazyProjectRef(p: Project): LazyProjectReference             = new LazyProjectReference(p)
-  def getAttributeMap(t: Task[?]): AttributeMap                                 = t.attributes
-  inline def toKey(settingKey: SettingKey[String]): StringAttributeKey          = StringAttributeKey(settingKey.key.label)
-  def toFinder(s: Seq[FileRef])(using conv: FileConverter): PathFinderRef       = PathFinder(s.map(toNioPath(_).toFile))
+
+  // File converter shims
+  inline def toFileRef(file: File)(using fc: FileConverter): FileRef             = fc.toVirtualFile(file.toPath)
+  inline def toFileRef(path: NioPath)(using fc: FileConverter): FileRef          = fc.toVirtualFile(path)
+  inline def toNioPath(hvf: VirtualFileRef)(using fc: FileConverter): NioPath    = fc.toPath(hvf)
+  inline def getFiles(c: Classpath)(implicit fc: FileConverter): Seq[File]       = c.files.map(_.toFile)
+  def toFinder(s: Seq[FileRef])(using fc: FileConverter): PathFinderRef          = PathFinder(s.map(toNioPath(_).toFile))
+
+  inline def fileName(file: FileRef): String                           = file.name
+  inline def createLazyProjectRef(p: Project): LazyProjectReference    = new LazyProjectReference(p)
+  inline def getAttributeMap(t: Task[?]): AttributeMap                 = t.attributes
+  inline def toKey(settingKey: SettingKey[String]): StringAttributeKey = StringAttributeKey(settingKey.key.label)
 end PluginCompat

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -73,7 +73,7 @@ object PlayCommands {
 
   val h2Command = Command.command("h2-browser") { (state: State) =>
     try {
-      val commonLoader  = Project.runTask(playCommonClassloader, state).get._2.toEither.right.get
+      val commonLoader  = PluginCompat.runTask(playCommonClassloader, state).get._2.toEither.right.get
       val h2ServerClass = commonLoader.loadClass("org.h2.tools.Server")
       h2ServerClass.getMethod("main", classOf[Array[String]]).invoke(null, Array.empty[String])
     } catch {

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -106,7 +106,7 @@ object PlayReload {
               // anymore before adding it to "allProblems", the field that eventually gets used by the Incomplete. (The transformation still takes place to show
               // the mapped source file in the logs) Play however needs to know the mapped source file to display it in it's error pages for a nice dev experience.
               // So the solution is that Play itself will try to transform the source file to the mapped file by running it "through" sourcePositionMappers:
-              Project
+              PluginCompat
                 .runTask(scope / sourcePositionMappers, state)
                 .flatMap(_._2.toEither.toOption)
                 .map(mappers =>

--- a/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
@@ -233,7 +233,7 @@ object PlayRun {
       state.fail
     }
 
-    Project.runTask(stage, state) match {
+    PluginCompat.runTask(stage, state) match {
       case None                             => fail(state)
       case Some((state, Inc(_)))            => fail(state)
       case Some((state, Value(stagingDir))) =>

--- a/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
@@ -99,13 +99,13 @@ object PlayRun {
           case _ => state
         }
         PlayReload.compile(
-          () => Project.runTask(scope / playReload, newState).map(_._2).get,
+          () => PluginCompat.runTask(scope / playReload, newState).map(_._2).get,
           () =>
-            Project
+            PluginCompat
               .runTask(scope / reloaderClasspath, newState.put(WebKeys.disableExportedProducts, true))
               .map(_._2)
               .get,
-          () => Project.runTask(scope / streamsManager, newState).map(_._2).get.toEither.right.toOption,
+          () => PluginCompat.runTask(scope / streamsManager, newState).map(_._2).get.toEither.right.toOption,
           newState,
           scope
         )
@@ -182,7 +182,7 @@ object PlayRun {
   val playAllAssetsSetting = playAllAssets := Seq(playPrefixAndAssets.value)
 
   val playAssetsClassLoaderSetting = {
-    playAssetsClassLoader := {
+    playAssetsClassLoader := uncached {
       val assets =
         playAllAssets.value.map(asset => JMap.entry(asset._1, asset._2))
       parent => new AssetsClassLoader(parent, assets.asJava)
@@ -242,7 +242,7 @@ object PlayRun {
           val isWin = System.getProperty("os.name").toLowerCase(java.util.Locale.ENGLISH).contains("win")
           if (isWin) s"$path.bat" else path
         }
-        val javaOpts = Project.runTask(Production / javaOptions, state).get._2.toEither.right.getOrElse(Nil)
+        val javaOpts = PluginCompat.runTask(Production / javaOptions, state).get._2.toEither.right.getOrElse(Nil)
 
         // Note that I'm unable to pass system properties along with properties... if I do then I receive:
         //  java.nio.charset.IllegalCharsetNameException: "UTF-8"


### PR DESCRIPTION
# Helpful things

## Fixes

Towards #13319 

## Purpose

Adds a shim for the changes to `runTask` in sbt 2.0. Clean up the PluginCompat shim.

## Background Context

`Project.runTask` was removed in SBT 2.0. This necessitated adding a shim to use other available `runTask` methods to achieve similar results.

This patch is not my favorite - it is currently a workaround to re-wrap task results in `Result` and `Option`, because sbt 2.0 does not give us access to the underlying `EvaluateTask` monadic results. This gives us a clean way to replace the shim once a better method is exposed in sbt 2.0. [sbt/sbt#8283](https://github.com/sbt/sbt/pull/8283) should make this a much cleaner shim.

Once this merges, we can start testing cross compatibility in scripted, and work towards publishing crossbuilds.