### PR TITLE
Revert temporary commits that make Pekko snapshots work

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation-java/build.gradle.kts.ftlh
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation-java/build.gradle.kts.ftlh
@@ -5,7 +5,6 @@ plugins {
 repositories {
   mavenCentral()
   mavenLocal()
-  maven("https://repository.apache.org/snapshots/")
 }
 
 sourceSets {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/build.gradle.kts.ftlh
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-routes-compilation/build.gradle.kts.ftlh
@@ -5,7 +5,6 @@ plugins {
 repositories {
   mavenCentral()
   mavenLocal()
-  maven("https://repository.apache.org/snapshots/")
 }
 
 sourceSets {

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -32,7 +32,11 @@ object ScriptedTools extends AutoPlugin {
     // the snapshot resolvers in `cron` builds.
     // If this is a scheduled GitHub Action
     // https://docs.github.com/en/actions/learn-github-actions/environment-variables
-    resolvers += Resolver.ApacheMavenSnapshotsRepo
+    resolvers ++= sys.env
+      .get("GITHUB_EVENT_NAME")
+      .filter(_.equalsIgnoreCase("schedule"))
+      .map(_ => Resolver.ApacheMavenSnapshotsRepo) // contains pekko(-http) snapshots
+      .toSeq
   )
 
   def scalaVersionFromJavaProperties() =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ import Keys._
 
 object Dependencies {
   val pekkoVersion: String = sys.props.getOrElse("pekko.version", "2.0.0-M3")
-  val pekkoHttpVersion     = sys.props.getOrElse("pekko.http.version", "2.0.0-M1+197-d53065af-SNAPSHOT")
+  val pekkoHttpVersion     = sys.props.getOrElse("pekko.http.version", "2.0.0-M1")
 
   val playJsonVersion = "3.1.0-M10"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ import Keys._
 
 object Dependencies {
   val pekkoVersion: String = sys.props.getOrElse("pekko.version", "2.0.0-M3")
-  val pekkoHttpVersion     = sys.props.getOrElse("pekko.http.version", "2.0.0-M1")
+  val pekkoHttpVersion     = sys.props.getOrElse("pekko.http.version", "2.0.0-M2")
 
   val playJsonVersion = "3.1.0-M10"
 

--- a/project/PlayBuildBase.scala
+++ b/project/PlayBuildBase.scala
@@ -62,7 +62,7 @@ object PlayBuildBase extends AutoPlugin {
     javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
     resolvers ++= {
       if (isSnapshot.value) {
-        Seq(Resolver.sonatypeCentralSnapshots, Resolver.ApacheMavenSnapshotsRepo)
+        Seq(Resolver.sonatypeCentralSnapshots)
       } else {
         Nil
       }


### PR DESCRIPTION
- Temporary introduced in #14065
  - Using snapshots currently so new features (like websocket compression) can be implemented