### PR TITLE
Handle `WebSocketCloseException` close messages consistently

### DIFF
--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -18,6 +18,9 @@ import scala.concurrent.Promise;
 
 /** Java actions for WebSocket spec */
 public class WebSocketSpecJavaActions {
+  public static class JavaJsonMessage {
+    public int count;
+  }
 
   private static <A> Sink<A, ?> getChunks(Consumer<List<A>> onDone) {
     return Sink.<List<A>, A>fold(
@@ -58,5 +61,22 @@ public class WebSocketSpecJavaActions {
         request ->
             new WebSocket.Accepted<>(
                 Flow.fromSinkAndSource(Sink.ignore(), Source.empty()), "graphql-transport-ws"));
+  }
+
+  public static WebSocket acceptText() {
+    return WebSocket.Text.accept(request -> Flow.fromSinkAndSource(Sink.ignore(), emptySource()));
+  }
+
+  public static WebSocket acceptBinary() {
+    return WebSocket.Binary.accept(request -> Flow.fromSinkAndSource(Sink.ignore(), emptySource()));
+  }
+
+  public static WebSocket acceptJson() {
+    return WebSocket.Json.accept(request -> Flow.fromSinkAndSource(Sink.ignore(), emptySource()));
+  }
+
+  public static WebSocket acceptJsonClass() {
+    return WebSocket.json(JavaJsonMessage.class)
+        .accept(request -> Flow.fromSinkAndSource(Sink.ignore(), emptySource()));
   }
 }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -267,6 +267,30 @@ trait WebSocketSpec
         }
       }
 
+      "close the websocket with the exception close code when the application source fails" in {
+        withServer(app =>
+          WebSocket.accept[Message, Message] { req =>
+            Flow.fromSinkAndSource(
+              Sink.ignore,
+              Source.failed[Message](WebSocketCloseException(CloseMessage(4001, "Application close")))
+            )
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow =>
+              Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames)
+            }
+          )
+          frames must contain(
+            exactly(
+              closeFrame(4001)
+            )
+          )
+        }
+      }
+
       "close when the consumer is done" in closeWhenTheConsumerIsDone { _ =>
         WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.cancelled, Source.maybe[String]) }
       }
@@ -491,7 +515,7 @@ trait WebSocketSpec
         }
       }
 
-      "close the websocket with the exception close code when JSON validation fails" in {
+      "close the websocket with 1003 when JSON validation fails" in {
         withServer(app =>
           WebSocket.accept[JsonMessage, JsValue] { req =>
             Flow.fromSinkAndSource(Sink.ignore, Source.maybe[JsValue])

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -445,6 +445,52 @@ trait WebSocketSpec
         }
       }
 
+      "close a binary websocket when a text frame is received" in {
+        withServer(app =>
+          WebSocket.accept[ByteString, ByteString] { req =>
+            Flow.fromSinkAndSource(Sink.ignore, Source.maybe[ByteString])
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(
+                TextMessage("first")
+              ).via(flow).runWith(consumeFrames)
+            }
+          )
+          frames must contain(
+            exactly(
+              closeFrame(1003)
+            )
+          )
+        }
+      }
+
+      "close a JSON websocket when the message is not valid JSON" in {
+        withServer(app =>
+          WebSocket.accept[JsValue, JsValue] { req =>
+            Flow.fromSinkAndSource(Sink.ignore, Source.maybe[JsValue])
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(
+                TextMessage("{")
+              ).via(flow).runWith(consumeFrames)
+            }
+          )
+          frames must contain(
+            exactly(
+              closeFrame(1003)
+            )
+          )
+        }
+      }
+
       "close the websocket with the exception close code when JSON validation fails" in {
         withServer(app =>
           WebSocket.accept[JsonMessage, JsValue] { req =>
@@ -602,6 +648,82 @@ trait WebSocketSpec
             .map { case (key, value) => (key.toLowerCase, value) }
             .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
             .head must be).equalTo("graphql-transport-ws")
+        }
+      }
+
+      "close a text websocket when a binary frame is received" in {
+        withServer(_ => WebSocketSpecJavaActions.acceptText()) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(
+                BinaryMessage(ByteString("first"))
+              ).via(flow).runWith(consumeFrames)
+            }
+          )
+          frames must contain(
+            exactly(
+              closeFrame(1003)
+            )
+          )
+        }
+      }
+
+      "close a binary websocket when a text frame is received" in {
+        withServer(_ => WebSocketSpecJavaActions.acceptBinary()) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(
+                TextMessage("first")
+              ).via(flow).runWith(consumeFrames)
+            }
+          )
+          frames must contain(
+            exactly(
+              closeFrame(1003)
+            )
+          )
+        }
+      }
+
+      "close a JSON websocket when the message is not valid JSON" in {
+        withServer(_ => WebSocketSpecJavaActions.acceptJson()) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(
+                TextMessage("{")
+              ).via(flow).runWith(consumeFrames)
+            }
+          )
+          frames must contain(
+            exactly(
+              closeFrame(1003)
+            )
+          )
+        }
+      }
+
+      "close a typed JSON websocket when JSON decoding fails" in {
+        withServer(_ => WebSocketSpecJavaActions.acceptJsonClass()) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(
+                TextMessage("""{"count":"not-a-number"}""")
+              ).via(flow).runWith(consumeFrames)
+            }
+          )
+          frames must contain(
+            exactly(
+              closeFrame(1003)
+            )
+          )
         }
       }
     }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -27,6 +27,9 @@ import org.specs2.matcher.Matcher
 import org.specs2.specification.AroundEach
 import play.api.http.websocket._
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+import play.api.libs.json.Reads
 import play.api.libs.streams.ActorFlow
 import play.api.libs.ws.WSClient
 import play.api.mvc.Handler
@@ -150,6 +153,12 @@ trait WebSocketSpec
     with ServerIntegrationSpecification
     with WebSocketSpecMethods
     with PingWebSocketSpec {
+  case class JsonMessage(name: String)
+
+  implicit val jsonMessageReads: Reads[JsonMessage]                                               = Json.reads[JsonMessage]
+  implicit val jsonMessageFlowTransformer: WebSocket.MessageFlowTransformer[JsonMessage, JsValue] =
+    WebSocket.MessageFlowTransformer.jsonMessageFlowTransformer[JsonMessage, JsValue]
+
   /*
    * This is the flakiest part of the test suite -- the CI server will timeout websockets
    * and fail tests seemingly at random.
@@ -425,6 +434,29 @@ trait WebSocketSpec
               sendFrames(
                 BinaryMessage(ByteString("first")),
                 TextMessage("foo")
+              ).via(flow).runWith(consumeFrames)
+            }
+          )
+          frames must contain(
+            exactly(
+              closeFrame(1003)
+            )
+          )
+        }
+      }
+
+      "close the websocket with the exception close code when JSON validation fails" in {
+        withServer(app =>
+          WebSocket.accept[JsonMessage, JsValue] { req =>
+            Flow.fromSinkAndSource(Sink.ignore, Source.maybe[JsValue])
+          }
+        ) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow =>
+              sendFrames(
+                TextMessage("""{"unknown":"value"}""")
               ).via(flow).runWith(consumeFrames)
             }
           )

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -133,7 +133,8 @@ public abstract class WebSocket {
                       play.libs.Json.mapper().readValue(((Message.Text) message).data(), in));
                 }
               } catch (Exception e) {
-                return F.Either.Right(new Message.Close(CloseCodes.Unacceptable(), e.getMessage()));
+                return F.Either.Right(
+                    new Message.Close(CloseCodes.Unacceptable(), "Unable to parse JSON message"));
               }
               throw Scala.noMatch();
             }),

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -44,6 +44,10 @@ trait WebSocket extends Handler {
  * Helper utilities to generate WebSocket results.
  */
 object WebSocket {
+  private def closeOnException(flow: Flow[Message, Message, ?]): Flow[Message, Message, ?] = {
+    flow.recover { case WebSocketCloseException(close) => close }
+  }
+
   private[play] def firstRequestedSubprotocol(request: RequestHeader): Option[String] = {
     request.headers
       .get("Sec-WebSocket-Protocol")
@@ -174,20 +178,26 @@ object WebSocket {
      * serialised to JSON.
      */
     def jsonMessageFlowTransformer[In: Reads, Out: Writes]: MessageFlowTransformer[In, Out] = {
-      jsonMessageFlowTransformer.map(
-        json =>
-          Json
-            .fromJson[In](json)
-            .fold(
-              { errors =>
-                throw WebSocketCloseException(
-                  CloseMessage(Some(CloseCodes.Unacceptable), Json.stringify(JsError.toJson(errors)))
+      (flow: Flow[In, Out, ?]) =>
+        {
+          def closeOnParseOrValidationError(block: => JsValue): Either[In, Message] =
+            try {
+              val json = block
+              Json
+                .fromJson[In](json)
+                .fold(
+                  errors => Right(CloseMessage(Some(CloseCodes.Unacceptable), Json.stringify(JsError.toJson(errors)))),
+                  in => Left(in)
                 )
-              },
-              identity
-            ),
-        out => Json.toJson(out)
-      )
+            } catch {
+              case NonFatal(_) => Right(CloseMessage(Some(CloseCodes.Unacceptable), "Unable to parse json message"))
+            }
+
+          PekkoStreams.bypassWith[Message, In, Message](Flow[Message].collect {
+            case BinaryMessage(data) => closeOnParseOrValidationError(Json.parse(data.asInputStream))
+            case TextMessage(text)   => closeOnParseOrValidationError(Json.parse(text))
+          })(flow.map(out => TextMessage(Json.stringify(Json.toJson(out)))))
+        }
     }
   }
 
@@ -216,7 +226,7 @@ object WebSocket {
   def acceptOrResult[In, Out](
       f: RequestHeader => Future[Either[Result, Flow[In, Out, ?]]]
   )(implicit transformer: MessageFlowTransformer[In, Out]): WebSocket = {
-    WebSocket { request => f(request).map(_.map(transformer.transform)) }
+    WebSocket { request => f(request).map(_.map(flow => closeOnException(transformer.transform(flow)))) }
   }
 
   /**
@@ -233,7 +243,7 @@ object WebSocket {
 
       override def applyWithOptions(request: RequestHeader): Future[Either[Result, Accepted[Message, Message]]] = {
         f(request).map(_.map { accepted =>
-          Accepted(transformer.transform(accepted.flow), accepted.subprotocol)
+          Accepted(closeOnException(transformer.transform(accepted.flow)), accepted.subprotocol)
         })
       }
     }

--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -58,3 +58,24 @@ This can happen when the network connection is interrupted, the client disconnec
 Because abnormal WebSocket termination is now reported as a `CloseMessage` before the stream completes, raw `Message` handlers that previously relied on `watchTermination` seeing a failed stream for transport loss should instead inspect `CloseMessage(Some(1006), ...)`.
 
 Handlers using typed APIs such as `WebSocket.accept[String, String]` still do not receive close control frames as typed messages. Use a raw `Message` flow if your application needs to inspect WebSocket close status codes directly.
+
+### WebSocket close messages from typed transformers and application failures are more consistent
+
+Play now preserves more application-level WebSocket close reasons as WebSocket Close frames instead of turning them into generic stream termination.
+
+For Scala WebSockets, if an application source failed with `play.api.http.websocket.WebSocketCloseException`, the close status carried by the exception was not preserved reliably. This could be handled as a generic application stream failure instead of closing the WebSocket with the supplied status. Play now closes the connection with the exception's embedded `CloseMessage`.
+
+Scala
+: @[websocket-close-exception](code/WebSocketCloseMigration.scala)
+
+Scala high-level JSON WebSockets created with `WebSocket.MessageFlowTransformer.jsonMessageFlowTransformer[In, Out]` now close with status `1003` when incoming JSON is syntactically valid but fails the configured `Reads[In]` validation. The invalid message is still not delivered to the typed application flow, but the remote peer now receives the intended `1003` close status with the validation error reason.
+
+Scala
+: @[typed-json-validation](code/WebSocketCloseMigration.scala)
+
+Java typed JSON WebSockets created with `play.mvc.WebSocket.json(Class)` now use a bounded generic close reason for JSON decoding failures. The close status remains `1003`, but the reason is now `"Unable to parse JSON message"` instead of the underlying Jackson exception message.
+
+Java
+: @[typed-json-decoding](code/WebSocketCloseMigration.java)
+
+This avoids creating invalid WebSocket Close frames: [RFC 6455 section 5.5](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5) limits all control frame payloads, including Close frames, to 125 bytes, and [section 5.5.1](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1) defines the first two bytes of a Close frame body as the status code, leaving at most 123 bytes for the UTF-8 reason.

--- a/documentation/manual/releases/release31/migration31/code/WebSocketCloseMigration.java
+++ b/documentation/manual/releases/release31/migration31/code/WebSocketCloseMigration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package javadoc.websocketmigration;
+
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import play.mvc.WebSocket;
+
+public class WebSocketCloseMigration {
+  public static class In {
+    public int count;
+  }
+
+  public WebSocket typedJsonWebSocket() {
+    // #typed-json-decoding
+    // Before: {"count":"not-a-number"} closed with status 1003, but used the
+    // underlying Jackson exception message as the close reason.
+    // After: Play still closes with status 1003, but uses
+    // "Unable to parse JSON message" as a bounded generic reason.
+    return WebSocket.json(In.class)
+        .accept(request -> Flow.fromSinkAndSource(Sink.ignore(), Source.maybe()));
+    // #typed-json-decoding
+  }
+}

--- a/documentation/manual/releases/release31/migration31/code/WebSocketCloseMigration.scala
+++ b/documentation/manual/releases/release31/migration31/code/WebSocketCloseMigration.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package scaladoc.websocketmigration
+
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.stream.scaladsl.Source
+import play.api.http.websocket.CloseMessage
+import play.api.http.websocket.Message
+import play.api.http.websocket.WebSocketCloseException
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+import play.api.libs.json.Reads
+import play.api.mvc.WebSocket
+
+object WebSocketCloseMigration {
+  def closeExceptionWebSocket: WebSocket = {
+    // #websocket-close-exception
+    // Before: the embedded close status was not preserved reliably.
+    // After: Play closes the WebSocket with status 4001.
+    WebSocket.accept[Message, Message] { _ =>
+      Flow.fromSinkAndSource(
+        Sink.ignore,
+        Source.failed(WebSocketCloseException(CloseMessage(4001, "Application close")))
+      )
+    }
+    // #websocket-close-exception
+  }
+
+  object TypedJsonWebSocket {
+    case class In(name: String)
+    implicit val reads: Reads[In] = Json.reads[In]
+    implicit val transformer: WebSocket.MessageFlowTransformer[In, JsValue] =
+      WebSocket.MessageFlowTransformer.jsonMessageFlowTransformer[In, JsValue]
+
+    def webSocket: WebSocket = {
+      // #typed-json-validation
+      // Before: {"unknown":"value"} could fail to close with the intended 1003 status.
+      // After: Play closes the WebSocket with status 1003 and the validation errors as reason.
+      WebSocket.accept[In, JsValue] { _ =>
+        Flow.fromSinkAndSource(Sink.ignore, Source.maybe[JsValue])
+      }
+      // #typed-json-validation
+    }
+  }
+}

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -358,8 +358,13 @@ object WebSocketFlowHandler {
             override def onUpstreamFailure(ex: Throwable) = {
               if (state == Open) {
                 appInitiatedClose = true
-                serverInitiatedClose(CloseMessage(Some(CloseCodes.UnexpectedCondition)))
-                logger.error("WebSocket flow threw exception", ex)
+                ex match {
+                  case WebSocketCloseException(close) =>
+                    serverInitiatedClose(close)
+                  case _ =>
+                    serverInitiatedClose(CloseMessage(Some(CloseCodes.UnexpectedCondition)))
+                    logger.error("WebSocket flow threw exception", ex)
+                }
               } else {
                 logger.debug("WebSocket flow threw exception after the WebSocket was closed", ex)
               }


### PR DESCRIPTION
This makes WebSocket close handling match the documented intent of `WebSocketCloseException` and fixes related typed JSON close behavior.

`WebSocketCloseException` is documented as a way to close a WebSocket with a specific close message:

https://github.com/playframework/playframework/blob/7970232f79a1f951721c7883043918839951e41f/core/play/src/main/scala/play/api/http/websocket/Message.scala#L61-L66

Before this change, that intent was not preserved consistently. Some close messages produced by application code or typed WebSocket transformers could be handled as generic stream termination instead of becoming the intended WebSocket Close frame.

## Fixed behavior

- `WebSocketCloseException(CloseMessage(...))` from an application source now closes with the embedded `CloseMessage`.
- Scala typed JSON validation failures now close with status `1003`.
- Java typed JSON decoding failures still close with status `1003`, but now use a bounded generic close reason instead of the raw Jackson exception message.

## Notes

RFC 6455 limits WebSocket control-frame payloads to 125 bytes. Close frames with a status code use 2 bytes for the code, leaving at most 123 bytes for the UTF-8 close reason. Raw Jackson exception messages can exceed that limit and produce invalid Close frames.
