### PR TITLE
replace deprecated Source.actorRef with dropNew with Source.queue

### DIFF
--- a/documentation/manual/releases/release25/migration25/StreamsMigration25.md
+++ b/documentation/manual/releases/release25/migration25/StreamsMigration25.md
@@ -332,22 +332,23 @@ If you want to replace your `*.Out` with a simple object that you can write mess
 Java:
 
 ```java
-Source<ByteString, ?> source = Source.<ByteString>actorRef(256, OverflowStrategy.dropNew())
-  .mapMaterializedValue(sourceActor -> {
-    sourceActor.tell(ByteString.fromString("hello"), null);
-    sourceActor.tell(ByteString.fromString("world"), null);
-    sourceActor.tell(new Status.Success(NotUsed.getInstance()), null);
-    return null;
+Source<ByteString, ?> source = Source.<ByteString>queue(256)
+  .mapMaterializedValue(queue -> {
+    queue.offer(ByteString.fromString("hello"));
+    queue.offer(ByteString.fromString("world"));
+    queue.complete();
+    return NotUsed.getInstance();
   });
 ```
 
 Scala:
 
 ```scala
-val source = Source.actorRef[ByteString](256, OverflowStrategy.dropNew).mapMaterializedValue { sourceActor =>
-  sourceActor ! ByteString("hello")
-  sourceActor ! ByteString("world")
-  sourceActor ! Status.Success(()) // close the source
+val source = Source.queue[ByteString](256).mapMaterializedValue { queue =>
+  queue.offer(ByteString.fromString("hello"))
+  queue.offer(ByteString.fromString("world"))
+  queue.complete()
+  NotUsed.getInstance()
 }
 ```
 

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
@@ -230,14 +230,14 @@ public class JavaStream extends WithApplication {
     public Result index() {
       // Prepare a chunked text stream
       Source<ByteString, ?> source =
-          Source.<ByteString>actorRef(256, OverflowStrategy.dropNew())
+          Source.<ByteString>queue(256)
               .mapMaterializedValue(
-                  sourceActor -> {
-                    sourceActor.tell(ByteString.fromString("kiki"), null);
-                    sourceActor.tell(ByteString.fromString("foo"), null);
-                    sourceActor.tell(ByteString.fromString("bar"), null);
-                    sourceActor.tell(new Status.Success(NotUsed.getInstance()), null);
-                    return NotUsed.getInstance();
+                  queue -> {
+                      queue.offer(ByteString.fromString("kiki"));
+                      queue.offer(ByteString.fromString("foo"));
+                      queue.offer(ByteString.fromString("bar"));
+                      queue.complete();
+                      return NotUsed.getInstance();
                   });
       // Serves this stream with 200 OK
       return ok().chunked(source);

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
@@ -14,8 +14,6 @@ import java.util.Collections;
 import java.util.Optional;
 import javaguide.testhelpers.MockJavaAction;
 import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.Status;
-import org.apache.pekko.stream.OverflowStrategy;
 import org.apache.pekko.stream.javadsl.FileIO;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
@@ -233,11 +231,11 @@ public class JavaStream extends WithApplication {
           Source.<ByteString>queue(256)
               .mapMaterializedValue(
                   queue -> {
-                      queue.offer(ByteString.fromString("kiki"));
-                      queue.offer(ByteString.fromString("foo"));
-                      queue.offer(ByteString.fromString("bar"));
-                      queue.complete();
-                      return NotUsed.getInstance();
+                    queue.offer(ByteString.fromString("kiki"));
+                    queue.offer(ByteString.fromString("foo"));
+                    queue.offer(ByteString.fromString("bar"));
+                    queue.complete();
+                    return NotUsed.getInstance();
                   });
       // Serves this stream with 200 OK
       return ok().chunked(source);


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Relates to #13741
The old call is deprecated and removed in pekko 2

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
