### PR TITLE
Harden RFC 7239 quoted parsing

### DIFF
--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -206,13 +206,56 @@ private[server] object ForwardedHeaderHandler {
     val nodeIdentifierParser = new NodeIdentifierParser(version)
 
     /**
-     * Removes surrounding quotes if present, otherwise returns original string.
-     * Not RFC compliant. To be compliant we need proper header field parsing.
+     * Removes surrounding quotes if present and decodes quoted-pair escapes,
+     * otherwise returns the original string.
      */
     private def unquote(s: String): String = {
       if (s.length >= 2 && s.charAt(0) == '"' && s.charAt(s.length - 1) == '"') {
-        s.substring(1, s.length - 1)
+        val builder = new StringBuilder(s.length - 2)
+        var index   = 1
+        while (index < s.length - 1) {
+          val char = s.charAt(index)
+          if (char == '\\' && index + 1 < s.length - 1) {
+            builder.append(s.charAt(index + 1))
+            index += 2
+          } else {
+            builder.append(char)
+            index += 1
+          }
+        }
+        builder.result()
       } else s
+    }
+
+    private def splitOutsideQuotes(s: String, separator: Char): Seq[String] = {
+      val entries = Vector.newBuilder[String]
+      val current = new StringBuilder(s.length)
+      var quoted  = false
+      var escaped = false
+      var index   = 0
+
+      while (index < s.length) {
+        val char = s.charAt(index)
+        if (escaped) {
+          current.append(char)
+          escaped = false
+        } else if (quoted && char == '\\') {
+          current.append(char)
+          escaped = true
+        } else if (char == '"') {
+          current.append(char)
+          quoted = !quoted
+        } else if (!quoted && char == separator) {
+          entries += current.result().trim
+          current.clear()
+        } else {
+          current.append(char)
+        }
+        index += 1
+      }
+
+      entries += current.result().trim
+      entries.result()
     }
 
     private def parsePort(s: String): Option[Int] = {
@@ -239,24 +282,20 @@ private[server] object ForwardedHeaderHandler {
       case Rfc7239 => {
         val params = for {
           fhs <- headers.getAll("Forwarded")
-          fh  <- fhs.split(",\\s*")
-        } yield fh
-          .split(";")
-          .iterator
-          .flatMap {
-            _.span(_ != '=') match {
-              case (_, "") => Option.empty[(String, String)] // no value
+          fh  <- splitOutsideQuotes(fhs, ',')
+        } yield splitOutsideQuotes(fh, ';').iterator.flatMap {
+          _.span(_ != '=') match {
+            case (_, "") => Option.empty[(String, String)] // no value
 
-              case (rawName, v) => {
-                // Remove surrounding quotes
-                val name  = rawName.toLowerCase(java.util.Locale.ENGLISH)
-                val value = unquote(v.tail)
+            case (rawName, v) => {
+              // Remove surrounding quotes
+              val name  = rawName.toLowerCase(java.util.Locale.ENGLISH)
+              val value = unquote(v.tail)
 
-                Some(name -> value)
-              }
+              Some(name -> value)
             }
           }
-          .toMap
+        }.toMap
 
         params.map { (paramMap: Map[String, String]) =>
           ForwardedEntry(paramMap.get("for"), paramMap.get("proto"), byString = paramMap.get("by"))

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -205,11 +205,17 @@ private[server] object ForwardedHeaderHandler {
   ) {
     val nodeIdentifierParser = new NodeIdentifierParser(version)
 
+    private def stripQuotes(s: String): String = {
+      if (s.length >= 2 && s.charAt(0) == '"' && s.charAt(s.length - 1) == '"') {
+        s.substring(1, s.length - 1)
+      } else s
+    }
+
     /**
-     * Removes surrounding quotes if present and decodes quoted-pair escapes,
+     * Removes surrounding RFC 7239 quotes and decodes quoted-pair escapes,
      * otherwise returns the original string.
      */
-    private def unquote(s: String): String = {
+    private def unquoteRfc7239(s: String): String = {
       if (s.length >= 2 && s.charAt(0) == '"' && s.charAt(s.length - 1) == '"') {
         val builder = new StringBuilder(s.length - 2)
         var index   = 1
@@ -290,7 +296,7 @@ private[server] object ForwardedHeaderHandler {
             case (rawName, v) => {
               // Remove surrounding quotes
               val name  = rawName.toLowerCase(java.util.Locale.ENGLISH)
-              val value = unquote(v.tail)
+              val value = unquoteRfc7239(v.tail)
 
               Some(name -> value)
             }
@@ -303,7 +309,7 @@ private[server] object ForwardedHeaderHandler {
       }
 
       case Xforwarded =>
-        def h(h: Headers, key: String) = h.getAll(key).flatMap(s => s.split(",\\s*")).map(unquote)
+        def h(h: Headers, key: String) = h.getAll(key).flatMap(s => s.split(",\\s*")).map(stripQuotes)
         val forHeaders                 = h(headers, "X-Forwarded-For")
         val protoHeaders               = h(headers, "X-Forwarded-Proto")
         val portHeaders                = h(headers, "X-Forwarded-Port")

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -518,21 +518,17 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("192.168.1.10", false, None)
     }
 
-    // This quotation handling is not RFC-compliant but we want to make sure we
-    // at least handle the case gracefully.
-    "don't unquote rfc7239 header field with one \" character" in {
+    "ignore an unterminated rfc7239 quoted value" in {
       remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
         """
-          |Forwarded: for==
+          |Forwarded: for="
           |Forwarded: for=192.168.1.10, for=127.0.0.1
         """.stripMargin
       ) mustEqual RemoteConnection("192.168.1.10", false, None)
     }
 
-    // This quotation handling is not RFC-compliant but we want to make sure we
-    // at least handle the case gracefully.
-    "unquote and ignore rfc7239 empty quoted header field" in {
+    "ignore an empty rfc7239 quoted value" in {
       remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
         """
@@ -542,9 +538,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
       ) mustEqual RemoteConnection("192.168.1.10", false, None)
     }
 
-    // This quotation handling is not RFC-compliant but we want to make sure we
-    // at least handle the case gracefully.
-    "kind of unquote rfc7239 header field with three \" characters" in {
+    "ignore a malformed rfc7239 value with three quote characters" in {
       remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
         """
@@ -552,6 +546,16 @@ class ForwardedHeaderHandlerSpec extends Specification {
                                                     |Forwarded: for=192.168.1.10, for=127.0.0.1
         """.stripMargin
       ) mustEqual RemoteConnection("192.168.1.10", false, None)
+    }
+
+    "not decode quoted-pair escapes in x-forwarded headers" in {
+      remoteConnectionToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1"),
+        """
+          |X-Forwarded-For: 203.0.113.43
+          |X-Forwarded-Proto: "h\ttps"
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
     }
 
     "default to trusting IPv4 and IPv6 localhost with x-forwarded when there is no config" in {

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -133,6 +133,52 @@ class ForwardedHeaderHandlerSpec extends Specification {
       )
     }
 
+    "parse rfc7239 quoted-pair escapes in forwarded nodes" in {
+      val results = processHeaders(
+        version("rfc7239") ++ trustedProxies(),
+        headers(
+          """
+            |Forwarded: for="_edge\.1";by="_proxy\-1"
+          """.stripMargin
+        )
+      )
+
+      results(0)._1 must_== ForwardedEntry(Some("_edge.1"), None, byString = Some("_proxy-1"))
+      results(0)._2 must beRight(
+        ParsedForwardedEntry(
+          RemoteNode.Obfuscated("_edge.1", None),
+          None,
+          None,
+          false,
+          Some(RemoteNode.Obfuscated("_proxy-1", None))
+        )
+      )
+    }
+
+    "parse rfc7239 lists and parameters with separators inside quoted strings" in {
+      val results = processHeaders(
+        version("rfc7239") ++ trustedProxies(),
+        headers(
+          """
+            |Forwarded: for="_bad,stillbad";proto=https, for=203.0.113.43
+            |Forwarded: for="_bad;stillbad";proto=https, for=198.51.100.17
+            |Forwarded: for="_bad=stillbad";proto=https, for=192.0.2.43
+          """.stripMargin
+        )
+      )
+
+      results.map(_._1) must containTheSameElementsAs(
+        Seq(
+          ForwardedEntry(Some("_bad,stillbad"), Some("https")),
+          ForwardedEntry(Some("203.0.113.43"), None),
+          ForwardedEntry(Some("_bad;stillbad"), Some("https")),
+          ForwardedEntry(Some("198.51.100.17"), None),
+          ForwardedEntry(Some("_bad=stillbad"), Some("https")),
+          ForwardedEntry(Some("192.0.2.43"), None)
+        )
+      )
+    }
+
     "expose rfc7239 by entries on the selected remote connection" in {
       val connection = remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("127.0.0.1"),


### PR DESCRIPTION
Improves RFC 7239 `Forwarded` header parsing without changing trusted-proxy scanning semantics.

This updates parsing to:

- split `Forwarded` elements on commas only outside quoted strings
- split parameters on semicolons only outside quoted strings
- decode quoted-pair escapes inside quoted values

This allows valid quoted RFC 7239 values such as escaped obfuscated identifiers and quoted commas, semicolons, or equals signs to be parsed correctly.

Includes tests for:

- quoted-pair escapes in `for` and `by` nodes
- quoted comma separators inside values
- quoted semicolon separators inside values
- quoted equals signs inside values
