### PR TITLE
Fix RedirectHttpsFilter URL construction and header trust

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -263,9 +263,30 @@ trait RequestHeader {
   }
 
   /**
-   * The HTTP domain. The domain part of the request's [[host]].
+   * The HTTP domain. This is the request's [[host]] without its port. Brackets
+   * around an IPv6 address are preserved so the result can be used in a URI.
    */
-  lazy val domain: String = host.split(':').head
+  lazy val domain: String = {
+    val hostValue = host
+    if (hostValue.startsWith("[")) {
+      val closingBracket = hostValue.indexOf(']')
+      if (
+        closingBracket >= 0 &&
+        (closingBracket == hostValue.length - 1 || hostValue.charAt(closingBracket + 1) == ':')
+      ) {
+        hostValue.substring(0, closingBracket + 1)
+      } else {
+        hostValue
+      }
+    } else {
+      val portSeparator = hostValue.indexOf(':')
+      if (portSeparator >= 0 && hostValue.indexOf(':', portSeparator + 1) < 0) {
+        hostValue.substring(0, portSeparator)
+      } else {
+        hostValue
+      }
+    }
+  }
 
   /**
    * The Request Langs extracted from the Accept-Language header and sorted by preference (preferred first).

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -180,6 +180,22 @@ class RequestHeaderSpec extends Specification {
       "relative uri with host header" in {
         val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
         rh.host must_== "playframework.com"
+        rh.domain must_== "playframework.com"
+      }
+      "relative uri with host header and port" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com:9000"))
+        rh.host must_== "playframework.com:9000"
+        rh.domain must_== "playframework.com"
+      }
+      "relative uri with bracketed IPv6 host and port" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "[2001:db8::1]:9000"))
+        rh.host must_== "[2001:db8::1]:9000"
+        rh.domain must_== "[2001:db8::1]"
+      }
+      "leave ambiguous host values unchanged when extracting the domain" in {
+        val hosts = Seq("2001:db8::1", "[2001:db8::1]suffix:9000")
+
+        hosts.forall { host => dummyRequestHeader("GET", "/", Headers(HOST -> host)).domain == host } must beTrue
       }
       "absolute uri" in {
         val rh = dummyRequestHeader("GET", "https://example.com/test", Headers(HOST -> "playframework.com"))

--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -72,6 +72,24 @@ For compatibility with Play 3.0, Play continues to accept these values without q
 
 When Play encounters a malformed `Forwarded` field while scanning a trusted proxy chain, it stops at that field and keeps the last verified connection information. Check that each trusted proxy emits valid RFC 7239 syntax before upgrading.
 
+### Redirect HTTPS filter only reads X-Forwarded-Proto when enabled
+
+The Redirect HTTPS filter previously treated `X-Forwarded-Proto: https` as a secure request even when `play.filters.https.xForwardedProtoEnabled` was `false`. The filter now ignores `X-Forwarded-Proto` unless that legacy option is explicitly enabled. Deployments that relied on this implicit header handling may otherwise repeatedly redirect a public HTTPS request when a proxy terminates HTTPS but Play still sees the proxy connection as insecure.
+
+Applications behind a trusted proxy should normally configure [[trusted proxies|HTTPServer#configuring-trusted-proxies]] so Play derives `request.secure` after validating the forwarded proxy chain. If a trusted proxy sends a single `X-Forwarded-Proto` value without `X-Forwarded-For`, enable:
+
+```hocon
+play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor = true
+```
+
+The immediate proxy must also be included in `play.http.forwarded.trustedProxies`. Applications that intentionally rely on the filter reading `X-Forwarded-Proto` directly can instead set:
+
+```hocon
+play.filters.https.xForwardedProtoEnabled = true
+```
+
+This legacy option changes more than the secure-request check: the filter redirects only requests with `X-Forwarded-Proto: http`. Requests with a missing or unexpected value are passed to the application without an HTTPS redirect or HSTS header, and the option does not update `request.secure`. Only enable it when bypassing redirects for requests without the header is intentional, or when a trusted proxy removes or overwrites every client-supplied value and reliably sends either `http` or `https`.
+
 ### HEAD responses no longer include generated Content-Length headers
 
 Play no longer renders generated `Content-Length` headers for `HEAD` responses. `HEAD` responses still do not include a response body, but applications and tests should not rely on `Content-Length` being present on a `HEAD` response, even when the equivalent `GET` response has a known length.

--- a/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
@@ -58,6 +58,8 @@ play.filters.https.port = 9443
 
 then the URL in the `Location` header will include the port specifically, e.g. `https://playframework.com:9443/some/url`.
 
+The redirect authority comes from the request's effective host, including a trusted forwarded host when configured. The incoming port is replaced by the configured HTTPS port, and bracketed IPv6 hosts are preserved. For both origin-form and absolute-form request targets, only the original path and query are appended to the redirect authority.
+
 ## X-Forwarded-Proto Header
 
 It is possible to only redirect if a `x-forwarded-proto` header is set to `http`, this can be enabled by adding the following to `application.conf`:
@@ -65,3 +67,9 @@ It is possible to only redirect if a `x-forwarded-proto` header is set to `http`
 ```
 play.filters.https.xForwardedProtoEnabled = true
 ```
+
+This legacy option reads `X-Forwarded-Proto` directly. It treats `https` as secure and redirects only `http`. A request with a missing or unexpected value is passed to the application without an HTTPS redirect or HSTS header. The option affects only this filter and does not update `request.secure`.
+
+Only enable it when bypassing redirects for requests without the header is intentional, or when a trusted proxy removes or overwrites every client-supplied value and reliably sends either `http` or `https`. When the option is disabled, the filter ignores the header and uses `request.secure`.
+
+Prefer configuring [[trusted proxies|HTTPServer#configuring-trusted-proxies]] so Play derives `request.secure` while validating the forwarded proxy chain. For a trusted proxy that sends a single `X-Forwarded-Proto` value without `X-Forwarded-For`, enable `play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor` instead of direct header handling in this filter.

--- a/web/play-filters-helpers/src/main/resources/reference.conf
+++ b/web/play-filters-helpers/src/main/resources/reference.conf
@@ -317,9 +317,12 @@ play.filters {
     # not change the HTTP method according to [RFC 7238](https://tools.ietf.org/html/rfc7538).
     redirectStatusCode = 308
 
-    # A boolean defining whether to only redirect if a x-forwarded-proto header is set to http.
-    # This is a defacto standard that will be used by various proxys or load balancers to determine
-    # if a redirect should happen.
+    # A boolean defining whether to read X-Forwarded-Proto directly and only redirect when it is set to http.
+    # Only enable this legacy option when a trusted proxy removes or overwrites client-supplied values.
+    # Otherwise, prefer play.http.forwarded configuration so the complete proxy chain is validated.
+    # For a single X-Forwarded-Proto without X-Forwarded-For, see
+    # play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor.
+    # When false, the filter ignores X-Forwarded-Proto.
     # [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto)
     xForwardedProtoEnabled = false
 

--- a/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/web/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -41,13 +41,17 @@ class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration) extends
 
   @inline
   private[this] def shouldRedirect(req: RequestHeader) = {
-    if (xForwardedProtoEnabled) req.headers.get(HeaderNames.X_FORWARDED_PROTO).contains("http")
+    if (xForwardedProtoEnabled) hasXForwardedProto(req, "http")
     else true
   }
 
   @inline
   private[this] def isSecure(req: RequestHeader) =
-    req.secure || req.headers.get(HeaderNames.X_FORWARDED_PROTO).contains("https")
+    req.secure || (xForwardedProtoEnabled && hasXForwardedProto(req, "https"))
+
+  @inline
+  private[this] def hasXForwardedProto(req: RequestHeader, protocol: String) =
+    req.headers.get(HeaderNames.X_FORWARDED_PROTO).exists(_.trim.equalsIgnoreCase(protocol))
 
   override def apply(next: EssentialAction): EssentialAction = EssentialAction { req =>
     import play.api.libs.streams.Accumulator
@@ -80,12 +84,16 @@ class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration) extends
 
   protected def createHttpsRedirectUrl(req: RequestHeader): String = {
     import req.domain
-    import req.uri
+    val path  = Option(req.path).filter(_.startsWith("/")).getOrElse("/")
+    val query = req.uri.indexOf('?') match {
+      case -1    => ""
+      case index => req.uri.substring(index)
+    }
     sslPort match {
       case None | Some(443) =>
-        s"https://$domain$uri"
+        s"https://$domain$path$query"
       case Some(port) =>
-        s"https://$domain:$port$uri"
+        s"https://$domain:$port$path$query"
     }
   }
 

--- a/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/web/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -12,8 +12,11 @@ import play.api._
 import play.api.http.HttpFilters
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSClient
 import play.api.mvc._
 import play.api.mvc.request.RemoteConnection
+import play.api.mvc.request.RequestAttrKey
+import play.api.mvc.request.RequestTarget
 import play.api.mvc.Handler.Stage
 import play.api.mvc.Results._
 import play.api.routing.HandlerDef
@@ -69,6 +72,19 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       }
     }
 
+    "redirect an absolute request target using only its path and query" in new WithApplication(
+      buildApp(mode = Mode.Prod)
+    ) {
+      override def running() = {
+        val result = route(
+          app,
+          absoluteRequest("http://playframework.com:9000/please/dont?version=GTI|V8", "/please/dont")
+        ).get
+
+        header(LOCATION, result) must beSome("https://playframework.com/please/dont?version=GTI|V8")
+      }
+    }
+
     "not redirect when on http in test" in new WithApplication(buildApp(mode = Mode.Test)) {
       override def running() = {
         val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
@@ -101,7 +117,7 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       }
     }
 
-    "not redirect when X-Forwarded-Proto header is 'https' (and not on https) but send HSTS header" in new WithApplication(
+    "handle an HTTPS X-Forwarded-Proto value case-insensitively when enabled" in new WithApplication(
       buildApp(
         """
           |play.filters.https.xForwardedProtoEnabled = true
@@ -111,7 +127,7 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
     ) {
       override def running() = {
         val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-        val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "https")).get
+        val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "HTTPS")).get
 
         header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
         status(result) must_== OK
@@ -125,6 +141,56 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         val result = route(app, request("/please/dont?remove=this&foo=bar")).get
 
         header(LOCATION, result) must beSome("https://playframework.com:9443/please/dont?remove=this&foo=bar")
+      }
+    }
+
+    "redirect a bracketed IPv6 host to a custom HTTPS port" in new WithApplication(
+      buildApp("play.filters.https.port = 9443", mode = Mode.Prod)
+    ) {
+      override def running() = {
+        val result = route(app, request("/please", host = "[2001:db8::1]:9000")).get
+
+        header(LOCATION, result) must beSome("https://[2001:db8::1]:9443/please")
+      }
+    }
+
+    "redirect using a trusted forwarded host" in new WithServer(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.http.forwarded.version = "rfc7239"
+          |play.http.forwarded.trustForwardedHost = true
+        """.stripMargin,
+        mode = Mode.Test,
+        withWs = true
+      ),
+      testServerPort
+    ) {
+      override def running() = {
+        val ws       = inject[WSClient]
+        val response = await(
+          ws.url(s"http://localhost:$port/please?foo=bar")
+            .addHttpHeaders("Forwarded" -> "for=192.0.2.43;host=\"public.example:8080\"")
+            .withFollowRedirects(false)
+            .get()
+        )
+
+        response.status must_== PERMANENT_REDIRECT
+        response.header(LOCATION) must beSome("https://public.example/please?foo=bar")
+      }
+    }
+
+    "prefer a trusted effective host over an absolute request target" in new WithApplication(
+      buildApp(mode = Mode.Prod)
+    ) {
+      override def running() = {
+        val result = route(
+          app,
+          absoluteRequest("http://internal.example/please?foo=bar", "/please")
+            .addAttr(RequestAttrKey.EffectiveHost, "public.example:8080")
+        ).get
+
+        header(LOCATION, result) must beSome("https://public.example/please?foo=bar")
       }
     }
 
@@ -196,7 +262,26 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         status(result) must_== PERMANENT_REDIRECT
       }
     }
-    "redirect when xForwardedProtoEnabled is set and header is present" in new WithApplication(
+    "ignore X-Forwarded-Proto when xForwardedProtoEnabled is false" in new WithApplication(
+      buildApp(
+        """
+          |play.filters.https.redirectEnabled = true
+          |play.filters.https.xForwardedProtoEnabled = false
+        """.stripMargin,
+        mode = Mode.Test
+      )
+    ) {
+      override def running() = {
+        val insecure =
+          RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
+        val result = route(app, request().withConnection(insecure).withHeaders("X-Forwarded-Proto" -> "https")).get
+
+        header(STRICT_TRANSPORT_SECURITY, result) must beNone
+        header(LOCATION, result) must beSome("https://playframework.com/")
+        status(result) must_== PERMANENT_REDIRECT
+      }
+    }
+    "handle an HTTP X-Forwarded-Proto value case-insensitively when enabled" in new WithApplication(
       buildApp(
         """
           |play.filters.https.redirectEnabled = true
@@ -207,7 +292,7 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
     ) {
       override def running() = {
         val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = false, clientCertificateChain = None)
-        val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "http")).get
+        val result = route(app, request().withConnection(secure).withHeaders("X-Forwarded-Proto" -> "HTTP")).get
 
         header(STRICT_TRANSPORT_SECURITY, result) must beNone
         status(result) must_== PERMANENT_REDIRECT
@@ -369,22 +454,33 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
     }
   }
 
-  private def request(path: String = "/", queryParams: Option[String] = None) = {
+  private def request(
+      path: String = "/",
+      queryParams: Option[String] = None,
+      host: String = "playframework.com"
+  ) = {
     FakeRequest(method = "GET", path = path + queryParams.map("?" + _).getOrElse(""))
-      .withHeaders(HOST -> "playframework.com")
+      .withHeaders(HOST -> host)
+  }
+
+  private def absoluteRequest(uri: String, path: String) = {
+    request(uri).withTarget(RequestTarget(uri, path, Map.empty))
   }
 
   def inject[T: ClassTag](implicit app: Application) = app.injector.instanceOf[T]
 
-  private def buildApp(config: String = "", mode: Mode = Mode.Test) =
-    GuiceApplicationBuilder(Environment.simple(mode = mode))
-      .configure(Configuration(ConfigFactory.parseString(config)))
-      .load(
+  private def buildApp(config: String = "", mode: Mode = Mode.Test, withWs: Boolean = false) = {
+    val modules: Seq[play.api.inject.guice.GuiceableModule] =
+      Seq[play.api.inject.guice.GuiceableModule](
         new play.api.inject.BuiltinModule,
         new play.api.mvc.CookiesModule,
         new play.api.i18n.I18nModule,
         new play.filters.https.RedirectHttpsModule
-      )
+      ) ++ (if (withWs) Seq[play.api.inject.guice.GuiceableModule](new play.api.libs.ws.ahc.AhcWSModule) else Seq.empty)
+
+    GuiceApplicationBuilder(Environment.simple(mode = mode))
+      .configure(Configuration(ConfigFactory.parseString(config)))
+      .load(modules*)
       .appRoutes(implicit app => {
         case ("GET", "/") =>
           val action = inject[DefaultActionBuilder]
@@ -421,4 +517,5 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
         bind[HttpFilters].to[TestFilters]
       )
       .build()
+  }
 }


### PR DESCRIPTION
Fix several correctness and security issues in `RedirectHttpsFilter`.

Redirect locations are now built from the request's effective host and its path/query components. This:

- avoids embedding an absolute request target in the redirect URL
- uses a trusted forwarded host when configured
- removes the incoming HTTP port
- applies the configured HTTPS port
- preserves brackets around IPv6 literals
- preserves the original query string

The filter now reads `X-Forwarded-Proto` directly only when the legacy `play.filters.https.xForwardedProtoEnabled` option is enabled. Protocol matching is trimmed and case-insensitive.

Previously, `X-Forwarded-Proto: https` caused the filter to treat a request as secure even when that option was disabled. This allowed a directly connected client to influence redirect behavior using a forwarded header.

## Proxy configuration

Applications should preferably configure Play's trusted proxy handling so the filter relies on `request.secure`.

For a trusted proxy that sends one `X-Forwarded-Proto` value without `X-Forwarded-For`, use:

```hocon
play.http.forwarded.trustXForwardedProtoWithoutXForwardedFor = true
```

Applications intentionally using direct header handling can retain the previous behavior with:

```hocon
play.filters.https.xForwardedProtoEnabled = true
```

That legacy option should only be enabled when a trusted proxy removes or overwrites client-supplied `X-Forwarded-Proto` values.

## Testing

Adds coverage for:

- ordinary origin-form redirects
- absolute-form request targets
- raw query-string preservation
- incoming and configured ports
- bracketed IPv6 hosts
- trusted forwarded hosts
- effective hosts overriding absolute-target authorities
- disabled direct `X-Forwarded-Proto` handling
- case-insensitive `http` and `https` protocol values