### PR TITLE
Allow setting headers, cookies, and session in WebSocket handshakes

### DIFF
--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -105,10 +105,20 @@ public class WebSocketSpecJavaActions {
     return WebSocket.Text.acceptWithOptions(
         request -> {
           Flow<String, String, ?> flow =
-              Flow.fromSinkAndSource(Sink.ignore(), Source.<String>empty());
-          return new WebSocket.Accepted<>(flow)
-              .withHeader("X-WebSocket-Trace", "java-trace")
+              Flow.fromSinkAndSource(Sink.ignore(), Source.single("plain server message"));
+          return new WebSocket.Accepted<>(flow, "graphql-transport-ws", false)
+              .withHeaders(
+                  "X-WebSocket-Trace",
+                  "discarded",
+                  "x-websocket-trace",
+                  "java-trace",
+                  "X-Remove",
+                  "remove",
+                  "Set-Cookie",
+                  "java-raw-cookie=raw-value; Path=/")
+              .withoutHeader("x-remove")
               .withCookies(Http.Cookie.builder("java-ws-cookie", "cookie-value").build())
+              .discardingCookie("java-expired", "/", null, true, Http.Cookie.SameSite.LAX, true)
               .addingToSession(request, "websocket", "connected");
         });
   }

--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -12,6 +12,7 @@ import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import play.libs.F;
+import play.mvc.Http;
 import play.mvc.Results;
 import play.mvc.WebSocket;
 import scala.concurrent.Promise;
@@ -98,5 +99,16 @@ public class WebSocketSpecJavaActions {
   public static WebSocket acceptJsonClass() {
     return WebSocket.json(JavaJsonMessage.class)
         .accept(request -> Flow.fromSinkAndSource(Sink.ignore(), emptySource()));
+  }
+
+  public static WebSocket addHandshakeHeadersAndCookies() {
+    return WebSocket.Text.acceptWithOptions(
+        request -> {
+          Flow<String, String, ?> flow =
+              Flow.fromSinkAndSource(Sink.ignore(), Source.<String>empty());
+          return new WebSocket.Accepted<>(flow)
+              .withHeader("X-WebSocket-Trace", "java-trace")
+              .withCookies(Http.Cookie.builder("java-ws-cookie", "cookie-value").build());
+        });
   }
 }

--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -108,7 +108,8 @@ public class WebSocketSpecJavaActions {
               Flow.fromSinkAndSource(Sink.ignore(), Source.<String>empty());
           return new WebSocket.Accepted<>(flow)
               .withHeader("X-WebSocket-Trace", "java-trace")
-              .withCookies(Http.Cookie.builder("java-ws-cookie", "cookie-value").build());
+              .withCookies(Http.Cookie.builder("java-ws-cookie", "cookie-value").build())
+              .addingToSession(request, "websocket", "connected");
         });
   }
 }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -1073,6 +1073,7 @@ trait WebSocketSpec
               .Accepted(flow)
               .withHeaders("X-WebSocket-Trace" -> "scala-trace")
               .withCookies(Cookie("scala-ws-cookie", "cookie-value", httpOnly = true))
+              .withSession("websocket" -> "connected")
           }
         ) { (app, port) =>
           val (_, responseHeaderSeq): (org.apache.pekko.Done, immutable.Seq[(String, String)]) = runWebSocket(
@@ -1089,6 +1090,9 @@ trait WebSocketSpec
           responseHeaders
             .collect { case ("set-cookie", value) => value }
             .mkString(";") must contain("scala-ws-cookie=cookie-value")
+          responseHeaders
+            .collect { case ("set-cookie", value) => value }
+            .mkString(";") must contain("PLAY_SESSION=")
         }
       }
 
@@ -1464,6 +1468,9 @@ trait WebSocketSpec
           responseHeaders
             .collect { case ("set-cookie", value) => value }
             .mkString(";") must contain("java-ws-cookie=cookie-value")
+          responseHeaders
+            .collect { case ("set-cookie", value) => value }
+            .mkString(";") must contain("PLAY_SESSION=")
         }
       }
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -37,10 +37,13 @@ import play.api.libs.json.Reads
 import play.api.libs.streams.ActorFlow
 import play.api.libs.ws.WSClient
 import play.api.mvc.Cookie
+import play.api.mvc.CookieHeaderEncoding
+import play.api.mvc.DiscardingCookie
 import play.api.mvc.Handler
 import play.api.mvc.RequestHeader
 import play.api.mvc.Result
 import play.api.mvc.Results
+import play.api.mvc.SessionCookieBaker
 import play.api.mvc.WebSocket
 import play.api.routing.HandlerDef
 import play.api.test._
@@ -1065,34 +1068,77 @@ trait WebSocketSpec
         }
       }
 
-      "allow the application to add WebSocket handshake headers and cookies" in {
-        withServer(app =>
-          WebSocket.acceptWithOptions[String, String] { req =>
-            val flow: Flow[String, String, ?] = Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
-            WebSocket
-              .Accepted(flow)
-              .withHeaders("X-WebSocket-Trace" -> "scala-trace")
-              .withCookies(Cookie("scala-ws-cookie", "cookie-value", httpOnly = true))
-              .withSession("websocket" -> "connected")
-          }
-        ) { (app, port) =>
-          val (_, responseHeaderSeq): (org.apache.pekko.Done, immutable.Seq[(String, String)]) = runWebSocket(
-            port,
-            { flow =>
-              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)(app.materializer)
+      "preserve all accepted options when adding handshake headers, cookies, and session data" in {
+        withServer(
+          app =>
+            WebSocket.acceptWithOptions[String, String] { req =>
+              val flow: Flow[String, String, ?] =
+                Flow.fromSinkAndSource(Sink.ignore, Source.single("plain server message"))
+              WebSocket
+                .Accepted(flow, Some("graphql-transport-ws"), compressionEnabled = false)
+                .withHeaders(
+                  "X-WebSocket-Trace" -> "discarded",
+                  "x-websocket-trace" -> "scala-trace",
+                  "X-Remove"          -> "remove",
+                  "Set-Cookie"        -> "scala-raw-cookie=raw-value; Path=/"
+                )
+                .discardingHeader("x-remove")
+                .withCookies(Cookie("scala-ws-cookie", "cookie-value", httpOnly = true))
+                .discardingCookies(
+                  DiscardingCookie(
+                    "scala-expired",
+                    secure = true,
+                    sameSite = Some(Cookie.SameSite.Lax),
+                    partitioned = true
+                  )
+                )
+                .withSession("websocket" -> "connected")
             },
-            None,
+          Map("play.http.session.cookieName" -> "SCALA_SESSION")
+        ) { (app, port) =>
+          import app.materializer
+          val (frames, responseHeaderSeq) = runWebSocket(
+            port,
+            { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+            Some("graphql-ws, graphql-transport-ws"),
             c => c,
-            CompressionMode.Disabled
+            CompressionMode.RequestOnly()
           )
           val responseHeaders = responseHeaderSeq.map { case (key, value) => (key.toLowerCase, value) }
+
+          responseHeaders.collect { case ("sec-websocket-protocol", value) => value } must contain(
+            exactly("graphql-transport-ws")
+          )
+          responseHeaders.collect { case ("sec-websocket-extensions", value) => value } must beEmpty
           responseHeaders must contain("x-websocket-trace" -> "scala-trace")
-          responseHeaders
+          responseHeaders.collect { case ("x-websocket-trace", value) => value } must contain(
+            exactly("scala-trace")
+          )
+          responseHeaders.collect { case ("x-remove", value) => value } must beEmpty
+          frames.collectFirst {
+            case SimpleMessage(TextMessage(data), true) => data
+          } must beSome("plain server message")
+
+          val cookieHeaderEncoding = app.injector.instanceOf[CookieHeaderEncoding]
+          val responseCookies      = responseHeaders
             .collect { case ("set-cookie", value) => value }
-            .mkString(";") must contain("scala-ws-cookie=cookie-value")
-          responseHeaders
-            .collect { case ("set-cookie", value) => value }
-            .mkString(";") must contain("PLAY_SESSION=")
+            .flatMap(cookieHeaderEncoding.decodeSetCookieHeader)
+          responseCookies.count(_.name == "scala-raw-cookie") must_== 1
+          responseCookies.find(_.name == "scala-raw-cookie").map(_.value) must beSome("raw-value")
+          responseCookies.find(_.name == "scala-ws-cookie").map(_.value) must beSome("cookie-value")
+          responseCookies.find(_.name == "scala-expired") must beSome[Cookie].like {
+            case cookie =>
+              (cookie.maxAge must beSome(Cookie.DiscardedMaxAge))
+                .and(cookie.secure must beTrue)
+                .and(cookie.sameSite must_== Some(Cookie.SameSite.Lax))
+                .and(cookie.partitioned must beTrue)
+          }
+
+          val sessionBaker = app.injector.instanceOf[SessionCookieBaker]
+          sessionBaker.COOKIE_NAME must_== "SCALA_SESSION"
+          sessionBaker.decodeFromCookie(responseCookies.find(_.name == sessionBaker.COOKIE_NAME)).data must_== Map(
+            "websocket" -> "connected"
+          )
         }
       }
 
@@ -1102,10 +1148,20 @@ trait WebSocketSpec
             val flow: Flow[String, String, ?] = Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
             WebSocket
               .Accepted(flow)
-              .withHeaders("Sec-WebSocket-Protocol" -> "bad-protocol", "X-WebSocket-Trace" -> "allowed")
+              .withHeaders(
+                "Connection"               -> "close",
+                "Content-Length"           -> "42",
+                "Transfer-Encoding"        -> "chunked",
+                "Upgrade"                  -> "h2c",
+                "Sec-WebSocket-Accept"     -> "bad-accept",
+                "Sec-WebSocket-Extensions" -> "bad-extension",
+                "Sec-WebSocket-Protocol"   -> "bad-protocol",
+                "Sec-WebSocket-Future"     -> "bad-future",
+                "X-WebSocket-Trace"        -> "allowed"
+              )
           }
         ) { (app, port) =>
-          val (_, responseHeaderSeq): (org.apache.pekko.Done, immutable.Seq[(String, String)]) = runWebSocket(
+          val responseHeaderSeq = runWebSocket(
             port,
             { flow =>
               sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)(app.materializer)
@@ -1113,10 +1169,43 @@ trait WebSocketSpec
             None,
             c => c,
             CompressionMode.Disabled
-          )
+          )._2
           val responseHeaders = responseHeaderSeq.map { case (key, value) => (key.toLowerCase, value) }
           responseHeaders must contain("x-websocket-trace" -> "allowed")
+          responseHeaders.contains("connection" -> "close") must beFalse
+          responseHeaders.contains("content-length" -> "42") must beFalse
+          responseHeaders.collect { case ("transfer-encoding", value) => value } must beEmpty
+          responseHeaders.contains("upgrade" -> "h2c") must beFalse
+          responseHeaders.contains("sec-websocket-accept" -> "bad-accept") must beFalse
+          responseHeaders.collect { case ("sec-websocket-extensions", value) => value } must beEmpty
           responseHeaders.collect { case ("sec-websocket-protocol", value) => value } must beEmpty
+          responseHeaders.collect { case ("sec-websocket-future", value) => value } must beEmpty
+        }
+      }
+
+      "reject invalid application supplied WebSocket handshake headers" in {
+        withServer(app =>
+          WebSocket.acceptWithOptions[String, String] { req =>
+            val flow: Flow[String, String, ?] = Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+            WebSocket
+              .Accepted(flow)
+              .withHeaders("X-WebSocket-Trace" -> "trace\r\nInjected: true")
+          }
+        ) { (app, port) =>
+          webSocketHandshakeStatus(app, port, None) must_== INTERNAL_SERVER_ERROR
+        }
+      }
+
+      "reject invalid application supplied WebSocket handshake cookie headers" in {
+        withServer(app =>
+          WebSocket.acceptWithOptions[String, String] { req =>
+            val flow: Flow[String, String, ?] = Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+            WebSocket
+              .Accepted(flow)
+              .withHeaders("Set-Cookie" -> "websocket=connected\r\nInjected: true")
+          }
+        ) { (app, port) =>
+          webSocketHandshakeStatus(app, port, None) must_== INTERNAL_SERVER_ERROR
         }
       }
 
@@ -1452,25 +1541,53 @@ trait WebSocketSpec
       }
 
       "allow adding handshake headers and cookies" in {
-        withServer(_ => WebSocketSpecJavaActions.addHandshakeHeadersAndCookies()) { (app, port) =>
+        withServer(
+          _ => WebSocketSpecJavaActions.addHandshakeHeadersAndCookies(),
+          Map("play.http.session.cookieName" -> "JAVA_SESSION")
+        ) { (app, port) =>
           import app.materializer
-          val (_, headers) = runWebSocket(
+          val (frames, headers) = runWebSocket(
             port,
-            { flow =>
-              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
-            },
-            None,
+            { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+            Some("graphql-ws, graphql-transport-ws"),
             c => c,
-            CompressionMode.Disabled
+            CompressionMode.RequestOnly()
           )
           val responseHeaders = headers.map { case (key, value) => (key.toLowerCase, value) }
+
+          responseHeaders.collect { case ("sec-websocket-protocol", value) => value } must contain(
+            exactly("graphql-transport-ws")
+          )
+          responseHeaders.collect { case ("sec-websocket-extensions", value) => value } must beEmpty
           responseHeaders must contain("x-websocket-trace" -> "java-trace")
-          responseHeaders
+          responseHeaders.collect { case ("x-websocket-trace", value) => value } must contain(
+            exactly("java-trace")
+          )
+          responseHeaders.collect { case ("x-remove", value) => value } must beEmpty
+          frames.collectFirst {
+            case SimpleMessage(TextMessage(data), true) => data
+          } must beSome("plain server message")
+
+          val cookieHeaderEncoding = app.injector.instanceOf[CookieHeaderEncoding]
+          val responseCookies      = responseHeaders
             .collect { case ("set-cookie", value) => value }
-            .mkString(";") must contain("java-ws-cookie=cookie-value")
-          responseHeaders
-            .collect { case ("set-cookie", value) => value }
-            .mkString(";") must contain("PLAY_SESSION=")
+            .flatMap(cookieHeaderEncoding.decodeSetCookieHeader)
+          responseCookies.count(_.name == "java-raw-cookie") must_== 1
+          responseCookies.find(_.name == "java-raw-cookie").map(_.value) must beSome("raw-value")
+          responseCookies.find(_.name == "java-ws-cookie").map(_.value) must beSome("cookie-value")
+          responseCookies.find(_.name == "java-expired") must beSome[Cookie].like {
+            case cookie =>
+              (cookie.maxAge must beSome(Cookie.DiscardedMaxAge))
+                .and(cookie.secure must beTrue)
+                .and(cookie.sameSite must_== Some(Cookie.SameSite.Lax))
+                .and(cookie.partitioned must beTrue)
+          }
+
+          val sessionBaker = app.injector.instanceOf[SessionCookieBaker]
+          sessionBaker.COOKIE_NAME must_== "JAVA_SESSION"
+          sessionBaker.decodeFromCookie(responseCookies.find(_.name == sessionBaker.COOKIE_NAME)).data must_== Map(
+            "websocket" -> "connected"
+          )
         }
       }
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -36,6 +36,7 @@ import play.api.libs.json.Json
 import play.api.libs.json.Reads
 import play.api.libs.streams.ActorFlow
 import play.api.libs.ws.WSClient
+import play.api.mvc.Cookie
 import play.api.mvc.Handler
 import play.api.mvc.RequestHeader
 import play.api.mvc.Result
@@ -1064,6 +1065,57 @@ trait WebSocketSpec
         }
       }
 
+      "allow the application to add WebSocket handshake headers and cookies" in {
+        withServer(app =>
+          WebSocket.acceptWithOptions[String, String] { req =>
+            val flow: Flow[String, String, ?] = Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+            WebSocket
+              .Accepted(flow)
+              .withHeaders("X-WebSocket-Trace" -> "scala-trace")
+              .withCookies(Cookie("scala-ws-cookie", "cookie-value", httpOnly = true))
+          }
+        ) { (app, port) =>
+          val (_, responseHeaderSeq): (org.apache.pekko.Done, immutable.Seq[(String, String)]) = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)(app.materializer)
+            },
+            None,
+            c => c,
+            CompressionMode.Disabled
+          )
+          val responseHeaders = responseHeaderSeq.map { case (key, value) => (key.toLowerCase, value) }
+          responseHeaders must contain("x-websocket-trace" -> "scala-trace")
+          responseHeaders
+            .collect { case ("set-cookie", value) => value }
+            .mkString(";") must contain("scala-ws-cookie=cookie-value")
+        }
+      }
+
+      "ignore application supplied WebSocket protocol-owned handshake headers" in {
+        withServer(app =>
+          WebSocket.acceptWithOptions[String, String] { req =>
+            val flow: Flow[String, String, ?] = Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+            WebSocket
+              .Accepted(flow)
+              .withHeaders("Sec-WebSocket-Protocol" -> "bad-protocol", "X-WebSocket-Trace" -> "allowed")
+          }
+        ) { (app, port) =>
+          val (_, responseHeaderSeq): (org.apache.pekko.Done, immutable.Seq[(String, String)]) = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)(app.materializer)
+            },
+            None,
+            c => c,
+            CompressionMode.Disabled
+          )
+          val responseHeaders = responseHeaderSeq.map { case (key, value) => (key.toLowerCase, value) }
+          responseHeaders must contain("x-websocket-trace" -> "allowed")
+          responseHeaders.collect { case ("sec-websocket-protocol", value) => value } must beEmpty
+        }
+      }
+
       // we keep getting timeouts on this test
       // java.util.concurrent.TimeoutException: Futures timed out after [5 seconds] (Helpers.scala:186)
       "close the websocket when the wrong type of frame is received" in {
@@ -1392,6 +1444,26 @@ trait WebSocketSpec
               closeFrame(1003)
             )
           )
+        }
+      }
+
+      "allow adding handshake headers and cookies" in {
+        withServer(_ => WebSocketSpecJavaActions.addHandshakeHeadersAndCookies()) { (app, port) =>
+          import app.materializer
+          val (_, headers) = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(TextMessage("foo"), CloseMessage(1000)).via(flow).runWith(Sink.ignore)
+            },
+            None,
+            c => c,
+            CompressionMode.Disabled
+          )
+          val responseHeaders = headers.map { case (key, value) => (key.toLowerCase, value) }
+          responseHeaders must contain("x-websocket-trace" -> "java-trace")
+          responseHeaders
+            .collect { case ("set-cookie", value) => value }
+            .mkString(";") must contain("java-ws-cookie=cookie-value")
         }
       }
     }

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -5,12 +5,20 @@
 package play.mvc;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.util.ByteString;
 import play.api.http.websocket.CloseCodes;
@@ -203,16 +211,21 @@ public abstract class WebSocket {
     private final Optional<String> subprotocol;
     private final boolean compressionEnabled;
     private final Predicate<CompressionContext> shouldCompress;
+    private final List<Map.Entry<String, String>> headers;
+    private final List<Http.Cookie> cookies;
 
     public Accepted(
         Flow<In, Out, ?> flow,
         Optional<String> subprotocol,
         boolean compressionEnabled,
         Predicate<CompressionContext> shouldCompress) {
-      this.flow = flow;
-      this.subprotocol = subprotocol;
-      this.compressionEnabled = compressionEnabled;
-      this.shouldCompress = shouldCompress;
+      this(
+          flow,
+          subprotocol,
+          compressionEnabled,
+          shouldCompress,
+          Collections.emptyList(),
+          Collections.emptyList());
     }
 
     public Accepted(
@@ -229,6 +242,38 @@ public abstract class WebSocket {
 
     public Accepted(Flow<In, Out, ?> flow, Optional<String> subprotocol) {
       this(flow, subprotocol, true);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        Optional<String> subprotocol,
+        List<Map.Entry<String, String>> headers,
+        List<Http.Cookie> cookies) {
+      this(flow, subprotocol, true, DEFAULT_SHOULD_COMPRESS, headers, cookies);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        Optional<String> subprotocol,
+        boolean compressionEnabled,
+        List<Map.Entry<String, String>> headers,
+        List<Http.Cookie> cookies) {
+      this(flow, subprotocol, compressionEnabled, DEFAULT_SHOULD_COMPRESS, headers, cookies);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        Optional<String> subprotocol,
+        boolean compressionEnabled,
+        Predicate<CompressionContext> shouldCompress,
+        List<Map.Entry<String, String>> headers,
+        List<Http.Cookie> cookies) {
+      this.flow = flow;
+      this.subprotocol = subprotocol;
+      this.compressionEnabled = compressionEnabled;
+      this.shouldCompress = shouldCompress;
+      this.headers = Collections.unmodifiableList(new ArrayList<>(headers));
+      this.cookies = Collections.unmodifiableList(new ArrayList<>(cookies));
     }
 
     public Accepted(Flow<In, Out, ?> flow, String subprotocol) {
@@ -302,6 +347,120 @@ public abstract class WebSocket {
      */
     public Predicate<CompressionContext> shouldCompress() {
       return shouldCompress;
+    }
+
+    public List<Map.Entry<String, String>> headers() {
+      return headers;
+    }
+
+    public List<Http.Cookie> cookies() {
+      return cookies;
+    }
+
+    /**
+     * Return a copy of this accepted WebSocket with the given handshake response header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> withHeader(String name, String value) {
+      List<Map.Entry<String, String>> newHeaders = new ArrayList<>(headers);
+      newHeaders.add(new AbstractMap.SimpleImmutableEntry<>(name, value));
+      return new Accepted<>(
+          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies);
+    }
+
+    /**
+     * Return a copy of this accepted WebSocket with the given handshake response headers.
+     *
+     * <p>The headers are processed in pairs, so nameValues(0) is the first header's name, and
+     * nameValues(1) is the first header's value, nameValues(2) is second header's name, and so on.
+     *
+     * @param nameValues the array of names and values.
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> withHeaders(String... nameValues) {
+      if (nameValues.length % 2 != 0) {
+        throw new IllegalArgumentException(
+            "Headers must be supplied as alternating name and value strings");
+      }
+
+      List<Map.Entry<String, String>> newHeaders = new ArrayList<>(headers);
+      for (int i = 0; i < nameValues.length; i += 2) {
+        newHeaders.add(new AbstractMap.SimpleImmutableEntry<>(nameValues[i], nameValues[i + 1]));
+      }
+      return new Accepted<>(
+          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies);
+    }
+
+    /**
+     * Discard a handshake response header.
+     *
+     * @param name the header name
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> withoutHeader(String name) {
+      String lowerName = name.toLowerCase(Locale.ROOT);
+      List<Map.Entry<String, String>> newHeaders =
+          headers.stream()
+              .filter(header -> !header.getKey().toLowerCase(Locale.ROOT).equals(lowerName))
+              .collect(Collectors.toList());
+      return new Accepted<>(
+          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies);
+    }
+
+    /**
+     * Returns a copy of this accepted WebSocket with the given cookies.
+     *
+     * @param newCookies the cookies to add to the handshake response.
+     * @return the transformed copy.
+     */
+    public Accepted<In, Out> withCookies(Http.Cookie... newCookies) {
+      List<Http.Cookie> finalCookies =
+          Stream.concat(
+                  cookies.stream()
+                      .filter(
+                          cookie -> {
+                            for (Http.Cookie newCookie : newCookies) {
+                              if (cookie.name().equals(newCookie.name())) return false;
+                            }
+                            return true;
+                          }),
+                  Stream.of(newCookies))
+              .collect(Collectors.toList());
+      return new Accepted<>(
+          flow, subprotocol, compressionEnabled, shouldCompress, headers, finalCookies);
+    }
+
+    /**
+     * Discard a cookie on the default path ("/") with no domain and that's not secure.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     */
+    public Accepted<In, Out> discardingCookie(String name) {
+      return discardingCookie(name, "/");
+    }
+
+    /**
+     * Discard a cookie on the given path with no domain and not that's secure.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie to discard, may be null
+     */
+    public Accepted<In, Out> discardingCookie(String name, String path) {
+      return discardingCookie(name, path, null);
+    }
+
+    /**
+     * Discard a cookie on the given path and domain that's not secure.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie te discard, may be null
+     * @param domain The domain of the cookie to discard, may be null
+     */
+    public Accepted<In, Out> discardingCookie(String name, String path, String domain) {
+      return withCookies(new Http.Cookie(name, "", 0, path, domain, false, true, null, false));
     }
   }
 
@@ -447,7 +606,9 @@ public abstract class WebSocket {
                             flow,
                             accepted.subprotocol(),
                             accepted.compressionEnabled(),
-                            accepted.shouldCompress()));
+                            accepted.shouldCompress(),
+                            accepted.headers(),
+                            accepted.cookies()));
                   }
                 });
       }

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -23,10 +23,12 @@ import java.util.stream.Stream;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.util.ByteString;
 import play.api.http.websocket.CloseCodes;
+import play.api.mvc.DiscardingCookie;
 import play.http.websocket.Message;
 import play.libs.F;
 import play.libs.Scala;
 import play.libs.streams.PekkoStreams;
+import scala.Option;
 import scala.PartialFunction;
 
 /** A WebSocket handler. */
@@ -311,7 +313,14 @@ public abstract class WebSocket {
       this.subprotocol = subprotocol;
       this.compressionEnabled = compressionEnabled;
       this.shouldCompress = shouldCompress;
-      this.headers = Collections.unmodifiableList(new ArrayList<>(headers));
+      this.headers =
+          Collections.unmodifiableList(
+              headers.stream()
+                  .map(
+                      header ->
+                          new AbstractMap.SimpleImmutableEntry<>(
+                              header.getKey(), header.getValue()))
+                  .collect(Collectors.toList()));
       this.cookies = Collections.unmodifiableList(new ArrayList<>(cookies));
       this.session = session;
     }
@@ -389,20 +398,27 @@ public abstract class WebSocket {
       return shouldCompress;
     }
 
+    /** Returns the application-supplied WebSocket handshake response headers. */
     public List<Map.Entry<String, String>> headers() {
       return headers;
     }
 
+    /** Returns the cookies to add to the WebSocket handshake response. */
     public List<Http.Cookie> cookies() {
       return cookies;
     }
 
+    /** Returns the session to add to the WebSocket handshake response, if one was set. */
     public Optional<Http.Session> session() {
       return Optional.ofNullable(session);
     }
 
     /**
-     * Return a copy of this accepted WebSocket with the given handshake response header.
+     * Return a copy of this accepted WebSocket with the given handshake response header added or
+     * replaced.
+     *
+     * <p>Connection and framing headers, and all {@code Sec-WebSocket-*} headers, are controlled by
+     * Play and will not be sent.
      *
      * @param name the header name
      * @param value the header value
@@ -410,13 +426,17 @@ public abstract class WebSocket {
      */
     public Accepted<In, Out> withHeader(String name, String value) {
       List<Map.Entry<String, String>> newHeaders = new ArrayList<>(headers);
-      newHeaders.add(new AbstractMap.SimpleImmutableEntry<>(name, value));
+      replaceHeader(newHeaders, name, value);
       return new Accepted<>(
           flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies, session);
     }
 
     /**
-     * Return a copy of this accepted WebSocket with the given handshake response headers.
+     * Return a copy of this accepted WebSocket with the given handshake response headers added or
+     * replaced.
+     *
+     * <p>Connection and framing headers, and all {@code Sec-WebSocket-*} headers, are controlled by
+     * Play and will not be sent.
      *
      * <p>The headers are processed in pairs, so nameValues(0) is the first header's name, and
      * nameValues(1) is the first header's value, nameValues(2) is second header's name, and so on.
@@ -432,10 +452,16 @@ public abstract class WebSocket {
 
       List<Map.Entry<String, String>> newHeaders = new ArrayList<>(headers);
       for (int i = 0; i < nameValues.length; i += 2) {
-        newHeaders.add(new AbstractMap.SimpleImmutableEntry<>(nameValues[i], nameValues[i + 1]));
+        replaceHeader(newHeaders, nameValues[i], nameValues[i + 1]);
       }
       return new Accepted<>(
           flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies, session);
+    }
+
+    private static void replaceHeader(
+        List<Map.Entry<String, String>> headers, String name, String value) {
+      headers.removeIf(header -> header.getKey().equalsIgnoreCase(name));
+      headers.add(new AbstractMap.SimpleImmutableEntry<>(name, value));
     }
 
     /**
@@ -504,7 +530,77 @@ public abstract class WebSocket {
      * @param domain The domain of the cookie to discard, may be null
      */
     public Accepted<In, Out> discardingCookie(String name, String path, String domain) {
-      return withCookies(new Http.Cookie(name, "", 0, path, domain, false, true, null, false));
+      return discardingCookie(name, path, domain, false);
+    }
+
+    /**
+     * Discard a cookie in this WebSocket upgrade response.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie to discard, may be null
+     * @param domain The domain of the cookie to discard, may be null
+     * @param secure Whether the cookie to discard is secure
+     */
+    public Accepted<In, Out> discardingCookie(
+        String name, String path, String domain, boolean secure) {
+      return discardingCookie(name, path, domain, secure, false);
+    }
+
+    /**
+     * Discard a cookie in this WebSocket upgrade response.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie to discard, may be null
+     * @param domain The domain of the cookie to discard, may be null
+     * @param secure Whether the cookie to discard is secure
+     * @param partitioned Whether the cookie to discard is partitioned
+     */
+    public Accepted<In, Out> discardingCookie(
+        String name, String path, String domain, boolean secure, boolean partitioned) {
+      return discardingCookie(name, path, domain, secure, null, partitioned);
+    }
+
+    /**
+     * Discard a cookie in this WebSocket upgrade response.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie to discard, may be null
+     * @param domain The domain of the cookie to discard, may be null
+     * @param secure Whether the cookie to discard is secure
+     * @param sameSite The SameSite attribute of the cookie to discard, may be null
+     */
+    public Accepted<In, Out> discardingCookie(
+        String name, String path, String domain, boolean secure, Http.Cookie.SameSite sameSite) {
+      return discardingCookie(name, path, domain, secure, sameSite, false);
+    }
+
+    /**
+     * Discard a cookie in this WebSocket upgrade response.
+     *
+     * @param name The name of the cookie to discard, must not be null
+     * @param path The path of the cookie to discard, may be null
+     * @param domain The domain of the cookie to discard, may be null
+     * @param secure Whether the cookie to discard is secure
+     * @param sameSite The SameSite attribute of the cookie to discard, may be null
+     * @param partitioned Whether the cookie to discard is partitioned
+     */
+    public Accepted<In, Out> discardingCookie(
+        String name,
+        String path,
+        String domain,
+        boolean secure,
+        Http.Cookie.SameSite sameSite,
+        boolean partitioned) {
+      return withCookies(
+          new DiscardingCookie(
+                  name,
+                  path,
+                  Option.apply(domain),
+                  secure,
+                  Option.apply(sameSite).map(Http.Cookie.SameSite::asScala),
+                  partitioned)
+              .toCookie()
+              .asJava());
     }
 
     /**

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -213,6 +214,7 @@ public abstract class WebSocket {
     private final Predicate<CompressionContext> shouldCompress;
     private final List<Map.Entry<String, String>> headers;
     private final List<Http.Cookie> cookies;
+    private final Http.Session session;
 
     public Accepted(
         Flow<In, Out, ?> flow,
@@ -249,7 +251,7 @@ public abstract class WebSocket {
         Optional<String> subprotocol,
         List<Map.Entry<String, String>> headers,
         List<Http.Cookie> cookies) {
-      this(flow, subprotocol, true, DEFAULT_SHOULD_COMPRESS, headers, cookies);
+      this(flow, subprotocol, true, DEFAULT_SHOULD_COMPRESS, headers, cookies, null);
     }
 
     public Accepted(
@@ -258,7 +260,16 @@ public abstract class WebSocket {
         boolean compressionEnabled,
         List<Map.Entry<String, String>> headers,
         List<Http.Cookie> cookies) {
-      this(flow, subprotocol, compressionEnabled, DEFAULT_SHOULD_COMPRESS, headers, cookies);
+      this(flow, subprotocol, compressionEnabled, DEFAULT_SHOULD_COMPRESS, headers, cookies, null);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        Optional<String> subprotocol,
+        List<Map.Entry<String, String>> headers,
+        List<Http.Cookie> cookies,
+        Http.Session session) {
+      this(flow, subprotocol, true, DEFAULT_SHOULD_COMPRESS, headers, cookies, session);
     }
 
     public Accepted(
@@ -268,12 +279,41 @@ public abstract class WebSocket {
         Predicate<CompressionContext> shouldCompress,
         List<Map.Entry<String, String>> headers,
         List<Http.Cookie> cookies) {
+      this(flow, subprotocol, compressionEnabled, shouldCompress, headers, cookies, null);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        Optional<String> subprotocol,
+        boolean compressionEnabled,
+        List<Map.Entry<String, String>> headers,
+        List<Http.Cookie> cookies,
+        Http.Session session) {
+      this(
+          flow,
+          subprotocol,
+          compressionEnabled,
+          DEFAULT_SHOULD_COMPRESS,
+          headers,
+          cookies,
+          session);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        Optional<String> subprotocol,
+        boolean compressionEnabled,
+        Predicate<CompressionContext> shouldCompress,
+        List<Map.Entry<String, String>> headers,
+        List<Http.Cookie> cookies,
+        Http.Session session) {
       this.flow = flow;
       this.subprotocol = subprotocol;
       this.compressionEnabled = compressionEnabled;
       this.shouldCompress = shouldCompress;
       this.headers = Collections.unmodifiableList(new ArrayList<>(headers));
       this.cookies = Collections.unmodifiableList(new ArrayList<>(cookies));
+      this.session = session;
     }
 
     public Accepted(Flow<In, Out, ?> flow, String subprotocol) {
@@ -357,6 +397,10 @@ public abstract class WebSocket {
       return cookies;
     }
 
+    public Optional<Http.Session> session() {
+      return Optional.ofNullable(session);
+    }
+
     /**
      * Return a copy of this accepted WebSocket with the given handshake response header.
      *
@@ -368,7 +412,7 @@ public abstract class WebSocket {
       List<Map.Entry<String, String>> newHeaders = new ArrayList<>(headers);
       newHeaders.add(new AbstractMap.SimpleImmutableEntry<>(name, value));
       return new Accepted<>(
-          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies);
+          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies, session);
     }
 
     /**
@@ -391,7 +435,7 @@ public abstract class WebSocket {
         newHeaders.add(new AbstractMap.SimpleImmutableEntry<>(nameValues[i], nameValues[i + 1]));
       }
       return new Accepted<>(
-          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies);
+          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies, session);
     }
 
     /**
@@ -407,7 +451,7 @@ public abstract class WebSocket {
               .filter(header -> !header.getKey().toLowerCase(Locale.ROOT).equals(lowerName))
               .collect(Collectors.toList());
       return new Accepted<>(
-          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies);
+          flow, subprotocol, compressionEnabled, shouldCompress, newHeaders, cookies, session);
     }
 
     /**
@@ -430,7 +474,7 @@ public abstract class WebSocket {
                   Stream.of(newCookies))
               .collect(Collectors.toList());
       return new Accepted<>(
-          flow, subprotocol, compressionEnabled, shouldCompress, headers, finalCookies);
+          flow, subprotocol, compressionEnabled, shouldCompress, headers, finalCookies, session);
     }
 
     /**
@@ -461,6 +505,83 @@ public abstract class WebSocket {
      */
     public Accepted<In, Out> discardingCookie(String name, String path, String domain) {
       return withCookies(new Http.Cookie(name, "", 0, path, domain, false, true, null, false));
+    }
+
+    /**
+     * @param request Current request
+     * @return The session carried by this WebSocket upgrade response. Reads the given request's
+     *     session if this response does not modify the session.
+     */
+    public Http.Session session(Http.RequestHeader request) {
+      if (session != null) {
+        return session;
+      } else {
+        return request.session();
+      }
+    }
+
+    /**
+     * Sets a new session for this WebSocket upgrade response, discarding the existing session.
+     *
+     * @param session the session to set with this WebSocket upgrade response
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> withSession(Http.Session session) {
+      return new Accepted<>(
+          flow, subprotocol, compressionEnabled, shouldCompress, headers, cookies, session);
+    }
+
+    /**
+     * Sets a new session for this WebSocket upgrade response, discarding the existing session.
+     *
+     * @param session the session to set with this WebSocket upgrade response
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> withSession(Map<String, String> session) {
+      return withSession(new Http.Session(session));
+    }
+
+    /**
+     * Discards the existing session for this WebSocket upgrade response.
+     *
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> withNewSession() {
+      return withSession(Collections.emptyMap());
+    }
+
+    /**
+     * Adds values to this WebSocket upgrade response's session.
+     *
+     * @param values A map with values to add to this response's session
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> addingToSession(
+        Http.RequestHeader request, Map<String, String> values) {
+      return withSession(session(request).adding(values));
+    }
+
+    /**
+     * Adds the given key and value to this WebSocket upgrade response's session.
+     *
+     * @param key The key to add to this response's session
+     * @param value The value to add to this response's session
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> addingToSession(Http.RequestHeader request, String key, String value) {
+      Map<String, String> newValues = new HashMap<>(1);
+      newValues.put(key, value);
+      return addingToSession(request, newValues);
+    }
+
+    /**
+     * Removes values from this WebSocket upgrade response's session.
+     *
+     * @param keys Keys to remove from session
+     * @return the transformed copy
+     */
+    public Accepted<In, Out> removingFromSession(Http.RequestHeader request, String... keys) {
+      return withSession(session(request).removing(keys));
     }
   }
 
@@ -608,7 +729,8 @@ public abstract class WebSocket {
                             accepted.compressionEnabled(),
                             accepted.shouldCompress(),
                             accepted.headers(),
-                            accepted.cookies()));
+                            accepted.cookies(),
+                            accepted.session().orElse(null)));
                   }
                 });
       }

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -130,7 +130,8 @@ object WebSocket {
       compressionEnabled: Boolean = true,
       shouldCompress: CompressionContext => Boolean = defaultShouldCompress,
       headers: Headers = Headers(),
-      newCookies: Seq[Cookie] = Seq.empty
+      newCookies: Seq[Cookie] = Seq.empty,
+      newSession: Option[Session] = None
   ) {
 
     /**
@@ -163,13 +164,51 @@ object WebSocket {
       withCookies(cookies.map(_.toCookie)*)
     }
 
+    /**
+     * Sets a new session for this WebSocket upgrade response, discarding the existing session.
+     */
+    def withSession(session: Session): Accepted[In, Out] = copy(newSession = Some(session))
+
+    /**
+     * Sets a new session for this WebSocket upgrade response, discarding the existing session.
+     */
+    def withSession(session: (String, String)*): Accepted[In, Out] = withSession(Session(session.toMap))
+
+    /**
+     * Discards the existing session for this WebSocket upgrade response.
+     */
+    def withNewSession: Accepted[In, Out] = withSession(Session())
+
+    /**
+     * @param request Current request
+     * @return The session carried by this WebSocket upgrade response. Reads the request's session if this response does
+     *         not modify the session.
+     */
+    def session(implicit request: RequestHeader): Session = newSession.getOrElse(request.session)
+
+    /**
+     * Adds values to this WebSocket upgrade response's session.
+     */
+    def addingToSession(values: (String, String)*)(implicit request: RequestHeader): Accepted[In, Out] =
+      withSession(new Session(session.data ++ values.toMap))
+
+    /**
+     * Removes values from this WebSocket upgrade response's session.
+     */
+    def removingFromSession(keys: String*)(implicit request: RequestHeader): Accepted[In, Out] =
+      withSession(new Session(session.data -- keys))
+
     private[play] def bakeCookies(
-        cookieHeaderEncoding: CookieHeaderEncoding = new DefaultCookieHeaderEncoding()
+        cookieHeaderEncoding: CookieHeaderEncoding = new DefaultCookieHeaderEncoding(),
+        sessionBaker: CookieBaker[Session] = new DefaultSessionCookieBaker()
     ): Accepted[In, Out] = {
       val allCookies = {
         val setCookieCookies =
           cookieHeaderEncoding.decodeSetCookieHeader(headers.get(HeaderNames.SET_COOKIE).getOrElse(""))
-        setCookieCookies ++ newCookies
+        val session = newSession.map { data =>
+          if (data.isEmpty) sessionBaker.discard.toCookie else sessionBaker.encodeAsCookie(data)
+        }
+        setCookieCookies ++ session ++ newCookies
       }
 
       if (allCookies.isEmpty) {
@@ -361,7 +400,8 @@ object WebSocket {
             accepted.compressionEnabled,
             accepted.shouldCompress,
             accepted.headers,
-            accepted.newCookies
+            accepted.newCookies,
+            accepted.newSession
           )
         })
       }

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -60,9 +60,8 @@ object WebSocket {
 
   private val ReservedHandshakeResponseHeaders = Set(
     "connection",
-    "sec-websocket-accept",
-    "sec-websocket-extensions",
-    "sec-websocket-protocol",
+    "content-length",
+    "transfer-encoding",
     "upgrade"
   )
 
@@ -85,7 +84,8 @@ object WebSocket {
   private[play] def allowedHandshakeResponseHeaders(headers: Headers): Seq[(String, String)] = {
     headers.headers.filterNot {
       case (name, _) =>
-        ReservedHandshakeResponseHeaders(name.toLowerCase(java.util.Locale.ROOT))
+        val lowerName = name.toLowerCase(java.util.Locale.ROOT)
+        ReservedHandshakeResponseHeaders(lowerName) || lowerName.startsWith("sec-websocket-")
     }
   }
 
@@ -123,6 +123,7 @@ object WebSocket {
    *                       an exception from it fails the WebSocket stream
    * @param headers additional HTTP headers to send with the WebSocket upgrade response
    * @param newCookies additional cookies to send with the WebSocket upgrade response
+   * @param newSession a session to send with the WebSocket upgrade response
    */
   case class Accepted[In, Out](
       flow: Flow[In, Out, ?],
@@ -135,10 +136,12 @@ object WebSocket {
   ) {
 
     /**
-     * Adds headers to this WebSocket upgrade response.
+     * Adds or replaces headers in this WebSocket upgrade response.
+     *
+     * Connection and framing headers, and all `Sec-WebSocket-*` headers, are controlled by Play and will not be sent.
      */
     def withHeaders(headers: (String, String)*): Accepted[In, Out] = {
-      copy(headers = this.headers.add(headers*))
+      copy(headers = headers.foldLeft(this.headers) { case (current, header) => current.replace(header) })
     }
 
     /**
@@ -203,8 +206,9 @@ object WebSocket {
         sessionBaker: CookieBaker[Session] = new DefaultSessionCookieBaker()
     ): Accepted[In, Out] = {
       val allCookies = {
-        val setCookieCookies =
-          cookieHeaderEncoding.decodeSetCookieHeader(headers.get(HeaderNames.SET_COOKIE).getOrElse(""))
+        val setCookieCookies = headers
+          .getAll(HeaderNames.SET_COOKIE)
+          .flatMap(cookieHeaderEncoding.decodeSetCookieHeader)
         val session = newSession.map { data =>
           if (data.isEmpty) sessionBaker.discard.toCookie else sessionBaker.encodeAsCookie(data)
         }
@@ -214,7 +218,9 @@ object WebSocket {
       if (allCookies.isEmpty) {
         this
       } else {
-        withHeaders(HeaderNames.SET_COOKIE -> cookieHeaderEncoding.encodeSetCookieHeader(allCookies))
+        copy(headers =
+          headers.replace(HeaderNames.SET_COOKIE -> cookieHeaderEncoding.encodeSetCookieHeader(allCookies))
+        )
       }
     }
   }

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -12,6 +12,7 @@ import org.apache.pekko.actor.Props
 import org.apache.pekko.stream.scaladsl.Flow
 import org.apache.pekko.util.ByteString
 import play.api.http.websocket._
+import play.api.http.HeaderNames
 import play.api.libs.json._
 import play.api.libs.streams.PekkoStreams
 import play.core.Execution.Implicits.trampoline
@@ -57,6 +58,14 @@ object WebSocket {
     flow.recover { case WebSocketCloseException(close) => close }
   }
 
+  private val ReservedHandshakeResponseHeaders = Set(
+    "connection",
+    "sec-websocket-accept",
+    "sec-websocket-extensions",
+    "sec-websocket-protocol",
+    "upgrade"
+  )
+
   private[play] def firstRequestedSubprotocol(request: RequestHeader): Option[String] = {
     requestedSubprotocols(request).headOption
   }
@@ -70,6 +79,13 @@ object WebSocket {
           s"The application selected WebSocket subprotocol '$selected', but the client offered [${requested.mkString(", ")}]"
         )
       }
+    }
+  }
+
+  private[play] def allowedHandshakeResponseHeaders(headers: Headers): Seq[(String, String)] = {
+    headers.headers.filterNot {
+      case (name, _) =>
+        ReservedHandshakeResponseHeaders(name.toLowerCase(java.util.Locale.ROOT))
     }
   }
 
@@ -105,13 +121,64 @@ object WebSocket {
    * @param shouldCompress selects which outbound text and binary messages to compress after compression is negotiated;
    *                       the default follows the configured compression threshold; this function must not block and
    *                       an exception from it fails the WebSocket stream
+   * @param headers additional HTTP headers to send with the WebSocket upgrade response
+   * @param newCookies additional cookies to send with the WebSocket upgrade response
    */
   case class Accepted[In, Out](
       flow: Flow[In, Out, ?],
       subprotocol: Option[String] = None,
       compressionEnabled: Boolean = true,
-      shouldCompress: CompressionContext => Boolean = defaultShouldCompress
-  )
+      shouldCompress: CompressionContext => Boolean = defaultShouldCompress,
+      headers: Headers = Headers(),
+      newCookies: Seq[Cookie] = Seq.empty
+  ) {
+
+    /**
+     * Adds headers to this WebSocket upgrade response.
+     */
+    def withHeaders(headers: (String, String)*): Accepted[In, Out] = {
+      copy(headers = this.headers.add(headers*))
+    }
+
+    /**
+     * Discards a header from this WebSocket upgrade response.
+     */
+    def discardingHeader(name: String): Accepted[In, Out] = {
+      copy(headers = headers.remove(name))
+    }
+
+    /**
+     * Adds cookies to this WebSocket upgrade response. If the response already contains cookies then cookies with the
+     * same name in the new list will override existing ones.
+     */
+    def withCookies(cookies: Cookie*): Accepted[In, Out] = {
+      val filteredCookies = newCookies.filter(cookie => !cookies.exists(_.name == cookie.name))
+      if (cookies.isEmpty) this else copy(newCookies = filteredCookies ++ cookies)
+    }
+
+    /**
+     * Discards cookies along this WebSocket upgrade response.
+     */
+    def discardingCookies(cookies: DiscardingCookie*): Accepted[In, Out] = {
+      withCookies(cookies.map(_.toCookie)*)
+    }
+
+    private[play] def bakeCookies(
+        cookieHeaderEncoding: CookieHeaderEncoding = new DefaultCookieHeaderEncoding()
+    ): Accepted[In, Out] = {
+      val allCookies = {
+        val setCookieCookies =
+          cookieHeaderEncoding.decodeSetCookieHeader(headers.get(HeaderNames.SET_COOKIE).getOrElse(""))
+        setCookieCookies ++ newCookies
+      }
+
+      if (allCookies.isEmpty) {
+        this
+      } else {
+        withHeaders(HeaderNames.SET_COOKIE -> cookieHeaderEncoding.encodeSetCookieHeader(allCookies))
+      }
+    }
+  }
 
   /**
    * Transforms WebSocket message flows into message flows of another type.
@@ -292,7 +359,9 @@ object WebSocket {
             closeOnException(transformer.transform(accepted.flow)),
             accepted.subprotocol,
             accepted.compressionEnabled,
-            accepted.shouldCompress
+            accepted.shouldCompress,
+            accepted.headers,
+            accepted.newCookies
           )
         })
       }

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -236,7 +236,8 @@ object HandlerInvokerFactory {
                               )
                             ),
                         Headers(accepted.headers().asScala.map(header => header.getKey -> header.getValue).toSeq*),
-                        accepted.cookies().asScala.map(_.asScala()).toSeq
+                        accepted.cookies().asScala.map(_.asScala()).toSeq,
+                        accepted.session().toScala.map(_.asScala())
                       )
                     )
                   }

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletionStage
 import java.util.Optional
 
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
 import scala.util.control.NonFatal
@@ -233,7 +234,9 @@ object HandlerInvokerFactory {
                                 context.payloadLength,
                                 context.isAboveCompressionThreshold
                               )
-                            )
+                            ),
+                        Headers(accepted.headers().asScala.map(header => header.getKey -> header.getValue).toSeq*),
+                        accepted.cookies().asScala.map(_.asScala()).toSeq
                       )
                     )
                   }

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -61,9 +61,9 @@ The selected subprotocol must be one offered by the client. Selecting any other 
 
 For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Selecting-a-WebSocket-subprotocol]] and [[Java WebSocket documentation|JavaWebSockets#Selecting-a-WebSocket-subprotocol]].
 
-### WebSocket Handshake Headers and Cookies
+### WebSocket Handshake Headers, Cookies, and Sessions
 
-`WebSocket.Accepted` now supports adding custom headers and cookies to the successful `101 Switching Protocols` response:
+`WebSocket.Accepted` now supports adding custom headers, cookies, and session data to the successful `101 Switching Protocols` response:
 
 Scala
 : ```scala
@@ -72,6 +72,7 @@ WebSocket.acceptWithOptions[String, String] { request =>
     .Accepted(flow)
     .withHeaders("X-WebSocket-Trace" -> request.id.toString)
     .withCookies(Cookie("ws-session", "connected", httpOnly = true))
+    .withSession(request.session + ("websocket" -> "connected"))
 }
 ```
 
@@ -80,10 +81,11 @@ Java
 WebSocket.Text.acceptWithOptions(request ->
   new WebSocket.Accepted<>(flow)
     .withHeader("X-WebSocket-Trace", request.id().toString())
-    .withCookies(Cookie.builder("ws-session", "connected").withHttpOnly(true).build()));
+    .withCookies(Cookie.builder("ws-session", "connected").withHttpOnly(true).build())
+    .addingToSession(request, "websocket", "connected"));
 ```
 
-This is useful for applications that need to attach handshake metadata, for example trace identifiers or cookies, while still using Play's WebSocket handling. These headers and cookies are sent only with the opening handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` remain controlled by Play and the selected `subprotocol`.
+This is useful for applications that need to attach handshake metadata, for example trace identifiers, cookies, or session updates, while still using Play's WebSocket handling. These headers, cookies, and session updates are sent only with the opening handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` remain controlled by Play and the selected `subprotocol`.
 
 For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Setting-WebSocket-handshake-headers-and-cookies]] and [[Java WebSocket documentation|JavaWebSockets#Setting-WebSocket-handshake-headers-and-cookies]].
 

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -85,9 +85,9 @@ WebSocket.Text.acceptWithOptions(request ->
     .addingToSession(request, "websocket", "connected"));
 ```
 
-This is useful for applications that need to attach handshake metadata, for example trace identifiers, cookies, or session updates, while still using Play's WebSocket handling. These headers, cookies, and session updates are sent only with the opening handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` remain controlled by Play and the selected `subprotocol`.
+This is useful for applications that need to attach handshake metadata, for example trace identifiers, cookies, or session updates, while still using Play's WebSocket handling. These headers, cookies, and session updates are sent only with the opening handshake response. Connection and framing headers, and all `Sec-WebSocket-*` headers, remain controlled by Play.
 
-For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Setting-WebSocket-handshake-headers-and-cookies]] and [[Java WebSocket documentation|JavaWebSockets#Setting-WebSocket-handshake-headers-and-cookies]].
+For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Setting-WebSocket-handshake-response-options]] and [[Java WebSocket documentation|JavaWebSockets#Setting-WebSocket-handshake-response-options]].
 
 ### WebSocket Abnormal Closure Status
 

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -61,6 +61,32 @@ The selected subprotocol must be one offered by the client. Selecting any other 
 
 For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Selecting-a-WebSocket-subprotocol]] and [[Java WebSocket documentation|JavaWebSockets#Selecting-a-WebSocket-subprotocol]].
 
+### WebSocket Handshake Headers and Cookies
+
+`WebSocket.Accepted` now supports adding custom headers and cookies to the successful `101 Switching Protocols` response:
+
+Scala
+: ```scala
+WebSocket.acceptWithOptions[String, String] { request =>
+  WebSocket
+    .Accepted(flow)
+    .withHeaders("X-WebSocket-Trace" -> request.id.toString)
+    .withCookies(Cookie("ws-session", "connected", httpOnly = true))
+}
+```
+
+Java
+: ```java
+WebSocket.Text.acceptWithOptions(request ->
+  new WebSocket.Accepted<>(flow)
+    .withHeader("X-WebSocket-Trace", request.id().toString())
+    .withCookies(Cookie.builder("ws-session", "connected").withHttpOnly(true).build()));
+```
+
+This is useful for applications that need to attach handshake metadata, for example trace identifiers or cookies, while still using Play's WebSocket handling. These headers and cookies are sent only with the opening handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` remain controlled by Play and the selected `subprotocol`.
+
+For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Setting-WebSocket-handshake-headers-and-cookies]] and [[Java WebSocket documentation|JavaWebSockets#Setting-WebSocket-handshake-headers-and-cookies]].
+
 ### WebSocket Abnormal Closure Status
 
 Play now reports abnormal WebSocket connection loss to raw WebSocket handlers with close status `1006`.

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -102,11 +102,11 @@ If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reje
 
 ## Setting WebSocket handshake headers and cookies
 
-`acceptWithOptions` and `acceptOrResultWithOptions` also let applications add headers and cookies to the successful `101 Switching Protocols` response:
+`acceptWithOptions` and `acceptOrResultWithOptions` also let applications add headers, cookies, and session data to the successful `101 Switching Protocols` response:
 
 @[handshake-options](code/javaguide/async/JavaWebSockets.java)
 
-These headers and cookies are sent only with the opening WebSocket handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` are controlled by Play and the selected `subprotocol`.
+These headers, cookies, and session updates are sent only with the opening WebSocket handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` are controlled by Play and the selected `subprotocol`.
 
 ## Accessing a WebSocket
 

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -100,6 +100,14 @@ A client can offer one or more WebSocket subprotocols using the `Sec-WebSocket-P
 
 If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. Selecting a subprotocol that the client did not offer is an application error. Play passes it to the configured `HttpErrorHandler` without completing the upgrade; the default response is HTTP 500. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `new WebSocket.Accepted<>(flow, Optional.empty())` and use a flow that closes the WebSocket.
 
+## Setting WebSocket handshake headers and cookies
+
+`acceptWithOptions` and `acceptOrResultWithOptions` also let applications add headers and cookies to the successful `101 Switching Protocols` response:
+
+@[handshake-options](code/javaguide/async/JavaWebSockets.java)
+
+These headers and cookies are sent only with the opening WebSocket handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` are controlled by Play and the selected `subprotocol`.
+
 ## Accessing a WebSocket
 
 To send data or access a websocket you need to add a route for your websocket in your routes file. For Example

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -100,13 +100,15 @@ A client can offer one or more WebSocket subprotocols using the `Sec-WebSocket-P
 
 If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. Selecting a subprotocol that the client did not offer is an application error. Play passes it to the configured `HttpErrorHandler` without completing the upgrade; the default response is HTTP 500. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `new WebSocket.Accepted<>(flow, Optional.empty())` and use a flow that closes the WebSocket.
 
-## Setting WebSocket handshake headers and cookies
+## Setting WebSocket handshake response options
 
 `acceptWithOptions` and `acceptOrResultWithOptions` also let applications add headers, cookies, and session data to the successful `101 Switching Protocols` response:
 
 @[handshake-options](code/javaguide/async/JavaWebSockets.java)
 
-These headers, cookies, and session updates are sent only with the opening WebSocket handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` are controlled by Play and the selected `subprotocol`.
+These headers, cookies, and session updates are sent only with the opening WebSocket handshake response. Connection and framing headers, and all `Sec-WebSocket-*` headers, are controlled by Play.
+
+Browser WebSocket APIs do not expose handshake response headers to JavaScript. Cookies can still be processed by the browser; other custom headers are mainly useful to non-browser clients and intermediaries.
 
 ## Accessing a WebSocket
 

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -225,7 +225,8 @@ public class JavaWebSockets {
                 .withCookies(
                     play.mvc.Http.Cookie.builder("ws-session", "connected")
                         .withHttpOnly(true)
-                        .build());
+                        .build())
+                .addingToSession(request, "websocket", "connected");
           });
     }
     // #handshake-options

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -212,4 +212,22 @@ public class JavaWebSockets {
     }
     // #subprotocol
   }
+
+  public static class Controller5 extends Controller {
+    // #handshake-options
+    public WebSocket socket() {
+      return WebSocket.Text.acceptWithOptions(
+          request -> {
+            Flow<String, String, ?> flow =
+                Flow.fromSinkAndSource(Sink.ignore(), Source.<String>maybe());
+            return new WebSocket.Accepted<>(flow)
+                .withHeader("X-WebSocket-Trace", request.id().toString())
+                .withCookies(
+                    play.mvc.Http.Cookie.builder("ws-session", "connected")
+                        .withHttpOnly(true)
+                        .build());
+          });
+    }
+    // #handshake-options
+  }
 }

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -102,6 +102,14 @@ A client can offer one or more WebSocket subprotocols using the `Sec-WebSocket-P
 
 If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. Selecting a subprotocol that the client did not offer is an application error. Play passes it to the configured `HttpErrorHandler` without completing the upgrade; the default response is HTTP 500. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `WebSocket.Accepted(flow, None)` and use a flow that closes the WebSocket.
 
+## Setting WebSocket handshake headers and cookies
+
+`acceptWithOptions` and `acceptOrResultWithOptions` also let applications add headers and cookies to the successful `101 Switching Protocols` response:
+
+@[handshake-options](code/ScalaWebSockets.scala)
+
+These headers and cookies are sent only with the opening WebSocket handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` are controlled by Play and the selected `subprotocol`.
+
 ## Accessing a WebSocket
 
 To send data or access a websocket you need to add a route for your websocket in your routes file. For Example

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -102,13 +102,15 @@ A client can offer one or more WebSocket subprotocols using the `Sec-WebSocket-P
 
 If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. Selecting a subprotocol that the client did not offer is an application error. Play passes it to the configured `HttpErrorHandler` without completing the upgrade; the default response is HTTP 500. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `WebSocket.Accepted(flow, None)` and use a flow that closes the WebSocket.
 
-## Setting WebSocket handshake headers and cookies
+## Setting WebSocket handshake response options
 
 `acceptWithOptions` and `acceptOrResultWithOptions` also let applications add headers, cookies, and session data to the successful `101 Switching Protocols` response:
 
 @[handshake-options](code/ScalaWebSockets.scala)
 
-These headers, cookies, and session updates are sent only with the opening WebSocket handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` are controlled by Play and the selected `subprotocol`.
+These headers, cookies, and session updates are sent only with the opening WebSocket handshake response. Connection and framing headers, and all `Sec-WebSocket-*` headers, are controlled by Play.
+
+Browser WebSocket APIs do not expose handshake response headers to JavaScript. Cookies can still be processed by the browser; other custom headers are mainly useful to non-browser clients and intermediaries.
 
 ## Accessing a WebSocket
 

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -104,11 +104,11 @@ If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reje
 
 ## Setting WebSocket handshake headers and cookies
 
-`acceptWithOptions` and `acceptOrResultWithOptions` also let applications add headers and cookies to the successful `101 Switching Protocols` response:
+`acceptWithOptions` and `acceptOrResultWithOptions` also let applications add headers, cookies, and session data to the successful `101 Switching Protocols` response:
 
 @[handshake-options](code/ScalaWebSockets.scala)
 
-These headers and cookies are sent only with the opening WebSocket handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` are controlled by Play and the selected `subprotocol`.
+These headers, cookies, and session updates are sent only with the opening WebSocket handshake response. Protocol-owned headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, and `Sec-WebSocket-Protocol` are controlled by Play and the selected `subprotocol`.
 
 ## Accessing a WebSocket
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -419,6 +419,7 @@ class Controller10 {
       .Accepted(flow)
       .withHeaders("X-WebSocket-Trace" -> request.id.toString)
       .withCookies(Cookie("ws-session", "connected", httpOnly = true))
+      .withSession(request.session + ("websocket" -> "connected"))
   }
   // #handshake-options
 }

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -407,3 +407,18 @@ class Controller9 {
   }
   // #subprotocol
 }
+
+class Controller10 {
+  // #handshake-options
+  import org.apache.pekko.stream.scaladsl._
+  import play.api.mvc._
+
+  def socket = WebSocket.acceptWithOptions[String, String] { request =>
+    val flow: Flow[String, String, ?] = Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String])
+    WebSocket
+      .Accepted(flow)
+      .withHeaders("X-WebSocket-Trace" -> request.id.toString)
+      .withCookies(Cookie("ws-session", "connected", httpOnly = true))
+  }
+  // #handshake-options
+}

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -16,7 +16,7 @@ import scala.util.Try
 
 import io.netty.channel._
 import io.netty.handler.codec.http._
-import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory
+import io.netty.handler.codec.http.websocketx.WebSocketDecoderConfig
 import io.netty.handler.codec.TooLongFrameException
 import io.netty.util.AttributeKey
 import org.apache.pekko.stream.Materializer
@@ -226,7 +226,25 @@ private[play] class PlayRequestHandler(
                   wsKeepAliveMaxIdle
                 )
               val factory =
-                new WebSocketServerHandshakerFactory(wsUrl, accepted.subprotocol.orNull, true, wsBufferLimit)
+                new PlayWebSocketServerHandshakerFactory(
+                  wsUrl,
+                  accepted.subprotocol.orNull,
+                  WebSocketDecoderConfig
+                    .newBuilder()
+                    .allowExtensions(true)
+                    .maxFramePayloadLength(wsBufferLimit)
+                    .build(),
+                  resultUtils(tryApp)
+                    .prepareWebSocketHandshakeHeaders(accepted)
+                    .flatMap {
+                      case (HeaderNames.SET_COOKIE, value) =>
+                        resultUtils(tryApp).splitSetCookieHeaderValue(value).map(HeaderNames.SET_COOKIE -> _)
+                      case (name, value) =>
+                        resultUtils(tryApp).validateHeaderNameChars(name)
+                        resultUtils(tryApp).validateHeaderValueChars(value)
+                        (name -> value) :: Nil
+                    }
+                )
               channel.attr(PlayWebSocketCompression.Enabled).set(java.lang.Boolean.valueOf(accepted.compressionEnabled))
               Future.successful(
                 new DefaultWebSocketHttpResponse(

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -234,16 +234,7 @@ private[play] class PlayRequestHandler(
                     .allowExtensions(true)
                     .maxFramePayloadLength(wsBufferLimit)
                     .build(),
-                  resultUtils(tryApp)
-                    .prepareWebSocketHandshakeHeaders(accepted)
-                    .flatMap {
-                      case (HeaderNames.SET_COOKIE, value) =>
-                        resultUtils(tryApp).splitSetCookieHeaderValue(value).map(HeaderNames.SET_COOKIE -> _)
-                      case (name, value) =>
-                        resultUtils(tryApp).validateHeaderNameChars(name)
-                        resultUtils(tryApp).validateHeaderValueChars(value)
-                        (name -> value) :: Nil
-                    }
+                  resultUtils(tryApp).prepareWebSocketHandshakeHeaders(accepted)
                 )
               channel.attr(PlayWebSocketCompression.Enabled).set(java.lang.Boolean.valueOf(accepted.compressionEnabled))
               Future.successful(

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayWebSocketServerHandshakerFactory.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayWebSocketServerHandshakerFactory.scala
@@ -12,6 +12,10 @@ import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpHeaders
 import io.netty.handler.codec.http.HttpRequest
 
+/**
+ * Supplies response headers through Netty's handshaker because netty-reactive-streams invokes the handshake overload
+ * without response headers.
+ */
 private[netty] final class PlayWebSocketServerHandshakerFactory(
     webSocketURL: String,
     subprotocols: String,

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayWebSocketServerHandshakerFactory.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayWebSocketServerHandshakerFactory.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.netty
+
+import io.netty.handler.codec.http.websocketx._
+import io.netty.handler.codec.http.DefaultHttpHeaders
+import io.netty.handler.codec.http.FullHttpRequest
+import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpHeaders
+import io.netty.handler.codec.http.HttpRequest
+
+private[netty] final class PlayWebSocketServerHandshakerFactory(
+    webSocketURL: String,
+    subprotocols: String,
+    decoderConfig: WebSocketDecoderConfig,
+    extraHeaders: Seq[(String, String)]
+) extends WebSocketServerHandshakerFactory(webSocketURL, subprotocols, decoderConfig) {
+
+  override def newHandshaker(req: HttpRequest): WebSocketServerHandshaker = {
+    Option(req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_VERSION)) match {
+      case Some(version) if version.toString == WebSocketVersion.V13.toHttpHeaderValue =>
+        new Handshaker13(webSocketURL, subprotocols, decoderConfig)
+      case Some(version) if version.toString == WebSocketVersion.V08.toHttpHeaderValue =>
+        new Handshaker08(webSocketURL, subprotocols, decoderConfig)
+      case Some(version) if version.toString == WebSocketVersion.V07.toHttpHeaderValue =>
+        new Handshaker07(webSocketURL, subprotocols, decoderConfig)
+      case Some(_) =>
+        null
+      case None =>
+        new Handshaker00(webSocketURL, subprotocols, decoderConfig)
+    }
+  }
+
+  private def merge(responseHeaders: HttpHeaders): HttpHeaders = {
+    if (extraHeaders.isEmpty) {
+      responseHeaders
+    } else {
+      val merged = Option(responseHeaders).getOrElse(new DefaultHttpHeaders())
+      extraHeaders.foreach { case (name, value) => merged.add(name, value) }
+      merged
+    }
+  }
+
+  private final class Handshaker13(
+      webSocketURL: String,
+      subprotocols: String,
+      decoderConfig: WebSocketDecoderConfig
+  ) extends WebSocketServerHandshaker13(webSocketURL, subprotocols, decoderConfig) {
+    protected override def newHandshakeResponse(req: FullHttpRequest, responseHeaders: HttpHeaders): FullHttpResponse =
+      super.newHandshakeResponse(req, merge(responseHeaders))
+  }
+
+  private final class Handshaker08(
+      webSocketURL: String,
+      subprotocols: String,
+      decoderConfig: WebSocketDecoderConfig
+  ) extends WebSocketServerHandshaker08(webSocketURL, subprotocols, decoderConfig) {
+    protected override def newHandshakeResponse(req: FullHttpRequest, responseHeaders: HttpHeaders): FullHttpResponse =
+      super.newHandshakeResponse(req, merge(responseHeaders))
+  }
+
+  private final class Handshaker07(
+      webSocketURL: String,
+      subprotocols: String,
+      decoderConfig: WebSocketDecoderConfig
+  ) extends WebSocketServerHandshaker07(webSocketURL, subprotocols, decoderConfig) {
+    protected override def newHandshakeResponse(req: FullHttpRequest, responseHeaders: HttpHeaders): FullHttpResponse =
+      super.newHandshakeResponse(req, merge(responseHeaders))
+  }
+
+  private final class Handshaker00(
+      webSocketURL: String,
+      subprotocols: String,
+      decoderConfig: WebSocketDecoderConfig
+  ) extends WebSocketServerHandshaker00(webSocketURL, subprotocols, decoderConfig) {
+    protected override def newHandshakeResponse(req: FullHttpRequest, responseHeaders: HttpHeaders): FullHttpResponse =
+      super.newHandshakeResponse(req, merge(responseHeaders))
+  }
+}

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -443,23 +443,32 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
               modelConversion(tryApp).convertResult(taggedRequestHeader, result, request.protocol, errorHandler(tryApp))
             case Right(accepted) =>
               WebSocket.validateSubprotocol(taggedRequestHeader, accepted.subprotocol)
-              Future.successful(
-                WebSocketHandler
-                  .handleWebSocket(
-                    upgrade,
-                    accepted.flow,
-                    wsBufferLimit,
-                    accepted.subprotocol,
-                    accepted.compressionEnabled,
-                    wsCompressionThreshold,
-                    (message, payloadLength, isAboveCompressionThreshold) =>
-                      accepted.shouldCompress(
-                        new WebSocket.CompressionContext(message(), payloadLength, isAboveCompressionThreshold)
-                      ),
-                    wsKeepAliveMode,
-                    wsKeepAliveMaxIdle
-                  )
-              )
+              val handshakeHeaders = resultUtils(tryApp)
+                .prepareWebSocketHandshakeHeaders(accepted)
+                .flatMap {
+                  case (HeaderNames.SET_COOKIE, value) =>
+                    resultUtils(tryApp).splitSetCookieHeaderValue(value).map(headers.RawHeader(HeaderNames.SET_COOKIE, _))
+                  case (name, value) =>
+                    resultUtils(tryApp).validateHeaderNameChars(name)
+                    resultUtils(tryApp).validateHeaderValueChars(value)
+                    headers.RawHeader(name, value) :: Nil
+                }
+              val response = WebSocketHandler
+                .handleWebSocket(
+                  upgrade,
+                  accepted.flow,
+                  wsBufferLimit,
+                  accepted.subprotocol,
+                  accepted.compressionEnabled,
+                  wsCompressionThreshold,
+                  (message, payloadLength, isAboveCompressionThreshold) =>
+                    accepted.shouldCompress(
+                      new WebSocket.CompressionContext(message(), payloadLength, isAboveCompressionThreshold)
+                    ),
+                  wsKeepAliveMode,
+                  wsKeepAliveMaxIdle
+                )
+              Future.successful(response.withHeaders(response.headers ++ handshakeHeaders))
           }
           .recoverWith {
             case NonFatal(error) =>

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -445,14 +445,7 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
               WebSocket.validateSubprotocol(taggedRequestHeader, accepted.subprotocol)
               val handshakeHeaders = resultUtils(tryApp)
                 .prepareWebSocketHandshakeHeaders(accepted)
-                .flatMap {
-                  case (HeaderNames.SET_COOKIE, value) =>
-                    resultUtils(tryApp).splitSetCookieHeaderValue(value).map(headers.RawHeader(HeaderNames.SET_COOKIE, _))
-                  case (name, value) =>
-                    resultUtils(tryApp).validateHeaderNameChars(name)
-                    resultUtils(tryApp).validateHeaderValueChars(value)
-                    headers.RawHeader(name, value) :: Nil
-                }
+                .map { case (name, value) => headers.RawHeader(name, value) }
               val response = WebSocketHandler
                 .handleWebSocket(
                   upgrade,

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -316,7 +316,7 @@ private[play] final class ServerResultUtils(
    * Bake cookies and return the headers that may be added to a WebSocket upgrade response.
    */
   def prepareWebSocketHandshakeHeaders(accepted: WebSocket.Accepted[?, ?]): Seq[(String, String)] = {
-    val baked = accepted.bakeCookies(cookieHeaderEncoding)
+    val baked = accepted.bakeCookies(cookieHeaderEncoding, sessionBaker)
     WebSocket.allowedHandshakeResponseHeaders(baked.headers)
   }
 

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -313,11 +313,22 @@ private[play] final class ServerResultUtils(
   }
 
   /**
-   * Bake cookies and return the headers that may be added to a WebSocket upgrade response.
+   * Bake cookies and return validated headers that may be added to a WebSocket upgrade response.
    */
   def prepareWebSocketHandshakeHeaders(accepted: WebSocket.Accepted[?, ?]): Seq[(String, String)] = {
     val baked = accepted.bakeCookies(cookieHeaderEncoding, sessionBaker)
-    WebSocket.allowedHandshakeResponseHeaders(baked.headers)
+    WebSocket
+      .allowedHandshakeResponseHeaders(baked.headers)
+      .flatMap {
+        case (name, value) if name.equalsIgnoreCase(SET_COOKIE) =>
+          splitSetCookieHeaderValue(value).map(SET_COOKIE -> _)
+        case header => header :: Nil
+      }
+      .map { header =>
+        validateHeaderNameChars(header._1)
+        validateHeaderValueChars(header._2)
+        header
+      }
   }
 
   /**

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -313,6 +313,14 @@ private[play] final class ServerResultUtils(
   }
 
   /**
+   * Bake cookies and return the headers that may be added to a WebSocket upgrade response.
+   */
+  def prepareWebSocketHandshakeHeaders(accepted: WebSocket.Accepted[?, ?]): Seq[(String, String)] = {
+    val baked = accepted.bakeCookies(cookieHeaderEncoding)
+    WebSocket.allowedHandshakeResponseHeaders(baked.headers)
+  }
+
+  /**
    * Given a map of headers, split it into a sequence of individual headers.
    * Most headers map into a single pair in the new sequence. The exception is
    * the `Set-Cookie` header which we split into a pair for each cookie it


### PR DESCRIPTION
Extend `WebSocket.Accepted` so applications can add custom headers, cookies, and session updates to a successful `101 Switching Protocols` response.

This supports use cases such as returning tracing metadata, setting authentication cookies, or updating the Play session during the opening WebSocket handshake.

The options apply only to successful upgrades. Rejected upgrades continue to use a normal `Result`.

## API

The Scala and Java APIs now provide `Result`-style operations for:

- Adding, replacing, and removing handshake response headers
- Adding and discarding cookies
- Setting, clearing, adding to, and removing from the session

Header helper methods use case-insensitive replacement semantics matching `Result`. The underlying handshake header representation remains multi-valued so repeated HTTP fields can be preserved.

Connection and framing headers, along with all `Sec-WebSocket-*` headers, remain controlled by Play and cannot be overridden by the application.

## Implementation

Both server backends support the new metadata:

- Pekko HTTP appends the validated headers to the upgrade response.
- Netty uses a Play-specific WebSocket handshaker factory so the metadata is added to the actual handshake response.
- Cookies and sessions are baked with Play's configured cookie encoders and session baker.
- Invalid header names or values are passed to the configured `HttpErrorHandler`.
- Existing subprotocol and WebSocket compression options are preserved when response metadata is added.

The Java and Scala WebSocket documentation and Play release highlights include examples of the new API.

## Testing

Shared integration coverage verifies both Netty and Pekko HTTP for:

- Scala and Java handshake APIs
- Custom headers, cookies, and sessions
- Case-insensitive header replacement and removal
- Cookie attributes and configured session cookie names
- Filtering protocol-owned headers
- Rejection of invalid response metadata
- Preservation of subprotocol and compression options