### PR TITLE
Support trusted RFC 7239 forwarded hosts

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -285,6 +285,26 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
       }
     }
 
+    "validate the trusted forwarded host with the allowed hosts filter" in {
+      withServerAndConfig(
+        "play.http.forwarded.version"            -> "rfc7239",
+        "play.http.forwarded.trustForwardedHost" -> true,
+        "play.filters.hosts.allowed"             -> Seq("public.example")
+      )((Action, _) => Action { rh => Results.Ok(rh.host) }) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("Forwarded" -> "for=192.0.2.43;host=public.example"),
+            ""
+          )
+        )
+        response.status must_== OK
+        response.body must beLeft("public.example")
+      }
+    }
+
     "respect max header value setting" in {
       withServerAndConfig("play.server.max-header-size" -> "64")((Action, _) => Action(Results.Ok)) { port =>
         val responses = BasicHttpClient.makeRequests(port)(

--- a/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -72,6 +72,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
       play.api.test.TestServer(
         serverConfig,
         GuiceApplicationBuilder()
+          .configure(configuration*)
           .appRoutes { app =>
             val Action = app.injector.instanceOf[DefaultActionBuilder]
             val parse  = app.injector.instanceOf[PlayBodyParsers]
@@ -229,6 +230,59 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
         "User-Agent",
         """Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_2 like Mac OS X) AppleWebKit/604.4.7 (KHTML, like Gecko) Mobile/15C202 [FBAN/FBIOS;FBAV/155.0.0.36.93;FBBV/87992437;FBDV/iPhone9,3;FBMD/iPhone;FBSN/iOS;FBSV/11.2.2;FBSS/2;FBCR/3Ireland;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]"""
       )
+    }
+
+    "keep the original host when forwarded host handling is disabled" in {
+      withServerAndConfig("play.http.forwarded.version" -> "rfc7239")((Action, _) =>
+        Action { rh => Results.Ok(s"${rh.host}|${rh.headers(HOST)}") }
+      ) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("Forwarded" -> "for=192.0.2.43;host=public.example"),
+            ""
+          )
+        )
+        response.body must beLeft("localhost|localhost")
+      }
+    }
+
+    "keep the original host when a forwarded host is invalid" in {
+      withServerAndConfig(
+        "play.http.forwarded.version"            -> "rfc7239",
+        "play.http.forwarded.trustForwardedHost" -> true
+      )((Action, _) => Action { rh => Results.Ok(s"${rh.host}|${rh.headers(HOST)}") }) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("Forwarded" -> "for=192.0.2.43;host=\"user@example.org\""),
+            ""
+          )
+        )
+        response.body must beLeft("localhost|localhost")
+      }
+    }
+
+    "use a trusted forwarded host with an absolute request target" in {
+      withServerAndConfig(
+        "play.http.forwarded.version"            -> "rfc7239",
+        "play.http.forwarded.trustForwardedHost" -> true
+      )((Action, _) => Action { rh => Results.Ok(s"${rh.host}|${rh.headers(HOST)}") }) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "http://localhost/path",
+            "HTTP/1.1",
+            Map("Forwarded" -> "for=192.0.2.43;host=public.example"),
+            ""
+          )
+        )
+        response.body must beLeft("public.example|public.example")
+      }
     }
 
     "respect max header value setting" in {

--- a/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -11,6 +11,7 @@ import play.api.test._
 import play.api.Configuration
 import play.api.Mode
 import play.core.server.ServerConfig
+import play.filters.hosts.AllowedHostsFilter
 import play.it._
 
 class NettyRequestHeadersSpec extends RequestHeadersSpec with NettyIntegrationSpecification
@@ -289,6 +290,7 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
       withServerAndConfig(
         "play.http.forwarded.version"            -> "rfc7239",
         "play.http.forwarded.trustForwardedHost" -> true,
+        "play.filters.enabled"                   -> Seq(classOf[AllowedHostsFilter].getName),
         "play.filters.hosts.allowed"             -> Seq("public.example")
       )((Action, _) => Action { rh => Results.Ok(rh.host) }) { port =>
         val Seq(response) = BasicHttpClient.makeRequests(port)(
@@ -302,6 +304,26 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
         )
         response.status must_== OK
         response.body must beLeft("public.example")
+      }
+    }
+
+    "reject a trusted forwarded host not accepted by the allowed hosts filter" in {
+      withServerAndConfig(
+        "play.http.forwarded.version"            -> "rfc7239",
+        "play.http.forwarded.trustForwardedHost" -> true,
+        "play.filters.enabled"                   -> Seq(classOf[AllowedHostsFilter].getName),
+        "play.filters.hosts.allowed"             -> Seq("localhost")
+      )((Action, _) => Action { rh => Results.Ok(rh.host) }) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("Forwarded" -> "for=192.0.2.43;host=public.example"),
+            ""
+          )
+        )
+        response.status must_== BAD_REQUEST
       }
     }
 

--- a/core/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
@@ -165,6 +165,7 @@ trait ServerReloadingSpec extends PlaySpecification with WsTestClient with Serve
               Success(
                 GuiceApplicationBuilder()
                   .configure("play.http.forwarded.version" -> "rfc7239")
+                  .configure("play.http.forwarded.trustForwardedHost" -> true)
                   .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
                   .build()
               )
@@ -191,6 +192,16 @@ trait ServerReloadingSpec extends PlaySpecification with WsTestClient with Serve
             }
             forwardedHeaderResponse.status must_== 200
             forwardedHeaderResponse.body[String] must_== "192.0.2.43"
+
+            val forwardedHostResponse = await {
+              wsUrl("/gethost")
+                .withHttpHeaders(
+                  "Forwarded" -> "for=192.0.2.43;host=\"public.example:9443\", for=\"[::1]\""
+                )
+                .get()
+            }
+            forwardedHostResponse.status must_== 200
+            forwardedHostResponse.body[String] must_== "public.example:9443"
           }
       }
     }
@@ -261,6 +272,8 @@ private[server] object ServerReloadingSpec {
         action { (request: Request[?]) => Results.Ok(request.flash.data.get("foo").toString) }
       case GET(p"/getremoteaddress") =>
         action { (request: Request[?]) => Results.Ok(request.remoteIdentity) }
+      case GET(p"/gethost") =>
+        action { (request: Request[?]) => Results.Ok(request.host) }
       case GET(p"/getserverconfigcachereloads") =>
         action { (request: Request[?]) =>
           val reloadCount: Option[Int] = request.attrs.get(ServerDebugInfo.Attr).map(_.serverConfigCacheReloads)

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -478,7 +478,11 @@ public class Http {
     Request withBody(RequestBody body);
 
     /**
-     * @return the request host
+     * Returns the effective request host, optionally including its port. Trusted forwarding
+     * information selected by the server takes precedence over the request-target authority and the
+     * {@code Host} header. This does not modify {@link #uri()} or {@link #path()}.
+     *
+     * @return the effective request host
      */
     String host();
 

--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -103,6 +103,12 @@ play {
       # trusted infrastructure and cannot be supplied by clients.
       trustedProxyIdentifiers = []
 
+      # Only applies to the rfc7239 version. When enabled, Play uses the host parameter from the
+      # selected trusted Forwarded element as the effective request Host. This is disabled by
+      # default because Host affects request routing, URL generation, and cache keys. Only enable
+      # it when trusted proxies remove or overwrite client-supplied Forwarded headers.
+      trustForwardedHost = false
+
       # Only applies to the x-forwarded version. When multiple proxies grow X-Forwarded-For but only the
       # outermost one sets a single X-Forwarded-Proto value (a common setup), the number of entries in the
       # two headers differs and, by default, the protocol information is discarded and the connection is

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -247,15 +247,17 @@ trait RequestHeader {
   def hasBody: Boolean = headers.hasBody
 
   /**
-   * The HTTP host (domain, optionally port). This value is derived from the request target, if a hostname is present.
-   * If the target doesn't have a host then the `Host` header is used, if present. If that's not present then an
-   * empty string is returned.
+   * The HTTP host (domain, optionally port). Trusted forwarding information takes precedence when the server has
+   * selected an effective host. Otherwise, this value is derived from the request target if a hostname is present,
+   * then from the `Host` header. If none of these is present, an empty string is returned.
    */
   lazy val host: String = {
     import RequestHeader.AbsoluteUri
-    uri match {
-      case AbsoluteUri(proto, hostPort, rest) => hostPort
-      case _                                  => headers.get(HeaderNames.HOST).getOrElse("")
+    attrs.get(RequestAttrKey.EffectiveHost).getOrElse {
+      uri match {
+        case AbsoluteUri(proto, hostPort, rest) => hostPort
+        case _                                  => headers.get(HeaderNames.HOST).getOrElse("")
+      }
     }
   }
 

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -249,7 +249,8 @@ trait RequestHeader {
   /**
    * The HTTP host (domain, optionally port). Trusted forwarding information takes precedence when the server has
    * selected an effective host. Otherwise, this value is derived from the request target if a hostname is present,
-   * then from the `Host` header. If none of these is present, an empty string is returned.
+   * then from the `Host` header. If none of these is present, an empty string is returned. Selecting an effective host
+   * does not modify the request target exposed through [[uri]] and [[path]].
    */
   lazy val host: String = {
     import RequestHeader.AbsoluteUri

--- a/core/play/src/main/scala/play/api/mvc/request/RequestAttrKey.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RequestAttrKey.scala
@@ -48,6 +48,11 @@ object RequestAttrKey {
   val Server = TypedKey[String]("Server-Name")
 
   /**
+   * The effective host selected from trusted forwarding information.
+   */
+  private[play] val EffectiveHost = TypedKey[String]("Effective-Host")
+
+  /**
    * The CSP nonce key.
    */
   val CSPNonce: TypedKey[String] = TypedKey("CSP-Nonce")

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -185,14 +185,29 @@ class RequestHeaderSpec extends Specification {
         val rh = dummyRequestHeader("GET", "https://example.com/test", Headers(HOST -> "playframework.com"))
         rh.host must_== "example.com"
       }
-      "trusted effective host with absolute uri" in {
-        val rh = dummyRequestHeader(
-          "GET",
-          "https://internal.example/test",
-          Headers(HOST                          -> "public.example"),
-          TypedMap(RequestAttrKey.EffectiveHost -> "public.example")
+      "trusted effective host with absolute uri for Scala and Java requests" in {
+        val requestHeader = dummyRequestHeader(
+          requestMethod = "GET",
+          requestUri = "https://internal.example/test",
+          headers = Headers(HOST -> "public.example"),
+          attrs = TypedMap(RequestAttrKey.EffectiveHost -> "public.example"),
+          requestPath = "/test"
         )
-        rh.host must_== "public.example"
+        val request = requestHeader.withBody("body")
+
+        requestHeader.host must_== "public.example"
+        request.host must_== "public.example"
+        requestHeader.asJava.host must_== "public.example"
+        request.asJava.host must_== "public.example"
+
+        requestHeader.uri must_== "https://internal.example/test"
+        requestHeader.path must_== "/test"
+        request.uri must_== "https://internal.example/test"
+        request.path must_== "/test"
+        requestHeader.asJava.uri must_== "https://internal.example/test"
+        requestHeader.asJava.path must_== "/test"
+        request.asJava.uri must_== "https://internal.example/test"
+        request.asJava.path must_== "/test"
       }
       "absolute uri with port" in {
         val rh = dummyRequestHeader("GET", "https://example.com:8080/test", Headers(HOST -> "playframework.com"))
@@ -268,12 +283,13 @@ class RequestHeaderSpec extends Specification {
       requestUri: String = "/",
       headers: Headers = Headers(),
       attrs: TypedMap = TypedMap.empty,
-      remotePort: Option[Int] = None
+      remotePort: Option[Int] = None,
+      requestPath: String = ""
   ): RequestHeader = {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
       connection = RemoteConnection("127.0.0.1", remotePort, false, None),
       method = requestMethod,
-      target = RequestTarget(requestUri, "", Map.empty),
+      target = RequestTarget(requestUri, requestPath, Map.empty),
       version = "",
       headers = headers,
       attrs = attrs

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -185,6 +185,15 @@ class RequestHeaderSpec extends Specification {
         val rh = dummyRequestHeader("GET", "https://example.com/test", Headers(HOST -> "playframework.com"))
         rh.host must_== "example.com"
       }
+      "trusted effective host with absolute uri" in {
+        val rh = dummyRequestHeader(
+          "GET",
+          "https://internal.example/test",
+          Headers(HOST                          -> "public.example"),
+          TypedMap(RequestAttrKey.EffectiveHost -> "public.example")
+        )
+        rh.host must_== "public.example"
+      }
       "absolute uri with port" in {
         val rh = dummyRequestHeader("GET", "https://example.com:8080/test", Headers(HOST -> "playframework.com"))
         rh.host must_== "example.com:8080"

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -14,6 +14,8 @@ This supports [RFC 7239](https://tools.ietf.org/html/rfc7239) `Forwarded` identi
 
 For RFC 7239 `Forwarded` headers, Play also exposes the selected element's `by` parameter through `RequestHeader.connection.byNode` in Scala, and `Http.RequestHeader.connection().byNode()` in Java. This identifies the proxy interface that received the request represented by `remoteNode`.
 
+Play can also use the selected trusted RFC 7239 `host` parameter for `RequestHeader.host`, allowing applications behind trusted proxies to reconstruct the original public host from standards-based forwarding information. This behavior is disabled by default and can be enabled with `play.http.forwarded.trustForwardedHost = true`.
+
 Known RFC 7239 obfuscated proxy identifiers can also be trusted explicitly:
 
 ```hocon

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -158,7 +158,7 @@ ProxyPassReverse / http://localhost:9998
 
 ## Configuring trusted proxies
 
-Play supports various forwarded headers used by proxies to indicate the incoming remote identity, IP address, receiving proxy node, port, and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteNode`, `remoteIdentity`, `remoteIpAddress`, `byNode`, `remotePort`, and `secure` fields of `RequestHeader.connection`.
+Play supports various forwarded headers used by proxies to indicate the incoming remote identity, IP address, receiving proxy node, port, protocol, and host of requests. Play uses this configuration to calculate the correct value for the `remoteNode`, `remoteIdentity`, `remoteIpAddress`, `byNode`, `remotePort`, and `secure` fields of `RequestHeader.connection`. When explicitly enabled, Play can also use a trusted RFC 7239 `host` parameter for `RequestHeader.host`.
 
 It is trivial for an HTTP client, whether it's a browser or other client, to forge forwarded headers, thereby spoofing the remote identity and protocol that Play reports. Consequently, Play needs to know which proxies are trusted. Play provides configuration options to configure trusted proxies, and will validate the incoming forwarded headers to verify that they are trusted, taking the first untrusted remote identity that it finds as the reported user remote identity (or the first identity if all proxies are trusted.)
 
@@ -215,6 +215,36 @@ Use `RequestHeader.connection.remoteIdentity` when you need the selected remote 
 When an RFC 7239 `Forwarded` element contains a `by` parameter, Play exposes it through `RequestHeader.connection.byNode`. This identifies the proxy interface that received the request represented by `remoteNode`; it is not the selected remote client identity.
 
 If Play selects an `unknown` or untrusted obfuscated remote node while scanning a trusted proxy chain, it stops scanning at that node because it cannot determine whether the non-IP identifier represents a trusted proxy.
+
+### RFC 7239 forwarded hosts
+
+RFC 7239 `Forwarded` headers can include a `host` parameter that identifies the original `Host` value received by the proxy. Host forwarding is disabled by default because the effective host affects request routing, URL generation, and cache keys. Enable it explicitly:
+
+```hocon
+play.http.forwarded.version = "rfc7239"
+play.http.forwarded.trustForwardedHost = true
+```
+
+Play then uses the `host` parameter from the selected trusted `Forwarded` element as `RequestHeader.host`.
+
+For example:
+
+```http
+Host: play.internal
+Forwarded: for=203.0.113.43;proto=https;host=www.example.com
+```
+
+When the proxy that sent this header is trusted, `request.host` is `www.example.com`. A host containing a port must be quoted because `:` is not valid in an RFC 7239 token:
+
+```http
+Forwarded: for=203.0.113.43;proto=https;host="www.example.com:8443"
+```
+
+IPv6 literals must also be quoted because their brackets are not token characters. As required by [RFC 7239](https://www.rfc-editor.org/rfc/rfc7239.html#section-5.3), the value must conform to the HTTP [`Host` field grammar](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2), including brackets around IPv6 addresses. If the proxy is not trusted, the selected `Forwarded` element has no valid `host` parameter, or host forwarding is disabled, Play keeps the original `Host` header.
+
+RFC 7239 parameters are independent, so a trusted proxy can send an element containing `host` without `for`. Play can use that host, but stops scanning the forwarded identity chain at the current connection because it cannot verify the preceding node without `for`.
+
+Only rely on forwarded hosts when your trusted edge proxy overwrites or removes any incoming client-supplied `Forwarded` header before setting the correct value. Otherwise, clients may be able to spoof the request host.
 
 ### Trusting RFC 7239 obfuscated proxy identifiers
 

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -246,6 +246,8 @@ RFC 7239 parameters are independent, so a trusted proxy can send an element cont
 
 Only rely on forwarded hosts when your trusted edge proxy overwrites or removes any incoming client-supplied `Forwarded` header before setting the correct value. Otherwise, clients may be able to spoof the request host.
 
+The [[Allowed Hosts filter|AllowedHostsFilter]] validates `RequestHeader.host`. When forwarded host handling is enabled, configure `play.filters.hosts.allowed` with the public forwarded hosts rather than only the internal proxy-facing host.
+
 ### Trusting RFC 7239 obfuscated proxy identifiers
 
 RFC 7239 allows proxies to use obfuscated identifiers, such as `_edge`, instead of IP addresses. By default, Play stops scanning the forwarded chain when it reaches an obfuscated identifier because `play.http.forwarded.trustedProxies` can only verify IP addresses and CIDR ranges.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -72,10 +72,10 @@ private[server] class NettyModelConversion(
     }
   }
 
-  /** Capture a request's connection info from its channel and headers. */
-  private def createRemoteConnection(channel: Channel, headers: Headers): RemoteConnection = {
+  /** Capture a request's raw connection info from its channel. */
+  private def createRawRemoteConnection(channel: Channel): RemoteConnection = {
     lazy val socketAddress = channel.remoteAddress().asInstanceOf[InetSocketAddress]
-    val rawConnection      = new RemoteConnection {
+    new RemoteConnection {
       override lazy val remoteAddress: InetAddress                           = socketAddress.getAddress
       override lazy val remotePort: Option[Int]                              = Some(socketAddress.getPort)
       private val sslHandler                                                 = Option(channel.pipeline().get(classOf[SslHandler]))
@@ -90,7 +90,6 @@ private[server] class NettyModelConversion(
         }
       }
     }
-    forwardedHeaderHandler.forwardedConnection(rawConnection, headers)
   }
 
   /** Create request target information from a Netty request. */
@@ -123,9 +122,12 @@ private[server] class NettyModelConversion(
    * later.
    */
   def createRequestHeader(channel: Channel, request: HttpRequest, target: RequestTarget): RequestHeader = {
-    val headers = new NettyHeadersWrapper(request.headers)
+    val rawConnection = createRawRemoteConnection(channel)
+    val rawHeaders    = new NettyHeadersWrapper(request.headers)
+    val forwarding    = forwardedHeaderHandler.forwardedRequest(rawConnection, rawHeaders)
+    val headers       = forwarding.host.fold[Headers](rawHeaders)(host => rawHeaders.replace(HOST -> host))
     new RequestHeaderImpl(
-      createRemoteConnection(channel, headers),
+      forwarding.connection,
       request.method.name(),
       target,
       request.protocolVersion.text(),

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -126,20 +126,22 @@ private[server] class NettyModelConversion(
     val rawHeaders    = new NettyHeadersWrapper(request.headers)
     val forwarding    = forwardedHeaderHandler.forwardedRequest(rawConnection, rawHeaders)
     val headers       = forwarding.host.fold[Headers](rawHeaders)(host => rawHeaders.replace(HOST -> host))
+    val attrs         = TypedMap(
+      // Send an attribute so our tests can tell which kind of server we're using.
+      // We only do this for the "non-default" engine, so we used to tag
+      // pekko-http explicitly, so that benchmarking isn't affected by this.
+      RequestAttrKey.Server -> "netty",
+      // This is the earliest stage of a Play request at which we can set an id.
+      RequestAttrKey.Id -> RequestIdProvider.freshId(),
+    )
+    val effectiveAttrs = forwarding.host.fold(attrs)(host => attrs.updated(RequestAttrKey.EffectiveHost, host))
     new RequestHeaderImpl(
       forwarding.connection,
       request.method.name(),
       target,
       request.protocolVersion.text(),
       headers,
-      TypedMap(
-        // Send an attribute so our tests can tell which kind of server we're using.
-        // We only do this for the "non-default" engine, so we used to tag
-        // pekko-http explicitly, so that benchmarking isn't affected by this.
-        RequestAttrKey.Server -> "netty",
-        // This is the earliest stage of a Play request at which we can set an id.
-        RequestAttrKey.Id -> RequestIdProvider.freshId(),
-      )
+      effectiveAttrs
     )
   }
 

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -88,30 +88,31 @@ private[server] class PekkoModelConversion(
       request: HttpRequest
   ): RequestHeader = {
     val remoteAddressArg = remoteAddress // Avoid clash between method arg and RequestHeader field
-    new RequestHeaderImpl(
-      forwardedHeaderHandler.forwardedConnection(
-        new RemoteConnection {
-          override def remoteAddress: InetAddress                           = remoteAddressArg.getAddress
-          override def remotePort: Option[Int]                              = Some(remoteAddressArg.getPort)
-          override def secure: Boolean                                      = secureProtocol
-          override def clientCertificateChain: Option[Seq[X509Certificate]] = {
-            try {
-              request.header[`Tls-Session-Info`].map { tlsSessionInfo =>
-                immutable.ArraySeq
-                  .unsafeWrapArray(tlsSessionInfo.getSession.getPeerCertificates)
-                  .collect { case x509: X509Certificate => x509 }
-              }
-            } catch {
-              case _: SSLPeerUnverifiedException => None
-            }
+    val rawConnection    = new RemoteConnection {
+      override def remoteAddress: InetAddress                           = remoteAddressArg.getAddress
+      override def remotePort: Option[Int]                              = Some(remoteAddressArg.getPort)
+      override def secure: Boolean                                      = secureProtocol
+      override def clientCertificateChain: Option[Seq[X509Certificate]] = {
+        try {
+          request.header[`Tls-Session-Info`].map { tlsSessionInfo =>
+            immutable.ArraySeq
+              .unsafeWrapArray(tlsSessionInfo.getSession.getPeerCertificates)
+              .collect { case x509: X509Certificate => x509 }
           }
-        },
-        headers
-      ),
+        } catch {
+          case _: SSLPeerUnverifiedException => None
+        }
+      }
+    }
+    val forwarding       = forwardedHeaderHandler.forwardedRequest(rawConnection, headers)
+    val forwardedHeaders = forwarding.host.fold(headers)(host => headers.replace(HeaderNames.HOST -> host))
+
+    new RequestHeaderImpl(
+      forwarding.connection,
       request.method.name,
       requestTarget,
       request.protocol.value,
-      headers,
+      forwardedHeaders,
       TypedMap(
         // This is the earliest stage of a Play request at which we can set an id.
         RequestAttrKey.Id -> RequestIdProvider.freshId(),

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -106,6 +106,11 @@ private[server] class PekkoModelConversion(
     }
     val forwarding       = forwardedHeaderHandler.forwardedRequest(rawConnection, headers)
     val forwardedHeaders = forwarding.host.fold(headers)(host => headers.replace(HeaderNames.HOST -> host))
+    val attrs            = TypedMap(
+      // This is the earliest stage of a Play request at which we can set an id.
+      RequestAttrKey.Id -> RequestIdProvider.freshId(),
+    )
+    val effectiveAttrs = forwarding.host.fold(attrs)(host => attrs.updated(RequestAttrKey.EffectiveHost, host))
 
     new RequestHeaderImpl(
       forwarding.connection,
@@ -113,10 +118,7 @@ private[server] class PekkoModelConversion(
       requestTarget,
       request.protocol.value,
       forwardedHeaders,
-      TypedMap(
-        // This is the earliest stage of a Play request at which we can set an id.
-        RequestAttrKey.Id -> RequestIdProvider.freshId(),
-      )
+      effectiveAttrs
     )
   }
 

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -71,6 +71,11 @@ import ForwardedHeaderHandler._
  *     A list of RFC 7239 obfuscated proxy identifiers that are ignored when getting the
  *     remote identity. This only applies when using <code>rfc7239</code>.
  *   </dd>
+ *   <dt>play.http.forwarded.trustForwardedHost</dt>
+ *   <dd>
+ *     Whether to use a trusted RFC 7239 <code>host</code> parameter as the
+ *     effective request host. This only applies when using <code>rfc7239</code>.
+ *   </dd>
  * </dl>
  */
 private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandlerConfig) {
@@ -84,41 +89,63 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
    */
   def forwardedConnection(rawConnection: RemoteConnection, headers: Headers): RemoteConnection = new RemoteConnection {
     // All public methods delegate to the lazily calculated connection info
-    override def remoteAddress: InetAddress                           = parsed.remoteAddress
-    override def remoteNode: RemoteNode                               = parsed.remoteNode
-    override def byNode: Option[RemoteNode]                           = parsed.byNode
-    override def remoteIpAddress: Option[InetAddress]                 = parsed.remoteIpAddress
-    override def remotePort: Option[Int]                              = parsed.remotePort
-    override def secure: Boolean                                      = parsed.secure
-    override def clientCertificateChain: Option[Seq[X509Certificate]] = parsed.clientCertificateChain
+    override def remoteAddress: InetAddress                           = parsed.connection.remoteAddress
+    override def remoteNode: RemoteNode                               = parsed.connection.remoteNode
+    override def byNode: Option[RemoteNode]                           = parsed.connection.byNode
+    override def remoteIpAddress: Option[InetAddress]                 = parsed.connection.remoteIpAddress
+    override def remotePort: Option[Int]                              = parsed.connection.remotePort
+    override def secure: Boolean                                      = parsed.connection.secure
+    override def clientCertificateChain: Option[Seq[X509Certificate]] = parsed.connection.clientCertificateChain
 
     /**
      * Perform header parsing lazily, yielding a RemoteConnection with the results.
      */
-    private lazy val parsed: RemoteConnection = {
-      // Use a mutable iterator for performance when scanning the
-      // header entries. Go through the headers in reverse order because
-      // the nearest proxies will be at the end of the list and we need
-      // to move backwards through the list to get to the original IP.
-      val headerEntries: Iterator[ForwardedEntry] = configuration.forwardedHeaders(headers).reverseIterator
+    private lazy val parsed: ParsedForwarding = parse(rawConnection, headers)
+  }
 
-      @tailrec
-      def scan(prev: RemoteConnection): RemoteConnection = {
-        // Check if there's a forwarded header for us to scan.
-        if (headerEntries.hasNext) {
-          // There is a forwarded header from 'prev', so lets check if 'prev' is trusted.
-          // If it's a trusted proxy then process the header, otherwise just use 'prev'.
+  /**
+   * Update connection and host information in one trusted-proxy scan.
+   *
+   * Host processing is eager when enabled because the server needs the effective
+   * host while constructing the request. Otherwise connection processing remains
+   * lazy through `forwardedConnection`.
+   */
+  def forwardedRequest(rawConnection: RemoteConnection, headers: Headers): ParsedForwarding = {
+    if (configuration.forwardsHost) parse(rawConnection, headers)
+    else ParsedForwarding(forwardedConnection(rawConnection, headers), None)
+  }
 
-          val previousFallbackAddress = configuration.trustedProxyFallbackAddress(prev)
-          if (previousFallbackAddress.isDefined) {
-            // 'prev' is a trusted proxy, so we process the next entry.
-            val entry = headerEntries.next()
+  private def parse(rawConnection: RemoteConnection, headers: Headers): ParsedForwarding = {
+    // Use a mutable iterator for performance when scanning the
+    // header entries. Go through the headers in reverse order because
+    // the nearest proxies will be at the end of the list and we need
+    // to move backwards through the list to get to the original IP.
+    val headerEntries: Iterator[ForwardedEntry] = configuration.forwardedHeaders(headers).reverseIterator
+
+    @tailrec
+    def scan(prev: RemoteConnection, host: Option[String]): ParsedForwarding = {
+      // Check if there's a forwarded header for us to scan.
+      if (headerEntries.hasNext) {
+        // There is a forwarded header from 'prev', so lets check if 'prev' is trusted.
+        // If it's a trusted proxy then process the header, otherwise just use 'prev'.
+
+        val previousFallbackAddress = configuration.trustedProxyFallbackAddress(prev)
+        if (previousFallbackAddress.isDefined) {
+          // 'prev' is a trusted proxy, so we process the next entry.
+          val entry     = headerEntries.next()
+          val entryHost = configuration.forwardedHost(entry)
+          if (entry.addressString.isEmpty && entryHost.isDefined) {
+            // RFC 7239 parameters are independent. A trusted proxy can forward
+            // the original host without identifying the preceding node, but the
+            // missing identity prevents scanning any earlier elements safely.
+            ParsedForwarding(prev, entryHost)
+          } else {
             configuration.parseEntry(entry, previousFallbackAddress) match {
               case Left(error) =>
                 ForwardedHeaderHandler.logger.debug(
                   s"Error with info in forwarding header $entry, using $prev instead: $error."
                 )
-                prev
+                ParsedForwarding(prev, host)
               case Right(parsedEntry) =>
                 val connection = RemoteConnection(
                   parsedEntry.address,
@@ -129,26 +156,26 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
                   None /* No cert chain for forward headers */
                 )
                 if (configuration.canContinueScanning(parsedEntry.remoteNode)) {
-                  scan(connection)
+                  scan(connection, entryHost)
                 } else {
-                  connection
+                  ParsedForwarding(connection, entryHost)
                 }
             }
-          } else {
-            // 'prev' is not a trusted proxy, so we don't scan ahead in the list of
-            // forwards, we just return 'prev'.
-            prev
           }
         } else {
-          // No more headers to process, so just use its address.
-          prev
+          // 'prev' is not a trusted proxy, so we don't scan ahead in the list of
+          // forwards, we just return 'prev'.
+          ParsedForwarding(prev, host)
         }
+      } else {
+        // No more headers to process, so just use its address.
+        ParsedForwarding(prev, host)
       }
-
-      // Start scanning through connections starting at the rawConnection that
-      // was made the Play server.
-      scan(rawConnection)
     }
+
+    // Start scanning through connections starting at the rawConnection that
+    // was made the Play server.
+    scan(rawConnection, None)
   }
 }
 
@@ -172,8 +199,11 @@ private[server] object ForwardedHeaderHandler {
       addressString: Option[String],
       protoString: Option[String],
       portString: Option[String] = None,
-      byString: Option[String] = None
+      byString: Option[String] = None,
+      hostString: Option[String] = None
   )
+
+  final case class ParsedForwarding(connection: RemoteConnection, host: Option[String])
 
   /**
    * Basic information about an HTTP connection, parsed from a ForwardedEntry.
@@ -201,7 +231,8 @@ private[server] object ForwardedHeaderHandler {
       trustedProxies: List[Subnet],
       trustedProxyIdentifiers: Set[String] = Set.empty,
       trustSingleXForwardedProto: Boolean = false,
-      trustSingleXForwardedPort: Boolean = false
+      trustSingleXForwardedPort: Boolean = false,
+      trustForwardedHost: Boolean = false
   ) {
     val nodeIdentifierParser = new NodeIdentifierParser(version)
 
@@ -228,8 +259,8 @@ private[server] object ForwardedHeaderHandler {
 
     /**
      * Parse any Forward or X-Forwarded-* headers into a sequence of ForwardedEntry
-     * objects. Each object a pair with an optional unparsed address and an
-     * optional unparsed protocol. Further parsing may happen later, see `remoteConnection`.
+     * objects containing optional unparsed connection and request metadata.
+     * Parameter-specific parsing happens while the trusted proxy chain is scanned.
      * A malformed RFC 7239 field produces an empty entry so trusted-proxy scanning
      * stops at that field.
      */
@@ -240,7 +271,12 @@ private[server] object ForwardedHeaderHandler {
           Rfc7239HeaderParser.parse(headerValue) match {
             case Right(elements) =>
               elements.map { paramMap =>
-                ForwardedEntry(paramMap.get("for"), paramMap.get("proto"), byString = paramMap.get("by"))
+                ForwardedEntry(
+                  paramMap.get("for"),
+                  paramMap.get("proto"),
+                  byString = paramMap.get("by"),
+                  hostString = paramMap.get("host")
+                )
               }
             case Left(error) =>
               logger.debug(s"Invalid RFC 7239 Forwarded header, treating it as untrusted: $error")
@@ -320,7 +356,13 @@ private[server] object ForwardedHeaderHandler {
                 nodePort.collect { case PortNumber(port) => port }
               }
               val connection =
-                ParsedForwardedEntry(RemoteNode.Ip(address, remotePort), fallbackAddress, remotePort, secure, byNode)
+                ParsedForwardedEntry(
+                  RemoteNode.Ip(address, remotePort),
+                  fallbackAddress,
+                  remotePort,
+                  secure,
+                  byNode
+                )
               Right(connection)
             case Right((UnknownIp, nodePort)) =>
               // RFC 7239 allows "unknown" when the proxy cannot or does not want to disclose the node.
@@ -395,6 +437,14 @@ private[server] object ForwardedHeaderHandler {
     def isTrustedProxyIdentifier(identifier: String): Boolean = {
       version == Rfc7239 && trustedProxyIdentifiers.contains(identifier)
     }
+
+    /** Whether trusted RFC 7239 host parameters are used. */
+    def forwardsHost: Boolean = version == Rfc7239 && trustForwardedHost
+
+    /** Return a syntactically valid host from this RFC 7239 element when enabled. */
+    def forwardedHost(entry: ForwardedEntry): Option[String] = {
+      Option.when(forwardsHost)(entry.hostString).flatten.flatMap(Rfc7239HostParser.parse)
+    }
   }
 
   object ForwardedHeaderHandlerConfig {
@@ -429,7 +479,8 @@ private[server] object ForwardedHeaderHandler {
         config.get[Seq[String]]("trustedProxies").map(Subnet.apply).toList,
         trustedProxyIdentifiers.toSet,
         config.getOptional[Boolean]("trustSingleXForwardedProto").getOrElse(false),
-        config.getOptional[Boolean]("trustSingleXForwardedPort").getOrElse(false)
+        config.getOptional[Boolean]("trustSingleXForwardedPort").getOrElse(false),
+        config.getOptional[Boolean]("trustForwardedHost").getOrElse(false)
       )
     }
   }

--- a/transport/server/play-server/src/main/scala/play/core/server/common/Rfc7239HostParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/Rfc7239HostParser.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import scala.util.Try
+
+import com.google.common.net.InetAddresses
+
+/** Validates the RFC 7239 host parameter against the HTTP Host field grammar. */
+private[common] object Rfc7239HostParser {
+
+  /**
+   * Return the original value when it matches `uri-host [ ":" port ]`.
+   *
+   * RFC 7239 requires this parameter to contain the original Host field value.
+   * The URI grammar permits an empty host or port and requires IPv6 and IPvFuture
+   * literals to be enclosed in brackets.
+   */
+  def parse(value: String): Option[String] = Option.when(isValid(value))(value)
+
+  private def isValid(value: String): Boolean = {
+    if (value.startsWith("[")) validIpLiteralHost(value)
+    else validRegisteredHost(value)
+  }
+
+  private def validIpLiteralHost(value: String): Boolean = {
+    val closingBracket = value.indexOf(']')
+    closingBracket > 1 &&
+    validIpLiteral(value.substring(1, closingBracket)) &&
+    validPortSuffix(value.substring(closingBracket + 1))
+  }
+
+  private def validRegisteredHost(value: String): Boolean = {
+    val colon = value.indexOf(':')
+    if (colon < 0) validRegisteredName(value)
+    else {
+      value.indexOf(':', colon + 1) < 0 &&
+      validRegisteredName(value.substring(0, colon)) &&
+      validPortSuffix(value.substring(colon))
+    }
+  }
+
+  private def validPortSuffix(value: String): Boolean = {
+    value.isEmpty || (value.charAt(0) == ':' && value.substring(1).forall(isDigit))
+  }
+
+  private def validIpLiteral(value: String): Boolean = validIpv6Address(value) || validIpvFuture(value)
+
+  private def validIpv6Address(value: String): Boolean = {
+    value.contains(':') && Try(InetAddresses.forString(value)).isSuccess
+  }
+
+  private def validIpvFuture(value: String): Boolean = {
+    if (value.length < 4 || (value.charAt(0) != 'v' && value.charAt(0) != 'V')) false
+    else {
+      val dot = value.indexOf('.')
+      dot > 1 &&
+      value.substring(1, dot).forall(isHexDigit) &&
+      dot + 1 < value.length &&
+      value.substring(dot + 1).forall(char => isUnreserved(char) || isSubDelimiter(char) || char == ':')
+    }
+  }
+
+  private def validRegisteredName(value: String): Boolean = {
+    var index = 0
+    while (index < value.length) {
+      val char = value.charAt(index)
+      if (isUnreserved(char) || isSubDelimiter(char)) {
+        index += 1
+      } else if (
+        char == '%' &&
+        index + 2 < value.length &&
+        isHexDigit(value.charAt(index + 1)) &&
+        isHexDigit(value.charAt(index + 2))
+      ) {
+        index += 3
+      } else {
+        return false
+      }
+    }
+    true
+  }
+
+  private def isUnreserved(char: Char): Boolean = {
+    isAlpha(char) || isDigit(char) || "-._~".indexOf(char) >= 0
+  }
+
+  private def isSubDelimiter(char: Char): Boolean = "!$&'()*+,;=".indexOf(char) >= 0
+
+  private def isAlpha(char: Char): Boolean =
+    (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z')
+
+  private def isDigit(char: Char): Boolean = char >= '0' && char <= '9'
+
+  private def isHexDigit(char: Char): Boolean =
+    isDigit(char) || (char >= 'A' && char <= 'F') || (char >= 'a' && char <= 'f')
+}

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -337,6 +337,102 @@ class ForwardedHeaderHandlerSpec extends Specification {
       connection.secure must beTrue
     }
 
+    "use rfc7239 host from the selected trusted forwarded entry" in {
+      val forwarding = forwardedRequestToLocalhost(
+        version("rfc7239") ++
+          trustedProxies("127.0.0.1", "192.168.1.1/24") ++
+          trustForwardedHost(true),
+        """
+          |Host: internal.example
+          |Forwarded: for=203.0.113.43;host="public.example:9443"
+          |Forwarded: for=192.168.1.43;host=proxy.example
+        """.stripMargin
+      )
+
+      forwarding.host must beSome("public.example:9443")
+      forwarding.connection.remoteIdentity mustEqual "203.0.113.43"
+    }
+
+    "not use rfc7239 host by default" in {
+      forwardedHostToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for=203.0.113.43;host=public.example
+        """.stripMargin
+      ) must beNone
+    }
+
+    "ignore rfc7239 host when the forwarding proxy is not trusted" in {
+      forwardedHostToLocalhost(
+        version("rfc7239") ++ trustedProxies("192.168.1.1/24") ++ trustForwardedHost(true),
+        """
+          |Host: internal.example
+          |Forwarded: for=203.0.113.43;host=public.example
+        """.stripMargin
+      ) must beNone
+    }
+
+    "not reuse rfc7239 host from a different forwarded entry" in {
+      forwardedHostToLocalhost(
+        version("rfc7239") ++
+          trustedProxies("127.0.0.1", "192.168.1.1/24") ++
+          trustForwardedHost(true),
+        """
+          |Host: internal.example
+          |Forwarded: for=203.0.113.43
+          |Forwarded: for=192.168.1.43;host=proxy.example
+        """.stripMargin
+      ) must beNone
+    }
+
+    "ignore invalid rfc7239 host values" in {
+      val forwarding = forwardedRequestToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1") ++ trustForwardedHost(true),
+        """
+          |Host: internal.example
+          |Forwarded: for=203.0.113.43;proto=https;host="user@example.org"
+        """.stripMargin
+      )
+
+      forwarding.host must beNone
+      forwarding.connection.remoteIdentity mustEqual "203.0.113.43"
+      forwarding.connection.secure must beTrue
+    }
+
+    "use rfc7239 host without for from a directly trusted proxy" in {
+      val forwarding = forwardedRequestToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1") ++ trustForwardedHost(true),
+        """
+          |Forwarded: host=public.example
+        """.stripMargin
+      )
+
+      forwarding.host must beSome("public.example")
+      forwarding.connection.remoteIdentity mustEqual "127.0.0.1"
+    }
+
+    "stop scanning before entries preceding an rfc7239 host without for" in {
+      val forwarding = forwardedRequestToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1") ++ trustForwardedHost(true),
+        """
+          |Forwarded: for=203.0.113.43;host=client.example, host=proxy.example
+        """.stripMargin
+      )
+
+      forwarding.host must beSome("proxy.example")
+      forwarding.connection.remoteIdentity mustEqual "127.0.0.1"
+    }
+
+    "not apply trustForwardedHost to x-forwarded headers" in {
+      forwardedHostToLocalhost(
+        version("x-forwarded") ++ trustedProxies("127.0.0.1") ++ trustForwardedHost(true),
+        """
+          |Forwarded: for=203.0.113.43;host=public.example
+          |X-Forwarded-For: 203.0.113.43
+        """.stripMargin
+      ) must beNone
+    }
+
     "parse x-forwarded entries" in {
       val results = processHeaders(
         version("x-forwarded") ++ trustedProxies("2001:db8:cafe::17"),
@@ -1160,6 +1256,12 @@ class ForwardedHeaderHandlerSpec extends Specification {
   def remoteConnectionToLocalhost(config: Map[String, Any], headersText: String): RemoteConnection =
     handler(config).forwardedConnection(RemoteConnection("127.0.0.1", false, None), headers(headersText))
 
+  def forwardedHostToLocalhost(config: Map[String, Any], headersText: String): Option[String] =
+    forwardedRequestToLocalhost(config, headersText).host
+
+  def forwardedRequestToLocalhost(config: Map[String, Any], headersText: String): ParsedForwarding =
+    handler(config).forwardedRequest(RemoteConnection("127.0.0.1", false, None), headers(headersText))
+
   def remoteConnectionToLocalhostWithPort(
       config: Map[String, Any],
       remotePort: Option[Int],
@@ -1184,6 +1286,10 @@ class ForwardedHeaderHandlerSpec extends Specification {
 
   def trustSingleXForwardedPort(b: Boolean) = {
     Map("play.http.forwarded.trustSingleXForwardedPort" -> b)
+  }
+
+  def trustForwardedHost(b: Boolean) = {
+    Map("play.http.forwarded.trustForwardedHost" -> b)
   }
 
   def trustedProxyIdentifiers(s: String*) = {

--- a/transport/server/play-server/src/test/scala/play/core/server/common/Rfc7239HostParserSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/Rfc7239HostParserSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import org.specs2.mutable.Specification
+
+class Rfc7239HostParserSpec extends Specification {
+
+  "Rfc7239HostParser" should {
+    "accept HTTP Host field values" in {
+      val validHosts = Seq(
+        "example.com",
+        "example.com:443",
+        "[2001:db8::1]",
+        "[2001:db8::1]:8443",
+        "[v1.fe80::a]:443",
+        "exa%6Dple.com",
+        "name!$&'()*+,;=.example",
+        "",
+        ":"
+      )
+
+      validHosts.forall(host => Rfc7239HostParser.parse(host).contains(host)) must beTrue
+    }
+
+    "reject values outside the HTTP Host field grammar" in {
+      val invalidHosts = Seq(
+        "user@example.com",
+        "example.com/path",
+        "example.com?query",
+        "example.com#fragment",
+        "example .com",
+        "example.com:http",
+        "example.com:443:extra",
+        "2001:db8::1",
+        "[2001:db8::1",
+        "[not-an-ip]",
+        "[v1.]",
+        "exa%mple.com",
+        "m\u00fcnich.example"
+      )
+
+      invalidHosts.forall(host => Rfc7239HostParser.parse(host).isEmpty) must beTrue
+    }
+  }
+}


### PR DESCRIPTION
Adds opt-in support for the RFC 7239 `Forwarded` header's `host` parameter.

When configured with:

```hocon
play.http.forwarded.version = "rfc7239"
play.http.forwarded.trustForwardedHost = true
```

Play uses the valid `host` parameter from the selected `Forwarded` element accepted through the trusted-proxy scan as the effective request host.

The effective host is exposed consistently through:

- Scala `RequestHeader` and `Request`
- Java `Http.RequestHeader` and `Http.Request`
- `RequestHeader.host`
- the effective `Host` request header

This also works with absolute-form request targets. The original request target remains available through `uri` and `path`.

Forwarded host values are validated against the HTTP Host field grammar required by RFC 7239. Invalid values are ignored. An element containing `host` without `for` can provide the effective host, but Play stops scanning before earlier elements because the preceding node cannot be verified.

The implementation uses the existing trusted-proxy scan for RFC 7239 forwarding information. Hosts supplied by untrusted proxies are ignored, and the feature does not apply to `X-Forwarded-*` headers.

The option is disabled by default, preserving existing behavior. It should only be enabled when trusted proxies remove or overwrite client-supplied `Forwarded` headers.

Netty and Pekko HTTP now behave consistently. The Allowed Hosts filter also validates the effective forwarded host rather than the internal proxy-facing host.

Tests cover:

- enabled and disabled forwarded-host handling
- trusted and untrusted proxy chains
- multiple `Forwarded` elements and header fields
- invalid host values
- host-only elements without `for`
- relative and absolute-form request targets
- Scala and Java request APIs
- Netty and Pekko HTTP behavior
- Allowed Hosts acceptance and rejection
- preserving the original host when forwarding is disabled or invalid

The documentation is updated with configuration, behavior, and security guidance.
