### PR TITLE
GzipFilter: Weaken ETag when gzipping

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -186,8 +186,18 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
    */
   private def isNotAlreadyCompressed(header: ResponseHeader) = header.headers.get(CONTENT_ENCODING).isEmpty
 
+  /**
+   * Weakens a strong ETag, since gzip encoding changes the byte representation.
+   */
+  private def weakenETag(etag: String): Option[String] = etag match {
+    case weak if weak.startsWith("W/")     => Some(weak)         // already weak, leave as-is
+    case strong if strong.startsWith("\"") => Some(s"W/$strong") // strong ETag: "tag" → W/"tag"
+    case _                                 => None               // invalid ETag: can't be weakened correctly, drop it
+  }
+
   private def setupHeader(rh: ResponseHeader): Map[String, String] = {
-    rh.headers + (CONTENT_ENCODING -> "gzip") + rh.varyWith(ACCEPT_ENCODING)
+    val headers = rh.headers.updatedWith(ETAG)(_.flatMap(weakenETag))
+    headers + (CONTENT_ENCODING -> "gzip") + rh.copy(headers = headers).varyWith(ACCEPT_ENCODING)
   }
 }
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -258,7 +258,7 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     }
 
     "remove invalid ETag header when gzipping a response" in withApplication(
-      Ok("hello").withHeaders(ETAG -> "abc123") // unquoted ETag value; a common violation of RFC 7232
+      Ok("hello").withHeaders(ETAG -> "abc123") // unquoted ETag value; a common violation of RFC 9110
     ) { implicit app =>
       val result = makeGzipRequest(app)
       checkGzippedBody(result, "hello")(using app.materializer)

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -225,6 +225,46 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       threshold = 18
     ) { implicit app => checkGzippedBody(makeGzipRequest(app), "these are 18 bytes")(using app.materializer) }
 
+    "weaken ETag header when gziping a response" in withApplication(
+      Ok("hello").withHeaders(ETAG -> "\"abc123\"")
+    ) { implicit app =>
+      val result = makeGzipRequest(app)
+      checkGzippedBody(result, "hello")(using app.materializer)
+      header(ETAG, result) must beSome("W/\"abc123\"")
+    }
+
+    "not weaken ETag header when not gziping a response" in withApplication(
+      Ok("hello").withHeaders(ETAG -> "\"abc123\"")
+    ) { implicit app =>
+      val result = route(app, FakeRequest().withHeaders(ACCEPT_ENCODING -> "identity")).get
+      checkNotGzipped(result, "hello")(using app.materializer)
+      header(ETAG, result) must beSome("\"abc123\"")
+    }
+
+    "not add ETag header when gziping a response without an ETag header" in withApplication(
+      Ok("hello")
+    ) { implicit app =>
+      val result = makeGzipRequest(app)
+      checkGzippedBody(result, "hello")(using app.materializer)
+      header(ETAG, result) must beNone
+    }
+
+    "not modify ETag header when gziping a response with an already weak ETag header" in withApplication(
+      Ok("hello").withHeaders(ETAG -> "W/\"abc123\"")
+    ) { implicit app =>
+      val result = makeGzipRequest(app)
+      checkGzippedBody(result, "hello")(using app.materializer)
+      header(ETAG, result) must beSome("W/\"abc123\"")
+    }
+
+    "remove invalid ETag header when gzipping a response" in withApplication(
+      Ok("hello").withHeaders(ETAG -> "abc123") // unquoted ETag value; a common violation of RFC 7232
+    ) { implicit app =>
+      val result = makeGzipRequest(app)
+      checkGzippedBody(result, "hello")(using app.materializer)
+      header(ETAG, result) must beNone
+    }
+
     val body = Random.nextString(1000)
 
     "a streamed body" should {


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

This PR updates GzipFilter to weaken strong ETags when compressing a Result.

If the Result contains an unquoted ETag, which is malformed according to [RFC 9110, Section 8.8.3](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3), GzipFilter removes the ETag header entirely.
I think this behavior is the safest fallback to prevent any downstream caching issue with invalid headers. It seems Cloudflare handles malformed ETags this way, according to their documentation.

https://developers.cloudflare.com/cache/reference/etag-headers/#important-remarks
> You must set the value in a strong ETag header using double quotes (for example, `etag: "foobar"`). If you use an incorrect format, Cloudflare will remove the ETag header instead of converting it to a weak ETag. 

I believe this improves adherence to the HTTP standards.
- Ref #12981
- See also #12980
