### PR TITLE
[2.9.x] Bump to lz4-java 1.10.1 to fix CVE-2025-66566

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -182,7 +182,9 @@ object Dependencies {
       Seq("akka-actor", "akka-actor-typed", "akka-slf4j", "akka-serialization-jackson")
         .map("com.typesafe.akka" %% _ % akkaVersion)
         .map(_.forScala3TestsUse2_13())
-        .map(_.excludeAll(ExclusionRule("org.lz4"))) ++ Seq("at.yawk.lz4" % "lz4-java" % "1.8.1") ++ // CVE‐2025‐12183
+        .map(_.excludeAll(ExclusionRule("org.lz4"))) ++ Seq(
+        "at.yawk.lz4" % "lz4-java" % "1.10.1" // CVE‐2025‐12183 + CVE-2025-66566
+      ) ++
       Seq("akka-testkit", "akka-actor-testkit-typed")
         .map("com.typesafe.akka" %% _ % akkaVersion % Test)
         .map(_.forScala3TestsUse2_13()) ++


### PR DESCRIPTION
- Backporting #13684