### PR TITLE
Improve API docs generation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -86,6 +86,18 @@ jobs:
         cd documentation
         sbt validateCode
 
+  check-api-docs-package-tree:
+    name: Check Public API Docs Packages
+    needs:
+      - "extra-vars"
+      - "check-code-style"
+      - "check-binary-compatibility"
+      - "check-code-style-docs"
+    uses: playframework/.github/.github/workflows/cmd.yml@v4
+    with:
+      cmd: >-
+        sbt "${{needs.extra-vars.outputs.pekko_version_opts}}" "${{needs.extra-vars.outputs.pekko_http_version_opts}}" +Play-Docs/checkApiDocsPackageTree
+
   publish-local:
     name: Publish Local
     needs:
@@ -214,6 +226,7 @@ jobs:
     name: Finish
     if: github.event_name == 'pull_request'
     needs: # Should be last
+      - "check-api-docs-package-tree"
       - "tests"
       - "docs-tests"
       - "scripted-tests"

--- a/core/play-streams/src/main/java/play/libs/streams/Accumulator.java
+++ b/core/play-streams/src/main/java/play/libs/streams/Accumulator.java
@@ -158,7 +158,7 @@ public abstract class Accumulator<E, A> {
    */
   public static <E> Accumulator<E, Source<E, ?>> source() {
     // If Pekko streams ever provides Sink.source(), we should use that instead.
-    // https://github.com/akka/akka/issues/18406
+    // https://github.com/akka/akka-core/issues/18406
     return new SinkAccumulator<>(
         Sink.<E>asPublisher(AsPublisher.WITHOUT_FANOUT)
             .mapMaterializedValue(

--- a/core/play-streams/src/main/java/play/libs/streams/ActorFlow.java
+++ b/core/play-streams/src/main/java/play/libs/streams/ActorFlow.java
@@ -16,7 +16,7 @@ import scala.runtime.AbstractFunction1;
 /**
  * Provides a flow that is handled by an actor.
  *
- * <p>See https://github.com/akka/akka/issues/16985.
+ * <p>See https://github.com/akka/akka-core/issues/16985.
  */
 public class ActorFlow {
 

--- a/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -275,7 +275,7 @@ object Accumulator {
    */
   def source[E]: Accumulator[E, Source[E, ?]] = {
     // If Pekko streams ever provides Sink.source(), we should use that instead.
-    // https://github.com/akka/akka/issues/18406
+    // https://github.com/akka/akka-core/issues/18406
     new SinkAccumulator(
       Sink
         .asPublisher[E](fanout = false)

--- a/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -16,7 +16,7 @@ import org.apache.pekko.stream.OverflowStrategy
 /**
  * Provides a flow that is handled by an actor.
  *
- * See https://github.com/akka/akka/issues/16985.
+ * See https://github.com/akka/akka-core/issues/16985.
  */
 object ActorFlow {
 

--- a/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/core/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -34,7 +34,8 @@ object ActorFlow {
    * Create a flow that is handled by an actor.
    *
    * Messages can be sent downstream by sending them to the actor passed into the props function.  This actor meets
-   * the contract of the actor returned by [[https://pekko.apache.org/api/pekko/1.0/org/apache/pekko/stream/scaladsl/Source$.html#actorRef[T](bufferSize:Int,overflowStrategy:org.apache.pekko.stream.OverflowStrategy):org.apache.pekko.stream.scaladsl.Source[T,org.apache.pekko.actor.ActorRef]] org.apache.pekko.stream.scaladsl.Source.actorRef]].
+   * the contract of the actor returned by
+   * [[https://pekko.apache.org/api/pekko/1.0/org/apache/pekko/stream/scaladsl/Source$.html#actorRef org.apache.pekko.stream.scaladsl.Source.actorRef]].
    *
    * The props function should return the props for an actor to handle the flow. This actor will be created using the
    * passed in [[https://pekko.apache.org/api/pekko/1.0/org/apache/pekko/actor/ActorRefFactory.html org.apache.pekko.actor.ActorRefFactory]]. Each message received will be sent to the actor - there is no back pressure,

--- a/core/play/src/main/java/play/core/cookie/encoding/Cookie.java
+++ b/core/play/src/main/java/play/core/cookie/encoding/Cookie.java
@@ -132,7 +132,7 @@ public interface Cookie extends Comparable<Cookie> {
    * Checks to see if this {@link Cookie} can only be accessed via HTTP. If this returns true, the
    * {@link Cookie} cannot be accessed through client side script - But only if the browser supports
    * it. For more information, please look <a
-   * href="http://www.owasp.org/index.php/HTTPOnly">here</a>
+   * href="https://owasp.org/www-community/HttpOnly">here</a>
    *
    * @return True if this {@link Cookie} is HTTP-only or false if it isn't
    */
@@ -141,7 +141,7 @@ public interface Cookie extends Comparable<Cookie> {
   /**
    * Determines if this {@link Cookie} is HTTP only. If set to true, this {@link Cookie} cannot be
    * accessed by a client side script. However, this works only if the browser supports it. For for
-   * information, please look <a href="http://www.owasp.org/index.php/HTTPOnly">here</a>.
+   * information, please look <a href="https://owasp.org/www-community/HttpOnly">here</a>.
    *
    * @param httpOnly True if the {@link Cookie} is HTTP only, otherwise false.
    */

--- a/core/play/src/main/java/play/libs/streams/PekkoStreams.java
+++ b/core/play/src/main/java/play/libs/streams/PekkoStreams.java
@@ -71,7 +71,7 @@ public class PekkoStreams {
                   // finishes, the merge
                   // will result in a cancel flowing up through the bypasser, which could lead to
                   // dropped messages.
-                  // Using scaladsl here because of https://github.com/akka/akka/issues/18384
+                  // Using scaladsl here because of https://github.com/akka/akka-core/issues/18384
                   UniformFanOutShape<F.Either<FlowIn, Out>, F.Either<FlowIn, Out>> broadcast =
                       builder.add(Broadcast.create(2, true));
                   UniformFanInShape<Out, Out> merge = builder.add(mergeStrategy);

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -149,9 +149,46 @@ object BuildSettings {
       // https://github.com/ThoughtWorksInc/sbt-api-mappings/blob/master/src/main/scala/com/thoughtworks/sbtApiMappings/ApiMappings.scala#L34
 
       val ScalaLibraryRegex  = """^.*[/\\]scala-library-([\d\.]+)\.jar$""".r
+      val Scala3LibraryRegex = """^.*[/\\]scala3-library_3-([\d\.]+)\.jar$""".r
       val JakartaInjectRegex = """^.*[/\\]jakarta.inject-api-([\d\.]+)\.jar$""".r
 
       val IvyRegex = """^.*[/\\]([\.\-_\w]+)[/\\]([\.\-_\w]+)[/\\](?:jars|bundles)[/\\]([\.\-_\w]+)\.jar$""".r
+
+      def docsUrl(apiOrganization: String, apiName: String, apiVersion: String, jarBaseFile: String) =
+        apiOrganization match {
+          case "org.apache.pekko" =>
+            Some(url(raw"https://pekko.apache.org/api/pekko/$apiVersion/"))
+
+          case default =>
+            val link = Docs.artifactToJavadoc(apiOrganization, apiName, apiVersion, jarBaseFile)
+            Some(url(link))
+        }
+
+      def coursierMavenCoordinates(path: String): Option[(String, String, String, String)] = {
+        val normalizedPath = path.replace(java.io.File.separatorChar, '/')
+        val marker         = "/maven2/"
+        val markerIndex    = normalizedPath.indexOf(marker)
+        if (markerIndex < 0) {
+          None
+        } else {
+          val parts = normalizedPath.substring(markerIndex + marker.length).split('/').toSeq
+          if (parts.length < 4) {
+            None
+          } else {
+            val jarFileName       = parts.last
+            val jarBaseFile       = jarFileName.stripSuffix(".jar")
+            val apiVersion        = parts(parts.length - 2)
+            val apiName           = parts(parts.length - 3)
+            val organizationParts = parts.dropRight(3)
+
+            if (jarFileName.endsWith(".jar") && organizationParts.nonEmpty && jarBaseFile == s"$apiName-$apiVersion") {
+              Some((organizationParts.mkString("."), apiName, apiVersion, jarBaseFile))
+            } else {
+              None
+            }
+          }
+        }
+      }
 
       (for {
         jar <- (Compile / doc / dependencyClasspath).value.toSet ++ (Test / doc / dependencyClasspath).value
@@ -160,23 +197,22 @@ object BuildSettings {
           case ScalaLibraryRegex(v) =>
             Some(url(raw"""http://scala-lang.org/files/archive/api/$v/index.html"""))
 
+          case Scala3LibraryRegex(v) =>
+            Some(url(raw"""http://scala-lang.org/files/archive/api/$v/index.html"""))
+
           case JakartaInjectRegex(v) =>
             // the jar file doesn't match up with $apiName-
             Some(url(Docs.jakartaInjectUrl))
 
           case re @ IvyRegex(apiOrganization, apiName, jarBaseFile) if jarBaseFile.startsWith(s"$apiName-") =>
             val apiVersion = jarBaseFile.substring(apiName.length + 1, jarBaseFile.length)
-            apiOrganization match {
-              case "org.apache.pekko" =>
-                Some(url(raw"https://pekko.apache.org/api/pekko/$apiVersion/"))
-
-              case default =>
-                val link = Docs.artifactToJavadoc(apiOrganization, apiName, apiVersion, jarBaseFile)
-                Some(url(link))
-            }
+            docsUrl(apiOrganization, apiName, apiVersion, jarBaseFile)
 
           case other =>
-            None
+            coursierMavenCoordinates(other).flatMap {
+              case (apiOrganization, apiName, apiVersion, jarBaseFile) =>
+                docsUrl(apiOrganization, apiName, apiVersion, jarBaseFile)
+            }
         }
         url <- urlOption
       } yield fullyFile -> url).toMap

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -4,7 +4,6 @@
 
 import java.net.URL
 import java.net.URLClassLoader
-import java.util.Locale
 import java.util.Optional
 
 import sbt._
@@ -366,12 +365,7 @@ object Docs {
 
   // Converts an artifact into a Javadoc URL.
   def artifactToJavadoc(organization: String, name: String, apiVersion: String, jarBaseFile: String): String = {
-    val slashedOrg = organization.replace('.', '/')
-    if (apiVersion.toLowerCase(Locale.ENGLISH).endsWith("-snapshot")) {
-      raw"""https://central.sonatype.com/repository/maven-snapshots/$slashedOrg/$name/$apiVersion/$jarBaseFile-javadoc.jar/!/index.html"""
-    } else {
-      raw"""https://repo1.maven.org/maven2/$slashedOrg/$name/$apiVersion/$jarBaseFile-javadoc.jar/!/index.html"""
-    }
+    raw"""https://javadoc.io/doc/$organization/$name/$apiVersion/index.html"""
   }
 
   // Converts an sbt module into a Javadoc URL.

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -259,6 +259,8 @@ object Docs {
     scaladoc(sources, classpath, outputDir, options, 10, log)
     if (scalaBinaryVersion.value == "2.13") {
       cleanUpInvalidScala2SourceLinks(outputDir)
+    } else {
+      fixScala3Specs2Links(outputDir)
     }
   }
 
@@ -357,6 +359,70 @@ object Docs {
     (apiTarget ** "*.html").get().foreach { f =>
       val content    = IO.read(f)
       val newContent = generatedSourceLinkRegex.replaceAllIn(content, "")
+      if (newContent != content) {
+        IO.write(f, newContent)
+      }
+    }
+  }
+
+  // Scala 3 Scaladoc emits local relative links for Specs2 members inherited by PlaySpecification,
+  // even though the org.specs2 package is intentionally excluded from Play API docs. Rewrite links
+  // that have exact pages in Specs2's published API docs and disable the generated links that do not.
+  private def fixScala3Specs2Links(apiTarget: File): Unit = {
+    val specs2Version = Dependencies.specs2Version
+
+    val unpublishedSpecs2LinkPrefixes = Seq(
+      "org/specs2/matcher/EitherBeHaveMatchers$",
+      "org/specs2/matcher/ExceptionBaseMatchers$",
+      "org/specs2/matcher/ExceptionBeHaveMatchers$",
+      "org/specs2/matcher/MapBeHaveMatchers$",
+      "org/specs2/matcher/NumericBeHaveMatchers$",
+      "org/specs2/matcher/OptionBeHaveMatchers$",
+      "org/specs2/matcher/StringBaseMatchers$",
+      "org/specs2/matcher/StringBeHaveMatchers$",
+      "org/specs2/matcher/TraversableBeHaveMatchers$",
+      "org/specs2/matcher/TryBeHaveMatchers$",
+      "org/specs2/specification/dsl/SpecStructureDsl1$",
+      "org/specs2/specification/dsl/SpecStructureDslLowImplicits$",
+      "org/specs2/specification/dsl/mutable/ExampleDsl0$",
+      "org/specs2/specification/dsl/mutable/ExampleDsl1$"
+    )
+
+    def moduleFor(path: String): Option[String] =
+      if (unpublishedSpecs2LinkPrefixes.exists(path.startsWith)) {
+        None
+      } else if (path.startsWith("org/specs2/control/")) {
+        Some("specs2-common_3")
+      } else if (path.startsWith("org/specs2/execute/ResultLogicalCombinators$")) {
+        Some("specs2-common_3")
+      } else if (path.startsWith("org/specs2/execute/")) {
+        Some("specs2-core_3")
+      } else if (path.startsWith("org/specs2/specification/")) {
+        Some("specs2-core_3")
+      } else if (path.startsWith("org/specs2/matcher/")) {
+        Some("specs2-matcher_3")
+      } else {
+        None
+      }
+
+    val specs2LinkRegex = """href="(?:\.\./)+(?=org/specs2/)(org/specs2/[^"]+)"""".r
+
+    (apiTarget ** "*.html").get().foreach { f =>
+      val content    = IO.read(f)
+      val newContent = specs2LinkRegex.replaceAllIn(
+        content,
+        m => {
+          val path = m.group(1)
+          moduleFor(path) match {
+            case Some(module) =>
+              val replacement =
+                s"""href="https://javadoc.io/doc/org.specs2/$module/$specs2Version/$path""""
+              scala.util.matching.Regex.quoteReplacement(replacement)
+            case None =>
+              """data-unresolved-link="""""
+          }
+        }
+      )
       if (newContent != content) {
         IO.write(f, newContent)
       }

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -2,6 +2,7 @@
  * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
+import java.net.URL
 import java.net.URLClassLoader
 import java.util.Locale
 import java.util.Optional
@@ -122,34 +123,137 @@ object Docs {
   val apiDocsDir                 = Def.setting(crossTarget.value / "apidocs")
   def apiDocsCache(name: String) = Def.setting(CacheStoreFactory(crossTarget.value / name))
 
+  private val InternalApiPathSegment        = "/internal/"
+  private val AllowedTopLevelApiPackages    = Seq("controllers", "play", "views")
+  private val ExcludedTopLevelScalaPackages = Seq("org", "models")
+
+  private def isNotInternalApiSource(source: File): Boolean = {
+    val path = source.getPath.replace(java.io.File.separatorChar, '/')
+
+    !path.contains(InternalApiPathSegment)
+  }
+
+  // Keeps javadoc input limited to Play's public Java package roots.
+  // Javadoc's -exclude option is not enough for this build because sources are passed explicitly.
+  private def isPublicJavaApiSource(source: File): Boolean = {
+    val path = source.getPath.replace(java.io.File.separatorChar, '/')
+
+    isNotInternalApiSource(source) &&
+    AllowedTopLevelApiPackages.exists(packageName => path.contains(s"/src/main/java/$packageName/"))
+  }
+
+  // Keeps Scala 3 Scaladoc input limited to public Play TASTy files.
+  // Scala 3 docs are generated from classpath TASTy, so filtering has to happen on compiled relative paths.
+  private def isPublicScala3TastyFile(classpathDirectory: File, tastyFile: File): Boolean = {
+    val path = classpathDirectory.toPath.relativize(tastyFile.toPath).toString.replace(java.io.File.separatorChar, '/')
+
+    !path.contains(InternalApiPathSegment) &&
+    !ExcludedTopLevelScalaPackages.exists(packageName => path.startsWith(s"$packageName/"))
+  }
+
+  private def scala3TastyFiles(classpath: Seq[File], baseDirectory: File): Seq[File] = {
+    val basePath = baseDirectory.getAbsolutePath.replace(java.io.File.separatorChar, '/')
+
+    classpath
+      .filter(_.isDirectory)
+      .filter(_.getAbsolutePath.replace(java.io.File.separatorChar, '/').startsWith(basePath))
+      .flatMap(dir => (dir ** "*.tasty").get.filter(isPublicScala3TastyFile(dir, _)))
+      .distinct
+  }
+
+  // Builds Scala 3 source-link options for actual Play source roots.
+  // This avoids invalid links for generated Twirl sources or dependency/library sources.
+  private def scala3SourceLinkMappings(scalaSources: Seq[File], rootDirectory: File, commitish: String): Seq[String] = {
+    val rootPath = rootDirectory.toPath
+
+    scalaSources
+      .filter(isNotInternalApiSource)
+      .flatMap { source =>
+        val path = source.getPath.replace(java.io.File.separatorChar, '/')
+
+        Seq("/src/main/scala/", "/src/main/scala-3/").collectFirst {
+          case marker if path.contains(marker) =>
+            new File(path.substring(0, path.indexOf(marker) + marker.length - 1))
+        }
+      }
+      .distinct
+      .map { sourceRoot =>
+        val relativePath = rootPath.relativize(sourceRoot.toPath).toString.replace(java.io.File.separatorChar, '/')
+        s"-source-links:$relativePath=https://github.com/playframework/playframework/tree/${commitish}/$relativePath€{FILE_PATH_EXT}"
+      }
+  }
+
+  // Converts sbt apiMappings into Scala 3 Scaladoc external mapping options.
+  // Scala 3 needs explicit mapping format tags, unlike the Scala 2 -doc-external-doc option.
+  private def scala3ExternalMappings(mappings: Map[File, URL]): Seq[String] = {
+    // Scala 3 external mappings expect the API base URL, not the index.html page used by sbt apiMappings.
+    def apiBase(url: URL): String =
+      url.toString.stripSuffix("index.html")
+
+    mappings.toSeq.sortBy { case (jar, _) => jar.getAbsolutePath }.map {
+      case (jar, url) =>
+        val name = jar.getName
+
+        val (format, apiUrl) =
+          if (name.startsWith("scala-library-") || name.startsWith("scala3-library_3-")) {
+            "scaladoc3" -> "https://www.scala-lang.org/api/3.x/"
+          } else if (url.toString.startsWith("https://pekko.apache.org/api/pekko/")) {
+            "scaladoc3" -> apiBase(url)
+          } else {
+            "javadoc" -> apiBase(url)
+          }
+
+        val jarPattern = name.stripSuffix(".jar").replace(".", "\\.")
+        s"-external-mappings:.*$jarPattern.*::$format::$apiUrl"
+    }
+  }
+
   def genApiScaladocs = Def.task {
     val version = Keys.version.value
     val label   = s"Play $version"
 
     val commitish   = if (version.endsWith("-SNAPSHOT")) BuildSettings.snapshotBranch else version
+    val mappings    = apiMappings.value
     val externalDoc =
-      Opts.doc.externalAPI(apiMappings.value).head.replace("-doc-external-doc:", "") // from the "doc" task
+      Opts.doc.externalAPI(mappings).head.replace("-doc-external-doc:", "") // from the "doc" task
+    val rootDirectory = (ThisBuild / baseDirectory).value
+    val scalaSources  = apiDocsScalaSources.value
 
-    val options = Seq(
-      // Note, this is used by the doc-source-url feature to determine the relative path of a given source file.
-      // If it's not a prefix of a the absolute path of the source file, the absolute path of that file will be put
-      // into the FILE_SOURCE variable below, which is definitely not what we want.
-      // Hence it needs to be the base directory for the build, not the base directory for the play-docs project.
-      "-sourcepath",
-      (ThisBuild / baseDirectory).value.getAbsolutePath,
-      "-doc-source-url",
-      s"https://github.com/playframework/playframework/tree/${commitish}€{FILE_PATH}.scala",
-      s"-doc-external-doc:$externalDoc",
-      "-Xsource:3"
-    )
+    val options =
+      if (scalaBinaryVersion.value == "2.13") {
+        Seq(
+          // Note, this is used by the doc-source-url feature to determine the relative path of a given source file.
+          // If it's not a prefix of a the absolute path of the source file, the absolute path of that file will be put
+          // into the FILE_SOURCE variable below, which is definitely not what we want.
+          // Hence it needs to be the base directory for the build, not the base directory for the play-docs project.
+          "-sourcepath",
+          rootDirectory.getAbsolutePath,
+          "-doc-source-url",
+          s"https://github.com/playframework/playframework/tree/${commitish}€{FILE_PATH}.scala",
+          s"-doc-external-doc:$externalDoc",
+          "-skip-packages",
+          ExcludedTopLevelScalaPackages.mkString(":"),
+          "-Xsource:3"
+        )
+      } else {
+        Seq(
+          s"-sourceroot:${rootDirectory.getAbsolutePath}"
+        ) ++ scala3ExternalMappings(mappings) ++ scala3SourceLinkMappings(
+          scalaSources,
+          rootDirectory,
+          commitish
+        )
+      }
 
     val cache  = apiDocsCache("scalaapidocs.cache").value
     val scalac = (Compile / doc / compilers).value.scalac().asInstanceOf[AnalyzingCompiler]
 
     val scaladoc = Doc.scaladoc(label, cache, scalac)
 
-    val sources   = apiDocsScalaSources.value
     val classpath = apiDocsClasspath.value.toList
+    val sources   =
+      if (scalaBinaryVersion.value == "3") scala3TastyFiles(classpath, rootDirectory)
+      else scalaSources.filter(isNotInternalApiSource)
     val outputDir = apiDocsDir.value / "scala"
     val log       = streams.value.log
 
@@ -185,7 +289,7 @@ object Docs {
 
     val javadoc = sbt.inc.Doc.cachedJavadoc(label, cache, javaTools)
 
-    val sources    = apiDocsJavaSources.value.toList
+    val sources    = apiDocsJavaSources.value.toList.filter(isPublicJavaApiSource)
     val classpath  = apiDocsClasspath.value.toList
     val outputDir  = apiDocsDir.value / "java"
     val incToolOpt = IncToolOptions.create(Optional.empty[ClassFileManager](), false)

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -258,6 +258,9 @@ object Docs {
     val log       = streams.value.log
 
     scaladoc(sources, classpath, outputDir, options, 10, log)
+    if (scalaBinaryVersion.value == "2.13") {
+      cleanUpInvalidScala2SourceLinks(outputDir)
+    }
   }
 
   def genApiJavadocs = Def.task {
@@ -341,6 +344,23 @@ object Docs {
           javadocLinkRegex(javadocURL).replaceAllIn(oldContent, fixJavaLinks)
       }
       IO.write(f, newContent)
+    }
+  }
+
+  // Removes Scala 2 Scaladoc source links to generated target files, such as Twirl output
+  // and managed sources. Those files do not exist in the GitHub repository. Scala 3
+  // Scaladoc does not emit source links for those generated files, so it does not need
+  // this cleanup.
+  private def cleanUpInvalidScala2SourceLinks(apiTarget: File): Unit = {
+    val generatedSourceLinkRegex =
+      """<dt>Source</dt><dd><a href="https://github\.com/playframework/playframework/tree/[^"]+/[^"]*/target/[^"]+" target="_blank">[^<]+</a></dd>""".r
+
+    (apiTarget ** "*.html").get().foreach { f =>
+      val content    = IO.read(f)
+      val newContent = generatedSourceLinkRegex.replaceAllIn(content, "")
+      if (newContent != content) {
+        IO.write(f, newContent)
+      }
     }
   }
 

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -26,12 +26,14 @@ object Docs {
   val apiDocsInclude        = settingKey[Boolean]("Whether this sub project should be included in the API docs")
   val apiDocsIncludeManaged =
     settingKey[Boolean]("Whether managed sources from this project should be included in the API docs")
-  val apiDocsScalaSources = taskKey[Seq[File]]("All the scala sources for all projects")
-  val apiDocsJavaSources  = taskKey[Seq[File]]("All the Java sources for all projects")
-  val apiDocsClasspath    = taskKey[Seq[File]]("The classpath for API docs generation")
-  val apiDocs             = taskKey[File]("Generate the API docs")
-  val extractWebjars      = taskKey[File]("Extract webjar contents")
-  val allConfs            = taskKey[Seq[(String, File)]]("Gather all configuration files")
+  val apiDocsScalaSources     = taskKey[Seq[File]]("All the scala sources for all projects")
+  val apiDocsJavaSources      = taskKey[Seq[File]]("All the Java sources for all projects")
+  val apiDocsClasspath        = taskKey[Seq[File]]("The classpath for API docs generation")
+  val apiDocs                 = taskKey[File]("Generate the API docs")
+  val checkApiDocsPackageTree =
+    taskKey[Unit]("Check the generated API docs top-level package directory tree")
+  val extractWebjars = taskKey[File]("Extract webjar contents")
+  val allConfs       = taskKey[Seq[(String, File)]]("Gather all configuration files")
 
   lazy val settings = Seq(
     apiDocsInclude        := false,
@@ -56,7 +58,8 @@ object Docs {
       val bs = buildStructure.value
       Def.task(allConfsTask(pr, bs).value)
     }.value,
-    apiDocs := apiDocsTask.value,
+    apiDocs                 := apiDocsTask.value,
+    checkApiDocsPackageTree := checkApiDocsPackageTreeTask.value,
     ivyConfigurations += Webjars,
     extractWebjars := extractWebjarContents.value,
     (Compile / packageBin / mappings) ++= {
@@ -121,6 +124,50 @@ object Docs {
 
   val apiDocsDir                 = Def.setting(crossTarget.value / "apidocs")
   def apiDocsCache(name: String) = Def.setting(CacheStoreFactory(crossTarget.value / name))
+
+  // Returns the first generated directory level under java/ and scala/ API docs.
+  // This is used by the check task to catch accidental publication of internal or third-party packages.
+  private def apiDocsTopLevelPackageTree(base: File): Seq[String] = {
+    val scalaDocAssetDirectories = Set("fonts", "hljs", "images", "lib", "scripts", "styles", "webfonts")
+
+    def children(dir: File): Seq[String] =
+      IO.listFiles(dir).filter(_.isDirectory).map(_.getName).sorted
+
+    children(base / "java").map(name => s"java/$name") ++
+      children(base / "scala").filterNot(scalaDocAssetDirectories).map(name => s"scala/$name")
+  }
+
+  // Verifies the generated API docs only expose the intended top-level package roots.
+  // This protects against regressions where javadoc/scaladoc starts documenting internal or dependency packages again.
+  def checkApiDocsPackageTreeTask = Def.task {
+    val apiDocsDir = apiDocs.value
+    val log        = streams.value.log
+
+    val actual                = apiDocsTopLevelPackageTree(apiDocsDir)
+    val expectedScalaPackages = AllowedTopLevelApiPackages.map(packageName => s"scala/$packageName").sorted
+    val expected              = Seq(
+      "java/legal",
+      "java/play",
+      "java/resources",
+      "java/script-dir"
+    ) ++ expectedScalaPackages
+
+    if (actual != expected) {
+      sys.error(
+        "Generated API docs top-level package tree differs from the expected tree." +
+          System.lineSeparator() +
+          "Expected:" +
+          System.lineSeparator() +
+          expected.mkString(System.lineSeparator()) +
+          System.lineSeparator() +
+          "Actual:" +
+          System.lineSeparator() +
+          actual.mkString(System.lineSeparator())
+      )
+    } else {
+      log.info("Generated API docs top-level package tree matches the expected tree")
+    }
+  }
 
   private val InternalApiPathSegment        = "/internal/"
   private val AllowedTopLevelApiPackages    = Seq("controllers", "play", "views")

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -176,8 +176,6 @@ object Docs {
       "-notimestamp",
       "-Xmaxwarns",
       "1000",
-      "-exclude",
-      "play.api:play.core",
       "-source",
       "17"
     )

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -175,7 +175,7 @@ object Docs {
       "https://pekko.apache.org/japi/pekko-http/1.0/",
       "-notimestamp",
       "-Xmaxwarns",
-      "1000",
+      "99999",
       "-source",
       "17"
     )

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -455,7 +455,7 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
       // If we expect 100 continue, then we must not feed the source into the accumulator until the accumulator
       // requests demand.  This is due to a semantic mismatch between Play and Pekko-HTTP, Play signals to continue
       // by requesting demand, Pekko-HTTP signals to continue by attaching a sink to the source. See
-      // https://github.com/akka/akka/issues/17782 for more details.
+      // https://github.com/akka/akka-core/issues/17782 for more details.
       requestBodySource.map(source => Source.lazySource(() => source))
     } else {
       requestBodySource

--- a/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -30,8 +30,8 @@ import play.api.Configuration
  * </ul>
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options">X-Frame-Options</a>
- * @see <a href="http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx">X-Content-Type-Options</a>
- * @see <a href="http://blogs.msdn.com/b/ie/archive/2008/07/02/ie8-security-part-iv-the-xss-filter.aspx">X-XSS-Protection</a>
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options">X-Content-Type-Options</a>
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection">X-XSS-Protection</a>
  * @see <a href="http://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html">Cross Domain Policy File Specification</a>
  * @see <a href="https://www.w3.org/TR/referrer-policy/">Referrer Policy</a>
  */


### PR DESCRIPTION
- Fixes #11788

This PR tightens API docs generation so only public Play API packages are included, and adds a CI check to catch regressions.

What changed:

- Remove the ineffective Javadoc `-exclude` option. It has no effect when source files are passed explicitly without `-subpackages` (see https://docs.oracle.com/en/java/javase/11/tools/javadoc.html)
  - `-subpackages` was removed in  7421e280775ce4d62cc5b72fe482f53654a7b909 (and before in 7057b193e53bbafecd1dffb01e0bc7df2f922a40 and got added again in 8cfff7d6d23216d72fb972da96e3416948cd79d5) without removing `-exclude`. `-exclude` alone is useless.
- Limit Javadoc input to public Play Java source roots.
- Limit Scaladoc input to public Play Scala/TASTy sources.
- Exclude internal and dependency packages from generated API docs.
- Fix Scala 3 external API mappings and source-link generation.
- Remove invalid Scala 2 source links to generated target files.
- Rewrite Scala 3 Specs2 links that Scaladoc generates for inherited members.
- Add `Play-Docs/checkApiDocsPackageTree`.
- Run the package-tree check in CI for Scala 2.13 and Scala 3.
- Update stale documentation links in generated API docs comments.

The new check verifies that generated API docs expose only the intended top-level roots:

```text
java/legal
java/play
java/resources
java/script-dir
scala/controllers
scala/play
scala/views
```

This prevents accidental publication of internal Play packages or third-party dependency packages in the generated API docs.
