### PR TITLE
[3.0.x] Bump to lz4-java 1.10.1 to fix CVE-2025-66566 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -165,7 +165,9 @@ object Dependencies {
     slf4j ++
       Seq("pekko-actor", "pekko-actor-typed", "pekko-slf4j", "pekko-serialization-jackson")
         .map("org.apache.pekko" %% _ % pekkoVersion)
-        .map(_.excludeAll(ExclusionRule("org.lz4"))) ++ Seq("at.yawk.lz4" % "lz4-java" % "1.8.1") ++ // CVE‐2025‐12183
+        .map(_.excludeAll(ExclusionRule("org.lz4"))) ++ Seq(
+        "at.yawk.lz4" % "lz4-java" % "1.10.1" // CVE‐2025‐12183 + CVE-2025-66566
+      ) ++
       Seq("pekko-testkit", "pekko-actor-testkit-typed")
         .map("org.apache.pekko" %% _ % pekkoVersion % Test) ++
       jacksons ++


### PR DESCRIPTION
This one is different than cve-2025-12183 in just merged #13682
Details: https://github.com/yawkat/lz4-java/security/advisories/GHSA-cmp6-m4wj-q63q