### PR TITLE
Use unshaded Guice with explicit ASM dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -130,9 +130,12 @@ object Dependencies {
   ).map(_ % Test)
 
   val guiceVersion = "7.0.0"
+  val asmVersion   = "9.10.1"
   val guiceDeps    = Seq(
-    "com.google.inject"            % "guice"                % guiceVersion,
-    "com.google.inject.extensions" % "guice-assistedinject" % guiceVersion
+    ("com.google.inject" % "guice" % guiceVersion).classifier("classes"),
+    // Keep assistedinject from pulling the default shaded Guice jar alongside the unshaded classes classifier.
+    ("com.google.inject.extensions" % "guice-assistedinject" % guiceVersion).exclude("com.google.inject", "guice"),
+    "org.ow2.asm"                   % "asm"                  % asmVersion
   )
 
   def runtime(scalaVersion: String) =


### PR DESCRIPTION
This switches Play’s Guice dependency to the `classes` classifier and adds an explicit ASM dependency.

Context:

- Play discussion: https://github.com/orgs/playframework/discussions/14037
- Guice issue: https://github.com/google/guice/issues/1926
- Similar downstream workaround: https://github.com/fieldenms/tg/commit/c4cdd7c62157719301ad929d675ac43c08c0d3f4

Guice 7.0.0 shades ASM 9.5 into its default jar. That isolates Guice from application classpaths, but it also means Play cannot pick up newer ASM support without a new Guice release. The `classes` classifier contains Guice’s original unshaded classes, so Play can provide a current ASM version directly.

This should be safe because Guice’s ASM usage is narrow and uses stable ASM APIs: class reading for source/line metadata and bytecode generation for AOP/fast-class support. The generated bytecode still targets Java 8, and Guice only needs `org.ow2.asm:asm`, not the wider ASM family. Adding ASM explicitly keeps dependency mediation under Play’s control.

`guice-assistedinject` still depends on the default Guice artifact, so this change excludes that transitive dependency to avoid putting both the shaded default jar and the unshaded `classes` jar on the classpath.

The advantage is that Play can update ASM independently of Guice when newer Java classfile versions need support, while keeping the dependency change small and explicit.
