### PR TITLE
Trust `X-Forwarded-Proto` without `X-Forwarded-For` (opt-in)

### DIFF
--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -116,6 +116,13 @@ play {
       # client address instead. Only enable this if the outermost trusted proxy is known to set it.
       trustSingleXForwardedProto = false
 
+      # Only applies to the x-forwarded version. Some proxy setups send X-Forwarded-Proto without
+      # X-Forwarded-For. By default, Play ignores that protocol value because there is no forwarded
+      # address chain to attach it to. When set to true, a single X-Forwarded-Proto value without
+      # X-Forwarded-For updates the secure flag of the trusted proxy connection without changing the
+      # remote identity. Only enable this if the trusted proxy is known to set it.
+      trustXForwardedProtoWithoutXForwardedFor = false
+
       # Only applies to the x-forwarded version. When multiple proxies grow X-Forwarded-For but only the
       # outermost one sets a single X-Forwarded-Port value, the number of entries in the two headers differs and,
       # by default, the port information is discarded. When set to true, a single X-Forwarded-Port value is

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -44,6 +44,14 @@ This helps deployments where trusted proxy chains append to `X-Forwarded-For`, b
 
 Only enable it when the trusted edge proxy overwrites or strips any incoming client-supplied `X-Forwarded-Proto` header before setting the correct value.
 
+Play can also be configured to trust a single `X-Forwarded-Proto` value when `X-Forwarded-For` is absent:
+
+```hocon
+play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor = true
+```
+
+This setting updates the secure flag for the trusted proxy connection, but does not change the selected remote identity.
+
 ### WebSocket Compression
 
 The Play Pekko HTTP and Netty server backends now support WebSocket compression using the RFC 7692 `permessage-deflate` extension.

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -284,6 +284,20 @@ This setting only applies when `play.http.forwarded.version = "x-forwarded"`. It
 
 Only enable this when your trusted edge proxy overwrites or removes any incoming client-supplied `X-Forwarded-Proto` header before setting the correct value. Otherwise, clients may be able to spoof whether a request was secure.
 
+### Trusting X-Forwarded-Proto without X-Forwarded-For
+
+Some proxy setups send `X-Forwarded-Proto` without sending `X-Forwarded-For`. By default, Play ignores that protocol value because there is no forwarded address chain to attach it to.
+
+If your trusted proxy is known to set `X-Forwarded-Proto` to the protocol used by the request before it reached Play, you can enable:
+
+```
+play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor = true
+```
+
+This setting only applies when `play.http.forwarded.version = "x-forwarded"`. It uses a single `X-Forwarded-Proto` value only when `X-Forwarded-For` is absent and the immediate proxy connection is trusted. It updates `RequestHeader.connection.secure`, but it does not change `remoteNode`, `remoteIdentity`, or `remoteIpAddress`.
+
+Only enable this when your trusted proxy overwrites or removes any incoming client-supplied `X-Forwarded-Proto` header before setting the correct value. Otherwise, clients may be able to spoof whether a request was secure.
+
 ### Trusting a single X-Forwarded-Port value
 
 Play uses `X-Forwarded-Port` when it can match port values to `X-Forwarded-For` addresses. A single `X-Forwarded-Port` value is used automatically when there is a single `X-Forwarded-For` address. Multiple port values are paired with forwarded addresses by position when both headers contain the same number of values.

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -47,6 +47,10 @@ import ForwardedHeaderHandler._
  * When `play.http.forwarded.trustSingleXForwardedProto` is enabled, a lone
  * `X-Forwarded-Proto` entry is associated with the client address instead of
  * being discarded.
+ * When `play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor` is
+ * enabled, a lone `X-Forwarded-Proto` entry without `X-Forwarded-For` updates
+ * the protocol of the trusted proxy connection without changing the remote
+ * identity.
  * When `play.http.forwarded.trustSingleXForwardedPort` is enabled, a lone
  * `X-Forwarded-Port` entry is associated with the client address instead of
  * being discarded.
@@ -140,25 +144,29 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
             // missing identity prevents scanning any earlier elements safely.
             ParsedForwarding(prev, entryHost)
           } else {
-            configuration.parseEntry(entry, previousFallbackAddress) match {
-              case Left(error) =>
-                ForwardedHeaderHandler.logger.debug(
-                  s"Error with info in forwarding header $entry, using $prev instead: $error."
-                )
-                ParsedForwarding(prev, host)
-              case Right(parsedEntry) =>
-                val connection = RemoteConnection(
-                  parsedEntry.address,
-                  parsedEntry.remoteNode,
-                  parsedEntry.remotePort,
-                  parsedEntry.byNode,
-                  parsedEntry.secure,
-                  None /* No cert chain for forward headers */
-                )
-                if (configuration.canContinueScanning(parsedEntry.remoteNode)) {
-                  scan(connection, entryHost)
-                } else {
-                  ParsedForwarding(connection, entryHost)
+            configuration.xForwardedSecureWithoutFor(entry) match {
+              case Some(secure) => ParsedForwarding(prev.withSecure(secure), host)
+              case None         =>
+                configuration.parseEntry(entry, previousFallbackAddress) match {
+                  case Left(error) =>
+                    ForwardedHeaderHandler.logger.debug(
+                      s"Error with info in forwarding header $entry, using $prev instead: $error."
+                    )
+                    ParsedForwarding(prev, host)
+                  case Right(parsedEntry) =>
+                    val connection = RemoteConnection(
+                      parsedEntry.address,
+                      parsedEntry.remoteNode,
+                      parsedEntry.remotePort,
+                      parsedEntry.byNode,
+                      parsedEntry.secure,
+                      None /* No cert chain for forward headers */
+                    )
+                    if (configuration.canContinueScanning(parsedEntry.remoteNode)) {
+                      scan(connection, entryHost)
+                    } else {
+                      ParsedForwarding(connection, entryHost)
+                    }
                 }
             }
           }
@@ -232,7 +240,8 @@ private[server] object ForwardedHeaderHandler {
       trustedProxyIdentifiers: Set[String] = Set.empty,
       trustSingleXForwardedProto: Boolean = false,
       trustSingleXForwardedPort: Boolean = false,
-      trustForwardedHost: Boolean = false
+      trustForwardedHost: Boolean = false,
+      trustXForwardedProtoWithoutXForwardedFor: Boolean = false
   ) {
     val nodeIdentifierParser = new NodeIdentifierParser(version)
 
@@ -324,8 +333,12 @@ private[server] object ForwardedHeaderHandler {
           }
         }
 
-        forHeaders.zipWithIndex.map {
-          case (f, index) => ForwardedEntry(Some(f), protoForIndex(index), portForIndex(index))
+        if (forHeaders.isEmpty && trustXForwardedProtoWithoutXForwardedFor && protoHeaders.length == 1) {
+          Seq(ForwardedEntry(None, protoHeaders.headOption))
+        } else {
+          forHeaders.zipWithIndex.map {
+            case (f, index) => ForwardedEntry(Some(f), protoForIndex(index), portForIndex(index))
+          }
         }
     }
 
@@ -445,6 +458,15 @@ private[server] object ForwardedHeaderHandler {
     def forwardedHost(entry: ForwardedEntry): Option[String] = {
       Option.when(forwardsHost)(entry.hostString).flatten.flatMap(Rfc7239HostParser.parse)
     }
+
+    /** Interpret a lone X-Forwarded-Proto entry that has no X-Forwarded-For identity. */
+    def xForwardedSecureWithoutFor(entry: ForwardedEntry): Option[Boolean] = {
+      if (version == Xforwarded && trustXForwardedProtoWithoutXForwardedFor && entry.addressString.isEmpty) {
+        entry.protoString.map(_.equalsIgnoreCase("https"))
+      } else {
+        None
+      }
+    }
   }
 
   object ForwardedHeaderHandlerConfig {
@@ -480,7 +502,8 @@ private[server] object ForwardedHeaderHandler {
         trustedProxyIdentifiers.toSet,
         config.getOptional[Boolean]("trustSingleXForwardedProto").getOrElse(false),
         config.getOptional[Boolean]("trustSingleXForwardedPort").getOrElse(false),
-        config.getOptional[Boolean]("trustForwardedHost").getOrElse(false)
+        config.getOptional[Boolean]("trustForwardedHost").getOrElse(false),
+        config.getOptional[Boolean]("trustXForwardedProtoWithoutXForwardedFor").getOrElse(false)
       )
     }
   }

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -1134,6 +1134,58 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection(localhost, false, None)
     }
 
+    "use single x-forwarded-proto without x-forwarded-for when enabled and proxy is trusted" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1") ++ trustXForwardedProtoWithoutXForwardedFor(true),
+        """
+          |X-Forwarded-Proto: https
+        """.stripMargin
+      ) mustEqual RemoteConnection(localhost, true, None)
+    }
+
+    "use single x-forwarded-proto without x-forwarded-for case-insensitively" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1") ++ trustXForwardedProtoWithoutXForwardedFor(true),
+        """
+          |X-Forwarded-Proto: HTTPS
+        """.stripMargin
+      ) mustEqual RemoteConnection(localhost, true, None)
+    }
+
+    "ignore single x-forwarded-proto without x-forwarded-for when proxy is untrusted" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("192.0.2.1") ++ trustXForwardedProtoWithoutXForwardedFor(true),
+        """
+          |X-Forwarded-Proto: https
+        """.stripMargin
+      ) mustEqual RemoteConnection(localhost, false, None)
+    }
+
+    "ignore multiple x-forwarded-proto values without x-forwarded-for even when enabled" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1") ++ trustXForwardedProtoWithoutXForwardedFor(true),
+        """
+          |X-Forwarded-Proto: https, http
+        """.stripMargin
+      ) mustEqual RemoteConnection(localhost, false, None)
+    }
+
+    "not apply trustXForwardedProtoWithoutXForwardedFor while forwarding an rfc7239 host" in {
+      val forwarding = forwardedRequestToLocalhost(
+        version("rfc7239") ++
+          trustedProxies("127.0.0.1") ++
+          trustForwardedHost(true) ++
+          trustXForwardedProtoWithoutXForwardedFor(true),
+        """
+          |Forwarded: host=public.example
+          |X-Forwarded-Proto: HTTPS
+        """.stripMargin
+      )
+
+      forwarding.connection mustEqual RemoteConnection(localhost, false, None)
+      forwarding.host must beSome("public.example")
+    }
+
     "assume http protocol with x-forwarded when proto list is longer than for list" in {
       remoteConnectionToLocalhost(
         version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
@@ -1282,6 +1334,10 @@ class ForwardedHeaderHandlerSpec extends Specification {
 
   def trustSingleXForwardedProto(b: Boolean) = {
     Map("play.http.forwarded.trustSingleXForwardedProto" -> b)
+  }
+
+  def trustXForwardedProtoWithoutXForwardedFor(b: Boolean) = {
+    Map("play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor" -> b)
   }
 
   def trustSingleXForwardedPort(b: Boolean) = {


### PR DESCRIPTION
Adds an opt-in setting for deployments where a trusted proxy sends `X-Forwarded-Proto` but does not send `X-Forwarded-For`:

```hocon
play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor = true
```

When enabled, Play uses a single `X-Forwarded-Proto` value to update the request `secure` flag if the immediate remote connection is a trusted proxy. The remote identity/address is left unchanged because there is no `X-Forwarded-For` chain to select a forwarded client from.

This is disabled by default. It only applies to `play.http.forwarded.version = "x-forwarded"`, when `X-Forwarded-For` is absent, and exactly one `X-Forwarded-Proto` value is present.

Includes tests and documentation covering:

- default behavior remains unchanged
- trusted proxy required
- untrusted proxy ignored
- multiple proto values ignored
- RFC 7239 `Forwarded` headers unaffected
- warning to strip or overwrite client-supplied forwarded headers at the trusted edge proxy
- protocol matching is case-insensitive
- RFC 7239 forwarded-host processing remains unaffected

