### PR TITLE
Add support for regex in allowed origins for the CORS filter.

### DIFF
--- a/documentation/manual/working/commonGuide/filters/CorsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/CorsFilter.md
@@ -22,6 +22,7 @@ The available options include:
 
 * `play.filters.cors.pathPrefixes` - filter paths by a whitelist of path prefixes
 * `play.filters.cors.allowedOrigins` - allow only requests from origins in this whitelist. By default the value is `null`, which means allow all origins. The value `"*"` has a special meaning, it will send back `Access-Control-Allow-Origin: *` if the request origin does not match any other origins in the list. `"null"` is treated as a valid origin, and can be whitelisted in allowedOrigins to allow origins with non-hierarchical schemes like `file:` and `data`: by sending `Access-Control-Allow-Origin: "null"`. Be aware that this is [discouraged by the W3C](https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null) as it can also grant hostile documents access to the response.
+* `play.filters.cors.allowedOriginsAsRegex` - enable/disable parsing of origins in the whitelist as regular expressions (by default they are treated as plain strings). When enabled, it's recommended to use full matches, like in `^https://[^\.]+\.example.net$`
 * `play.filters.cors.allowedHttpMethods` - allow only HTTP methods from a whitelist for preflight requests (by default all methods are allowed)
 * `play.filters.cors.allowedHttpHeaders` - allow only HTTP headers from a whitelist for preflight requests (by default all headers are allowed)
 * `play.filters.cors.exposedHeaders` - set custom HTTP headers to be exposed in the response (by default no headers are exposed)

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -250,6 +250,9 @@ play.filters {
     # if the request origin does not match any other origins in the list.
     allowedOrigins = null
 
+    # Whether the allowed origins should be parsed as regular expressions
+    allowedOriginsAsRegex = false
+
     # The allowed HTTP methods. If null, all methods are allowed
     allowedHttpMethods = null
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [X] Have you added copyright headers to new files?
* [X] Have you checked that both Scala and Java APIs are updated?
* [X] Have you updated the documentation for both Scala and Java sections?
* [X] Have you added tests for any changed functionality?

# Helpful things

## Purpose

This PR adds the ability to use regular expressions when defining the allowed origins for the CORS filter.

## Background Context

Sometimes explicitely declaring all allowed origins is not possible, for example when dynamic hostnames under the same domain are used. Currently the only option is to allow any origin, but this is sub-optimal. I've evaluated two different approaches to solve the issue:
1. add support for wildcards (simpler, but still limited)
2. add support for regular expressions (more complex, but more flexible)

Considering that other common web frameworks (like Node Express) already support regular expressions, I've opted for the second solution.

The change has been done in a full backward compatible way, so the CORS behavior is unchanged unless the new `allowedOriginsAsRegex` config parameter is set to `true`.