### PR TITLE
Limit cumulative Java form auto-growth during binding

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -61,6 +61,8 @@ By default, Play Java forms can bind common scalar types, including their primit
 
 Concrete enum types, `java.util.Date`, `java.util.Optional`, arrays, collections, and maps using supported element, key, or value types can also be bound.
 
+When binding indexed arrays, collections, maps, or nested objects, Play may need to auto-grow intermediate values. Play limits each indexed collection path with `play.forms.binding.autoGrowCollectionLimit`, which defaults to `256`, and also limits cumulative auto-grow work for one Java form binding with `play.forms.binding.maxAutoGrowOperations`, which defaults to `1024`. You can override the cumulative limit for one form with `withMaxAutoGrowOperations`.
+
 If you have a request available in the scope, you can bind directly from the request content:
 
 @[bind-from-request](code/javaguide/forms/JavaForms.java)

--- a/web/play-java-forms/src/main/java/play/data/Form.java
+++ b/web/play-java-forms/src/main/java/play/data/Form.java
@@ -177,7 +177,7 @@ public class Form<T> {
        * Spring turns regular PropertyAccessException failures, such as type mismatches, into
        * FieldErrors. InvalidPropertyException is different: it is a FatalBeanException and escapes
        * DataBinder.bind(...). One common way to trigger it is an indexed path beyond the
-       * auto-grow collection limit, for example list[256].name with Spring's default limit of 256.
+       * auto-grow collection limit, for example list[256].name with Play's default limit of 256.
        *
        * From Play's Form API perspective that should behave like any other invalid submitted
        * field: the returned Form should contain an error and still expose successfully bound
@@ -232,6 +232,7 @@ public class Form<T> {
   private final Lang lang;
   private final boolean directFieldAccess;
   private final int autoGrowCollectionLimit;
+  private final int maxAutoGrowOperations;
   final MessagesApi messagesApi;
   final Langs langs;
   final Formatters formatters;
@@ -255,6 +256,10 @@ public class Form<T> {
 
   private static int configuredAutoGrowCollectionLimit(Config config) {
     return config != null ? config.getInt("play.forms.binding.autoGrowCollectionLimit") : 256;
+  }
+
+  private static int configuredMaxAutoGrowOperations(Config config) {
+    return config != null ? config.getInt("play.forms.binding.maxAutoGrowOperations") : 1024;
   }
 
   /**
@@ -623,7 +628,8 @@ public class Form<T> {
         config,
         lang,
         config != null && config.getBoolean("play.forms.binding.directFieldAccess"),
-        configuredAutoGrowCollectionLimit(config));
+        configuredAutoGrowCollectionLimit(config),
+        configuredMaxAutoGrowOperations(config));
   }
 
   /**
@@ -674,7 +680,8 @@ public class Form<T> {
         config,
         lang,
         directFieldAccess,
-        configuredAutoGrowCollectionLimit(config));
+        configuredAutoGrowCollectionLimit(config),
+        configuredMaxAutoGrowOperations(config));
   }
 
   /**
@@ -714,6 +721,64 @@ public class Form<T> {
       Lang lang,
       boolean directFieldAccess,
       int autoGrowCollectionLimit) {
+    this(
+        rootName,
+        clazz,
+        data,
+        files,
+        errors,
+        value,
+        groups,
+        messagesApi,
+        langs,
+        formatters,
+        validatorFactory,
+        config,
+        lang,
+        directFieldAccess,
+        autoGrowCollectionLimit,
+        configuredMaxAutoGrowOperations(config));
+  }
+
+  /**
+   * Creates a new <code>Form</code>. Consider using a {@link FormFactory} rather than this
+   * constructor.
+   *
+   * @param rootName the root name.
+   * @param clazz wrapped class
+   * @param data the current form data (used to display the form)
+   * @param files the current form file data
+   * @param errors the collection of errors associated with this form
+   * @param value optional concrete value of type <code>T</code> if the form submission was
+   *     successful
+   * @param groups the array of classes with the groups.
+   * @param messagesApi needed to look up various messages
+   * @param formatters used for parsing and printing form fields
+   * @param validatorFactory the validatorFactory component.
+   * @param config the config component.
+   * @param lang used for formatting when retrieving a field (via {@link #field(String)} or {@link
+   *     #apply(String)}) and for translations in {@link #errorsAsJson()}
+   * @param directFieldAccess access fields of form directly during binding instead of using getters
+   * @param autoGrowCollectionLimit the limit for array and collection auto-growing
+   * @param maxAutoGrowOperations the limit for cumulative auto-growing during one form binding
+   */
+  public Form(
+      String rootName,
+      Class<T> clazz,
+      Map<String, String> data,
+      Map<String, Http.MultipartFormData.FilePart<?>> files,
+      List<ValidationError> errors,
+      Optional<T> value,
+      Class<?>[] groups,
+      MessagesApi messagesApi,
+      Langs langs,
+      Formatters formatters,
+      ValidatorFactory validatorFactory,
+      Config config,
+      Lang lang,
+      boolean directFieldAccess,
+      int autoGrowCollectionLimit,
+      int maxAutoGrowOperations) {
     this.rootName = rootName;
     this.backedType = clazz;
     this.rawData = data != null ? new HashMap<>(data) : new HashMap<>();
@@ -729,6 +794,7 @@ public class Form<T> {
     this.lang = lang;
     this.directFieldAccess = directFieldAccess;
     this.autoGrowCollectionLimit = autoGrowCollectionLimit;
+    this.maxAutoGrowOperations = maxAutoGrowOperations;
   }
 
   /** The default maximum number of chars to support when binding a form from JSON. */
@@ -1077,6 +1143,7 @@ public class Form<T> {
     play.data.format.FormattersInternals$.MODULE$.configureDataBinder(formatters, dataBinder);
     dataBinder.setAutoGrowNestedPaths(true);
     dataBinder.setAutoGrowCollectionLimit(this.autoGrowCollectionLimit);
+    dataBinder.setMaxAutoGrowOperations(this.maxAutoGrowOperations);
     if (this.directFieldAccess) {
       // FYI: initBeanPropertyAccess() is the default, let's switch to direct field access instead
       dataBinder
@@ -1293,7 +1360,8 @@ public class Form<T> {
           config,
           lang,
           directFieldAccess,
-          autoGrowCollectionLimit);
+          autoGrowCollectionLimit,
+          maxAutoGrowOperations);
     }
     return new Form<>(
         rootName,
@@ -1310,7 +1378,8 @@ public class Form<T> {
         config,
         lang,
         directFieldAccess,
-        autoGrowCollectionLimit);
+        autoGrowCollectionLimit,
+        maxAutoGrowOperations);
   }
 
   /**
@@ -1381,7 +1450,8 @@ public class Form<T> {
         config,
         lang,
         directFieldAccess,
-        autoGrowCollectionLimit);
+        autoGrowCollectionLimit,
+        maxAutoGrowOperations);
   }
 
   /**
@@ -1538,7 +1608,8 @@ public class Form<T> {
         this.config,
         this.lang,
         this.directFieldAccess,
-        this.autoGrowCollectionLimit);
+        this.autoGrowCollectionLimit,
+        this.maxAutoGrowOperations);
   }
 
   /**
@@ -1597,7 +1668,8 @@ public class Form<T> {
         this.config,
         this.lang,
         this.directFieldAccess,
-        this.autoGrowCollectionLimit);
+        this.autoGrowCollectionLimit,
+        this.maxAutoGrowOperations);
   }
 
   /**
@@ -1787,7 +1859,8 @@ public class Form<T> {
         this.config,
         lang,
         this.directFieldAccess,
-        this.autoGrowCollectionLimit);
+        this.autoGrowCollectionLimit,
+        this.maxAutoGrowOperations);
   }
 
   /**
@@ -1812,7 +1885,8 @@ public class Form<T> {
         this.config,
         lang,
         directFieldAccess,
-        this.autoGrowCollectionLimit);
+        this.autoGrowCollectionLimit,
+        this.maxAutoGrowOperations);
   }
 
   /**
@@ -1836,7 +1910,33 @@ public class Form<T> {
         this.config,
         lang,
         this.directFieldAccess,
-        autoGrowCollectionLimit);
+        autoGrowCollectionLimit,
+        this.maxAutoGrowOperations);
+  }
+
+  /**
+   * Sets the limit for cumulative auto-growing during a single form binding.
+   *
+   * @param maxAutoGrowOperations the limit for cumulative auto-growing during one form binding
+   */
+  public Form<T> withMaxAutoGrowOperations(int maxAutoGrowOperations) {
+    return new Form<>(
+        this.rootName,
+        this.backedType,
+        this.rawData,
+        this.files,
+        this.errors,
+        this.value,
+        this.groups,
+        this.messagesApi,
+        this.langs,
+        this.formatters,
+        this.validatorFactory,
+        this.config,
+        lang,
+        this.directFieldAccess,
+        this.autoGrowCollectionLimit,
+        maxAutoGrowOperations);
   }
 
   ConfigurablePropertyAccessor propertyAccessor(Object target) {

--- a/web/play-java-forms/src/main/java/play/data/internal/binding/beans/AbstractNestablePropertyAccessor.java
+++ b/web/play-java-forms/src/main/java/play/data/internal/binding/beans/AbstractNestablePropertyAccessor.java
@@ -98,6 +98,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 		setWrappedInstance(object, nestedPath, parent.getWrappedInstance());
 		setAutoGrowNestedPaths(parent.isAutoGrowNestedPaths());
 		setAutoGrowCollectionLimit(parent.getAutoGrowCollectionLimit());
+		setAutoGrowBudget(parent.getAutoGrowBudget());
 		setConversionService(parent.getConversionService());
 	}
 
@@ -226,6 +227,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 						componentType, ph.nested(tokens.keys.length));
 				int length = Array.getLength(propValue);
 				if (arrayIndex >= length && arrayIndex < getAutoGrowCollectionLimit()) {
+					consumeAutoGrowBudget(arrayIndex + 1 - length, tokens.canonicalName);
 					Object newArray = Array.newInstance(componentType, arrayIndex + 1);
 					System.arraycopy(propValue, 0, newArray, 0, length);
 					int lastKeyIndex = tokens.canonicalName.lastIndexOf('[');
@@ -248,6 +250,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 					requiredType.getResolvableType().resolve(), requiredType);
 			int size = list.size();
 			if (index >= size && index < getAutoGrowCollectionLimit()) {
+				consumeAutoGrowBudget(index + 1 - size, tokens.canonicalName);
 				for (int i = size; i < index; i++) {
 					try {
 						list.add(null);
@@ -280,6 +283,9 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 					mapKeyType.getResolvableType().resolve(), mapKeyType);
 			Object convertedMapValue = convertIfNecessary(tokens.canonicalName, pv.getValue(),
 					mapValueType.getResolvableType().resolve(), mapValueType);
+			if (!map.containsKey(convertedMapKey)) {
+				consumeAutoGrowBudget(1, tokens.canonicalName);
+			}
 			map.put(convertedMapKey, convertedMapValue);
 		}
 
@@ -617,12 +623,22 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 	protected abstract NotWritablePropertyException createNotWritablePropertyException(String propertyName);
 
 
+	private void consumeAutoGrowBudget(int amount, String propertyName) {
+		AutoGrowBudget budget = getAutoGrowBudget();
+		if (!budget.canConsume(amount)) {
+			throw new InvalidPropertyException(getRootClass(), this.nestedPath + propertyName,
+					"Auto-grow operation limit of " + budget.getLimit() + " exceeded");
+		}
+		budget.consume(amount);
+	}
+
 	private Object growArrayIfNecessary(Object array, int index, String name) {
 		if (!isAutoGrowNestedPaths()) {
 			return array;
 		}
 		int length = Array.getLength(array);
 		if (index >= length && index < getAutoGrowCollectionLimit()) {
+			consumeAutoGrowBudget(index + 1 - length, name);
 			Class<?> componentType = array.getClass().componentType();
 			Object newArray = Array.newInstance(componentType, index + 1);
 			System.arraycopy(array, 0, newArray, 0, length);
@@ -649,6 +665,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 		if (index >= size && index < getAutoGrowCollectionLimit()) {
 			Class<?> elementType = ph.getResolvableType().getNested(nestingLevel).asCollection().resolveGeneric();
 			if (elementType != null) {
+				consumeAutoGrowBudget(index + 1 - size, name);
 				for (int i = collection.size(); i < index + 1; i++) {
 					collection.add(newValue(elementType, null, name));
 				}
@@ -733,6 +750,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 	}
 
 	private Object setDefaultValue(PropertyTokenHolder tokens) {
+		consumeAutoGrowBudget(1, tokens.canonicalName);
 		PropertyValue pv = createDefaultPropertyValue(tokens);
 		setPropertyValue(tokens, pv);
 		Object defaultValue = getPropertyValue(tokens);

--- a/web/play-java-forms/src/main/java/play/data/internal/binding/beans/AbstractPropertyAccessor.java
+++ b/web/play-java-forms/src/main/java/play/data/internal/binding/beans/AbstractPropertyAccessor.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import play.data.internal.binding.core.convert.ConversionService;
+import play.data.internal.binding.util.Assert;
 
 /**
  * Abstract implementation of the {@link PropertyAccessor} interface.
@@ -41,6 +42,8 @@ public abstract class AbstractPropertyAccessor implements ConfigurablePropertyAc
 	private boolean autoGrowNestedPaths = false;
 
 	private int autoGrowCollectionLimit = Integer.MAX_VALUE;
+
+	private AutoGrowBudget autoGrowBudget = new AutoGrowBudget(Integer.MAX_VALUE);
 
 	private ConversionService conversionService;
 
@@ -73,6 +76,17 @@ public abstract class AbstractPropertyAccessor implements ConfigurablePropertyAc
 	@Override
 	public int getAutoGrowCollectionLimit() {
 		return this.autoGrowCollectionLimit;
+	}
+
+	@Override
+	public void setAutoGrowBudget(AutoGrowBudget autoGrowBudget) {
+		Assert.notNull(autoGrowBudget, "AutoGrowBudget must not be null");
+		this.autoGrowBudget = autoGrowBudget;
+	}
+
+	@Override
+	public AutoGrowBudget getAutoGrowBudget() {
+		return this.autoGrowBudget;
 	}
 
 

--- a/web/play-java-forms/src/main/java/play/data/internal/binding/beans/AutoGrowBudget.java
+++ b/web/play-java-forms/src/main/java/play/data/internal/binding/beans/AutoGrowBudget.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Modified from the original Spring Framework source for Play Framework form binding by the Play Framework contributors.
+ */
+
+package play.data.internal.binding.beans;
+
+/**
+ * Tracks cumulative auto-growing performed while binding a single object graph.
+ *
+ * <p>The budget is intentionally mutable and shared by nested property accessors so a deeply nested
+ * bind can be limited as one operation, rather than as separate per-accessor limits.
+ */
+public final class AutoGrowBudget {
+
+	private final int limit;
+
+	private int operations;
+
+	public AutoGrowBudget(int limit) {
+		if (limit < 0) {
+			throw new IllegalArgumentException("Auto-grow operation limit must not be negative");
+		}
+		this.limit = limit;
+	}
+
+	public int getLimit() {
+		return this.limit;
+	}
+
+	public int getOperations() {
+		return this.operations;
+	}
+
+	public boolean canConsume(int amount) {
+		if (amount < 0) {
+			throw new IllegalArgumentException("Auto-grow operation amount must not be negative");
+		}
+		return amount <= this.limit - this.operations;
+	}
+
+	public void consume(int amount) {
+		if (!canConsume(amount)) {
+			throw new IllegalStateException("Auto-grow operation limit exceeded");
+		}
+		this.operations += amount;
+	}
+
+}

--- a/web/play-java-forms/src/main/java/play/data/internal/binding/beans/ConfigurablePropertyAccessor.java
+++ b/web/play-java-forms/src/main/java/play/data/internal/binding/beans/ConfigurablePropertyAccessor.java
@@ -56,4 +56,14 @@ public interface ConfigurablePropertyAccessor extends PropertyAccessor {
 	 */
 	int getAutoGrowCollectionLimit();
 
+	/**
+	 * Specify the shared budget for cumulative auto-growing.
+	 */
+	void setAutoGrowBudget(AutoGrowBudget autoGrowBudget);
+
+	/**
+	 * Return the shared budget for cumulative auto-growing.
+	 */
+	AutoGrowBudget getAutoGrowBudget();
+
 }

--- a/web/play-java-forms/src/main/java/play/data/internal/binding/validation/BeanPropertyBindingResult.java
+++ b/web/play-java-forms/src/main/java/play/data/internal/binding/validation/BeanPropertyBindingResult.java
@@ -22,6 +22,7 @@ package play.data.internal.binding.validation;
 
 import java.io.Serializable;
 
+import play.data.internal.binding.beans.AutoGrowBudget;
 import play.data.internal.binding.beans.BeanWrapperImpl;
 import play.data.internal.binding.beans.ConfigurablePropertyAccessor;
 
@@ -49,6 +50,8 @@ public class BeanPropertyBindingResult extends AbstractPropertyBindingResult imp
 
 	private final int autoGrowCollectionLimit;
 
+	private final AutoGrowBudget autoGrowBudget;
+
 	private transient BeanWrapperImpl beanWrapper;
 
 	/**
@@ -57,14 +60,16 @@ public class BeanPropertyBindingResult extends AbstractPropertyBindingResult imp
 	 * @param objectName the name of the target object
 	 * @param autoGrowNestedPaths whether to "auto-grow" a nested path that contains a null value
 	 * @param autoGrowCollectionLimit the limit for array and collection auto-growing
+	 * @param autoGrowBudget the budget for cumulative auto-growing
 	 */
 	public BeanPropertyBindingResult(Object target, String objectName,
-			boolean autoGrowNestedPaths, int autoGrowCollectionLimit) {
+			boolean autoGrowNestedPaths, int autoGrowCollectionLimit, AutoGrowBudget autoGrowBudget) {
 
 		super(objectName);
 		this.target = target;
 		this.autoGrowNestedPaths = autoGrowNestedPaths;
 		this.autoGrowCollectionLimit = autoGrowCollectionLimit;
+		this.autoGrowBudget = autoGrowBudget;
 	}
 
 
@@ -84,6 +89,7 @@ public class BeanPropertyBindingResult extends AbstractPropertyBindingResult imp
 			this.beanWrapper = createBeanWrapper();
 			this.beanWrapper.setAutoGrowNestedPaths(this.autoGrowNestedPaths);
 			this.beanWrapper.setAutoGrowCollectionLimit(this.autoGrowCollectionLimit);
+			this.beanWrapper.setAutoGrowBudget(this.autoGrowBudget);
 		}
 		return this.beanWrapper;
 	}

--- a/web/play-java-forms/src/main/java/play/data/internal/binding/validation/DataBinder.java
+++ b/web/play-java-forms/src/main/java/play/data/internal/binding/validation/DataBinder.java
@@ -22,6 +22,7 @@ package play.data.internal.binding.validation;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import play.data.internal.binding.beans.AutoGrowBudget;
 import play.data.internal.binding.beans.ConfigurablePropertyAccessor;
 import play.data.internal.binding.beans.MutablePropertyValues;
 import play.data.internal.binding.beans.PropertyAccessException;
@@ -85,6 +86,11 @@ public class DataBinder {
 	/** Default limit for bean property array and collection growing: 256. */
 	public static final int DEFAULT_AUTO_GROW_COLLECTION_LIMIT = 256;
 
+	/**
+	 * Default limit for cumulative auto-growing while binding a single object graph.
+	 */
+	public static final int DEFAULT_AUTO_GROW_OPERATIONS = 1024;
+
 
 	/**
 	 * We'll create a lot of DataBinder instances: Let's use a static logger.
@@ -102,6 +108,8 @@ public class DataBinder {
 	private boolean autoGrowNestedPaths = true;
 
 	private int autoGrowCollectionLimit = DEFAULT_AUTO_GROW_COLLECTION_LIMIT;
+
+	private int maxAutoGrowOperations = DEFAULT_AUTO_GROW_OPERATIONS;
 
 	private String [] allowedFields;
 
@@ -189,12 +197,30 @@ public class DataBinder {
 	}
 
 	/**
+	 * Specify the limit for cumulative auto-growing.
+	 * <p>Default is 1024, preventing excessive nested object graph growth.
+	 */
+	public void setMaxAutoGrowOperations(int maxAutoGrowOperations) {
+		Assert.state(this.bindingResult == null,
+				"DataBinder is already initialized - call setMaxAutoGrowOperations before other configuration methods");
+		this.maxAutoGrowOperations = maxAutoGrowOperations;
+	}
+
+	/**
+	 * Return the current limit for cumulative auto-growing.
+	 */
+	public int getMaxAutoGrowOperations() {
+		return this.maxAutoGrowOperations;
+	}
+
+	/**
 	 * Create the {@link AbstractPropertyBindingResult} instance using standard
 	 * JavaBean property access.
 	 */
 	protected AbstractPropertyBindingResult createBeanPropertyBindingResult() {
 		BeanPropertyBindingResult result = new BeanPropertyBindingResult(getTarget(),
-				getObjectName(), isAutoGrowNestedPaths(), getAutoGrowCollectionLimit());
+				getObjectName(), isAutoGrowNestedPaths(), getAutoGrowCollectionLimit(),
+				new AutoGrowBudget(getMaxAutoGrowOperations()));
 
 		if (this.conversionService != null) {
 			result.initConversion(this.conversionService);
@@ -220,7 +246,8 @@ public class DataBinder {
 	 */
 	protected AbstractPropertyBindingResult createDirectFieldBindingResult() {
 		DirectFieldBindingResult result = new DirectFieldBindingResult(getTarget(),
-				getObjectName(), isAutoGrowNestedPaths(), getAutoGrowCollectionLimit());
+				getObjectName(), isAutoGrowNestedPaths(), getAutoGrowCollectionLimit(),
+				new AutoGrowBudget(getMaxAutoGrowOperations()));
 
 		if (this.conversionService != null) {
 			result.initConversion(this.conversionService);

--- a/web/play-java-forms/src/main/java/play/data/internal/binding/validation/DirectFieldBindingResult.java
+++ b/web/play-java-forms/src/main/java/play/data/internal/binding/validation/DirectFieldBindingResult.java
@@ -20,6 +20,7 @@
 
 package play.data.internal.binding.validation;
 
+import play.data.internal.binding.beans.AutoGrowBudget;
 import play.data.internal.binding.beans.ConfigurablePropertyAccessor;
 import play.data.internal.binding.beans.DirectFieldAccessor;
 
@@ -44,6 +45,8 @@ public class DirectFieldBindingResult extends AbstractPropertyBindingResult {
 
 	private final int autoGrowCollectionLimit;
 
+	private final AutoGrowBudget autoGrowBudget;
+
 	private transient ConfigurablePropertyAccessor directFieldAccessor;
 
 	/**
@@ -52,14 +55,16 @@ public class DirectFieldBindingResult extends AbstractPropertyBindingResult {
 	 * @param objectName the name of the target object
 	 * @param autoGrowNestedPaths whether to "auto-grow" a nested path that contains a null value
 	 * @param autoGrowCollectionLimit the limit for array and collection auto-growing
+	 * @param autoGrowBudget the budget for cumulative auto-growing
 	 */
 	public DirectFieldBindingResult(Object target, String objectName,
-			boolean autoGrowNestedPaths, int autoGrowCollectionLimit) {
+			boolean autoGrowNestedPaths, int autoGrowCollectionLimit, AutoGrowBudget autoGrowBudget) {
 
 		super(objectName);
 		this.target = target;
 		this.autoGrowNestedPaths = autoGrowNestedPaths;
 		this.autoGrowCollectionLimit = autoGrowCollectionLimit;
+		this.autoGrowBudget = autoGrowBudget;
 	}
 
 
@@ -79,6 +84,7 @@ public class DirectFieldBindingResult extends AbstractPropertyBindingResult {
 			this.directFieldAccessor = createDirectFieldAccessor();
 			this.directFieldAccessor.setAutoGrowNestedPaths(this.autoGrowNestedPaths);
 			this.directFieldAccessor.setAutoGrowCollectionLimit(this.autoGrowCollectionLimit);
+			this.directFieldAccessor.setAutoGrowBudget(this.autoGrowBudget);
 		}
 		return this.directFieldAccessor;
 	}

--- a/web/play-java-forms/src/main/resources/reference.conf
+++ b/web/play-java-forms/src/main/resources/reference.conf
@@ -20,6 +20,12 @@ play {
       # This prevents accidental or malicious submissions with very large indexes from allocating
       # excessive memory.
       autoGrowCollectionLimit = 256
+
+      # Limits the total amount of auto-growing Play will perform while binding a single Java form.
+      # This complements autoGrowCollectionLimit: autoGrowCollectionLimit caps each individual
+      # indexed collection path, while maxAutoGrowOperations caps cumulative nested growth across
+      # the submitted form data.
+      maxAutoGrowOperations = 1024
     }
 
   }

--- a/web/play-java-forms/src/test/java/play/data/DefaultFormBindingTest.java
+++ b/web/play-java-forms/src/test/java/play/data/DefaultFormBindingTest.java
@@ -5,6 +5,8 @@
 package play.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -32,6 +34,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import org.junit.Test;
+import play.data.internal.binding.beans.AutoGrowBudget;
 import play.data.internal.binding.beans.MutablePropertyValues;
 import play.data.internal.binding.validation.DataBinder;
 import play.data.internal.binding.validation.FieldError;
@@ -3994,6 +3997,80 @@ public class DefaultFormBindingTest extends WithApplication {
     assertThat(bean.list.get(1).nested.list.get(1).name).isEqualTo("nested-list-one");
     assertThat(bean.map.get("key1").nested.map.get("key1").name).isEqualTo("nested-map-one");
     assertThat(bean.map.get("key2").nested.map.get("key2").name).isEqualTo("nested-map-two");
+  }
+
+  @Test
+  public void shouldRejectIndexedBindingBeyondMaxAutoGrowOperations() {
+    FormFactory formFactory = instanceOf(FormFactory.class);
+    Map<String, String> data = new HashMap<>();
+    data.put("list[2].nested.list[2].name", "too-much-growth");
+
+    Form<IndexedFormData> form =
+        formFactory
+            .form(IndexedFormData.class)
+            .withMaxAutoGrowOperations(6)
+            .bind(Lang.defaultLang(), TypedMap.empty(), data);
+
+    assertThat(form.hasErrors()).isTrue();
+    assertThat(form.errors())
+        .anySatisfy(error -> assertThat(error.key()).isEqualTo("list[2].nested.list"));
+  }
+
+  @Test
+  public void shouldRejectDirectFieldIndexedBindingBeyondMaxAutoGrowOperations() {
+    FormFactory formFactory = instanceOf(FormFactory.class);
+    Map<String, String> data = new HashMap<>();
+    data.put("list[2].nested.list[2].name", "too-much-growth");
+
+    Form<IndexedFormData> form =
+        formFactory
+            .form(IndexedFormData.class)
+            .withDirectFieldAccess(true)
+            .withMaxAutoGrowOperations(6)
+            .bind(Lang.defaultLang(), TypedMap.empty(), data);
+
+    assertThat(form.hasErrors()).isTrue();
+    assertThat(form.errors())
+        .anySatisfy(error -> assertThat(error.key()).isEqualTo("list[2].nested.list"));
+  }
+
+  @Test
+  public void shouldBindIndexedPropertiesWithinMaxAutoGrowOperations() {
+    FormFactory formFactory = instanceOf(FormFactory.class);
+    Map<String, String> data = new HashMap<>();
+    data.put("list[2].nested.list[2].name", "within-budget");
+
+    Form<IndexedFormData> form =
+        formFactory
+            .form(IndexedFormData.class)
+            .withMaxAutoGrowOperations(9)
+            .bind(Lang.defaultLang(), TypedMap.empty(), data);
+
+    assertThat(form.errors()).isEmpty();
+    assertThat(form.get().getList().get(2).getNested().getList().get(2).getName())
+        .isEqualTo("within-budget");
+  }
+
+  @Test
+  public void shouldTrackAutoGrowBudgetConsumption() {
+    AutoGrowBudget budget = new AutoGrowBudget(3);
+
+    assertThat(budget.canConsume(2)).isTrue();
+    budget.consume(2);
+
+    assertThat(budget.getOperations()).isEqualTo(2);
+    assertThat(budget.canConsume(1)).isTrue();
+    assertThat(budget.canConsume(2)).isFalse();
+    budget.consume(1);
+    assertThat(budget.getOperations()).isEqualTo(3);
+    assertThatIllegalStateException().isThrownBy(() -> budget.consume(1));
+  }
+
+  @Test
+  public void shouldRejectInvalidAutoGrowBudgetAmounts() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new AutoGrowBudget(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> new AutoGrowBudget(1).canConsume(-1));
+    assertThatIllegalArgumentException().isThrownBy(() -> new AutoGrowBudget(1).consume(-1));
   }
 
   @Test

--- a/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/web/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -366,6 +366,37 @@ trait FormSpec extends CommonFormSpec {
       myForm.hasErrors() must beEqualTo(true)
       myForm.errors("emails[1]").size must beEqualTo(1)
     }
+    "reject indexed binding beyond max auto-grow operations configured for Java forms" in new WithApplication(
+      application("play.forms.binding.maxAutoGrowOperations" -> "1")
+    ) {
+      override def running() = {
+        val req = FormSpec.dummyRequest(
+          Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com"), "emails[1]" -> Array("kiki@zen.com"))
+        )
+
+        val myForm = formFactory.form(classOf[AnotherUser]).bindFromRequest(req)
+        myForm.hasErrors() must beEqualTo(true)
+        myForm.errors("emails[1]").size must beEqualTo(1)
+      }
+    }
+    "reject indexed binding beyond max auto-grow operations set on a Java form" in {
+      val req = FormSpec.dummyRequest(
+        Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com"), "emails[1]" -> Array("kiki@zen.com"))
+      )
+
+      val myForm = formFactory.form(classOf[AnotherUser]).withMaxAutoGrowOperations(1).bindFromRequest(req)
+      myForm.hasErrors() must beEqualTo(true)
+      myForm.errors("emails[1]").size must beEqualTo(1)
+    }
+    "bind indexed fields within max auto-grow operations set on a Java form" in {
+      val req = FormSpec.dummyRequest(
+        Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com"), "emails[1]" -> Array("kiki@zen.com"))
+      )
+
+      val myForm = formFactory.form(classOf[AnotherUser]).withMaxAutoGrowOperations(2).bindFromRequest(req)
+      myForm.hasErrors() must beEqualTo(false)
+      myForm.get().getEmails must beEqualTo(List("kiki@gmail.com", "kiki@zen.com").asJava)
+    }
     "reject direct field indexed binding beyond auto-grow collection limit configured for Java forms" in new WithApplication(
       application("play.forms.binding.directFieldAccess" -> "true", "play.forms.binding.autoGrowCollectionLimit" -> "1")
     ) {


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #13982

## Purpose

Adds a cumulative auto-grow limit for Java form binding so nested indexed form payloads cannot repeatedly grow object graphs, arrays, collections, or maps while staying below the existing per-path `autoGrowCollectionLimit`.

## Background Context

Java forms already limit each indexed collection path with `play.forms.binding.autoGrowCollectionLimit`, but that limit applies per collection path. Deeply nested payloads can still cause substantial cumulative auto-growth during a single bind operation.

This PR introduces `play.forms.binding.maxAutoGrowOperations`, defaulting to `1024`, and wires it through `Form`, `DataBinder`, bean property access, and direct field access. Nested property accessors share one mutable budget so the whole bind operation is bounded.

Tests cover configured limits, per-form overrides, direct field access, nested indexed binding, and budget boundary behavior.

## References

* #13982