### PR TITLE
EssentialActionCaller: call run(bytes) directly to skip materialization

### DIFF
--- a/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -18,7 +18,6 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.stream.testkit.NoMaterializer
 import org.apache.pekko.util.ByteString
 import org.apache.pekko.util.Timeout
@@ -308,8 +307,14 @@ trait EssentialActionCaller {
    * Execute an [[play.api.mvc.EssentialAction]].
    *
    * The body is serialised using the implicit writable, so that the action body parser can deserialize it.
+   *
+   * For body parsers that require stream materialization (e.g. `parse.multipartFormData`), an explicit
+   * `Materializer` must be provided.
    */
-  def call[T](action: EssentialAction, req: Request[T])(implicit w: Writeable[T], mat: Materializer): Future[Result] =
+  def call[T](action: EssentialAction, req: Request[T])(
+      implicit w: Writeable[T],
+      mat: Materializer = NoMaterializer
+  ): Future[Result] =
     call(action, req, req.body)
 
   /**
@@ -328,7 +333,7 @@ trait EssentialActionCaller {
     val contentLength = rh.headers.get(CONTENT_LENGTH).orElse(Some(bytes.length.toString)).map(CONTENT_LENGTH -> _)
     val newHeaders    = rh.headers.replace(contentLength.toSeq ++ contentType.toSeq: _*)
 
-    action(rh.withHeaders(newHeaders)).run(Source.single(bytes))
+    action(rh.withHeaders(newHeaders)).run(bytes)
   }
 }
 

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -13,6 +13,7 @@ import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.util.ByteString
 import org.specs2.mutable._
+import play.api.libs.json.Json
 import play.api.mvc._
 import play.api.mvc.Results._
 import play.api.test.Helpers._
@@ -23,19 +24,31 @@ class HelpersSpec extends Specification {
   sequential // needed because we read/write sys.props in differents tests below
 
   val ctrl = new HelpersTest
-  class HelpersTest extends ControllerHelpers {
-    lazy val Action: ActionBuilder[Request, AnyContent] = ActionBuilder.ignoringBody
-    def abcAction: EssentialAction                      = Action {
+  class HelpersTest extends BaseControllerHelpers {
+    protected override val controllerComponents: ControllerComponents = stubControllerComponents()
+    lazy val Action: ActionBuilder[Request, AnyContent]               = ActionBuilder.ignoringBody
+    def abcAction: EssentialAction                                    = Action {
       Ok("abc").as("text/plain")
     }
     def jsonAction: EssentialAction = Action {
       Ok("""{"content": "abc"}""").as("application/json")
+    }
+    def parseJsonAction: EssentialAction = Action(parse.json) { request =>
+      Ok((request.body \ "content").as[String])
     }
   }
 
   "call" should {
     "execute an action with parse.ignore body parser without a Materializer" in {
       val result = call(ctrl.abcAction, FakeRequest())
+      status(result) must_== OK
+      contentAsString(result) must_== "abc"
+    }
+
+    "execute an action with parse.json body parser without a Materializer" in {
+      val request = FakeRequest(POST, "/").withJsonBody(Json.obj("content" -> "abc"))
+      val result  = call(ctrl.parseJsonAction, request)
+
       status(result) must_== OK
       contentAsString(result) must_== "abc"
     }

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -33,6 +33,14 @@ class HelpersSpec extends Specification {
     }
   }
 
+  "call" should {
+    "execute an action with parse.ignore body parser without a Materializer" in {
+      val result = call(ctrl.abcAction, FakeRequest())
+      status(result) must_== OK
+      contentAsString(result) must_== "abc"
+    }
+  }
+
   "inMemoryDatabase" should {
     "change database with a name argument" in {
       val inMemoryDatabaseConfiguration = inMemoryDatabase("test")


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

`call()` was feeding the request body to the action's body parser via `run(Source.single(bytes))`. This always materializes a stream, even when the body parser returns a `StrictAccumulator` (e.g. `parse.json`) that can handle a `ByteString` directly without any stream infrastructure.