### PR TITLE
[2.9.x] sbt-ci-release 0.12.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,7 +31,7 @@ addSbtPlugin("com.github.sbt"     % "sbt-java-formatter"    % sbtJavaFormatter)
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"               % sbtJmh)
 addSbtPlugin("com.github.sbt"     % "sbt-header"            % sbtHeader)
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"          % scalafmt)
-addSbtPlugin("com.github.sbt"     % "sbt-ci-release"        % "1.11.2")
+addSbtPlugin("com.github.sbt"     % "sbt-ci-release"        % "1.12.0")
 
 addSbtPlugin("com.markatta" % "sbt-akka-version-check" % "0.4")
 


### PR DESCRIPTION
Removes sbt-git dependency - works out of the box with git worktrees
