### PR TITLE
Remove unused `SpringValidatorAdapter` from Java form binding

### DIFF
--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -55,7 +55,6 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.DataBinder;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
-import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 import play.data.format.Formatters;
 import play.data.validation.Constraints;
 import play.data.validation.Constraints.ValidationPayload;
@@ -913,9 +912,6 @@ public class Form<T> {
     if (allowedFields.length > 0) {
       dataBinder.setAllowedFields(allowedFields);
     }
-    SpringValidatorAdapter validator =
-        new SpringValidatorAdapter(this.validatorFactory.getValidator());
-    dataBinder.setValidator(validator);
     dataBinder.setConversionService(formatters.conversion);
     dataBinder.setAutoGrowNestedPaths(true);
     if (this.directFieldAccess) {


### PR DESCRIPTION
`Form.bind` uses the `DataBinder` for binding/conversion, then runs Bean Validation explicitly through the configured `ValidatorFactory` in `runValidation`. Since the form flow does not call `DataBinder.validate()`, assigning a Spring validator to the binder has no effect.