### PR TITLE
add parentheses for `sbt.io.PathFinder.get`

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -66,9 +66,9 @@ object Docs {
       val docBase     = baseDirectory.value / "../../documentation"
       val raw         = (docBase \ "manual" ** "*") +++ (docBase \ "style" ** "*")
       val filtered    = raw.filter(_.getName != ".DS_Store")
-      val docMappings = filtered.get.pair(rebase(docBase, "play/docs/content/"))
+      val docMappings = filtered.get().pair(rebase(docBase, "play/docs/content/"))
 
-      val apiDocMappings = (apiBase ** "*").get.pair(rebase(apiBase, "play/docs/content/api"))
+      val apiDocMappings = (apiBase ** "*").get().pair(rebase(apiBase, "play/docs/content/api"))
 
       // The play version is added so that resource paths are versioned
       val webjarMappings = webjars.allPaths.pair(rebase(webjars, "play/docs/content/webjars/" + version.value))
@@ -92,7 +92,7 @@ object Docs {
       val docBase     = base / "documentation"
       val raw         = (docBase / "manual").allPaths +++ (docBase / "style").allPaths
       val filtered    = raw.filter(_.getName != ".DS_Store")
-      val docMappings = filtered.get.pair(relativeTo(docBase))
+      val docMappings = filtered.get().pair(relativeTo(docBase))
 
       // The play version is added so that resource paths are versioned
       val webjars        = extractWebjars.value
@@ -233,7 +233,7 @@ object Docs {
     // Maps to Javadoc references in Scaladoc, and fixes the link so that it uses query parameters in
     // Javadoc style to link directly to the referenced class.
     // https://stackoverflow.com/questions/16934488/how-to-link-classes-from-jdk-into-scaladoc-generated-doc/
-    (apiTarget ** "*.html").get.filter(hasJavadocLink).foreach { f =>
+    (apiTarget ** "*.html").get().filter(hasJavadocLink).foreach { f =>
       val newContent: String = externalJavadocLinks.foldLeft(IO.read(f)) {
         case (oldContent: String, javadocURL: String) =>
           javadocLinkRegex(javadocURL).replaceAllIn(oldContent, fixJavaLinks)


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose

prepare sbt 2.x

https://github.com/sbt/io/blob/d2c91e78c011eadd508274db8b9ae834086f2331/io/src/main/scala/sbt/io/Path.scala#L448

```
Welcome to Scala 3.7.2 (21.0.8, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> def get(): Int = 2
def get(): Int
                                                                                                                                             
scala> get
-- [E100] Syntax Error: --------------------------------------------------------
1 |get
  |^^^
  |method get must be called with () argument
  |
  | longer explanation available when compiling with `-explain`
1 error found
```

## Background Context


## References
