### PR TITLE
GzipFilter: Add Vary header for compressible responses even when not gzipped

### DIFF
--- a/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -76,67 +76,76 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
     GzipFlow.gzip(config.bufferSize, config.compressionLevel)
 
   private def handleResult(request: RequestHeader, result: Result): Future[Result] = {
-    implicit val ec = mat.executionContext
     if (shouldCompress(result) && config.shouldGzip(request, result)) {
-      val header = result.header.copy(headers = setupHeader(result.header))
-
-      result.body match {
-        case HttpEntity.Strict(data, contentType) =>
-          compressStrictEntity(Source.single(data), contentType)
-            .map(entity => result.copy(header = header, body = entity))
-
-        case entity @ HttpEntity.Streamed(_, Some(contentLength), contentType)
-            if contentLength <= config.chunkedThreshold =>
-          // It's below the chunked threshold, so buffer then compress and send
-          compressStrictEntity(entity.data, contentType)
-            .map(strictEntity => result.copy(header = header, body = strictEntity))
-
-        case HttpEntity.Streamed(data, _, contentType) if request.version == HttpProtocol.HTTP_1_0 =>
-          // It's above the chunked threshold, but we can't chunk it because we're using HTTP 1.0.
-          // Instead, we use a close delimited body (ie, regular body with no content length)
-          val gzipped = data.via(createGzipFlow)
-          Future.successful(
-            result.copy(header = header, body = HttpEntity.Streamed(gzipped, None, contentType))
-          )
-
-        case HttpEntity.Streamed(data, _, contentType) =>
-          // It's above the chunked threshold, compress through the gzip flow, and send as chunked
-          val gzipped = data.via(createGzipFlow).map(d => HttpChunk.Chunk(d))
-          Future.successful(
-            result.copy(header = header, body = HttpEntity.Chunked(gzipped, contentType))
-          )
-
-        case HttpEntity.Chunked(chunks, contentType) =>
-          val gzipFlow = Flow.fromGraph(GraphDSL.create[FlowShape[HttpChunk, HttpChunk]]() { implicit builder =>
-            import GraphDSL.Implicits._
-
-            val extractChunks   = Flow[HttpChunk].collect { case HttpChunk.Chunk(data) => data }
-            val createChunks    = Flow[ByteString].map[HttpChunk](HttpChunk.Chunk.apply)
-            val filterLastChunk = Flow[HttpChunk]
-              .filter(_.isInstanceOf[HttpChunk.LastChunk])
-              // Since we're doing a merge by concatenating, the filter last chunk won't receive demand until the gzip
-              // flow is finished. But the broadcast won't start broadcasting until both flows start demanding. So we
-              // put a buffer of one in to ensure the filter last chunk flow demands from the broadcast.
-              .buffer(1, OverflowStrategy.backpressure)
-
-            val broadcast = builder.add(Broadcast[HttpChunk](2))
-            val concat    = builder.add(Concat[HttpChunk]())
-
-            // Broadcast the stream through two separate flows, one that collects chunks and turns them into
-            // ByteStrings, sends those ByteStrings through the Gzip flow, and then turns them back into chunks,
-            // the other that just allows the last chunk through. Then concat those two flows together.
-            broadcast.out(0) ~> extractChunks ~> createGzipFlow ~> createChunks ~> concat.in(0)
-            broadcast.out(1) ~> filterLastChunk ~> concat.in(1)
-
-            new FlowShape(broadcast.in, concat.out)
-          })
-
-          Future.successful(
-            result.copy(header = header, body = HttpEntity.Chunked(chunks.via(gzipFlow), contentType))
-          )
+      val resultWithVary = result.withHeaders(result.header.varyWith(ACCEPT_ENCODING))
+      if (gzipIsAcceptedAndPreferredBy(request)) {
+        compressResult(request, resultWithVary)
+      } else {
+        Future.successful(resultWithVary)
       }
     } else {
       Future.successful(result)
+    }
+  }
+
+  private def compressResult(request: RequestHeader, result: Result): Future[Result] = {
+    implicit val ec = mat.executionContext
+    val header = result.header.copy(headers = setupHeader(result.header))
+
+    result.body match {
+      case HttpEntity.Strict(data, contentType) =>
+        compressStrictEntity(Source.single(data), contentType)
+          .map(entity => result.copy(header = header, body = entity))
+
+      case entity @ HttpEntity.Streamed(_, Some(contentLength), contentType)
+          if contentLength <= config.chunkedThreshold =>
+        // It's below the chunked threshold, so buffer then compress and send
+        compressStrictEntity(entity.data, contentType)
+          .map(strictEntity => result.copy(header = header, body = strictEntity))
+
+      case HttpEntity.Streamed(data, _, contentType) if request.version == HttpProtocol.HTTP_1_0 =>
+        // It's above the chunked threshold, but we can't chunk it because we're using HTTP 1.0.
+        // Instead, we use a close delimited body (ie, regular body with no content length)
+        val gzipped = data.via(createGzipFlow)
+        Future.successful(
+          result.copy(header = header, body = HttpEntity.Streamed(gzipped, None, contentType))
+        )
+
+      case HttpEntity.Streamed(data, _, contentType) =>
+        // It's above the chunked threshold, compress through the gzip flow, and send as chunked
+        val gzipped = data.via(createGzipFlow).map(d => HttpChunk.Chunk(d))
+        Future.successful(
+          result.copy(header = header, body = HttpEntity.Chunked(gzipped, contentType))
+        )
+
+      case HttpEntity.Chunked(chunks, contentType) =>
+        val gzipFlow = Flow.fromGraph(GraphDSL.create[FlowShape[HttpChunk, HttpChunk]]() { implicit builder =>
+          import GraphDSL.Implicits._
+
+          val extractChunks   = Flow[HttpChunk].collect { case HttpChunk.Chunk(data) => data }
+          val createChunks    = Flow[ByteString].map[HttpChunk](HttpChunk.Chunk.apply)
+          val filterLastChunk = Flow[HttpChunk]
+            .filter(_.isInstanceOf[HttpChunk.LastChunk])
+            // Since we're doing a merge by concatenating, the filter last chunk won't receive demand until the gzip
+            // flow is finished. But the broadcast won't start broadcasting until both flows start demanding. So we
+            // put a buffer of one in to ensure the filter last chunk flow demands from the broadcast.
+            .buffer(1, OverflowStrategy.backpressure)
+
+          val broadcast = builder.add(Broadcast[HttpChunk](2))
+          val concat    = builder.add(Concat[HttpChunk]())
+
+          // Broadcast the stream through two separate flows, one that collects chunks and turns them into
+          // ByteStrings, sends those ByteStrings through the Gzip flow, and then turns them back into chunks,
+          // the other that just allows the last chunk through. Then concat those two flows together.
+          broadcast.out(0) ~> extractChunks ~> createGzipFlow ~> createChunks ~> concat.in(0)
+          broadcast.out(1) ~> filterLastChunk ~> concat.in(1)
+
+          new FlowShape(broadcast.in, concat.out)
+        })
+
+        Future.successful(
+          result.copy(header = header, body = HttpEntity.Chunked(chunks.via(gzipFlow), contentType))
+        )
     }
   }
 
@@ -151,7 +160,7 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
    * Whether this request may be compressed.
    */
   private def mayCompress(request: RequestHeader) =
-    request.method != "HEAD" && gzipIsAcceptedAndPreferredBy(request)
+    request.method != "HEAD"
 
   private def gzipIsAcceptedAndPreferredBy(request: RequestHeader) = {
     val codings                        = acceptHeader(request.headers, ACCEPT_ENCODING)

--- a/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -90,7 +90,7 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
 
   private def compressResult(request: RequestHeader, result: Result): Future[Result] = {
     implicit val ec = mat.executionContext
-    val header = result.header.copy(headers = setupHeader(result.header))
+    val header      = result.header.copy(headers = setupHeader(result.header))
 
     result.body match {
       case HttpEntity.Strict(data, contentType) =>

--- a/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -319,6 +319,23 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
         await(result).body must beAnInstanceOf[HttpEntity.Strict]
       }
 
+      "add a Vary header when gzipped" in withApplication(Ok("hello")) { implicit app =>
+        val result = makeGzipRequest(app)
+        checkGzipped(result)
+        header(VARY, result) must beSome[String].which(_.contains(ACCEPT_ENCODING))
+      }
+
+      "add a Vary header even when not gzipped" in withApplication(Ok("hello")) { implicit app =>
+        val result = route(app, FakeRequest()).get
+        header(CONTENT_ENCODING, result) must beNone
+        header(VARY, result) must beSome[String].which(_.contains(ACCEPT_ENCODING))
+      }
+
+      "not add a Vary header if the result is not compressible" in withApplication(NoContent) { implicit app =>
+        val result = makeGzipRequest(app)
+        header(VARY, result) must beNone
+      }
+
       "preserve original headers, cookie, flash and session values" in withApplication(
         Ok("hello")
           .withHeaders(SERVER -> "Play")


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

Previously, the Vary: Accept-Encoding header was only added when the response was actually gzipped. Now it is also added when the response is compressible but not gzipped (e.g., when the client doesn't send Accept-Encoding: gzip).
I believe this behavior better conforms to the standard, because the Vary header must indicate that the response depends on the Accept-Encoding request header, preventing downstream caches from incorrectly serving a cached uncompressed response to subsequent clients that support compression.

The diff is larger than it should be, due to indentation changes. Please let me know if you have any suggestions to minimize it.

Part of #12981 