### PR TITLE
support pekko.http.server.enable-http2

### DIFF
--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -130,10 +130,9 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
    */
   protected def createPekkoHttpConfig(): Config =
     Configuration(
-      "pekko.http.server.enable-http2" -> http2Enabled,
+      "pekko.http.server.enable-http2"         -> http2Enabled,
       "pekko.http.server.preview.enable-http2" -> http2Enabled,
-    ).withFallback(Configuration(context.actorSystem.settings.config))
-      .underlying
+    ).withFallback(Configuration(context.actorSystem.settings.config)).underlying
 
   /** Play's parser settings for Pekko HTTP. Initialized by a call to [[createParserSettings()]]. */
   protected val parserSettings: ParserSettings = createParserSettings()

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -129,8 +129,10 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
    * configuration, with an additional setting patched in to enable or disable HTTP/2.
    */
   protected def createPekkoHttpConfig(): Config =
-    Configuration("pekko.http.server.preview.enable-http2" -> http2Enabled)
-      .withFallback(Configuration(context.actorSystem.settings.config))
+    Configuration(
+      "pekko.http.server.enable-http2" -> http2Enabled,
+      "pekko.http.server.preview.enable-http2" -> http2Enabled,
+    ).withFallback(Configuration(context.actorSystem.settings.config))
       .underlying
 
   /** Play's parser settings for Pekko HTTP. Initialized by a call to [[createParserSettings()]]. */


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

Since Pekko 1.3, `pekko.http.server.enable-http2` is preferred but worth also setting the older setting just in case too.

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
