### PR TITLE
Avoid internal `sun.security.x509` / `--add-exports`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -129,9 +129,6 @@ jobs:
           { "sbt_test_task": "${{ github.event_name == 'schedule' || 'Play-Microbenchmark/jmh:run -i 1 -wi 0 -f 1 -t 1 $JMH_PARAMS -foe=true' }}" }
         ]
       cmd: >-
-        if [ "$MATRIX_JAVA" = 17 ]; then
-          export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED";
-        fi;
         sbt "${{needs.extra-vars.outputs.pekko_version_opts}}" "${{needs.extra-vars.outputs.pekko_http_version_opts}}" ++$MATRIX_SCALA "$(eval "echo $MATRIX_SBT_TEST_TASK")"
 
   docs-tests:
@@ -173,9 +170,6 @@ jobs:
           { "java": "${{ github.event_name == 'schedule' || '21' }}" }
         ]
       cmd: >-
-        if [ "$MATRIX_JAVA" = 17 ]; then
-          export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED";
-        fi;
         export SCALA_CROSS_VERSIONS=`sbt -batch -error 'print Play/crossScalaVersions' | sed "s/\*//g" | xargs`;
         sbt "${{needs.extra-vars.outputs.pekko_version_opts}}" "${{needs.extra-vars.outputs.pekko_http_version_opts}}" "
           project Sbt-Plugin;

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -132,10 +132,6 @@ jobs:
         if [ "$MATRIX_JAVA" = 17 ]; then
           export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS --add-exports=java.base/sun.security.x509=ALL-UNNAMED";
         fi;
-        if [[ "$MATRIX_JAVA" != 11 && "$MATRIX_JAVA" != 17 ]]; then
-            # When on Java 21+ we only run plain tests, see https://github.com/lightbend/ssl-config/issues/367
-            export JMH_PARAMS="-p endpoint=nt-11-pln,ak-11-pln";
-        fi;
         sbt "${{needs.extra-vars.outputs.pekko_version_opts}}" "${{needs.extra-vars.outputs.pekko_http_version_opts}}" ++$MATRIX_SCALA "$(eval "echo $MATRIX_SBT_TEST_TASK")"
 
   docs-tests:

--- a/build.sbt
+++ b/build.sbt
@@ -258,13 +258,16 @@ lazy val SbtPluginProject = PlaySbtPluginProject("Sbt-Plugin", "dev-mode/sbt-plu
       )
     }.taskValue,
     InputKey[Unit]("disableIncompatibleScriptedTests") := {
+      /*
+      // Example how you can disable a scripted test:
       if (scala.util.Properties.isJavaAtLeast("21")) {
-        val disabledTests = Seq("generated-keystore") // because of https://github.com/lightbend/ssl-config/issues/367
+        val disabledTests = Seq("generated-keystore")
         disabledTests.foreach(t => {
           streams.value.log.info(s"Disabling $t scripted test because it is not compatible with Java 21 or newer")
           IO.touch(new File(s"./dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/${t}/disabled"))
         })
       }
+       */
     },
     (Compile / headerSources) ++= (sbtTestDirectory.value ** ("*.scala" || "*.java" || "*.sbt")).get,
   )

--- a/core/play-integration-test/src/test/java/play/it/JavaServerIntegrationTest.java
+++ b/core/play-integration-test/src/test/java/play/it/JavaServerIntegrationTest.java
@@ -5,7 +5,6 @@
 package play.it;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,7 +20,6 @@ import javax.net.ssl.SSLSocketFactory;
 import org.junit.Test;
 import play.routing.Router;
 import play.server.Server;
-import scala.util.Properties;
 
 public class JavaServerIntegrationTest {
   @Test
@@ -45,7 +43,6 @@ public class JavaServerIntegrationTest {
 
   @Test
   public void testHttpsEmbeddedServerUsesCorrectProtocolAndPort() throws Exception {
-    assumeFalse(Properties.isJavaAtLeast(21)); // because of lightbend/ssl-config#367
     int port = _availablePort();
     _running(
         new Server.Builder().https(port).build(_emptyRouter()),
@@ -65,7 +62,6 @@ public class JavaServerIntegrationTest {
 
   @Test
   public void testEmbeddedServerCanServeBothProtocolsSimultaneously() throws Exception {
-    assumeFalse(Properties.isJavaAtLeast(21)); // because of lightbend/ssl-config#367
     List<Integer> availablePorts = _availablePorts(2);
     int httpPort = availablePorts.get(0);
     int httpsPort = availablePorts.get(1);

--- a/core/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -9,7 +9,6 @@ import java.net.SocketException
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits._
-import scala.util.Properties
 import scala.util.Random
 
 import org.apache.pekko.stream.scaladsl.Sink
@@ -50,22 +49,18 @@ class IdleTimeoutSpec extends PlaySpecification with EndpointIntegrationSpecific
     }
 
     def endpoints(extraConfig: Map[String, Any]): Seq[ServerEndpointRecipe] =
-      (Seq(
+      Seq(
         PekkoHttpServerEndpointRecipes.PekkoHttp11Plaintext,
+        PekkoHttpServerEndpointRecipes.PekkoHttp11Encrypted,
         NettyServerEndpointRecipes.Netty11Plaintext,
-      ) ++
-        Seq(PekkoHttpServerEndpointRecipes.PekkoHttp11Encrypted, NettyServerEndpointRecipes.Netty11Encrypted)
-          .filter(_ => !Properties.isJavaAtLeast(21))) // because of lightbend/ssl-config#367
-        .map(_.withExtraServerConfiguration(extraConfig))
+        NettyServerEndpointRecipes.Netty11Encrypted,
+      ).map(_.withExtraServerConfiguration(extraConfig))
 
     def pekkoHttp2endpoints(extraConfig: Map[String, Any]): Seq[ServerEndpointRecipe] =
-      (Seq(
+      Seq(
         PekkoHttpServerEndpointRecipes.PekkoHttp20Plaintext,
-      ) ++
-        Seq(
-          PekkoHttpServerEndpointRecipes.PekkoHttp20Encrypted,
-        ).filter(_ => !Properties.isJavaAtLeast(21))) // because of lightbend/ssl-config#367
-        .map(_.withExtraServerConfiguration(extraConfig))
+        PekkoHttpServerEndpointRecipes.PekkoHttp20Encrypted,
+      ).map(_.withExtraServerConfiguration(extraConfig))
 
     def doRequests(port: Int, trickle: Long, secure: Boolean = false) = {
       val body      = new String(Random.alphanumeric.take(50 * 1024).toArray)

--- a/core/play-integration-test/src/test/scala/play/it/test/NettyServerEndpointRecipes.scala
+++ b/core/play-integration-test/src/test/scala/play/it/test/NettyServerEndpointRecipes.scala
@@ -4,8 +4,6 @@
 
 package play.it.test
 
-import scala.util.Properties
-
 import play.api.http.HttpProtocol
 import play.api.test.HttpServerEndpointRecipe
 import play.api.test.HttpsServerEndpointRecipe
@@ -32,7 +30,6 @@ object NettyServerEndpointRecipes {
 
   val AllRecipes: Seq[ServerEndpointRecipe] = Seq(
     Netty11Plaintext,
-  ) ++ Seq(
-    Netty11Encrypted,
-  ).filter(_ => !Properties.isJavaAtLeast(21)) // because of https://github.com/lightbend/ssl-config/issues/367
+    Netty11Encrypted
+  )
 }

--- a/core/play-integration-test/src/test/scala/play/it/test/PekkoHttpServerEndpointRecipes.scala
+++ b/core/play-integration-test/src/test/scala/play/it/test/PekkoHttpServerEndpointRecipes.scala
@@ -4,8 +4,6 @@
 
 package play.it.test
 
-import scala.util.Properties
-
 import play.api.http.HttpProtocol
 import play.api.test.HttpServerEndpointRecipe
 import play.api.test.HttpsServerEndpointRecipe
@@ -53,10 +51,9 @@ object PekkoHttpServerEndpointRecipes {
 
   val AllRecipes: Seq[ServerEndpointRecipe] = Seq(
     PekkoHttp11Plaintext,
-  ) ++ Seq(
     PekkoHttp11Encrypted,
-    PekkoHttp20Encrypted,
-  ).filter(_ => !Properties.isJavaAtLeast(21)) // because of https://github.com/lightbend/ssl-config/issues/367
+    PekkoHttp20Encrypted
+  )
 
   val AllRecipesIncludingExperimental: Seq[ServerEndpointRecipe] = AllRecipes :+ PekkoHttp20Plaintext
 }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/generated-keystore/test
@@ -1,5 +1,3 @@
-# This test will fail on Java 21+, see https://github.com/lightbend/ssl-config/issues/367
-
 # runs the devmode and checks that a generated-keystore file is created
 > run -Dhttps.port=9443
 > makeRequest / 200

--- a/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
+++ b/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
@@ -18,8 +18,6 @@ HTTPS configuration can either be supplied using system properties or in `applic
 
 By default, Play will generate itself a self-signed certificate, however typically this will not be suitable for serving a website.  Play uses Java key stores to configure SSL certificates and keys.
 
-> Please be aware that binding an HTTPS port with a self-signed certificate in Java 17 and Java 21 may lead to issues. For more details on this matter, refer to [["Generation of Self-Signed Certificates Fails in Java 17 and Java 21"|Migration29#Generation-of-Self-Signed-Certificates-Fails-in-Java-17-and-Java-21]] in the Play 2.9 Migration Guide.
-
 Signing authorities often provide instructions on how to create a Java keystore (typically with reference to Tomcat configuration).  The official Oracle documentation on how to generate keystores using the JDK keytool utility can be found [here](https://docs.oracle.com/en/java/javase/17/docs/specs/man/keytool.html).  There is also an example in the [Generating X.509 Certificates](https://lightbend.github.io/ssl-config/CertificateGeneration.html) section.
 
 Having created your keystore, the following configuration properties can be used to configure Play to use it:

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -457,6 +457,8 @@ object BuildSettings {
       ProblemFilters.exclude[MissingClassProblem]("play.utils.ReadingList$"),
       ProblemFilters.exclude[MissingClassProblem]("play.utils.ReadingMap"),
       ProblemFilters.exclude[MissingClassProblem]("play.utils.ReadingMap$"),
+      // Remove unused, package-private method
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.AhcWSClient.loggerFactory"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -246,10 +246,13 @@ object Dependencies {
     "org.apache.pekko"   %% "pekko-stream"     % pekkoVersion,
   ) ++ specs2Deps.map(_ % Test) ++ javaTestDeps
 
+  val bouncyCastleVersion    = "1.82"
   val playServerDependencies = specs2Deps.map(_ % Test) ++ Seq(
-    mockitoAll % Test,
-    guava      % Test,
-    logback    % Test
+    "org.bouncycastle" % "bcprov-jdk18on" % bouncyCastleVersion,
+    "org.bouncycastle" % "bcpkix-jdk18on" % bouncyCastleVersion,
+    mockitoAll         % Test,
+    guava              % Test,
+    logback            % Test
   )
 
   val clusterDependencies = Seq(

--- a/testkit/play-test/src/test/java/play/test/TestServerTest.java
+++ b/testkit/play-test/src/test/java/play/test/TestServerTest.java
@@ -6,10 +6,8 @@ package play.test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 
 import org.junit.Test;
-import scala.util.Properties;
 
 public class TestServerTest {
   @Test
@@ -29,7 +27,6 @@ public class TestServerTest {
 
   @Test
   public void shouldReturnHttpAndHttpsPorts() {
-    assumeFalse(Properties.isJavaAtLeast(21)); // because of lightbend/ssl-config#367
     int port = play.api.test.Helpers.testServerPort();
     int httpsPort = 0;
     final TestServer testServer = Helpers.testServer(port, httpsPort);

--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClient.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClient.scala
@@ -47,7 +47,6 @@ class AhcWSClient(underlyingClient: StandaloneAhcWSClient) extends WSClient {
 }
 
 object AhcWSClient {
-  private[ahc] val loggerFactory = new AhcLoggerFactory()
 
   /**
    * Convenient factory method that uses a play.api.libs.ws.WSClientConfig value for configuration instead of

--- a/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
@@ -7,11 +7,12 @@ package play.core.server
 import java.security.cert.X509Certificate
 import java.security.KeyStore
 import javax.net.ssl._
+
 import org.apache.pekko.annotation.ApiMayChange
 import org.slf4j.LoggerFactory
-import play.core.ApplicationProvider
 import play.core.server.ssl.FakeKeyStore
 import play.core.server.ssl.FakeSSLTools
+import play.core.ApplicationProvider
 import play.server.api.SSLEngineProvider
 
 /** Contains a statically initialized self-signed certificate. */

--- a/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/SelfSigned.scala
@@ -7,12 +7,11 @@ package play.core.server
 import java.security.cert.X509Certificate
 import java.security.KeyStore
 import javax.net.ssl._
-
-import com.typesafe.sslconfig.ssl.FakeKeyStore
-import com.typesafe.sslconfig.ssl.FakeSSLTools
 import org.apache.pekko.annotation.ApiMayChange
 import org.slf4j.LoggerFactory
 import play.core.ApplicationProvider
+import play.core.server.ssl.FakeKeyStore
+import play.core.server.ssl.FakeSSLTools
 import play.server.api.SSLEngineProvider
 
 /** Contains a statically initialized self-signed certificate. */

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
@@ -15,8 +15,6 @@ import javax.net.ssl.X509TrustManager
 
 import scala.util.control.NonFatal
 
-import com.typesafe.sslconfig.{ ssl => sslconfig }
-import com.typesafe.sslconfig.util.NoopLogger
 import play.api.Logger
 import play.core.server.ServerConfig
 import play.core.ApplicationProvider
@@ -63,8 +61,8 @@ class DefaultSSLEngineProvider(serverConfig: ServerConfig, appProvider: Applicat
     } else {
       // Load a generated key store
       logger.warn("Using generated key with self signed certificate for HTTPS. This should NOT be used in production.")
-      val FakeKeyStore = new sslconfig.FakeKeyStore(NoopLogger.factory())
-      FakeKeyStore.keyManagerFactory(serverConfig.rootDir)
+      val fakeKeyStore = new FakeKeyStore()
+      fakeKeyStore.keyManagerFactory(serverConfig.rootDir)
     }
 
     // Load the configured trust manager

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -137,7 +137,7 @@ final class FakeKeyStore {
   def getKeyStoreFilePath(appPath: File) = new File(appPath, KeystoreSettings.GeneratedKeyStore)
 
   private[ssl] def shouldGenerate(keyStoreFile: File): Boolean = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     if (!keyStoreFile.exists()) {
       return true

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -4,9 +4,10 @@
 
 package play.core.server.ssl
 
+import play.api.Logger
+
 import java.security.{ KeyPair, KeyPairGenerator, KeyStore, SecureRandom }
 
-import com.typesafe.sslconfig.util.{ LoggerFactory, NoDepsLogger }
 import sun.security.x509._
 import sun.security.util.ObjectIdentifier
 import java.util.Date
@@ -29,8 +30,6 @@ import java.security.interfaces.RSAPublicKey
  * sslconfig-selfsigned, Oct 4, 2018, PrivateKeyEntry,
  * Certificate fingerprint (SHA1): 19:2D:20:F0:36:59:E3:AD:C1:AA:55:82:0D:D2:94:5D:B3:75:3F:F8
  * }}}
- *
- * Was: play.core.server.ssl.FakeKeyStore
  */
 object FakeKeyStore {
 
@@ -125,14 +124,12 @@ object FakeKeyStore {
 
 /**
  * A fake key store
- *
- * Was: play.core.server.ssl.FakeKeyStore
  */
-final class FakeKeyStore(mkLogger: LoggerFactory) {
+final class FakeKeyStore {
 
   import FakeKeyStore._
 
-  private val logger: NoDepsLogger = mkLogger(getClass)
+  private val logger = Logger(getClass)
 
   /**
    * @param appPath a file descriptor to the root folder of the project (the root, not a particular module).

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.ssl
+
+import java.security.{ KeyPair, KeyPairGenerator, KeyStore, SecureRandom }
+
+import com.typesafe.sslconfig.util.{ LoggerFactory, NoDepsLogger }
+import sun.security.x509._
+import sun.security.util.ObjectIdentifier
+import java.util.Date
+import java.math.BigInteger
+import java.security.cert.X509Certificate
+import java.io._
+
+import javax.net.ssl.KeyManagerFactory
+import java.security.interfaces.RSAPublicKey
+
+/**
+ * A fake key store with a single, selfsigned certificate and keypair. Includes also a `trustedCertEntry` for
+ * that certificate.
+ *
+ * {{{
+ * Your keystore contains 2 entries
+ *
+ * sslconfig-selfsigned-trust, Oct 4, 2018, trustedCertEntry,
+ * Certificate fingerprint (SHA1): 19:2D:20:F0:36:59:E3:AD:C1:AA:55:82:0D:D2:94:5D:B3:75:3F:F8
+ * sslconfig-selfsigned, Oct 4, 2018, PrivateKeyEntry,
+ * Certificate fingerprint (SHA1): 19:2D:20:F0:36:59:E3:AD:C1:AA:55:82:0D:D2:94:5D:B3:75:3F:F8
+ * }}}
+ *
+ * Was: play.core.server.ssl.FakeKeyStore
+ */
+object FakeKeyStore {
+
+  private val EMPTY_PASSWORD = Array.emptyCharArray
+
+  object SelfSigned {
+
+    object Alias {
+      // These two constants use a weird capitalization but that's what keystore uses internally (see class scaladoc)
+      val trustedCertEntry = "sslconfig-selfsigned-trust"
+      val PrivateKeyEntry = "sslconfig-selfsigned"
+    }
+
+    val DistinguishedName = "CN=localhost, OU=Unit Testing (self-signed), O=Mavericks, L=SSL Config Base 1, ST=Cyberspace, C=CY"
+    val keyPassword: Array[Char] = EMPTY_PASSWORD
+  }
+
+  object KeystoreSettings {
+    val GeneratedKeyStore: String = fileInDevModeDir("selfsigned.keystore")
+    val SignatureAlgorithmName = "SHA256withRSA"
+    val KeyPairAlgorithmName = "RSA"
+    val KeyPairKeyLength = 2048 // 2048 is the NIST acceptable key length until 2030
+    val KeystoreType = "JKS"
+    val keystorePassword: Array[Char] = EMPTY_PASSWORD
+  }
+
+  private def fileInDevModeDir(filename: String): String = {
+    "target" + File.separatorChar + "dev-mode" + File.separatorChar + filename
+  }
+
+  /**
+   * Generate a fresh KeyStore object in memory. This KeyStore
+   * is not saved to disk. If you want that, then call `keyManagerFactory`.
+   *
+   * This method is public only for consumption by Play/Lagom.
+   */
+  def generateKeyStore: KeyStore = {
+    // Create a new KeyStore
+    val keyStore: KeyStore = KeyStore.getInstance(KeystoreSettings.KeystoreType)
+
+    // Generate the key pair
+    val keyPairGenerator = KeyPairGenerator.getInstance(KeystoreSettings.KeyPairAlgorithmName)
+    keyPairGenerator.initialize(KeystoreSettings.KeyPairKeyLength)
+    val keyPair = keyPairGenerator.generateKeyPair()
+
+    val cert = createSelfSignedCertificate(keyPair)
+
+    // Create the key store, first set the store pass
+    keyStore.load(null, KeystoreSettings.keystorePassword)
+    keyStore.setKeyEntry(SelfSigned.Alias.PrivateKeyEntry, keyPair.getPrivate, SelfSigned.keyPassword, Array(cert))
+    keyStore.setCertificateEntry(SelfSigned.Alias.trustedCertEntry, cert)
+    keyStore
+  }
+
+  def createSelfSignedCertificate(keyPair: KeyPair): X509Certificate = {
+    val certInfo = new X509CertInfo()
+
+    // Serial number and version
+    certInfo.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(new BigInteger(64, new SecureRandom())))
+    certInfo.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3))
+
+    // Validity
+    val validFrom = new Date()
+    val validTo = new Date(validFrom.getTime + 50l * 365l * 24l * 60l * 60l * 1000l)
+    val validity = new CertificateValidity(validFrom, validTo)
+    certInfo.set(X509CertInfo.VALIDITY, validity)
+
+    // Subject and issuer
+    val owner = new X500Name(SelfSigned.DistinguishedName)
+    certInfo.set(X509CertInfo.SUBJECT, owner)
+    certInfo.set(X509CertInfo.ISSUER, owner)
+
+    // Key and algorithm
+    certInfo.set(X509CertInfo.KEY, new CertificateX509Key(keyPair.getPublic))
+    val algorithm = AlgorithmId.get("SHA256WithRSA")
+    certInfo.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithm))
+
+    // Create a new certificate and sign it
+    val cert = new X509CertImpl(certInfo)
+    cert.sign(keyPair.getPrivate, KeystoreSettings.SignatureAlgorithmName)
+
+    // Since the signature provider may have a different algorithm ID to what we think it should be,
+    // we need to reset the algorithm ID, and resign the certificate
+    val actualAlgorithm = cert.get(X509CertImpl.SIG_ALG).asInstanceOf[AlgorithmId]
+    certInfo.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, actualAlgorithm)
+    val newCert = new X509CertImpl(certInfo)
+    newCert.sign(keyPair.getPrivate, KeystoreSettings.SignatureAlgorithmName)
+    newCert
+  }
+
+}
+
+/**
+ * A fake key store
+ *
+ * Was: play.core.server.ssl.FakeKeyStore
+ */
+final class FakeKeyStore(mkLogger: LoggerFactory) {
+
+  import FakeKeyStore._
+
+  private val logger: NoDepsLogger = mkLogger(getClass)
+
+  /**
+   * @param appPath a file descriptor to the root folder of the project (the root, not a particular module).
+   */
+  def getKeyStoreFilePath(appPath: File) = new File(appPath, KeystoreSettings.GeneratedKeyStore)
+
+  private[ssl] def shouldGenerate(keyStoreFile: File): Boolean = {
+    import scala.collection.JavaConverters._
+
+    if (!keyStoreFile.exists()) {
+      return true
+    }
+
+    // Should regenerate if we find an unacceptably weak key in there.
+    val store = loadKeyStore(keyStoreFile)
+    store.aliases().asScala.exists { alias =>
+      Option(store.getCertificate(alias)).exists(c => certificateTooWeak(c))
+    }
+  }
+
+  private def loadKeyStore(file: File): KeyStore = {
+    val keyStore: KeyStore = KeyStore.getInstance(KeystoreSettings.KeystoreType)
+    val in = java.nio.file.Files.newInputStream(file.toPath)
+    try {
+      keyStore.load(in, "".toCharArray)
+    } finally {
+      closeQuietly(in)
+    }
+    keyStore
+  }
+
+  private[ssl] def certificateTooWeak(c: java.security.cert.Certificate): Boolean = {
+    val key: RSAPublicKey = c.getPublicKey.asInstanceOf[RSAPublicKey]
+    key.getModulus.bitLength < KeystoreSettings.KeyPairKeyLength || c.asInstanceOf[X509CertImpl].getSigAlgName != KeystoreSettings.SignatureAlgorithmName
+  }
+
+  /** Public only for consumption by Play/Lagom. */
+  def createKeyStore(appPath: File): KeyStore = {
+    val keyStoreFile = getKeyStoreFilePath(appPath)
+    val keyStoreDir = keyStoreFile.getParentFile
+
+    createKeystoreParentDirectory(keyStoreDir)
+
+    val keyStore: KeyStore = synchronized(if (shouldGenerate(keyStoreFile)) {
+      logger.info(s"Generating HTTPS key pair in ${keyStoreFile.getAbsolutePath} - this may take some time. If nothing happens, try moving the mouse/typing on the keyboard to generate some entropy.")
+
+      val freshKeyStore: KeyStore = generateKeyStore
+      val out = java.nio.file.Files.newOutputStream(keyStoreFile.toPath)
+      try {
+        freshKeyStore.store(out, KeystoreSettings.keystorePassword)
+      } finally {
+        closeQuietly(out)
+      }
+      freshKeyStore
+    } else {
+      // Load a KeyStore from a file
+      val loadedKeyStore = loadKeyStore(keyStoreFile)
+      logger.info(s"HTTPS key pair generated in ${keyStoreFile.getAbsolutePath}.")
+      loadedKeyStore
+    })
+    keyStore
+  }
+
+  private def createKeystoreParentDirectory(keyStoreDir: File): Unit = {
+    if (keyStoreDir.mkdirs()) {
+      logger.debug(s"Parent directory for keystore successfully created at ${keyStoreDir.getAbsolutePath}")
+    } else if (keyStoreDir.exists() && keyStoreDir.isDirectory) {
+      // File.mkdirs returns false when the directory already exists.
+      logger.debug(s"No need to create $keyStoreDir since it already exists.")
+    } else if (keyStoreDir.exists() && keyStoreDir.isFile) {
+      // File.mkdirs also returns false when there is a file for that path.
+      // A consumer will then fail to write the keystore file later, so we fail fast here.
+      throw new IllegalStateException(s"$keyStoreDir exists, but it is NOT a directory, making it not possible to generate a key store file.")
+    } else {
+      // Not being able to create a directory inside target folder is weird, but if it happens
+      // a consumer will then fail to write the keystore file later, so we fail fast here.
+      throw new IllegalStateException(s"Failed to create $keyStoreDir. Check if there is permission to create such folder.")
+    }
+  }
+
+  /** Public only for consumption by Play/Lagom. */
+  def keyManagerFactory(appPath: File): KeyManagerFactory = {
+    val keyStore = createKeyStore(appPath)
+
+    // Load the key and certificate into a key manager factory
+    val kmf = KeyManagerFactory.getInstance("SunX509")
+    kmf.init(keyStore, KeystoreSettings.keystorePassword)
+    kmf
+  }
+
+  /**
+   * Close the given closeable quietly.
+   *
+   * Logs any IOExceptions encountered.
+   */
+  def closeQuietly(closeable: Closeable): Unit = {
+    try {
+      if (closeable != null) {
+        closeable.close()
+      }
+    } catch {
+      case e: IOException => logger.warn(s"Error closing stream. Cause: $e")
+    }
+  }
+
+}

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -51,19 +51,20 @@ private[server] object FakeKeyStore {
     object Alias {
       // These two constants use a weird capitalization but that's what keystore uses internally (see class scaladoc)
       val trustedCertEntry = "sslconfig-selfsigned-trust"
-      val PrivateKeyEntry = "sslconfig-selfsigned"
+      val PrivateKeyEntry  = "sslconfig-selfsigned"
     }
 
-    val DistinguishedName = "CN=localhost, OU=Unit Testing (self-signed), O=Mavericks, L=SSL Config Base 1, ST=Cyberspace, C=CY"
+    val DistinguishedName =
+      "CN=localhost, OU=Unit Testing (self-signed), O=Mavericks, L=SSL Config Base 1, ST=Cyberspace, C=CY"
     val keyPassword: Array[Char] = EMPTY_PASSWORD
   }
 
   object KeystoreSettings {
-    val GeneratedKeyStore: String = fileInDevModeDir("selfsigned.keystore")
-    val SignatureAlgorithmName = "SHA256withRSA"
-    val KeyPairAlgorithmName = "RSA"
-    val KeyPairKeyLength = 2048 // 2048 is the NIST acceptable key length until 2030
-    val KeystoreType = "JKS"
+    val GeneratedKeyStore: String     = fileInDevModeDir("selfsigned.keystore")
+    val SignatureAlgorithmName        = "SHA256withRSA"
+    val KeyPairAlgorithmName          = "RSA"
+    val KeyPairKeyLength              = 2048 // 2048 is the NIST acceptable key length until 2030
+    val KeystoreType                  = "JKS"
     val keystorePassword: Array[Char] = EMPTY_PASSWORD
   }
 
@@ -128,7 +129,11 @@ private[server] object FakeKeyStore {
     // Subject Key Identifier & Authority Key Identifier
     val extUtils = new JcaX509ExtensionUtils()
     builder.addExtension(Extension.subjectKeyIdentifier, false, extUtils.createSubjectKeyIdentifier(keyPair.getPublic))
-    builder.addExtension(Extension.authorityKeyIdentifier, false, extUtils.createAuthorityKeyIdentifier(keyPair.getPublic))
+    builder.addExtension(
+      Extension.authorityKeyIdentifier,
+      false,
+      extUtils.createAuthorityKeyIdentifier(keyPair.getPublic)
+    )
 
     // Subject Alternative Names: localhost (DNS) + loopback IPs
     val sans = new GeneralNames(
@@ -145,7 +150,7 @@ private[server] object FakeKeyStore {
     val signer = new JcaContentSignerBuilder(KeystoreSettings.SignatureAlgorithmName).build(keyPair.getPrivate)
 
     val certHolder = builder.build(signer)
-    val cert = new JcaX509CertificateConverter().getCertificate(certHolder)
+    val cert       = new JcaX509CertificateConverter().getCertificate(certHolder)
 
     // Sanity check
     cert.verify(keyPair.getPublic)
@@ -184,7 +189,7 @@ private[server] final class FakeKeyStore {
 
   private def loadKeyStore(file: File): KeyStore = {
     val keyStore: KeyStore = KeyStore.getInstance(KeystoreSettings.KeystoreType)
-    val in = java.nio.file.Files.newInputStream(file.toPath)
+    val in                 = java.nio.file.Files.newInputStream(file.toPath)
     try {
       keyStore.load(in, "".toCharArray)
     } finally {
@@ -216,15 +221,17 @@ private[server] final class FakeKeyStore {
 
   def createKeyStore(appPath: File): KeyStore = {
     val keyStoreFile = getKeyStoreFilePath(appPath)
-    val keyStoreDir = keyStoreFile.getParentFile
+    val keyStoreDir  = keyStoreFile.getParentFile
 
     createKeystoreParentDirectory(keyStoreDir)
 
     val keyStore: KeyStore = synchronized(if (shouldGenerate(keyStoreFile)) {
-      logger.info(s"Generating HTTPS key pair in ${keyStoreFile.getAbsolutePath} - this may take some time. If nothing happens, try moving the mouse/typing on the keyboard to generate some entropy.")
+      logger.info(
+        s"Generating HTTPS key pair in ${keyStoreFile.getAbsolutePath} - this may take some time. If nothing happens, try moving the mouse/typing on the keyboard to generate some entropy."
+      )
 
       val freshKeyStore: KeyStore = generateKeyStore
-      val out = java.nio.file.Files.newOutputStream(keyStoreFile.toPath)
+      val out                     = java.nio.file.Files.newOutputStream(keyStoreFile.toPath)
       try {
         freshKeyStore.store(out, KeystoreSettings.keystorePassword)
       } finally {
@@ -249,11 +256,15 @@ private[server] final class FakeKeyStore {
     } else if (keyStoreDir.exists() && keyStoreDir.isFile) {
       // File.mkdirs also returns false when there is a file for that path.
       // A consumer will then fail to write the keystore file later, so we fail fast here.
-      throw new IllegalStateException(s"$keyStoreDir exists, but it is NOT a directory, making it not possible to generate a key store file.")
+      throw new IllegalStateException(
+        s"$keyStoreDir exists, but it is NOT a directory, making it not possible to generate a key store file."
+      )
     } else {
       // Not being able to create a directory inside target folder is weird, but if it happens
       // a consumer will then fail to write the keystore file later, so we fail fast here.
-      throw new IllegalStateException(s"Failed to create $keyStoreDir. Check if there is permission to create such folder.")
+      throw new IllegalStateException(
+        s"Failed to create $keyStoreDir. Check if there is permission to create such folder."
+      )
     }
   }
 

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -42,7 +42,7 @@ import play.api.Logger
  * Certificate fingerprint (SHA1): 19:2D:20:F0:36:59:E3:AD:C1:AA:55:82:0D:D2:94:5D:B3:75:3F:F8
  * }}}
  */
-object FakeKeyStore {
+private[server] object FakeKeyStore {
 
   private val EMPTY_PASSWORD = Array.emptyCharArray
 
@@ -74,8 +74,6 @@ object FakeKeyStore {
   /**
    * Generate a fresh KeyStore object in memory. This KeyStore
    * is not saved to disk. If you want that, then call `keyManagerFactory`.
-   *
-   * This method is public only for consumption by Play/Lagom.
    */
   def generateKeyStore: KeyStore = {
     // Create a new KeyStore
@@ -159,7 +157,7 @@ object FakeKeyStore {
 /**
  * A fake key store
  */
-final class FakeKeyStore {
+private[server] final class FakeKeyStore {
 
   import FakeKeyStore._
 
@@ -216,7 +214,6 @@ final class FakeKeyStore {
     weakKey || wrongSigAlg
   }
 
-  /** Public only for consumption by Play/Lagom. */
   def createKeyStore(appPath: File): KeyStore = {
     val keyStoreFile = getKeyStoreFilePath(appPath)
     val keyStoreDir = keyStoreFile.getParentFile
@@ -260,7 +257,6 @@ final class FakeKeyStore {
     }
   }
 
-  /** Public only for consumption by Play/Lagom. */
   def keyManagerFactory(appPath: File): KeyManagerFactory = {
     val keyStore = createKeyStore(appPath)
 

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeSSLTools.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeSSLTools.scala
@@ -5,10 +5,10 @@
 package play.core.server.ssl
 
 import java.security.KeyStore
-
 import javax.net.ssl._
 
 private[server] object FakeSSLTools {
+
   /**
    * NOT FOR PRODUCTION USE. Builds a "TLS" `SSLContext` and `X509TrustManager` initializing both with the keys and
    * certificates in the provided `KeyStore`. This means the `SSLContext` will produce `SSLEngine`'s, `SSLSocket``s

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeSSLTools.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeSSLTools.scala
@@ -8,7 +8,7 @@ import java.security.KeyStore
 
 import javax.net.ssl._
 
-object FakeSSLTools {
+private[server] object FakeSSLTools {
   /**
    * NOT FOR PRODUCTION USE. Builds a "TLS" `SSLContext` and `X509TrustManager` initializing both with the keys and
    * certificates in the provided `KeyStore`. This means the `SSLContext` will produce `SSLEngine`'s, `SSLSocket``s

--- a/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeSSLTools.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/ssl/FakeSSLTools.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.ssl
+
+import java.security.KeyStore
+
+import javax.net.ssl._
+
+object FakeSSLTools {
+  /**
+   * NOT FOR PRODUCTION USE. Builds a "TLS" `SSLContext` and `X509TrustManager` initializing both with the keys and
+   * certificates in the provided `KeyStore`. This means the `SSLContext` will produce `SSLEngine`'s, `SSLSocket``s
+   * and `SSLServerSocket`'s that will use a `KeyPair` from the `KeyStore`, and will trust any  `trustedCertEntry`
+   * in the `KeyStore`.
+   *
+   * This is a naïve implementation for testing purposes only.
+   */
+  def buildContextAndTrust(keyStore: KeyStore): (SSLContext, X509TrustManager) = {
+    val kmf: KeyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+    kmf.init(keyStore, Array.emptyCharArray)
+    val kms: Array[KeyManager] = kmf.getKeyManagers
+
+    val tmf: TrustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    tmf.init(keyStore)
+    val tms: Array[TrustManager] = tmf.getTrustManagers
+
+    val x509TrustManager: X509TrustManager = tms(0).asInstanceOf[X509TrustManager]
+
+    val sslContext: SSLContext = SSLContext.getInstance("TLS")
+    sslContext.init(kms, tms, null)
+
+    (sslContext, x509TrustManager)
+  }
+}

--- a/transport/server/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
@@ -10,13 +10,7 @@ import java.util.Properties
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngine
 
-import scala.util.Properties.isJavaAtLeast
-
 import org.mockito.Mockito
-import org.specs2.execute.AsResult
-import org.specs2.execute.Pending
-import org.specs2.execute.Result
-import org.specs2.execute.ResultExecution
 import org.specs2.matcher.MustThrownExpectations
 import org.specs2.mutable.After
 import org.specs2.mutable.Specification
@@ -69,13 +63,6 @@ class ServerSSLEngineSpec extends Specification {
     }
   }
 
-  implicit class UntilJavaFixesSelfSignedCertificates[T: AsResult](t: => T) {
-    def skipOnJava21andAbove: Result = {
-      if (isJavaAtLeast(21)) Pending("PENDING [INCOMPATIBLE WITH JAVA 21+]")
-      else ResultExecution.execute(AsResult(t))
-    }
-  }
-
   def serverConfig(tempDir: File, engineProvider: Option[String]): ServerConfig = {
     val props = new Properties()
     engineProvider.foreach(props.put("play.server.https.engineProvider", _))
@@ -97,7 +84,7 @@ class ServerSSLEngineSpec extends Specification {
   "ServerSSLContext" should {
     "default create a SSL engine suitable for development" in new ApplicationContext with TempConfDir {
       createEngine(None, Some(tempDir)) must beAnInstanceOf[SSLEngine]
-    }.skipOnJava21andAbove // because of https://github.com/lightbend/ssl-config/issues/367
+    }
 
     "fail to load a non existing SSLEngineProvider" in new ApplicationContext {
       createEngine(Some("bla bla")) must throwA[ClassNotFoundException]


### PR DESCRIPTION
- Fixes https://github.com/playframework/playframework/issues/13234

Until now, we used ssl-config's `FakeKeyStore` class to generate self signed certificates for dev mode and for testing. The classes in `sun.security.x509` which are used to generate a self signed certificate are actually internal Java code (which they use for their `keytool` command line tool as I understood). Because of [JEP 403](https://openjdk.org/jeps/403) Java strongly encapsulates JDK internals as of Java 17, meaning there is no other way to access that code but to add `--add-exports=java.base/sun.security.x509=ALL-UNNAMED"` (or using a specific module name if we would use one) to the `java` command.
With Java 20 (or 19 or 18, not sure) that internal code even changed - which of course [fails hard](https://github.com/lightbend/ssl-config/issues/367) when trying to run artifacts targeting Java 17 on Java 21.
Of course, we could [adjust the code](https://github.com/lightbend/ssl-config/compare/v0.6.1...mkurz:ssl-config:java21) and [create a multi-release jar](https://openjdk.org/jeps/238), so depending on the java runtime it would pick up the working implemention. However, even then, we still would need to add the `--add-exports=...` flag. Plus, since this is internal code, we never know when things change again, so we would need to catch up every now and then again. Even worse, maybe the code would change between Java patch releases (unlikely, but possible). Even more worse, if we use that internal code, it could easily be possible that it's actually not portable - maybe Amazon Corretto has a different internal API? Who knows.

So we should not really rely on that interal code - also it looks like there never will be a public Java API to generate self signed certificates, see the last comment from last year in [JDK-8058778](https://bugs.openjdk.org/browse/JDK-8058778). (never say never, but I don't hold my breath for the next 10 years).

So we need either implement that certificate generation ourselves (good luck ;) or use a 3rd party library.
So I was checking lots of stuff, but _all_ (really _all_) libraries I found use Bouncy Castle under the hood. So let's use it directly (it's just a couple of lines of code anyway).
I was somehow reluctant to pull in that dependency because it has more than 8 MB - and I want to avoid new dependencies in general if not really necessary.
The good thing on the other hand is that bouncycastle is very well maintained and itself has no dependencies:
- https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.82/bcprov-jdk18on-1.82.pom
- https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.82/bcpkix-jdk18on-1.82.pom (yes we need that one too, another 1 MB)

If you want to review this PR I recommend per-commit.
So what this PR does, it brings back the `FakeKeyStore` class from ssl-config (originally the `ssl` package [was moved from play to ssl-config](https://github.com/playframework/playframework/commit/d5c07f5b1891c887e9a47768c5c26aaf14e6c6cc)) and adjust that code to use Bouncy Castle.
Side note: ssl-config is more or less dead - actually Lightbend reached out to me last week if they should archive it - there is no decision yet. Even if it will be maintained further it should not pull in Bouncy Castle because ssl-config always tried to have zero dependencies - it should just be used for it's original purpose of configuring an ssl-context via hocon.