### PR TITLE
Fix websocket setting to use random factory

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/code/CustomPekkoHttpServer.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/CustomPekkoHttpServer.scala
@@ -31,7 +31,7 @@ class CustomPekkoHttpServer(context: PekkoHttpServer.Context) extends PekkoHttpS
     val defaultSettings: ServerSettings =
       super.createServerSettings(port, connectionContext, secure)
     val defaultWebsocketSettings = defaultSettings.websocketSettings()
-    defaultSettings.withWebsocketSettings(defaultWebsocketSettings.withRandomFactoryFactory(() => new Random())
+    defaultSettings.withWebsocketSettings(defaultWebsocketSettings.withRandomFactoryFactory(() => new Random()))
   }
 }
 

--- a/documentation/manual/working/commonGuide/configuration/code/CustomPekkoHttpServer.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/CustomPekkoHttpServer.scala
@@ -30,7 +30,7 @@ class CustomPekkoHttpServer(context: PekkoHttpServer.Context) extends PekkoHttpS
   ): ServerSettings = {
     val defaultSettings: ServerSettings =
       super.createServerSettings(port, connectionContext, secure)
-    val defaultWebsocketSettings = defaultSettings.websocketSettings()
+    val defaultWebsocketSettings = defaultSettings.websocketSettings
     defaultSettings.withWebsocketSettings(defaultWebsocketSettings.withRandomFactoryFactory(() => new Random()))
   }
 }

--- a/documentation/manual/working/commonGuide/configuration/code/CustomPekkoHttpServer.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/CustomPekkoHttpServer.scala
@@ -30,7 +30,8 @@ class CustomPekkoHttpServer(context: PekkoHttpServer.Context) extends PekkoHttpS
   ): ServerSettings = {
     val defaultSettings: ServerSettings =
       super.createServerSettings(port, connectionContext, secure)
-    defaultSettings.withWebsocketRandomFactory(() => new Random())
+    val defaultWebsocketSettings = defaultSettings.websocketSettings()
+    defaultSettings.withWebsocketSettings(defaultWebsocketSettings.withRandomFactoryFactory(() => new Random())
   }
 }
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

One of the issues in #13741 
Current Play code uses a deprecated Pekko API that is being removed in 2.0.0.
Try to use the non-deprecated methods instead.

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
