### PR TITLE
 Expose RFC 7239 `by` nodes

### DIFF
--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -262,6 +262,18 @@ public class Http {
     }
 
     /**
+     * The RFC 7239 {@code by} node for the selected forwarded element, if present.
+     *
+     * <p>This identifies the proxy interface that received the request represented by {@link
+     * #remoteNode()}. It is not the selected remote identity; use {@link #remoteNode()} for that.
+     *
+     * @return the receiving proxy node
+     */
+    public Optional<RemoteNode> byNode() {
+      return OptionConverters.toJava(underlying.byNode()).map(node -> node.asJava());
+    }
+
+    /**
      * @return the selected remote IP address, if the remote identity is an IP address
      */
     public Optional<InetAddress> remoteIpAddress() {

--- a/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RemoteConnection.scala
@@ -54,6 +54,15 @@ trait RemoteConnection {
   def remoteNode: RemoteNode = RemoteNode.Ip(remoteAddress, remotePort)
 
   /**
+   * The RFC 7239 `by` node for the selected forwarded element, if present.
+   *
+   * This identifies the proxy interface that received the request represented by
+   * `remoteNode`. It is not the selected remote identity; use `remoteNode` for
+   * that.
+   */
+  def byNode: Option[RemoteNode] = None
+
+  /**
    * The selected remote IP address, if the remote identity is an IP address.
    */
   def remoteIpAddress: Option[InetAddress] = remoteNode match {
@@ -98,34 +107,36 @@ trait RemoteConnection {
    * Return a copy of this remote connection with the given remote port.
    */
   def withRemotePort(remotePort: Option[Int]): RemoteConnection =
-    RemoteConnection(remoteAddress, remoteNode, remotePort, secure, clientCertificateChain)
+    RemoteConnection(remoteAddress, remoteNode, remotePort, byNode, secure, clientCertificateChain)
 
   /**
    * Return a copy of this remote connection with the given secure flag.
    */
   def withSecure(secure: Boolean): RemoteConnection =
-    RemoteConnection(remoteAddress, remoteNode, remotePort, secure, clientCertificateChain)
+    RemoteConnection(remoteAddress, remoteNode, remotePort, byNode, secure, clientCertificateChain)
 
   /**
    * Return a copy of this remote connection with the given client certificate chain.
    */
   def withClientCertificateChain(clientCertificateChain: Option[Seq[X509Certificate]]): RemoteConnection =
-    RemoteConnection(remoteAddress, remoteNode, remotePort, secure, clientCertificateChain)
+    RemoteConnection(remoteAddress, remoteNode, remotePort, byNode, secure, clientCertificateChain)
 
   override def toString: String =
-    s"RemoteAddress(${remoteAddress.getHostAddress}, node=$remoteNode, port=$remotePort, secure=$secure, certs=$clientCertificateChain)"
+    s"RemoteConnection(address=${remoteAddress.getHostAddress}, remoteNode=$remoteNode, byNode=$byNode, port=$remotePort, secure=$secure, certs=$clientCertificateChain)"
 
   override def equals(obj: scala.Any): Boolean = obj match {
     case that: RemoteConnection =>
       (this.remoteAddress == that.remoteAddress) &&
       (this.remoteNode == that.remoteNode) &&
+      (this.byNode == that.byNode) &&
       (this.remotePort == that.remotePort) &&
       (this.secure == that.secure) &&
       (this.clientCertificateChain == that.clientCertificateChain)
     case _ => false
   }
 
-  override def hashCode(): Int = (remoteAddress, remoteNode, remotePort, secure, clientCertificateChain).hashCode()
+  override def hashCode(): Int =
+    (remoteAddress, remoteNode, byNode, remotePort, secure, clientCertificateChain).hashCode()
 }
 
 object RemoteConnection {
@@ -219,14 +230,30 @@ object RemoteConnection {
       secure: Boolean,
       clientCertificateChain: Option[Seq[X509Certificate]]
   ): RemoteConnection = {
+    apply(remoteAddress, remoteNode, remotePort, None, secure, clientCertificateChain)
+  }
+
+  /**
+   * Create a RemoteConnection object.
+   */
+  def apply(
+      remoteAddress: InetAddress,
+      remoteNode: RemoteNode,
+      remotePort: Option[Int],
+      byNode: Option[RemoteNode],
+      secure: Boolean,
+      clientCertificateChain: Option[Seq[X509Certificate]]
+  ): RemoteConnection = {
     val s   = secure
     val ra  = remoteAddress
     val rn  = remoteNode
     val rp  = remotePort
+    val bn  = byNode
     val ccc = clientCertificateChain
     new RemoteConnection {
       override val remoteAddress: InetAddress                           = ra
       override val remoteNode: RemoteNode                               = rn
+      override val byNode: Option[RemoteNode]                           = bn
       override val remotePort: Option[Int]                              = rp
       override val secure: Boolean                                      = s
       override val clientCertificateChain: Option[Seq[X509Certificate]] = ccc

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -101,6 +101,7 @@ trait JavaHelpers {
         override def remoteAddress: InetAddress                           = c.remoteAddress
         override def remoteAddressString: String                          = c.remoteAddressString
         override def remoteNode: RemoteConnection.RemoteNode              = c.remoteNode
+        override def byNode: Option[RemoteConnection.RemoteNode]          = c.byNode
         override def remoteIpAddress: Option[InetAddress]                 = c.remoteIpAddress
         override def remotePort: Option[Int]                              = c.remotePort
         override def secure: Boolean                                      = newSecure

--- a/core/play/src/test/scala/play/api/mvc/request/RemoteConnectionSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/request/RemoteConnectionSpec.scala
@@ -55,6 +55,35 @@ class RemoteConnectionSpec extends Specification {
       connection.remoteNode must beEqualTo(RemoteConnection.RemoteNode.Unknown(None))
     }
 
+    "store the receiving proxy node when supplied" in {
+      val connection = RemoteConnection(
+        InetAddresses.forString("127.0.0.1"),
+        RemoteConnection.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), None),
+        None,
+        Some(RemoteConnection.RemoteNode.Obfuscated("_edge", None)),
+        secure = false,
+        None
+      )
+
+      connection.byNode must beSome(RemoteConnection.RemoteNode.Obfuscated("_edge", None))
+    }
+
+    "preserve the receiving proxy node when copying connection metadata" in {
+      val byNode     = RemoteConnection.RemoteNode.Obfuscated("_edge", None)
+      val connection = RemoteConnection(
+        InetAddresses.forString("127.0.0.1"),
+        RemoteConnection.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), None),
+        None,
+        Some(byNode),
+        secure = false,
+        None
+      )
+
+      connection.withRemotePort(Some(12345)).byNode must beSome(byNode)
+      connection.withSecure(secure = true).byNode must beSome(byNode)
+      connection.withClientCertificateChain(None).byNode must beSome(byNode)
+    }
+
     "store the remote port when created from an inet address" in {
       RemoteConnection(InetAddresses.forString("127.0.0.1"), Some(12345), secure = false, None).remotePort must beSome(
         12345
@@ -70,6 +99,22 @@ class RemoteConnectionSpec extends Specification {
     "include the remote port when comparing connections" in {
       RemoteConnection("127.0.0.1", Some(12345), secure = false, None) must not(
         beEqualTo(RemoteConnection("127.0.0.1", Some(54321), secure = false, None))
+      )
+    }
+
+    "include the receiving proxy node when comparing connections" in {
+      val address    = InetAddresses.forString("127.0.0.1")
+      val remoteNode = RemoteConnection.RemoteNode.Ip(address, None)
+
+      RemoteConnection(
+        address,
+        remoteNode,
+        None,
+        Some(RemoteConnection.RemoteNode.Obfuscated("_edge", None)),
+        secure = false,
+        None
+      ) must not(
+        beEqualTo(RemoteConnection(address, remoteNode, None, None, secure = false, None))
       )
     }
 

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -150,12 +150,22 @@ class RequestHeaderSpec extends Specification {
 
     "remote node" in {
       "wrap scala remote connections" in {
-        val scalaConnection = RemoteConnection("127.0.0.1", Some(12345), secure = true, None)
-        val javaConnection  = new Http.RemoteConnection(scalaConnection)
+        val scalaConnection = RemoteConnection(
+          InetAddresses.forString("127.0.0.1"),
+          RemoteConnection.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), Some(12345)),
+          Some(12345),
+          Some(RemoteConnection.RemoteNode.Obfuscated("_edge", None)),
+          secure = true,
+          None
+        )
+        val javaConnection = new Http.RemoteConnection(scalaConnection)
 
         javaConnection.asScala must beEqualTo(scalaConnection)
         javaConnection.remoteNode must beEqualTo(
           new Http.RemoteNode.Ip(InetAddresses.forString("127.0.0.1"), java.util.Optional.of(12345))
+        )
+        javaConnection.byNode must beEqualTo(
+          java.util.Optional.of(new Http.RemoteNode.Obfuscated("_edge", java.util.Optional.empty[String]))
         )
         javaConnection.remoteIpAddress must beEqualTo(java.util.Optional.of(InetAddresses.forString("127.0.0.1")))
         javaConnection.remoteIdentity must beEqualTo("127.0.0.1")

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -12,6 +12,8 @@ Play now exposes the selected remote identity through `RequestHeader.connection.
 
 This supports [RFC 7239](https://tools.ietf.org/html/rfc7239) `Forwarded` identifiers that are not IP addresses, such as `for=unknown` and obfuscated identifiers like `for=_hidden`. The existing `remoteAddress` APIs are deprecated because they cannot represent these identifiers and may return a fallback proxy address when the selected forwarded identity is not an IP address.
 
+For RFC 7239 `Forwarded` headers, Play also exposes the selected element's `by` parameter through `RequestHeader.connection.byNode` in Scala, and `Http.RequestHeader.connection().byNode()` in Java. This identifies the proxy interface that received the request represented by `remoteNode`.
+
 Known RFC 7239 obfuscated proxy identifiers can also be trusted explicitly:
 
 ```hocon

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -158,7 +158,7 @@ ProxyPassReverse / http://localhost:9998
 
 ## Configuring trusted proxies
 
-Play supports various forwarded headers used by proxies to indicate the incoming remote identity, IP address, port, and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteNode`, `remoteIdentity`, `remoteIpAddress`, `remotePort`, and `secure` fields of `RequestHeader.connection`.
+Play supports various forwarded headers used by proxies to indicate the incoming remote identity, IP address, receiving proxy node, port, and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteNode`, `remoteIdentity`, `remoteIpAddress`, `byNode`, `remotePort`, and `secure` fields of `RequestHeader.connection`.
 
 It is trivial for an HTTP client, whether it's a browser or other client, to forge forwarded headers, thereby spoofing the remote identity and protocol that Play reports. Consequently, Play needs to know which proxies are trusted. Play provides configuration options to configure trusted proxies, and will validate the incoming forwarded headers to verify that they are trusted, taking the first untrusted remote identity that it finds as the reported user remote identity (or the first identity if all proxies are trusted.)
 
@@ -196,6 +196,8 @@ For more information, please read the [RFC 7239](https://tools.ietf.org/html/rfc
 RFC 7239 `Forwarded` headers can identify the remote client with an IP address, the `unknown` identifier, or an obfuscated identifier such as `_hidden`. Play exposes this value through `RequestHeader.connection.remoteNode`.
 
 Use `RequestHeader.connection.remoteIdentity` when you need the selected remote identity as a string. `RequestHeader.remoteIdentity` is available as a request-level shortcut. When the selected remote node is an IP address, `RequestHeader.connection.remoteIpAddress` contains that address. When the selected remote node is `unknown` or obfuscated, `remoteIpAddress` is empty. The deprecated `RequestHeader.remoteAddress` method still returns a fallback IP address for compatibility, usually the previous trusted proxy address, and should not be used when applications need the actual RFC 7239 remote identity.
+
+When an RFC 7239 `Forwarded` element contains a `by` parameter, Play exposes it through `RequestHeader.connection.byNode`. This identifies the proxy interface that received the request represented by `remoteNode`; it is not the selected remote client identity.
 
 If Play selects an `unknown` or untrusted obfuscated remote node while scanning a trusted proxy chain, it stops scanning at that node because it cannot determine whether the non-IP identifier represents a trusted proxy.
 

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -163,13 +163,14 @@ private[server] object ForwardedHeaderHandler {
   type HeaderParser = Headers => Seq[ForwardedEntry]
 
   /**
-   * An unparsed address, protocol, and port from a forwarded header. Each value is
-   * optional.
+   * An unparsed address, protocol, port, and receiving proxy node from a forwarded
+   * header. Each value is optional.
    */
   final case class ForwardedEntry(
       addressString: Option[String],
       protoString: Option[String],
-      portString: Option[String] = None
+      portString: Option[String] = None,
+      byString: Option[String] = None
   )
 
   /**
@@ -182,7 +183,8 @@ private[server] object ForwardedHeaderHandler {
       remoteNode: RemoteNode,
       fallbackAddress: Option[InetAddress],
       remotePort: Option[Int],
-      secure: Boolean
+      secure: Boolean,
+      byNode: Option[RemoteNode] = None
   ) {
     def remoteIpAddress: Option[InetAddress] = remoteNode match {
       case RemoteNode.Ip(address, _) => Some(address)
@@ -254,7 +256,9 @@ private[server] object ForwardedHeaderHandler {
           }
           .toMap
 
-        params.map { (paramMap: Map[String, String]) => ForwardedEntry(paramMap.get("for"), paramMap.get("proto")) }
+        params.map { (paramMap: Map[String, String]) =>
+          ForwardedEntry(paramMap.get("for"), paramMap.get("proto"), byString = paramMap.get("by"))
+        }
       }
 
       case Xforwarded =>
@@ -308,6 +312,10 @@ private[server] object ForwardedHeaderHandler {
         entry: ForwardedEntry,
         fallbackAddress: Option[InetAddress] = None
     ): Either[String, ParsedForwardedEntry] = {
+      val byNode = entry.byString.flatMap { byString =>
+        parseRemoteNode(byString).toOption
+      }
+
       entry.addressString match {
         case None =>
           // We had a forwarding header, but it was missing the address entry for some reason.
@@ -321,13 +329,19 @@ private[server] object ForwardedHeaderHandler {
                 nodePort.collect { case PortNumber(port) => port }
               }
               val connection =
-                ParsedForwardedEntry(RemoteNode.Ip(address, remotePort), fallbackAddress, remotePort, secure)
+                ParsedForwardedEntry(RemoteNode.Ip(address, remotePort), fallbackAddress, remotePort, secure, byNode)
               Right(connection)
             case Right((UnknownIp, nodePort)) =>
               // RFC 7239 allows "unknown" when the proxy cannot or does not want to disclose the node.
               val secure     = entry.protoString.fold(false)(_ == "https") // Assume insecure by default
               val connection =
-                ParsedForwardedEntry(RemoteNode.Unknown(nodePort.flatMap(portString)), fallbackAddress, None, secure)
+                ParsedForwardedEntry(
+                  RemoteNode.Unknown(nodePort.flatMap(portString)),
+                  fallbackAddress,
+                  None,
+                  secure,
+                  byNode
+                )
               Right(connection)
             case Right((ObfuscatedIp(identifier), nodePort)) =>
               // RFC 7239 allows obfuscated identifiers such as "_hidden" to avoid disclosing the node.
@@ -337,13 +351,25 @@ private[server] object ForwardedHeaderHandler {
                   RemoteNode.Obfuscated(identifier, nodePort.flatMap(portString)),
                   fallbackAddress,
                   None,
-                  secure
+                  secure,
+                  byNode
                 )
               Right(connection)
             case errorOrNonIp =>
               // The forwarding address entry couldn't be parsed for some reason.
               Left(s"Parse error: $errorOrNonIp")
           }
+      }
+    }
+
+    private def parseRemoteNode(nodeString: String): Either[String, RemoteNode] = {
+      nodeIdentifierParser.parseNode(nodeString).map {
+        case (Ip(address), nodePort) =>
+          RemoteNode.Ip(address, nodePort.collect { case PortNumber(port) => port })
+        case (UnknownIp, nodePort) =>
+          RemoteNode.Unknown(nodePort.flatMap(portString))
+        case (ObfuscatedIp(identifier), nodePort) =>
+          RemoteNode.Obfuscated(identifier, nodePort.flatMap(portString))
       }
     }
 

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -86,6 +86,7 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
     // All public methods delegate to the lazily calculated connection info
     override def remoteAddress: InetAddress                           = parsed.remoteAddress
     override def remoteNode: RemoteNode                               = parsed.remoteNode
+    override def byNode: Option[RemoteNode]                           = parsed.byNode
     override def remoteIpAddress: Option[InetAddress]                 = parsed.remoteIpAddress
     override def remotePort: Option[Int]                              = parsed.remotePort
     override def secure: Boolean                                      = parsed.secure
@@ -123,6 +124,7 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
                   parsedEntry.address,
                   parsedEntry.remoteNode,
                   parsedEntry.remotePort,
+                  parsedEntry.byNode,
                   parsedEntry.secure,
                   None /* No cert chain for forward headers */
                 )

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -45,8 +45,16 @@ class ForwardedHeaderHandlerSpec extends Specification {
         ParsedForwardedEntry(RemoteNode.Ip(addr("2001:db8:cafe::17"), Some(4711)), None, Some(4711), false)
       )
       results(1)._3 must beSome(false)
-      results(2)._1 must_== ForwardedEntry(Some("192.0.2.60"), Some("http"))
-      results(2)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("192.0.2.60"), None), None, None, false))
+      results(2)._1 must_== ForwardedEntry(Some("192.0.2.60"), Some("http"), byString = Some("203.0.113.43"))
+      results(2)._2 must beRight(
+        ParsedForwardedEntry(
+          RemoteNode.Ip(addr("192.0.2.60"), None),
+          None,
+          None,
+          false,
+          Some(RemoteNode.Ip(addr("203.0.113.43"), None))
+        )
+      )
       results(2)._3 must beSome(true)
       results(3)._1 must_== ForwardedEntry(Some("192.0.2.43"), None)
       results(3)._2 must beRight(ParsedForwardedEntry(RemoteNode.Ip(addr("192.0.2.43"), None), None, None, false))
@@ -68,6 +76,61 @@ class ForwardedHeaderHandlerSpec extends Specification {
         ParsedForwardedEntry(RemoteNode.Ip(addr("::ffff:192.168.0.9"), None), None, None, true)
       )
       results(8)._3 must beSome(false)
+    }
+
+    "parse rfc7239 by entries without changing selected remote identity" in {
+      val results = processHeaders(
+        version("rfc7239") ++ trustedProxies(),
+        headers(
+          """
+            |Forwarded: for=192.0.2.43;proto=https;by=203.0.113.43
+            |Forwarded: for=192.0.2.44;by="_edge"
+            |Forwarded: for=192.0.2.45;by=unknown
+            |Forwarded: for=192.0.2.46;by="[2001:db8:cafe::17]:4711"
+            |Forwarded: for=192.0.2.47;by=???
+          """.stripMargin
+        )
+      )
+
+      results(0)._2 must beRight(
+        ParsedForwardedEntry(
+          RemoteNode.Ip(addr("192.0.2.43"), None),
+          None,
+          None,
+          true,
+          Some(RemoteNode.Ip(addr("203.0.113.43"), None))
+        )
+      )
+      results(1)._2 must beRight(
+        ParsedForwardedEntry(
+          RemoteNode.Ip(addr("192.0.2.44"), None),
+          None,
+          None,
+          false,
+          Some(RemoteNode.Obfuscated("_edge", None))
+        )
+      )
+      results(2)._2 must beRight(
+        ParsedForwardedEntry(
+          RemoteNode.Ip(addr("192.0.2.45"), None),
+          None,
+          None,
+          false,
+          Some(RemoteNode.Unknown(None))
+        )
+      )
+      results(3)._2 must beRight(
+        ParsedForwardedEntry(
+          RemoteNode.Ip(addr("192.0.2.46"), None),
+          None,
+          None,
+          false,
+          Some(RemoteNode.Ip(addr("2001:db8:cafe::17"), Some(4711)))
+        )
+      )
+      results(4)._2 must beRight(
+        ParsedForwardedEntry(RemoteNode.Ip(addr("192.0.2.47"), None), None, None, false, None)
+      )
     }
 
     "parse x-forwarded entries" in {

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -133,6 +133,19 @@ class ForwardedHeaderHandlerSpec extends Specification {
       )
     }
 
+    "expose rfc7239 by entries on the selected remote connection" in {
+      val connection = remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for=203.0.113.43;by=192.0.2.10;proto=https
+        """.stripMargin
+      )
+
+      connection.remoteNode must beEqualTo(RemoteNode.Ip(addr("203.0.113.43"), None))
+      connection.byNode must beSome(RemoteNode.Ip(addr("192.0.2.10"), None))
+      connection.secure must beTrue
+    }
+
     "parse x-forwarded entries" in {
       val results = processHeaders(
         version("x-forwarded") ++ trustedProxies("2001:db8:cafe::17"),
@@ -217,7 +230,14 @@ class ForwardedHeaderHandlerSpec extends Specification {
           |Forwarded: for=192.0.2.60;proto=http;by=203.0.113.43
           |Forwarded: for=192.168.1.10, for=127.0.0.1
         """.stripMargin
-      ) mustEqual RemoteConnection("192.0.2.60", false, None)
+      ) mustEqual RemoteConnection(
+        addr("192.0.2.60"),
+        RemoteNode.Ip(addr("192.0.2.60"), None),
+        None,
+        Some(RemoteNode.Ip(addr("203.0.113.43"), None)),
+        secure = false,
+        None
+      )
     }
 
     "get first untrusted proxy protocol with rfc7239 with trusted localhost proxy" in {
@@ -241,7 +261,14 @@ class ForwardedHeaderHandlerSpec extends Specification {
           |Forwarded: for=192.0.2.60;proto=https;by=203.0.113.43
           |Forwarded: for=192.168.1.10, for=127.0.0.1
         """.stripMargin
-      ) mustEqual RemoteConnection("192.0.2.60", true, None)
+      ) mustEqual RemoteConnection(
+        addr("192.0.2.60"),
+        RemoteNode.Ip(addr("192.0.2.60"), None),
+        None,
+        Some(RemoteNode.Ip(addr("203.0.113.43"), None)),
+        secure = true,
+        None
+      )
     }
 
     "handle IPv6 addresses with rfc7239" in {


### PR DESCRIPTION
Expose the RFC 7239 `Forwarded` `by` parameter on Play's remote connection API.

RFC 7239 defines `by` as the node/interface where the request was received by the proxy. Play already selects the remote identity from `for`; this PR keeps that behavior unchanged and exposes the `by` node for the selected forwarded element as additional connection metadata.

## Changes

- Parse RFC 7239 `by` parameters into the forwarded-header model.
- Expose the selected forwarded element's `by` value as:
  - Scala: `RequestHeader.connection.byNode`
  - Java: `Http.RequestHeader.connection().byNode()`
- Support the same node forms as `for`:
  - IP addresses
  - IPv6 addresses
  - `unknown`
  - obfuscated identifiers
  - ports where RFC 7239 allows them
- Keep malformed `by` values non-fatal.
- Preserve `byNode` in `RemoteConnection` copy methods.
- Include `byNode` in `RemoteConnection` equality, hash code, and string output.
- Update docs
- Add Scala, Java, and forwarded-header tests.

## Compatibility

This is additive API. Existing `remoteNode`, `remoteIdentity`, `remoteIpAddress`, `remotePort`, and `secure` behavior is unchanged.

`byNode` is not used for trust scanning; trust scanning continues to use the selected remote identity from `for`.
