### PR TITLE
Fix Gradle playRun project dependency classpath build order

### DIFF
--- a/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayRunPlugin.java
+++ b/dev-mode/gradle-plugin/src/main/java/play/gradle/plugin/PlayRunPlugin.java
@@ -4,6 +4,7 @@
 package play.gradle.plugin;
 
 import static org.gradle.api.plugins.ApplicationPlugin.APPLICATION_GROUP;
+import static org.gradle.api.plugins.JavaPlugin.CLASSES_TASK_NAME;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_JAVA_TASK_NAME;
 import static org.gradle.api.plugins.JavaPlugin.PROCESS_RESOURCES_TASK_NAME;
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
@@ -30,7 +31,6 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.language.jvm.tasks.ProcessResources;
 import org.jetbrains.annotations.NotNull;
@@ -103,7 +103,7 @@ public class PlayRunPlugin implements Plugin<Project> {
             playRun -> {
               playRun.setDescription("Runs the Play application for local development.");
               playRun.setGroup(APPLICATION_GROUP);
-              playRun.dependsOn(project.getTasks().findByName(JavaPlugin.CLASSES_TASK_NAME));
+              playRun.dependsOn(project.getTasks().findByName(CLASSES_TASK_NAME));
               playRun.getOutputs().upToDateWhen(task -> ((PlayRun) task).isUpToDate());
               playRun.getWorkingDir().convention(project.getLayout().getProjectDirectory());
               playRun.getClasses().from(findClasspathDirectories(project));
@@ -124,7 +124,7 @@ public class PlayRunPlugin implements Plugin<Project> {
                         Project child = project.findProject(path);
                         if (child == null) return;
                         playRun.getClasses().from(findClasspathDirectories(child));
-                        playRun.dependsOn(child.getTasks().findByName(PROCESS_RESOURCES_TASK_NAME));
+                        playRun.dependsOn(child.getTasks().findByName(CLASSES_TASK_NAME));
                         if (isPlayProject(child)) {
                           playRun.getAssetsDirs().from(findAssetsDirectories(child));
                           playRun.dependsOn(child.getTasks().findByName(PROCESS_ASSETS_TASK_NAME));

--- a/dev-mode/gradle-plugin/src/test/java/play/gradle/PlayRunPluginTest.java
+++ b/dev-mode/gradle-plugin/src/test/java/play/gradle/PlayRunPluginTest.java
@@ -8,7 +8,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.project.DefaultProject;
 import org.gradle.groovy.scripts.ScriptSource;
@@ -72,7 +75,9 @@ class PlayRunPluginTest {
     ((DefaultProject) kotlinLib).evaluate();
     ((DefaultProject) project).evaluate();
 
-    assertThat(((PlayRun) project.getTasks().findByName("playRun")).getClasses())
+    PlayRun playRun = (PlayRun) project.getTasks().findByName("playRun");
+
+    assertThat(playRun.getClasses())
         .contains(
             project.getLayout().getBuildDirectory().file("classes/scala/main").get().getAsFile(),
             project.getLayout().getBuildDirectory().file("classes/java/main").get().getAsFile(),
@@ -85,5 +90,13 @@ class PlayRunPluginTest {
             kotlinLib.getLayout().getBuildDirectory().file("classes/kotlin/main").get().getAsFile(),
             kotlinLib.getLayout().getBuildDirectory().file("classes/java/main").get().getAsFile(),
             kotlinLib.getLayout().getBuildDirectory().file("resources/main").get().getAsFile());
+
+    Set<Task> dependencies = new HashSet<>(playRun.getTaskDependencies().getDependencies(playRun));
+    assertThat(dependencies)
+        .contains(
+            project.getTasks().findByName("classes"),
+            javaLib.getTasks().findByName("classes"),
+            scalaLib.getTasks().findByName("classes"),
+            kotlinLib.getTasks().findByName("classes"));
   }
 }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #13513

## Purpose

Ensure Gradle `playRun` builds project dependencies before starting a Play application.

When a Play app depends on sibling modules via `implementation(project(":module"))`, `playRun` already adds those modules' output directories to the application classpath. This PR makes `playRun` also depend on each project dependency's `classes` task so those outputs are compiled and available at runtime.

## Background Context

Previously, `playRun` depended only on dependent projects' `processResources` tasks. That could leave project dependency class directories present in the classpath but empty or stale, causing classes from sibling modules to be unavailable when the app starts.

Depending on `classes` matches what `playRun` needs: compiled classes plus processed resources.

## References

Issue: #13513
