### PR TITLE
Parse remote ports from forwarded headers

### DIFF
--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -65,18 +65,19 @@ play {
     filters = null
 
     # Forwarded header configuration
-    # Play supports various forwarded headers used by proxies to indicate the incoming IP address and protocol of
-    # requests. Play uses this in the implementation of the RequestHeader.remoteAddress and RequestHeader.secure
-    # fields.
+    # Play supports various forwarded headers used by proxies to indicate the incoming IP address, port, and protocol
+    # of requests. Play uses this in the implementation of the RequestHeader.remoteAddress, RequestHeader.remotePort,
+    # and RequestHeader.secure fields.
     forwarded = {
 
       # The version of forwarded headers to use.
       # Valid values are x-forwarded and rfc7239.
-      # x-forwarded uses the de facto standard X-Forwarded-For and X-Forwarded-Proto headers to determine the correct
-      # remote address and protocol for the request. These headers are widely used, however, they have some serious
-      # limitations, for example, if you have multiple proxies, and only one of them adds the X-Forwarded-Proto header,
-      # it's impossible to reliably determine which proxy added it and therefore whether the request from the client
-      # was made using https or http. rfc7239 uses the new Forwarded header standard, and solves many of the
+      # x-forwarded uses the de facto standard X-Forwarded-For, X-Forwarded-Port, and X-Forwarded-Proto headers to
+      # determine the correct remote address, port, and protocol for the request. These headers are widely used,
+      # however, they have some serious limitations, for example, if you have multiple proxies, and only one of them
+      # adds the X-Forwarded-Proto header, it's impossible to reliably determine which proxy added it and therefore
+      # whether the request from the client was made using https or http. rfc7239 uses the new Forwarded header
+      # standard, and solves many of the
       # limitations of the X-Forwarded-* headers.
       version = "x-forwarded"
 
@@ -99,6 +100,12 @@ play {
       # treated as insecure. When set to true, a single X-Forwarded-Proto value is associated with the
       # client address instead. Only enable this if the outermost trusted proxy is known to set it.
       trustSingleXForwardedProto = false
+
+      # Only applies to the x-forwarded version. When multiple proxies grow X-Forwarded-For but only the
+      # outermost one sets a single X-Forwarded-Port value, the number of entries in the two headers differs and,
+      # by default, the port information is discarded. When set to true, a single X-Forwarded-Port value is
+      # associated with the client address instead. Only enable this if the outermost trusted proxy is known to set it.
+      trustSingleXForwardedPort = false
     }
 
     # Parsing configuration

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -10,7 +10,7 @@ This section highlights the new features of Play 3.1. If you want to learn about
 
 Play now exposes the remote connection port, when known, through `RequestHeader.remotePort` and `RequestHeader.connection.remotePort` in Scala, and `Http.RequestHeader.remotePort()` in Java.
 
-The Netty and Pekko HTTP server backends populate this value from the raw socket connection. If trusted forwarded headers replace the remote address and do not provide a port, the remote port is unknown.
+The Netty and Pekko HTTP server backends populate this value from the raw socket connection. Trusted forwarded headers can also provide this value through RFC 7239 `Forwarded` ports or `X-Forwarded-Port`.
 
 ### Trusting Single X-Forwarded-Proto Values
 

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -158,7 +158,7 @@ ProxyPassReverse / http://localhost:9998
 
 ## Configuring trusted proxies
 
-Play supports various forwarded headers used by proxies to indicate the incoming IP address and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteAddress` and `secure` fields of `RequestHeader`. `RequestHeader.remotePort` exposes the remote port when Play knows it, but forwarded port headers are not currently parsed.
+Play supports various forwarded headers used by proxies to indicate the incoming IP address, port, and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteAddress`, `remotePort`, and `secure` fields of `RequestHeader`.
 
 It is trivial for an HTTP client, whether it's a browser or other client, to forge forwarded headers, thereby spoofing the IP address and protocol that Play reports, consequently, Play needs to know which proxies are trusted. Play provides a configuration option to configure a list of trusted proxies, and will validate the incoming forwarded headers to verify that they are trusted, taking the first untrusted IP address that it finds as the reported user remote address (or the last IP address if all proxies are trusted.)
 
@@ -187,7 +187,7 @@ Play supports two different versions of forwarded headers:
 
 This is configured using `play.http.forwarded.version`, with valid values being `x-forwarded` or `rfc7239`. The default is `x-forwarded`.
 
-`x-forwarded` uses the de facto standard `X-Forwarded-For` and `X-Forwarded-Proto` headers to determine the correct remote address and protocol for the request. These headers are widely used, however, they have some serious limitations, for example, if you have multiple proxies, and only one of them adds the `X-Forwarded-Proto` header, it's impossible to reliably determine which proxy added it and therefore whether the request from the client was made using https or http. `rfc7239` uses the new `Forwarded` header standard, and solves many of the limitations of the `X-Forwarded-*` headers.
+`x-forwarded` uses the de facto standard `X-Forwarded-For`, `X-Forwarded-Port`, and `X-Forwarded-Proto` headers to determine the correct remote address, port, and protocol for the request. These headers are widely used, however, they have some serious limitations, for example, if you have multiple proxies, and only one of them adds the `X-Forwarded-Proto` header, it's impossible to reliably determine which proxy added it and therefore whether the request from the client was made using https or http. `rfc7239` uses the new `Forwarded` header standard, and solves many of the limitations of the `X-Forwarded-*` headers.
 
 For more information, please read the [RFC 7239](https://tools.ietf.org/html/rfc7239) specification.
 
@@ -204,3 +204,19 @@ play.http.forwarded.trustSingleXForwardedProto = true
 This setting only applies when `play.http.forwarded.version = "x-forwarded"`. It associates a single `X-Forwarded-Proto` value with the client address from `X-Forwarded-For`. It does not apply to RFC 7239 `Forwarded` headers, and it does not use `X-Forwarded-Proto` when `X-Forwarded-For` is absent.
 
 Only enable this when your trusted edge proxy overwrites or removes any incoming client-supplied `X-Forwarded-Proto` header before setting the correct value. Otherwise, clients may be able to spoof whether a request was secure.
+
+### Trusting a single X-Forwarded-Port value
+
+Play uses `X-Forwarded-Port` when it can match port values to `X-Forwarded-For` addresses. A single `X-Forwarded-Port` value is used automatically when there is a single `X-Forwarded-For` address. Multiple port values are paired with forwarded addresses by position when both headers contain the same number of values.
+
+Some proxy chains append to `X-Forwarded-For`, but set a single `X-Forwarded-Port` value. In that case, Play cannot normally match each forwarded address to a port value, so it discards the port information.
+
+If your trusted edge proxy is known to set `X-Forwarded-Port` to the port used by the original client request, you can enable:
+
+```
+play.http.forwarded.trustSingleXForwardedPort = true
+```
+
+This setting only applies when `play.http.forwarded.version = "x-forwarded"`. It associates a single `X-Forwarded-Port` value with the client address from `X-Forwarded-For`. It does not apply to RFC 7239 `Forwarded` headers, where the port is part of the `for` value, and it does not use `X-Forwarded-Port` when `X-Forwarded-For` is absent.
+
+Only enable this when your trusted edge proxy overwrites or removes any incoming client-supplied `X-Forwarded-Port` header before setting the correct value. Otherwise, clients may be able to spoof the forwarded port.

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -571,6 +571,36 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "org.apache.pekko.http.play.WebSocketHandler.handleWebSocket"
       ),
+      // ForwardedEntry and ParsedForwardedEntry are private server internals.
+      // Their case class signatures changed to carry forwarded port values.
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ForwardedEntry.apply"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ForwardedEntry.copy"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ForwardedEntry.this"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry.apply"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry.copy"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry.this"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry.copy$default$2"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry._2"
+      ),
+      ProblemFilters.exclude[MissingTypesProblem]("play.core.server.common.ForwardedHeaderHandler$ForwardedEntry$"),
+      ProblemFilters.exclude[MissingTypesProblem](
+        "play.core.server.common.ForwardedHeaderHandler$ParsedForwardedEntry$"
+      ),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -14,6 +14,7 @@ import play.api.mvc.Headers
 import play.api.Configuration
 import play.api.Logger
 import play.core.server.common.NodeIdentifierParser.Ip
+import play.core.server.common.NodeIdentifierParser.PortNumber
 import ForwardedHeaderHandler._
 
 /**
@@ -33,14 +34,18 @@ import ForwardedHeaderHandler._
  * 5. If the immediate connection *is not* a trusted proxy, then return the
  *    immediate connection info and don't do any further processing.
  *
- * Each address is associated with a secure or insecure protocol by pairing
- * it with a `proto` entry in the headers. If the `proto` entry is missing, or if
- * `proto` entries can't be matched with addresses, then the default is insecure.
+ * Each address is associated with a port and a secure or insecure protocol by
+ * pairing it with a `port` and `proto` entry in the headers. If the `proto`
+ * entry is missing, or if `proto` entries can't be matched with addresses,
+ * then the default is insecure.
  * When `play.http.forwarded.trustSingleXForwardedProto` is enabled, a lone
  * `X-Forwarded-Proto` entry is associated with the client address instead of
  * being discarded.
+ * When `play.http.forwarded.trustSingleXForwardedPort` is enabled, a lone
+ * `X-Forwarded-Port` entry is associated with the client address instead of
+ * being discarded.
  *
- * It is configured by two configuration options:
+ * It is configured by these configuration options:
  * <dl>
  *   <dt>play.http.forwarded.version</dt>
  *   <dd>
@@ -103,7 +108,7 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
                 scan(
                   RemoteConnection(
                     parsedEntry.address,
-                    None,
+                    parsedEntry.remotePort,
                     parsedEntry.secure,
                     None /* No cert chain for forward headers */
                   )
@@ -140,20 +145,29 @@ private[server] object ForwardedHeaderHandler {
   type HeaderParser = Headers => Seq[ForwardedEntry]
 
   /**
-   * An unparsed address and protocol pair from a forwarded header. Both values are
+   * An unparsed address, protocol, and port from a forwarded header. Each value is
    * optional.
    */
-  final case class ForwardedEntry(addressString: Option[String], protoString: Option[String])
+  final case class ForwardedEntry(
+      addressString: Option[String],
+      protoString: Option[String],
+      portString: Option[String] = None
+  )
 
   /**
    * Basic information about an HTTP connection, parsed from a ForwardedEntry.
    */
-  final case class ParsedForwardedEntry(address: InetAddress, secure: Boolean)
+  final case class ParsedForwardedEntry(
+      address: InetAddress,
+      remotePort: Option[Int],
+      secure: Boolean
+  )
 
   case class ForwardedHeaderHandlerConfig(
       version: ForwardedHeaderVersion,
       trustedProxies: List[Subnet],
-      trustSingleXForwardedProto: Boolean = false
+      trustSingleXForwardedProto: Boolean = false,
+      trustSingleXForwardedPort: Boolean = false
   ) {
     val nodeIdentifierParser = new NodeIdentifierParser(version)
 
@@ -165,6 +179,16 @@ private[server] object ForwardedHeaderHandler {
       if (s.length >= 2 && s.charAt(0) == '"' && s.charAt(s.length - 1) == '"') {
         s.substring(1, s.length - 1)
       } else s
+    }
+
+    private def parsePort(s: String): Option[Int] = {
+      if (s.matches("\\d{1,5}")) {
+        val port = s.toInt
+        // Port numbers are 16-bit unsigned values.
+        Option.when(port <= 65535)(port)
+      } else {
+        None
+      }
     }
 
     /**
@@ -202,25 +226,40 @@ private[server] object ForwardedHeaderHandler {
         def h(h: Headers, key: String) = h.getAll(key).flatMap(s => s.split(",\\s*")).map(unquote)
         val forHeaders                 = h(headers, "X-Forwarded-For")
         val protoHeaders               = h(headers, "X-Forwarded-Proto")
-        if (forHeaders.length == protoHeaders.length) {
-          forHeaders.lazyZip(protoHeaders).map { (f, p) =>
-            ForwardedEntry(Some(f), Some(p))
+        val portHeaders                = h(headers, "X-Forwarded-Port")
+
+        def protoForIndex(index: Int): Option[String] = {
+          if (forHeaders.length == protoHeaders.length) {
+            protoHeaders.lift(index)
+          } else if (
+            trustSingleXForwardedProto &&
+            forHeaders.nonEmpty &&
+            protoHeaders.length == 1 &&
+            index == 0
+          ) {
+            protoHeaders.headOption
+          } else {
+            None
           }
-        } else if (trustSingleXForwardedProto && forHeaders.nonEmpty && protoHeaders.length == 1) {
-          // A single X-Forwarded-Proto entry describes the protocol the client used to reach
-          // the outermost proxy. Associate it with the client (the first X-Forwarded-For
-          // entry); the remaining entries are left without a protocol.
-          forHeaders.zipWithIndex.map {
-            case (f, 0) => ForwardedEntry(Some(f), protoHeaders.headOption)
-            case (f, _) => ForwardedEntry(Some(f), None)
+        }
+
+        def portForIndex(index: Int): Option[String] = {
+          if (forHeaders.length == portHeaders.length) {
+            portHeaders.lift(index)
+          } else if (
+            trustSingleXForwardedPort &&
+            forHeaders.nonEmpty &&
+            portHeaders.length == 1 &&
+            index == 0
+          ) {
+            portHeaders.headOption
+          } else {
+            None
           }
-        } else {
-          // If the lengths vary, then discard the protoHeaders because we can't tell which
-          // proto matches which header. The connections will all appear to be insecure by
-          // default.
-          forHeaders.map {
-            case f => ForwardedEntry(Some(f), None)
-          }
+        }
+
+        forHeaders.zipWithIndex.map {
+          case (f, index) => ForwardedEntry(Some(f), protoForIndex(index), portForIndex(index))
         }
     }
 
@@ -237,10 +276,13 @@ private[server] object ForwardedHeaderHandler {
           Left("No address")
         case Some(addressString) =>
           nodeIdentifierParser.parseNode(addressString) match {
-            case Right((Ip(address), _)) =>
+            case Right((Ip(address), nodePort)) =>
               // Parsing was successful, use this connection and scan for another connection.
               val secure     = entry.protoString.fold(false)(_ == "https") // Assume insecure by default
-              val connection = ParsedForwardedEntry(address, secure)
+              val remotePort = entry.portString.flatMap(parsePort).orElse {
+                nodePort.collect { case PortNumber(port) => port }
+              }
+              val connection = ParsedForwardedEntry(address, remotePort, secure)
               Right(connection)
             case errorOrNonIp =>
               // The forwarding address entry couldn't be parsed for some reason.
@@ -271,7 +313,8 @@ private[server] object ForwardedHeaderHandler {
       ForwardedHeaderHandlerConfig(
         version,
         config.get[Seq[String]]("trustedProxies").map(Subnet.apply).toList,
-        config.getOptional[Boolean]("trustSingleXForwardedProto").getOrElse(false)
+        config.getOptional[Boolean]("trustSingleXForwardedProto").getOrElse(false),
+        config.getOptional[Boolean]("trustSingleXForwardedPort").getOrElse(false)
       )
     }
   }

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -40,28 +40,28 @@ class ForwardedHeaderHandlerSpec extends Specification {
       results(0)._2 must beLeft
       results(0)._3 must beNone
       results(1)._1 must_== ForwardedEntry(Some("[2001:db8:cafe::17]:4711"), None)
-      results(1)._2 must beRight(ParsedForwardedEntry(addr("2001:db8:cafe::17"), false))
+      results(1)._2 must beRight(ParsedForwardedEntry(addr("2001:db8:cafe::17"), Some(4711), false))
       results(1)._3 must beSome(false)
       results(2)._1 must_== ForwardedEntry(Some("192.0.2.60"), Some("http"))
-      results(2)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.60"), false))
+      results(2)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.60"), None, false))
       results(2)._3 must beSome(true)
       results(3)._1 must_== ForwardedEntry(Some("192.0.2.43"), None)
-      results(3)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.43"), false))
+      results(3)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.43"), None, false))
       results(3)._3 must beSome(true)
       results(4)._1 must_== ForwardedEntry(Some("198.51.100.17"), None)
-      results(4)._2 must beRight(ParsedForwardedEntry(addr("198.51.100.17"), false))
+      results(4)._2 must beRight(ParsedForwardedEntry(addr("198.51.100.17"), None, false))
       results(4)._3 must beSome(false)
       results(5)._1 must_== ForwardedEntry(Some("127.0.0.1"), None)
-      results(5)._2 must beRight(ParsedForwardedEntry(addr("127.0.0.1"), false))
+      results(5)._2 must beRight(ParsedForwardedEntry(addr("127.0.0.1"), None, false))
       results(5)._3 must beSome(false)
       results(6)._1 must_== ForwardedEntry(Some("192.0.2.61"), Some("https"))
-      results(6)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.61"), true))
+      results(6)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.61"), None, true))
       results(6)._3 must beSome(true)
       results(7)._1 must_== ForwardedEntry(Some("unknown"), None)
       results(7)._2 must beLeft
       results(7)._3 must beNone
       results(8)._1 must_== ForwardedEntry(Some("[::ffff:192.168.0.9]"), Some("https"))
-      results(8)._2 must beRight(ParsedForwardedEntry(addr("::ffff:192.168.0.9"), true))
+      results(8)._2 must beRight(ParsedForwardedEntry(addr("::ffff:192.168.0.9"), None, true))
       results(8)._3 must beSome(false)
     }
 
@@ -77,19 +77,19 @@ class ForwardedHeaderHandlerSpec extends Specification {
       )
       results.length must_== 5
       results(0)._1 must_== ForwardedEntry(Some("192.168.1.1"), Some("https"))
-      results(0)._2 must beRight(ParsedForwardedEntry(addr("192.168.1.1"), true))
+      results(0)._2 must beRight(ParsedForwardedEntry(addr("192.168.1.1"), None, true))
       results(0)._3 must beSome(false)
       results(1)._1 must_== ForwardedEntry(Some("::1"), Some("http"))
-      results(1)._2 must beRight(ParsedForwardedEntry(addr("::1"), false))
+      results(1)._2 must beRight(ParsedForwardedEntry(addr("::1"), None, false))
       results(1)._3 must beSome(false)
       results(2)._1 must_== ForwardedEntry(Some("[2001:db8:cafe::17]"), Some("https"))
-      results(2)._2 must beRight(ParsedForwardedEntry(addr("2001:db8:cafe::17"), true))
+      results(2)._2 must beRight(ParsedForwardedEntry(addr("2001:db8:cafe::17"), None, true))
       results(2)._3 must beSome(true)
       results(3)._1 must_== ForwardedEntry(Some("127.0.0.1"), Some("http"))
-      results(3)._2 must beRight(ParsedForwardedEntry(addr("127.0.0.1"), false))
+      results(3)._2 must beRight(ParsedForwardedEntry(addr("127.0.0.1"), None, false))
       results(3)._3 must beSome(false)
       results(4)._1 must_== ForwardedEntry(Some("::ffff:123.123.123.123"), Some("https"))
-      results(4)._2 must beRight(ParsedForwardedEntry(addr("::ffff:123.123.123.123"), true))
+      results(4)._2 must beRight(ParsedForwardedEntry(addr("::ffff:123.123.123.123"), None, true))
       results(4)._3 must beSome(false)
     }
 
@@ -180,7 +180,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
         """
           |Forwarded: For=[2001:db8:cafe::17]:4711
         """.stripMargin
-      ) mustEqual RemoteConnection("2001:db8:cafe::17", false, None)
+      ) mustEqual RemoteConnection("2001:db8:cafe::17", Some(4711), secure = false, None)
     }
 
     "handle quoted IPv6 addresses with rfc7239" in {
@@ -189,7 +189,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
         """
           |Forwarded: For="[2001:db8:cafe::17]:4711"
         """.stripMargin
-      ) mustEqual RemoteConnection("2001:db8:cafe::17", false, None)
+      ) mustEqual RemoteConnection("2001:db8:cafe::17", Some(4711), secure = false, None)
     }
 
     "handle quoted IPv4-mapped IPv6 addresses with rfc7239" in {
@@ -200,7 +200,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
                     |Forwarded: For="[::ffff:99.99.99.99]:4711"
                     |Forwarded: For="[::ffff:123.123.123.123]"
         """.stripMargin)
-        ) mustEqual RemoteConnection(addr("::ffff:99.99.99.99"), false, None)
+        ) mustEqual RemoteConnection(addr("::ffff:99.99.99.99"), Some(4711), secure = false, None)
     }
 
     "ignore obfuscated addresses with rfc7239" in {
@@ -213,11 +213,30 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("192.168.1.10", false, None)
     }
 
+    "ignore obfuscated ports with rfc7239" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for="192.0.2.43:_hidden"
+        """.stripMargin
+      ) mustEqual RemoteConnection("192.0.2.43", false, None)
+    }
+
     "ignore unknown addresses with rfc7239" in {
       remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
         """
           |Forwarded: for=unknown
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin
+      ) mustEqual RemoteConnection("192.168.1.10", false, None)
+    }
+
+    "ignore unknown addresses with ports with rfc7239" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
+        """
+          |Forwarded: for=unknown:1234
           |Forwarded: for=192.168.1.10, for=127.0.0.1
         """.stripMargin
       ) mustEqual RemoteConnection("192.168.1.10", false, None)
@@ -324,6 +343,152 @@ class ForwardedHeaderHandlerSpec extends Specification {
           |X-Forwarded-For: 192.0.2.43
         """.stripMargin
       ) mustEqual RemoteConnection("192.0.2.43", false, None)
+    }
+
+    "use the port from an rfc7239 forwarded IPv4 address" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for="192.0.2.43:443";proto=https
+        """.stripMargin
+      ) mustEqual RemoteConnection("192.0.2.43", Some(443), secure = true, None)
+    }
+
+    "use the port from an rfc7239 forwarded IPv6 address" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for="[2001:db8:cafe::17]:443";proto=https
+        """.stripMargin
+      ) mustEqual RemoteConnection("2001:db8:cafe::17", Some(443), secure = true, None)
+    }
+
+    "use the port from the first untrusted rfc7239 forwarded address" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
+        """
+          |Forwarded: for="203.0.113.43:443"
+          |Forwarded: for="192.168.1.43:9000"
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", Some(443), secure = false, None)
+    }
+
+    "use x-forwarded-port when it matches a single x-forwarded-for address" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43
+          |X-Forwarded-Port: 443
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", Some(443), secure = false, None)
+    }
+
+    "accept the maximum x-forwarded-port value" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43
+          |X-Forwarded-Port: 65535
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", Some(65535), secure = false, None)
+    }
+
+    "ignore x-forwarded-port values above the maximum port value" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43
+          |X-Forwarded-Port: 65536
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "use the port from an x-forwarded-for address" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43:443
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", Some(443), secure = false, None)
+    }
+
+    "prefer x-forwarded-port over the port in an x-forwarded-for address" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43:80
+          |X-Forwarded-Port: 443
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", Some(443), secure = false, None)
+    }
+
+    "pair x-forwarded-port entries with x-forwarded-for entries" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43, 192.168.1.43
+          |X-Forwarded-Port: 443, 9000
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", Some(443), secure = false, None)
+    }
+
+    "ignore a single x-forwarded-port with multiple x-forwarded-for entries by default" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43, 192.168.1.43
+          |X-Forwarded-Port: 443
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "associate a single x-forwarded-port with the client when trustSingleXForwardedPort is enabled" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1") ++ trustSingleXForwardedPort(true),
+        """
+          |X-Forwarded-For: 203.0.113.43, 192.168.1.43
+          |X-Forwarded-Port: 443
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", Some(443), secure = false, None)
+    }
+
+    "ignore multiple x-forwarded-port entries shorter than x-forwarded-for" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("0.0.0.0/0") ++ trustSingleXForwardedPort(true),
+        """
+          |X-Forwarded-For: 203.0.113.43, 192.168.1.43, 192.168.1.44
+          |X-Forwarded-Port: 443, 9000
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "ignore x-forwarded-port when x-forwarded-for is missing" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1") ++ trustSingleXForwardedPort(true),
+        """
+          |X-Forwarded-Port: 443
+        """.stripMargin
+      ) mustEqual RemoteConnection(localhost, false, None)
+    }
+
+    "ignore invalid x-forwarded-port values" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43
+          |X-Forwarded-Port: 70000
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "ignore non-numeric x-forwarded-port values" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43
+          |X-Forwarded-Port: abc
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
     }
 
     "trust IPv4 and IPv6 localhost with x-forwarded when there is config with default settings" in {
@@ -597,6 +762,10 @@ class ForwardedHeaderHandlerSpec extends Specification {
 
   def trustSingleXForwardedProto(b: Boolean) = {
     Map("play.http.forwarded.trustSingleXForwardedProto" -> b)
+  }
+
+  def trustSingleXForwardedPort(b: Boolean) = {
+    Map("play.http.forwarded.trustSingleXForwardedPort" -> b)
   }
 
   def headers(s: String): Headers = {


### PR DESCRIPTION
- Fixes #8877
- This PR builds on #14077, which adds the `RemoteConnection.remotePort` API.

This lets Play populate `RequestHeader.remotePort` from trusted forwarded headers, including `X-Forwarded-Port` and RFC 7239 `Forwarded` `for=` node ports.

- Parse numeric ports from RFC 7239 `Forwarded` `for=` nodes.
- Parse `X-Forwarded-Port`.
- Pair `X-Forwarded-Port` values with `X-Forwarded-For` values by position when both headers have the same number of entries.
- Use a single `X-Forwarded-Port` automatically when there is only one `X-Forwarded-For` entry.
- Add `play.http.forwarded.trustSingleXForwardedPort`, disabled by default, for proxy chains that append to `X-Forwarded-For` but set one port value for the original client request.
- Ignore ambiguous or invalid forwarded port values.
- docs and configs

Forwarded ports are trusted only through the existing trusted proxy chain validation. `X-Forwarded-Port` without `X-Forwarded-For` is not used.

RFC 7239 ports are part of the `for=` node, so they do not need the single-value opt-in setting.



