### PR TITLE
Expose remote connection port on `RequestHeader`

### DIFF
--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -233,6 +233,15 @@ public class Http {
     String remoteAddress();
 
     /**
+     * The client port, if known.
+     *
+     * @return the remote port
+     */
+    default Optional<Integer> remotePort() {
+      return Optional.empty();
+    }
+
+    /**
      * @return true if the client is using SSL
      */
     boolean secure();
@@ -1115,6 +1124,7 @@ public class Http {
           req.withConnection(
               RemoteConnection$.MODULE$.apply(
                   req.connection().remoteAddress(),
+                  req.connection().remotePort(),
                   secure,
                   req.connection().clientCertificateChain()));
       return this;
@@ -1333,6 +1343,15 @@ public class Http {
     }
 
     /**
+     * @return the remote port, if known
+     */
+    @SuppressWarnings("unchecked")
+    public Optional<Integer> remotePort() {
+      return (Optional<Integer>)
+          (Optional<?>) OptionConverters.toJava(req.connection().remotePort());
+    }
+
+    /**
      * @param remoteAddress sets the remote address
      * @return the builder instance
      */
@@ -1341,9 +1360,36 @@ public class Http {
           req.withConnection(
               RemoteConnection$.MODULE$.apply(
                   remoteAddress,
+                  req.connection().remotePort(),
                   req.connection().secure(),
                   req.connection().clientCertificateChain()));
       return this;
+    }
+
+    /**
+     * @param remotePort sets the remote port
+     * @return the builder instance
+     */
+    @SuppressWarnings("unchecked")
+    public RequestBuilder remotePort(Optional<Integer> remotePort) {
+      scala.Option<Object> scalaRemotePort =
+          (scala.Option<Object>) (scala.Option<?>) OptionConverters.toScala(remotePort);
+      req =
+          req.withConnection(
+              RemoteConnection$.MODULE$.apply(
+                  req.connection().remoteAddress(),
+                  scalaRemotePort,
+                  req.connection().secure(),
+                  req.connection().clientCertificateChain()));
+      return this;
+    }
+
+    /**
+     * @param remotePort sets the remote port
+     * @return the builder instance
+     */
+    public RequestBuilder remotePort(int remotePort) {
+      return remotePort(Optional.of(remotePort));
     }
 
     /**
@@ -1363,6 +1409,7 @@ public class Http {
           req.withConnection(
               RemoteConnection$.MODULE$.apply(
                   req.connection().remoteAddress(),
+                  req.connection().remotePort(),
                   req.connection().secure(),
                   OptionConverters.toScala(
                       Optional.ofNullable(Scala.asScala(clientCertificateChain)))));

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -116,6 +116,13 @@ trait RequestHeader {
   final def remoteAddress: String = connection.remoteAddressString
 
   /**
+   * The client port, if known.
+   *
+   * This method delegates to `connection.remotePort`.
+   */
+  final def remotePort: Option[Int] = connection.remotePort
+
+  /**
    * Is the client using SSL? This method delegates to `connection.secure`.
    */
   final def secure: Boolean = connection.secure

--- a/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
@@ -27,6 +27,11 @@ trait RemoteConnection {
   def remoteAddressString: String = remoteAddress.getHostAddress
 
   /**
+   * The remote client's port, if known.
+   */
+  def remotePort: Option[Int] = None
+
+  /**
    * Whether or not the connection was over a secure (e.g. HTTPS) connection.
    */
   def secure: Boolean
@@ -36,15 +41,19 @@ trait RemoteConnection {
    */
   def clientCertificateChain: Option[Seq[X509Certificate]]
 
-  override def toString: String = s"RemoteAddress($remoteAddressString, secure=$secure, certs=$clientCertificateChain)"
+  override def toString: String =
+    s"RemoteAddress($remoteAddressString, port=$remotePort, secure=$secure, certs=$clientCertificateChain)"
 
   override def equals(obj: scala.Any): Boolean = obj match {
     case that: RemoteConnection =>
       (this.remoteAddress == that.remoteAddress) &&
+      (this.remotePort == that.remotePort) &&
       (this.secure == that.secure) &&
       (this.clientCertificateChain == that.clientCertificateChain)
     case _ => false
   }
+
+  override def hashCode(): Int = (remoteAddress, remotePort, secure, clientCertificateChain).hashCode()
 }
 
 object RemoteConnection {
@@ -57,12 +66,26 @@ object RemoteConnection {
       secure: Boolean,
       clientCertificateChain: Option[Seq[X509Certificate]]
   ): RemoteConnection = {
+    apply(remoteAddressString, None, secure, clientCertificateChain)
+  }
+
+  /**
+   * Create a RemoteConnection object. The address string is parsed lazily.
+   */
+  def apply(
+      remoteAddressString: String,
+      remotePort: Option[Int],
+      secure: Boolean,
+      clientCertificateChain: Option[Seq[X509Certificate]]
+  ): RemoteConnection = {
     val s   = secure
     val ras = remoteAddressString
+    val rp  = remotePort
     val ccc = clientCertificateChain
     new RemoteConnection {
       override lazy val remoteAddress: InetAddress                      = InetAddresses.forString(ras)
       override val remoteAddressString: String                          = ras
+      override val remotePort: Option[Int]                              = rp
       override val secure: Boolean                                      = s
       override val clientCertificateChain: Option[Seq[X509Certificate]] = ccc
     }
@@ -76,11 +99,25 @@ object RemoteConnection {
       secure: Boolean,
       clientCertificateChain: Option[Seq[X509Certificate]]
   ): RemoteConnection = {
+    apply(remoteAddress, None, secure, clientCertificateChain)
+  }
+
+  /**
+   * Create a RemoteConnection object.
+   */
+  def apply(
+      remoteAddress: InetAddress,
+      remotePort: Option[Int],
+      secure: Boolean,
+      clientCertificateChain: Option[Seq[X509Certificate]]
+  ): RemoteConnection = {
     val s   = secure
     val ra  = remoteAddress
+    val rp  = remotePort
     val ccc = clientCertificateChain
     new RemoteConnection {
       override val remoteAddress: InetAddress                           = ra
+      override val remotePort: Option[Int]                              = rp
       override val secure: Boolean                                      = s
       override val clientCertificateChain: Option[Seq[X509Certificate]] = ccc
     }

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -100,6 +100,7 @@ trait JavaHelpers {
       r.withConnection(new RemoteConnection {
         override def remoteAddress: InetAddress                           = c.remoteAddress
         override def remoteAddressString: String                          = c.remoteAddressString
+        override def remotePort: Option[Int]                              = c.remotePort
         override def secure: Boolean                                      = newSecure
         override def clientCertificateChain: Option[Seq[X509Certificate]] = c.clientCertificateChain
       })
@@ -195,11 +196,14 @@ object JavaHelpers extends JavaHelpers {
 class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def asScala: RequestHeader = header
 
-  override def uri: String           = header.uri
-  override def method: String        = header.method
-  override def version: String       = header.version
-  override def remoteAddress: String = header.remoteAddress
-  override def secure: Boolean       = header.secure
+  override def uri: String                   = header.uri
+  override def method: String                = header.method
+  override def version: String               = header.version
+  override def remoteAddress: String         = header.remoteAddress
+  override def remotePort: Optional[Integer] = {
+    header.remotePort.map(Int.box).toJava
+  }
+  override def secure: Boolean = header.secure
 
   override def attrs: TypedMap                                                                   = new TypedMap(header.attrs)
   override def withAttrs(newAttrs: TypedMap): JRequestHeader                                     = header.withAttrs(newAttrs.asScala).asJava

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -30,6 +30,11 @@ class RequestHeaderSpec extends Specification {
         val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
         rh.asJava.headers.contains("host") must beTrue
       }
+      "keep the remote port" in {
+        val rh = dummyRequestHeader(remotePort = Some(12345))
+        rh.remotePort must beSome(12345)
+        rh.asJava.remotePort must beEqualTo(java.util.Optional.of(12345))
+      }
     }
 
     "have typed attributes" in {
@@ -231,10 +236,11 @@ class RequestHeaderSpec extends Specification {
       requestMethod: String = "GET",
       requestUri: String = "/",
       headers: Headers = Headers(),
-      attrs: TypedMap = TypedMap.empty
+      attrs: TypedMap = TypedMap.empty,
+      remotePort: Option[Int] = None
   ): RequestHeader = {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
-      connection = RemoteConnection("", false, None),
+      connection = RemoteConnection("", remotePort, false, None),
       method = requestMethod,
       target = RequestTarget(requestUri, "", Map.empty),
       version = "",

--- a/core/play/src/test/scala/play/api/mvc/request/RemoteConnectionSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/request/RemoteConnectionSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc.request
+
+import com.google.common.net.InetAddresses
+import org.specs2.mutable.Specification
+
+class RemoteConnectionSpec extends Specification {
+  "RemoteConnection" should {
+    "default to an unknown remote port" in {
+      RemoteConnection("127.0.0.1", secure = false, None).remotePort must beNone
+    }
+
+    "store the remote port when created from an address string" in {
+      RemoteConnection("127.0.0.1", Some(12345), secure = false, None).remotePort must beSome(12345)
+    }
+
+    "store the remote port when created from an inet address" in {
+      RemoteConnection(InetAddresses.forString("127.0.0.1"), Some(12345), secure = false, None).remotePort must beSome(
+        12345
+      )
+    }
+
+    "compare connections with the same remote port as equal" in {
+      RemoteConnection("127.0.0.1", Some(12345), secure = false, None) must beEqualTo(
+        RemoteConnection("127.0.0.1", Some(12345), secure = false, None)
+      )
+    }
+
+    "include the remote port when comparing connections" in {
+      RemoteConnection("127.0.0.1", Some(12345), secure = false, None) must not(
+        beEqualTo(RemoteConnection("127.0.0.1", Some(54321), secure = false, None))
+      )
+    }
+
+    "use the same hash code for equal connections" in {
+      RemoteConnection("127.0.0.1", Some(12345), secure = false, None).hashCode must_== RemoteConnection(
+        "127.0.0.1",
+        Some(12345),
+        secure = false,
+        None
+      ).hashCode
+    }
+  }
+}

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -188,12 +188,13 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       version: String = "HTTP/1.1",
       id: Long = 666,
       secure: Boolean = false,
+      remotePort: Option[Int] = None,
       clientCertificateChain: Option[Seq[X509Certificate]] = None,
       attrs: TypedMap = TypedMap.empty
   ): FakeRequest[A] = {
     val _uri                = uri
     val request: Request[A] = requestFactory.createRequest(
-      RemoteConnection(remoteAddress, secure, clientCertificateChain),
+      RemoteConnection(remoteAddress, remotePort, secure, clientCertificateChain),
       method,
       new RequestTarget {
         override lazy val uri: URI                           = new URI(uriString)

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -116,5 +116,20 @@ class RequestHeaderSpec extends Specification {
         requestHeader().asJava.hasBody must beFalse
       }
     }
+
+    "remote port" in {
+      "expose the scala request remote port" in {
+        val request = requestHeader().withConnection(RemoteConnection("127.0.0.1", Some(12345), secure = false, None))
+
+        request.asJava.remotePort must beEqualTo(java.util.Optional.of(12345))
+      }
+
+      "be set by the request builder" in {
+        val request = new Http.RequestBuilder().remoteAddress("127.0.0.1").remotePort(12345).build()
+
+        request.remotePort must beEqualTo(java.util.Optional.of(12345))
+        request.asScala.connection.remotePort must beSome(12345)
+      }
+    }
   }
 }

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -6,6 +6,12 @@ This section highlights the new features of Play 3.1. If you want to learn about
 
 ## Other Additions
 
+### Remote Connection Port
+
+Play now exposes the remote connection port, when known, through `RequestHeader.remotePort` and `RequestHeader.connection.remotePort` in Scala, and `Http.RequestHeader.remotePort()` in Java.
+
+The Netty and Pekko HTTP server backends populate this value from the raw socket connection. If trusted forwarded headers replace the remote address and do not provide a port, the remote port is unknown.
+
 ### Trusting Single X-Forwarded-Proto Values
 
 Play can now be configured to trust a single `X-Forwarded-Proto` value when `X-Forwarded-For` contains multiple addresses:

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -158,7 +158,7 @@ ProxyPassReverse / http://localhost:9998
 
 ## Configuring trusted proxies
 
-Play supports various forwarded headers used by proxies to indicate the incoming IP address and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteAddress` and `secure` fields of `RequestHeader`.
+Play supports various forwarded headers used by proxies to indicate the incoming IP address and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteAddress` and `secure` fields of `RequestHeader`. `RequestHeader.remotePort` exposes the remote port when Play knows it, but forwarded port headers are not currently parsed.
 
 It is trivial for an HTTP client, whether it's a browser or other client, to forge forwarded headers, thereby spoofing the IP address and protocol that Play reports, consequently, Play needs to know which proxies are trusted. Play provides a configuration option to configure a list of trusted proxies, and will validate the incoming forwarded headers to verify that they are trusted, taking the first untrusted IP address that it finds as the reported user remote address (or the last IP address if all proxies are trusted.)
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -74,8 +74,10 @@ private[server] class NettyModelConversion(
 
   /** Capture a request's connection info from its channel and headers. */
   private def createRemoteConnection(channel: Channel, headers: Headers): RemoteConnection = {
-    val rawConnection = new RemoteConnection {
-      override lazy val remoteAddress: InetAddress                           = channel.remoteAddress().asInstanceOf[InetSocketAddress].getAddress
+    lazy val socketAddress = channel.remoteAddress().asInstanceOf[InetSocketAddress]
+    val rawConnection      = new RemoteConnection {
+      override lazy val remoteAddress: InetAddress                           = socketAddress.getAddress
+      override lazy val remotePort: Option[Int]                              = Some(socketAddress.getPort)
       private val sslHandler                                                 = Option(channel.pipeline().get(classOf[SslHandler]))
       override def secure: Boolean                                           = sslHandler.isDefined
       override lazy val clientCertificateChain: Option[Seq[X509Certificate]] = {

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -92,6 +92,7 @@ private[server] class PekkoModelConversion(
       forwardedHeaderHandler.forwardedConnection(
         new RemoteConnection {
           override def remoteAddress: InetAddress                           = remoteAddressArg.getAddress
+          override def remotePort: Option[Int]                              = Some(remoteAddressArg.getPort)
           override def secure: Boolean                                      = secureProtocol
           override def clientCertificateChain: Option[Seq[X509Certificate]] = {
             try {

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -69,6 +69,7 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
   def forwardedConnection(rawConnection: RemoteConnection, headers: Headers): RemoteConnection = new RemoteConnection {
     // All public methods delegate to the lazily calculated connection info
     override def remoteAddress: InetAddress                           = parsed.remoteAddress
+    override def remotePort: Option[Int]                              = parsed.remotePort
     override def secure: Boolean                                      = parsed.secure
     override def clientCertificateChain: Option[Seq[X509Certificate]] = parsed.clientCertificateChain
 
@@ -102,6 +103,7 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
                 scan(
                   RemoteConnection(
                     parsedEntry.address,
+                    None,
                     parsedEntry.secure,
                     None /* No cert chain for forward headers */
                   )

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -309,6 +309,23 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("192.0.2.43", true, None)
     }
 
+    "preserve the raw remote port when no forwarded headers are present" in {
+      noConfigHandler.forwardedConnection(
+        RemoteConnection(localhost, Some(12345), secure = false, None),
+        Headers()
+      ) mustEqual RemoteConnection(localhost, Some(12345), secure = false, None)
+    }
+
+    "clear the raw remote port when x-forwarded changes the remote address" in {
+      remoteConnectionToLocalhostWithPort(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        Some(12345),
+        """
+          |X-Forwarded-For: 192.0.2.43
+        """.stripMargin
+      ) mustEqual RemoteConnection("192.0.2.43", false, None)
+    }
+
     "trust IPv4 and IPv6 localhost with x-forwarded when there is config with default settings" in {
       remoteConnectionToLocalhost(
         version("x-forwarded"),
@@ -559,6 +576,16 @@ class ForwardedHeaderHandlerSpec extends Specification {
 
   def remoteConnectionToLocalhost(config: Map[String, Any], headersText: String): RemoteConnection =
     handler(config).forwardedConnection(RemoteConnection("127.0.0.1", false, None), headers(headersText))
+
+  def remoteConnectionToLocalhostWithPort(
+      config: Map[String, Any],
+      remotePort: Option[Int],
+      headersText: String
+  ): RemoteConnection =
+    handler(config).forwardedConnection(
+      RemoteConnection("127.0.0.1", remotePort, secure = false, None),
+      headers(headersText)
+    )
 
   def version(s: String) = {
     Map("play.http.forwarded.version" -> s)


### PR DESCRIPTION
- Fixes #8467

Expose the remote peer port for incoming requests.

This allows applications to log the same `address:port` tuple that can appear in lower-level server logs, making it easier to correlate request logs with connection-level diagnostics.

- Add `remotePort` to `RemoteConnection`.
- Add `RequestHeader.remotePort` in Scala.
- Add `Http.RequestHeader.remotePort()` in Java.
- Add `remotePort(...)` support to `Http.RequestBuilder`.
- Populate the port from the raw socket in Netty and Pekko HTTP.
- Preserve the port when converting between Scala and Java requests.
- Clear the raw port when trusted forwarded headers replace the remote address, because forwarded port headers are not parsed yet.


The exposed value is the remote TCP peer port Play sees directly. With a proxy or load balancer, this is usually the proxy's source port, not the original client's port.

This PR does not add support for `X-Forwarded-Port` or RFC 7239 forwarded ports. That will be handled in a upcoming PR.
