### PR TITLE
Make `Formatter.conversion` package private to hide spring implementation

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -512,6 +512,8 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.DynamicForm.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.FormFactory.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.data.Form.this"),
+      // Make Java's Formatter.conversion package private to hide spring implementation
+      ProblemFilters.exclude[InaccessibleFieldProblem]("play.data.format.Formatters.conversion"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -1108,7 +1108,7 @@ public class Form<T> {
     if (allowedFields.length > 0) {
       dataBinder.setAllowedFields(allowedFields);
     }
-    dataBinder.setConversionService(formatters.conversion);
+    play.data.format.FormattersInternals$.MODULE$.configureDataBinder(formatters, dataBinder);
     dataBinder.setAutoGrowNestedPaths(true);
     dataBinder.setAutoGrowCollectionLimit(this.autoGrowCollectionLimit);
     if (this.directFieldAccess) {

--- a/web/play-java-forms/src/main/java/play/data/format/Formatters.java
+++ b/web/play-java-forms/src/main/java/play/data/format/Formatters.java
@@ -108,7 +108,7 @@ public class Formatters {
   // --
 
   /** The underlying conversion service. */
-  public final FormattingConversionService conversion = new FormattingConversionService();
+  final FormattingConversionService conversion = new FormattingConversionService();
 
   /**
    * Super-type for custom simple formatters.
@@ -231,6 +231,21 @@ public class Formatters {
           }
         });
 
+    return this;
+  }
+
+  /**
+   * Unregisters all formatters for the given class.
+   *
+   * <p>This removes both directions used by Play formatters: parsing from {@link String} to the
+   * given class and printing from the given class to {@link String}.
+   *
+   * @param clazz class handled by the formatters to unregister
+   * @return the modified Formatters object.
+   */
+  public Formatters unregisterAll(final Class<?> clazz) {
+    conversion.removeConvertible(clazz, String.class);
+    conversion.removeConvertible(String.class, clazz);
     return this;
   }
 

--- a/web/play-java-forms/src/main/scala/play/data/format/FormattersInternals.scala
+++ b/web/play-java-forms/src/main/scala/play/data/format/FormattersInternals.scala
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.data.format
+
+import org.springframework.validation.DataBinder
+
+private[data] object FormattersInternals {
+
+  def configureDataBinder(formatters: Formatters, dataBinder: DataBinder): Unit = {
+    dataBinder.setConversionService(formatters.conversion)
+  }
+}

--- a/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/web/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -134,10 +134,7 @@ public class HttpFormsTest {
               .isEqualTo("1,234,567.89");
 
           // Clean up (Actually not really necassary because formatters are not global anyway ;-)
-          formatters.conversion.removeConvertible(
-              BigDecimal.class, String.class); // removes print conversion
-          formatters.conversion.removeConvertible(
-              String.class, BigDecimal.class); // removes parse conversion
+          formatters.unregisterAll(BigDecimal.class);
         });
   }
 
@@ -206,10 +203,7 @@ public class HttpFormsTest {
               .isEqualTo("1,234,567.89");
 
           // Clean up (Actually not really necassary because formatters are not global anyway ;-)
-          formatters.conversion.removeConvertible(
-              BigDecimal.class, String.class); // removes print conversion
-          formatters.conversion.removeConvertible(
-              String.class, BigDecimal.class); // removes parse conversion
+          formatters.unregisterAll(BigDecimal.class);
         });
   }
 

--- a/web/play-java-forms/src/test/scala/play/data/format/FormattersTest.java
+++ b/web/play-java-forms/src/test/scala/play/data/format/FormattersTest.java
@@ -6,6 +6,7 @@ package play.data.format;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.core.convert.ConverterNotFoundException;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -13,8 +14,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.text.ParseException;
 import java.util.Locale;
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class FormattersTest {
 
@@ -39,11 +42,31 @@ public class FormattersTest {
         assertEquals(15, integerFromAnnotatedField);
     }
 
+    @Test
+    public void testUnregisterAllRemovesParseAndPrintConverters() throws NoSuchFieldException {
+        formatters.register(Value.class, new ValueFormatter());
+        Value value = new Value("10");
+
+        assertEquals(new Value("10"), formatters.parse(Bean.class.getDeclaredField("valueField"), "10"));
+        assertEquals("formatted-10", formatters.print(Bean.class.getDeclaredField("valueField"), value));
+
+        assertEquals(formatters, formatters.unregisterAll(Value.class));
+
+        try {
+            formatters.parse(Bean.class.getDeclaredField("valueField"), "10");
+            fail("Expected parsing converter to be removed");
+        } catch (ConverterNotFoundException expected) {
+        }
+
+        assertEquals("value-10", formatters.print(Bean.class.getDeclaredField("valueField"), value));
+    }
+
     @SuppressWarnings("unused")
     private static class Bean {
         private Integer plainIntegerField;
         @CustomInteger
         private Integer annotatedIntegerField;
+        private Value valueField;
     }
 
     @Target(ElementType.FIELD)
@@ -81,6 +104,48 @@ public class FormattersTest {
         @Override
         public String print(Integer t, Locale locale) {
             return t == null ? null : t.toString();
+        }
+    }
+
+    private static class Value {
+        private final String text;
+
+        private Value(String text) {
+            this.text = text;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Value)) {
+                return false;
+            }
+            Value value = (Value) o;
+            return Objects.equals(text, value.text);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(text);
+        }
+
+        @Override
+        public String toString() {
+            return "value-" + text;
+        }
+    }
+
+    public static class ValueFormatter extends Formatters.SimpleFormatter<Value> {
+        @Override
+        public Value parse(String text, Locale locale) {
+            return new Value(text);
+        }
+
+        @Override
+        public String print(Value value, Locale locale) {
+            return "formatted-" + value.text;
         }
     }
 }


### PR DESCRIPTION
Devs should avoid interacting directly with `formatters.conversion` because that actually is a spring instance.

Instead they should use Play's `register(...)`, `unregisterAll(...)` methods.
We can add more if desired by users.

That allows us to replace the spring implemention at some point.

Actually this is follow up to #13968