### PR TITLE
Remove redundant `asInstanceOf`

### DIFF
--- a/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
+++ b/transport/client/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSRequest.scala
@@ -136,7 +136,7 @@ case class AhcWSRequest(underlying: StandaloneAhcWSRequest) extends WSRequest wi
   }
 
   override def withRequestFilter(filter: WSRequestFilter): Self = toWSRequest {
-    underlying.withRequestFilter(filter.asInstanceOf[WSRequestFilter])
+    underlying.withRequestFilter(filter)
   }
 
   override def withVirtualHost(vh: String): Self = toWSRequest {

--- a/web/play-openid/src/test/scala/play/api/libs/openid/WsMock.scala
+++ b/web/play-openid/src/test/scala/play/api/libs/openid/WsMock.scala
@@ -24,11 +24,11 @@ class WSMock extends WSClient {
   when(response.header(HeaderNames.CONTENT_TYPE)).thenReturn(Some("text/html;charset=UTF-8"))
   when(response.body).thenReturn("")
 
-  when(request.get()).thenReturn(Future.successful(response.asInstanceOf[request.Response]))
+  when(request.get()).thenReturn(Future.successful(response))
   when(request.post(anyString)(using any[BodyWritable[String]]))
-    .thenReturn(Future.successful(response.asInstanceOf[request.Response]))
+    .thenReturn(Future.successful(response))
   when(request.post(any[Map[String, Seq[String]]])(using any[BodyWritable[Map[String, Seq[String]]]]))
-    .thenReturn(Future.successful(response.asInstanceOf[request.Response]))
+    .thenReturn(Future.successful(response))
 
   def url(url: String): WSRequest = {
     urls += url


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose


## Background Context


## References

