### PR TITLE
avoid deprecated Pekko HttpRequest.copy()

### DIFF
--- a/transport/server/play-pekko-http-server/src/test/scala/play/core/server/pekkohttp/PekkoHeadersWrapperTest.scala
+++ b/transport/server/play-pekko-http-server/src/test/scala/play/core/server/pekkohttp/PekkoHeadersWrapperTest.scala
@@ -13,8 +13,8 @@ class PekkoHeadersWrapperTest extends Specification {
   val emptyRequest: HttpRequest = HttpRequest()
 
   "PekkoHeadersWrapper" should {
-    "return no Content-Type Header when there's not entity (therefore no content type ) in the request" in {
-      val request        = emptyRequest.copy()
+    "return no Content-Type Header when there's no entity (therefore no content type ) in the request" in {
+      val request        = HttpRequest()
       val headersWrapper = PekkoHeadersWrapper(request, None, request.headers, None, "some-uri")
 
       headersWrapper.headers.find { case (k, _) => k == HeaderNames.CONTENT_TYPE } must be(None)


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

One of the issues in #13741.
https://pekko.apache.org/api/pekko-http/1.1/org/apache/pekko/http/scaladsl/model/HttpRequest.html
copy method deprecated and later removed in 2.0.0-M1.
The docs say to use the `withXYZ` methods instead but in this case, the intent is to do a plain copy.
It seems easiest in this one test that is affected to create a fresh HttpRequest instance.

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
