### PR TITLE
Support RFC 7239 unknown and obfuscated remote identities

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/mvc/HttpSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/mvc/HttpSpec.scala
@@ -11,6 +11,17 @@ import play.api.test.FakeRequest
 class HttpSpec extends org.specs2.mutable.Specification {
   title("HTTP")
 
+  private def withSecureConnection(req: RequestHeader): RequestHeader =
+    req.withConnection(
+      RemoteConnection(
+        req.connection.remoteIpAddress.get,
+        req.connection.remoteNode,
+        req.connection.remotePort,
+        secure = true,
+        req.connection.clientCertificateChain
+      )
+    )
+
   "Absolute URL" should {
     val req = FakeRequest().withHeaders(HeaderNames.HOST -> "playframework.com")
 
@@ -27,8 +38,7 @@ class HttpSpec extends org.specs2.mutable.Specification {
     "have HTTPS scheme" in {
       (Call("GET", "/playframework")
         .absoluteURL()(
-          using req
-            .withConnection(RemoteConnection(req.connection.remoteAddress, true, req.connection.clientCertificateChain))
+          using withSecureConnection(req)
         )
         .aka("absolute URL 1") must_== "https://playframework.com/playframework").and(
         Call("GET", "/playframework")
@@ -54,8 +64,7 @@ class HttpSpec extends org.specs2.mutable.Specification {
     "have wss scheme" in {
       (Call("GET", "/playframework")
         .webSocketURL()(
-          using req
-            .withConnection(RemoteConnection(req.connection.remoteAddress, true, req.connection.clientCertificateChain))
+          using withSecureConnection(req)
         )
         .aka("absolute URL 1") must_== "wss://playframework.com/playframework").and(
         Call("GET", "/playframework")

--- a/core/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
@@ -260,7 +260,7 @@ private[server] object ServerReloadingSpec {
       case GET(p"/getflash") =>
         action { (request: Request[?]) => Results.Ok(request.flash.data.get("foo").toString) }
       case GET(p"/getremoteaddress") =>
-        action { (request: Request[?]) => Results.Ok(request.remoteAddress) }
+        action { (request: Request[?]) => Results.Ok(request.remoteIdentity) }
       case GET(p"/getserverconfigcachereloads") =>
         action { (request: Request[?]) =>
           val reloadCount: Option[Int] = request.attrs.get(ServerDebugInfo.Attr).map(_.serverConfigCacheReloads)

--- a/core/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/core/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -31,7 +31,7 @@ import play.filters.gzip.GzipFilter
 object HttpBinApplication {
   private val requestHeaderWriter = new Writes[RequestHeader] {
     def writes(r: RequestHeader): JsValue = Json.obj(
-      "origin"  -> r.remoteAddress,
+      "origin"  -> r.remoteIdentity,
       "url"     -> "",
       "args"    -> r.queryString.view.mapValues(_.head).toMap[String, String],
       "headers" -> r.headers.toSimpleMap
@@ -68,7 +68,7 @@ object HttpBinApplication {
 
   def getIp(implicit Action: DefaultActionBuilder): Routes = {
     case GET(p"/ip") =>
-      Action { request => Ok(Json.obj("origin" -> request.remoteAddress)) }
+      Action { request => Ok(Json.obj("origin" -> request.remoteIdentity)) }
   }
 
   def getUserAgent(implicit Action: DefaultActionBuilder): Routes = {

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -197,6 +198,113 @@ public class Http {
     }
   }
 
+  public sealed interface RemoteNode
+      permits RemoteNode.Ip, RemoteNode.Obfuscated, RemoteNode.Unknown {
+
+    /**
+     * @return the Scala version of this remote node.
+     */
+    play.api.mvc.request.RemoteConnection.RemoteNode asScala();
+
+    public record Ip(InetAddress address, Optional<Integer> port) implements RemoteNode {
+      @SuppressWarnings("unchecked")
+      @Override
+      public play.api.mvc.request.RemoteConnection.RemoteNode asScala() {
+        scala.Option<Object> scalaPort =
+            (scala.Option<Object>) (scala.Option<?>) OptionConverters.toScala(port);
+        return play.api.mvc.request.RemoteConnection.RemoteNode$.MODULE$.ip(address, scalaPort);
+      }
+    }
+
+    public record Obfuscated(String identifier, Optional<String> port) implements RemoteNode {
+      @Override
+      public play.api.mvc.request.RemoteConnection.RemoteNode asScala() {
+        return new play.api.mvc.request.RemoteConnection$RemoteNode$Obfuscated(
+            identifier, OptionConverters.toScala(port));
+      }
+    }
+
+    public record Unknown(Optional<String> port) implements RemoteNode {
+      @Override
+      public play.api.mvc.request.RemoteConnection.RemoteNode asScala() {
+        return new play.api.mvc.request.RemoteConnection$RemoteNode$Unknown(
+            OptionConverters.toScala(port));
+      }
+    }
+  }
+
+  /** Metadata about the remote connection for a request. */
+  public static final class RemoteConnection {
+    private final play.api.mvc.request.RemoteConnection underlying;
+
+    public RemoteConnection(play.api.mvc.request.RemoteConnection underlying) {
+      this.underlying = underlying;
+    }
+
+    /**
+     * @return the Scala version of this remote connection.
+     */
+    public play.api.mvc.request.RemoteConnection asScala() {
+      return underlying;
+    }
+
+    /**
+     * The selected remote identity.
+     *
+     * <p>When the identity is an IP address, the node may also include the selected remote port.
+     * RFC 7239 {@code unknown} and obfuscated identifiers are represented explicitly so
+     * applications do not need to parse a string value.
+     *
+     * @return the remote node
+     */
+    public RemoteNode remoteNode() {
+      return underlying.remoteNode().asJava();
+    }
+
+    /**
+     * @return the selected remote IP address, if the remote identity is an IP address
+     */
+    public Optional<InetAddress> remoteIpAddress() {
+      return OptionConverters.toJava(underlying.remoteIpAddress());
+    }
+
+    /**
+     * The selected remote identity as a string.
+     *
+     * <p>If the remote identity is an IP address, this returns the address in textual form. If the
+     * remote identity is an RFC 7239 {@code unknown} or obfuscated identifier, this returns that
+     * identifier.
+     *
+     * @return the remote identity
+     */
+    public String remoteIdentity() {
+      return underlying.remoteIdentity();
+    }
+
+    /**
+     * @return the remote port, if known
+     */
+    @SuppressWarnings("unchecked")
+    public Optional<Integer> remotePort() {
+      return (Optional<Integer>) (Optional<?>) OptionConverters.toJava(underlying.remotePort());
+    }
+
+    /**
+     * @return true if the client is using SSL
+     */
+    public boolean secure() {
+      return underlying.secure();
+    }
+
+    /**
+     * @return the client certificate chain, if any
+     */
+    public Optional<List<X509Certificate>> clientCertificateChain() {
+      return OptionConverters.toJava(underlying.clientCertificateChain())
+          .map(list -> new ArrayList<>(Scala.asJava(list)));
+    }
+  }
+
   public interface RequestHeader {
 
     /**
@@ -223,14 +331,51 @@ public class Http {
     String version();
 
     /**
-     * The client IP address.
+     * The client IP address, or a fallback IP address when the remote client is represented by an
+     * RFC 7239 unknown or obfuscated identifier.
      *
      * <p>Retrieves the last untrusted proxy from the Forwarded-Headers or the
      * X-Forwarded-*-Headers.
      *
      * @return the remote address
+     * @deprecated Use {@link #connection()}.{@link RemoteConnection#remoteIdentity()
+     *     remoteIdentity()} for the remote identity as a string, {@link #connection()}.{@link
+     *     RemoteConnection#remoteNode() remoteNode()} for the structured RFC 7239 remote identity,
+     *     or {@link #connection()}.{@link RemoteConnection#remoteIpAddress() remoteIpAddress()} for
+     *     an IP-only value. This legacy address cannot represent RFC 7239 unknown or obfuscated
+     *     identifiers and may return a fallback proxy address when the selected forwarded identity
+     *     is not an IP.
      */
+    @Deprecated
     String remoteAddress();
+
+    /**
+     * The remote identity as a string.
+     *
+     * <p>If the remote identity is an IP address, this returns the address in textual form. If the
+     * remote identity is an RFC 7239 {@code unknown} or obfuscated identifier, this returns that
+     * identifier.
+     *
+     * <p>This is a request-level shortcut for {@link #connection()}.{@link
+     * RemoteConnection#remoteIdentity() remoteIdentity()}.
+     *
+     * @return the remote identity
+     */
+    default String remoteIdentity() {
+      return connection().remoteIdentity();
+    }
+
+    /**
+     * The remote connection metadata for this request.
+     *
+     * <p>This is the primary API for connection metadata such as the selected remote identity, IP
+     * address, port, secure flag, and client certificate chain.
+     *
+     * @return the remote connection metadata
+     */
+    default RemoteConnection connection() {
+      return asScala().connection().asJava();
+    }
 
     /**
      * The client port, if known.
@@ -238,7 +383,7 @@ public class Http {
      * @return the remote port
      */
     default Optional<Integer> remotePort() {
-      return Optional.empty();
+      return connection().remotePort();
     }
 
     /**
@@ -476,7 +621,9 @@ public class Http {
      * @return The chain of X509Certificates used for the request if the request is secure and the
      *     server supports it.
      */
-    Optional<List<X509Certificate>> clientCertificateChain();
+    default Optional<List<X509Certificate>> clientCertificateChain() {
+      return connection().clientCertificateChain();
+    }
 
     /**
      * Create a new version of this object with the given transient language set. The transient
@@ -1120,13 +1267,7 @@ public class Http {
      * @return the builder instance
      */
     public RequestBuilder secure(boolean secure) {
-      req =
-          req.withConnection(
-              RemoteConnection$.MODULE$.apply(
-                  req.connection().remoteAddress(),
-                  req.connection().remotePort(),
-                  secure,
-                  req.connection().clientCertificateChain()));
+      req = req.withConnection(req.connection().withSecure(secure));
       return this;
     }
 
@@ -1337,18 +1478,31 @@ public class Http {
 
     /**
      * @return the remote address
+     * @deprecated Use {@link #connection()}.{@link RemoteConnection#remoteIdentity()
+     *     remoteIdentity()} for the remote identity as a string, {@link #connection()}.{@link
+     *     RemoteConnection#remoteNode() remoteNode()} for the structured RFC 7239 remote identity,
+     *     or {@link #connection()}.{@link RemoteConnection#remoteIpAddress() remoteIpAddress()} for
+     *     an IP-only value. This legacy address cannot represent RFC 7239 unknown or obfuscated
+     *     identifiers and may return a fallback proxy address when the selected forwarded identity
+     *     is not an IP.
      */
+    @Deprecated
     public String remoteAddress() {
       return req.connection().remoteAddressString();
     }
 
     /**
+     * @return the remote connection metadata
+     */
+    public RemoteConnection connection() {
+      return new RemoteConnection(req.connection());
+    }
+
+    /**
      * @return the remote port, if known
      */
-    @SuppressWarnings("unchecked")
     public Optional<Integer> remotePort() {
-      return (Optional<Integer>)
-          (Optional<?>) OptionConverters.toJava(req.connection().remotePort());
+      return connection().remotePort();
     }
 
     /**
@@ -1374,13 +1528,7 @@ public class Http {
     public RequestBuilder remotePort(Optional<Integer> remotePort) {
       scala.Option<Object> scalaRemotePort =
           (scala.Option<Object>) (scala.Option<?>) OptionConverters.toScala(remotePort);
-      req =
-          req.withConnection(
-              RemoteConnection$.MODULE$.apply(
-                  req.connection().remoteAddress(),
-                  scalaRemotePort,
-                  req.connection().secure(),
-                  req.connection().clientCertificateChain()));
+      req = req.withConnection(req.connection().withRemotePort(scalaRemotePort));
       return this;
     }
 
@@ -1396,8 +1544,7 @@ public class Http {
      * @return the client X509Certificates if they have been set
      */
     public Optional<List<X509Certificate>> clientCertificateChain() {
-      return OptionConverters.toJava(req.connection().clientCertificateChain())
-          .map(list -> new ArrayList<>(Scala.asJava(list)));
+      return connection().clientCertificateChain();
     }
 
     /**
@@ -1407,12 +1554,10 @@ public class Http {
     public RequestBuilder clientCertificateChain(List<X509Certificate> clientCertificateChain) {
       req =
           req.withConnection(
-              RemoteConnection$.MODULE$.apply(
-                  req.connection().remoteAddress(),
-                  req.connection().remotePort(),
-                  req.connection().secure(),
-                  OptionConverters.toScala(
-                      Optional.ofNullable(Scala.asScala(clientCertificateChain)))));
+              req.connection()
+                  .withClientCertificateChain(
+                      OptionConverters.toScala(
+                          Optional.ofNullable(Scala.asScala(clientCertificateChain)))));
       return this;
     }
 

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -27,7 +27,10 @@ trait RequestHeader {
   top =>
 
   /**
-   * The remote connection that made the request.
+   * The remote connection metadata for this request.
+   *
+   * This is the primary API for connection metadata such as the selected remote
+   * identity, IP address, port, secure flag, and client certificate chain.
    */
   def connection: RemoteConnection
 
@@ -100,20 +103,38 @@ trait RequestHeader {
   def headers: Headers
 
   /**
-   * The remote connection that made the request.
+   * Return a new copy of the request with its HTTP headers changed.
    */
   def withHeaders(newHeaders: Headers): RequestHeader =
     new RequestHeaderImpl(connection, method, target, version, newHeaders, attrs)
 
   /**
-   * The client IP address.
+   * The client IP address, or a fallback IP address when the remote client is
+   * represented by an RFC 7239 unknown or obfuscated identifier.
    *
    * retrieves the last untrusted proxy
    * from the Forwarded-Headers or the X-Forwarded-*-Headers.
    *
    * This method delegates to `connection.remoteAddressString`.
    */
+  @deprecated(
+    "Use connection.remoteIdentity for the remote identity as a string, connection.remoteNode for the structured RFC 7239 remote identity, or connection.remoteIpAddress for an IP-only value. " +
+      "This legacy address cannot represent RFC 7239 unknown or obfuscated identifiers and may " +
+      "return a fallback proxy address when the selected forwarded identity is not an IP.",
+    "3.1.0"
+  )
   final def remoteAddress: String = connection.remoteAddressString
+
+  /**
+   * The remote identity as a string.
+   *
+   * If the remote identity is an IP address, this returns the address in textual
+   * form. If the remote identity is an RFC 7239 `unknown` or obfuscated
+   * identifier, this returns that identifier.
+   *
+   * This is a request-level shortcut for `connection.remoteIdentity`.
+   */
+  final def remoteIdentity: String = connection.remoteIdentity
 
   /**
    * The client port, if known.

--- a/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
@@ -7,24 +7,72 @@ package play.api.mvc.request
 import java.net.InetAddress
 import java.security.cert.X509Certificate
 
+import scala.jdk.javaapi.OptionConverters
+
 import com.google.common.net.InetAddresses
+import play.api.mvc.request.RemoteConnection.RemoteNode
 
 /**
- * Contains information about the connection from the remote client to the server.
- * Connection information may come from the socket or from other metadata attached
- * to the request by an upstream proxy, e.g. `Forwarded` headers.
+ * Contains metadata about the remote connection for a request.
+ *
+ * Connection metadata may come from the socket or from metadata attached to the
+ * request by an upstream proxy, e.g. `Forwarded` headers.
  */
 trait RemoteConnection {
 
   /**
-   * The remote client's address.
+   * The remote client's IP address, or a fallback IP address when the remote
+   * client is represented by an RFC 7239 unknown or obfuscated identifier.
    */
+  @deprecated(
+    "Use remoteIdentity for the remote identity as a string, remoteNode for the structured RFC 7239 remote identity, or remoteIpAddress for an IP-only value. " +
+      "This legacy address cannot represent RFC 7239 unknown or obfuscated identifiers and may " +
+      "return a fallback proxy address when the selected forwarded identity is not an IP.",
+    "3.1.0"
+  )
   def remoteAddress: InetAddress
 
   /**
-   * The remote client's address in text form.
+   * The remote client's IP address in text form, or a fallback IP address when the
+   * remote client is represented by an RFC 7239 unknown or obfuscated identifier.
    */
+  @deprecated(
+    "Use remoteIdentity for the remote identity as a string, remoteNode for the structured RFC 7239 remote identity, or remoteIpAddress for an IP-only value. " +
+      "This legacy address cannot represent RFC 7239 unknown or obfuscated identifiers and may " +
+      "return a fallback proxy address when the selected forwarded identity is not an IP.",
+    "3.1.0"
+  )
   def remoteAddressString: String = remoteAddress.getHostAddress
+
+  /**
+   * The selected remote identity.
+   *
+   * When the identity is an IP address, the node may also include the selected
+   * remote port. RFC 7239 `unknown` and obfuscated identifiers are represented
+   * explicitly so applications do not need to parse a string value.
+   */
+  def remoteNode: RemoteNode = RemoteNode.Ip(remoteAddress, remotePort)
+
+  /**
+   * The selected remote IP address, if the remote identity is an IP address.
+   */
+  def remoteIpAddress: Option[InetAddress] = remoteNode match {
+    case RemoteNode.Ip(address, _) => Some(address)
+    case _                         => None
+  }
+
+  /**
+   * The selected remote identity as a string.
+   *
+   * If the remote identity is an IP address, this returns the address in textual
+   * form. If the remote identity is an RFC 7239 `unknown` or obfuscated
+   * identifier, this returns that identifier.
+   */
+  def remoteIdentity: String = remoteNode match {
+    case RemoteNode.Ip(address, _)            => address.getHostAddress
+    case RemoteNode.Obfuscated(identifier, _) => identifier
+    case RemoteNode.Unknown(_)                => "unknown"
+  }
 
   /**
    * The remote client's port, if known.
@@ -41,22 +89,68 @@ trait RemoteConnection {
    */
   def clientCertificateChain: Option[Seq[X509Certificate]]
 
+  /**
+   * The Java API representation of this remote connection.
+   */
+  def asJava: play.mvc.Http.RemoteConnection = new play.mvc.Http.RemoteConnection(this)
+
+  /**
+   * Return a copy of this remote connection with the given remote port.
+   */
+  def withRemotePort(remotePort: Option[Int]): RemoteConnection =
+    RemoteConnection(remoteAddress, remoteNode, remotePort, secure, clientCertificateChain)
+
+  /**
+   * Return a copy of this remote connection with the given secure flag.
+   */
+  def withSecure(secure: Boolean): RemoteConnection =
+    RemoteConnection(remoteAddress, remoteNode, remotePort, secure, clientCertificateChain)
+
+  /**
+   * Return a copy of this remote connection with the given client certificate chain.
+   */
+  def withClientCertificateChain(clientCertificateChain: Option[Seq[X509Certificate]]): RemoteConnection =
+    RemoteConnection(remoteAddress, remoteNode, remotePort, secure, clientCertificateChain)
+
   override def toString: String =
-    s"RemoteAddress($remoteAddressString, port=$remotePort, secure=$secure, certs=$clientCertificateChain)"
+    s"RemoteAddress(${remoteAddress.getHostAddress}, node=$remoteNode, port=$remotePort, secure=$secure, certs=$clientCertificateChain)"
 
   override def equals(obj: scala.Any): Boolean = obj match {
     case that: RemoteConnection =>
       (this.remoteAddress == that.remoteAddress) &&
+      (this.remoteNode == that.remoteNode) &&
       (this.remotePort == that.remotePort) &&
       (this.secure == that.secure) &&
       (this.clientCertificateChain == that.clientCertificateChain)
     case _ => false
   }
 
-  override def hashCode(): Int = (remoteAddress, remotePort, secure, clientCertificateChain).hashCode()
+  override def hashCode(): Int = (remoteAddress, remoteNode, remotePort, secure, clientCertificateChain).hashCode()
 }
 
 object RemoteConnection {
+  sealed trait RemoteNode {
+
+    /**
+     * The Java API representation of this remote node.
+     */
+    def asJava: play.mvc.Http.RemoteNode = this match {
+      case RemoteNode.Ip(address, port) =>
+        new play.mvc.Http.RemoteNode.Ip(address, OptionConverters.toJava(port.map(Integer.valueOf)))
+      case RemoteNode.Obfuscated(identifier, port) =>
+        new play.mvc.Http.RemoteNode.Obfuscated(identifier, OptionConverters.toJava(port))
+      case RemoteNode.Unknown(port) =>
+        new play.mvc.Http.RemoteNode.Unknown(OptionConverters.toJava(port))
+    }
+  }
+
+  object RemoteNode {
+    final case class Ip(address: InetAddress, port: Option[Int])          extends RemoteNode
+    final case class Obfuscated(identifier: String, port: Option[String]) extends RemoteNode
+    final case class Unknown(port: Option[String])                        extends RemoteNode
+
+    def ip(address: InetAddress, port: Option[Int]): RemoteNode = Ip(address, port)
+  }
 
   /**
    * Create a RemoteConnection object. The address string is parsed lazily.
@@ -85,6 +179,7 @@ object RemoteConnection {
     new RemoteConnection {
       override lazy val remoteAddress: InetAddress                      = InetAddresses.forString(ras)
       override val remoteAddressString: String                          = ras
+      override lazy val remoteNode: RemoteNode                          = RemoteNode.Ip(remoteAddress, rp)
       override val remotePort: Option[Int]                              = rp
       override val secure: Boolean                                      = s
       override val clientCertificateChain: Option[Seq[X509Certificate]] = ccc
@@ -111,12 +206,27 @@ object RemoteConnection {
       secure: Boolean,
       clientCertificateChain: Option[Seq[X509Certificate]]
   ): RemoteConnection = {
+    apply(remoteAddress, RemoteNode.Ip(remoteAddress, remotePort), remotePort, secure, clientCertificateChain)
+  }
+
+  /**
+   * Create a RemoteConnection object.
+   */
+  def apply(
+      remoteAddress: InetAddress,
+      remoteNode: RemoteNode,
+      remotePort: Option[Int],
+      secure: Boolean,
+      clientCertificateChain: Option[Seq[X509Certificate]]
+  ): RemoteConnection = {
     val s   = secure
     val ra  = remoteAddress
+    val rn  = remoteNode
     val rp  = remotePort
     val ccc = clientCertificateChain
     new RemoteConnection {
       override val remoteAddress: InetAddress                           = ra
+      override val remoteNode: RemoteNode                               = rn
       override val remotePort: Option[Int]                              = rp
       override val secure: Boolean                                      = s
       override val clientCertificateChain: Option[Seq[X509Certificate]] = ccc

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -100,6 +100,8 @@ trait JavaHelpers {
       r.withConnection(new RemoteConnection {
         override def remoteAddress: InetAddress                           = c.remoteAddress
         override def remoteAddressString: String                          = c.remoteAddressString
+        override def remoteNode: RemoteConnection.RemoteNode              = c.remoteNode
+        override def remoteIpAddress: Option[InetAddress]                 = c.remoteIpAddress
         override def remotePort: Option[Int]                              = c.remotePort
         override def secure: Boolean                                      = newSecure
         override def clientCertificateChain: Option[Seq[X509Certificate]] = c.clientCertificateChain
@@ -196,11 +198,12 @@ object JavaHelpers extends JavaHelpers {
 class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def asScala: RequestHeader = header
 
-  override def uri: String                   = header.uri
-  override def method: String                = header.method
-  override def version: String               = header.version
-  override def remoteAddress: String         = header.remoteAddress
-  override def remotePort: Optional[Integer] = {
+  override def uri: String                       = header.uri
+  override def method: String                    = header.method
+  override def version: String                   = header.version
+  override def connection: Http.RemoteConnection = new Http.RemoteConnection(header.connection)
+  override def remoteAddress: String             = header.remoteAddress
+  override def remotePort: Optional[Integer]     = {
     header.remotePort.map(Int.box).toJava
   }
   override def secure: Boolean = header.secure

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -6,6 +6,7 @@ package play.api.mvc
 
 import java.util.Locale
 
+import com.google.common.net.InetAddresses
 import org.specs2.mutable.Specification
 import play.api.http.HeaderNames._
 import play.api.http.HttpConfiguration
@@ -18,6 +19,7 @@ import play.api.mvc.request.DefaultRequestFactory
 import play.api.mvc.request.RemoteConnection
 import play.api.mvc.request.RequestAttrKey
 import play.api.mvc.request.RequestTarget
+import play.mvc.Http
 
 class RequestHeaderSpec extends Specification {
   "request header" should {
@@ -34,6 +36,26 @@ class RequestHeaderSpec extends Specification {
         val rh = dummyRequestHeader(remotePort = Some(12345))
         rh.remotePort must beSome(12345)
         rh.asJava.remotePort must beEqualTo(java.util.Optional.of(12345))
+      }
+      "keep the remote port in connection" in {
+        val rh = dummyRequestHeader(remotePort = Some(12345))
+        rh.connection.remotePort must beSome(12345)
+        rh.asJava.connection.remotePort must beEqualTo(java.util.Optional.of(12345))
+      }
+      "keep the remote node and remote IP address" in {
+        val rh = dummyRequestHeader(remotePort = Some(12345))
+        rh.connection.remoteNode must beEqualTo(
+          RemoteConnection.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), Some(12345))
+        )
+        rh.connection.remoteIpAddress must beSome(InetAddresses.forString("127.0.0.1"))
+        rh.remoteIdentity must beEqualTo("127.0.0.1")
+        rh.asJava.connection.remoteNode must beEqualTo(
+          new Http.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), java.util.Optional.of(12345))
+        )
+        rh.asJava.connection.remoteIpAddress must beEqualTo(
+          java.util.Optional.of(InetAddresses.forString("127.0.0.1"))
+        )
+        rh.asJava.remoteIdentity must beEqualTo("127.0.0.1")
       }
     }
 
@@ -240,7 +262,7 @@ class RequestHeaderSpec extends Specification {
       remotePort: Option[Int] = None
   ): RequestHeader = {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
-      connection = RemoteConnection("", remotePort, false, None),
+      connection = RemoteConnection("127.0.0.1", remotePort, false, None),
       method = requestMethod,
       target = RequestTarget(requestUri, "", Map.empty),
       version = "",

--- a/core/play/src/test/scala/play/api/mvc/request/RemoteConnectionSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/request/RemoteConnectionSpec.scala
@@ -17,6 +17,44 @@ class RemoteConnectionSpec extends Specification {
       RemoteConnection("127.0.0.1", Some(12345), secure = false, None).remotePort must beSome(12345)
     }
 
+    "expose an IP remote node for IP connections" in {
+      val connection = RemoteConnection("127.0.0.1", Some(12345), secure = false, None)
+
+      connection.remoteNode must beEqualTo(
+        RemoteConnection.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), Some(12345))
+      )
+      connection.remoteIpAddress must beSome(InetAddresses.forString("127.0.0.1"))
+      connection.remoteIdentity must beEqualTo("127.0.0.1")
+    }
+
+    "return no remote IP address for obfuscated remote nodes" in {
+      val connection = RemoteConnection(
+        InetAddresses.forString("127.0.0.1"),
+        RemoteConnection.RemoteNode.Obfuscated("_hidden", None),
+        None,
+        secure = false,
+        None
+      )
+
+      connection.remoteNode must beEqualTo(RemoteConnection.RemoteNode.Obfuscated("_hidden", None))
+      connection.remoteIpAddress must beNone
+      connection.remoteIdentity must beEqualTo("_hidden")
+    }
+
+    "return unknown as the remote identity for unknown remote nodes" in {
+      val connection = RemoteConnection(
+        InetAddresses.forString("127.0.0.1"),
+        RemoteConnection.RemoteNode.Unknown(None),
+        None,
+        secure = false,
+        None
+      )
+
+      connection.remoteIdentity must beEqualTo("unknown")
+      connection.remoteIpAddress must beNone
+      connection.remoteNode must beEqualTo(RemoteConnection.RemoteNode.Unknown(None))
+    }
+
     "store the remote port when created from an inet address" in {
       RemoteConnection(InetAddresses.forString("127.0.0.1"), Some(12345), secure = false, None).remotePort must beSome(
         12345

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -4,9 +4,12 @@
 
 package play.mvc
 
+import java.net.InetAddress
+
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
+import com.google.common.net.InetAddresses
 import org.specs2.mutable.Specification
 import play.api.http.HttpConfiguration
 import play.api.libs.typedmap.TypedMap
@@ -20,7 +23,7 @@ import play.mvc.Http.HeaderNames
 class RequestHeaderSpec extends Specification {
   private def requestHeader(headers: (String, String)*): RequestHeader = {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
-      connection = RemoteConnection("", secure = false, None),
+      connection = RemoteConnection("127.0.0.1", secure = false, None),
       method = "GET",
       target = RequestTarget("/", "", Map.empty),
       version = "",
@@ -124,11 +127,81 @@ class RequestHeaderSpec extends Specification {
         request.asJava.remotePort must beEqualTo(java.util.Optional.of(12345))
       }
 
+      "expose the scala request remote port in connection" in {
+        val request = requestHeader().withConnection(RemoteConnection("127.0.0.1", Some(12345), secure = false, None))
+
+        request.asJava.connection.remotePort must beEqualTo(java.util.Optional.of(12345))
+      }
+
       "be set by the request builder" in {
         val request = new Http.RequestBuilder().remoteAddress("127.0.0.1").remotePort(12345).build()
 
         request.remotePort must beEqualTo(java.util.Optional.of(12345))
         request.asScala.connection.remotePort must beSome(12345)
+      }
+
+      "be set by the request builder in connections" in {
+        val request = new Http.RequestBuilder().remoteAddress("127.0.0.1").remotePort(12345).build()
+
+        request.connection.remotePort must beEqualTo(java.util.Optional.of(12345))
+        request.asScala.connection.remotePort must beSome(12345)
+      }
+    }
+
+    "remote node" in {
+      "wrap scala remote connections" in {
+        val scalaConnection = RemoteConnection("127.0.0.1", Some(12345), secure = true, None)
+        val javaConnection  = new Http.RemoteConnection(scalaConnection)
+
+        javaConnection.asScala must beEqualTo(scalaConnection)
+        javaConnection.remoteNode must beEqualTo(
+          new Http.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), java.util.Optional.of(12345))
+        )
+        javaConnection.remoteIpAddress must beEqualTo(java.util.Optional.of(InetAddresses.forString("127.0.0.1")))
+        javaConnection.remoteIdentity must beEqualTo("127.0.0.1")
+        javaConnection.remotePort must beEqualTo(java.util.Optional.of(12345))
+        javaConnection.secure must beTrue
+        javaConnection.clientCertificateChain must beEqualTo(
+          java.util.Optional.empty[java.util.List[java.security.cert.X509Certificate]]
+        )
+      }
+
+      "convert remote node wrappers to and from scala" in {
+        val obfuscated = new Http.RemoteNode.Obfuscated("_hidden", java.util.Optional.of("_port"))
+        val unknown    = new Http.RemoteNode.Unknown(java.util.Optional.empty[String])
+
+        obfuscated.asScala.asJava must beEqualTo(obfuscated)
+        unknown.asScala.asJava must beEqualTo(unknown)
+      }
+
+      "expose the scala request remote node" in {
+        val request = requestHeader().withConnection(RemoteConnection("127.0.0.1", Some(12345), secure = false, None))
+
+        request.asJava.connection.remoteNode must beEqualTo(
+          new Http.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), java.util.Optional.of(12345))
+        )
+        request.asJava.connection.remoteIpAddress must beEqualTo(
+          java.util.Optional.of(InetAddresses.forString("127.0.0.1"))
+        )
+      }
+
+      "expose an empty remote IP address for obfuscated remote nodes" in {
+        val request = requestHeader().withConnection(
+          RemoteConnection(
+            InetAddresses.forString("127.0.0.1"),
+            RemoteConnection.RemoteNode.Obfuscated("_hidden", None),
+            None,
+            secure = false,
+            None
+          )
+        )
+
+        request.asJava.connection.remoteNode must beEqualTo(
+          new Http.RemoteNode.Obfuscated("_hidden", java.util.Optional.empty[String])
+        )
+        request.asJava.connection.remoteIpAddress must beEqualTo(java.util.Optional.empty[InetAddress])
+        request.asJava.connection.remoteIdentity must beEqualTo("_hidden")
+        request.asJava.remoteIdentity must beEqualTo("_hidden")
       }
     }
   }

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -6,9 +6,15 @@ This section highlights the new features of Play 3.1. If you want to learn about
 
 ## Other Additions
 
+### RFC 7239 Remote Identities
+
+Play now exposes the selected remote identity through `RequestHeader.connection.remoteNode` in Scala, and `Http.RequestHeader.connection().remoteNode()` in Java. Applications that need the selected identity as a string can use `RequestHeader.connection.remoteIdentity` in Scala, or `Http.RequestHeader.connection().remoteIdentity()` in Java. `RequestHeader.remoteIdentity` and `Http.RequestHeader.remoteIdentity()` are available as request-level shortcuts.
+
+This supports [RFC 7239](https://tools.ietf.org/html/rfc7239) `Forwarded` identifiers that are not IP addresses, such as `for=unknown` and obfuscated identifiers like `for=_hidden`. The existing `remoteAddress` APIs are deprecated because they cannot represent these identifiers and may return a fallback proxy address when the selected forwarded identity is not an IP address.
+
 ### Remote Connection Port
 
-Play now exposes the remote connection port, when known, through `RequestHeader.remotePort` and `RequestHeader.connection.remotePort` in Scala, and `Http.RequestHeader.remotePort()` in Java.
+Play now exposes the remote connection port, when known, through `RequestHeader.connection.remotePort` in Scala, and `Http.RequestHeader.connection().remotePort()` in Java. `RequestHeader.remotePort` and `Http.RequestHeader.remotePort()` are available as request-level shortcuts.
 
 The Netty and Pekko HTTP server backends populate this value from the raw socket connection. Trusted forwarded headers can also provide this value through RFC 7239 `Forwarded` ports or `X-Forwarded-Port`.
 

--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -26,6 +26,37 @@ Play now uses Pekko 2 and Pekko HTTP 2. If your build overrides Play's Pekko dep
 
 The deprecated low-level `org.apache.pekko.http.play.WebSocketHandler.handleWebSocket` overloads that accepted Pekko HTTP's old `UpgradeToWebSocket` API have been removed. Code using this internal Pekko HTTP bridge should use the maintained `WebSocketUpgrade` overload instead.
 
+### Remote address APIs deprecated in favor of remote node APIs
+
+Play now supports RFC 7239 `Forwarded` remote identifiers that are not IP addresses, such as `for=unknown` and obfuscated identifiers like `for=_hidden`. The old `remoteAddress` APIs cannot represent these values, so they are deprecated:
+
+* Scala `RequestHeader.remoteAddress`
+* Scala `RemoteConnection.remoteAddress`
+* Scala `RemoteConnection.remoteAddressString`
+* Java `Http.RequestHeader.remoteAddress()`
+
+Use `RequestHeader.connection.remoteNode` when you need the structured remote identity selected from trusted forwarded headers. Use `RequestHeader.connection.remoteIdentity` when you need that identity as a string, or `RequestHeader.connection.remoteIpAddress` when you specifically need an IP address. `RequestHeader.remoteIdentity` is available as a request-level shortcut.
+
+For compatibility, the deprecated `remoteAddress` APIs still return an IP address. If the selected RFC 7239 remote identity is `unknown` or obfuscated, that IP address is only a fallback, usually the previous trusted proxy address, and does not represent the actual RFC 7239 remote identity.
+
+For example, with a trusted direct proxy at `127.0.0.1`:
+
+```http
+Forwarded: for=_hidden;proto=https
+```
+
+Play reports:
+
+```scala
+request.connection.remoteNode      // RemoteNode.Obfuscated("_hidden", None)
+request.connection.remoteIdentity  // "_hidden"
+request.connection.remoteIpAddress // None
+request.secure                     // true
+```
+
+The deprecated `request.remoteAddress` method still returns the fallback legacy value, such as
+`"127.0.0.1"` in this example.
+
 ### HEAD responses no longer include generated Content-Length headers
 
 Play no longer renders generated `Content-Length` headers for `HEAD` responses. `HEAD` responses still do not include a response body, but applications and tests should not rely on `Content-Length` being present on a `HEAD` response, even when the equivalent `GET` response has a known length.

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -158,7 +158,7 @@ ProxyPassReverse / http://localhost:9998
 
 ## Configuring trusted proxies
 
-Play supports various forwarded headers used by proxies to indicate the incoming IP address, port, and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteAddress`, `remotePort`, and `secure` fields of `RequestHeader`.
+Play supports various forwarded headers used by proxies to indicate the incoming remote identity, IP address, port, and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteNode`, `remoteIdentity`, `remoteIpAddress`, `remotePort`, and `secure` fields of `RequestHeader.connection`.
 
 It is trivial for an HTTP client, whether it's a browser or other client, to forge forwarded headers, thereby spoofing the IP address and protocol that Play reports, consequently, Play needs to know which proxies are trusted. Play provides a configuration option to configure a list of trusted proxies, and will validate the incoming forwarded headers to verify that they are trusted, taking the first untrusted IP address that it finds as the reported user remote address (or the last IP address if all proxies are trusted.)
 
@@ -190,6 +190,14 @@ This is configured using `play.http.forwarded.version`, with valid values being 
 `x-forwarded` uses the de facto standard `X-Forwarded-For`, `X-Forwarded-Port`, and `X-Forwarded-Proto` headers to determine the correct remote address, port, and protocol for the request. These headers are widely used, however, they have some serious limitations, for example, if you have multiple proxies, and only one of them adds the `X-Forwarded-Proto` header, it's impossible to reliably determine which proxy added it and therefore whether the request from the client was made using https or http. `rfc7239` uses the new `Forwarded` header standard, and solves many of the limitations of the `X-Forwarded-*` headers.
 
 For more information, please read the [RFC 7239](https://tools.ietf.org/html/rfc7239) specification.
+
+### RFC 7239 remote identities
+
+RFC 7239 `Forwarded` headers can identify the remote client with an IP address, the `unknown` identifier, or an obfuscated identifier such as `_hidden`. Play exposes this value through `RequestHeader.connection.remoteNode`.
+
+Use `RequestHeader.connection.remoteIdentity` when you need the selected remote identity as a string. `RequestHeader.remoteIdentity` is available as a request-level shortcut. When the selected remote node is an IP address, `RequestHeader.connection.remoteIpAddress` contains that address. When the selected remote node is `unknown` or obfuscated, `remoteIpAddress` is empty. The deprecated `RequestHeader.remoteAddress` method still returns a fallback IP address for compatibility, usually the previous trusted proxy address, and should not be used when applications need the actual RFC 7239 remote identity.
+
+If Play selects an `unknown` or obfuscated remote node while scanning a trusted proxy chain, it stops scanning at that node because it cannot determine whether a non-IP identifier represents a trusted proxy.
 
 ### Trusting a single X-Forwarded-Proto value
 

--- a/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/Application.java
+++ b/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/Application.java
@@ -43,7 +43,7 @@ class AccessLoggingAction extends Action.Simple {
         "method={} uri={} remote-address={}",
         request.method(),
         request.uri(),
-        request.remoteAddress());
+        request.connection().remoteIdentity());
 
     return delegate.call(request);
   }

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -115,7 +115,9 @@ class ScalaLoggingSpec extends Specification {
           extends ActionBuilderImpl(parser) {
         val accessLogger                                                                        = Logger("access")
         override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
-          accessLogger.info(s"method=${request.method} uri=${request.uri} remote-address=${request.remoteAddress}")
+          accessLogger.info(
+            s"method=${request.method} uri=${request.uri} remote-address=${request.connection.remoteIdentity}"
+          )
           block(request)
         }
       }
@@ -167,8 +169,9 @@ class ScalaLoggingSpec extends Specification {
           val resultFuture = next(request)
 
           resultFuture.foreach(result => {
-            val msg = s"method=${request.method} uri=${request.uri} remote-address=${request.remoteAddress}" +
-              s" status=${result.header.status}";
+            val msg =
+              s"method=${request.method} uri=${request.uri} remote-address=${request.connection.remoteIdentity}" +
+                s" status=${result.header.status}";
             accessLogger.info(msg)
           })
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -571,8 +571,11 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "org.apache.pekko.http.play.WebSocketHandler.handleWebSocket"
       ),
-      // ForwardedEntry and ParsedForwardedEntry are private server internals.
-      // Their case class signatures changed to carry forwarded port values.
+      // ForwardedHeaderHandler parser models are private server internals.
+      // Their signatures changed to carry forwarded port values and RFC 7239 remote identities.
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ForwardedHeaderHandlerConfig.parseEntry"
+      ),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "play.core.server.common.ForwardedHeaderHandler#ForwardedEntry.apply"
       ),
@@ -593,6 +596,12 @@ object BuildSettings {
       ),
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
         "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry.copy$default$2"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry.copy$default$1"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry._1"
       ),
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
         "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry._2"

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -10,15 +10,19 @@ import java.security.cert.X509Certificate
 import scala.annotation.tailrec
 
 import play.api.mvc.request.RemoteConnection
+import play.api.mvc.request.RemoteConnection.RemoteNode
 import play.api.mvc.Headers
 import play.api.Configuration
 import play.api.Logger
 import play.core.server.common.NodeIdentifierParser.Ip
+import play.core.server.common.NodeIdentifierParser.ObfuscatedIp
+import play.core.server.common.NodeIdentifierParser.ObfuscatedPort
 import play.core.server.common.NodeIdentifierParser.PortNumber
+import play.core.server.common.NodeIdentifierParser.UnknownIp
 import ForwardedHeaderHandler._
 
 /**
- * The ForwardedHeaderHandler class works out the remote address and protocol
+ * The ForwardedHeaderHandler class works out the remote identity, address, port, and protocol
  * by taking
  * into account Forward and X-Forwarded-* headers from trusted proxies. The
  * algorithm it uses is as follows:
@@ -30,11 +34,13 @@ import ForwardedHeaderHandler._
  *    checking whether the immediate connection is in our list of trusted
  *    proxies.
  * 4. If the immediate connection *is* a trusted proxy, then resume at step
- *    1 using the connection info in the forwarded header.
+ *    1 using the connection info in the forwarded header. If the forwarded
+ *    identity is not an IP address, keep it as the selected remote identity
+ *    and stop scanning because trusted proxies are configured as IP ranges.
  * 5. If the immediate connection *is not* a trusted proxy, then return the
  *    immediate connection info and don't do any further processing.
  *
- * Each address is associated with a port and a secure or insecure protocol by
+ * Each identity is associated with a port and a secure or insecure protocol by
  * pairing it with a `port` and `proto` entry in the headers. If the `proto`
  * entry is missing, or if `proto` entries can't be matched with addresses,
  * then the default is insecure.
@@ -56,7 +62,7 @@ import ForwardedHeaderHandler._
  *   </dd>
  *   <dt>play.http.forwarded.trustedProxies</dt>
  *   <dd>
- *     A list of proxies that are ignored when getting the remote address or the remote port.
+ *     A list of proxies that are ignored when getting the remote identity, remote address, or remote port.
  *     It can have optionally an address block size. When the address block size is set,
  *     all IP-addresses in the range of the subnet will be treated as trusted.
  *   </dd>
@@ -74,6 +80,8 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
   def forwardedConnection(rawConnection: RemoteConnection, headers: Headers): RemoteConnection = new RemoteConnection {
     // All public methods delegate to the lazily calculated connection info
     override def remoteAddress: InetAddress                           = parsed.remoteAddress
+    override def remoteNode: RemoteNode                               = parsed.remoteNode
+    override def remoteIpAddress: Option[InetAddress]                 = parsed.remoteIpAddress
     override def remotePort: Option[Int]                              = parsed.remotePort
     override def secure: Boolean                                      = parsed.secure
     override def clientCertificateChain: Option[Seq[X509Certificate]] = parsed.clientCertificateChain
@@ -95,24 +103,29 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
           // There is a forwarded header from 'prev', so lets check if 'prev' is trusted.
           // If it's a trusted proxy then process the header, otherwise just use 'prev'.
 
-          if (configuration.isTrustedProxy(prev.remoteAddress)) {
+          val previousAddress = prev.remoteIpAddress
+          if (previousAddress.exists(configuration.isTrustedProxy)) {
             // 'prev' is a trusted proxy, so we process the next entry.
             val entry = headerEntries.next()
-            configuration.parseEntry(entry) match {
+            configuration.parseEntry(entry, previousAddress) match {
               case Left(error) =>
                 ForwardedHeaderHandler.logger.debug(
                   s"Error with info in forwarding header $entry, using $prev instead: $error."
                 )
                 prev
               case Right(parsedEntry) =>
-                scan(
-                  RemoteConnection(
-                    parsedEntry.address,
-                    parsedEntry.remotePort,
-                    parsedEntry.secure,
-                    None /* No cert chain for forward headers */
-                  )
+                val connection = RemoteConnection(
+                  parsedEntry.address,
+                  parsedEntry.remoteNode,
+                  parsedEntry.remotePort,
+                  parsedEntry.secure,
+                  None /* No cert chain for forward headers */
                 )
+                if (parsedEntry.remoteIpAddress.isDefined) {
+                  scan(connection)
+                } else {
+                  connection
+                }
             }
           } else {
             // 'prev' is not a trusted proxy, so we don't scan ahead in the list of
@@ -156,12 +169,23 @@ private[server] object ForwardedHeaderHandler {
 
   /**
    * Basic information about an HTTP connection, parsed from a ForwardedEntry.
+   * `remoteNode` is the selected forwarded identity. `fallbackAddress` is the
+   * previous trusted proxy address used for legacy remote address APIs when the
+   * selected identity is not an IP address.
    */
   final case class ParsedForwardedEntry(
-      address: InetAddress,
+      remoteNode: RemoteNode,
+      fallbackAddress: Option[InetAddress],
       remotePort: Option[Int],
       secure: Boolean
-  )
+  ) {
+    def remoteIpAddress: Option[InetAddress] = remoteNode match {
+      case RemoteNode.Ip(address, _) => Some(address)
+      case _                         => None
+    }
+
+    def address: InetAddress = remoteIpAddress.orElse(fallbackAddress).get
+  }
 
   case class ForwardedHeaderHandlerConfig(
       version: ForwardedHeaderVersion,
@@ -189,6 +213,11 @@ private[server] object ForwardedHeaderHandler {
       } else {
         None
       }
+    }
+
+    private def portString(port: NodeIdentifierParser.Port): Option[String] = port match {
+      case PortNumber(number)     => Some(number.toString)
+      case ObfuscatedPort(string) => Some(string)
     }
 
     /**
@@ -264,12 +293,15 @@ private[server] object ForwardedHeaderHandler {
     }
 
     /**
-     * Try to parse a `ForwardedEntry` into a valid `ConnectionInfo` with an IP address
-     * and information about the protocol security. If this cannot happen, either because
-     * parsing fails or because the connection info doesn't include an IP address, this
-     * method will return `Left` with an error message.
+     * Try to parse a `ForwardedEntry` into a valid `ParsedForwardedEntry`
+     * containing the remote identity, port, protocol security, and optional
+     * fallback IP address. This method returns `Left` when the forwarded entry is
+     * missing an address or the node identifier cannot be parsed.
      */
-    def parseEntry(entry: ForwardedEntry): Either[String, ParsedForwardedEntry] = {
+    def parseEntry(
+        entry: ForwardedEntry,
+        fallbackAddress: Option[InetAddress] = None
+    ): Either[String, ParsedForwardedEntry] = {
       entry.addressString match {
         case None =>
           // We had a forwarding header, but it was missing the address entry for some reason.
@@ -277,12 +309,30 @@ private[server] object ForwardedHeaderHandler {
         case Some(addressString) =>
           nodeIdentifierParser.parseNode(addressString) match {
             case Right((Ip(address), nodePort)) =>
-              // Parsing was successful, use this connection and scan for another connection.
+              // IP identities can be checked against trustedProxies, so the caller may continue scanning.
               val secure     = entry.protoString.fold(false)(_ == "https") // Assume insecure by default
               val remotePort = entry.portString.flatMap(parsePort).orElse {
                 nodePort.collect { case PortNumber(port) => port }
               }
-              val connection = ParsedForwardedEntry(address, remotePort, secure)
+              val connection =
+                ParsedForwardedEntry(RemoteNode.Ip(address, remotePort), fallbackAddress, remotePort, secure)
+              Right(connection)
+            case Right((UnknownIp, nodePort)) =>
+              // RFC 7239 allows "unknown" when the proxy cannot or does not want to disclose the node.
+              val secure     = entry.protoString.fold(false)(_ == "https") // Assume insecure by default
+              val connection =
+                ParsedForwardedEntry(RemoteNode.Unknown(nodePort.flatMap(portString)), fallbackAddress, None, secure)
+              Right(connection)
+            case Right((ObfuscatedIp(identifier), nodePort)) =>
+              // RFC 7239 allows obfuscated identifiers such as "_hidden" to avoid disclosing the node.
+              val secure     = entry.protoString.fold(false)(_ == "https") // Assume insecure by default
+              val connection =
+                ParsedForwardedEntry(
+                  RemoteNode.Obfuscated(identifier, nodePort.flatMap(portString)),
+                  fallbackAddress,
+                  None,
+                  secure
+                )
               Right(connection)
             case errorOrNonIp =>
               // The forwarding address entry couldn't be parsed for some reason.

--- a/transport/server/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
@@ -7,6 +7,7 @@ package play.core.server.common
 import java.net.Inet4Address
 import java.net.Inet6Address
 import java.net.InetAddress
+import java.util.Locale
 
 import scala.util.parsing.combinator.RegexParsers
 import scala.util.Try
@@ -39,11 +40,11 @@ private[common] class NodeIdentifierParser(version: ForwardedHeaderVersion) exte
   private lazy val nodename = version match {
     case Rfc7239 =>
       // RFC 7239 recognizes IPv4 addresses, escaped IPv6 addresses, unknown and obfuscated addresses
-      (ipv4Address | "[" ~> ipv6Address <~ "]" | "unknown" | obfnode) ^^ {
-        case x: Inet4Address => Ip(x)
-        case x: Inet6Address => Ip(x)
-        case "unknown"       => UnknownIp
-        case x               => ObfuscatedIp(x.toString)
+      (ipv4Address | "[" ~> ipv6Address <~ "]" | "(?i)unknown".r | obfnode) ^^ {
+        case x: Inet4Address                                          => Ip(x)
+        case x: Inet6Address                                          => Ip(x)
+        case x if x.toString.toLowerCase(Locale.ENGLISH) == "unknown" => UnknownIp
+        case x                                                        => ObfuscatedIp(x.toString)
       }
     case Xforwarded =>
       // X-Forwarded-For recognizes IPv4 and escaped or unescaped IPv6 addresses

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -9,6 +9,7 @@ import java.net.InetAddress
 import com.google.common.net.InetAddresses
 import org.specs2.mutable.Specification
 import play.api.mvc.request.RemoteConnection
+import play.api.mvc.request.RemoteConnection.RemoteNode
 import play.api.mvc.Headers
 import play.api.Configuration
 import play.api.PlayException
@@ -37,31 +38,35 @@ class ForwardedHeaderHandlerSpec extends Specification {
       )
       results.length must_== 9
       results(0)._1 must_== ForwardedEntry(Some("_gazonk"), None)
-      results(0)._2 must beLeft
+      results(0)._2 must beRight(ParsedForwardedEntry(RemoteNode.Obfuscated("_gazonk", None), None, None, false))
       results(0)._3 must beNone
       results(1)._1 must_== ForwardedEntry(Some("[2001:db8:cafe::17]:4711"), None)
-      results(1)._2 must beRight(ParsedForwardedEntry(addr("2001:db8:cafe::17"), Some(4711), false))
+      results(1)._2 must beRight(
+        ParsedForwardedEntry(RemoteNode.Ip(addr("2001:db8:cafe::17"), Some(4711)), None, Some(4711), false)
+      )
       results(1)._3 must beSome(false)
       results(2)._1 must_== ForwardedEntry(Some("192.0.2.60"), Some("http"))
-      results(2)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.60"), None, false))
+      results(2)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("192.0.2.60"), None), None, None, false))
       results(2)._3 must beSome(true)
       results(3)._1 must_== ForwardedEntry(Some("192.0.2.43"), None)
-      results(3)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.43"), None, false))
+      results(3)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("192.0.2.43"), None), None, None, false))
       results(3)._3 must beSome(true)
       results(4)._1 must_== ForwardedEntry(Some("198.51.100.17"), None)
-      results(4)._2 must beRight(ParsedForwardedEntry(addr("198.51.100.17"), None, false))
+      results(4)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("198.51.100.17"), None), None, None, false))
       results(4)._3 must beSome(false)
       results(5)._1 must_== ForwardedEntry(Some("127.0.0.1"), None)
-      results(5)._2 must beRight(ParsedForwardedEntry(addr("127.0.0.1"), None, false))
+      results(5)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("127.0.0.1"), None), None, None, false))
       results(5)._3 must beSome(false)
       results(6)._1 must_== ForwardedEntry(Some("192.0.2.61"), Some("https"))
-      results(6)._2 must beRight(ParsedForwardedEntry(addr("192.0.2.61"), None, true))
+      results(6)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("192.0.2.61"), None), None, None, true))
       results(6)._3 must beSome(true)
       results(7)._1 must_== ForwardedEntry(Some("unknown"), None)
-      results(7)._2 must beLeft
+      results(7)._2 must beRight(ParsedForwardedEntry(RemoteNode.Unknown(None), None, None, false))
       results(7)._3 must beNone
       results(8)._1 must_== ForwardedEntry(Some("[::ffff:192.168.0.9]"), Some("https"))
-      results(8)._2 must beRight(ParsedForwardedEntry(addr("::ffff:192.168.0.9"), None, true))
+      results(8)._2 must beRight(
+        ParsedForwardedEntry(RemoteNode.Ip(addr("::ffff:192.168.0.9"), None), None, None, true)
+      )
       results(8)._3 must beSome(false)
     }
 
@@ -77,19 +82,21 @@ class ForwardedHeaderHandlerSpec extends Specification {
       )
       results.length must_== 5
       results(0)._1 must_== ForwardedEntry(Some("192.168.1.1"), Some("https"))
-      results(0)._2 must beRight(ParsedForwardedEntry(addr("192.168.1.1"), None, true))
+      results(0)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("192.168.1.1"), None), None, None, true))
       results(0)._3 must beSome(false)
       results(1)._1 must_== ForwardedEntry(Some("::1"), Some("http"))
-      results(1)._2 must beRight(ParsedForwardedEntry(addr("::1"), None, false))
+      results(1)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("::1"), None), None, None, false))
       results(1)._3 must beSome(false)
       results(2)._1 must_== ForwardedEntry(Some("[2001:db8:cafe::17]"), Some("https"))
-      results(2)._2 must beRight(ParsedForwardedEntry(addr("2001:db8:cafe::17"), None, true))
+      results(2)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("2001:db8:cafe::17"), None), None, None, true))
       results(2)._3 must beSome(true)
       results(3)._1 must_== ForwardedEntry(Some("127.0.0.1"), Some("http"))
-      results(3)._2 must beRight(ParsedForwardedEntry(addr("127.0.0.1"), None, false))
+      results(3)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("127.0.0.1"), None), None, None, false))
       results(3)._3 must beSome(false)
       results(4)._1 must_== ForwardedEntry(Some("::ffff:123.123.123.123"), Some("https"))
-      results(4)._2 must beRight(ParsedForwardedEntry(addr("::ffff:123.123.123.123"), None, true))
+      results(4)._2 must beRight(
+        ParsedForwardedEntry(RemoteNode.Ip(addr("::ffff:123.123.123.123"), None), None, None, true)
+      )
       results(4)._3 must beSome(false)
     }
 
@@ -203,14 +210,40 @@ class ForwardedHeaderHandlerSpec extends Specification {
         ) mustEqual RemoteConnection(addr("::ffff:99.99.99.99"), Some(4711), secure = false, None)
     }
 
-    "ignore obfuscated addresses with rfc7239" in {
+    "use obfuscated addresses with rfc7239 and keep the previous IP address as fallback" in {
       remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
         """
           |Forwarded: for="_gazonk"
           |Forwarded: for=192.168.1.10, for=127.0.0.1
         """.stripMargin
-      ) mustEqual RemoteConnection("192.168.1.10", false, None)
+      ) mustEqual RemoteConnection(addr("192.168.1.10"), RemoteNode.Obfuscated("_gazonk", None), None, false, None)
+    }
+
+    "use proto from obfuscated addresses with rfc7239" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for="_gazonk";proto=https
+        """.stripMargin
+      ) mustEqual RemoteConnection(addr("127.0.0.1"), RemoteNode.Obfuscated("_gazonk", None), None, secure = true, None)
+    }
+
+    "stop scanning at obfuscated addresses with rfc7239" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
+        """
+          |Forwarded: for=203.0.113.43;proto=https
+          |Forwarded: for="_gazonk";proto=http
+          |Forwarded: for=192.168.1.10
+        """.stripMargin
+      ) mustEqual RemoteConnection(
+        addr("192.168.1.10"),
+        RemoteNode.Obfuscated("_gazonk", None),
+        None,
+        secure = false,
+        None
+      )
     }
 
     "ignore obfuscated ports with rfc7239" in {
@@ -222,24 +255,33 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("192.0.2.43", false, None)
     }
 
-    "ignore unknown addresses with rfc7239" in {
+    "use unknown addresses with rfc7239 and keep the previous IP address as fallback" in {
       remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
         """
           |Forwarded: for=unknown
           |Forwarded: for=192.168.1.10, for=127.0.0.1
         """.stripMargin
-      ) mustEqual RemoteConnection("192.168.1.10", false, None)
+      ) mustEqual RemoteConnection(addr("192.168.1.10"), RemoteNode.Unknown(None), None, false, None)
     }
 
-    "ignore unknown addresses with ports with rfc7239" in {
+    "use unknown addresses with ports with rfc7239" in {
       remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
         """
           |Forwarded: for=unknown:1234
           |Forwarded: for=192.168.1.10, for=127.0.0.1
         """.stripMargin
-      ) mustEqual RemoteConnection("192.168.1.10", false, None)
+      ) mustEqual RemoteConnection(addr("192.168.1.10"), RemoteNode.Unknown(Some("1234")), None, false, None)
+    }
+
+    "use unknown addresses case-insensitively with rfc7239" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for=Unknown;proto=https
+        """.stripMargin
+      ) mustEqual RemoteConnection(addr("127.0.0.1"), RemoteNode.Unknown(None), None, secure = true, None)
     }
 
     "ignore rfc7239 header with empty addresses" in {
@@ -786,7 +828,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
       val errorOrConnection = configuration.parseEntry(forwardedEntry)
       val trusted           = errorOrConnection match {
         case Left(_)           => None
-        case Right(connection) => Some(configuration.isTrustedProxy(connection.address))
+        case Right(connection) => connection.remoteIpAddress.map(configuration.isTrustedProxy)
       }
       (forwardedEntry, errorOrConnection, trusted)
     }

--- a/transport/server/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
@@ -48,6 +48,11 @@ class NodeIdentifierParserSpec extends Specification {
       parseNode(Rfc7239, "unknown") must beRight(UnknownIp -> None)
     }
 
+    "parse an unknown ip address case-insensitively" in {
+      parseNode(Rfc7239, "Unknown") must beRight(UnknownIp -> None)
+      parseNode(Rfc7239, "UNKNOWN") must beRight(UnknownIp -> None)
+    }
+
     "parse an obfuscated ip address without port" in {
       parseNode(Rfc7239, "_harry") must beRight(ObfuscatedIp("_harry") -> None)
     }

--- a/web/play-filters-helpers/src/main/scala/play/filters/ip/IPFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/ip/IPFilter.scala
@@ -47,12 +47,12 @@ class IPFilter @Inject() (config: IPFilterConfig, httpErrorHandler: HttpErrorHan
     if (this.config.ipAllowed(req)) {
       next(req)
     } else {
-      logger.warn(s"Access denied to ${req.path} for IP ${req.remoteAddress}.")
+      logger.warn(s"Access denied to ${req.path} for IP ${req.remoteIdentity}.")
       Accumulator.done(
         httpErrorHandler.onClientError(
           req.addAttr(HttpErrorHandler.Attrs.HttpErrorInfo, HttpErrorInfo("ip-filter")),
           this.config.accessDeniedHttpStatusCode,
-          s"IP not allowed: ${req.remoteAddress}"
+          s"IP not allowed: ${req.remoteIdentity}"
         )
       )
     }
@@ -91,11 +91,15 @@ object IPFilterConfig {
           true // default case, both whitelist and blacklist are empty so all IPs are allowed.
         } else {
           // The blacklist is defined, so we accept the IP if it's not blacklisted.
-          blackList.forall(!JArrays.equals(_, req.connection.remoteAddress.getAddress))
+          req.connection.remoteIpAddress.exists { remoteAddress =>
+            blackList.forall(!JArrays.equals(_, remoteAddress.getAddress))
+          }
         }
       } else {
         // The whitelist is defined. We accept the IP if there is a matching whitelist entry.
-        whiteList.exists(JArrays.equals(_, req.connection.remoteAddress.getAddress))
+        req.connection.remoteIpAddress.exists { remoteAddress =>
+          whiteList.exists(JArrays.equals(_, remoteAddress.getAddress))
+        }
       }
     }
 


### PR DESCRIPTION
- Fixes #6875.

Play’s  [RFC 7239](https://tools.ietf.org/html/rfc7239) `Forwarded` header support only handled IP address node identifiers. RFC 7239 also allows `for=unknown` and obfuscated identifiers such as `for=_hidden`. Before this change, those values could cause Play to ignore otherwise useful forwarded metadata such as `proto=https`.

## Changes

- Add structured remote identity APIs:
  - Scala `RequestHeader.connection.remoteNode`
  - Scala `RequestHeader.connection.remoteIdentity`
  - Scala `RequestHeader.connection.remoteIpAddress`
  - Java `Http.RequestHeader.connection().remoteNode()`
  - Java `Http.RequestHeader.connection().remoteIdentity()`
  - Java `Http.RequestHeader.connection().remoteIpAddress()`
- Support RFC 7239 node identifiers:
  - IP addresses
  - `unknown`
  - obfuscated identifiers such as `_hidden`
- Preserve `proto` when the selected RFC 7239 `for` value is `unknown` or obfuscated.
- Keep legacy `remoteAddress` APIs as compatibility fallbacks and deprecate them because they cannot represent non-IP RFC 7239 identities.
- Document `request.connection` / `request.connection()` as the primary API for connection metadata.
- Update docs, migration notes, release highlights, filters, Java wrappers, and tests.

## Behavior

For example:

```http
Forwarded: for=_hidden;proto=https
```

Play now reports:

```scala
request.connection.remoteNode      // RemoteNode.Obfuscated("_hidden", None)
request.connection.remoteIdentity  // "_hidden"
request.connection.remoteIpAddress // None
request.secure                     // true
```

The deprecated `request.remoteAddress` still returns an IP fallback for compatibility, usually the previous trusted proxy address.

If Play encounters an `unknown` or obfuscated remote identity while scanning a trusted proxy chain, it selects that identity and stops scanning because `play.http.forwarded.trustedProxies` is currently IP/CIDR based. A follow-up PR will add support for explicitly trusted obfuscated proxy identifiers.