### PR TITLE
Validate RFC 7239 Forwarded field syntax

### DIFF
--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -22,6 +22,8 @@ play.http.forwarded.trustedProxyIdentifiers = ["_edge"]
 
 This allows Play to continue scanning through configured obfuscated proxy identifiers. The setting only applies to RFC 7239 `Forwarded` headers and does not make the `unknown` identifier trusted.
 
+Play also validates RFC 7239 field syntax, including tokens, quoted strings, quoted-pair escapes, HTTP lists, and duplicate parameters. Malformed fields stop trusted-proxy scanning at the last verified connection instead of being skipped. Existing support for unquoted `for` node values containing IPv6 addresses or ports remains available for Play 3.0 compatibility. Play applies the same allowance to `by` values for consistent node parsing, although proxies should emit the quoted RFC syntax.
+
 ### Remote Connection Port
 
 Play now exposes the remote connection port, when known, through `RequestHeader.connection.remotePort` in Scala, and `Http.RequestHeader.connection().remotePort()` in Java. `RequestHeader.remotePort` and `Http.RequestHeader.remotePort()` are available as request-level shortcuts.

--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -57,6 +57,21 @@ request.secure                     // true
 The deprecated `request.remoteAddress` method still returns the fallback legacy value, such as
 `"127.0.0.1"` in this example.
 
+### RFC 7239 Forwarded header syntax is validated
+
+Play now validates RFC 7239 `Forwarded` field values before using them. Parameter names must be valid tokens, values must be tokens or quoted strings, and a parameter cannot occur more than once in one forwarded element. Empty HTTP list elements remain accepted and are ignored.
+
+RFC 7239 requires IPv6 addresses and node identifiers with ports to be quoted because they contain `:`:
+
+```http
+Forwarded: for="[2001:db8:cafe::17]:4711"
+Forwarded: for="192.0.2.43:4711"
+```
+
+For compatibility with Play 3.0, Play continues to accept these values without quotes in the `for` parameter. Play applies the same allowance to `by` for consistent node parsing. Proxy configurations should nevertheless be updated to emit the quoted RFC syntax. Other parameters do not receive this compatibility allowance.
+
+When Play encounters a malformed `Forwarded` field while scanning a trusted proxy chain, it stops at that field and keeps the last verified connection information. Check that each trusted proxy emits valid RFC 7239 syntax before upgrading.
+
 ### HEAD responses no longer include generated Content-Length headers
 
 Play no longer renders generated `Content-Length` headers for `HEAD` responses. `HEAD` responses still do not include a response body, but applications and tests should not rely on `Content-Length` being present on a `HEAD` response, even when the equivalent `GET` response has a known length.

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -191,6 +191,21 @@ This is configured using `play.http.forwarded.version`, with valid values being 
 
 For more information, please read the [RFC 7239](https://tools.ietf.org/html/rfc7239) specification.
 
+### RFC 7239 syntax validation
+
+Play validates `Forwarded` field values using the RFC 7239 token, quoted-string, parameter, and HTTP list syntax. Parameter names cannot be repeated within one forwarded element. Empty HTTP list elements are ignored.
+
+RFC 7239 requires IPv6 addresses and node identifiers containing a port to be quoted because `:` is not valid in an unquoted token:
+
+```http
+Forwarded: for="[2001:db8:cafe::17]:4711"
+Forwarded: for="192.0.2.43:4711"
+```
+
+For compatibility with Play 3.0, Play also accepts these node values without quotes in the `for` parameter. Play applies the same allowance to `by` for consistent node parsing. New and updated proxy configurations should emit the quoted RFC 7239 syntax. This compatibility does not allow non-token characters in other parameter values.
+
+If a `Forwarded` field value is malformed, Play treats that field as an unverifiable proxy boundary. Trusted-proxy scanning stops when it reaches that field and keeps the last verified connection information; it never skips malformed forwarding information to trust an earlier entry.
+
 ### RFC 7239 remote identities
 
 RFC 7239 `Forwarded` headers can identify the remote client with an IP address, the `unknown` identifier, or an obfuscated identifier such as `_hidden`. Play exposes this value through `RequestHeader.connection.remoteNode`.

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -211,59 +211,6 @@ private[server] object ForwardedHeaderHandler {
       } else s
     }
 
-    /**
-     * Removes surrounding RFC 7239 quotes and decodes quoted-pair escapes,
-     * otherwise returns the original string.
-     */
-    private def unquoteRfc7239(s: String): String = {
-      if (s.length >= 2 && s.charAt(0) == '"' && s.charAt(s.length - 1) == '"') {
-        val builder = new StringBuilder(s.length - 2)
-        var index   = 1
-        while (index < s.length - 1) {
-          val char = s.charAt(index)
-          if (char == '\\' && index + 1 < s.length - 1) {
-            builder.append(s.charAt(index + 1))
-            index += 2
-          } else {
-            builder.append(char)
-            index += 1
-          }
-        }
-        builder.result()
-      } else s
-    }
-
-    private def splitOutsideQuotes(s: String, separator: Char): Seq[String] = {
-      val entries = Vector.newBuilder[String]
-      val current = new StringBuilder(s.length)
-      var quoted  = false
-      var escaped = false
-      var index   = 0
-
-      while (index < s.length) {
-        val char = s.charAt(index)
-        if (escaped) {
-          current.append(char)
-          escaped = false
-        } else if (quoted && char == '\\') {
-          current.append(char)
-          escaped = true
-        } else if (char == '"') {
-          current.append(char)
-          quoted = !quoted
-        } else if (!quoted && char == separator) {
-          entries += current.result().trim
-          current.clear()
-        } else {
-          current.append(char)
-        }
-        index += 1
-      }
-
-      entries += current.result().trim
-      entries.result()
-    }
-
     private def parsePort(s: String): Option[Int] = {
       if (s.matches("\\d{1,5}")) {
         val port = s.toInt
@@ -283,29 +230,26 @@ private[server] object ForwardedHeaderHandler {
      * Parse any Forward or X-Forwarded-* headers into a sequence of ForwardedEntry
      * objects. Each object a pair with an optional unparsed address and an
      * optional unparsed protocol. Further parsing may happen later, see `remoteConnection`.
+     * A malformed RFC 7239 field produces an empty entry so trusted-proxy scanning
+     * stops at that field.
      */
     def forwardedHeaders(headers: Headers): Seq[ForwardedEntry] = version match {
       case Rfc7239 => {
-        val params = for {
-          fhs <- headers.getAll("Forwarded")
-          fh  <- splitOutsideQuotes(fhs, ',')
-        } yield splitOutsideQuotes(fh, ';').iterator.flatMap {
-          _.span(_ != '=') match {
-            case (_, "") => Option.empty[(String, String)] // no value
-
-            case (rawName, v) => {
-              // Remove surrounding quotes
-              val name  = rawName.toLowerCase(java.util.Locale.ENGLISH)
-              val value = unquoteRfc7239(v.tail)
-
-              Some(name -> value)
-            }
+        val headerValues = headers.getAll("Forwarded")
+        val entries      = headerValues.flatMap { headerValue =>
+          Rfc7239HeaderParser.parse(headerValue) match {
+            case Right(elements) =>
+              elements.map { paramMap =>
+                ForwardedEntry(paramMap.get("for"), paramMap.get("proto"), byString = paramMap.get("by"))
+              }
+            case Left(error) =>
+              logger.debug(s"Invalid RFC 7239 Forwarded header, treating it as untrusted: $error")
+              Seq(ForwardedEntry(None, None))
           }
-        }.toMap
-
-        params.map { (paramMap: Map[String, String]) =>
-          ForwardedEntry(paramMap.get("for"), paramMap.get("proto"), byString = paramMap.get("by"))
         }
+        // Forwarded uses 1#forwarded-element, so the combined field value must
+        // contain an element even though empty HTTP list members are ignored.
+        if (headerValues.nonEmpty && entries.isEmpty) Seq(ForwardedEntry(None, None)) else entries
       }
 
       case Xforwarded =>

--- a/transport/server/play-server/src/main/scala/play/core/server/common/Rfc7239HeaderParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/Rfc7239HeaderParser.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import java.util.Locale
+
+import scala.collection.mutable
+
+/** Parses RFC 7239 field syntax. Parameter-specific values are parsed later. */
+private[common] object Rfc7239HeaderParser {
+
+  def parse(input: String): Either[String, Vector[Map[String, String]]] = new Parser(input).parse()
+
+  private final class Parser(input: String) {
+    private var index = 0
+
+    def parse(): Either[String, Vector[Map[String, String]]] = {
+      val elements = Vector.newBuilder[Map[String, String]]
+
+      skipOptionalWhitespace()
+      while (index < input.length) {
+        if (input.charAt(index) == ',') {
+          // HTTP list recipients ignore empty list elements.
+          index += 1
+          skipOptionalWhitespace()
+        } else {
+          parseElement() match {
+            case Left(error)    => return Left(error)
+            case Right(element) =>
+              elements += element
+          }
+
+          skipOptionalWhitespace()
+          if (index < input.length) {
+            if (input.charAt(index) != ',') {
+              return Left(s"Expected ',' at position $index")
+            }
+            index += 1
+            skipOptionalWhitespace()
+          }
+        }
+      }
+
+      Right(elements.result())
+    }
+
+    private def parseElement(): Either[String, Map[String, String]] = {
+      val parameters = mutable.LinkedHashMap.empty[String, String]
+
+      if (input.charAt(index) != ';') {
+        parsePair(parameters) match {
+          case Left(error) => return Left(error)
+          case Right(_)    =>
+        }
+      }
+
+      while (index < input.length && input.charAt(index) == ';') {
+        index += 1
+        if (index < input.length && input.charAt(index) != ';' && input.charAt(index) != ',') {
+          if (isOptionalWhitespace(input.charAt(index))) {
+            skipOptionalWhitespace()
+            if (index < input.length && input.charAt(index) != ',') {
+              return Left(s"Whitespace is not allowed before a parameter at position $index")
+            }
+          } else {
+            parsePair(parameters) match {
+              case Left(error) => return Left(error)
+              case Right(_)    =>
+            }
+          }
+        }
+      }
+
+      Right(parameters.toMap)
+    }
+
+    private def parsePair(parameters: mutable.Map[String, String]): Either[String, Unit] = {
+      val rawName = parseToken() match {
+        case Left(error) => return Left(error)
+        case Right(name) => name
+      }
+      val name = rawName.toLowerCase(Locale.ENGLISH)
+
+      if (index >= input.length || input.charAt(index) != '=') {
+        return Left(s"Expected '=' after parameter '$rawName' at position $index")
+      }
+      index += 1
+
+      val value =
+        if (index < input.length && input.charAt(index) == '"') parseQuotedString()
+        else if (name == "for" || name == "by") parseLegacyNodeValue()
+        else parseToken()
+
+      value.flatMap { parsedValue =>
+        if (parameters.contains(name)) {
+          Left(s"Duplicate parameter '$rawName'")
+        } else {
+          parameters += name -> parsedValue
+          Right(())
+        }
+      }
+    }
+
+    private def parseToken(): Either[String, String] = {
+      val start = index
+      while (index < input.length && isTokenCharacter(input.charAt(index))) {
+        index += 1
+      }
+      if (index == start) Left(s"Expected token at position $index")
+      else Right(input.substring(start, index))
+    }
+
+    /**
+     * Play 3.0 accepted unquoted RFC 7239 `for` values containing IPv6 brackets
+     * or ports. Preserve that behavior and apply the same allowance to `by` so
+     * both node parameters are parsed consistently. Other parameter values remain
+     * restricted to the RFC token grammar.
+     */
+    private def parseLegacyNodeValue(): Either[String, String] = {
+      val start = index
+      while (
+        index < input.length &&
+        (isTokenCharacter(input.charAt(index)) || ":[]".indexOf(input.charAt(index)) >= 0)
+      ) {
+        index += 1
+      }
+      if (index == start) Left(s"Expected node value at position $index")
+      else Right(input.substring(start, index))
+    }
+
+    private def parseQuotedString(): Either[String, String] = {
+      val value = new StringBuilder
+      index += 1
+
+      while (index < input.length) {
+        val char = input.charAt(index)
+        if (char == '"') {
+          index += 1
+          return Right(value.result())
+        } else if (char == '\\') {
+          index += 1
+          if (index >= input.length || !isQuotedPairCharacter(input.charAt(index))) {
+            return Left(s"Invalid quoted-pair at position $index")
+          }
+          value.append(input.charAt(index))
+          index += 1
+        } else if (isQuotedTextCharacter(char)) {
+          value.append(char)
+          index += 1
+        } else {
+          return Left(s"Invalid quoted-string character at position $index")
+        }
+      }
+
+      Left("Unterminated quoted-string")
+    }
+
+    private def skipOptionalWhitespace(): Unit = {
+      while (index < input.length && isOptionalWhitespace(input.charAt(index))) {
+        index += 1
+      }
+    }
+
+    private def isOptionalWhitespace(char: Char): Boolean = char == ' ' || char == '\t'
+
+    private def isTokenCharacter(char: Char): Boolean = {
+      (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+      (char >= '0' && char <= '9') || "!#$%&'*+-.^_`|~".indexOf(char) >= 0
+    }
+
+    private def isQuotedTextCharacter(char: Char): Boolean = {
+      char == '\t' || char == ' ' || char == '!' ||
+      (char >= '#' && char <= '[') || (char >= ']' && char <= '~') ||
+      (char >= '\u0080' && char <= '\u00ff')
+    }
+
+    private def isQuotedPairCharacter(char: Char): Boolean = {
+      char == '\t' || char == ' ' || (char >= '!' && char <= '~') ||
+      (char >= '\u0080' && char <= '\u00ff')
+    }
+  }
+}

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -87,7 +87,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
             |Forwarded: for=192.0.2.44;by="_edge"
             |Forwarded: for=192.0.2.45;by=unknown
             |Forwarded: for=192.0.2.46;by="[2001:db8:cafe::17]:4711"
-            |Forwarded: for=192.0.2.47;by=???
+            |Forwarded: for=192.0.2.47;by="???"
           """.stripMargin
         )
       )
@@ -177,6 +177,120 @@ class ForwardedHeaderHandlerSpec extends Specification {
           ForwardedEntry(Some("192.0.2.43"), None)
         )
       )
+    }
+
+    "parse all rfc7239 token characters" in {
+      val results = processHeaders(
+        version("rfc7239") ++ trustedProxies(),
+        headers(
+          """
+            |Forwarded: !#$%&'*+-.^_`|~=value;for=203.0.113.43
+          """.stripMargin
+        )
+      )
+
+      results.map(_._1) must containTheSameElementsAs(Seq(ForwardedEntry(Some("203.0.113.43"), None)))
+    }
+
+    "parse empty rfc7239 parameter slots" in {
+      val results = processHeaders(
+        version("rfc7239") ++ trustedProxies(),
+        headers(
+          """
+            |Forwarded: ;for=203.0.113.43;;proto=https;
+          """.stripMargin
+        )
+      )
+
+      results.map(_._1) must containTheSameElementsAs(
+        Seq(ForwardedEntry(Some("203.0.113.43"), Some("https")))
+      )
+    }
+
+    "ignore empty rfc7239 list elements" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: , , for=203.0.113.43, , for=127.0.0.1, ,
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "ignore empty rfc7239 list elements split over header fields" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: , ,
+          |Forwarded: for=203.0.113.43, for=127.0.0.1
+          |Forwarded: ,
+        """.stripMargin
+      ) mustEqual RemoteConnection("203.0.113.43", false, None)
+    }
+
+    "reject combined rfc7239 fields containing only empty list elements" in {
+      val results = processHeaders(
+        version("rfc7239") ++ trustedProxies(),
+        headers(
+          """
+            |Forwarded: , ,
+            |Forwarded: ,
+          """.stripMargin
+        )
+      )
+
+      results must haveSize(1)
+      results.head._1 must_== ForwardedEntry(None, None)
+      results.head._2 must beLeft
+    }
+
+    "reject duplicate rfc7239 parameters case-insensitively" in {
+      val results = processHeaders(
+        version("rfc7239") ++ trustedProxies(),
+        headers(
+          """
+            |Forwarded: for=203.0.113.43;For=198.51.100.17
+          """.stripMargin
+        )
+      )
+
+      results must haveSize(1)
+      results.head._1 must_== ForwardedEntry(None, None)
+      results.head._2 must beLeft
+    }
+
+    "stop trusted proxy scanning at a malformed rfc7239 field" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1"),
+        """
+          |Forwarded: for=203.0.113.43
+          |Forwarded: for=198.51.100.17;for=192.0.2.43
+          |Forwarded: for=192.168.1.43, for=127.0.0.1
+        """.stripMargin
+      ) mustEqual RemoteConnection("192.168.1.43", false, None)
+    }
+
+    "reject a complete rfc7239 field when one of its elements is malformed" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for=203.0.113.43, for=127.0.0.1;for=192.0.2.43
+        """.stripMargin
+      ) mustEqual RemoteConnection(localhost, None, secure = false, None)
+    }
+
+    "reject whitespace around rfc7239 parameter separators" in {
+      val results = processHeaders(
+        version("rfc7239") ++ trustedProxies(),
+        headers(
+          """
+            |Forwarded: for =203.0.113.43
+            |Forwarded: for=203.0.113.43 ;proto=https
+            |Forwarded: for=203.0.113.43; proto=https
+          """.stripMargin
+        )
+      )
+
+      results.map(_._1) must containTheSameElementsAs(Seq.fill(3)(ForwardedEntry(None, None)))
     }
 
     "expose rfc7239 by entries on the selected remote connection" in {
@@ -317,7 +431,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
       )
     }
 
-    "handle IPv6 addresses with rfc7239" in {
+    "handle unquoted IPv6 addresses with rfc7239 for compatibility" in {
       remoteConnectionToLocalhost(
         version("rfc7239") ++ trustedProxies("127.0.0.1"),
         """
@@ -592,6 +706,22 @@ class ForwardedHeaderHandlerSpec extends Specification {
           |Forwarded: for="192.0.2.43:443";proto=https
         """.stripMargin
       ) mustEqual RemoteConnection("192.0.2.43", Some(443), secure = true, None)
+    }
+
+    "use unquoted rfc7239 node ports for compatibility" in {
+      remoteConnectionToLocalhost(
+        version("rfc7239") ++ trustedProxies("127.0.0.1"),
+        """
+          |Forwarded: for=192.0.2.43:443;by=[2001:db8:cafe::17]:8080
+        """.stripMargin
+      ) mustEqual RemoteConnection(
+        addr("192.0.2.43"),
+        RemoteNode.Ip(addr("192.0.2.43"), Some(443)),
+        Some(443),
+        Some(RemoteNode.Ip(addr("2001:db8:cafe::17"), Some(8080))),
+        secure = false,
+        None
+      )
     }
 
     "use the port from an rfc7239 forwarded IPv6 address" in {

--- a/transport/server/play-server/src/test/scala/play/core/server/common/Rfc7239HeaderParserSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/Rfc7239HeaderParserSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import org.specs2.mutable.Specification
+
+class Rfc7239HeaderParserSpec extends Specification {
+
+  "Rfc7239HeaderParser" should {
+    "parse elements, parameters, and optional list whitespace" in {
+      Rfc7239HeaderParser.parse("\tfor=192.0.2.43;proto=https \t,\t for=198.51.100.17\t") must beRight(
+        Vector(
+          Map("for" -> "192.0.2.43", "proto" -> "https"),
+          Map("for" -> "198.51.100.17")
+        )
+      )
+    }
+
+    "parse every token character" in {
+      Rfc7239HeaderParser.parse("!#$%&'*+-.^_`|~=value") must beRight(
+        Vector(Map("!#$%&'*+-.^_`|~" -> "value"))
+      )
+    }
+
+    "parse quoted text, separators, and quoted-pair escapes" in {
+      Rfc7239HeaderParser.parse("""for="_edge\",still";proto="ht\\tps"""") must beRight(
+        Vector(Map("for" -> "_edge\",still", "proto" -> "ht\\tps"))
+      )
+    }
+
+    "parse empty parameter slots" in {
+      Rfc7239HeaderParser.parse(";for=192.0.2.43;;proto=https;") must beRight(
+        Vector(Map("for" -> "192.0.2.43", "proto" -> "https"))
+      )
+    }
+
+    "parse legacy unquoted for and by node values" in {
+      Rfc7239HeaderParser.parse(
+        "for=[2001:db8:cafe::17]:4711;by=192.0.2.43:8080"
+      ) must beRight(
+        Vector(
+          Map(
+            "for" -> "[2001:db8:cafe::17]:4711",
+            "by"  -> "192.0.2.43:8080"
+          )
+        )
+      )
+    }
+
+    "ignore empty HTTP list elements" in {
+      Rfc7239HeaderParser.parse(", ,for=192.0.2.43,,") must beRight(
+        Vector(Map("for" -> "192.0.2.43"))
+      )
+    }
+
+    "parse a field line containing only empty HTTP list elements for later recombination" in {
+      Seq("", ",", ", \t,").forall(
+        Rfc7239HeaderParser.parse(_) == Right(Vector.empty[Map[String, String]])
+      ) must beTrue
+    }
+
+    "parse obs-text in quoted strings and quoted-pairs" in {
+      Rfc7239HeaderParser.parse("proto=\"\u00ff\\\u00fe\"") must beRight(
+        Vector(Map("proto" -> "\u00ff\u00fe"))
+      )
+    }
+
+    "reject duplicate parameters case-insensitively" in {
+      Rfc7239HeaderParser.parse("for=192.0.2.43;For=198.51.100.17") must beLeft
+    }
+
+    "reject whitespace outside HTTP list separators" in {
+      Seq(
+        "for =192.0.2.43",
+        "for= 192.0.2.43",
+        "for=192.0.2.43 ;proto=https",
+        "for=192.0.2.43; proto=https"
+      ).forall(Rfc7239HeaderParser.parse(_).isLeft) must beTrue
+    }
+
+    "reject values that are neither tokens nor quoted strings" in {
+      Seq(
+        "proto=https:443",
+        "extension=value:part",
+        "for=192.0.2.43/24",
+        "for=\"192.0.2.43\"suffix"
+      ).forall(Rfc7239HeaderParser.parse(_).isLeft) must beTrue
+    }
+
+    "reject malformed quoted strings" in {
+      Seq(
+        "for=\"unterminated",
+        "for=\"invalid\u0007text\"",
+        "for=\"invalid\\\u0007pair\"",
+        "for=\"invalid\u0100text\""
+      ).forall(Rfc7239HeaderParser.parse(_).isLeft) must beTrue
+    }
+
+    "reject non-ASCII token characters" in {
+      Rfc7239HeaderParser.parse("f\u00f6r=192.0.2.43") must beLeft
+    }
+  }
+}


### PR DESCRIPTION
Replace the delimiter-based RFC 7239 `Forwarded` header parsing with a single-pass field-syntax parser.

The parser now handles:

- HTTP tokens
- quoted strings
- quoted-pair escapes
- comma-separated forwarded elements
- semicolon-separated parameters
- optional HTTP list whitespace
- empty HTTP list members
- multiple `Forwarded` field lines
- case-insensitive parameter names
- duplicate parameter detection

Malformed fields are treated as unverifiable proxy boundaries. Trusted proxy scanning stops at the last verified connection instead of skipping malformed forwarding information.

## Compatibility

Play continues to accept unquoted `for` node values containing IPv6 brackets or ports for compatibility with Play 3.0. The same allowance is applied to `by` values for consistent node parsing.

New and updated proxy configurations should emit the quoted syntax required by RFC 7239.

Valid existing `Forwarded` headers remain supported. The behavioral changes apply to malformed or ambiguous syntax that the previous delimiter-based parser could accidentally accept or split incorrectly.

## Additional changes

- Add focused parser tests covering the RFC field grammar.
- Add trusted-proxy integration tests for malformed fields.
- Document the stricter parsing behavior in the HTTP server guide,
  Play 3.1 highlights, and migration guide.
