### PR TITLE
Use `readAllBytes` instead of `ByteArrayOutputStream`

### DIFF
--- a/core/play-configuration/src/main/scala/play/api/Configuration.scala
+++ b/core/play-configuration/src/main/scala/play/api/Configuration.scala
@@ -4,7 +4,6 @@
 
 package play.api
 
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -174,14 +173,7 @@ object Configuration {
    */
   private def readStream(stream: InputStream): Array[Byte] = {
     try {
-      val buffer = new Array[Byte](8192)
-      var len    = stream.read(buffer)
-      val out    = new ByteArrayOutputStream() // Doesn't need closing
-      while (len != -1) {
-        out.write(buffer, 0, len)
-        len = stream.read(buffer)
-      }
-      out.toByteArray
+      stream.readAllBytes()
     } finally {
       try {
         if (stream != null) {

--- a/core/play/src/main/scala/play/utils/PlayIO.scala
+++ b/core/play/src/main/scala/play/utils/PlayIO.scala
@@ -28,14 +28,7 @@ private[play] object PlayIO {
    */
   private def readStream(stream: InputStream): Array[Byte] = {
     try {
-      val buffer = new Array[Byte](8192)
-      var len    = stream.read(buffer)
-      val out    = new ByteArrayOutputStream() // Doesn't need closing
-      while (len != -1) {
-        out.write(buffer, 0, len)
-        len = stream.read(buffer)
-      }
-      out.toByteArray
+      stream.readAllBytes()
     } finally closeQuietly(stream)
   }
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

## Purpose


## Background Context

`InputStream` has `readAllBytes` method since JDK 9.


https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/InputStream.html#readAllBytes()



## References

