### PR TITLE
Keep externalizeResourcesExcludes source-compatible on sbt 2

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -105,7 +105,7 @@ object PlayImport {
     )
     val playExternalizedResources =
       TaskKey[Seq[(FileRef, String)]]("playExternalizedResources", "The resources to externalize")
-    val externalizeResourcesExcludes = SettingKey[Seq[FileRef]](
+    val externalizeResourcesExcludes = SettingKey[Seq[File]](
       "externalizeResourcesExcludes",
       "Resources that should not be externalized but stay in the generated jar"
     )

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -290,7 +290,7 @@ object PlaySettings {
     playExternalizedResources := uncached {
       implicit val fc: FileConverter = fileConverter.value
       val rdirs                      = unmanagedResourceDirectories.value
-      (unmanagedResources.value --- rdirs --- toFinder(externalizeResourcesExcludes.value))
+      (unmanagedResources.value --- rdirs --- PathFinder(externalizeResourcesExcludes.value))
         .pair(relativeTo(rdirs) | flat)
         .map(mapping => (toFileRef(mapping._1), mapping._2))
     },


### PR DESCRIPTION
Fixes the [java/jpa sample](https://github.com/playframework/play-samples/tree/main/java/jpa)