### PR TITLE
Pass `Langs` into Java form

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -508,6 +508,10 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.PathBindable.<clinit>"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.mvc.Session.<clinit>"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.ServerProvider.<clinit>"),
+      // Pass Lang into java form
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.DynamicForm.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.FormFactory.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.this"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/web/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/web/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import play.data.format.Formatters;
 import play.data.validation.ValidationError;
 import play.i18n.Lang;
+import play.i18n.Langs;
 import play.i18n.MessagesApi;
 import play.libs.typedmap.TypedMap;
 import play.mvc.Http;
@@ -38,10 +39,11 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
    */
   public DynamicForm(
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
-    super(DynamicForm.Dynamic.class, messagesApi, formatters, validatorFactory, config);
+    super(DynamicForm.Dynamic.class, messagesApi, langs, formatters, validatorFactory, config);
   }
 
   /**
@@ -60,6 +62,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
       List<ValidationError> errors,
       Optional<Dynamic> value,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -69,6 +72,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         errors,
         value,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config);
@@ -92,10 +96,12 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
       List<ValidationError> errors,
       Optional<Dynamic> value,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
-    this(data, files, errors, value, messagesApi, formatters, validatorFactory, config, null);
+    this(
+        data, files, errors, value, messagesApi, langs, formatters, validatorFactory, config, null);
   }
 
   /**
@@ -116,6 +122,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
       List<ValidationError> errors,
       Optional<Dynamic> value,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config,
@@ -126,6 +133,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         errors,
         value,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -152,6 +160,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
       List<ValidationError> errors,
       Optional<Dynamic> value,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config,
@@ -165,6 +174,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         value,
         null,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -244,6 +254,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         form.errors(),
         form.value(),
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -324,6 +335,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         form.errors(),
         form.value(),
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -370,6 +382,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         form.errors(),
         form.value(),
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,
@@ -385,6 +398,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         form.errors(),
         form.value(),
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,
@@ -405,6 +419,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         form.errors(),
         form.value(),
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,
@@ -425,6 +440,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         form.errors(),
         form.value(),
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,
@@ -439,6 +455,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         this.errors(),
         this.value(),
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -60,6 +60,7 @@ import play.data.validation.Constraints;
 import play.data.validation.Constraints.ValidationPayload;
 import play.data.validation.ValidationError;
 import play.i18n.Lang;
+import play.i18n.Langs;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.i18n.MessagesImpl;
@@ -108,6 +109,7 @@ public class Form<T> {
   private final Lang lang;
   private final boolean directFieldAccess;
   final MessagesApi messagesApi;
+  final Langs langs;
   final Formatters formatters;
   final ValidatorFactory validatorFactory;
   final Config config;
@@ -140,20 +142,23 @@ public class Form<T> {
   public Form(
       Class<T> clazz,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
-    this(null, clazz, messagesApi, formatters, validatorFactory, config);
+    this(null, clazz, messagesApi, langs, formatters, validatorFactory, config);
   }
 
   public Form(
       String rootName,
       Class<T> clazz,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
-    this(rootName, clazz, (Class<?>) null, messagesApi, formatters, validatorFactory, config);
+    this(
+        rootName, clazz, (Class<?>) null, messagesApi, langs, formatters, validatorFactory, config);
   }
 
   public Form(
@@ -161,6 +166,7 @@ public class Form<T> {
       Class<T> clazz,
       Class<?> group,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -169,6 +175,7 @@ public class Form<T> {
         clazz,
         group != null ? new Class[] {group} : null,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config);
@@ -179,6 +186,7 @@ public class Form<T> {
       Class<T> clazz,
       Class<?>[] groups,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -190,6 +198,7 @@ public class Form<T> {
         Optional.empty(),
         groups,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config);
@@ -202,6 +211,7 @@ public class Form<T> {
       List<ValidationError> errors,
       Optional<T> value,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -213,6 +223,7 @@ public class Form<T> {
         errors,
         value,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config);
@@ -226,6 +237,7 @@ public class Form<T> {
       List<ValidationError> errors,
       Optional<T> value,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -238,6 +250,7 @@ public class Form<T> {
         value,
         (Class<?>) null,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config);
@@ -251,6 +264,7 @@ public class Form<T> {
       Optional<T> value,
       Class<?> group,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -263,6 +277,7 @@ public class Form<T> {
         value,
         group,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config);
@@ -277,6 +292,7 @@ public class Form<T> {
       Optional<T> value,
       Class<?> group,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -289,6 +305,7 @@ public class Form<T> {
         value,
         group != null ? new Class[] {group} : null,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config);
@@ -318,6 +335,7 @@ public class Form<T> {
       Optional<T> value,
       Class<?>[] groups,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -330,6 +348,7 @@ public class Form<T> {
         value,
         groups,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config);
@@ -361,6 +380,7 @@ public class Form<T> {
       Optional<T> value,
       Class<?>[] groups,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
@@ -373,6 +393,7 @@ public class Form<T> {
         value,
         groups,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -405,6 +426,7 @@ public class Form<T> {
       Optional<T> value,
       Class<?>[] groups,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config,
@@ -418,6 +440,7 @@ public class Form<T> {
         value,
         groups,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -452,6 +475,7 @@ public class Form<T> {
       Optional<T> value,
       Class<?>[] groups,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config,
@@ -465,6 +489,7 @@ public class Form<T> {
         value,
         groups,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -499,6 +524,7 @@ public class Form<T> {
       Optional<T> value,
       Class<?>[] groups,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config,
@@ -513,6 +539,7 @@ public class Form<T> {
         value,
         groups,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -549,6 +576,7 @@ public class Form<T> {
       Optional<T> value,
       Class<?>[] groups,
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config,
@@ -562,6 +590,7 @@ public class Form<T> {
     this.value = value;
     this.groups = groups;
     this.messagesApi = messagesApi;
+    this.langs = langs;
     this.formatters = formatters;
     this.validatorFactory = validatorFactory;
     this.config = config;
@@ -1124,6 +1153,7 @@ public class Form<T> {
           Optional.ofNullable((T) result.getTarget()),
           groups,
           messagesApi,
+          langs,
           formatters,
           this.validatorFactory,
           config,
@@ -1139,6 +1169,7 @@ public class Form<T> {
         Optional.ofNullable((T) result.getTarget()),
         groups,
         messagesApi,
+        langs,
         formatters,
         this.validatorFactory,
         config,
@@ -1212,6 +1243,7 @@ public class Form<T> {
         Optional.ofNullable(value),
         groups,
         messagesApi,
+        langs,
         formatters,
         validatorFactory,
         config,
@@ -1367,6 +1399,7 @@ public class Form<T> {
         this.value,
         this.groups,
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,
@@ -1424,6 +1457,7 @@ public class Form<T> {
         this.value,
         this.groups,
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,
@@ -1611,6 +1645,7 @@ public class Form<T> {
         this.value,
         this.groups,
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,
@@ -1634,6 +1669,7 @@ public class Form<T> {
         this.value,
         this.groups,
         this.messagesApi,
+        this.langs,
         this.formatters,
         this.validatorFactory,
         this.config,

--- a/web/play-java-forms/src/main/java/play/data/FormFactory.java
+++ b/web/play-java-forms/src/main/java/play/data/FormFactory.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.validation.ValidatorFactory;
 import play.data.format.Formatters;
+import play.i18n.Langs;
 import play.i18n.MessagesApi;
 
 /** Helper to create HTML forms. */
@@ -16,6 +17,8 @@ import play.i18n.MessagesApi;
 public class FormFactory {
 
   private final MessagesApi messagesApi;
+
+  private final Langs langs;
 
   private final Formatters formatters;
 
@@ -26,10 +29,12 @@ public class FormFactory {
   @Inject
   public FormFactory(
       MessagesApi messagesApi,
+      Langs langs,
       Formatters formatters,
       ValidatorFactory validatorFactory,
       Config config) {
     this.messagesApi = messagesApi;
+    this.langs = langs;
     this.formatters = formatters;
     this.validatorFactory = validatorFactory;
     this.config = config;
@@ -39,7 +44,7 @@ public class FormFactory {
    * @return a dynamic form.
    */
   public DynamicForm form() {
-    return new DynamicForm(messagesApi, formatters, validatorFactory, config);
+    return new DynamicForm(messagesApi, langs, formatters, validatorFactory, config);
   }
 
   /**
@@ -48,7 +53,7 @@ public class FormFactory {
    * @return a new form that wraps the specified class.
    */
   public <T> Form<T> form(Class<T> clazz) {
-    return new Form<>(clazz, messagesApi, formatters, validatorFactory, config);
+    return new Form<>(clazz, messagesApi, langs, formatters, validatorFactory, config);
   }
 
   /**
@@ -58,7 +63,7 @@ public class FormFactory {
    * @return a new form that wraps the specified class.
    */
   public <T> Form<T> form(String name, Class<T> clazz) {
-    return new Form<>(name, clazz, messagesApi, formatters, validatorFactory, config);
+    return new Form<>(name, clazz, messagesApi, langs, formatters, validatorFactory, config);
   }
 
   /**
@@ -69,7 +74,8 @@ public class FormFactory {
    * @return a new form that wraps the specified class.
    */
   public <T> Form<T> form(String name, Class<T> clazz, Class<?>... groups) {
-    return new Form<>(name, clazz, groups, messagesApi, formatters, validatorFactory, config);
+    return new Form<>(
+        name, clazz, groups, messagesApi, langs, formatters, validatorFactory, config);
   }
 
   /**
@@ -79,6 +85,7 @@ public class FormFactory {
    * @return a new form that wraps the specified class.
    */
   public <T> Form<T> form(Class<T> clazz, Class<?>... groups) {
-    return new Form<>(null, clazz, groups, messagesApi, formatters, validatorFactory, config);
+    return new Form<>(
+        null, clazz, groups, messagesApi, langs, formatters, validatorFactory, config);
   }
 }

--- a/web/play-java-forms/src/main/java/play/data/FormFactoryComponents.java
+++ b/web/play-java-forms/src/main/java/play/data/FormFactoryComponents.java
@@ -18,6 +18,6 @@ public interface FormFactoryComponents
   }
 
   default FormFactory formFactory() {
-    return new FormFactory(messagesApi(), formatters(), validatorFactory(), config());
+    return new FormFactory(messagesApi(), langs(), formatters(), validatorFactory(), config());
   }
 }

--- a/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -22,6 +22,7 @@ import play.data.*;
 import play.data.format.Formatters;
 import play.data.validation.ValidationError;
 import play.i18n.Lang;
+import play.i18n.Langs;
 import play.i18n.MessagesApi;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http.Request;
@@ -61,6 +62,7 @@ public class HttpFormsTest {
         formToCopy.value(),
         (Class[]) null,
         app.injector().instanceOf(MessagesApi.class),
+        app.injector().instanceOf(Langs.class),
         app.injector().instanceOf(Formatters.class),
         app.injector().instanceOf(ValidatorFactory.class),
         app.injector().instanceOf(Config.class),
@@ -216,6 +218,7 @@ public class HttpFormsTest {
     withApplication(
         (app) -> {
           MessagesApi messagesApi = app.injector().instanceOf(MessagesApi.class);
+          Langs langs = app.injector().instanceOf(Langs.class);
           Formatters formatters = app.injector().instanceOf(Formatters.class);
           ValidatorFactory validatorFactory = app.injector().instanceOf(ValidatorFactory.class);
           Config config = app.injector().instanceOf(Config.class);
@@ -239,6 +242,7 @@ public class HttpFormsTest {
                   Optional.empty(),
                   null,
                   messagesApi,
+                  langs,
                   formatters,
                   validatorFactory,
                   config,
@@ -255,13 +259,13 @@ public class HttpFormsTest {
         (app) -> {
           // The messagesApi is empty
           MessagesApi emptyMessagesApi = play.test.Helpers.stubMessagesApi();
+          Langs langs = new DefaultLangs().asJava();
           Formatters formatters = app.injector().instanceOf(Formatters.class);
           ValidatorFactory validatorFactory = app.injector().instanceOf(ValidatorFactory.class);
           Config config = app.injector().instanceOf(Config.class);
 
           // The lang has to be build from an empty messagesApi
-          final Lang lang =
-              emptyMessagesApi.preferred(new DefaultLangs().asJava().availables()).lang();
+          final Lang lang = emptyMessagesApi.preferred(langs.availables()).lang();
 
           // Also the form should contain the empty messagesApi
           Form<Money> form =
@@ -272,6 +276,7 @@ public class HttpFormsTest {
                   new ArrayList<>(),
                   Optional.empty(),
                   emptyMessagesApi,
+                  langs,
                   formatters,
                   validatorFactory,
                   config);

--- a/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -24,7 +24,8 @@ import views.html.helper.FieldConstructor.defaultField
  * Specs for Java dynamic forms
  */
 class DynamicFormSpec extends CommonFormSpec {
-  val messagesApi                 = new DefaultMessagesApi()
+  val jLangs                      = new play.api.i18n.DefaultLangs().asJava
+  val messagesApi                 = new DefaultMessagesApi(langs = jLangs.asScala())
   implicit val messages: Messages = messagesApi.preferred(Seq.empty)
   val jMessagesApi                = new play.i18n.MessagesApi(messagesApi)
   val validatorFactory            = FormSpec.validatorFactory()
@@ -32,7 +33,7 @@ class DynamicFormSpec extends CommonFormSpec {
 
   "a dynamic form" should {
     "bind values from a request" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      val form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.get("foo") must_== "bar"
       form.value("foo").get must_== "bar"
@@ -47,7 +48,8 @@ class DynamicFormSpec extends CommonFormSpec {
         val req = createThesisRequestWithFileParts(files)
 
         val myForm =
-          new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config).bindFromRequest(req)
+          new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
+            .bindFromRequest(req)
 
         myForm.hasErrors() must beEqualTo(false)
         myForm.hasGlobalErrors() must beEqualTo(false)
@@ -178,13 +180,13 @@ class DynamicFormSpec extends CommonFormSpec {
     }
 
     "allow access to raw data values from request" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      val form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.rawData().get("foo") must_== "bar"
     }
 
     "display submitted values in template helpers" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      val form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       val html = inputText(form("foo")).body
       html must contain("value=\"bar\"")
@@ -192,7 +194,7 @@ class DynamicFormSpec extends CommonFormSpec {
     }
 
     "render correctly when no value is submitted in template helpers" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      val form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .bindFromRequest(FormSpec.dummyRequest(Map()))
       val html = inputText(form("foo")).body
       html must contain("value=\"\"")
@@ -200,7 +202,7 @@ class DynamicFormSpec extends CommonFormSpec {
     }
 
     "display errors in template helpers" in {
-      var form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      var form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form = form.withError("foo", "There was an error")
       val html = inputText(form("foo")).body
@@ -208,7 +210,7 @@ class DynamicFormSpec extends CommonFormSpec {
     }
 
     "display errors when a field is not present" in {
-      var form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      var form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .bindFromRequest(FormSpec.dummyRequest(Map()))
       form = form.withError("foo", "Foo is required")
       val html = inputText(form("foo")).body
@@ -216,27 +218,27 @@ class DynamicFormSpec extends CommonFormSpec {
     }
 
     "allow access to the property when filled" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      val form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form.get("foo") must_== "bar"
       form.value("foo").get must_== "bar"
     }
 
     "allow access to the equivalent of the raw data when filled" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      val form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form("foo").value().get() must_== "bar"
     }
 
     "fail with exception when trying to switch on direct field access" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      val form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
       form.withDirectFieldAccess(true) must throwA[RuntimeException].like {
         case e => e.getMessage must endWith("Not possible to enable direct field access for dynamic forms.")
       }
     }
 
     "work when switch off direct field access" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, config)
+      val form = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, config)
         .withDirectFieldAccess(false)
         .bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.get("foo") must_== "bar"
@@ -245,7 +247,7 @@ class DynamicFormSpec extends CommonFormSpec {
 
     "don't throw NullPointerException when all components of form are null" in {
       val form =
-        new DynamicForm(null, null, null, null).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
+        new DynamicForm(null, null, null, null, null).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form("foo").value().get() must_== "bar"
     }
 
@@ -267,7 +269,7 @@ class DynamicFormSpec extends CommonFormSpec {
                        |play.http.parser.maxMemoryBuffer = 32
                        |""".stripMargin)
         .withFallback(config)
-      val form       = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validatorFactory, cfg)
+      val form       = new DynamicForm(jMessagesApi, jLangs, new Formatters(jMessagesApi), validatorFactory, cfg)
       val longString =
         "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
       val textNode: JsonNode = new TextNode(longString)

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -1257,7 +1257,21 @@ trait FormSpec extends CommonFormSpec {
       ).asJava.asInstanceOf[util.Map[String, Http.MultipartFormData.FilePart[?]]]
 
       val form: Form[Object] =
-        new Form(null, null, dataPart, filePart, null, Optional.empty[Object](), null, null, null, null, null, null)
+        new Form(
+          null,
+          null,
+          dataPart,
+          filePart,
+          null,
+          Optional.empty[Object](),
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        )
 
       val dataField = new Form.Field(form, "someDataField", null, null, null, null, null)
       dataField.indexes() must beEqualTo(List(0, 1, 2, 4, 59, 70, 81).asJava)
@@ -1290,6 +1304,7 @@ trait FormSpec extends CommonFormSpec {
         map.asJava,
         List.empty.asJava.asInstanceOf[java.util.List[ValidationError]],
         Optional.empty[JavaForm],
+        null,
         null,
         null,
         FormSpec.validatorFactory(),

--- a/web/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -15,11 +15,18 @@ import play.data.validation.Constraints.Required
 import play.libs.typedmap.TypedMap
 
 class PartialValidationSpec extends Specification {
-  val messagesApi = new DefaultMessagesApi()
+  val jLangs      = new DefaultLangs().asJava
+  val messagesApi = new DefaultMessagesApi(langs = jLangs.asScala())
 
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val formFactory  =
-    new FormFactory(jMessagesApi, new Formatters(jMessagesApi), FormSpec.validatorFactory(), ConfigFactory.load())
+    new FormFactory(
+      jMessagesApi,
+      jLangs,
+      new Formatters(jMessagesApi),
+      FormSpec.validatorFactory(),
+      ConfigFactory.load()
+    )
 
   "partial validation" should {
     "not fail when fields not in the same group fail validation" in {


### PR DESCRIPTION
Very simple PR, just passes Langs in the constructors.
Without `Langs` its not possible to determine the default and the available language when not having a request available.

Needed for a later PR/commit that might remove `LocaleContextHolder`.
(Even if that later PR never gets merged its not to bad to have `Langs` available in Java Forms, even if unused currently, maybe one day it is needed in a patch fix, so we break compatibily now before a major release)