### PR TITLE
Avoid accessing ThreadLocal

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -113,7 +113,7 @@ object Dependencies {
   )
 
   val javaFormsDeps = Seq(
-    "org.hibernate.validator" % "hibernate-validator" % "9.1.0.Final"
+    "org.hibernate.validator" % "hibernate-validator" % "9.2.0-SNAPSHOT"
   ) ++ specs2Deps.map(_ % Test)
 
   val junitInterface = "com.github.sbt" % "junit-interface" % "0.13.3"

--- a/web/play-java-forms/src/main/java/play/data/validation/ValidatorFactoryProvider.java
+++ b/web/play-java-forms/src/main/java/play/data/validation/ValidatorFactoryProvider.java
@@ -15,10 +15,9 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import org.hibernate.validator.messageinterpolation.HibernateMessageInterpolatorContext;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
-import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
-import org.hibernate.validator.spi.messageinterpolation.LocaleResolverContext;
-import play.data.internal.binding.context.i18n.LocaleContextHolder;
+import play.data.validation.Constraints.ValidationPayload;
 import play.i18n.Lang;
 import play.i18n.Langs;
 import play.inject.ApplicationLifecycle;
@@ -39,8 +38,24 @@ public class ValidatorFactoryProvider implements Provider<ValidatorFactory> {
     Locale defaultLocale = langs.preferred(langs.availables()).toLocale();
 
     ParameterMessageInterpolator messageInterpolator =
-        new ParameterMessageInterpolator(
-            supportedLocales, defaultLocale, new RequestAwareLocaleResolver(langs), false);
+        new ParameterMessageInterpolator(supportedLocales, defaultLocale, false) {
+          @Override
+          public String interpolate(String message, Context context) {
+            final Lang requestLang =
+                context
+                    .unwrap(HibernateMessageInterpolatorContext.class)
+                    .getConstraintValidatorPayload(ValidationPayload.class)
+                    .getLang();
+            return interpolate(
+                message,
+                context,
+                requestLang == null || requestLang.toLocale() == null
+                    ? defaultLocale
+                    : langs
+                        .preferred(Collections.singleton(new Lang(requestLang.toLocale())))
+                        .toLocale());
+          }
+        };
 
     this.validatorFactory =
         Validation.byDefaultProvider()
@@ -58,26 +73,5 @@ public class ValidatorFactoryProvider implements Provider<ValidatorFactory> {
 
   public ValidatorFactory get() {
     return this.validatorFactory;
-  }
-
-  static class RequestAwareLocaleResolver implements LocaleResolver {
-
-    private Langs langs;
-
-    public RequestAwareLocaleResolver(Langs langs) {
-      this.langs = langs;
-    }
-
-    @Override
-    public Locale resolve(LocaleResolverContext context) {
-      Locale defaultLocale = context.getDefaultLocale();
-      Locale requestLocale = LocaleContextHolder.getLocale();
-
-      if (requestLocale == null) {
-        return defaultLocale;
-      }
-
-      return langs.preferred(Collections.singleton(new Lang(requestLocale))).toLocale();
-    }
   }
 }


### PR DESCRIPTION
- Requires https://github.com/hibernate/hibernate-validator/pull/1989
  - Ticket: https://hibernate.atlassian.net/browse/HV-2219
  - Means we need to wait for at least next Hibernate Validator release (but not urgent anyway)

Covered by following test:
https://github.com/playframework/playframework/blob/8c364d6a987ae1404734eedde33c1dd91c7d3ed7/web/play-java-forms/src/test/scala/play/data/FormSpec.scala#L1630-L1652