### PR TITLE
Billy/sbt 2 use runtaskunhandled

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
+++ b/dev-mode/sbt-plugin/src/main/scala-3/play/sbt/PluginCompat.scala
@@ -29,9 +29,6 @@ object PluginCompat:
 
   val Inc   = sbt.Result.Inc
   val Value = sbt.Result.Value
-
-  private def execValue[T](t: T) = sbt.Result.Value(t)
-
   /**
    * Shim for runTask. Project.runTask is removed in sbt 2.0.
    *
@@ -39,11 +36,7 @@ object PluginCompat:
    * is supported in sbt 2.0.
    */
   def runTask[T](taskKey: TaskKey[T], state: State): Option[(State, Result[T])] =
-    Some(
-      Project.extract(state).runTask(taskKey, state) match {
-        case (state, t) => (state, execValue(t))
-      }
-    )
+      Project.extract(state).runTaskUnhandled(taskKey, state)
 
   // File converter shims
   inline def toFileRef(file: File)(using fc: FileConverter): FileRef             = fc.toVirtualFile(file.toPath)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -6,9 +6,10 @@ object ScalaVersions {
   val scala212 = "2.12.20"
   val scala213 = "2.13.16"
   val scala3   = "3.3.6"
+  val scala37  = "3.7.2"
 }
 
 object SbtVersions {
   val sbt111 = "1.11.6"
-  val sbt2   = "2.0.0-RC3"
+  val sbt2   = "2.0.0-RC5"
 }


### PR DESCRIPTION
# Helpful things

## Fixes

Towards #13319

## Purpose

In #13553 we wrapped `Extracted.runTask` results for type compatibility. sbt `2.0.0-RC5` exposes a deeper underlying method that doesn't attempt to process `Result` and `Option`, thus preventing a series of unnecessary `apply` operations.

This change updates to `2.0.0-RC5`, and uses the new `Extracted.runTaskUnhandled` method. There is also a new `scala37` crossbuild option, which will be used later for sbt plugins.
