### PR TITLE
Make WebSocket Close frame serialization RFC-compliant

### DIFF
--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -85,3 +85,20 @@ Java
 : @[typed-json-decoding](code/WebSocketCloseMigration.java)
 
 This avoids creating invalid WebSocket Close frames: [RFC 6455 section 5.5](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5) limits all control frame payloads, including Close frames, to 125 bytes, and [section 5.5.1](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1) defines the first two bytes of a Close frame body as the status code, leaving at most 123 bytes for the UTF-8 reason.
+
+### WebSocket Close frame handling is more RFC-compliant
+
+Play now normalizes additional WebSocket Close frame edge cases in the common WebSocket flow handler. These changes keep application-visible close status reporting compatible where possible, while avoiding invalid Close frames on the wire.
+
+[RFC 6455 section 5.5](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5) limits WebSocket control frames to 125 bytes. [Section 5.5.1](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1) defines Close frame payloads as an optional 2-byte status code followed by an optional UTF-8 reason. [Section 7.4.1](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1) defines status codes such as `1005`, `1006`, and `1015` as reserved values that must not be sent as status codes in a Close control frame.
+
+| **Case** | **Previous behavior** | **New behavior** |
+| --- | --- | --- |
+| Play echoes an empty Close frame from the remote peer | Play could represent the echoed frame as `CloseMessage(Some(1005), "")`. | Play sends an empty Close frame, represented as `CloseMessage(None, "")`, so `1005` is not sent on the wire. |
+| Application code sends `CloseMessage(Some(1005), "")` | Play could pass `1005` toward the backend as a status code. | Play sends an empty Close frame, represented as `CloseMessage(None, "")`. |
+| Application code sends a reserved or invalid close status code, such as `1006` or `999` | Play sent the status code unchanged. | Play still sends the status code unchanged for compatibility, but logs a warning because the value is not valid in a Close frame. |
+| Application code sends a Close reason that cannot be encoded as UTF-8 | Play could pass the reason toward the backend unchanged. | Play logs a warning and drops the reason. |
+| Application code sends a Close reason longer than 123 UTF-8 bytes | Play could pass an invalid oversized Close frame toward the backend. | Play logs a warning and truncates the reason to the longest valid UTF-8 prefix that fits in 123 bytes. |
+| Application code sends `CloseMessage(None, "reason")` | The close reason had no valid wire encoding because Close reasons require a status code. | Play logs a warning and sends `CloseMessage(None, "")`, dropping the reason. |
+
+Applications that create raw `CloseMessage` values should avoid sending reserved status codes such as `1005`, `1006`, and `1015`, and should keep Close reasons short enough to fit in 123 UTF-8 bytes.

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -4,6 +4,12 @@
 
 package play.core.server.common
 
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
+import java.nio.ByteBuffer
+import java.nio.CharBuffer
+
 import scala.concurrent.duration._
 
 import org.apache.pekko.stream._
@@ -103,19 +109,21 @@ object WebSocketFlowHandler {
         // The lowest priority is pong messages.
 
         def serverInitiatedClose(close: CloseMessage) = {
+          val closeToSend = toValidCloseFrame(close)
+
           // Cancel appIn, because we must not send any more messages once we initiate a close.
           cancel(appIn)
 
           if (state == Open || state.isInstanceOf[ServerInitiatingClose]) {
             if (isAvailable(remoteOut)) {
               state = ServerInitiatedClose
-              push(remoteOut, close)
+              push(remoteOut, closeToSend)
               // If appOut is closed, then we may need to do our own pull so that we can get the ack
               if (isClosed(appOut) && !isClosed(remoteIn) && !hasBeenPulled(remoteIn)) {
                 pull(remoteIn)
               }
             } else {
-              state = ServerInitiatingClose(close)
+              state = ServerInitiatingClose(closeToSend)
             }
           } else {
             // Initiating close when we've already sent a close message means we must have encountered an error in
@@ -303,7 +311,7 @@ object WebSocketFlowHandler {
                         // This is a client initiated close, so send back
                         if (isAvailable(remoteOut)) {
                           // We can send the close frame
-                          push(remoteOut, close)
+                          push(remoteOut, toValidCloseFrame(close))
                           // And complete both remote out and remote in
                           complete(remoteOut)
                           cancel(remoteIn)
@@ -379,7 +387,7 @@ object WebSocketFlowHandler {
               state match {
                 case ClientInitiatedClose(close) =>
                   // Acknowledge the client close, and then complete
-                  push(remoteOut, close)
+                  push(remoteOut, toValidCloseFrame(close))
                   completeStage()
                 case ServerInitiatingClose(close) =>
                   // If there is a buffered message, send that first
@@ -451,6 +459,88 @@ object WebSocketFlowHandler {
       invalid("close code must be length 2 but was 1")
     } else {
       CloseMessage(CloseCodes.NoStatus)
+    }
+  }
+
+  private def toValidCloseFrame(close: CloseMessage): CloseMessage = {
+    close.statusCode match {
+      case Some(CloseCodes.NoStatus) if close.reason.isEmpty =>
+        CloseMessage(None)
+      case Some(code) =>
+        invalidCloseStatusCodeReason(code).foreach { reason =>
+          logger.warn(s"Application sent WebSocket close frame with invalid status code $code: $reason")
+        }
+        CloseMessage(Some(code), toValidCloseReason(close.reason))
+      case None if close.reason.isEmpty =>
+        close
+      case None =>
+        logger.warn("Application sent WebSocket close frame with a reason but no status code; dropping close reason")
+        CloseMessage(None)
+    }
+  }
+
+  private def invalidCloseStatusCodeReason(code: Int): Option[String] = {
+    code match {
+      case CloseCodes.NoStatus =>
+        Some("close code 1005 must not be sent")
+      case CloseCodes.ConnectionAbort =>
+        Some("close code 1006 must not be sent")
+      case CloseCodes.TLSHandshakeFailure =>
+        Some("close code 1015 must not be sent")
+      case 1004 =>
+        Some("close code 1004 is reserved")
+      case code if code < 1000 || code >= 5000 =>
+        Some(s"close code must be between 1000 and 4999 but was $code")
+      case _ =>
+        None
+    }
+  }
+
+  private def toValidCloseReason(reason: String): String = {
+    encodeUtf8(reason) match {
+      case Left(reason) =>
+        logger.warn(s"Application sent WebSocket close frame with invalid close reason: $reason; dropping close reason")
+        ""
+      case Right(bytes) if bytes.remaining() > 123 =>
+        logger.warn(
+          s"Application sent WebSocket close reason longer than 123 UTF-8 bytes (${bytes.remaining()} bytes); truncating close reason"
+        )
+        truncateUtf8(reason, 123)
+      case Right(_) =>
+        reason
+    }
+  }
+
+  private def truncateUtf8(value: String, maxBytes: Int): String = {
+    val builder = new StringBuilder
+    var index   = 0
+    var bytes   = 0
+
+    while (index < value.length) {
+      val codePoint = value.codePointAt(index)
+      val chars     = new String(Character.toChars(codePoint))
+      val charBytes = chars.getBytes(StandardCharsets.UTF_8).length
+      if (bytes + charBytes > maxBytes) {
+        return builder.toString
+      }
+      builder.append(chars)
+      bytes += charBytes
+      index += Character.charCount(codePoint)
+    }
+
+    builder.toString
+  }
+
+  private def encodeUtf8(value: String): Either[String, ByteBuffer] = {
+    val encoder = StandardCharsets.UTF_8
+      .newEncoder()
+      .onMalformedInput(CodingErrorAction.REPORT)
+      .onUnmappableCharacter(CodingErrorAction.REPORT)
+
+    try {
+      Right(encoder.encode(CharBuffer.wrap(value)))
+    } catch {
+      case _: CharacterCodingException => Left("close reason must be valid UTF-8")
     }
   }
 }

--- a/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
@@ -48,11 +48,57 @@ class WebSocketFlowHandlerSpec extends Specification {
       messages must contain(exactly(closeMessage(CloseCodes.GoingAway)))
     }
 
+    "parse an empty close frame as application-visible 1005" in {
+      WebSocketFlowHandler.parseCloseMessage(ByteString.empty) must beEqualTo(CloseMessage(CloseCodes.NoStatus))
+    }
+
+    "preserve a remote close frame with a reserved status code for application visibility" in {
+      WebSocketFlowHandler.parseCloseMessage(rawCloseData(CloseCodes.ConnectionAbort)) must beEqualTo(
+        CloseMessage(CloseCodes.ConnectionAbort)
+      )
+    }
+
+    "preserve a remote close frame with an invalid status code range for application visibility" in {
+      WebSocketFlowHandler.parseCloseMessage(rawCloseData(999)) must beEqualTo(CloseMessage(999))
+    }
+
     "send 1006 after remote input completes even when the application has no immediate demand" in withActorSystem {
       implicit materializer =>
         val messages = runCompletedRemoteInputWithoutInitialAppDemand()
 
         messages must contain(exactly(closeMessage(CloseCodes.ConnectionAbort)))
+    }
+
+    "send a reserved application close status code to the remote peer" in withActorSystem { implicit materializer =>
+      val message = runAppClose(CloseMessage(CloseCodes.ConnectionAbort))
+
+      message must beEqualTo(CloseMessage(CloseCodes.ConnectionAbort))
+    }
+
+    "truncate an oversized application close reason before sending it to the remote peer" in withActorSystem {
+      implicit materializer =>
+        val message = runAppClose(CloseMessage(CloseCodes.Regular, "x" * 124))
+
+        message must beEqualTo(CloseMessage(CloseCodes.Regular, "x" * 123))
+    }
+
+    "truncate an oversized application close reason to a valid UTF-8 prefix" in withActorSystem {
+      implicit materializer =>
+        val message = runAppClose(CloseMessage(CloseCodes.Regular, ("x" * 122) + "\u20ac"))
+
+        message must beEqualTo(CloseMessage(CloseCodes.Regular, "x" * 122))
+    }
+
+    "drop an application close reason when no close status code is sent" in withActorSystem { implicit materializer =>
+      val message = runAppClose(CloseMessage(None, "reason"))
+
+      message must beEqualTo(CloseMessage(None))
+    }
+
+    "echo an empty remote close frame without serializing 1005" in withActorSystem { implicit materializer =>
+      val (_, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(rawClose(None))
+
+      remoteMessages must contain(exactly(beEqualTo(CloseMessage(None))))
     }
   }
 
@@ -76,13 +122,49 @@ class WebSocketFlowHandlerSpec extends Specification {
       remoteIn: Source[WebSocketFlowHandler.RawMessage, ?],
       appIn: Source[Message, ?]
   )(implicit materializer: Materializer): Seq[Message] = {
+    runRemoteInputAndCollectAppAndRemoteMessages(remoteIn, appIn)._1
+  }
+
+  private def runRemoteInputAndCollectAppAndRemoteMessages(
+      remoteIn: Source[WebSocketFlowHandler.RawMessage, ?],
+      appIn: Source[Message, ?] = Source.maybe[Message]
+  )(implicit materializer: Materializer): (Seq[Message], Seq[Message]) = {
     val appFlow = Flow.fromSinkAndSourceMat(Sink.seq[Message], appIn)(Keep.left)
     val flow    = protocol.joinMat(appFlow)(Keep.right)
 
-    val (appMessages, remoteOutDone) = remoteIn.viaMat(flow)(Keep.right).toMat(Sink.ignore)(Keep.both).run()
+    val (appMessages, remoteMessages) = remoteIn.viaMat(flow)(Keep.right).toMat(Sink.seq[Message])(Keep.both).run()
 
-    awaitRemoteOut(remoteOutDone)
+    (Await.result(appMessages, 5.seconds), Await.result(remoteMessages, 5.seconds))
+  }
+
+  private def runRemoteInputAndCollectAppAndRemoteMessages(
+      messages: WebSocketFlowHandler.RawMessage*
+  )(implicit materializer: Materializer): (Seq[Message], Seq[Message]) = {
+    runRemoteInputAndCollectAppAndRemoteMessages(Source(messages.toList))
+  }
+
+  private def runAppClose(close: CloseMessage)(implicit materializer: Materializer): Message = {
+    val appFlow = Flow.fromSinkAndSourceMat(
+      Sink.seq[Message],
+      Source.single(close)
+    )(Keep.left)
+    val flow = protocol.joinMat(appFlow)(Keep.right)
+
+    val ((remoteIn, appMessages), remoteMessage) =
+      Source
+        .queue[WebSocketFlowHandler.RawMessage](1)
+        .viaMat(flow)(Keep.both)
+        .toMat(Sink.head[Message])(Keep.both)
+        .run()
+
+    val closeSent = Await.result(remoteMessage, 5.seconds)
+    try {
+      remoteIn.fail(new RuntimeException("connection failed"))
+    } catch {
+      case _: IllegalStateException =>
+    }
     Await.result(appMessages, 5.seconds)
+    closeSent
   }
 
   private def runAppInitiatedCloseThenFailedRemoteInput()(implicit materializer: Materializer): Seq[Message] = {
@@ -129,11 +211,19 @@ class WebSocketFlowHandlerSpec extends Specification {
     )
 
   private def rawClose(statusCode: Int): WebSocketFlowHandler.RawMessage = {
+    rawClose(Some(statusCode))
+  }
+
+  private def rawClose(statusCode: Option[Int]): WebSocketFlowHandler.RawMessage = {
     WebSocketFlowHandler.RawMessage(
       WebSocketFlowHandler.MessageType.Close,
-      ByteString((statusCode >> 8).toByte, statusCode.toByte),
+      statusCode.fold(ByteString.empty)(rawCloseData),
       isFinal = true
     )
+  }
+
+  private def rawCloseData(statusCode: Int): ByteString = {
+    ByteString((statusCode >> 8).toByte, statusCode.toByte)
   }
 
   private def awaitRemoteOut(done: Future[Done]): Unit = {


### PR DESCRIPTION
This improves WebSocket Close frame handling in Play’s common WebSocket flow handler.

`CloseMessage` can represent application-visible close states such as `1005` / no status, but RFC 6455 reserves some status codes and limits Close frame payloads. Before this change, Play could pass some invalid Close frame shapes toward the backend.

## Changes

- Convert `CloseMessage(Some(1005), "")` to `CloseMessage(None, "")` before sending it on the wire.
- Echo empty remote Close frames as empty Close frames instead of serializing `1005`.
- Keep reserved or invalid application-provided close codes unchanged for compatibility, but log a warning.
- Truncate application-provided Close reasons longer than 123 UTF-8 bytes.
- Drop application-provided Close reasons that cannot be encoded as UTF-8.
- Drop Close reasons when application code sends `CloseMessage(None, reason)`, because a reason without a status code has no valid wire encoding.

## Notes

RFC 6455 limits WebSocket control-frame payloads to 125 bytes. Close frames use 2 bytes for the status code, leaving at most 123 bytes for the UTF-8 reason.

The change intentionally preserves received close status codes for application visibility, including values such as `1006` or otherwise invalid codes reported by the backend. The compatibility-oriented behavior change is only on what Play sends toward the remote peer.
