### PR TITLE
Add WebSocket subprotocol selection APIs

### DIFF
--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -52,4 +52,11 @@ public class WebSocketSpecJavaActions {
     return WebSocket.Text.acceptOrResult(
         request -> CompletableFuture.completedFuture(F.Either.Left(Results.status(statusCode))));
   }
+
+  public static WebSocket selectSubprotocol() {
+    return WebSocket.Text.acceptWithOptions(
+        request ->
+            new WebSocket.Accepted<>(
+                Flow.fromSinkAndSource(Sink.ignore(), Source.empty()), "graphql-transport-ws"));
+  }
 }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -291,6 +291,51 @@ trait WebSocketSpec
         }
       }
 
+      "select the first subprotocol proposed by the client for flow-only handlers" in {
+        withServer(app =>
+          WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source(Nil)) }
+        ) { (app, port) =>
+          import app.materializer
+          val (_, headers) = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
+            },
+            Some("first-protocol, second-protocol, third-protocol"),
+            c => c
+          )
+          (headers
+            .map { case (key, value) => (key.toLowerCase, value) }
+            .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
+            .head must be).equalTo("first-protocol")
+        }
+      }
+
+      "allow the application to select a subprotocol proposed by the client" in {
+        withServer(app =>
+          WebSocket.acceptWithOptions[String, String] { req =>
+            WebSocket.Accepted(
+              Flow.fromSinkAndSource(Sink.ignore, Source(Nil)),
+              Some("graphql-transport-ws")
+            )
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val (_, headers) = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
+            },
+            Some("graphql-ws, graphql-transport-ws"),
+            c => c
+          )
+          (headers
+            .map { case (key, value) => (key.toLowerCase, value) }
+            .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
+            .head must be).equalTo("graphql-transport-ws")
+        }
+      }
+
       // we keep getting timeouts on this test
       // java.util.concurrent.TimeoutException: Futures timed out after [5 seconds] (Helpers.scala:186)
       "close the websocket when the wrong type of frame is received" in {
@@ -432,6 +477,24 @@ trait WebSocketSpec
 
       "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult { _ => statusCode =>
         WebSocketSpecJavaActions.allowRejectingAWebSocketWithAResult(statusCode)
+      }
+
+      "allow selecting a subprotocol" in {
+        withServer(_ => WebSocketSpecJavaActions.selectSubprotocol()) { (app, port) =>
+          import app.materializer
+          val (_, headers) = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
+            },
+            Some("graphql-ws, graphql-transport-ws"),
+            c => c
+          )
+          (headers
+            .map { case (key, value) => (key.toLowerCase, value) }
+            .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
+            .head must be).equalTo("graphql-transport-ws")
+        }
       }
     }
   }

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -5,6 +5,7 @@
 package play.mvc;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -29,6 +30,27 @@ public abstract class WebSocket {
    */
   public abstract CompletionStage<F.Either<Result, Flow<Message, Message, ?>>> apply(
       Http.RequestHeader request);
+
+  /**
+   * Invoke the WebSocket, including WebSocket handshake metadata.
+   *
+   * @param request The request for the WebSocket.
+   * @return A future of either a result to reject the WebSocket connection with, or an accepted
+   *     WebSocket with the flow and handshake metadata.
+   */
+  public CompletionStage<F.Either<Result, Accepted<Message, Message>>> applyWithOptions(
+      Http.RequestHeader request) {
+    return apply(request)
+        .thenApply(
+            resultOrFlow -> {
+              if (resultOrFlow.left.isPresent()) {
+                return F.Either.Left(resultOrFlow.left.get());
+              } else {
+                return F.Either.Right(
+                    new Accepted<>(resultOrFlow.right.get(), firstRequestedSubprotocol(request)));
+              }
+            });
+  }
 
   /** Acceptor for WebSockets to directly handle Play's Message objects. */
   public static final MappedWebSocketAcceptor<Message, Message> Message =
@@ -125,6 +147,39 @@ public abstract class WebSocket {
   }
 
   /**
+   * An accepted WebSocket, including the flow that handles WebSocket messages and optional
+   * handshake metadata.
+   *
+   * @param <In> the type the websocket reads from clients
+   * @param <Out> the type the websocket outputs back to remote clients
+   */
+  public static class Accepted<In, Out> {
+    private final Flow<In, Out, ?> flow;
+    private final Optional<String> subprotocol;
+
+    public Accepted(Flow<In, Out, ?> flow, Optional<String> subprotocol) {
+      this.flow = flow;
+      this.subprotocol = subprotocol;
+    }
+
+    public Accepted(Flow<In, Out, ?> flow, String subprotocol) {
+      this(flow, Optional.of(subprotocol));
+    }
+
+    public Accepted(Flow<In, Out, ?> flow) {
+      this(flow, Optional.empty());
+    }
+
+    public Flow<In, Out, ?> flow() {
+      return flow;
+    }
+
+    public Optional<String> subprotocol() {
+      return subprotocol;
+    }
+  }
+
+  /**
    * Utility class for creating WebSockets.
    *
    * @param <In> the type the websocket reads from clients (e.g. String, JsonNode)
@@ -154,6 +209,19 @@ public abstract class WebSocket {
     }
 
     /**
+     * Accept a WebSocket with handshake metadata.
+     *
+     * @param f A function that takes the request header, and returns a future of either the result
+     *     to reject the WebSocket connection with, or an accepted WebSocket with its flow and
+     *     handshake metadata.
+     * @return The WebSocket handler.
+     */
+    public WebSocket acceptOrResultWithOptions(
+        Function<Http.RequestHeader, CompletionStage<F.Either<Result, Accepted<In, Out>>>> f) {
+      return WebSocket.acceptOrResultWithOptions(inMapper, f, outMapper);
+    }
+
+    /**
      * Accept a WebSocket.
      *
      * @param f A function that takes the request header, and returns a flow to handle the WebSocket
@@ -162,6 +230,18 @@ public abstract class WebSocket {
      */
     public WebSocket accept(Function<Http.RequestHeader, Flow<In, Out, ?>> f) {
       return acceptOrResult(
+          request -> CompletableFuture.completedFuture(F.Either.Right(f.apply(request))));
+    }
+
+    /**
+     * Accept a WebSocket with handshake metadata.
+     *
+     * @param f A function that takes the request header, and returns an accepted WebSocket with its
+     *     flow and handshake metadata.
+     * @return The WebSocket handler.
+     */
+    public WebSocket acceptWithOptions(Function<Http.RequestHeader, Accepted<In, Out>> f) {
+      return acceptOrResultWithOptions(
           request -> CompletableFuture.completedFuture(F.Either.Right(f.apply(request))));
     }
   }
@@ -200,5 +280,61 @@ public abstract class WebSocket {
                 });
       }
     };
+  }
+
+  private static <In, Out> WebSocket acceptOrResultWithOptions(
+      PartialFunction<Message, F.Either<In, Message>> inMapper,
+      Function<Http.RequestHeader, CompletionStage<F.Either<Result, Accepted<In, Out>>>> f,
+      Function<Out, Message> outMapper) {
+    return new WebSocket() {
+      @Override
+      public CompletionStage<F.Either<Result, Flow<Message, Message, ?>>> apply(
+          Http.RequestHeader request) {
+        return applyWithOptions(request)
+            .thenApply(
+                resultOrAccepted -> {
+                  if (resultOrAccepted.left.isPresent()) {
+                    return F.Either.Left(resultOrAccepted.left.get());
+                  } else {
+                    return F.Either.Right(resultOrAccepted.right.get().flow());
+                  }
+                });
+      }
+
+      @Override
+      public CompletionStage<F.Either<Result, Accepted<Message, Message>>> applyWithOptions(
+          Http.RequestHeader request) {
+        return f.apply(request)
+            .thenApply(
+                resultOrAccepted -> {
+                  if (resultOrAccepted.left.isPresent()) {
+                    return F.Either.Left(resultOrAccepted.left.get());
+                  } else {
+                    Accepted<In, Out> accepted = resultOrAccepted.right.get();
+                    Flow<Message, Message, ?> flow =
+                        PekkoStreams.bypassWith(
+                            Flow.<Message>create().collect(inMapper),
+                            play.api.libs.streams.PekkoStreams.onlyFirstCanFinishMerge(2),
+                            accepted.flow().map(outMapper::apply));
+                    return F.Either.Right(new Accepted<>(flow, accepted.subprotocol()));
+                  }
+                });
+      }
+    };
+  }
+
+  private static Optional<String> firstRequestedSubprotocol(Http.RequestHeader request) {
+    return request
+        .header("Sec-WebSocket-Protocol")
+        .flatMap(
+            header -> {
+              for (String protocol : header.split(",")) {
+                String trimmed = protocol.trim();
+                if (!trimmed.isEmpty()) {
+                  return Optional.of(trimmed);
+                }
+              }
+              return Optional.empty();
+            });
   }
 }

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -28,15 +28,41 @@ trait WebSocket extends Handler {
    * a flow to handle the WebSocket messages.
    */
   def apply(request: RequestHeader): Future[Either[Result, Flow[Message, Message, ?]]]
+
+  /**
+   * Execute the WebSocket, including WebSocket handshake metadata.
+   *
+   * The return value is either a result to reject the WebSocket with (or otherwise respond in a different way), or
+   * an accepted WebSocket containing a flow to handle the WebSocket messages and optional handshake metadata.
+   */
+  def applyWithOptions(request: RequestHeader): Future[Either[Result, WebSocket.Accepted[Message, Message]]] = {
+    apply(request).map(_.map(flow => WebSocket.Accepted(flow, WebSocket.firstRequestedSubprotocol(request))))
+  }
 }
 
 /**
  * Helper utilities to generate WebSocket results.
  */
 object WebSocket {
+  private[play] def firstRequestedSubprotocol(request: RequestHeader): Option[String] = {
+    request.headers
+      .get("Sec-WebSocket-Protocol")
+      .toSeq
+      .flatMap(_.split(",").iterator.map(_.trim).filter(_.nonEmpty))
+      .headOption
+  }
+
   def apply(f: RequestHeader => Future[Either[Result, Flow[Message, Message, ?]]]): WebSocket = {
     (request: RequestHeader) => f(request)
   }
+
+  /**
+   * An accepted WebSocket, including the flow that handles WebSocket messages and optional handshake metadata.
+   *
+   * @param flow the flow that handles WebSocket messages
+   * @param subprotocol the WebSocket subprotocol selected by the application, if any
+   */
+  case class Accepted[In, Out](flow: Flow[In, Out, ?], subprotocol: Option[String] = None)
 
   /**
    * Transforms WebSocket message flows into message flows of another type.
@@ -175,6 +201,15 @@ object WebSocket {
   }
 
   /**
+   * Accepts a WebSocket using the given flow and handshake metadata.
+   */
+  def acceptWithOptions[In, Out](
+      f: RequestHeader => Accepted[In, Out]
+  )(implicit transformer: MessageFlowTransformer[In, Out]): WebSocket = {
+    acceptOrResultWithOptions(f.andThen(accepted => Future.successful(Right(accepted))))
+  }
+
+  /**
    * Creates an action that will either accept the websocket, using the given flow to handle the in and out stream, or
    * return a result to reject the Websocket.
    */
@@ -182,6 +217,26 @@ object WebSocket {
       f: RequestHeader => Future[Either[Result, Flow[In, Out, ?]]]
   )(implicit transformer: MessageFlowTransformer[In, Out]): WebSocket = {
     WebSocket { request => f(request).map(_.map(transformer.transform)) }
+  }
+
+  /**
+   * Creates an action that will either accept the websocket, using the given flow and handshake metadata, or return a
+   * result to reject the Websocket.
+   */
+  def acceptOrResultWithOptions[In, Out](
+      f: RequestHeader => Future[Either[Result, Accepted[In, Out]]]
+  )(implicit transformer: MessageFlowTransformer[In, Out]): WebSocket = {
+    new WebSocket {
+      override def apply(request: RequestHeader): Future[Either[Result, Flow[Message, Message, ?]]] = {
+        applyWithOptions(request).map(_.map(_.flow))
+      }
+
+      override def applyWithOptions(request: RequestHeader): Future[Either[Result, Accepted[Message, Message]]] = {
+        f(request).map(_.map { accepted =>
+          Accepted(transformer.transform(accepted.flow), accepted.subprotocol)
+        })
+      }
+    }
   }
 
   /**

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -191,33 +191,38 @@ object HandlerInvokerFactory {
 
         def call(wsCall: => JWebSocket): Handler = new JavaHandler {
           def withComponents(handlerComponents: JavaHandlerComponents): WebSocket = {
-            WebSocket.acceptOrResult[Message, Message] { request =>
-              def callWebSocketAction(req: RequestHeader) = wsCall(req.asJava).asScala.map { resultOrFlow =>
-                if (resultOrFlow.left.isPresent) {
-                  Left(resultOrFlow.left.get.asScala())
-                } else {
-                  Right(
-                    Flow[Message]
-                      .map {
-                        case TextMessage(text)          => new JMessage.Text(text)
-                        case BinaryMessage(data)        => new JMessage.Binary(data)
-                        case PingMessage(data)          => new JMessage.Ping(data)
-                        case PongMessage(data)          => new JMessage.Pong(data)
-                        case CloseMessage(code, reason) =>
-                          new JMessage.Close(code.toJava.asInstanceOf[Optional[Integer]], reason)
-                      }
-                      .via(resultOrFlow.right.get.asScala)
-                      .map {
-                        case text: JMessage.Text     => TextMessage(text.data)
-                        case binary: JMessage.Binary => BinaryMessage(binary.data)
-                        case ping: JMessage.Ping     => PingMessage(ping.data)
-                        case pong: JMessage.Pong     => PongMessage(pong.data)
-                        case close: JMessage.Close   =>
-                          CloseMessage(close.code.toScala.asInstanceOf[Option[Int]], close.reason)
-                      }
-                  )
+            WebSocket.acceptOrResultWithOptions[Message, Message] { request =>
+              def callWebSocketAction(req: RequestHeader) =
+                wsCall.applyWithOptions(req.asJava).asScala.map { resultOrAccepted =>
+                  if (resultOrAccepted.left.isPresent) {
+                    Left(resultOrAccepted.left.get.asScala())
+                  } else {
+                    val accepted = resultOrAccepted.right.get
+                    Right(
+                      WebSocket.Accepted(
+                        Flow[Message]
+                          .map[JMessage] {
+                            case TextMessage(text)          => new JMessage.Text(text)
+                            case BinaryMessage(data)        => new JMessage.Binary(data)
+                            case PingMessage(data)          => new JMessage.Ping(data)
+                            case PongMessage(data)          => new JMessage.Pong(data)
+                            case CloseMessage(code, reason) =>
+                              new JMessage.Close(code.toJava.asInstanceOf[Optional[Integer]], reason)
+                          }
+                          .via(accepted.flow().asScala)
+                          .map[Message] {
+                            case text: JMessage.Text     => TextMessage(text.data)
+                            case binary: JMessage.Binary => BinaryMessage(binary.data)
+                            case ping: JMessage.Ping     => PingMessage(ping.data)
+                            case pong: JMessage.Pong     => PongMessage(pong.data)
+                            case close: JMessage.Close   =>
+                              CloseMessage(close.code.toScala.asInstanceOf[Option[Int]], close.reason)
+                          },
+                        accepted.subprotocol().toScala
+                      )
+                    )
+                  }
                 }
-              }
               if (handlerComponents.httpConfiguration.actionComposition.includeWebSocketActions) {
                 new play.core.j.JavaAction(handlerComponents) {
                   override def invocation(req: JRequest): CompletionStage[JResult] = // Simulates called action method

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -2,4 +2,35 @@
 
 # What's new in Play 3.1 (maybe 4.0)
 
-TBA
+This section highlights the new features of Play 3.1. If you want to learn about the changes you need to make when you migrate to Play 3.1, check out the [[Play 3.1 Migration Guide|Migration31]].
+
+## Other Additions
+
+### WebSocket Subprotocol Selection
+
+Play now lets applications explicitly select the WebSocket subprotocol that is sent back in the successful `101 Switching Protocols` response.
+
+Previously, WebSocket handlers could inspect the incoming `Sec-WebSocket-Protocol` request header and decide whether to accept or reject the connection, but the accepted `WebSocket` only returned a flow. This meant the server backend decided which subprotocol to announce, which made it difficult to support clients that offer multiple protocols, such as:
+
+```http
+Sec-WebSocket-Protocol: graphql-ws, graphql-transport-ws
+```
+
+Applications can now return a `WebSocket.Accepted` value from the new `acceptWithOptions` or `acceptOrResultWithOptions` APIs and include the selected subprotocol:
+
+Scala
+: ```scala
+WebSocket.acceptWithOptions[String, String] { request =>
+  WebSocket.Accepted(flow, subprotocol = Some("graphql-transport-ws"))
+}
+```
+
+Java
+: ```java
+WebSocket.Text.acceptWithOptions(request ->
+  new WebSocket.Accepted<>(flow, "graphql-transport-ws"));
+```
+
+This is useful for protocols where the client and server need to agree on an application-level WebSocket protocol during the opening handshake. Existing `accept` and `acceptOrResult` handlers keep their previous behavior.
+
+For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Selecting-a-WebSocket-subprotocol]] and [[Java WebSocket documentation|JavaWebSockets#Selecting-a-WebSocket-subprotocol]].

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -92,6 +92,14 @@ Here is another example in which the input data is logged to standard out and th
 
 @[streams3](code/javaguide/async/JavaWebSockets.java)
 
+## Selecting a WebSocket subprotocol
+
+A client can offer one or more WebSocket subprotocols using the `Sec-WebSocket-Protocol` header. Play handles the WebSocket transport, but your application is responsible for deciding which application-level subprotocol it supports. Use `acceptWithOptions` or `acceptOrResultWithOptions` to select one of the protocols offered by the client and have Play announce it in the upgrade response:
+
+@[subprotocol](code/javaguide/async/JavaWebSockets.java)
+
+If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `new WebSocket.Accepted<>(flow, Optional.empty())` and use a flow that closes the WebSocket.
+
 ## Accessing a WebSocket
 
 To send data or access a websocket you need to add a route for your websocket in your routes file. For Example

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -18,6 +18,9 @@ import org.apache.pekko.stream.javadsl.*;
 import play.mvc.Controller;
 
 import java.io.Closeable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class JavaWebSockets {
@@ -176,5 +179,37 @@ public class JavaWebSockets {
           });
     }
     // #streams3
+  }
+
+  public static class Controller4 extends Controller {
+    // #subprotocol
+    private final List<Map.Entry<String, Flow<String, String, ?>>> supportedProtocols =
+        List.of(
+            Map.entry(
+                "graphql-transport-ws", Flow.fromSinkAndSource(Sink.ignore(), Source.maybe())),
+            Map.entry("graphql-ws", Flow.fromSinkAndSource(Sink.ignore(), Source.maybe())));
+
+    public WebSocket socket() {
+      return WebSocket.Text.acceptOrResultWithOptions(
+          request -> {
+            String header = request.header("Sec-WebSocket-Protocol").orElse("");
+            java.util.List<String> offered =
+                Arrays.stream(header.split(",")).map(String::trim).toList();
+
+            return supportedProtocols.stream()
+                .filter(entry -> offered.contains(entry.getKey()))
+                .findFirst()
+                .<CompletableFuture<F.Either<Result, WebSocket.Accepted<String, String>>>>map(
+                    entry ->
+                        CompletableFuture.completedFuture(
+                            F.Either.Right(
+                                new WebSocket.Accepted<>(entry.getValue(), entry.getKey()))))
+                .orElseGet(
+                    () ->
+                        CompletableFuture.completedFuture(
+                            F.Either.Left(badRequest("Unsupported WebSocket subprotocol"))));
+          });
+    }
+    // #subprotocol
   }
 }

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -94,6 +94,14 @@ Here is another example in which the input data is logged to standard out and th
 
 @[streams3](code/ScalaWebSockets.scala)
 
+## Selecting a WebSocket subprotocol
+
+A client can offer one or more WebSocket subprotocols using the `Sec-WebSocket-Protocol` header. Play handles the WebSocket transport, but your application is responsible for deciding which application-level subprotocol it supports. Use `acceptWithOptions` or `acceptOrResultWithOptions` to select one of the protocols offered by the client and have Play announce it in the upgrade response:
+
+@[subprotocol](code/ScalaWebSockets.scala)
+
+If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `WebSocket.Accepted(flow, None)` and use a flow that closes the WebSocket.
+
 ## Accessing a WebSocket
 
 To send data or access a websocket you need to add a route for your websocket in your routes file. For Example

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -370,3 +370,40 @@ class Controller8 {
   }
   // #streams3
 }
+
+class Controller9 {
+  // #subprotocol
+  import scala.concurrent.Future
+
+  import org.apache.pekko.stream.scaladsl._
+  import play.api.mvc._
+  import play.api.mvc.Results._
+
+  private val supportedProtocols = Seq(
+    "graphql-transport-ws" -> Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]),
+    "graphql-ws"           -> Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+  )
+
+  def socket = WebSocket.acceptOrResultWithOptions[String, String] { request =>
+    val offered = request.headers
+      .get("Sec-WebSocket-Protocol")
+      .toSeq
+      .flatMap(_.split(",").iterator.map(_.trim).filter(_.nonEmpty))
+
+    supportedProtocols.find { case (protocol, _) => offered.contains(protocol) } match {
+      case Some((protocol, flow)) =>
+        Future.successful {
+          Right(
+            WebSocket.Accepted(
+              flow = flow,
+              subprotocol = Some(protocol)
+            )
+          )
+        }
+
+      case None =>
+        Future.successful(Left(BadRequest("Unsupported WebSocket subprotocol")))
+    }
+  }
+  // #subprotocol
+}

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -154,9 +154,8 @@ private[play] class PlayRequestHandler(
         val app        = tryApp.get // Guaranteed to be Success for a WebSocket handler
         val wsProtocol = if (requestHeader.secure) "wss" else "ws"
         val wsUrl      = s"$wsProtocol://${requestHeader.host}${requestHeader.path}"
-        val factory    = new WebSocketServerHandshakerFactory(wsUrl, "*", true, wsBufferLimit)
 
-        val executed = Future(ws(requestHeader))(using app.actorSystem.dispatcher)
+        val executed = Future(ws.applyWithOptions(requestHeader))(using app.actorSystem.dispatcher)
 
         import play.core.Execution.Implicits.trampoline
         executed
@@ -166,10 +165,17 @@ private[play] class PlayRequestHandler(
               // WebSocket was rejected, send result
               val action = EssentialAction(_ => Accumulator.done(result))
               handleAction(action, requestHeader, request, tryApp)
-            case Right(flow) =>
+            case Right(accepted) =>
               import app.materializer
               val processor =
-                WebSocketHandler.messageFlowToFrameProcessor(flow, wsBufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle)
+                WebSocketHandler.messageFlowToFrameProcessor(
+                  accepted.flow,
+                  wsBufferLimit,
+                  wsKeepAliveMode,
+                  wsKeepAliveMaxIdle
+                )
+              val factory =
+                new WebSocketServerHandshakerFactory(wsUrl, accepted.subprotocol.orNull, true, wsBufferLimit)
               Future.successful(
                 new DefaultWebSocketHttpResponse(request.protocolVersion(), HttpResponseStatus.OK, processor, factory)
               )

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -408,17 +408,20 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
       case (action: EssentialAction, _) =>
         runAction(tryApp, request, taggedRequestHeader, requestBodySource, action, errorHandler(tryApp), true)
       case (websocket: WebSocket, Some(upgrade)) =>
-        websocket(taggedRequestHeader).fast.flatMap {
+        websocket.applyWithOptions(taggedRequestHeader).fast.flatMap {
           case Left(result) =>
             modelConversion(tryApp).convertResult(taggedRequestHeader, result, request.protocol, errorHandler(tryApp))
-          case Right(flow) =>
-            // For now, like Netty, select an arbitrary subprotocol from the list of subprotocols proposed by the client
-            // Eventually it would be better to allow the handler to specify the protocol it selected
-            // See also https://github.com/playframework/playframework/issues/7895
-            val selectedSubprotocol = upgrade.requestedProtocols.headOption
+          case Right(accepted) =>
             Future.successful(
               WebSocketHandler
-                .handleWebSocket(upgrade, flow, wsBufferLimit, selectedSubprotocol, wsKeepAliveMode, wsKeepAliveMaxIdle)
+                .handleWebSocket(
+                  upgrade,
+                  accepted.flow,
+                  wsBufferLimit,
+                  accepted.subprotocol,
+                  wsKeepAliveMode,
+                  wsKeepAliveMaxIdle
+                )
             )
         }
 


### PR DESCRIPTION
- (Correctly) Fixes #7895
- Partly fixes #9473
  -  It does fix what the the comments in that issue is about, but not allow "manipulate _all_ the headers"
- Fixes https://stackoverflow.com/questions/57006270/play-framework-upgrade-to-web-socket-manually