### PR TITLE
Fix old vararg splices syntax

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -21,7 +21,7 @@ class DefaultBodyParserSpec extends PlaySpecification {
         defaultBodyParser: BodyParser[AnyContent]
     ) = {
       val request = FakeRequest(method, "/x").withHeaders(
-        contentType.map(CONTENT_TYPE -> _).toSeq :+ (CONTENT_LENGTH -> body.length.toString): _*
+        (contentType.map(CONTENT_TYPE -> _).toSeq :+ (CONTENT_LENGTH -> body.length.toString))*
       )
       await(defaultBodyParser(request).run(Source.single(body)))
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -686,7 +686,7 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
           ).delay(sendCloseAfterDelay).via(flow).runWith(consumeFrames)
         }
       )
-      frames must contain(exactly(expectedFrames ++ List(closeFrame()): _*))
+      frames must contain(exactly((expectedFrames ++ List(closeFrame()))*))
     }
   }
 }

--- a/core/play/src/main/scala/play/api/libs/concurrent/Pekko.scala
+++ b/core/play/src/main/scala/play/api/libs/concurrent/Pekko.scala
@@ -237,7 +237,7 @@ object ActorSystemProvider {
     val name = config.get[String]("play.pekko.actor-system")
 
     val bootstrapSetup   = BootstrapSetup(Some(classLoader), Some(pekkoConfig), None)
-    val actorSystemSetup = ActorSystemSetup(bootstrapSetup +: additionalSetups: _*)
+    val actorSystemSetup = ActorSystemSetup((bootstrapSetup +: additionalSetups)*)
 
     logger.debug(s"Starting application default Pekko system: $name")
     ActorSystem(name, actorSystemSetup)


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose


## Background Context

https://docs.scala-lang.org/scala3/reference/changed-features/vararg-splices.html

## References

