### PR TITLE
use Source.completionStage instead of using a Scala Future

### DIFF
--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -15,7 +15,6 @@ import play.libs.F;
 import play.mvc.Results;
 import play.mvc.WebSocket;
 import scala.concurrent.Promise;
-import scala.jdk.javaapi.FutureConverters;
 
 /** Java actions for WebSocket spec */
 public class WebSocketSpecJavaActions {
@@ -31,7 +30,7 @@ public class WebSocketSpecJavaActions {
   }
 
   private static <A> Source<A, ?> emptySource() {
-    return Source.fromFuture(FutureConverters.asScala(new CompletableFuture<>()));
+    return Source.fromFuture(new CompletableFuture<>());
   }
 
   public static WebSocket allowConsumingMessages(Promise<List<String>> messages) {

--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -30,7 +30,7 @@ public class WebSocketSpecJavaActions {
   }
 
   private static <A> Source<A, ?> emptySource() {
-    return Source.fromFuture(new CompletableFuture<>());
+    return Source.completionStage(new CompletableFuture<>());
   }
 
   public static WebSocket allowConsumingMessages(Promise<List<String>> messages) {


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

One of the issues in #13741 

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
