### PR TITLE
Fix WSRequest timeout JavaDoc

### DIFF
--- a/transport/client/play-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/transport/client/play-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -512,11 +512,11 @@ public interface WSRequest extends StandaloneWSRequest {
   WSRequest setVirtualHost(String virtualHost);
 
   /**
-  * Sets the request timeout.
-  *
-  * @param timeout the request timeout duration
-  * @return the modified WSRequest.
-  */
+   * Sets the request timeout.
+   *
+   * @param timeout the request timeout duration
+   * @return the modified WSRequest.
+   */
   @Override
   WSRequest setRequestTimeout(Duration timeout);
 

--- a/transport/client/play-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/transport/client/play-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -512,12 +512,11 @@ public interface WSRequest extends StandaloneWSRequest {
   WSRequest setVirtualHost(String virtualHost);
 
   /**
-   * Sets the request timeout in milliseconds.
-   *
-   * @param timeout the request timeout in milliseconds. A value of -1 indicates an infinite request
-   *     timeout.
-   * @return the modified WSRequest.
-   */
+  * Sets the request timeout.
+  *
+  * @param timeout the request timeout duration
+  * @return the modified WSRequest.
+  */
   @Override
   WSRequest setRequestTimeout(Duration timeout);
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

No issue.

## Purpose

This PR fixes the JavaDoc for WSRequest#setRequestTimeout(Duration).

The current JavaDoc says that the timeout is specified in milliseconds and mentions -1 for an infinite request timeout. That wording appears to have been copied from the deprecated long overload below it.

Since this overload takes a java.time.Duration, this PR updates the JavaDoc to avoid saying that the parameter is in milliseconds.

No behavior change.

## Background Context

This is a documentation-only correction.

## References

None.
