### PR TITLE
Trust a single X-Forwarded-Proto when X-Forwarded-For has more than one entry (opt-in)

### DIFF
--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -92,6 +92,13 @@ play {
       # you need to trust all IP addresses, therefore making it possible for clients to spoof the incoming address.
       # To trust all IP addresses, set this to ["0.0.0.0/0", "::/0"].
       trustedProxies = ["127.0.0.1", "::1"]
+
+      # Only applies to the x-forwarded version. When multiple proxies grow X-Forwarded-For but only the
+      # outermost one sets a single X-Forwarded-Proto value (a common setup), the number of entries in the
+      # two headers differs and, by default, the protocol information is discarded and the connection is
+      # treated as insecure. When set to true, a single X-Forwarded-Proto value is associated with the
+      # client address instead. Only enable this if the outermost trusted proxy is known to set it.
+      trustSingleForwardedProto = false
     }
 
     # Parsing configuration

--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -98,7 +98,7 @@ play {
       # two headers differs and, by default, the protocol information is discarded and the connection is
       # treated as insecure. When set to true, a single X-Forwarded-Proto value is associated with the
       # client address instead. Only enable this if the outermost trusted proxy is known to set it.
-      trustSingleForwardedProto = false
+      trustSingleXForwardedProto = false
     }
 
     # Parsing configuration

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -6,6 +6,18 @@ This section highlights the new features of Play 3.1. If you want to learn about
 
 ## Other Additions
 
+### Trusting Single X-Forwarded-Proto Values
+
+Play can now be configured to trust a single `X-Forwarded-Proto` value when `X-Forwarded-For` contains multiple addresses:
+
+```hocon
+play.http.forwarded.trustSingleXForwardedProto = true
+```
+
+This helps deployments where trusted proxy chains append to `X-Forwarded-For`, but the edge proxy sets one `X-Forwarded-Proto` value for the original client request. The setting is disabled by default and only applies to `play.http.forwarded.version = "x-forwarded"`.
+
+Only enable it when the trusted edge proxy overwrites or strips any incoming client-supplied `X-Forwarded-Proto` header before setting the correct value.
+
 ### WebSocket Compression
 
 The Play Pekko HTTP and Netty server backends now support WebSocket compression using the RFC 7692 `permessage-deflate` extension.

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -190,3 +190,17 @@ This is configured using `play.http.forwarded.version`, with valid values being 
 `x-forwarded` uses the de facto standard `X-Forwarded-For` and `X-Forwarded-Proto` headers to determine the correct remote address and protocol for the request. These headers are widely used, however, they have some serious limitations, for example, if you have multiple proxies, and only one of them adds the `X-Forwarded-Proto` header, it's impossible to reliably determine which proxy added it and therefore whether the request from the client was made using https or http. `rfc7239` uses the new `Forwarded` header standard, and solves many of the limitations of the `X-Forwarded-*` headers.
 
 For more information, please read the [RFC 7239](https://tools.ietf.org/html/rfc7239) specification.
+
+### Trusting a single X-Forwarded-Proto value
+
+Some proxy chains append to `X-Forwarded-For`, but set a single `X-Forwarded-Proto` value. In that case, Play cannot normally match each forwarded address to a protocol value, so it discards the protocol information and treats the forwarded connection as insecure.
+
+If your trusted edge proxy is known to set `X-Forwarded-Proto` to the protocol used by the original client request, you can enable:
+
+```
+play.http.forwarded.trustSingleXForwardedProto = true
+```
+
+This setting only applies when `play.http.forwarded.version = "x-forwarded"`. It associates a single `X-Forwarded-Proto` value with the client address from `X-Forwarded-For`. It does not apply to RFC 7239 `Forwarded` headers, and it does not use `X-Forwarded-Proto` when `X-Forwarded-For` is absent.
+
+Only enable this when your trusted edge proxy overwrites or removes any incoming client-supplied `X-Forwarded-Proto` header before setting the correct value. Otherwise, clients may be able to spoof whether a request was secure.

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -316,7 +316,7 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.this"),
       ProblemFilters.exclude[MissingTypesProblem]("play.filters.https.RedirectHttpsConfiguration$"),
-      // Add trustSingleForwardedProto to ForwardedHeaderHandlerConfig
+      // Add trustSingleXForwardedProto to ForwardedHeaderHandlerConfig
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "play.core.server.common.ForwardedHeaderHandler#ForwardedHeaderHandlerConfig.apply"
       ),

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -316,6 +316,16 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.filters.https.RedirectHttpsConfiguration.this"),
       ProblemFilters.exclude[MissingTypesProblem]("play.filters.https.RedirectHttpsConfiguration$"),
+      // Add trustSingleForwardedProto to ForwardedHeaderHandlerConfig
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ForwardedHeaderHandlerConfig.apply"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ForwardedHeaderHandlerConfig.copy"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ForwardedHeaderHandlerConfig.this"
+      ),
       // Switch to Jakarta DI
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.http.DefaultHttpErrorHandler.this"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.http.DefaultHttpRequestHandler.this"),

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -34,9 +34,11 @@ import ForwardedHeaderHandler._
  *    immediate connection info and don't do any further processing.
  *
  * Each address is associated with a secure or insecure protocol by pairing
- * it with a `proto` entry in the headers. If the `proto` entry is missing or
- * if `proto` entries can't be matched with addresses, then the default is
- * insecure.
+ * it with a `proto` entry in the headers. If the `proto` entry is missing, or if
+ * `proto` entries can't be matched with addresses, then the default is insecure.
+ * When `play.http.forwarded.trustSingleForwardedProto` is enabled, a lone
+ * `X-Forwarded-Proto` entry is associated with the client address instead of
+ * being discarded.
  *
  * It is configured by two configuration options:
  * <dl>
@@ -146,7 +148,11 @@ private[server] object ForwardedHeaderHandler {
    */
   final case class ParsedForwardedEntry(address: InetAddress, secure: Boolean)
 
-  case class ForwardedHeaderHandlerConfig(version: ForwardedHeaderVersion, trustedProxies: List[Subnet]) {
+  case class ForwardedHeaderHandlerConfig(
+      version: ForwardedHeaderVersion,
+      trustedProxies: List[Subnet],
+      trustSingleForwardedProto: Boolean = false
+  ) {
     val nodeIdentifierParser = new NodeIdentifierParser(version)
 
     /**
@@ -197,6 +203,14 @@ private[server] object ForwardedHeaderHandler {
         if (forHeaders.length == protoHeaders.length) {
           forHeaders.lazyZip(protoHeaders).map { (f, p) =>
             ForwardedEntry(Some(f), Some(p))
+          }
+        } else if (trustSingleForwardedProto && protoHeaders.length == 1) {
+          // A single X-Forwarded-Proto entry describes the protocol the client used to reach
+          // the outermost proxy. Associate it with the client (the first X-Forwarded-For
+          // entry); the remaining entries are left without a protocol.
+          forHeaders.zipWithIndex.map {
+            case (f, 0) => ForwardedEntry(Some(f), protoHeaders.headOption)
+            case (f, _) => ForwardedEntry(Some(f), None)
           }
         } else {
           // If the lengths vary, then discard the protoHeaders because we can't tell which
@@ -252,7 +266,11 @@ private[server] object ForwardedHeaderHandler {
         case _             => throw config.reportError("version", "Forwarded header version must be either x-forwarded or rfc7239")
       }
 
-      ForwardedHeaderHandlerConfig(version, config.get[Seq[String]]("trustedProxies").map(Subnet.apply).toList)
+      ForwardedHeaderHandlerConfig(
+        version,
+        config.get[Seq[String]]("trustedProxies").map(Subnet.apply).toList,
+        config.getOptional[Boolean]("trustSingleForwardedProto").getOrElse(false)
+      )
     }
   }
 }

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -36,7 +36,7 @@ import ForwardedHeaderHandler._
  * Each address is associated with a secure or insecure protocol by pairing
  * it with a `proto` entry in the headers. If the `proto` entry is missing, or if
  * `proto` entries can't be matched with addresses, then the default is insecure.
- * When `play.http.forwarded.trustSingleForwardedProto` is enabled, a lone
+ * When `play.http.forwarded.trustSingleXForwardedProto` is enabled, a lone
  * `X-Forwarded-Proto` entry is associated with the client address instead of
  * being discarded.
  *
@@ -151,7 +151,7 @@ private[server] object ForwardedHeaderHandler {
   case class ForwardedHeaderHandlerConfig(
       version: ForwardedHeaderVersion,
       trustedProxies: List[Subnet],
-      trustSingleForwardedProto: Boolean = false
+      trustSingleXForwardedProto: Boolean = false
   ) {
     val nodeIdentifierParser = new NodeIdentifierParser(version)
 
@@ -204,7 +204,7 @@ private[server] object ForwardedHeaderHandler {
           forHeaders.lazyZip(protoHeaders).map { (f, p) =>
             ForwardedEntry(Some(f), Some(p))
           }
-        } else if (trustSingleForwardedProto && protoHeaders.length == 1) {
+        } else if (trustSingleXForwardedProto && forHeaders.nonEmpty && protoHeaders.length == 1) {
           // A single X-Forwarded-Proto entry describes the protocol the client used to reach
           // the outermost proxy. Associate it with the client (the first X-Forwarded-For
           // entry); the remaining entries are left without a protocol.
@@ -269,7 +269,7 @@ private[server] object ForwardedHeaderHandler {
       ForwardedHeaderHandlerConfig(
         version,
         config.get[Seq[String]]("trustedProxies").map(Subnet.apply).toList,
-        config.getOptional[Boolean]("trustSingleForwardedProto").getOrElse(false)
+        config.getOptional[Boolean]("trustSingleXForwardedProto").getOrElse(false)
       )
     }
   }

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -359,9 +359,19 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("203.0.113.43", false, None)
     }
 
-    "associate a single x-forwarded-proto with the client when trustSingleForwardedProto is enabled" in {
+    "assume http protocol with x-forwarded when proto list is shorter than for list and all addresses are trusted" in {
       remoteConnectionToLocalhost(
-        version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1") ++ trustSingleForwardedProto(true),
+        version("x-forwarded") ++ trustedProxies("0.0.0.0/0"),
+        """
+          |X-Forwarded-For: 203.0.113.43, 192.168.1.43
+          |X-Forwarded-Proto: https
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "associate a single x-forwarded-proto with the client when trustSingleXForwardedProto is enabled" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1") ++ trustSingleXForwardedProto(true),
         """
           |X-Forwarded-For: 203.0.113.43, 192.168.1.43
           |X-Forwarded-Proto: https
@@ -369,9 +379,9 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("203.0.113.43", true, None)
     }
 
-    "associate a single x-forwarded-proto with the client when trustSingleForwardedProto is enabled and all addresses are trusted" in {
+    "associate a single x-forwarded-proto with the client when trustSingleXForwardedProto is enabled and all addresses are trusted" in {
       remoteConnectionToLocalhost(
-        version("x-forwarded") ++ trustedProxies("0.0.0.0/0") ++ trustSingleForwardedProto(true),
+        version("x-forwarded") ++ trustedProxies("0.0.0.0/0") ++ trustSingleXForwardedProto(true),
         """
           |X-Forwarded-For: 203.0.113.43, 192.168.1.43
           |X-Forwarded-Proto: https
@@ -379,14 +389,53 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("203.0.113.43", true, None)
     }
 
-    "assume http protocol with x-forwarded when proto list has multiple entries shorter than for list even when trustSingleForwardedProto is enabled" in {
+    "associate a single x-forwarded-proto with the client when multiple forwarded-for entries are trusted" in {
       remoteConnectionToLocalhost(
-        version("x-forwarded") ++ trustedProxies("0.0.0.0/0") ++ trustSingleForwardedProto(true),
+        version("x-forwarded") ++ trustedProxies("0.0.0.0/0") ++ trustSingleXForwardedProto(true),
+        """
+          |X-Forwarded-For: 203.0.113.43, 192.168.1.43, 192.168.1.44
+          |X-Forwarded-Proto: https
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", true, None)
+    }
+
+    "stop at an untrusted proxy when trustSingleXForwardedProto is enabled" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1") ++ trustSingleXForwardedProto(true),
+        """
+          |X-Forwarded-For: 203.0.113.43, 198.51.100.17, 192.168.1.43
+          |X-Forwarded-Proto: https
+        """.stripMargin
+      ) mustEqual RemoteConnection("198.51.100.17", false, None)
+    }
+
+    "assume http protocol with x-forwarded when proto list has multiple entries shorter than for list even when trustSingleXForwardedProto is enabled" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("0.0.0.0/0") ++ trustSingleXForwardedProto(true),
         """
           |X-Forwarded-For: 203.0.113.43, 192.168.1.43, 192.168.1.44
           |X-Forwarded-Proto: https, https
         """.stripMargin
       ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "not apply trustSingleXForwardedProto to rfc7239 forwarded headers" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1") ++ trustSingleXForwardedProto(true),
+        """
+          |Forwarded: for=203.0.113.43
+          |Forwarded: for=192.168.1.43;proto=https
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "ignore single x-forwarded-proto when x-forwarded-for is missing even when trustSingleXForwardedProto is enabled" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1") ++ trustSingleXForwardedProto(true),
+        """
+          |X-Forwarded-Proto: https
+        """.stripMargin
+      ) mustEqual RemoteConnection(localhost, false, None)
     }
 
     "assume http protocol with x-forwarded when proto list is longer than for list" in {
@@ -519,8 +568,8 @@ class ForwardedHeaderHandlerSpec extends Specification {
     Map("play.http.forwarded.trustedProxies" -> s)
   }
 
-  def trustSingleForwardedProto(b: Boolean) = {
-    Map("play.http.forwarded.trustSingleForwardedProto" -> b)
+  def trustSingleXForwardedProto(b: Boolean) = {
+    Map("play.http.forwarded.trustSingleXForwardedProto" -> b)
   }
 
   def headers(s: String): Headers = {

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -359,12 +359,32 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("203.0.113.43", false, None)
     }
 
-    "assume http protocol with x-forwarded when proto list is shorter than for list and all addresses are trusted" in {
+    "associate a single x-forwarded-proto with the client when trustSingleForwardedProto is enabled" in {
       remoteConnectionToLocalhost(
-        version("x-forwarded") ++ trustedProxies("0.0.0.0/0"),
+        version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1") ++ trustSingleForwardedProto(true),
         """
           |X-Forwarded-For: 203.0.113.43, 192.168.1.43
           |X-Forwarded-Proto: https
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", true, None)
+    }
+
+    "associate a single x-forwarded-proto with the client when trustSingleForwardedProto is enabled and all addresses are trusted" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("0.0.0.0/0") ++ trustSingleForwardedProto(true),
+        """
+          |X-Forwarded-For: 203.0.113.43, 192.168.1.43
+          |X-Forwarded-Proto: https
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", true, None)
+    }
+
+    "assume http protocol with x-forwarded when proto list has multiple entries shorter than for list even when trustSingleForwardedProto is enabled" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("0.0.0.0/0") ++ trustSingleForwardedProto(true),
+        """
+          |X-Forwarded-For: 203.0.113.43, 192.168.1.43, 192.168.1.44
+          |X-Forwarded-Proto: https, https
         """.stripMargin
       ) mustEqual RemoteConnection("203.0.113.43", false, None)
     }
@@ -497,6 +517,10 @@ class ForwardedHeaderHandlerSpec extends Specification {
 
   def trustedProxies(s: String*) = {
     Map("play.http.forwarded.trustedProxies" -> s)
+  }
+
+  def trustSingleForwardedProto(b: Boolean) = {
+    Map("play.http.forwarded.trustSingleForwardedProto" -> b)
   }
 
   def headers(s: String): Headers = {


### PR DESCRIPTION
## Fixes

Fixes #6845

## Purpose

With `play.http.forwarded.version = x-forwarded`, when `X-Forwarded-For` has more entries than `X-Forwarded-Proto`, the protocol is discarded and the connection is treated as insecure. Proxies commonly append to `X-Forwarded-For` while setting a single `X-Forwarded-Proto`, so `RequestHeader.secure` is `false` even when the client reached the outermost proxy over https.

## Background Context

Adds an opt-in `play.http.forwarded.trustSingleForwardedProto` (default `false`). When enabled, a single `X-Forwarded-Proto` value is associated with the client address (the first `X-Forwarded-For` entry) instead of being discarded. The default keeps the existing secure-by-default behaviour, and mismatches with more than one proto entry are still discarded. Only the `x-forwarded` version is affected.

Tests added in `ForwardedHeaderHandlerSpec`.