### PR TITLE
Support trusted forwarded client certificates

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -14,6 +14,8 @@ import play.api._
 import play.api.http.DefaultHttpErrorHandler
 import play.api.http.HttpErrorHandler
 import play.api.mvc._
+import play.api.mvc.request.ClientCertificateInfo
+import play.api.mvc.request.ClientCertificateSource
 import play.api.mvc.request.ForwardingInfo
 import play.api.mvc.request.ForwardingSource
 import play.api.mvc.request.RemoteEndpoint
@@ -29,6 +31,18 @@ class NettyBadClientHandlingSpec     extends BadClientHandlingSpec with NettyInt
 class PekkoHttpBadClientHandlingSpec extends BadClientHandlingSpec with PekkoHttpIntegrationSpecification
 
 trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpecification {
+  // RFC 9440 Appendix A's leaf certificate (serial number 7).
+  private val forwardedClientCertificateBase64 =
+    "MIIBqDCCAU6gAwIBAgIBBzAKBggqhkjOPQQDAjA6MRswGQYDVQQKDBJMZXQncyBB" +
+      "dXRoZW50aWNhdGUxGzAZBgNVBAMMEkxBIEludGVybWVkaWF0ZSBDQTAeFw0yMDAx" +
+      "MTQyMjU1MzNaFw0yMTAxMjMyMjU1MzNaMA0xCzAJBgNVBAMMAkJDMFkwEwYHKoZI" +
+      "zj0CAQYIKoZIzj0DAQcDQgAE8YnXXfaUgmnMtOXU/IncWalRhebrXmckC8vdgJ1p" +
+      "5Be5F/3YC8OthxM4+k1M6aEAEFcGzkJiNy6J84y7uzo9M6NyMHAwCQYDVR0TBAIw" +
+      "ADAfBgNVHSMEGDAWgBRm3WjLa38lbEYCuiCPct0ZaSED2DAOBgNVHQ8BAf8EBAMC" +
+      "BsAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwHQYDVR0RAQH/BBMwEYEPYmRjQGV4YW1w" +
+      "bGUuY29tMAoGCCqGSM49BAMCA0gAMEUCIBHda/r1vaL6G3VliL4/Di6YK0Q6bMje" +
+      "SkC3dFCOOB8TAiEAx/kHSB4urmiZ0NX5r5XarmPk0wmuydBVoU4hBVZ1yhk="
+
   "Play" should {
     def withServer[T](
         errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
@@ -142,6 +156,99 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
 
       response.status must_== 400
       response.body must beLeft("203.0.113.43|https|true|public.example")
+    }
+
+    "preserve a trusted RFC 9440 client certificate in an error handler" in {
+      val seen = new AtomicReference[RequestHeader]()
+
+      withServer(
+        capturingErrorHandler(seen),
+        Map(
+          "play.http.forwarded.clientCertificates.mode"           -> "rfc9440",
+          "play.http.forwarded.clientCertificates.trustedProxies" -> java.util.List.of("127.0.0.0/8", "::1/128")
+        )
+      ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/[",
+            "HTTP/1.1",
+            Map("Client-Cert" -> s":$forwardedClientCertificateBase64:"),
+            ""
+          )
+        )(0)
+
+        response.status must_== 400
+      }
+
+      val request = Option(seen.get()).getOrElse(throw new IllegalStateException("The error handler was not called"))
+
+      request.clientCertificate must beSome[ClientCertificateInfo].like {
+        case certificate =>
+          (certificate.source must_== ClientCertificateSource.Rfc9440)
+            .and(certificate.certificate.getSerialNumber.intValue must_== 7)
+      }
+      request.xForwardedClientCertificates must beEmpty
+    }
+
+    "preserve trusted XFCC assertion metadata in an error handler" in {
+      val seen = new AtomicReference[RequestHeader]()
+
+      withServer(
+        capturingErrorHandler(seen),
+        Map(
+          "play.http.forwarded.clientCertificates.mode"           -> "x-forwarded-client-cert",
+          "play.http.forwarded.clientCertificates.trustedProxies" ->
+            java.util.List.of("127.0.0.0/8", "::1/128")
+        )
+      ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/[",
+            "HTTP/1.1",
+            Map(
+              "X-Forwarded-Client-Cert" ->
+                s"Hash=${"a" * 64};URI=spiffe://example.test/workload"
+            ),
+            ""
+          )
+        )(0)
+
+        response.status must_== 400
+      }
+
+      val request = Option(seen.get()).getOrElse(throw new IllegalStateException("The error handler was not called"))
+
+      request.clientCertificate must beNone
+      request.xForwardedClientCertificates must beLike {
+        case Vector(assertion) =>
+          (assertion.hash must beSome("a" * 64))
+            .and(assertion.uris must_== Vector("spiffe://example.test/workload"))
+      }
+    }
+
+    "omit malformed trusted client certificate metadata in an error handler" in {
+      val seen = new AtomicReference[RequestHeader]()
+
+      withServer(
+        capturingErrorHandler(seen),
+        Map(
+          "play.http.forwarded.clientCertificates.mode"           -> "rfc9440",
+          "play.http.forwarded.clientCertificates.trustedProxies" -> java.util.List.of("127.0.0.0/8", "::1/128")
+        )
+      ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/[", "HTTP/1.1", Map("Client-Cert" -> ":not base64:"), "")
+        )(0)
+
+        response.status must_== 400
+      }
+
+      val request = Option(seen.get()).getOrElse(throw new IllegalStateException("The error handler was not called"))
+
+      request.clientCertificate must beNone
+      request.xForwardedClientCertificates must beEmpty
     }
 
     "preserve the accepted forwarding path and provenance in an error handler" in {

--- a/core/play-integration-test/src/test/scala/play/it/http/DirectClientCertificateSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/DirectClientCertificateSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.it.http
+
+import play.api.mvc.request.ClientCertificateSource
+import play.api.mvc.Results
+import play.api.test.ApplicationFactories
+import play.api.test.PlaySpecification
+import play.api.test.ServerEndpointRecipe
+import play.it.test.EndpointIntegrationSpecification
+import play.it.test.NettyServerEndpointRecipes
+import play.it.test.OkHttpEndpointSupport
+import play.it.test.PekkoHttpServerEndpointRecipes
+
+class DirectClientCertificateSpec
+    extends PlaySpecification
+    with EndpointIntegrationSpecification
+    with OkHttpEndpointSupport
+    with ApplicationFactories {
+
+  private val mutualTlsEndpoints: Seq[ServerEndpointRecipe] = Seq(
+    NettyServerEndpointRecipes.Netty11Encrypted,
+    PekkoHttpServerEndpointRecipes.PekkoHttp11Encrypted
+  ).map(
+    _.withExtraServerConfiguration(
+      Map("play.server.https.needClientAuth" -> true)
+    )
+  )
+
+  private val application = withAction { Action =>
+    Action { request =>
+      val directCertificateMatchesTransport = for {
+        clientCertificate <- request.clientCertificate
+        transportTls      <- request.transport.tls
+      } yield {
+        val selectedCertificates  = clientCertificate.certificates.map(_.getEncoded.toSeq)
+        val transportCertificates = transportTls.peerCertificates.map(_.getEncoded.toSeq)
+        clientCertificate.source == ClientCertificateSource.DirectTransport &&
+        selectedCertificates == transportCertificates
+      }
+
+      Results.Ok(directCertificateMatchesTransport.contains(true).toString)
+    }
+  }
+
+  "Play HTTPS servers" should {
+    "expose a real mutual-TLS client certificate as direct transport metadata" in application
+      .withOkHttpEndpoints(mutualTlsEndpoints) { endpoint =>
+        val response = endpoint.call("/")
+
+        response.code must_== 200
+        response.body.string must_== "true"
+      }
+  }
+}

--- a/core/play-integration-test/src/test/scala/play/it/http/DirectClientCertificateSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/DirectClientCertificateSpec.scala
@@ -41,7 +41,9 @@ class DirectClientCertificateSpec
         selectedCertificates == transportCertificates
       }
 
-      Results.Ok(directCertificateMatchesTransport.contains(true).toString)
+      Results.Ok(
+        (directCertificateMatchesTransport.contains(true) && request.xForwardedClientCertificates.isEmpty).toString
+      )
     }
   }
 

--- a/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -79,6 +79,46 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
   /** Whether the backend passes an absolute-form request with an empty Host field to Play. */
   protected def backendPassesAbsoluteTargetWithEmptyHostToPlay: Boolean
 
+  // RFC 9440 Appendix A's leaf certificate (serial number 7).
+  private val forwardedClientCertificateBase64 =
+    "MIIBqDCCAU6gAwIBAgIBBzAKBggqhkjOPQQDAjA6MRswGQYDVQQKDBJMZXQncyBB" +
+      "dXRoZW50aWNhdGUxGzAZBgNVBAMMEkxBIEludGVybWVkaWF0ZSBDQTAeFw0yMDAx" +
+      "MTQyMjU1MzNaFw0yMTAxMjMyMjU1MzNaMA0xCzAJBgNVBAMMAkJDMFkwEwYHKoZI" +
+      "zj0CAQYIKoZIzj0DAQcDQgAE8YnXXfaUgmnMtOXU/IncWalRhebrXmckC8vdgJ1p" +
+      "5Be5F/3YC8OthxM4+k1M6aEAEFcGzkJiNy6J84y7uzo9M6NyMHAwCQYDVR0TBAIw" +
+      "ADAfBgNVHSMEGDAWgBRm3WjLa38lbEYCuiCPct0ZaSED2DAOBgNVHQ8BAf8EBAMC" +
+      "BsAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwHQYDVR0RAQH/BBMwEYEPYmRjQGV4YW1w" +
+      "bGUuY29tMAoGCCqGSM49BAMCA0gAMEUCIBHda/r1vaL6G3VliL4/Di6YK0Q6bMje" +
+      "SkC3dFCOOB8TAiEAx/kHSB4urmiZ0NX5r5XarmPk0wmuydBVoU4hBVZ1yhk="
+
+  private val trustedForwardedCertificateProxyConfig = Seq(
+    "play.http.forwarded.clientCertificates.trustedProxies" -> Seq("127.0.0.0/8", "::1/128"),
+    "play.server.max-header-size"                           -> "64k"
+  )
+
+  private def percentEncode(value: String): String = {
+    val result = new StringBuilder(value.length * 3)
+    val hex    = "0123456789ABCDEF"
+    value.getBytes(java.nio.charset.StandardCharsets.US_ASCII).foreach { byte =>
+      val unsigned = byte & 0xff
+      if (
+        (unsigned >= 'a' && unsigned <= 'z') ||
+        (unsigned >= 'A' && unsigned <= 'Z') ||
+        (unsigned >= '0' && unsigned <= '9') ||
+        unsigned == '-' || unsigned == '.' || unsigned == '_' || unsigned == '~'
+      ) result.append(unsigned.toChar)
+      else {
+        result.append('%')
+        result.append(hex.charAt(unsigned >>> 4))
+        result.append(hex.charAt(unsigned & 0x0f))
+      }
+    }
+    result.result()
+  }
+
+  private def forwardedClientCertificatePem: String =
+    s"-----BEGIN CERTIFICATE-----\n$forwardedClientCertificateBase64\n-----END CERTIFICATE-----\n"
+
   def withServerAndConfig[T](
       configuration: (String, Any)*
   )(action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T): T = {
@@ -427,6 +467,227 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
         // HTTP request authorities model host[:port], not userinfo. Strict request conversion rejects
         // user@localhost, and both server backends must report that validation failure as a stable 400.
         response.status must_== BAD_REQUEST
+      }
+    }
+
+    "expose a trusted RFC 9440 client certificate as typed request metadata" in {
+      withServerAndConfig(
+        (trustedForwardedCertificateProxyConfig :+
+          ("play.http.forwarded.clientCertificates.mode" -> "rfc9440"))*
+      )((Action, _) =>
+        Action { request =>
+          val certificate = request.clientCertificate
+          Results.Ok(
+            Seq(
+              certificate.exists(_.source == play.api.mvc.request.ClientCertificateSource.Rfc9440),
+              certificate.map(_.certificate.getSerialNumber).getOrElse("none"),
+              certificate.fold(-1)(_.chain.size),
+              request.xForwardedClientCertificates.size
+            ).mkString("|")
+          )
+        }
+      ) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("Client-Cert" -> s":$forwardedClientCertificateBase64:"),
+            ""
+          )
+        )
+
+        response.status must_== OK
+        response.body must beLeft("true|7|0|0")
+      }
+    }
+
+    "ignore a malformed RFC 9440 client certificate from a trusted proxy" in {
+      withServerAndConfig(
+        (trustedForwardedCertificateProxyConfig :+
+          ("play.http.forwarded.clientCertificates.mode" -> "rfc9440"))*
+      )((Action, _) => Action(request => Results.Ok(request.clientCertificate.isEmpty.toString))) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("Client-Cert" -> ":not base64:"),
+            ""
+          )
+        )
+
+        response.status must_== OK
+        response.body must beLeft("true")
+      }
+    }
+
+    "ignore a malformed RFC 9440 chain while retaining its valid leaf" in {
+      withServerAndConfig(
+        (trustedForwardedCertificateProxyConfig :+
+          ("play.http.forwarded.clientCertificates.mode" -> "rfc9440"))*
+      )((Action, _) =>
+        Action { request =>
+          Results.Ok(
+            request.clientCertificate
+              .map(certificate => s"${certificate.certificate.getSerialNumber}|${certificate.chain.size}")
+              .getOrElse("none")
+          )
+        }
+      ) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map(
+              "Client-Cert"       -> s":$forwardedClientCertificateBase64:",
+              "Client-Cert-Chain" -> ":AQID:"
+            ),
+            ""
+          )
+        )
+
+        response.status must_== OK
+        response.body must beLeft("7|0")
+      }
+    }
+
+    "retain a trusted metadata-only X-Forwarded-Client-Cert assertion" in {
+      withServerAndConfig(
+        (trustedForwardedCertificateProxyConfig :+
+          ("play.http.forwarded.clientCertificates.mode" -> "x-forwarded-client-cert"))*
+      )((Action, _) =>
+        Action { request =>
+          request.xForwardedClientCertificates match {
+            case Vector(assertion) =>
+              Results.Ok(
+                Seq(
+                  request.clientCertificate.isEmpty,
+                  assertion.hash.contains("a" * 64),
+                  assertion.subject.contains(""),
+                  assertion.uris == Vector("spiffe://example.test/workload"),
+                  assertion.dnsNames == Vector("client.example.test")
+                ).mkString("|")
+              )
+            case assertions => Results.InternalServerError(s"unexpected assertion count: ${assertions.size}")
+          }
+        }
+      ) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map(
+              "X-Forwarded-Client-Cert" ->
+                s"Hash=${"a" * 64};Subject=\"\";URI=spiffe://example.test/workload;DNS=client.example.test"
+            ),
+            ""
+          )
+        )
+
+        response.status must_== OK
+        response.body must beLeft("true|true|true|true|true")
+      }
+    }
+
+    "expose a certificate-bearing X-Forwarded-Client-Cert assertion and effective certificate" in {
+      withServerAndConfig(
+        (trustedForwardedCertificateProxyConfig :+
+          ("play.http.forwarded.clientCertificates.mode" -> "x-forwarded-client-cert"))*
+      )((Action, _) =>
+        Action { request =>
+          val certificate = request.clientCertificate
+          val assertion   = request.xForwardedClientCertificates.headOption
+          Results.Ok(
+            Seq(
+              certificate.exists(_.source == play.api.mvc.request.ClientCertificateSource.XForwardedClientCert),
+              certificate.map(_.certificate.getSerialNumber).getOrElse("none"),
+              certificate.fold(-1)(_.chain.size),
+              assertion.flatMap(_.certificate).exists(_.getSerialNumber.intValue == 7),
+              request.xForwardedClientCertificates.size
+            ).mkString("|")
+          )
+        }
+      ) { port =>
+        val encodedPem    = percentEncode(forwardedClientCertificatePem)
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("X-Forwarded-Client-Cert" -> s"Cert=$encodedPem"),
+            ""
+          )
+        )
+
+        response.status must_== OK
+        response.body must beLeft("true|7|0|true|1")
+      }
+    }
+
+    "reject malformed forwarded client-certificate metadata from a trusted proxy" in {
+      withServerAndConfig(
+        (trustedForwardedCertificateProxyConfig :+
+          ("play.http.forwarded.clientCertificates.mode" -> "x-forwarded-client-cert"))*
+      )((Action, _) => Action(Results.Ok)) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port, checkClosed = true)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("X-Forwarded-Client-Cert" -> "Cert=%ZZ"),
+            ""
+          )
+        )
+
+        response.status must_== BAD_REQUEST
+      }
+    }
+
+    "ignore malformed forwarded client-certificate fields while handling is off" in {
+      withServerAndConfig("play.http.forwarded.clientCertificates.mode" -> "off")((Action, _) =>
+        Action { request =>
+          Results.Ok(s"${request.clientCertificate.isEmpty}|${request.xForwardedClientCertificates.isEmpty}")
+        }
+      ) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("Client-Cert" -> ":not base64:", "X-Forwarded-Client-Cert" -> "Cert=%ZZ"),
+            ""
+          )
+        )
+
+        response.status must_== OK
+        response.body must beLeft("true|true")
+      }
+    }
+
+    "ignore malformed forwarded client-certificate metadata from an untrusted peer" in {
+      withServerAndConfig(
+        "play.http.forwarded.clientCertificates.mode"           -> "x-forwarded-client-cert",
+        "play.http.forwarded.clientCertificates.trustedProxies" -> Seq("192.0.2.0/24")
+      )((Action, _) =>
+        Action { request =>
+          Results.Ok(s"${request.clientCertificate.isEmpty}|${request.xForwardedClientCertificates.isEmpty}")
+        }
+      ) { port =>
+        val Seq(response) = BasicHttpClient.makeRequests(port)(
+          BasicRequest(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            Map("X-Forwarded-Client-Cert" -> "Cert=%ZZ"),
+            ""
+          )
+        )
+
+        response.status must_== OK
+        response.body must beLeft("true|true")
       }
     }
 

--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -7,6 +7,7 @@ package play.mvc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.net.InetAddresses;
 import java.io.File;
@@ -14,6 +15,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.Inet6Address;
 import java.net.URISyntaxException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -274,6 +276,26 @@ public class RequestBuilderTest {
     assertTrue(request.transport().tls().isPresent());
     assertEquals(List.of(), request.transport().tls().orElseThrow().peerCertificates());
     assertFalse(request.secure());
+  }
+
+  @Test
+  public void testClientCertificateIsBuilderState() {
+    X509Certificate leaf = mock(X509Certificate.class);
+    X509Certificate intermediate = mock(X509Certificate.class);
+    Http.ClientCertificateInfo certificate =
+        new Http.ClientCertificateInfo(
+            leaf, List.of(intermediate), Http.ClientCertificateSource.RFC_9440);
+
+    RequestBuilder builder = new RequestBuilder().clientCertificate(certificate);
+    Request request = builder.build();
+
+    assertEquals(Optional.of(certificate), builder.clientCertificate());
+    assertEquals(Optional.of(certificate), request.clientCertificate());
+    assertEquals(certificate, request.asScala().clientCertificate().get().asJava());
+
+    builder.clientCertificate(Optional.empty());
+    assertEquals(Optional.empty(), builder.clientCertificate());
+    assertEquals(Optional.empty(), builder.build().clientCertificate());
   }
 
   @Test

--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -299,6 +299,39 @@ public class RequestBuilderTest {
   }
 
   @Test
+  public void testXForwardedClientCertificatesAreOrderedBuilderState() {
+    Http.XForwardedClientCert client =
+        new Http.XForwardedClientCert(
+            List.of("spiffe://example/edge"),
+            Optional.empty(),
+            Optional.empty(),
+            List.of(),
+            Optional.empty(),
+            List.of("spiffe://example/client"),
+            List.of("client.example"));
+    Http.XForwardedClientCert proxy =
+        new Http.XForwardedClientCert(
+            List.of("spiffe://example/sidecar"),
+            Optional.empty(),
+            Optional.empty(),
+            List.of(),
+            Optional.empty(),
+            List.of("spiffe://example/proxy"),
+            List.of());
+    List<Http.XForwardedClientCert> mutableAssertions = new ArrayList<>(List.of(client, proxy));
+
+    Request request = new RequestBuilder().xForwardedClientCertificates(mutableAssertions).build();
+    mutableAssertions.clear();
+
+    assertEquals(List.of(client, proxy), request.xForwardedClientCertificates());
+    assertEquals(2, request.asScala().xForwardedClientCertificates().size());
+    assertEquals(client, request.asScala().xForwardedClientCertificates().apply(0).asJava());
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> request.xForwardedClientCertificates().add(client));
+  }
+
+  @Test
   public void testPathPreservesRawTargetAuthority() {
     RequestBuilder oversizedPort =
         new RequestBuilder()

--- a/core/play-microbenchmark/src/test/scala/play/core/server/netty/NettyHelpers.scala
+++ b/core/play-microbenchmark/src/test/scala/play/core/server/netty/NettyHelpers.scala
@@ -20,6 +20,7 @@ import play.api.libs.crypto.CookieSignerProvider
 import play.api.mvc.DefaultCookieHeaderEncoding
 import play.api.mvc.DefaultFlashCookieBaker
 import play.api.mvc.DefaultSessionCookieBaker
+import play.core.server.common.ClientCertificateHeaderHandler
 import play.core.server.common.ForwardedHeaderHandler
 import play.core.server.common.ServerResultUtils
 
@@ -38,6 +39,7 @@ object NettyHelpers {
     new NettyModelConversion(
       serverResultUtils,
       new ForwardedHeaderHandler(ForwardedHeaderHandler.ForwardedHeaderHandlerConfig(None)),
+      new ClientCertificateHeaderHandler(ClientCertificateHeaderHandler.Config(None)),
       None
     )
   }

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -292,6 +292,63 @@ public class Http {
     }
   }
 
+  /** One accepted {@code X-Forwarded-Client-Cert} assertion. */
+  public record XForwardedClientCert(
+      List<String> by,
+      Optional<String> hash,
+      Optional<X509Certificate> certificate,
+      List<X509Certificate> chain,
+      Optional<String> subject,
+      List<String> uris,
+      List<String> dnsNames) {
+
+    public XForwardedClientCert {
+      by = List.copyOf(by);
+      Objects.requireNonNull(hash, "hash");
+      Objects.requireNonNull(certificate, "certificate");
+      chain = List.copyOf(chain);
+      Objects.requireNonNull(subject, "subject");
+      uris = List.copyOf(uris);
+      dnsNames = List.copyOf(dnsNames);
+      if (certificate.isEmpty() && !chain.isEmpty()) {
+        throw new IllegalArgumentException("An XFCC certificate chain requires a leaf certificate");
+      }
+      if (certificate.isPresent() && chain.contains(certificate.orElseThrow())) {
+        throw new IllegalArgumentException(
+            "An XFCC certificate chain must not repeat the leaf certificate");
+      }
+    }
+
+    /**
+     * Return the asserted leaf-and-chain sequence.
+     *
+     * @return the immutable sequence, or an empty list when no certificate was asserted
+     */
+    public List<X509Certificate> certificates() {
+      if (certificate.isEmpty()) {
+        return List.of();
+      }
+      ArrayList<X509Certificate> certificates = new ArrayList<>(chain.size() + 1);
+      certificates.add(certificate.orElseThrow());
+      certificates.addAll(chain);
+      return List.copyOf(certificates);
+    }
+
+    /**
+     * @return the Scala version of this XFCC assertion
+     */
+    public play.api.mvc.request.XForwardedClientCert asScala() {
+      return play.api.mvc.request.XForwardedClientCert$.MODULE$.create(
+          Scala.asScala(by),
+          OptionConverters.toScala(hash),
+          OptionConverters.toScala(certificate),
+          Scala.asScala(chain),
+          OptionConverters.toScala(subject),
+          Scala.asScala(uris),
+          Scala.asScala(dnsNames));
+    }
+  }
+
   /** Immutable metadata about the transport connection directly terminating at Play. */
   public record TransportConnection(PeerEndpoint peer, Optional<TransportTls> tls) {
     public TransportConnection {
@@ -795,6 +852,18 @@ public class Http {
     }
 
     /**
+     * Return accepted {@code X-Forwarded-Client-Cert} assertions in client-to-Play order.
+     *
+     * @return the immutable ordered assertions
+     */
+    default List<XForwardedClientCert> xForwardedClientCertificates() {
+      return List.copyOf(
+          Scala.asJava(asScala().xForwardedClientCertificates()).stream()
+              .map(value -> value.asJava())
+              .toList());
+    }
+
+    /**
      * @return the normalized effective request scheme
      */
     default Scheme scheme() {
@@ -1246,6 +1315,7 @@ public class Http {
           requestFactory.createRequest(
               transport,
               OptionConverters.toScala(Optional.empty()),
+              scala.collection.immutable.Vector$.MODULE$.empty(),
               remote,
               play.api.mvc.request.Scheme$.MODULE$.Http(),
               OptionConverters.toScala(Optional.empty()),
@@ -2061,6 +2131,29 @@ public class Http {
      */
     public RequestBuilder clientCertificate(ClientCertificateInfo clientCertificate) {
       return clientCertificate(Optional.of(clientCertificate));
+    }
+
+    /**
+     * @return accepted {@code X-Forwarded-Client-Cert} assertions in client-to-Play order
+     */
+    public List<XForwardedClientCert> xForwardedClientCertificates() {
+      return List.copyOf(
+          Scala.asJava(req.xForwardedClientCertificates()).stream()
+              .map(value -> value.asJava())
+              .toList());
+    }
+
+    /**
+     * @param xForwardedClientCertificates sets the ordered accepted XFCC assertions
+     * @return the builder instance
+     */
+    public RequestBuilder xForwardedClientCertificates(
+        List<XForwardedClientCert> xForwardedClientCertificates) {
+      Objects.requireNonNull(xForwardedClientCertificates, "xForwardedClientCertificates");
+      List<play.api.mvc.request.XForwardedClientCert> scalaValues =
+          xForwardedClientCertificates.stream().map(XForwardedClientCert::asScala).toList();
+      req = req.withXForwardedClientCertificates(Scala.toSeq(scalaValues));
+      return this;
     }
 
     /**

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -232,6 +232,66 @@ public class Http {
     }
   }
 
+  /** The source from which Play selected an effective client certificate. */
+  public enum ClientCertificateSource {
+    /** The certificate was observed on the TLS connection directly terminating at Play. */
+    DIRECT_TRANSPORT,
+
+    /** The certificate was accepted from the RFC 9440 {@code Client-Cert} header fields. */
+    RFC_9440,
+
+    /** The certificate was accepted from {@code X-Forwarded-Client-Cert}. */
+    X_FORWARDED_CLIENT_CERT;
+
+    /**
+     * @return the Scala version of this client certificate source
+     */
+    public play.api.mvc.request.ClientCertificateSource asScala() {
+      return switch (this) {
+        case DIRECT_TRANSPORT ->
+            play.api.mvc.request.ClientCertificateSource$.MODULE$.directTransport();
+        case RFC_9440 -> play.api.mvc.request.ClientCertificateSource$.MODULE$.rfc9440();
+        case X_FORWARDED_CLIENT_CERT ->
+            play.api.mvc.request.ClientCertificateSource$.MODULE$.xForwardedClientCert();
+      };
+    }
+  }
+
+  /** The effective X.509 client certificate selected for a request. */
+  public record ClientCertificateInfo(
+      X509Certificate certificate, List<X509Certificate> chain, ClientCertificateSource source) {
+
+    public ClientCertificateInfo {
+      Objects.requireNonNull(certificate, "certificate");
+      chain = List.copyOf(chain);
+      Objects.requireNonNull(source, "source");
+      if (chain.contains(certificate)) {
+        throw new IllegalArgumentException(
+            "An effective client certificate chain must not repeat the leaf certificate");
+      }
+    }
+
+    /**
+     * Return the effective leaf-and-chain sequence, with the leaf first.
+     *
+     * @return the immutable leaf-and-chain sequence
+     */
+    public List<X509Certificate> certificates() {
+      ArrayList<X509Certificate> certificates = new ArrayList<>(chain.size() + 1);
+      certificates.add(certificate);
+      certificates.addAll(chain);
+      return List.copyOf(certificates);
+    }
+
+    /**
+     * @return the Scala version of this effective client certificate information
+     */
+    public play.api.mvc.request.ClientCertificateInfo asScala() {
+      return play.api.mvc.request.ClientCertificateInfo$.MODULE$.create(
+          certificate, Scala.asScala(chain), source.asScala());
+    }
+  }
+
   /** Immutable metadata about the transport connection directly terminating at Play. */
   public record TransportConnection(PeerEndpoint peer, Optional<TransportTls> tls) {
     public TransportConnection {
@@ -728,6 +788,13 @@ public class Http {
     }
 
     /**
+     * @return the effective X.509 client certificate selected for this request, if present
+     */
+    default Optional<ClientCertificateInfo> clientCertificate() {
+      return OptionConverters.toJava(asScala().clientCertificate()).map(value -> value.asJava());
+    }
+
+    /**
      * @return the normalized effective request scheme
      */
     default Scheme scheme() {
@@ -1178,6 +1245,7 @@ public class Http {
       req =
           requestFactory.createRequest(
               transport,
+              OptionConverters.toScala(Optional.empty()),
               remote,
               play.api.mvc.request.Scheme$.MODULE$.Http(),
               OptionConverters.toScala(Optional.empty()),
@@ -1966,6 +2034,33 @@ public class Http {
     public RequestBuilder transport(TransportConnection transport) {
       req = req.withTransport(transport.asScala());
       return this;
+    }
+
+    /**
+     * @return the effective X.509 client certificate selected for this request, if present
+     */
+    public Optional<ClientCertificateInfo> clientCertificate() {
+      return OptionConverters.toJava(req.clientCertificate()).map(value -> value.asJava());
+    }
+
+    /**
+     * @param clientCertificate sets the effective client certificate, or empty to remove it
+     * @return the builder instance
+     */
+    public RequestBuilder clientCertificate(Optional<ClientCertificateInfo> clientCertificate) {
+      Objects.requireNonNull(clientCertificate, "clientCertificate");
+      req =
+          req.withClientCertificate(
+              OptionConverters.toScala(clientCertificate.map(ClientCertificateInfo::asScala)));
+      return this;
+    }
+
+    /**
+     * @param clientCertificate sets the effective client certificate
+     * @return the builder instance
+     */
+    public RequestBuilder clientCertificate(ClientCertificateInfo clientCertificate) {
+      return clientCertificate(Optional.of(clientCertificate));
     }
 
     /**

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -3232,6 +3232,7 @@ public class Http {
     String WWW_AUTHENTICATE = "WWW-Authenticate";
     String CLIENT_CERT = "Client-Cert";
     String CLIENT_CERT_CHAIN = "Client-Cert-Chain";
+    String X_FORWARDED_CLIENT_CERT = "X-Forwarded-Client-Cert";
     String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
     String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
     String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";

--- a/core/play/src/main/java/play/mvc/Http.java
+++ b/core/play/src/main/java/play/mvc/Http.java
@@ -3137,6 +3137,8 @@ public class Http {
     String VIA = "Via";
     String WARNING = "Warning";
     String WWW_AUTHENTICATE = "WWW-Authenticate";
+    String CLIENT_CERT = "Client-Cert";
+    String CLIENT_CERT_CHAIN = "Client-Cert-Chain";
     String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
     String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
     String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";

--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -154,8 +154,9 @@ play {
       # independent from the trusted proxies used for remote addresses and request metadata.
       clientCertificates = {
 
-        # Valid values are off and rfc9440. When off, Play leaves Client-Cert and
-        # Client-Cert-Chain available as raw headers but does not interpret them.
+        # Valid values are off, rfc9440, and x-forwarded-client-cert. When off,
+        # Play leaves certificate forwarding fields available as raw headers but
+        # does not interpret them.
         mode = "off"
 
         # Only a directly connected peer in this list may assert a forwarded client certificate.
@@ -175,6 +176,15 @@ play {
 
           # Maximum number of chain certificates, excluding the leaf.
           maxChainLength = 8
+        }
+
+        xForwardedClientCert = {
+          # Play currently accepts only one assertion set by the directly connected proxy.
+          policy = "sanitized-single"
+
+          # Envoy's semicolon-delimited text form. JSON is not currently supported. Raw comma
+          # and semicolon characters are ambiguous in Envoy's unescaped By and URI values.
+          format = "text"
         }
       }
 

--- a/core/play/src/main/resources/reference.conf
+++ b/core/play/src/main/resources/reference.conf
@@ -150,6 +150,34 @@ play {
       # incoming client-supplied X-Forwarded-Host values.
       trustXForwardedHost = false
 
+      # Forwarded TLS client certificate configuration. This trust boundary is deliberately
+      # independent from the trusted proxies used for remote addresses and request metadata.
+      clientCertificates = {
+
+        # Valid values are off and rfc9440. When off, Play leaves Client-Cert and
+        # Client-Cert-Chain available as raw headers but does not interpret them.
+        mode = "off"
+
+        # Only a directly connected peer in this list may assert a forwarded client certificate.
+        # Keep this list empty unless the proxy authenticates client certificates, removes incoming
+        # certificate fields, and is reachable over an authenticated or equivalently isolated path.
+        trustedProxies = []
+
+        limits = {
+          # Aggregate encoded size of the selected certificate header fields.
+          maxHeaderBytes = 64k
+
+          # Aggregate decoded DER certificate bytes.
+          maxDecodedBytes = 64k
+
+          # Maximum decoded DER size of one certificate.
+          maxCertificateBytes = 16k
+
+          # Maximum number of chain certificates, excluding the leaf.
+          maxChainLength = 8
+        }
+      }
+
     }
 
     # Parsing configuration

--- a/core/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/core/play/src/main/scala/play/api/http/StandardValues.scala
@@ -305,6 +305,8 @@ trait HeaderNames {
   val WWW_AUTHENTICATE = "WWW-Authenticate"
 
   val FORWARDED         = "Forwarded"
+  val CLIENT_CERT       = "Client-Cert"
+  val CLIENT_CERT_CHAIN = "Client-Cert-Chain"
   val X_FORWARDED_FOR   = "X-Forwarded-For"
   val X_FORWARDED_HOST  = "X-Forwarded-Host"
   val X_FORWARDED_PORT  = "X-Forwarded-Port"

--- a/core/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/core/play/src/main/scala/play/api/http/StandardValues.scala
@@ -304,13 +304,14 @@ trait HeaderNames {
   val WARNING          = "Warning"
   val WWW_AUTHENTICATE = "WWW-Authenticate"
 
-  val FORWARDED         = "Forwarded"
-  val CLIENT_CERT       = "Client-Cert"
-  val CLIENT_CERT_CHAIN = "Client-Cert-Chain"
-  val X_FORWARDED_FOR   = "X-Forwarded-For"
-  val X_FORWARDED_HOST  = "X-Forwarded-Host"
-  val X_FORWARDED_PORT  = "X-Forwarded-Port"
-  val X_FORWARDED_PROTO = "X-Forwarded-Proto"
+  val FORWARDED               = "Forwarded"
+  val CLIENT_CERT             = "Client-Cert"
+  val CLIENT_CERT_CHAIN       = "Client-Cert-Chain"
+  val X_FORWARDED_CLIENT_CERT = "X-Forwarded-Client-Cert"
+  val X_FORWARDED_FOR         = "X-Forwarded-For"
+  val X_FORWARDED_HOST        = "X-Forwarded-Host"
+  val X_FORWARDED_PORT        = "X-Forwarded-Port"
+  val X_FORWARDED_PROTO       = "X-Forwarded-Proto"
 
   val X_REQUESTED_WITH = "X-Requested-With"
 

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -15,6 +15,7 @@ import play.api.i18n.Messages
 import play.api.libs.typedmap.TypedEntry
 import play.api.libs.typedmap.TypedKey
 import play.api.libs.typedmap.TypedMap
+import play.api.mvc.request.ClientCertificateInfo
 import play.api.mvc.request.RemoteInfo
 import play.api.mvc.request.RequestAuthority
 import play.api.mvc.request.RequestTarget
@@ -81,19 +82,117 @@ trait Request[+A] extends RequestHeader {
 
   // Override the return type and default implementation of these RequestHeader methods
   override def withTransport(newTransport: TransportConnection): Request[A] =
-    new RequestImpl[A](remote, method, target, version, headers, attrs, body, newTransport, scheme, authority)
+    new RequestImpl[A](
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      body,
+      newTransport,
+      clientCertificate,
+      scheme,
+      authority
+    )
+  override def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): Request[A] =
+    new RequestImpl[A](
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      body,
+      transport,
+      newClientCertificate,
+      scheme,
+      authority
+    )
   override def withScheme(newScheme: Scheme): Request[A] =
-    new RequestImpl[A](remote, method, target, version, headers, attrs, body, transport, newScheme, authority)
+    new RequestImpl[A](
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      body,
+      transport,
+      clientCertificate,
+      newScheme,
+      authority
+    )
   override def withAuthority(newAuthority: Option[RequestAuthority]): Request[A] =
-    new RequestImpl[A](remote, method, target, version, headers, attrs, body, transport, scheme, newAuthority)
+    new RequestImpl[A](
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      body,
+      transport,
+      clientCertificate,
+      scheme,
+      newAuthority
+    )
   override def withRemote(newRemote: RemoteInfo): Request[A] =
-    new RequestImpl[A](newRemote, method, target, version, headers, attrs, body, transport, scheme, authority)
+    new RequestImpl[A](
+      newRemote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      body,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
   override def withMethod(newMethod: String): Request[A] =
-    new RequestImpl[A](remote, newMethod, target, version, headers, attrs, body, transport, scheme, authority)
+    new RequestImpl[A](
+      remote,
+      newMethod,
+      target,
+      version,
+      headers,
+      attrs,
+      body,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
   override def withTarget(newTarget: RequestTarget): Request[A] =
-    new RequestImpl[A](remote, method, newTarget, version, headers, attrs, body, transport, scheme, authority)
+    new RequestImpl[A](
+      remote,
+      method,
+      newTarget,
+      version,
+      headers,
+      attrs,
+      body,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
   override def withVersion(newVersion: String): Request[A] =
-    new RequestImpl[A](remote, method, target, newVersion, headers, attrs, body, transport, scheme, authority)
+    new RequestImpl[A](
+      remote,
+      method,
+      target,
+      newVersion,
+      headers,
+      attrs,
+      body,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
   override def withHeaders(newHeaders: Headers): Request[A] =
     new RequestImpl[A](
       remote,
@@ -104,11 +203,24 @@ trait Request[+A] extends RequestHeader {
       attrs,
       body,
       transport,
+      clientCertificate,
       scheme,
       authority
     )
   override def withAttrs(newAttrs: TypedMap): Request[A] =
-    new RequestImpl[A](remote, method, target, version, headers, newAttrs, body, transport, scheme, authority)
+    new RequestImpl[A](
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      newAttrs,
+      body,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
   override def addAttr[B](key: TypedKey[B], value: B): Request[A] =
     withAttrs(attrs.updated(key, value))
   override def addAttrs(e1: TypedEntry[?]): Request[A]                                       = withAttrs(attrs.updated(e1))
@@ -171,8 +283,13 @@ private[play] class RequestImpl[+A](
     override val attrs: TypedMap,
     override val body: A,
     override val transport: TransportConnection,
+    override val clientCertificate: Option[ClientCertificateInfo],
     override val scheme: Scheme,
     override val authority: Option[RequestAuthority]
 ) extends Request[A] {
+  require(
+    clientCertificate != null && clientCertificate.forall(_ != null),
+    "Effective client certificate option must not be null or contain null"
+  )
   override val headers: Headers = RequestHeader.canonicalHeaders(requestHeaders, authority)
 }

--- a/core/play/src/main/scala/play/api/mvc/Request.scala
+++ b/core/play/src/main/scala/play/api/mvc/Request.scala
@@ -21,6 +21,7 @@ import play.api.mvc.request.RequestAuthority
 import play.api.mvc.request.RequestTarget
 import play.api.mvc.request.Scheme
 import play.api.mvc.request.TransportConnection
+import play.api.mvc.request.XForwardedClientCert
 import play.mvc.Http
 
 /**
@@ -93,7 +94,8 @@ trait Request[+A] extends RequestHeader {
       newTransport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   override def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): Request[A] =
     new RequestImpl[A](
@@ -107,8 +109,28 @@ trait Request[+A] extends RequestHeader {
       transport,
       newClientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
+  override def withXForwardedClientCertificates(
+      newXForwardedClientCertificates: Seq[XForwardedClientCert]
+  ): Request[A] = {
+    require(newXForwardedClientCertificates != null, "The XFCC assertion sequence must not be null")
+    new RequestImpl[A](
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      body,
+      transport,
+      clientCertificate,
+      scheme,
+      authority,
+      newXForwardedClientCertificates.toVector
+    )
+  }
   override def withScheme(newScheme: Scheme): Request[A] =
     new RequestImpl[A](
       remote,
@@ -121,7 +143,8 @@ trait Request[+A] extends RequestHeader {
       transport,
       clientCertificate,
       newScheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   override def withAuthority(newAuthority: Option[RequestAuthority]): Request[A] =
     new RequestImpl[A](
@@ -135,7 +158,8 @@ trait Request[+A] extends RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      newAuthority
+      newAuthority,
+      xForwardedClientCertificates
     )
   override def withRemote(newRemote: RemoteInfo): Request[A] =
     new RequestImpl[A](
@@ -149,7 +173,8 @@ trait Request[+A] extends RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   override def withMethod(newMethod: String): Request[A] =
     new RequestImpl[A](
@@ -163,7 +188,8 @@ trait Request[+A] extends RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   override def withTarget(newTarget: RequestTarget): Request[A] =
     new RequestImpl[A](
@@ -177,7 +203,8 @@ trait Request[+A] extends RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   override def withVersion(newVersion: String): Request[A] =
     new RequestImpl[A](
@@ -191,7 +218,8 @@ trait Request[+A] extends RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   override def withHeaders(newHeaders: Headers): Request[A] =
     new RequestImpl[A](
@@ -205,7 +233,8 @@ trait Request[+A] extends RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   override def withAttrs(newAttrs: TypedMap): Request[A] =
     new RequestImpl[A](
@@ -219,7 +248,8 @@ trait Request[+A] extends RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   override def addAttr[B](key: TypedKey[B], value: B): Request[A] =
     withAttrs(attrs.updated(key, value))
@@ -285,11 +315,16 @@ private[play] class RequestImpl[+A](
     override val transport: TransportConnection,
     override val clientCertificate: Option[ClientCertificateInfo],
     override val scheme: Scheme,
-    override val authority: Option[RequestAuthority]
+    override val authority: Option[RequestAuthority],
+    override val xForwardedClientCertificates: Vector[XForwardedClientCert] = Vector.empty
 ) extends Request[A] {
   require(
     clientCertificate != null && clientCertificate.forall(_ != null),
     "Effective client certificate option must not be null or contain null"
+  )
+  require(
+    xForwardedClientCertificates != null && xForwardedClientCertificates.forall(_ != null),
+    "The XFCC assertion sequence must not be null or contain null"
   )
   override val headers: Headers = RequestHeader.canonicalHeaders(requestHeaders, authority)
 }

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -40,7 +40,8 @@ trait RequestHeader {
       newTransport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /** The effective X.509 client certificate selected for this request, if present. */
@@ -58,8 +59,32 @@ trait RequestHeader {
       transport,
       newClientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
+
+  /** Accepted `X-Forwarded-Client-Cert` assertions in client-to-Play order. */
+  def xForwardedClientCertificates: Vector[XForwardedClientCert]
+
+  /** Return a copy with a different ordered sequence of accepted XFCC assertions. */
+  def withXForwardedClientCertificates(
+      newXForwardedClientCertificates: Seq[XForwardedClientCert]
+  ): RequestHeader = {
+    require(newXForwardedClientCertificates != null, "The XFCC assertion sequence must not be null")
+    new RequestHeaderImpl(
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      transport,
+      clientCertificate,
+      scheme,
+      authority,
+      newXForwardedClientCertificates.toVector
+    )
+  }
 
   /**
    * The normalized effective request scheme.
@@ -80,7 +105,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       newScheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /**
@@ -106,7 +132,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      newAuthority
+      newAuthority,
+      xForwardedClientCertificates
     )
 
   /**
@@ -126,7 +153,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /**
@@ -153,7 +181,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /**
@@ -178,7 +207,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /**
@@ -216,7 +246,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /**
@@ -246,7 +277,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /** Whether the effective request scheme is HTTPS. */
@@ -275,7 +307,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /**
@@ -451,7 +484,8 @@ trait RequestHeader {
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
 
   /**
@@ -773,7 +807,8 @@ private[play] class RequestHeaderImpl(
     override val transport: TransportConnection,
     override val clientCertificate: Option[ClientCertificateInfo],
     override val scheme: Scheme,
-    override val authority: Option[RequestAuthority]
+    override val authority: Option[RequestAuthority],
+    override val xForwardedClientCertificates: Vector[XForwardedClientCert] = Vector.empty
 ) extends RequestHeader {
   require(remote != null, "Selected remote metadata must not be null")
   require(transport != null, "Direct transport metadata must not be null")
@@ -785,6 +820,10 @@ private[play] class RequestHeaderImpl(
   require(
     authority != null && authority.forall(_ != null),
     "Effective request authority option must not be null or contain null"
+  )
+  require(
+    xForwardedClientCertificates != null && xForwardedClientCertificates.forall(_ != null),
+    "The XFCC assertion sequence must not be null or contain null"
   )
 
   override val headers: Headers = RequestHeader.canonicalHeaders(requestHeaders, authority)

--- a/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/core/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -30,7 +30,36 @@ trait RequestHeader {
 
   /** Return a copy with different direct transport metadata. */
   def withTransport(newTransport: TransportConnection): RequestHeader =
-    new RequestHeaderImpl(remote, method, target, version, headers, attrs, newTransport, scheme, authority)
+    new RequestHeaderImpl(
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      newTransport,
+      clientCertificate,
+      scheme,
+      authority
+    )
+
+  /** The effective X.509 client certificate selected for this request, if present. */
+  def clientCertificate: Option[ClientCertificateInfo]
+
+  /** Return a copy with different effective client certificate information. */
+  def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): RequestHeader =
+    new RequestHeaderImpl(
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      transport,
+      newClientCertificate,
+      scheme,
+      authority
+    )
 
   /**
    * The normalized effective request scheme.
@@ -41,7 +70,18 @@ trait RequestHeader {
 
   /** Return a copy with a different effective request scheme. */
   def withScheme(newScheme: Scheme): RequestHeader =
-    new RequestHeaderImpl(remote, method, target, version, headers, attrs, transport, newScheme, authority)
+    new RequestHeaderImpl(
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      transport,
+      clientCertificate,
+      newScheme,
+      authority
+    )
 
   /**
    * The normalized effective request authority, if the request has one.
@@ -56,7 +96,18 @@ trait RequestHeader {
    * This is the only copy operation that changes the canonical `Host` header.
    */
   def withAuthority(newAuthority: Option[RequestAuthority]): RequestHeader =
-    new RequestHeaderImpl(remote, method, target, version, headers, attrs, transport, scheme, newAuthority)
+    new RequestHeaderImpl(
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      transport,
+      clientCertificate,
+      scheme,
+      newAuthority
+    )
 
   /**
    * The selected remote-node metadata for this request.
@@ -65,7 +116,18 @@ trait RequestHeader {
 
   /** Return a copy with different selected remote-node metadata. */
   def withRemote(newRemote: RemoteInfo): RequestHeader =
-    new RequestHeaderImpl(newRemote, method, target, version, headers, attrs, transport, scheme, authority)
+    new RequestHeaderImpl(
+      newRemote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
 
   /**
    * The request id. The request id is stored as an attribute indexed by [[play.api.mvc.request.RequestAttrKey.Id]].
@@ -81,7 +143,18 @@ trait RequestHeader {
    * Return a new copy of the request with its method changed.
    */
   def withMethod(newMethod: String): RequestHeader =
-    new RequestHeaderImpl(remote, newMethod, target, version, headers, attrs, transport, scheme, authority)
+    new RequestHeaderImpl(
+      remote,
+      newMethod,
+      target,
+      version,
+      headers,
+      attrs,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
 
   /**
    * The target of the HTTP request, i.e. the URI or path that was
@@ -95,7 +168,18 @@ trait RequestHeader {
    * This operation preserves the effective [[scheme]] and [[authority]].
    */
   def withTarget(newTarget: RequestTarget): RequestHeader =
-    new RequestHeaderImpl(remote, method, newTarget, version, headers, attrs, transport, scheme, authority)
+    new RequestHeaderImpl(
+      remote,
+      method,
+      newTarget,
+      version,
+      headers,
+      attrs,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
 
   /**
    * The complete request URI, containing both path and query string.
@@ -122,7 +206,18 @@ trait RequestHeader {
    * Return a new copy of the request with its HTTP version changed.
    */
   def withVersion(newVersion: String): RequestHeader =
-    new RequestHeaderImpl(remote, method, target, newVersion, headers, attrs, transport, scheme, authority)
+    new RequestHeaderImpl(
+      remote,
+      method,
+      target,
+      newVersion,
+      headers,
+      attrs,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
 
   /**
    * The parsed query string. This method delegates to `target.queryMap`.
@@ -149,6 +244,7 @@ trait RequestHeader {
       RequestHeader.validateReplacementHeaders(newHeaders, authority),
       attrs,
       transport,
+      clientCertificate,
       scheme,
       authority
     )
@@ -169,7 +265,18 @@ trait RequestHeader {
    * @return The new version of this object with the attributes attached.
    */
   def withAttrs(newAttrs: TypedMap): RequestHeader =
-    new RequestHeaderImpl(remote, method, target, version, headers, newAttrs, transport, scheme, authority)
+    new RequestHeaderImpl(
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      newAttrs,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
 
   /**
    * Create a new versions of this object with the given attribute attached to it.
@@ -333,7 +440,19 @@ trait RequestHeader {
    * @return A new request with the body attached to the header.
    */
   def withBody[A](body: A): Request[A] =
-    new RequestImpl[A](remote, method, target, version, headers, attrs, body, transport, scheme, authority)
+    new RequestImpl[A](
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      attrs,
+      body,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
 
   /**
    * Create a new versions of this object with the given transient language set.
@@ -652,11 +771,16 @@ private[play] class RequestHeaderImpl(
     requestHeaders: Headers,
     override val attrs: TypedMap,
     override val transport: TransportConnection,
+    override val clientCertificate: Option[ClientCertificateInfo],
     override val scheme: Scheme,
     override val authority: Option[RequestAuthority]
 ) extends RequestHeader {
   require(remote != null, "Selected remote metadata must not be null")
   require(transport != null, "Direct transport metadata must not be null")
+  require(
+    clientCertificate != null && clientCertificate.forall(_ != null),
+    "Effective client certificate option must not be null or contain null"
+  )
   require(scheme != null, "Effective request scheme must not be null")
   require(
     authority != null && authority.forall(_ != null),

--- a/core/play/src/main/scala/play/api/mvc/WrappedRequest.scala
+++ b/core/play/src/main/scala/play/api/mvc/WrappedRequest.scala
@@ -11,6 +11,7 @@ import play.api.mvc.request.RequestAuthority
 import play.api.mvc.request.RequestTarget
 import play.api.mvc.request.Scheme
 import play.api.mvc.request.TransportConnection
+import play.api.mvc.request.XForwardedClientCert
 
 /**
  * Wrap an existing request. Useful to extend a request.
@@ -20,17 +21,18 @@ import play.api.mvc.request.TransportConnection
  * methods.
  */
 class WrappedRequest[+A](request: Request[A]) extends Request[A] {
-  override def transport: TransportConnection                   = request.transport
-  override def clientCertificate: Option[ClientCertificateInfo] = request.clientCertificate
-  override def scheme: Scheme                                   = request.scheme
-  override def authority: Option[RequestAuthority]              = request.authority
-  override def remote: RemoteInfo                               = request.remote
-  override def method: String                                   = request.method
-  override def target: RequestTarget                            = request.target
-  override def version: String                                  = request.version
-  override def headers: Headers                                 = request.headers
-  override def body: A                                          = request.body
-  override def attrs: TypedMap                                  = request.attrs
+  override def transport: TransportConnection                             = request.transport
+  override def clientCertificate: Option[ClientCertificateInfo]           = request.clientCertificate
+  override def xForwardedClientCertificates: Vector[XForwardedClientCert] = request.xForwardedClientCertificates
+  override def scheme: Scheme                                             = request.scheme
+  override def authority: Option[RequestAuthority]                        = request.authority
+  override def remote: RemoteInfo                                         = request.remote
+  override def method: String                                             = request.method
+  override def target: RequestTarget                                      = request.target
+  override def version: String                                            = request.version
+  override def headers: Headers                                           = request.headers
+  override def body: A                                                    = request.body
+  override def attrs: TypedMap                                            = request.attrs
 
   /**
    * Create a copy of this wrapper, but wrapping a new request.
@@ -45,6 +47,10 @@ class WrappedRequest[+A](request: Request[A]) extends Request[A] {
     newWrapper(request.withTransport(newTransport))
   override def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): WrappedRequest[A] =
     newWrapper(request.withClientCertificate(newClientCertificate))
+  override def withXForwardedClientCertificates(
+      newXForwardedClientCertificates: Seq[XForwardedClientCert]
+  ): WrappedRequest[A] =
+    newWrapper(request.withXForwardedClientCertificates(newXForwardedClientCertificates))
   override def withScheme(newScheme: Scheme): WrappedRequest[A] =
     newWrapper(request.withScheme(newScheme))
   override def withAuthority(newAuthority: Option[RequestAuthority]): WrappedRequest[A] =

--- a/core/play/src/main/scala/play/api/mvc/WrappedRequest.scala
+++ b/core/play/src/main/scala/play/api/mvc/WrappedRequest.scala
@@ -5,6 +5,7 @@
 package play.api.mvc
 
 import play.api.libs.typedmap.TypedMap
+import play.api.mvc.request.ClientCertificateInfo
 import play.api.mvc.request.RemoteInfo
 import play.api.mvc.request.RequestAuthority
 import play.api.mvc.request.RequestTarget
@@ -19,16 +20,17 @@ import play.api.mvc.request.TransportConnection
  * methods.
  */
 class WrappedRequest[+A](request: Request[A]) extends Request[A] {
-  override def transport: TransportConnection      = request.transport
-  override def scheme: Scheme                      = request.scheme
-  override def authority: Option[RequestAuthority] = request.authority
-  override def remote: RemoteInfo                  = request.remote
-  override def method: String                      = request.method
-  override def target: RequestTarget               = request.target
-  override def version: String                     = request.version
-  override def headers: Headers                    = request.headers
-  override def body: A                             = request.body
-  override def attrs: TypedMap                     = request.attrs
+  override def transport: TransportConnection                   = request.transport
+  override def clientCertificate: Option[ClientCertificateInfo] = request.clientCertificate
+  override def scheme: Scheme                                   = request.scheme
+  override def authority: Option[RequestAuthority]              = request.authority
+  override def remote: RemoteInfo                               = request.remote
+  override def method: String                                   = request.method
+  override def target: RequestTarget                            = request.target
+  override def version: String                                  = request.version
+  override def headers: Headers                                 = request.headers
+  override def body: A                                          = request.body
+  override def attrs: TypedMap                                  = request.attrs
 
   /**
    * Create a copy of this wrapper, but wrapping a new request.
@@ -41,6 +43,8 @@ class WrappedRequest[+A](request: Request[A]) extends Request[A] {
     newWrapper(request.withRemote(newRemote))
   override def withTransport(newTransport: TransportConnection): WrappedRequest[A] =
     newWrapper(request.withTransport(newTransport))
+  override def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): WrappedRequest[A] =
+    newWrapper(request.withClientCertificate(newClientCertificate))
   override def withScheme(newScheme: Scheme): WrappedRequest[A] =
     newWrapper(request.withScheme(newScheme))
   override def withAuthority(newAuthority: Option[RequestAuthority]): WrappedRequest[A] =

--- a/core/play/src/main/scala/play/api/mvc/request/ClientCertificateInfo.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/ClientCertificateInfo.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc.request
+
+import java.security.cert.X509Certificate
+
+/** The source from which Play selected an effective client certificate. */
+sealed trait ClientCertificateSource {
+
+  /** Convert this source to the Java API. */
+  def asJava: play.mvc.Http.ClientCertificateSource = this match {
+    case ClientCertificateSource.DirectTransport      => play.mvc.Http.ClientCertificateSource.DIRECT_TRANSPORT
+    case ClientCertificateSource.Rfc9440              => play.mvc.Http.ClientCertificateSource.RFC_9440
+    case ClientCertificateSource.XForwardedClientCert => play.mvc.Http.ClientCertificateSource.X_FORWARDED_CLIENT_CERT
+  }
+}
+
+object ClientCertificateSource {
+
+  /** The certificate was observed on the TLS connection directly terminating at Play. */
+  case object DirectTransport extends ClientCertificateSource
+
+  /** The certificate was accepted from the RFC 9440 `Client-Cert` header fields. */
+  case object Rfc9440 extends ClientCertificateSource
+
+  /** The certificate was accepted from `X-Forwarded-Client-Cert`. */
+  case object XForwardedClientCert extends ClientCertificateSource
+
+  /** Java-friendly accessor for the direct-transport source. */
+  def directTransport: ClientCertificateSource = DirectTransport
+
+  /** Java-friendly accessor for the RFC 9440 source. */
+  def rfc9440: ClientCertificateSource = Rfc9440
+
+  /** Java-friendly accessor for the `X-Forwarded-Client-Cert` source. */
+  def xForwardedClientCert: ClientCertificateSource = XForwardedClientCert
+}
+
+/**
+ * The effective X.509 client certificate selected for a request.
+ *
+ * @param certificate the leaf certificate identifying the client
+ * @param chain remaining effective chain certificates in leaf-to-root order, excluding [[certificate]]
+ * @param source where Play obtained the certificate information
+ */
+final case class ClientCertificateInfo(
+    certificate: X509Certificate,
+    chain: Vector[X509Certificate],
+    source: ClientCertificateSource
+) {
+  require(certificate != null, "An effective client leaf certificate must not be null")
+  require(
+    chain != null && chain.forall(_ != null),
+    "An effective client certificate chain must not be null or contain null"
+  )
+  require(!chain.contains(certificate), "An effective client certificate chain must not repeat the leaf certificate")
+  require(source != null, "An effective client certificate source must not be null")
+
+  /** The effective leaf-and-chain sequence, with the leaf first. */
+  def certificates: Vector[X509Certificate] = certificate +: chain
+
+  /** Convert this client certificate information to the Java API. */
+  def asJava: play.mvc.Http.ClientCertificateInfo =
+    new play.mvc.Http.ClientCertificateInfo(
+      certificate,
+      java.util.List.copyOf(play.libs.Scala.asJava(chain)),
+      source.asJava
+    )
+}
+
+object ClientCertificateInfo {
+
+  /** Java-friendly factory from a leaf certificate, its remaining chain, and source. */
+  def create(
+      certificate: X509Certificate,
+      chain: Seq[X509Certificate],
+      source: ClientCertificateSource
+  ): ClientCertificateInfo = {
+    require(chain != null, "An effective client certificate chain must not be null")
+    ClientCertificateInfo(certificate, chain.toVector, source)
+  }
+
+  /** Derive direct effective client certificate information from Play's transport metadata. */
+  private[play] def fromTransport(transport: TransportConnection): Option[ClientCertificateInfo] = {
+    require(transport != null, "Direct transport metadata must not be null")
+    transport.tls.flatMap { tls =>
+      tls.peerCertificates.headOption.map { certificate =>
+        ClientCertificateInfo(
+          certificate,
+          tls.peerCertificates.iterator.drop(1).filterNot(_ == certificate).toVector,
+          ClientCertificateSource.DirectTransport
+        )
+      }
+    }
+  }
+}

--- a/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
@@ -22,6 +22,7 @@ trait RequestFactory {
   def createRequestHeader(
       transport: TransportConnection,
       clientCertificate: Option[ClientCertificateInfo],
+      xForwardedClientCertificates: Vector[XForwardedClientCert],
       remote: RemoteInfo,
       scheme: Scheme,
       authority: Option[RequestAuthority],
@@ -41,6 +42,7 @@ trait RequestFactory {
     createRequestHeader(
       rh.transport,
       rh.clientCertificate,
+      rh.xForwardedClientCertificates,
       rh.remote,
       rh.scheme,
       rh.authority,
@@ -59,6 +61,7 @@ trait RequestFactory {
   def createRequest[A](
       transport: TransportConnection,
       clientCertificate: Option[ClientCertificateInfo],
+      xForwardedClientCertificates: Vector[XForwardedClientCert],
       remote: RemoteInfo,
       scheme: Scheme,
       authority: Option[RequestAuthority],
@@ -72,6 +75,7 @@ trait RequestFactory {
     createRequestHeader(
       transport,
       clientCertificate,
+      xForwardedClientCertificates,
       remote,
       scheme,
       authority,
@@ -93,6 +97,7 @@ trait RequestFactory {
     createRequest[A](
       r.transport,
       r.clientCertificate,
+      r.xForwardedClientCertificates,
       r.remote,
       r.scheme,
       r.authority,
@@ -116,6 +121,7 @@ object RequestFactory {
     override def createRequestHeader(
         transport: TransportConnection,
         clientCertificate: Option[ClientCertificateInfo],
+        xForwardedClientCertificates: Vector[XForwardedClientCert],
         remote: RemoteInfo,
         scheme: Scheme,
         authority: Option[RequestAuthority],
@@ -135,7 +141,8 @@ object RequestFactory {
         transport,
         clientCertificate,
         scheme,
-        authority
+        authority,
+        xForwardedClientCertificates
       )
   }
 }
@@ -162,6 +169,7 @@ class DefaultRequestFactory @Inject() (
   override def createRequestHeader(
       transport: TransportConnection,
       clientCertificate: Option[ClientCertificateInfo],
+      xForwardedClientCertificates: Vector[XForwardedClientCert],
       remote: RemoteInfo,
       scheme: Scheme,
       authority: Option[RequestAuthority],
@@ -203,7 +211,8 @@ class DefaultRequestFactory @Inject() (
       transport,
       clientCertificate,
       scheme,
-      authority
+      authority,
+      xForwardedClientCertificates
     )
   }
 }

--- a/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/RequestFactory.scala
@@ -21,6 +21,7 @@ trait RequestFactory {
    */
   def createRequestHeader(
       transport: TransportConnection,
+      clientCertificate: Option[ClientCertificateInfo],
       remote: RemoteInfo,
       scheme: Scheme,
       authority: Option[RequestAuthority],
@@ -39,6 +40,7 @@ trait RequestFactory {
   def copyRequestHeader(rh: RequestHeader): RequestHeader = {
     createRequestHeader(
       rh.transport,
+      rh.clientCertificate,
       rh.remote,
       rh.scheme,
       rh.authority,
@@ -56,6 +58,7 @@ trait RequestFactory {
    */
   def createRequest[A](
       transport: TransportConnection,
+      clientCertificate: Option[ClientCertificateInfo],
       remote: RemoteInfo,
       scheme: Scheme,
       authority: Option[RequestAuthority],
@@ -66,7 +69,18 @@ trait RequestFactory {
       attrs: TypedMap,
       body: A
   ): Request[A] =
-    createRequestHeader(transport, remote, scheme, authority, method, target, version, headers, attrs).withBody(
+    createRequestHeader(
+      transport,
+      clientCertificate,
+      remote,
+      scheme,
+      authority,
+      method,
+      target,
+      version,
+      headers,
+      attrs
+    ).withBody(
       body
     )
 
@@ -78,6 +92,7 @@ trait RequestFactory {
   def copyRequest[A](r: Request[A]): Request[A] = {
     createRequest[A](
       r.transport,
+      r.clientCertificate,
       r.remote,
       r.scheme,
       r.authority,
@@ -100,6 +115,7 @@ object RequestFactory {
   val plain = new RequestFactory {
     override def createRequestHeader(
         transport: TransportConnection,
+        clientCertificate: Option[ClientCertificateInfo],
         remote: RemoteInfo,
         scheme: Scheme,
         authority: Option[RequestAuthority],
@@ -109,7 +125,18 @@ object RequestFactory {
         headers: Headers,
         attrs: TypedMap
     ): RequestHeader =
-      new RequestHeaderImpl(remote, method, target, version, headers, attrs, transport, scheme, authority)
+      new RequestHeaderImpl(
+        remote,
+        method,
+        target,
+        version,
+        headers,
+        attrs,
+        transport,
+        clientCertificate,
+        scheme,
+        authority
+      )
   }
 }
 
@@ -134,6 +161,7 @@ class DefaultRequestFactory @Inject() (
 
   override def createRequestHeader(
       transport: TransportConnection,
+      clientCertificate: Option[ClientCertificateInfo],
       remote: RemoteInfo,
       scheme: Scheme,
       authority: Option[RequestAuthority],
@@ -165,6 +193,17 @@ class DefaultRequestFactory @Inject() (
       RequestAttrKey.Session -> sessionCell,
       RequestAttrKey.Flash   -> flashCell
     )
-    new RequestHeaderImpl(remote, method, target, version, headers, updatedAttrMap, transport, scheme, authority)
+    new RequestHeaderImpl(
+      remote,
+      method,
+      target,
+      version,
+      headers,
+      updatedAttrMap,
+      transport,
+      clientCertificate,
+      scheme,
+      authority
+    )
   }
 }

--- a/core/play/src/main/scala/play/api/mvc/request/XForwardedClientCert.scala
+++ b/core/play/src/main/scala/play/api/mvc/request/XForwardedClientCert.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc.request
+
+import java.security.cert.X509Certificate
+
+import scala.jdk.javaapi.OptionConverters
+
+/**
+ * One accepted `X-Forwarded-Client-Cert` assertion.
+ *
+ * Repeated values retain their header order. [[certificate]] is the asserted leaf certificate;
+ * [[chain]] contains the remaining presented chain in leaf-to-root order and never repeats the leaf.
+ */
+final case class XForwardedClientCert(
+    by: Vector[String],
+    hash: Option[String],
+    certificate: Option[X509Certificate],
+    chain: Vector[X509Certificate],
+    subject: Option[String],
+    uris: Vector[String],
+    dnsNames: Vector[String]
+) {
+  require(by != null && by.forall(_ != null), "XFCC by values must not be null or contain null")
+  require(hash != null && hash.forall(_ != null), "An XFCC hash option must not be null or contain null")
+  require(
+    certificate != null && certificate.forall(_ != null),
+    "An XFCC certificate option must not be null or contain null"
+  )
+  require(chain != null && chain.forall(_ != null), "An XFCC certificate chain must not be null or contain null")
+  require(subject != null && subject.forall(_ != null), "An XFCC subject option must not be null or contain null")
+  require(uris != null && uris.forall(_ != null), "XFCC URI values must not be null or contain null")
+  require(dnsNames != null && dnsNames.forall(_ != null), "XFCC DNS values must not be null or contain null")
+  require(certificate.isDefined || chain.isEmpty, "An XFCC certificate chain requires a leaf certificate")
+  require(
+    certificate.forall(leaf => !chain.contains(leaf)),
+    "An XFCC certificate chain must not repeat the leaf certificate"
+  )
+
+  /** The asserted leaf-and-chain sequence, or empty when no certificate was asserted. */
+  def certificates: Vector[X509Certificate] = certificate.toVector ++ chain
+
+  /** Convert this assertion to the Java API. */
+  def asJava: play.mvc.Http.XForwardedClientCert =
+    new play.mvc.Http.XForwardedClientCert(
+      java.util.List.copyOf(play.libs.Scala.asJava(by)),
+      OptionConverters.toJava(hash),
+      OptionConverters.toJava(certificate),
+      java.util.List.copyOf(play.libs.Scala.asJava(chain)),
+      OptionConverters.toJava(subject),
+      java.util.List.copyOf(play.libs.Scala.asJava(uris)),
+      java.util.List.copyOf(play.libs.Scala.asJava(dnsNames))
+    )
+}
+
+object XForwardedClientCert {
+
+  /** Java-friendly factory that defensively normalizes all repeated values to vectors. */
+  def create(
+      by: Seq[String],
+      hash: Option[String],
+      certificate: Option[X509Certificate],
+      chain: Seq[X509Certificate],
+      subject: Option[String],
+      uris: Seq[String],
+      dnsNames: Seq[String]
+  ): XForwardedClientCert = {
+    require(by != null, "XFCC by values must not be null")
+    require(chain != null, "An XFCC certificate chain must not be null")
+    require(uris != null, "XFCC URI values must not be null")
+    require(dnsNames != null, "XFCC DNS values must not be null")
+    XForwardedClientCert(by.toVector, hash, certificate, chain.toVector, subject, uris.toVector, dnsNames.toVector)
+  }
+}

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -215,6 +215,8 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def remote: Http.RemoteInfo                                 = header.remote.asJava
   override def clientCertificate: Optional[Http.ClientCertificateInfo] =
     header.clientCertificate.map(_.asJava).toJava
+  override def xForwardedClientCertificates: util.List[Http.XForwardedClientCert] =
+    java.util.List.copyOf(header.xForwardedClientCertificates.map(_.asJava).asJava)
   override def secure: Boolean = header.secure
 
   override def attrs: TypedMap                                                                   = new TypedMap(header.attrs)

--- a/core/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/core/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -207,13 +207,15 @@ object JavaHelpers extends JavaHelpers {
 class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def asScala: RequestHeader = header
 
-  override def uri: String                                = header.uri
-  override def method: String                             = header.method
-  override def version: String                            = header.version
-  override def scheme: Http.Scheme                        = header.scheme.asJava
-  override def authority: Optional[Http.RequestAuthority] = header.authority.map(_.asJava).toJava
-  override def remote: Http.RemoteInfo                    = header.remote.asJava
-  override def secure: Boolean                            = header.secure
+  override def uri: String                                             = header.uri
+  override def method: String                                          = header.method
+  override def version: String                                         = header.version
+  override def scheme: Http.Scheme                                     = header.scheme.asJava
+  override def authority: Optional[Http.RequestAuthority]              = header.authority.map(_.asJava).toJava
+  override def remote: Http.RemoteInfo                                 = header.remote.asJava
+  override def clientCertificate: Optional[Http.ClientCertificateInfo] =
+    header.clientCertificate.map(_.asJava).toJava
+  override def secure: Boolean = header.secure
 
   override def attrs: TypedMap                                                                   = new TypedMap(header.attrs)
   override def withAttrs(newAttrs: TypedMap): JRequestHeader                                     = header.withAttrs(newAttrs.asScala).asJava

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -7,6 +7,8 @@ package play.api.mvc
 import java.security.cert.X509Certificate
 import java.util.Locale
 
+import scala.jdk.CollectionConverters._
+
 import com.google.common.net.InetAddresses
 import org.mockito.Mockito
 import org.specs2.mutable.Specification
@@ -31,6 +33,7 @@ import play.api.mvc.request.RequestTarget
 import play.api.mvc.request.Scheme
 import play.api.mvc.request.TransportConnection
 import play.api.mvc.request.TransportTls
+import play.api.mvc.request.XForwardedClientCert
 import play.mvc.Http
 
 class RequestHeaderSpec extends Specification {
@@ -131,6 +134,42 @@ class RequestHeaderSpec extends Specification {
       request.withClientCertificate(Some(null)) must throwA[IllegalArgumentException]
     }
 
+    "preserve ordered XFCC assertions across unrelated request copies" in {
+      def assertion(uri: String) = XForwardedClientCert(
+        by = Vector.empty,
+        hash = None,
+        certificate = None,
+        chain = Vector.empty,
+        subject = None,
+        uris = Vector(uri),
+        dnsNames = Vector.empty
+      )
+      val assertions = Vector(assertion("spiffe://example/client"), assertion("spiffe://example/proxy"))
+      val request    = dummyRequestHeader().withXForwardedClientCertificates(assertions)
+
+      request.xForwardedClientCertificates must contain(exactly(assertions*).inOrder)
+      request.asJava.xForwardedClientCertificates must beEqualTo(assertions.map(_.asJava).asJava)
+      Seq(
+        request.withTransport(
+          TransportConnection(PeerEndpoint(InetAddresses.forString("192.0.2.10"), Some(53124)), None)
+        ),
+        request.withClientCertificate(None),
+        request.withRemote(RemoteInfo.ip("203.0.113.43", None)),
+        request.withScheme(Scheme.Https),
+        request.withAuthority(Some(RequestAuthority.parseOrThrow("public.example"))),
+        request.withMethod("POST"),
+        request.withTarget(RequestTarget("/copy", "/copy", Map.empty)),
+        request.withVersion("HTTP/2"),
+        request.withHeaders(Headers("X-Test" -> "copy")),
+        request.withAttrs(TypedMap.empty),
+        request.withBody("body")
+      ).foreach(_.xForwardedClientCertificates must contain(exactly(assertions*).inOrder))
+
+      request.withXForwardedClientCertificates(Vector.empty).xForwardedClientCertificates must beEmpty
+      request.withXForwardedClientCertificates(null) must throwA[IllegalArgumentException]
+      request.withXForwardedClientCertificates(Vector(null)) must throwA[IllegalArgumentException]
+    }
+
     "preserve selected remote metadata across unrelated request copies" in {
       val remote  = RemoteInfo(RemoteNode.Obfuscated("_anonymous", Some(NodePort.Obfuscated("_source"))), None)
       val request = dummyRequestHeader().withRemote(remote)
@@ -169,6 +208,7 @@ class RequestHeaderSpec extends Specification {
         RequestFactory.plain.createRequestHeader(
           transport,
           request.clientCertificate,
+          request.xForwardedClientCertificates,
           remote,
           scheme,
           authority,
@@ -188,16 +228,18 @@ class RequestHeaderSpec extends Specification {
 
     "allow custom request headers to define their own remote shortcut names" in {
       final class CustomRequestHeader(delegate: RequestHeader) extends RequestHeader {
-        override def transport: TransportConnection                   = delegate.transport
-        override def clientCertificate: Option[ClientCertificateInfo] = delegate.clientCertificate
-        override def remote: RemoteInfo                               = delegate.remote
-        override def scheme: Scheme                                   = delegate.scheme
-        override def authority: Option[RequestAuthority]              = delegate.authority
-        override def method: String                                   = delegate.method
-        override def target: RequestTarget                            = delegate.target
-        override def version: String                                  = delegate.version
-        override def headers: Headers                                 = delegate.headers
-        override def attrs: TypedMap                                  = delegate.attrs
+        override def transport: TransportConnection                             = delegate.transport
+        override def clientCertificate: Option[ClientCertificateInfo]           = delegate.clientCertificate
+        override def xForwardedClientCertificates: Vector[XForwardedClientCert] =
+          delegate.xForwardedClientCertificates
+        override def remote: RemoteInfo                  = delegate.remote
+        override def scheme: Scheme                      = delegate.scheme
+        override def authority: Option[RequestAuthority] = delegate.authority
+        override def method: String                      = delegate.method
+        override def target: RequestTarget               = delegate.target
+        override def version: String                     = delegate.version
+        override def headers: Headers                    = delegate.headers
+        override def attrs: TypedMap                     = delegate.attrs
 
         def remoteIdentity: String  = "application-defined"
         def remotePort: Option[Int] = Some(43210)
@@ -697,6 +739,7 @@ class RequestHeaderSpec extends Specification {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
       transport = transport,
       clientCertificate = None,
+      xForwardedClientCertificates = Vector.empty,
       remote = remote,
       scheme = RequestHeader.initialScheme(transport),
       authority = authority,
@@ -717,15 +760,16 @@ class RequestHeaderSpec extends Specification {
     RequestHeader.initialRequestTarget(method, RequestTarget(uri, "", Map.empty), version, headers)
 
   private def dummyRawRequestHeaderWithEmptyAttrs() = new RequestHeader {
-    override def transport: TransportConnection                   = ???
-    override def clientCertificate: Option[ClientCertificateInfo] = ???
-    override def scheme: Scheme                                   = ???
-    override def authority: Option[RequestAuthority]              = ???
-    override def remote: RemoteInfo                               = ???
-    override def method: String                                   = ???
-    override def target: RequestTarget                            = ???
-    override def version: String                                  = ???
-    override def headers: Headers                                 = ???
-    override def attrs: TypedMap                                  = TypedMap.empty
+    override def transport: TransportConnection                             = ???
+    override def clientCertificate: Option[ClientCertificateInfo]           = ???
+    override def xForwardedClientCertificates: Vector[XForwardedClientCert] = ???
+    override def scheme: Scheme                                             = ???
+    override def authority: Option[RequestAuthority]                        = ???
+    override def remote: RemoteInfo                                         = ???
+    override def method: String                                             = ???
+    override def target: RequestTarget                                      = ???
+    override def version: String                                            = ???
+    override def headers: Headers                                           = ???
+    override def attrs: TypedMap                                            = TypedMap.empty
   }
 }

--- a/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -4,9 +4,11 @@
 
 package play.api.mvc
 
+import java.security.cert.X509Certificate
 import java.util.Locale
 
 import com.google.common.net.InetAddresses
+import org.mockito.Mockito
 import org.specs2.mutable.Specification
 import play.api.http.HeaderNames._
 import play.api.http.HttpConfiguration
@@ -15,6 +17,8 @@ import play.api.i18n.Messages
 import play.api.libs.typedmap.TypedEntry
 import play.api.libs.typedmap.TypedKey
 import play.api.libs.typedmap.TypedMap
+import play.api.mvc.request.ClientCertificateInfo
+import play.api.mvc.request.ClientCertificateSource
 import play.api.mvc.request.DefaultRequestFactory
 import play.api.mvc.request.NodePort
 import play.api.mvc.request.PeerEndpoint
@@ -100,6 +104,33 @@ class RequestHeaderSpec extends Specification {
       ok
     }
 
+    "preserve effective client certificate metadata across unrelated request copies" in {
+      val leaf         = Mockito.mock(classOf[X509Certificate])
+      val intermediate = Mockito.mock(classOf[X509Certificate])
+      val certificate  = ClientCertificateInfo(leaf, Vector(intermediate), ClientCertificateSource.Rfc9440)
+      val request      = dummyRequestHeader().withClientCertificate(Some(certificate))
+
+      request.asJava.clientCertificate.orElseThrow() must beEqualTo(certificate.asJava)
+      Seq(
+        request.withTransport(
+          TransportConnection(PeerEndpoint(InetAddresses.forString("192.0.2.10"), Some(53124)), None)
+        ),
+        request.withRemote(RemoteInfo.ip("203.0.113.43", None)),
+        request.withScheme(Scheme.Https),
+        request.withAuthority(Some(RequestAuthority.parseOrThrow("public.example"))),
+        request.withMethod("POST"),
+        request.withTarget(RequestTarget("/copy", "/copy", Map.empty)),
+        request.withVersion("HTTP/2"),
+        request.withHeaders(Headers("X-Test" -> "copy")),
+        request.withAttrs(TypedMap.empty),
+        request.withBody("body")
+      ).foreach(_.clientCertificate must beSome(certificate))
+
+      request.withClientCertificate(None).clientCertificate must beNone
+      request.withClientCertificate(null) must throwA[IllegalArgumentException]
+      request.withClientCertificate(Some(null)) must throwA[IllegalArgumentException]
+    }
+
     "preserve selected remote metadata across unrelated request copies" in {
       val remote  = RemoteInfo(RemoteNode.Obfuscated("_anonymous", Some(NodePort.Obfuscated("_source"))), None)
       val request = dummyRequestHeader().withRemote(remote)
@@ -137,6 +168,7 @@ class RequestHeaderSpec extends Specification {
       ): RequestHeader =
         RequestFactory.plain.createRequestHeader(
           transport,
+          request.clientCertificate,
           remote,
           scheme,
           authority,
@@ -156,15 +188,16 @@ class RequestHeaderSpec extends Specification {
 
     "allow custom request headers to define their own remote shortcut names" in {
       final class CustomRequestHeader(delegate: RequestHeader) extends RequestHeader {
-        override def transport: TransportConnection      = delegate.transport
-        override def remote: RemoteInfo                  = delegate.remote
-        override def scheme: Scheme                      = delegate.scheme
-        override def authority: Option[RequestAuthority] = delegate.authority
-        override def method: String                      = delegate.method
-        override def target: RequestTarget               = delegate.target
-        override def version: String                     = delegate.version
-        override def headers: Headers                    = delegate.headers
-        override def attrs: TypedMap                     = delegate.attrs
+        override def transport: TransportConnection                   = delegate.transport
+        override def clientCertificate: Option[ClientCertificateInfo] = delegate.clientCertificate
+        override def remote: RemoteInfo                               = delegate.remote
+        override def scheme: Scheme                                   = delegate.scheme
+        override def authority: Option[RequestAuthority]              = delegate.authority
+        override def method: String                                   = delegate.method
+        override def target: RequestTarget                            = delegate.target
+        override def version: String                                  = delegate.version
+        override def headers: Headers                                 = delegate.headers
+        override def attrs: TypedMap                                  = delegate.attrs
 
         def remoteIdentity: String  = "application-defined"
         def remotePort: Option[Int] = Some(43210)
@@ -663,6 +696,7 @@ class RequestHeaderSpec extends Specification {
       .fold(error => throw new IllegalArgumentException(error), identity)
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
       transport = transport,
+      clientCertificate = None,
       remote = remote,
       scheme = RequestHeader.initialScheme(transport),
       authority = authority,
@@ -683,14 +717,15 @@ class RequestHeaderSpec extends Specification {
     RequestHeader.initialRequestTarget(method, RequestTarget(uri, "", Map.empty), version, headers)
 
   private def dummyRawRequestHeaderWithEmptyAttrs() = new RequestHeader {
-    override def transport: TransportConnection      = ???
-    override def scheme: Scheme                      = ???
-    override def authority: Option[RequestAuthority] = ???
-    override def remote: RemoteInfo                  = ???
-    override def method: String                      = ???
-    override def target: RequestTarget               = ???
-    override def version: String                     = ???
-    override def headers: Headers                    = ???
-    override def attrs: TypedMap                     = TypedMap.empty
+    override def transport: TransportConnection                   = ???
+    override def clientCertificate: Option[ClientCertificateInfo] = ???
+    override def scheme: Scheme                                   = ???
+    override def authority: Option[RequestAuthority]              = ???
+    override def remote: RemoteInfo                               = ???
+    override def method: String                                   = ???
+    override def target: RequestTarget                            = ???
+    override def version: String                                  = ???
+    override def headers: Headers                                 = ???
+    override def attrs: TypedMap                                  = TypedMap.empty
   }
 }

--- a/core/play/src/test/scala/play/api/mvc/RequestSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestSpec.scala
@@ -150,6 +150,7 @@ class RequestSpec extends Specification {
       .fold(error => throw new IllegalArgumentException(error), identity)
     new DefaultRequestFactory(HttpConfiguration()).createRequest(
       transport = transport,
+      clientCertificate = None,
       remote = remote,
       scheme = RequestHeader.initialScheme(transport),
       authority = authority,

--- a/core/play/src/test/scala/play/api/mvc/RequestSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RequestSpec.scala
@@ -151,6 +151,7 @@ class RequestSpec extends Specification {
     new DefaultRequestFactory(HttpConfiguration()).createRequest(
       transport = transport,
       clientCertificate = None,
+      xForwardedClientCertificates = Vector.empty,
       remote = remote,
       scheme = RequestHeader.initialScheme(transport),
       authority = authority,

--- a/core/play/src/test/scala/play/api/mvc/request/ClientCertificateInfoSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/request/ClientCertificateInfoSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc.request
+
+import java.security.cert.X509Certificate
+
+import com.google.common.net.InetAddresses
+import org.mockito.Mockito
+import org.specs2.mutable.Specification
+import play.mvc.Http
+
+class ClientCertificateInfoSpec extends Specification {
+  private val leaf         = Mockito.mock(classOf[X509Certificate])
+  private val intermediate = Mockito.mock(classOf[X509Certificate])
+
+  "Scala effective client certificate metadata" should {
+    "keep the leaf separate from its remaining chain" in {
+      val info = ClientCertificateInfo(
+        leaf,
+        Vector(intermediate),
+        ClientCertificateSource.DirectTransport
+      )
+
+      info.certificate must beEqualTo(leaf)
+      info.chain must contain(exactly(intermediate))
+      info.certificates must contain(exactly(leaf, intermediate).inOrder)
+    }
+
+    "reject null values" in {
+      ClientCertificateInfo(null, Vector.empty, ClientCertificateSource.DirectTransport) must
+        throwA[IllegalArgumentException]
+      ClientCertificateInfo(leaf, null, ClientCertificateSource.DirectTransport) must
+        throwA[IllegalArgumentException]
+      ClientCertificateInfo(leaf, Vector(null), ClientCertificateSource.DirectTransport) must
+        throwA[IllegalArgumentException]
+      ClientCertificateInfo(leaf, Vector(leaf), ClientCertificateSource.DirectTransport) must
+        throwA[IllegalArgumentException]
+      ClientCertificateInfo(leaf, Vector.empty, null) must throwA[IllegalArgumentException]
+    }
+
+    "derive a direct leaf and remaining chain from transport metadata" in {
+      val peer      = PeerEndpoint(InetAddresses.forString("192.0.2.10"), Some(443))
+      val transport = TransportConnection(
+        peer,
+        Some(TransportTls(Seq(leaf, intermediate)))
+      )
+
+      ClientCertificateInfo.fromTransport(transport) must beSome(
+        ClientCertificateInfo(leaf, Vector(intermediate), ClientCertificateSource.DirectTransport)
+      )
+      ClientCertificateInfo.fromTransport(TransportConnection(peer, Some(TransportTls(Seq.empty)))) must beNone
+      ClientCertificateInfo.fromTransport(TransportConnection(peer, None)) must beNone
+    }
+
+    "remove repeated leaves from direct transport chains" in {
+      val peer = PeerEndpoint(InetAddresses.forString("192.0.2.10"), Some(443))
+
+      ClientCertificateInfo.fromTransport(
+        TransportConnection(peer, Some(TransportTls(Seq(leaf, leaf))))
+      ) must beSome(ClientCertificateInfo(leaf, Vector.empty, ClientCertificateSource.DirectTransport))
+      ClientCertificateInfo.fromTransport(
+        TransportConnection(peer, Some(TransportTls(Seq(leaf, intermediate, leaf))))
+      ) must beSome(ClientCertificateInfo(leaf, Vector(intermediate), ClientCertificateSource.DirectTransport))
+    }
+
+    "round-trip through the Java API" in {
+      val info = ClientCertificateInfo(leaf, Vector(intermediate), ClientCertificateSource.Rfc9440)
+
+      info.asJava.asScala must_== info
+    }
+  }
+
+  "Java effective client certificate metadata" should {
+    "defensively copy its chain" in {
+      val chain = new java.util.ArrayList[X509Certificate]()
+      chain.add(intermediate)
+      val info = new Http.ClientCertificateInfo(leaf, chain, Http.ClientCertificateSource.X_FORWARDED_CLIENT_CERT)
+      chain.clear()
+
+      info.chain must beEqualTo(java.util.List.of(intermediate))
+      info.certificates must beEqualTo(java.util.List.of(leaf, intermediate))
+      info.chain.add(intermediate) must throwA[UnsupportedOperationException]
+      info.certificates.add(intermediate) must throwA[UnsupportedOperationException]
+    }
+
+    "reject null values" in {
+      new Http.ClientCertificateInfo(null, java.util.List.of(), Http.ClientCertificateSource.DIRECT_TRANSPORT) must
+        throwA[NullPointerException]
+      new Http.ClientCertificateInfo(leaf, null, Http.ClientCertificateSource.DIRECT_TRANSPORT) must
+        throwA[NullPointerException]
+      new Http.ClientCertificateInfo(
+        leaf,
+        java.util.Arrays.asList(null.asInstanceOf[X509Certificate]),
+        Http.ClientCertificateSource.DIRECT_TRANSPORT
+      ) must throwA[NullPointerException]
+      new Http.ClientCertificateInfo(leaf, java.util.List.of(), null) must throwA[NullPointerException]
+      new Http.ClientCertificateInfo(
+        leaf,
+        java.util.List.of(leaf),
+        Http.ClientCertificateSource.DIRECT_TRANSPORT
+      ) must throwA[IllegalArgumentException]
+    }
+
+    "round-trip all sources through the Scala API" in {
+      Seq(
+        Http.ClientCertificateSource.DIRECT_TRANSPORT,
+        Http.ClientCertificateSource.RFC_9440,
+        Http.ClientCertificateSource.X_FORWARDED_CLIENT_CERT
+      ).foreach { source =>
+        val info = new Http.ClientCertificateInfo(leaf, java.util.List.of(intermediate), source)
+        info.asScala.asJava must_== info
+      }
+      ok
+    }
+  }
+}

--- a/core/play/src/test/scala/play/api/mvc/request/XForwardedClientCertSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/request/XForwardedClientCertSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc.request
+
+import java.security.cert.X509Certificate
+
+import org.mockito.Mockito
+import org.specs2.mutable.Specification
+import play.mvc.Http
+
+class XForwardedClientCertSpec extends Specification {
+  private val leaf         = Mockito.mock(classOf[X509Certificate])
+  private val intermediate = Mockito.mock(classOf[X509Certificate])
+
+  private val assertion = XForwardedClientCert(
+    by = Vector("spiffe://mesh.example/edge", "spiffe://mesh.example/sidecar"),
+    hash = Some("0123456789abcdef"),
+    certificate = Some(leaf),
+    chain = Vector(intermediate),
+    subject = Some("CN=client"),
+    uris = Vector("spiffe://example/client", "https://client.example/identity"),
+    dnsNames = Vector("client.example", "client.internal")
+  )
+
+  "Scala XFCC assertions" should {
+    "preserve repeated-value order and keep the leaf out of the remaining chain" in {
+      assertion.by must contain(exactly("spiffe://mesh.example/edge", "spiffe://mesh.example/sidecar").inOrder)
+      assertion.uris must contain(exactly("spiffe://example/client", "https://client.example/identity").inOrder)
+      assertion.dnsNames must contain(exactly("client.example", "client.internal").inOrder)
+      assertion.certificate must beSome(leaf)
+      assertion.chain must contain(exactly(intermediate))
+      assertion.certificates must contain(exactly(leaf, intermediate).inOrder)
+    }
+
+    "represent assertions without an encoded certificate" in {
+      val metadataOnly = assertion.copy(certificate = None, chain = Vector.empty)
+
+      metadataOnly.certificates must beEmpty
+      metadataOnly.hash must beSome("0123456789abcdef")
+      metadataOnly.uris must not(beEmpty)
+    }
+
+    "reject null values and certificate chains without a leaf" in {
+      assertion.copy(by = null) must throwA[IllegalArgumentException]
+      assertion.copy(by = Vector(null)) must throwA[IllegalArgumentException]
+      assertion.copy(hash = null) must throwA[IllegalArgumentException]
+      assertion.copy(certificate = null) must throwA[IllegalArgumentException]
+      assertion.copy(chain = null) must throwA[IllegalArgumentException]
+      assertion.copy(chain = Vector(null)) must throwA[IllegalArgumentException]
+      assertion.copy(subject = null) must throwA[IllegalArgumentException]
+      assertion.copy(uris = Vector(null)) must throwA[IllegalArgumentException]
+      assertion.copy(dnsNames = Vector(null)) must throwA[IllegalArgumentException]
+      assertion.copy(certificate = None) must throwA[IllegalArgumentException]
+      assertion.copy(chain = Vector(leaf)) must throwA[IllegalArgumentException]
+    }
+
+    "round-trip through the Java API" in {
+      assertion.asJava.asScala must_== assertion
+    }
+  }
+
+  "Java XFCC assertions" should {
+    "defensively copy all repeated values" in {
+      val by            = new java.util.ArrayList[String](java.util.List.of("spiffe://mesh.example/edge"))
+      val chain         = new java.util.ArrayList[X509Certificate](java.util.List.of(intermediate))
+      val uris          = new java.util.ArrayList[String](java.util.List.of("spiffe://example/client"))
+      val dnsNames      = new java.util.ArrayList[String](java.util.List.of("client.example"))
+      val javaAssertion = new Http.XForwardedClientCert(
+        by,
+        java.util.Optional.of("0123456789abcdef"),
+        java.util.Optional.of(leaf),
+        chain,
+        java.util.Optional.of("CN=client"),
+        uris,
+        dnsNames
+      )
+      by.clear()
+      chain.clear()
+      uris.clear()
+      dnsNames.clear()
+
+      javaAssertion.by must beEqualTo(java.util.List.of("spiffe://mesh.example/edge"))
+      javaAssertion.chain must beEqualTo(java.util.List.of(intermediate))
+      javaAssertion.uris must beEqualTo(java.util.List.of("spiffe://example/client"))
+      javaAssertion.dnsNames must beEqualTo(java.util.List.of("client.example"))
+      javaAssertion.certificates must beEqualTo(java.util.List.of(leaf, intermediate))
+      javaAssertion.by.add("another") must throwA[UnsupportedOperationException]
+    }
+
+    "reject certificate chains without a leaf" in {
+      new Http.XForwardedClientCert(
+        java.util.List.of(),
+        java.util.Optional.empty(),
+        java.util.Optional.empty(),
+        java.util.List.of(intermediate),
+        java.util.Optional.empty(),
+        java.util.List.of(),
+        java.util.List.of()
+      ) must throwA[IllegalArgumentException]
+    }
+
+    "round-trip through the Scala API" in {
+      assertion.asJava.asScala.asJava must_== assertion.asJava
+    }
+  }
+}

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -37,21 +37,24 @@ case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(
  * @tparam A the body content type.
  */
 class FakeRequest[+A](request: Request[A]) extends Request[A] {
-  override def transport: TransportConnection      = request.transport
-  override def remote: RemoteInfo                  = request.remote
-  override def scheme: Scheme                      = request.scheme
-  override def authority: Option[RequestAuthority] = request.authority
-  override def method: String                      = request.method
-  override def target: RequestTarget               = request.target
-  override def version: String                     = request.version
-  override def headers: Headers                    = request.headers
-  override def body: A                             = request.body
-  override def attrs: TypedMap                     = request.attrs
+  override def transport: TransportConnection                   = request.transport
+  override def clientCertificate: Option[ClientCertificateInfo] = request.clientCertificate
+  override def remote: RemoteInfo                               = request.remote
+  override def scheme: Scheme                                   = request.scheme
+  override def authority: Option[RequestAuthority]              = request.authority
+  override def method: String                                   = request.method
+  override def target: RequestTarget                            = request.target
+  override def version: String                                  = request.version
+  override def headers: Headers                                 = request.headers
+  override def body: A                                          = request.body
+  override def attrs: TypedMap                                  = request.attrs
 
   override def withRemote(newRemote: RemoteInfo): FakeRequest[A] =
     new FakeRequest(request.withRemote(newRemote))
   override def withTransport(newTransport: TransportConnection): FakeRequest[A] =
     new FakeRequest(request.withTransport(newTransport))
+  override def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): FakeRequest[A] =
+    new FakeRequest(request.withClientCertificate(newClientCertificate))
   override def withScheme(newScheme: Scheme): FakeRequest[A] =
     new FakeRequest(request.withScheme(newScheme))
   override def withAuthority(newAuthority: Option[RequestAuthority]): FakeRequest[A] =
@@ -217,7 +220,8 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       scheme: Scheme = Scheme.Http,
       version: String = "HTTP/1.1",
       id: Long = 666,
-      attrs: TypedMap = TypedMap.empty
+      attrs: TypedMap = TypedMap.empty,
+      clientCertificate: Option[ClientCertificateInfo] = None
   ): FakeRequest[A] = {
     val _uri   = uri
     val target = new RequestTarget {
@@ -231,6 +235,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       .fold(error => throw new IllegalArgumentException(error), identity)
     val request: Request[A] = requestFactory.createRequest(
       transport,
+      clientCertificate,
       remote,
       scheme,
       authority,

--- a/core/play/src/test/scala/play/core/test/Fakes.scala
+++ b/core/play/src/test/scala/play/core/test/Fakes.scala
@@ -37,17 +37,18 @@ case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(
  * @tparam A the body content type.
  */
 class FakeRequest[+A](request: Request[A]) extends Request[A] {
-  override def transport: TransportConnection                   = request.transport
-  override def clientCertificate: Option[ClientCertificateInfo] = request.clientCertificate
-  override def remote: RemoteInfo                               = request.remote
-  override def scheme: Scheme                                   = request.scheme
-  override def authority: Option[RequestAuthority]              = request.authority
-  override def method: String                                   = request.method
-  override def target: RequestTarget                            = request.target
-  override def version: String                                  = request.version
-  override def headers: Headers                                 = request.headers
-  override def body: A                                          = request.body
-  override def attrs: TypedMap                                  = request.attrs
+  override def transport: TransportConnection                             = request.transport
+  override def clientCertificate: Option[ClientCertificateInfo]           = request.clientCertificate
+  override def xForwardedClientCertificates: Vector[XForwardedClientCert] = request.xForwardedClientCertificates
+  override def remote: RemoteInfo                                         = request.remote
+  override def scheme: Scheme                                             = request.scheme
+  override def authority: Option[RequestAuthority]                        = request.authority
+  override def method: String                                             = request.method
+  override def target: RequestTarget                                      = request.target
+  override def version: String                                            = request.version
+  override def headers: Headers                                           = request.headers
+  override def body: A                                                    = request.body
+  override def attrs: TypedMap                                            = request.attrs
 
   override def withRemote(newRemote: RemoteInfo): FakeRequest[A] =
     new FakeRequest(request.withRemote(newRemote))
@@ -55,6 +56,10 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
     new FakeRequest(request.withTransport(newTransport))
   override def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): FakeRequest[A] =
     new FakeRequest(request.withClientCertificate(newClientCertificate))
+  override def withXForwardedClientCertificates(
+      newXForwardedClientCertificates: Seq[XForwardedClientCert]
+  ): FakeRequest[A] =
+    new FakeRequest(request.withXForwardedClientCertificates(newXForwardedClientCertificates))
   override def withScheme(newScheme: Scheme): FakeRequest[A] =
     new FakeRequest(request.withScheme(newScheme))
   override def withAuthority(newAuthority: Option[RequestAuthority]): FakeRequest[A] =
@@ -221,7 +226,8 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       version: String = "HTTP/1.1",
       id: Long = 666,
       attrs: TypedMap = TypedMap.empty,
-      clientCertificate: Option[ClientCertificateInfo] = None
+      clientCertificate: Option[ClientCertificateInfo] = None,
+      xForwardedClientCertificates: Vector[XForwardedClientCert] = Vector.empty
   ): FakeRequest[A] = {
     val _uri   = uri
     val target = new RequestTarget {
@@ -236,6 +242,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
     val request: Request[A] = requestFactory.createRequest(
       transport,
       clientCertificate,
+      xForwardedClientCertificates,
       remote,
       scheme,
       authority,

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -35,6 +35,7 @@ class RequestHeaderSpec extends Specification {
     val scalaHeaders = Headers(headers*)
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
       transport = transport,
+      clientCertificate = None,
       remote = remote,
       scheme = Scheme.Http,
       authority = RequestHeader

--- a/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/core/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -36,6 +36,7 @@ class RequestHeaderSpec extends Specification {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
       transport = transport,
       clientCertificate = None,
+      xForwardedClientCertificates = Vector.empty,
       remote = remote,
       scheme = Scheme.Http,
       authority = RequestHeader

--- a/documentation/manual/releases/release31/RequestMetadataHighlights31.md
+++ b/documentation/manual/releases/release31/RequestMetadataHighlights31.md
@@ -26,6 +26,14 @@ Matcher configuration is parsed strictly without DNS resolution. Hostnames, endp
 
 `RequestHeader.transport` in Scala and `Http.RequestHeader.transport()` in Java retain the immutable network connection directly terminating at Play. `transport.peer` contains the socket peer address and source port, while `transport.tls` describes actual peer-to-Play TLS and peer certificates. Selecting a forwarded remote identity, scheme, or authority never replaces these transport facts.
 
+## Source-aware client certificates
+
+`RequestHeader.clientCertificate` in Scala and `Http.RequestHeader.clientCertificate()` in Java expose the effective X.509 client certificate selected for application use. The value separates the leaf certificate from the rest of its chain and records whether Play obtained it from direct transport TLS, the standardized RFC 9440 `Client-Cert` fields, or `X-Forwarded-Client-Cert`.
+
+Selecting a trusted forwarded certificate never replaces `RequestHeader.transport.tls`, which continues to describe the physical connection terminating at Play. For `X-Forwarded-Client-Cert`, `RequestHeader.xForwardedClientCertificates` also retains the accepted assertion metadata, including identities that do not carry a certificate.
+
+Forwarded certificate interpretation is disabled by default and uses a dedicated trusted-proxy list, parser limits, and protocol mode. See [[Forwarded client certificates|HTTPServer#forwarded-client-certificates]] for the supported RFC 9440 and sanitized Envoy XFCC profiles and their deployment requirements.
+
 ## First-class Request Scheme and Authority
 
 The effective request scheme and authority are now first-class immutable values through `RequestHeader.scheme` and `RequestHeader.authority`, with corresponding Java APIs. Schemes use RFC 3986 syntax, and authorities distinguish registered names, IPv4, IPv6, and IPvFuture while preserving arbitrary-size decimal URI ports. `request.secure`, `request.host`, `request.domain`, and the canonical exposed `Host` field are derived from these values.

--- a/documentation/manual/releases/release31/migration31/RequestMetadataMigration31.md
+++ b/documentation/manual/releases/release31/migration31/RequestMetadataMigration31.md
@@ -19,14 +19,14 @@ Java request accessors migrate as follows:
 | Removed API | Replacement |
 | --- | --- |
 | `Http.RequestHeader.remoteAddress()` | Use `remote().identity()` for the complete selected identity, which can also be `unknown` or obfuscated. Use `remote().ipAddress()` when the application specifically requires an IP address. |
-| `Http.RequestHeader.clientCertificateChain()` | Use `transport().tls().map(Http.TransportTls::peerCertificates)` for certificates presented on the connection directly terminating at Play. |
+| `Http.RequestHeader.clientCertificateChain()` | Use `transport().tls().map(Http.TransportTls::peerCertificates)` to preserve the old direct-connection semantics. Use `clientCertificate()` when the application intentionally needs Play's new effective certificate selection. |
 
 Java test builders replace the former connection accessors and setters with the corresponding typed values:
 
 | Removed API | Replacement |
 | --- | --- |
 | `RequestBuilder.remoteAddress()` and `remoteAddress(...)` | Use `remote()` and `remote(...)` with a `RemoteInfo` containing a typed `RemoteNode`. |
-| `RequestBuilder.clientCertificateChain()` and `clientCertificateChain(...)` | Use `transport()` and `transport(...)` with certificates stored in `TransportTls`. |
+| `RequestBuilder.clientCertificateChain()` and `clientCertificateChain(...)` | Use `transport()` and `transport(...)` with certificates stored in `TransportTls` for direct TLS metadata. Set `clientCertificate(...)` separately when code under test reads the effective certificate. |
 
 For example:
 
@@ -42,15 +42,21 @@ Http.PeerEndpoint peer =
 Http.TransportConnection transport =
     new Http.TransportConnection(
         peer, Optional.of(new Http.TransportTls(certificates)));
+Http.ClientCertificateInfo clientCertificate =
+    new Http.ClientCertificateInfo(
+        certificates.get(0),
+        certificates.subList(1, certificates.size()),
+        Http.ClientCertificateSource.DIRECT_TRANSPORT);
 
 Http.RequestBuilder request =
     new Http.RequestBuilder()
         .remote(remote)
         .transport(transport)
+        .clientCertificate(clientCertificate)
         .scheme(Http.Scheme.HTTPS);
 ```
 
-The full Scala `FakeRequest.apply` overload likewise replaces `remoteAddress`, `secure`, and `clientCertificateChain` with `remote`, `scheme`, and `transport`. Code that previously changed the combined value through `withConnection` should now change only the relevant dimension with `withRemote`, `withScheme`, or `withTransport`:
+The full Scala `FakeRequest.apply` overload likewise replaces `remoteAddress`, `secure`, and `clientCertificateChain` with separate `remote`, `scheme`, `transport`, and effective-certificate metadata. Code that previously changed the combined value through `withConnection` should now change only the relevant dimension with `withRemote`, `withScheme`, `withTransport`, or `withClientCertificate`:
 
 ```scala
 val remote = RemoteInfo.ip(
@@ -59,10 +65,18 @@ val remote = RemoteInfo.ip(
 )
 val peer      = PeerEndpoint(InetAddress.getByName("127.0.0.1"), Some(44000))
 val transport = TransportConnection(peer, Some(TransportTls(certificates)))
+val clientCertificate = certificates.headOption.map { certificate =>
+  ClientCertificateInfo(
+    certificate,
+    certificates.drop(1).toVector,
+    ClientCertificateSource.DirectTransport
+  )
+}
 
 val request = FakeRequest(GET, "/")
   .withRemote(remote)
   .withTransport(transport)
+  .withClientCertificate(clientCertificate)
   .withScheme(Scheme.Https)
 ```
 
@@ -81,6 +95,16 @@ request.remote.ipAddress // None
 request.remote.nodePort  // None, or a numeric/obfuscated NodePort
 request.secure           // true
 ```
+
+## Effective client certificates are separate from direct transport TLS
+
+`RequestHeader.transport.tls` always describes TLS on the connection directly terminating at Play. `RequestHeader.clientCertificate` is a separate effective value for application use, containing a leaf certificate, the remaining chain, and a `DirectTransport`, `Rfc9440`, or `XForwardedClientCert` source.
+
+When forwarded certificate handling is off, or the directly connected peer is not trusted for certificate assertions, Play selects an observed direct peer certificate with the `DirectTransport` source. When a trusted RFC 9440 or XFCC mode is enabled, the configured header protocol describes the original client instead. If that trusted proxy supplies no client-certificate assertion, the effective value is empty rather than falling back to the proxy's own transport certificate. The immutable direct TLS information remains available through `transport.tls` in every case.
+
+Custom Scala `RequestHeader` and `RequestFactory` implementations must provide and preserve both `clientCertificate` and the ordered `xForwardedClientCertificates` assertions. Test code sets these dimensions independently: use `FakeRequest.withClientCertificate` and `withXForwardedClientCertificates` in Scala, or `RequestBuilder.clientCertificate(...)` and `xForwardedClientCertificates(...)` in Java. Changing only `transport` deliberately does not rewrite either effective value.
+
+See [[Forwarded client certificates|HTTPServer#forwarded-client-certificates]] for protocol configuration, trust-boundary requirements, parser limits, and the distinction between certificate parsing and authentication or authorization.
 
 ## IP filter entries match typed remote identities
 

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -601,3 +601,125 @@ Play accepts exactly one non-empty, non-negative decimal URI port and preserves 
 The effective `Host` header, Scala and Java request APIs, request-aware absolute and WebSocket URL generation, and the allowed hosts filter all observe the resulting authority. When trusted `X-Forwarded-Host` is also available, the port replaces any port in that forwarded authority. The HTTPS redirect filter continues to select its destination port from `play.filters.https.port`; an incoming destination port is not necessarily the correct HTTPS redirect port.
 
 Only enable this setting when the trusted proxy removes or overwrites any incoming client-supplied `X-Forwarded-Port` header before setting the correct value. Otherwise, clients may be able to spoof the effective request authority.
+
+### Forwarded client certificates
+
+A reverse proxy that terminates mutually authenticated TLS can forward the certificate presented by the original client to Play. This has a separate trust boundary and configuration from the remote address, scheme, and authority forwarding described above.
+
+Play exposes three deliberately different views of certificate information:
+
+* `request.transport.tls.map(_.peerCertificates)` is physical transport metadata. It contains the certificate sequence observed on the TLS connection that terminates at Play. Behind a TLS proxy this is the proxy's certificate sequence, not the original client's.
+* `request.clientCertificate` is the effective client certificate selected for application use. Its `certificate` is the leaf, its `chain` contains the remaining effective chain certificates in leaf-to-root order without repeating the leaf, and its `source` is `DirectTransport`, `Rfc9440`, or `XForwardedClientCert`.
+* `request.xForwardedClientCertificates` is the ordered sequence of accepted `X-Forwarded-Client-Cert` assertions. An assertion can contain `By`, `Hash`, `Subject`, `URI`, and `DNS` metadata without containing a certificate, so this sequence can be non-empty while `request.clientCertificate` is empty.
+
+The corresponding Java accessors are `request.transport()`, `request.clientCertificate()`, and `request.xForwardedClientCertificates()`.
+
+All three accessors are available in every mode. `request.clientCertificate` is the common effective-certificate API; inspect its `source` when the application needs to distinguish direct TLS from either forwarding protocol:
+
+| Mode and direct-peer trust | `request.clientCertificate` | `request.xForwardedClientCertificates` | `request.transport.tls` |
+| --- | --- | --- | --- |
+| `off`, or peer not trusted | Direct TLS leaf and chain with source `DirectTransport`, or empty | Empty | Direct TLS metadata, if present |
+| `rfc9440` with trusted peer | `Client-Cert` leaf and `Client-Cert-Chain` with source `Rfc9440`, or empty | Empty | Direct proxy-to-Play TLS metadata, if present |
+| `x-forwarded-client-cert` with trusted peer | Certificate from the accepted XFCC assertion with source `XForwardedClientCert`, or empty | Accepted XFCC assertion, including metadata-only assertions | Direct proxy-to-Play TLS metadata, if present |
+
+For example, Scala applications can consume the selected certificate independently of its source while retaining access to the physical connection:
+
+```scala
+request.clientCertificate.foreach { info =>
+  val leafAndChain = info.certificates
+  val source = info.source
+}
+
+val directPeerCertificates =
+  request.transport.tls.toSeq.flatMap(_.peerCertificates)
+```
+
+The equivalent Java APIs are:
+
+```java
+request.clientCertificate().ifPresent(info -> {
+  List<X509Certificate> leafAndChain = info.certificates();
+  Http.ClientCertificateSource source = info.source();
+});
+
+List<X509Certificate> directPeerCertificates =
+    request.transport().tls()
+        .map(Http.TransportTls::peerCertificates)
+        .orElseGet(List::of);
+```
+
+Forwarded client certificates are disabled by default. Configure one of the two supported protocols and a dedicated set of directly connected trusted proxies:
+
+```hocon
+play.http.forwarded.clientCertificates {
+  # off, rfc9440, or x-forwarded-client-cert
+  mode = "rfc9440"
+
+  # Independent from play.http.forwarded.trustedProxies
+  trustedProxies = ["10.0.0.0/24", "2001:db8:1234::/48"]
+
+  limits {
+    maxHeaderBytes = 64k
+    maxDecodedBytes = 64k
+    maxCertificateBytes = 16k
+    maxChainLength = 8
+  }
+
+  xForwardedClientCert {
+    policy = "sanitized-single"
+    format = "text"
+  }
+}
+```
+
+The limits bound the aggregate encoded header size, aggregate decoded certificate data, each decoded certificate, and the number of chain certificates excluding the leaf, respectively. These are application-level parser limits and do not increase the HTTP server's header-size limit.
+
+In `off` mode, or when the directly connected peer is not in `clientCertificates.trustedProxies`, Play does not interpret forwarded certificate fields. The original `Client-Cert`, `Client-Cert-Chain`, and `X-Forwarded-Client-Cert` fields remain available through `request.headers`, but the typed forwarded-certificate APIs ignore them. A certificate observed directly by Play remains available through `request.transport.tls` and is selected in `request.clientCertificate` with the `DirectTransport` source.
+
+When a trusted proxy and a forwarded-certificate mode are configured, the selected protocol describes the original client rather than the proxy-to-Play connection. If the trusted proxy supplies no client-certificate assertion, `request.clientCertificate` is empty; Play does not misidentify the proxy's own transport certificate as the original client's certificate. `request.transport.tls` still retains that physical connection information.
+
+#### RFC 9440 Client-Cert
+
+Set `mode = "rfc9440"` for the standardized [`Client-Cert` and `Client-Cert-Chain` fields](https://www.rfc-editor.org/rfc/rfc9440.html). `Client-Cert` contains exactly one DER X.509 end-entity certificate encoded as an RFC 8941 Byte Sequence. The optional `Client-Cert-Chain` is a list of Byte Sequences in TLS order, excludes the leaf, and may include the trust anchor:
+
+```http
+Client-Cert: :<base64-DER-leaf>:
+Client-Cert-Chain: :<base64-DER-chain-certificate-1>:, :<base64-DER-chain-certificate-2>:
+```
+
+Play exposes the result through `request.clientCertificate` with the `Rfc9440` source. `Client-Cert` is a singleton; `Client-Cert-Chain` can be split across repeated fields as permitted by RFC 9440. Syntactically valid Structured Fields parameters on either certificate item are accepted for forward compatibility and ignored.
+
+Following RFC 8941, Play treats a field that fails Structured Fields parsing as absent. A duplicated or malformed `Client-Cert`, including invalid Base64, DER, or trailing certificate data, therefore produces no effective client certificate. `Client-Cert-Chain` is handled independently: if its syntax or certificate data is invalid, Play ignores the chain but retains a valid `Client-Cert` leaf. A chain without a valid leaf has no effect. Exceeding a configured parser limit still rejects the request with HTTP 400.
+
+#### X-Forwarded-Client-Cert
+
+Set `mode = "x-forwarded-client-cert"` for the [Envoy-compatible text form](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html#x-forwarded-client-cert) of `X-Forwarded-Client-Cert` (XFCC). The currently supported `sanitized-single` policy accepts no field or exactly one physical field containing exactly one assertion; it does not accept repeated fields or an appended comma-separated multi-proxy history. The trusted proxy must therefore replace the field rather than append to it. With Envoy, use its `SANITIZE_SET` behavior. `format = "text"` selects the semicolon-delimited `Key=Value` representation; JSON and other vendor-specific encodings are not accepted.
+
+This requires explicit attention in multi-proxy service meshes. [Istio ingress gateways default to `SANITIZE_SET`, while sidecars default to `APPEND_FORWARD`](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/#configuring-x-forwarded-client-cert-headers). A sidecar can therefore append a workload assertion to the ingress assertion and produce a multi-entry history that Play rejects. Configure the proxy chain so the proxy directly connected to Play delivers exactly one assertion sanitized by a trusted component; Play does not guess an effective client certificate from an appended history.
+
+Play recognizes repeatable `By`, `URI`, and `DNS` values and singleton `Hash`, `Cert`, `Chain`, and `Subject` values. Their order is retained in `request.xForwardedClientCertificates`. An assertion containing only identity metadata, for example a SPIFFE `URI`, is valid and does not invent an X.509 certificate. When present, `Hash` is the hexadecimal SHA-256 digest of the leaf certificate.
+
+Envoy's text form emits `By` and `URI` values without escaping its comma and semicolon delimiters. Those characters therefore cannot be recovered unambiguously: identities used with this mode must not contain raw `,` or `;` in `By` or URI SAN values. Percent-encode them when issuing URI identities. An empty `URI=` marker, which Envoy emits when URI forwarding is enabled but the certificate has no URI SAN, is accepted without adding an empty identity.
+
+`Cert` is a percent-encoded PEM leaf certificate. Envoy's `Chain` value is a percent-encoded PEM sequence that includes the leaf; Play normalizes it so both `XForwardedClientCert.chain` and `ClientCertificateInfo.chain` contain only the remaining chain certificates. This is the chain presented by the client and is not necessarily the chain that the proxy validated. If both `Cert` and `Chain` are present, their leaf certificates must match. When either value supplies a certificate, `request.clientCertificate` uses the `XForwardedClientCert` source. The accepted assertion remains available separately so applications can inspect its other metadata.
+
+Malformed XFCC input from a configured, trusted proxy is rejected with HTTP 400 rather than being partly accepted. Exceeding a configured parser limit in either forwarded-certificate mode also rejects the request. Input from an untrusted peer is ignored by the typed APIs without being parsed. These rules apply independently of `play.http.forwarded.version`, which selects only remote address, scheme, and authority forwarding.
+
+#### Certificate trust and deployment requirements
+
+Parsing a forwarded certificate proves only that the field has the expected syntax and contains a parseable X.509 object. Play does not perform PKIX path validation, check certificate validity or revocation, prove possession of the private key, map a certificate to an application principal, or authorize the request. An XFCC hash consistency check likewise does not authenticate the assertion. The TLS-terminating proxy must authenticate the client certificate according to deployment policy, and the application must perform any required identity mapping and authorization.
+
+Before enabling either mode, enforce all of the following:
+
+* Prevent clients from connecting directly to Play, so they cannot bypass the proxy and supply certificate fields themselves.
+* On every request, have the trusted edge remove all incoming `Client-Cert`, `Client-Cert-Chain`, and `X-Forwarded-Client-Cert` fields before setting the one configured representation. It must also remove them when client-certificate authentication did not occur.
+* Protect and authenticate the proxy-to-Play path with mutually authenticated TLS or equivalently strong network isolation. An IP address in `trustedProxies` does not itself protect the assertion from interception, modification, or source-address impersonation.
+* Put only the proxy addresses that are authoritative for client-certificate assertions in `clientCertificates.trustedProxies`; do not copy a broader forwarding trust range without reviewing it.
+
+Certificate fields can exceed Play's default `play.server.max-header-size` of `8k`, especially when a chain is included. Increase that server setting when required, while keeping the client-certificate parser limits as small as the deployment permits:
+
+```hocon
+play.server.max-header-size = 64k
+```
+
+Finally, do not let a shared cache reuse certificate-dependent content across clients. When `Client-Cert` influences the response, RFC 9440 requires either an uncacheable response such as `Cache-Control: no-store` or `Vary: Client-Cert`; it also recommends that the TLS-terminating proxy turn that `Vary` value into `*` before returning the response to the user agent. `Cache-Control: no-store` is the safest default for certificate-dependent responses, including those based on XFCC metadata. Play does not add these response fields automatically.

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -664,6 +664,23 @@ object BuildSettings {
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
         "play.core.server.common.ForwardedHeaderHandler#ParsedForwardedEntry._1"
       ),
+      // Add source-aware client certificate support for direct TLS and trusted forwarding headers
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.FakeRequest.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.test.FakeRequestFactory.apply"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.CLIENT_CERT"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.CLIENT_CERT_CHAIN"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.http.HeaderNames.X_FORWARDED_CLIENT_CERT"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$CLIENT_CERT_="
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$CLIENT_CERT_CHAIN_="
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "play.api.http.HeaderNames.play$api$http$HeaderNames$_setter_$X_FORWARDED_CLIENT_CERT_="
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.RequestHeader.clientCertificate"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.RequestHeader.xForwardedClientCertificates"),
     ),
     (Compile / unmanagedSourceDirectories) += {
       val suffix = CrossVersion.partialVersion(scalaVersion.value) match {

--- a/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -34,17 +34,18 @@ case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(
  * @tparam A the body content type.
  */
 class FakeRequest[+A](request: Request[A]) extends Request[A] {
-  override def transport: TransportConnection                   = request.transport
-  override def clientCertificate: Option[ClientCertificateInfo] = request.clientCertificate
-  override def remote: RemoteInfo                               = request.remote
-  override def scheme: Scheme                                   = request.scheme
-  override def authority: Option[RequestAuthority]              = request.authority
-  override def method: String                                   = request.method
-  override def target: RequestTarget                            = request.target
-  override def version: String                                  = request.version
-  override def headers: Headers                                 = request.headers
-  override def body: A                                          = request.body
-  override def attrs: TypedMap                                  = request.attrs
+  override def transport: TransportConnection                             = request.transport
+  override def clientCertificate: Option[ClientCertificateInfo]           = request.clientCertificate
+  override def xForwardedClientCertificates: Vector[XForwardedClientCert] = request.xForwardedClientCertificates
+  override def remote: RemoteInfo                                         = request.remote
+  override def scheme: Scheme                                             = request.scheme
+  override def authority: Option[RequestAuthority]                        = request.authority
+  override def method: String                                             = request.method
+  override def target: RequestTarget                                      = request.target
+  override def version: String                                            = request.version
+  override def headers: Headers                                           = request.headers
+  override def body: A                                                    = request.body
+  override def attrs: TypedMap                                            = request.attrs
 
   override def withRemote(newRemote: RemoteInfo): FakeRequest[A] =
     new FakeRequest(request.withRemote(newRemote))
@@ -52,6 +53,10 @@ class FakeRequest[+A](request: Request[A]) extends Request[A] {
     new FakeRequest(request.withTransport(newTransport))
   override def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): FakeRequest[A] =
     new FakeRequest(request.withClientCertificate(newClientCertificate))
+  override def withXForwardedClientCertificates(
+      newXForwardedClientCertificates: Seq[XForwardedClientCert]
+  ): FakeRequest[A] =
+    new FakeRequest(request.withXForwardedClientCertificates(newXForwardedClientCertificates))
   override def withScheme(newScheme: Scheme): FakeRequest[A] =
     new FakeRequest(request.withScheme(newScheme))
   override def withAuthority(newAuthority: Option[RequestAuthority]): FakeRequest[A] =
@@ -242,6 +247,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
    * @param remote The selected remote node metadata.
    * @param scheme The effective request scheme.
    * @param clientCertificate The effective client certificate metadata.
+   * @param xForwardedClientCertificates Accepted `X-Forwarded-Client-Cert` assertions.
    */
   def apply[A](
       method: String,
@@ -254,7 +260,8 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       version: String = "HTTP/1.1",
       id: Long = 666,
       attrs: TypedMap = TypedMap.empty,
-      clientCertificate: Option[ClientCertificateInfo] = None
+      clientCertificate: Option[ClientCertificateInfo] = None,
+      xForwardedClientCertificates: Vector[XForwardedClientCert] = Vector.empty
   ): FakeRequest[A] = {
     val _uri   = uri
     val target = new RequestTarget {
@@ -269,6 +276,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
     val request: Request[A] = requestFactory.createRequest(
       transport,
       clientCertificate,
+      xForwardedClientCertificates,
       remote,
       scheme,
       authority,

--- a/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/testkit/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -34,21 +34,24 @@ case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(
  * @tparam A the body content type.
  */
 class FakeRequest[+A](request: Request[A]) extends Request[A] {
-  override def transport: TransportConnection      = request.transport
-  override def remote: RemoteInfo                  = request.remote
-  override def scheme: Scheme                      = request.scheme
-  override def authority: Option[RequestAuthority] = request.authority
-  override def method: String                      = request.method
-  override def target: RequestTarget               = request.target
-  override def version: String                     = request.version
-  override def headers: Headers                    = request.headers
-  override def body: A                             = request.body
-  override def attrs: TypedMap                     = request.attrs
+  override def transport: TransportConnection                   = request.transport
+  override def clientCertificate: Option[ClientCertificateInfo] = request.clientCertificate
+  override def remote: RemoteInfo                               = request.remote
+  override def scheme: Scheme                                   = request.scheme
+  override def authority: Option[RequestAuthority]              = request.authority
+  override def method: String                                   = request.method
+  override def target: RequestTarget                            = request.target
+  override def version: String                                  = request.version
+  override def headers: Headers                                 = request.headers
+  override def body: A                                          = request.body
+  override def attrs: TypedMap                                  = request.attrs
 
   override def withRemote(newRemote: RemoteInfo): FakeRequest[A] =
     new FakeRequest(request.withRemote(newRemote))
   override def withTransport(newTransport: TransportConnection): FakeRequest[A] =
     new FakeRequest(request.withTransport(newTransport))
+  override def withClientCertificate(newClientCertificate: Option[ClientCertificateInfo]): FakeRequest[A] =
+    new FakeRequest(request.withClientCertificate(newClientCertificate))
   override def withScheme(newScheme: Scheme): FakeRequest[A] =
     new FakeRequest(request.withScheme(newScheme))
   override def withAuthority(newAuthority: Option[RequestAuthority]): FakeRequest[A] =
@@ -238,6 +241,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
    * @param transport The network connection directly terminating at Play.
    * @param remote The selected remote node metadata.
    * @param scheme The effective request scheme.
+   * @param clientCertificate The effective client certificate metadata.
    */
   def apply[A](
       method: String,
@@ -249,7 +253,8 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       scheme: Scheme = Scheme.Http,
       version: String = "HTTP/1.1",
       id: Long = 666,
-      attrs: TypedMap = TypedMap.empty
+      attrs: TypedMap = TypedMap.empty,
+      clientCertificate: Option[ClientCertificateInfo] = None
   ): FakeRequest[A] = {
     val _uri   = uri
     val target = new RequestTarget {
@@ -263,6 +268,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       .fold(error => throw new IllegalArgumentException(error), identity)
     val request: Request[A] = requestFactory.createRequest(
       transport,
+      clientCertificate,
       remote,
       scheme,
       authority,

--- a/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/testkit/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -282,6 +282,21 @@ class HelpersSpec extends Specification {
         request.scheme mustEqual scheme
       }
 
+      "preserve the positional request-metadata parameter order" in {
+        val transport = TransportConnection(
+          PeerEndpoint(InetAddresses.forString("192.0.2.10"), Some(53124)),
+          None
+        )
+        val remote = RemoteInfo.fromPeer(PeerEndpoint(InetAddresses.forString("198.51.100.20"), Some(443)))
+        val scheme = Scheme.Https
+
+        val request = FakeRequest("GET", "/uri", FakeHeaders(), AnyContentAsEmpty, transport, remote, scheme)
+
+        request.transport mustEqual transport
+        request.remote mustEqual remote
+        request.scheme mustEqual scheme
+      }
+
       "synchronize Host header helpers with the effective authority" in {
         val fromHeaders = FakeRequest().withHeaders(Headers("host" -> "EXAMPLE.com:00080", "X-Test" -> "one"))
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -42,6 +42,7 @@ import play.api.mvc.request.RequestTarget
 import play.api.mvc.request.TransportConnection
 import play.api.mvc.request.TransportTls
 import play.api.Logger
+import play.core.server.common.ClientCertificateHeaderHandler
 import play.core.server.common.ForwardedHeaderHandler
 import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
@@ -50,6 +51,7 @@ import play.core.system.RequestIdProvider
 private[server] class NettyModelConversion(
     resultUtils: ServerResultUtils,
     forwardedHeaderHandler: ForwardedHeaderHandler,
+    clientCertificateHeaderHandler: ClientCertificateHeaderHandler,
     serverHeader: Option[String]
 ) {
   private val logger = Logger(classOf[NettyModelConversion])
@@ -120,9 +122,9 @@ private[server] class NettyModelConversion(
    */
   def createRequestHeader(channel: Channel, request: HttpRequest, target: RequestTarget): RequestHeader = {
     val transport         = createTransport(channel)
-    val clientCertificate = ClientCertificateInfo.fromTransport(transport)
     val rawRemote         = RemoteInfo.fromPeer(transport.peer)
     val rawHeaders        = new NettyHeadersWrapper(request.headers)
+    val clientCertificate = clientCertificateHeaderHandler.clientCertificate(transport, rawHeaders)
     val directScheme      = RequestHeader.initialScheme(transport)
     val initialTarget     = RequestHeader
       .initialRequestTarget(request.method.name(), target, request.protocolVersion.text(), rawHeaders)

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -34,6 +34,7 @@ import play.api.http.HttpEntity
 import play.api.http.HttpErrorHandler
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
+import play.api.mvc.request.ClientCertificateInfo
 import play.api.mvc.request.PeerEndpoint
 import play.api.mvc.request.RemoteInfo
 import play.api.mvc.request.RequestAttrKey
@@ -118,11 +119,12 @@ private[server] class NettyModelConversion(
    * later.
    */
   def createRequestHeader(channel: Channel, request: HttpRequest, target: RequestTarget): RequestHeader = {
-    val transport     = createTransport(channel)
-    val rawRemote     = RemoteInfo.fromPeer(transport.peer)
-    val rawHeaders    = new NettyHeadersWrapper(request.headers)
-    val directScheme  = RequestHeader.initialScheme(transport)
-    val initialTarget = RequestHeader
+    val transport         = createTransport(channel)
+    val clientCertificate = ClientCertificateInfo.fromTransport(transport)
+    val rawRemote         = RemoteInfo.fromPeer(transport.peer)
+    val rawHeaders        = new NettyHeadersWrapper(request.headers)
+    val directScheme      = RequestHeader.initialScheme(transport)
+    val initialTarget     = RequestHeader
       .initialRequestTarget(request.method.name(), target, request.protocolVersion.text(), rawHeaders)
       .fold(error => throw new IllegalArgumentException(error), identity)
     val forwarding = forwardedHeaderHandler.forwardedRequest(
@@ -151,6 +153,7 @@ private[server] class NettyModelConversion(
       rawHeaders,
       attrs,
       transport,
+      clientCertificate,
       effectiveScheme,
       forwarding.authority
     )
@@ -166,11 +169,12 @@ private[server] class NettyModelConversion(
    * repeat the original failure.
    */
   def createErrorRequestHeader(channel: Channel, request: HttpRequest, target: RequestTarget): RequestHeader = {
-    val transport     = createTransport(channel)
-    val rawRemote     = RemoteInfo.fromPeer(transport.peer)
-    val rawHeaders    = new NettyHeadersWrapper(request.headers)
-    val directScheme  = RequestHeader.initialScheme(transport)
-    val initialTarget = RequestHeader
+    val transport         = createTransport(channel)
+    val clientCertificate = ClientCertificateInfo.fromTransport(transport)
+    val rawRemote         = RemoteInfo.fromPeer(transport.peer)
+    val rawHeaders        = new NettyHeadersWrapper(request.headers)
+    val directScheme      = RequestHeader.initialScheme(transport)
+    val initialTarget     = RequestHeader
       .initialRequestTarget(request.method.name(), target, request.protocolVersion.text(), rawHeaders)
       .toOption
     val initialAuthority = initialTarget.flatMap(_.authority)
@@ -197,6 +201,7 @@ private[server] class NettyModelConversion(
       rawHeaders,
       attrs,
       transport,
+      clientCertificate,
       scheme,
       forwarding.authority
     )

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -121,12 +121,12 @@ private[server] class NettyModelConversion(
    * later.
    */
   def createRequestHeader(channel: Channel, request: HttpRequest, target: RequestTarget): RequestHeader = {
-    val transport         = createTransport(channel)
-    val rawRemote         = RemoteInfo.fromPeer(transport.peer)
-    val rawHeaders        = new NettyHeadersWrapper(request.headers)
-    val clientCertificate = clientCertificateHeaderHandler.clientCertificate(transport, rawHeaders)
-    val directScheme      = RequestHeader.initialScheme(transport)
-    val initialTarget     = RequestHeader
+    val transport          = createTransport(channel)
+    val rawRemote          = RemoteInfo.fromPeer(transport.peer)
+    val rawHeaders         = new NettyHeadersWrapper(request.headers)
+    val clientCertificates = clientCertificateHeaderHandler.clientCertificates(transport, rawHeaders)
+    val directScheme       = RequestHeader.initialScheme(transport)
+    val initialTarget      = RequestHeader
       .initialRequestTarget(request.method.name(), target, request.protocolVersion.text(), rawHeaders)
       .fold(error => throw new IllegalArgumentException(error), identity)
     val forwarding = forwardedHeaderHandler.forwardedRequest(
@@ -155,9 +155,10 @@ private[server] class NettyModelConversion(
       rawHeaders,
       attrs,
       transport,
-      clientCertificate,
+      clientCertificates.clientCertificate,
       effectiveScheme,
-      forwarding.authority
+      forwarding.authority,
+      clientCertificates.xForwardedClientCertificates
     )
   }
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -34,7 +34,6 @@ import play.api.http.HttpEntity
 import play.api.http.HttpErrorHandler
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
-import play.api.mvc.request.ClientCertificateInfo
 import play.api.mvc.request.PeerEndpoint
 import play.api.mvc.request.RemoteInfo
 import play.api.mvc.request.RequestAttrKey
@@ -121,12 +120,11 @@ private[server] class NettyModelConversion(
    * later.
    */
   def createRequestHeader(channel: Channel, request: HttpRequest, target: RequestTarget): RequestHeader = {
-    val transport          = createTransport(channel)
-    val rawRemote          = RemoteInfo.fromPeer(transport.peer)
-    val rawHeaders         = new NettyHeadersWrapper(request.headers)
-    val clientCertificates = clientCertificateHeaderHandler.clientCertificates(transport, rawHeaders)
-    val directScheme       = RequestHeader.initialScheme(transport)
-    val initialTarget      = RequestHeader
+    val transport     = createTransport(channel)
+    val rawRemote     = RemoteInfo.fromPeer(transport.peer)
+    val rawHeaders    = new NettyHeadersWrapper(request.headers)
+    val directScheme  = RequestHeader.initialScheme(transport)
+    val initialTarget = RequestHeader
       .initialRequestTarget(request.method.name(), target, request.protocolVersion.text(), rawHeaders)
       .fold(error => throw new IllegalArgumentException(error), identity)
     val forwarding = forwardedHeaderHandler.forwardedRequest(
@@ -138,8 +136,9 @@ private[server] class NettyModelConversion(
     val effectiveScheme = RequestHeader
       .effectiveScheme(initialTarget.scheme, directScheme, forwarding.scheme)
       .fold(error => throw new IllegalArgumentException(error), identity)
-    val normalizedTarget = RequestHeader.normalizeRequestTargetPath(target, initialTarget)
-    val attrs            = TypedMap(
+    val normalizedTarget   = RequestHeader.normalizeRequestTargetPath(target, initialTarget)
+    val clientCertificates = clientCertificateHeaderHandler.clientCertificates(transport, rawHeaders)
+    val attrs              = TypedMap(
       // Send an attribute so our tests can tell which kind of server we're using.
       // We only do this for the "non-default" engine, so we used to tag
       // pekko-http explicitly, so that benchmarking isn't affected by this.
@@ -171,13 +170,19 @@ private[server] class NettyModelConversion(
    * falls back to the directly observed request metadata so construction for HttpErrorHandler cannot
    * repeat the original failure.
    */
-  def createErrorRequestHeader(channel: Channel, request: HttpRequest, target: RequestTarget): RequestHeader = {
-    val transport         = createTransport(channel)
-    val clientCertificate = ClientCertificateInfo.fromTransport(transport)
-    val rawRemote         = RemoteInfo.fromPeer(transport.peer)
-    val rawHeaders        = new NettyHeadersWrapper(request.headers)
-    val directScheme      = RequestHeader.initialScheme(transport)
-    val initialTarget     = RequestHeader
+  def createErrorRequestHeader(
+      channel: Channel,
+      request: HttpRequest,
+      target: RequestTarget,
+      requestFailure: Throwable
+  ): RequestHeader = {
+    val transport          = createTransport(channel)
+    val rawRemote          = RemoteInfo.fromPeer(transport.peer)
+    val rawHeaders         = new NettyHeadersWrapper(request.headers)
+    val clientCertificates =
+      clientCertificateHeaderHandler.clientCertificatesForErrorRequest(transport, rawHeaders, requestFailure)
+    val directScheme  = RequestHeader.initialScheme(transport)
+    val initialTarget = RequestHeader
       .initialRequestTarget(request.method.name(), target, request.protocolVersion.text(), rawHeaders)
       .toOption
     val initialAuthority = initialTarget.flatMap(_.authority)
@@ -204,9 +209,10 @@ private[server] class NettyModelConversion(
       rawHeaders,
       attrs,
       transport,
-      clientCertificate,
+      clientCertificates.clientCertificate,
       scheme,
-      forwarding.authority
+      forwarding.authority,
+      clientCertificates.xForwardedClientCertificates
     )
   }
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -116,11 +116,19 @@ private[play] class PlayRequestHandler(
         statusCode: Int,
         message: String,
         convertedRequestHeader: Option[RequestHeader] = None,
+        requestFailure: Option[Throwable] = None,
         bypassErrorHandler: Boolean = false
     ): (RequestHeader, Handler) = {
       val requestHeader = convertedRequestHeader.getOrElse {
         val unparsedTarget = Server.createUnparsedRequestTarget(request.uri)
-        modelConversion(tryApp).createErrorRequestHeader(channel, request, unparsedTarget)
+        modelConversion(tryApp).createErrorRequestHeader(
+          channel,
+          request,
+          unparsedTarget,
+          requestFailure.getOrElse {
+            throw new IllegalStateException("Request conversion failure is required to construct an error request")
+          }
+        )
       }
       val debugHeader   = attachDebugInfo(requestHeader)
       val cleanMessage  = if (message == null) "" else message
@@ -139,10 +147,17 @@ private[play] class PlayRequestHandler(
 
     val (requestHeader, handler): (RequestHeader, Handler) = tryRequest match {
       case Failure(exception: IllegalArgumentException) if exception.getMessage.startsWith("invalid hex byte") =>
-        clientError(Status.BAD_REQUEST, exception.getMessage, bypassErrorHandler = true)
-      case Failure(exception: TooLongFrameException) => clientError(Status.REQUEST_URI_TOO_LONG, exception.getMessage)
-      case Failure(exception)                        => clientError(Status.BAD_REQUEST, exception.getMessage)
-      case Success(untagged)                         =>
+        clientError(
+          Status.BAD_REQUEST,
+          exception.getMessage,
+          requestFailure = Some(exception),
+          bypassErrorHandler = true
+        )
+      case Failure(exception: TooLongFrameException) =>
+        clientError(Status.REQUEST_URI_TOO_LONG, exception.getMessage, requestFailure = Some(exception))
+      case Failure(exception) =>
+        clientError(Status.BAD_REQUEST, exception.getMessage, requestFailure = Some(exception))
+      case Success(untagged) =>
         if (
           untagged.headers
             .get(HeaderNames.CONTENT_LENGTH)

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -72,9 +72,15 @@ private[play] class PlayRequestHandler(
    */
   private val reloadCache = new ReloadCache[ReloadCacheValues] {
     protected override def reloadValue(tryApp: Try[Application]): ReloadCacheValues = {
-      val serverResultUtils      = reloadServerResultUtils(tryApp)
-      val forwardedHeaderHandler = reloadForwardedHeaderHandler(tryApp)
-      val modelConversion        = new NettyModelConversion(serverResultUtils, forwardedHeaderHandler, serverHeader)
+      val serverResultUtils              = reloadServerResultUtils(tryApp)
+      val forwardedHeaderHandler         = reloadForwardedHeaderHandler(tryApp)
+      val clientCertificateHeaderHandler = reloadClientCertificateHeaderHandler(tryApp)
+      val modelConversion                = new NettyModelConversion(
+        serverResultUtils,
+        forwardedHeaderHandler,
+        clientCertificateHeaderHandler,
+        serverHeader
+      )
       ReloadCacheValues(
         resultUtils = serverResultUtils,
         modelConversion = modelConversion,

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -266,12 +266,13 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
       try {
         ConnectionContext.httpsServer(() => {
           val engine = sslContext.createSSLEngine()
+          engine.setUseClientMode(false)
           createClientAuth() match {
             case Some(auth) if auth == TLSClientAuth.need =>
               engine.setNeedClientAuth(true)
             case Some(auth) if auth == TLSClientAuth.want =>
               engine.setWantClientAuth(true)
-            case _ => engine.setUseClientMode(false)
+            case _ => ()
           }
           engine
         })

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -354,11 +354,12 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
       ServerDebugInfo.attachToRequestHeader(rh, debugInfo)
     }
 
-    def clientError(statusCode: Int, message: String): (RequestHeader, Handler) = {
+    def clientError(statusCode: Int, message: String, requestFailure: Throwable): (RequestHeader, Handler) = {
       val headers        = modelConversion(tryApp).convertRequestHeadersPekko(decodedRequest)
       val unparsedTarget = Server.createUnparsedRequestTarget(headers.uri)
       val requestHeader  =
-        modelConversion(tryApp).createErrorRequestHeader(headers, secure, remoteAddress, unparsedTarget, request)
+        modelConversion(tryApp)
+          .createErrorRequestHeader(headers, secure, remoteAddress, unparsedTarget, request, requestFailure)
       val debugHeader   = attachDebugInfo(requestHeader)
       val maybeEnriched = Server.tryToEnrichHeader(tryApp, debugHeader)
       val result        = errorHandler(tryApp).onClientError(
@@ -372,7 +373,7 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
 
     val (taggedRequestHeader, handler): (RequestHeader, Handler) = convertedRequestHeader match {
       case Failure(exception) =>
-        clientError(Status.BAD_REQUEST, exception.getMessage)
+        clientError(Status.BAD_REQUEST, exception.getMessage, exception)
       case Success(untagged) =>
         val debugHeader = attachDebugInfo(untagged)
         Server.getHandlerFor(debugHeader, tryApp, fallbackErrorHandler)

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -201,13 +201,19 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
    */
   private val reloadCache = new ReloadCache[ReloadCacheValues] {
     protected override def reloadValue(tryApp: Try[Application]): ReloadCacheValues = {
-      val serverResultUtils          = reloadServerResultUtils(tryApp)
-      val forwardedHeaderHandler     = reloadForwardedHeaderHandler(tryApp)
-      val illegalResponseHeaderValue = ParserSettings.IllegalResponseHeaderValueProcessingMode(
+      val serverResultUtils              = reloadServerResultUtils(tryApp)
+      val forwardedHeaderHandler         = reloadForwardedHeaderHandler(tryApp)
+      val clientCertificateHeaderHandler = reloadClientCertificateHeaderHandler(tryApp)
+      val illegalResponseHeaderValue     = ParserSettings.IllegalResponseHeaderValueProcessingMode(
         illegalResponseHeaderValueProcessingMode
       )
       val modelConversion =
-        new PekkoModelConversion(serverResultUtils, forwardedHeaderHandler, illegalResponseHeaderValue)
+        new PekkoModelConversion(
+          serverResultUtils,
+          forwardedHeaderHandler,
+          clientCertificateHeaderHandler,
+          illegalResponseHeaderValue
+        )
       ReloadCacheValues(
         resultUtils = serverResultUtils,
         modelConversion = modelConversion,

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -27,7 +27,6 @@ import play.api.http.HttpChunk
 import play.api.http.HttpErrorHandler
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
-import play.api.mvc.request.ClientCertificateInfo
 import play.api.mvc.request.PeerEndpoint
 import play.api.mvc.request.RemoteInfo
 import play.api.mvc.request.RequestAttrKey
@@ -92,11 +91,10 @@ private[server] class PekkoModelConversion(
       requestTarget: RequestTarget,
       request: HttpRequest
   ): RequestHeader = {
-    val transport          = createTransport(remoteAddress, secureProtocol, request)
-    val rawRemote          = RemoteInfo.fromPeer(transport.peer)
-    val clientCertificates = clientCertificateHeaderHandler.clientCertificates(transport, headers)
-    val directScheme       = RequestHeader.initialScheme(transport)
-    val initialTarget      = RequestHeader
+    val transport     = createTransport(remoteAddress, secureProtocol, request)
+    val rawRemote     = RemoteInfo.fromPeer(transport.peer)
+    val directScheme  = RequestHeader.initialScheme(transport)
+    val initialTarget = RequestHeader
       .initialRequestTarget(request.method.name, requestTarget, request.protocol.value, headers)
       .fold(error => throw new IllegalArgumentException(error), identity)
     val forwarding = forwardedHeaderHandler.forwardedRequest(
@@ -108,8 +106,9 @@ private[server] class PekkoModelConversion(
     val effectiveScheme = RequestHeader
       .effectiveScheme(initialTarget.scheme, directScheme, forwarding.scheme)
       .fold(error => throw new IllegalArgumentException(error), identity)
-    val normalizedTarget = RequestHeader.normalizeRequestTargetPath(requestTarget, initialTarget)
-    val attrs            = TypedMap(
+    val normalizedTarget   = RequestHeader.normalizeRequestTargetPath(requestTarget, initialTarget)
+    val clientCertificates = clientCertificateHeaderHandler.clientCertificates(transport, headers)
+    val attrs              = TypedMap(
       // This is the earliest stage of a Play request at which we can set an id.
       RequestAttrKey.Id -> RequestIdProvider.freshId(),
     )
@@ -142,13 +141,15 @@ private[server] class PekkoModelConversion(
       secureProtocol: Boolean,
       remoteAddress: InetSocketAddress,
       requestTarget: RequestTarget,
-      request: HttpRequest
+      request: HttpRequest,
+      requestFailure: Throwable
   ): RequestHeader = {
-    val transport         = createTransport(remoteAddress, secureProtocol, request)
-    val clientCertificate = ClientCertificateInfo.fromTransport(transport)
-    val rawRemote         = RemoteInfo.fromPeer(transport.peer)
-    val directScheme      = RequestHeader.initialScheme(transport)
-    val initialTarget     = RequestHeader
+    val transport          = createTransport(remoteAddress, secureProtocol, request)
+    val clientCertificates =
+      clientCertificateHeaderHandler.clientCertificatesForErrorRequest(transport, headers, requestFailure)
+    val rawRemote     = RemoteInfo.fromPeer(transport.peer)
+    val directScheme  = RequestHeader.initialScheme(transport)
+    val initialTarget = RequestHeader
       .initialRequestTarget(request.method.name, requestTarget, request.protocol.value, headers)
       .toOption
     val initialAuthority = initialTarget.flatMap(_.authority)
@@ -172,9 +173,10 @@ private[server] class PekkoModelConversion(
       headers,
       attrs,
       transport,
-      clientCertificate,
+      clientCertificates.clientCertificate,
       scheme,
-      forwarding.authority
+      forwarding.authority,
+      clientCertificates.xForwardedClientCertificates
     )
   }
 

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -35,6 +35,7 @@ import play.api.mvc.request.RequestTarget
 import play.api.mvc.request.TransportConnection
 import play.api.mvc.request.TransportTls
 import play.api.Logger
+import play.core.server.common.ClientCertificateHeaderHandler
 import play.core.server.common.ForwardedHeaderHandler
 import play.core.server.common.PathAndQueryParser
 import play.core.server.common.ServerResultUtils
@@ -47,6 +48,7 @@ import play.mvc.Http.HeaderNames
 private[server] class PekkoModelConversion(
     resultUtils: ServerResultUtils,
     forwardedHeaderHandler: ForwardedHeaderHandler,
+    clientCertificateHeaderHandler: ClientCertificateHeaderHandler,
     illegalResponseHeaderValue: ParserSettings.IllegalResponseHeaderValueProcessingMode
 ) {
   private val logger = Logger(getClass)
@@ -91,8 +93,8 @@ private[server] class PekkoModelConversion(
       request: HttpRequest
   ): RequestHeader = {
     val transport         = createTransport(remoteAddress, secureProtocol, request)
-    val clientCertificate = ClientCertificateInfo.fromTransport(transport)
     val rawRemote         = RemoteInfo.fromPeer(transport.peer)
+    val clientCertificate = clientCertificateHeaderHandler.clientCertificate(transport, headers)
     val directScheme      = RequestHeader.initialScheme(transport)
     val initialTarget     = RequestHeader
       .initialRequestTarget(request.method.name, requestTarget, request.protocol.value, headers)

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -92,11 +92,11 @@ private[server] class PekkoModelConversion(
       requestTarget: RequestTarget,
       request: HttpRequest
   ): RequestHeader = {
-    val transport         = createTransport(remoteAddress, secureProtocol, request)
-    val rawRemote         = RemoteInfo.fromPeer(transport.peer)
-    val clientCertificate = clientCertificateHeaderHandler.clientCertificate(transport, headers)
-    val directScheme      = RequestHeader.initialScheme(transport)
-    val initialTarget     = RequestHeader
+    val transport          = createTransport(remoteAddress, secureProtocol, request)
+    val rawRemote          = RemoteInfo.fromPeer(transport.peer)
+    val clientCertificates = clientCertificateHeaderHandler.clientCertificates(transport, headers)
+    val directScheme       = RequestHeader.initialScheme(transport)
+    val initialTarget      = RequestHeader
       .initialRequestTarget(request.method.name, requestTarget, request.protocol.value, headers)
       .fold(error => throw new IllegalArgumentException(error), identity)
     val forwarding = forwardedHeaderHandler.forwardedRequest(
@@ -121,9 +121,10 @@ private[server] class PekkoModelConversion(
       headers,
       attrs,
       transport,
-      clientCertificate,
+      clientCertificates.clientCertificate,
       effectiveScheme,
-      forwarding.authority
+      forwarding.authority,
+      clientCertificates.xForwardedClientCertificates
     )
   }
 

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/pekkohttp/PekkoModelConversion.scala
@@ -27,6 +27,7 @@ import play.api.http.HttpChunk
 import play.api.http.HttpErrorHandler
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
+import play.api.mvc.request.ClientCertificateInfo
 import play.api.mvc.request.PeerEndpoint
 import play.api.mvc.request.RemoteInfo
 import play.api.mvc.request.RequestAttrKey
@@ -89,10 +90,11 @@ private[server] class PekkoModelConversion(
       requestTarget: RequestTarget,
       request: HttpRequest
   ): RequestHeader = {
-    val transport     = createTransport(remoteAddress, secureProtocol, request)
-    val rawRemote     = RemoteInfo.fromPeer(transport.peer)
-    val directScheme  = RequestHeader.initialScheme(transport)
-    val initialTarget = RequestHeader
+    val transport         = createTransport(remoteAddress, secureProtocol, request)
+    val clientCertificate = ClientCertificateInfo.fromTransport(transport)
+    val rawRemote         = RemoteInfo.fromPeer(transport.peer)
+    val directScheme      = RequestHeader.initialScheme(transport)
+    val initialTarget     = RequestHeader
       .initialRequestTarget(request.method.name, requestTarget, request.protocol.value, headers)
       .fold(error => throw new IllegalArgumentException(error), identity)
     val forwarding = forwardedHeaderHandler.forwardedRequest(
@@ -117,6 +119,7 @@ private[server] class PekkoModelConversion(
       headers,
       attrs,
       transport,
+      clientCertificate,
       effectiveScheme,
       forwarding.authority
     )
@@ -138,10 +141,11 @@ private[server] class PekkoModelConversion(
       requestTarget: RequestTarget,
       request: HttpRequest
   ): RequestHeader = {
-    val transport     = createTransport(remoteAddress, secureProtocol, request)
-    val rawRemote     = RemoteInfo.fromPeer(transport.peer)
-    val directScheme  = RequestHeader.initialScheme(transport)
-    val initialTarget = RequestHeader
+    val transport         = createTransport(remoteAddress, secureProtocol, request)
+    val clientCertificate = ClientCertificateInfo.fromTransport(transport)
+    val rawRemote         = RemoteInfo.fromPeer(transport.peer)
+    val directScheme      = RequestHeader.initialScheme(transport)
+    val initialTarget     = RequestHeader
       .initialRequestTarget(request.method.name, requestTarget, request.protocol.value, headers)
       .toOption
     val initialAuthority = initialTarget.flatMap(_.authority)
@@ -165,6 +169,7 @@ private[server] class PekkoModelConversion(
       headers,
       attrs,
       transport,
+      clientCertificate,
       scheme,
       forwarding.authority
     )

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ClientCertificateHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ClientCertificateHeaderHandler.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import com.typesafe.config.ConfigMemorySize
+import play.api.mvc.request.ClientCertificateInfo
+import play.api.mvc.request.TransportConnection
+import play.api.mvc.Headers
+import play.api.Configuration
+import play.core.server.common.ClientCertificateHeaderHandler._
+
+/** Selects direct or trusted forwarded client-certificate metadata for a request. */
+private[server] final class ClientCertificateHeaderHandler(configuration: Config) {
+
+  def clientCertificate(transport: TransportConnection, headers: Headers): Option[ClientCertificateInfo] = {
+    configuration.mode match {
+      case Off                                                 => ClientCertificateInfo.fromTransport(transport)
+      case Rfc9440 if !configuration.isTrustedProxy(transport) => ClientCertificateInfo.fromTransport(transport)
+      case Rfc9440                                             =>
+        Rfc9440ClientCertificateParser.parse(headers, configuration.limits) match {
+          case Right(value) => value
+          case Left(error)  =>
+            throw new IllegalArgumentException(s"Forwarded client certificate limits exceeded: $error")
+        }
+    }
+  }
+}
+
+private[server] object ClientCertificateHeaderHandler {
+  sealed trait Mode
+  case object Off     extends Mode
+  case object Rfc9440 extends Mode
+
+  final case class Config(mode: Mode, trustedProxies: List[Subnet], limits: ClientCertificateHeaderLimits) {
+    def isTrustedProxy(transport: TransportConnection): Boolean =
+      trustedProxies.exists(_.isInRange(transport.peer.address))
+  }
+
+  object Config {
+    def apply(configuration: Option[Configuration]): Config = {
+      val config = configuration
+        .getOrElse(Configuration.reference)
+        .get[Configuration]("play.http.forwarded.clientCertificates")
+
+      val mode = config.get[String]("mode") match {
+        case "off"     => Off
+        case "rfc9440" => Rfc9440
+        case _         =>
+          throw config.reportError("mode", "Forwarded client certificate mode must be either off or rfc9440")
+      }
+
+      def positiveBytes(path: String): Long = {
+        val value = config.get[ConfigMemorySize](path).toBytes
+        if (value <= 0) throw config.reportError(path, "Forwarded client certificate size limits must be positive")
+        value
+      }
+
+      val maxChainLength = config.get[Int]("limits.maxChainLength")
+      if (maxChainLength < 0) {
+        throw config.reportError("limits.maxChainLength", "maxChainLength must not be negative")
+      }
+
+      Config(
+        mode,
+        config.get[Seq[String]]("trustedProxies").map(Subnet.apply).toList,
+        ClientCertificateHeaderLimits(
+          positiveBytes("limits.maxHeaderBytes"),
+          positiveBytes("limits.maxDecodedBytes"),
+          positiveBytes("limits.maxCertificateBytes"),
+          maxChainLength
+        )
+      )
+    }
+  }
+}

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ClientCertificateHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ClientCertificateHeaderHandler.scala
@@ -6,7 +6,9 @@ package play.core.server.common
 
 import com.typesafe.config.ConfigMemorySize
 import play.api.mvc.request.ClientCertificateInfo
+import play.api.mvc.request.ClientCertificateSource
 import play.api.mvc.request.TransportConnection
+import play.api.mvc.request.XForwardedClientCert
 import play.api.mvc.Headers
 import play.api.Configuration
 import play.core.server.common.ClientCertificateHeaderHandler._
@@ -14,24 +16,62 @@ import play.core.server.common.ClientCertificateHeaderHandler._
 /** Selects direct or trusted forwarded client-certificate metadata for a request. */
 private[server] final class ClientCertificateHeaderHandler(configuration: Config) {
 
-  def clientCertificate(transport: TransportConnection, headers: Headers): Option[ClientCertificateInfo] = {
+  def clientCertificates(transport: TransportConnection, headers: Headers): Selection = {
     configuration.mode match {
-      case Off                                                 => ClientCertificateInfo.fromTransport(transport)
-      case Rfc9440 if !configuration.isTrustedProxy(transport) => ClientCertificateInfo.fromTransport(transport)
-      case Rfc9440                                             =>
+      case Off                                           => Selection.direct(transport)
+      case _ if !configuration.isTrustedProxy(transport) => Selection.direct(transport)
+      case Rfc9440                                       =>
         Rfc9440ClientCertificateParser.parse(headers, configuration.limits) match {
-          case Right(value) => value
+          case Right(value) => Selection(value, Vector.empty)
           case Left(error)  =>
             throw new IllegalArgumentException(s"Forwarded client certificate limits exceeded: $error")
         }
+      case XForwardedClientCertMode =>
+        XForwardedClientCertHeaderParser.parse(
+          headers.getAll(play.api.http.HeaderNames.X_FORWARDED_CLIENT_CERT),
+          XForwardedClientCertHeaderParser.Limits(
+            configuration.limits.maxHeaderBytes,
+            configuration.limits.maxDecodedBytes,
+            configuration.limits.maxCertificateBytes,
+            configuration.limits.maxChainLength
+          )
+        ) match {
+          case Right(assertions) => Selection.fromXForwardedClientCert(assertions)
+          case Left(error)       =>
+            throw new IllegalArgumentException(s"Invalid forwarded client certificate: $error")
+        }
     }
   }
+
+  /** Select only the effective certificate when XFCC assertion metadata is not needed. */
+  def clientCertificate(transport: TransportConnection, headers: Headers): Option[ClientCertificateInfo] =
+    clientCertificates(transport, headers).clientCertificate
 }
 
 private[server] object ClientCertificateHeaderHandler {
   sealed trait Mode
-  case object Off     extends Mode
-  case object Rfc9440 extends Mode
+  case object Off                      extends Mode
+  case object Rfc9440                  extends Mode
+  case object XForwardedClientCertMode extends Mode
+
+  final case class Selection(
+      clientCertificate: Option[ClientCertificateInfo],
+      xForwardedClientCertificates: Vector[XForwardedClientCert]
+  )
+
+  object Selection {
+    def direct(transport: TransportConnection): Selection =
+      Selection(ClientCertificateInfo.fromTransport(transport), Vector.empty)
+
+    def fromXForwardedClientCert(assertions: Vector[XForwardedClientCert]): Selection = {
+      val effective = assertions.headOption.flatMap { assertion =>
+        assertion.certificate.map { certificate =>
+          ClientCertificateInfo(certificate, assertion.chain, ClientCertificateSource.XForwardedClientCert)
+        }
+      }
+      Selection(effective, assertions)
+    }
+  }
 
   final case class Config(mode: Mode, trustedProxies: List[Subnet], limits: ClientCertificateHeaderLimits) {
     def isTrustedProxy(transport: TransportConnection): Boolean =
@@ -45,10 +85,24 @@ private[server] object ClientCertificateHeaderHandler {
         .get[Configuration]("play.http.forwarded.clientCertificates")
 
       val mode = config.get[String]("mode") match {
-        case "off"     => Off
-        case "rfc9440" => Rfc9440
-        case _         =>
-          throw config.reportError("mode", "Forwarded client certificate mode must be either off or rfc9440")
+        case "off"                     => Off
+        case "rfc9440"                 => Rfc9440
+        case "x-forwarded-client-cert" => XForwardedClientCertMode
+        case _                         =>
+          throw config.reportError(
+            "mode",
+            "Forwarded client certificate mode must be off, rfc9440, or x-forwarded-client-cert"
+          )
+      }
+
+      if (config.get[String]("xForwardedClientCert.policy") != "sanitized-single") {
+        throw config.reportError(
+          "xForwardedClientCert.policy",
+          "X-Forwarded-Client-Cert policy must be sanitized-single"
+        )
+      }
+      if (config.get[String]("xForwardedClientCert.format") != "text") {
+        throw config.reportError("xForwardedClientCert.format", "X-Forwarded-Client-Cert format must be text")
       }
 
       def positiveBytes(path: String): Long = {
@@ -61,7 +115,6 @@ private[server] object ClientCertificateHeaderHandler {
       if (maxChainLength < 0) {
         throw config.reportError("limits.maxChainLength", "maxChainLength must not be negative")
       }
-
       Config(
         mode,
         config.get[Seq[String]]("trustedProxies").map(Subnet.apply).toList,

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ClientCertificateHeaderHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ClientCertificateHeaderHandler.scala
@@ -4,6 +4,8 @@
 
 package play.core.server.common
 
+import scala.util.control.NonFatal
+
 import com.typesafe.config.ConfigMemorySize
 import play.api.mvc.request.ClientCertificateInfo
 import play.api.mvc.request.ClientCertificateSource
@@ -11,10 +13,12 @@ import play.api.mvc.request.TransportConnection
 import play.api.mvc.request.XForwardedClientCert
 import play.api.mvc.Headers
 import play.api.Configuration
+import play.api.Logger
 import play.core.server.common.ClientCertificateHeaderHandler._
 
 /** Selects direct or trusted forwarded client-certificate metadata for a request. */
 private[server] final class ClientCertificateHeaderHandler(configuration: Config) {
+  private val logger = Logger(classOf[ClientCertificateHeaderHandler])
 
   def clientCertificates(transport: TransportConnection, headers: Headers): Selection = {
     configuration.mode match {
@@ -24,7 +28,9 @@ private[server] final class ClientCertificateHeaderHandler(configuration: Config
         Rfc9440ClientCertificateParser.parse(headers, configuration.limits) match {
           case Right(value) => Selection(value, Vector.empty)
           case Left(error)  =>
-            throw new IllegalArgumentException(s"Forwarded client certificate limits exceeded: $error")
+            throw new InvalidClientCertificateHeaderException(
+              s"Forwarded client certificate limits exceeded: $error"
+            )
         }
       case XForwardedClientCertMode =>
         XForwardedClientCertHeaderParser.parse(
@@ -38,8 +44,34 @@ private[server] final class ClientCertificateHeaderHandler(configuration: Config
         ) match {
           case Right(assertions) => Selection.fromXForwardedClientCert(assertions)
           case Left(error)       =>
-            throw new IllegalArgumentException(s"Invalid forwarded client certificate: $error")
+            throw new InvalidClientCertificateHeaderException(s"Invalid forwarded client certificate: $error")
         }
+    }
+  }
+
+  /**
+   * Select certificate metadata for an error request without repeating selection that already
+   * failed during normal request conversion.
+   */
+  def clientCertificatesForErrorRequest(
+      transport: TransportConnection,
+      headers: Headers,
+      requestFailure: Throwable
+  ): Selection = {
+    if (requestFailure.isInstanceOf[InvalidClientCertificateHeaderException]) {
+      Selection.empty
+    } else {
+      try {
+        clientCertificates(transport, headers)
+      } catch {
+        case _: InvalidClientCertificateHeaderException => Selection.empty
+        case NonFatal(error)                            =>
+          logger.warn(
+            "Failed to apply forwarded client certificate metadata to an error request; omitting effective metadata.",
+            error
+          )
+          Selection.empty
+      }
     }
   }
 
@@ -49,6 +81,9 @@ private[server] final class ClientCertificateHeaderHandler(configuration: Config
 }
 
 private[server] object ClientCertificateHeaderHandler {
+  private[server] final class InvalidClientCertificateHeaderException(message: String)
+      extends IllegalArgumentException(message)
+
   sealed trait Mode
   case object Off                      extends Mode
   case object Rfc9440                  extends Mode
@@ -60,6 +95,8 @@ private[server] object ClientCertificateHeaderHandler {
   )
 
   object Selection {
+    val empty: Selection = Selection(None, Vector.empty)
+
     def direct(transport: TransportConnection): Selection =
       Selection(ClientCertificateInfo.fromTransport(transport), Vector.empty)
 

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ClientCertificateHeaderLimits.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ClientCertificateHeaderLimits.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+/** Resource limits shared by forwarded client-certificate parsers. */
+private[server] final case class ClientCertificateHeaderLimits(
+    maxHeaderBytes: Long,
+    maxDecodedBytes: Long,
+    maxCertificateBytes: Long,
+    maxChainLength: Int
+)

--- a/transport/server/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
@@ -114,4 +114,13 @@ private[play] abstract class ReloadCache[+T] {
       ForwardedHeaderHandler.ForwardedHeaderHandlerConfig(tryApp.toOption.map(_.configuration))
     new ForwardedHeaderHandler(forwardedHeaderConfiguration)
   }
+
+  /** Helper to calculate a forwarded client-certificate handler. */
+  protected final def reloadClientCertificateHeaderHandler(
+      tryApp: Try[Application]
+  ): ClientCertificateHeaderHandler = {
+    val clientCertificateConfiguration =
+      ClientCertificateHeaderHandler.Config(tryApp.toOption.map(_.configuration))
+    new ClientCertificateHeaderHandler(clientCertificateConfiguration)
+  }
 }

--- a/transport/server/play-server/src/main/scala/play/core/server/common/Rfc9440ClientCertificateParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/Rfc9440ClientCertificateParser.scala
@@ -1,0 +1,434 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.security.cert.CertificateException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Arrays
+import java.util.Base64
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
+
+import play.api.http.HeaderNames
+import play.api.mvc.request.ClientCertificateInfo
+import play.api.mvc.request.ClientCertificateSource
+import play.api.mvc.Headers
+
+/**
+ * Strict, bounded parsing for the RFC 9440 Client-Cert request fields. Malformed fields are ignored
+ * independently as required by RFC 8941; configured resource-limit violations remain errors.
+ */
+private[common] object Rfc9440ClientCertificateParser {
+
+  def parse(headers: Headers, limits: ClientCertificateHeaderLimits): Either[String, Option[ClientCertificateInfo]] = {
+    val leafValues  = headers.getAll(HeaderNames.CLIENT_CERT)
+    val chainValues = headers.getAll(HeaderNames.CLIENT_CERT_CHAIN)
+
+    checkRawSize(leafValues, chainValues, limits.maxHeaderBytes) match {
+      case Left(error) => Left(error.message)
+      case Right(_)    =>
+        val decodedBytes = new DecodedByteBudget(limits.maxDecodedBytes)
+        val leaf         = parseLeaf(leafValues, limits, decodedBytes) match {
+          case Left(LimitExceeded(message)) => return Left(message)
+          case Left(_: InvalidField)        => None
+          case Right(value)                 => value
+        }
+        val chain = parseChain(chainValues, limits, decodedBytes) match {
+          case Left(LimitExceeded(message)) => return Left(message)
+          case Left(_: InvalidField)        => Vector.empty
+          case Right(value)                 => value
+        }
+
+        leaf match {
+          case None       => Right(None)
+          case Some(cert) =>
+            rejectRepeatedLeaf(cert, chain) match {
+              case Left(_)      => Right(Some(certificateInfo(cert, Vector.empty)))
+              case Right(value) => Right(Some(certificateInfo(cert, value)))
+            }
+        }
+    }
+  }
+
+  private sealed trait ParseFailure {
+    def message: String
+  }
+
+  private final case class InvalidField(message: String)  extends ParseFailure
+  private final case class LimitExceeded(message: String) extends ParseFailure
+
+  private type ParseResult[A] = Either[ParseFailure, A]
+
+  private def invalid[A](message: String): ParseResult[A] = Left(InvalidField(message))
+  private def limit[A](message: String): ParseResult[A]   = Left(LimitExceeded(message))
+
+  private def certificateInfo(leaf: X509Certificate, chain: Vector[X509Certificate]): ClientCertificateInfo =
+    ClientCertificateInfo(leaf, chain, ClientCertificateSource.Rfc9440)
+
+  private def parseLeaf(
+      values: Seq[String],
+      limits: ClientCertificateHeaderLimits,
+      decodedBytes: DecodedByteBudget
+  ): ParseResult[Option[X509Certificate]] = {
+    if (values.isEmpty) {
+      Right(None)
+    } else if (values.sizeCompare(1) > 0) {
+      invalid("Client-Cert must occur exactly once")
+    } else {
+      for {
+        bytes       <- parseSingleByteSequence(values.head, limits.maxCertificateBytes, decodedBytes)
+        certificate <- parseCertificate(bytes)
+      } yield Some(certificate)
+    }
+  }
+
+  private def rejectRepeatedLeaf(
+      leaf: X509Certificate,
+      chain: Vector[X509Certificate]
+  ): ParseResult[Vector[X509Certificate]] = {
+    val certificates = chain.iterator
+    while (certificates.hasNext) {
+      if (Arrays.equals(leaf.getEncoded, certificates.next().getEncoded)) {
+        return invalid("Client-Cert-Chain must not repeat the Client-Cert leaf certificate")
+      }
+    }
+    Right(chain)
+  }
+
+  private def checkRawSize(
+      leafValues: Seq[String],
+      chainValues: Seq[String],
+      maximum: Long
+  ): ParseResult[Unit] = {
+    var total = 0L
+
+    def addBytes(size: Long): Boolean = {
+      if (size > maximum - total) false
+      else {
+        total += size
+        true
+      }
+    }
+
+    val leafIterator = leafValues.iterator
+    while (leafIterator.hasNext) {
+      if (!addBytes(leafIterator.next().getBytes(StandardCharsets.UTF_8).length.toLong)) {
+        return limit("Forwarded client certificate fields exceed maxHeaderBytes")
+      }
+    }
+
+    var firstChainValue = true
+    val chainIterator   = chainValues.iterator
+    while (chainIterator.hasNext) {
+      // Repeated Structured Fields List lines are joined with a comma before parsing.
+      if (!firstChainValue && !addBytes(1L)) {
+        return limit("Forwarded client certificate fields exceed maxHeaderBytes")
+      }
+      if (!addBytes(chainIterator.next().getBytes(StandardCharsets.UTF_8).length.toLong)) {
+        return limit("Forwarded client certificate fields exceed maxHeaderBytes")
+      }
+      firstChainValue = false
+    }
+    Right(())
+  }
+
+  private def parseSingleByteSequence(
+      value: String,
+      maxCertificateBytes: Long,
+      decodedBytes: DecodedByteBudget
+  ): ParseResult[Array[Byte]] = {
+    val parser = new ByteSequenceParser(value, maxCertificateBytes, decodedBytes)
+    parser.skipLeadingSpaces()
+    for {
+      bytes <- parser.parseByteSequenceItem()
+      _     <- parser.skipSpacesAndRequireEnd()
+    } yield bytes
+  }
+
+  private def parseChain(
+      values: Seq[String],
+      limits: ClientCertificateHeaderLimits,
+      decodedBytes: DecodedByteBudget
+  ): ParseResult[Vector[X509Certificate]] = {
+    if (values.isEmpty) return Right(Vector.empty)
+
+    val certificates = Vector.newBuilder[X509Certificate]
+    // Structured Fields combines repeated List field lines with a comma before parsing.
+    val parser = new ByteSequenceParser(values.mkString(","), limits.maxCertificateBytes, decodedBytes)
+    parser.skipLeadingSpaces()
+    parser.parseList(limits.maxChainLength) match {
+      case Left(error)  => return Left(error)
+      case Right(items) =>
+        val itemIterator = items.iterator
+        while (itemIterator.hasNext) {
+          parseCertificate(itemIterator.next()) match {
+            case Left(error)        => return Left(error)
+            case Right(certificate) => certificates += certificate
+          }
+        }
+    }
+    Right(certificates.result())
+  }
+
+  private def parseCertificate(bytes: Array[Byte]): ParseResult[X509Certificate] = {
+    val input = new ByteArrayInputStream(bytes)
+    try {
+      CertificateFactory.getInstance("X.509").generateCertificate(input) match {
+        case certificate: X509Certificate if input.available() == 0 && Arrays.equals(certificate.getEncoded, bytes) =>
+          Right(certificate)
+        case _: X509Certificate => invalid("Client certificate is not one exact DER-encoded X.509 certificate")
+        case _                  => invalid("Client certificate is not an X.509 certificate")
+      }
+    } catch {
+      case _: CertificateException => invalid("Client certificate contains invalid X.509 data")
+      case NonFatal(_)             => invalid("Client certificate could not be decoded")
+    }
+  }
+
+  private final class DecodedByteBudget(maximum: Long) {
+    private var total = 0L
+
+    def add(size: Int): ParseResult[Unit] = {
+      total += size
+      if (total <= maximum) Right(()) else limit("Forwarded client certificates exceed maxDecodedBytes")
+    }
+  }
+
+  /** Minimal RFC 8941 Byte Sequence/List parser for the two RFC 9440 fields. */
+  private final class ByteSequenceParser(
+      input: String,
+      maxCertificateBytes: Long,
+      decodedBytes: DecodedByteBudget
+  ) {
+    private var index = 0
+
+    def skipLeadingSpaces(): Unit = skipSpaces()
+
+    def parseList(maximumItems: Int): ParseResult[Vector[Array[Byte]]] = {
+      val result = ArrayBuffer.empty[Array[Byte]]
+      if (atEnd) return Right(Vector.empty)
+
+      var done = false
+      while (!done) {
+        if (result.size >= maximumItems) return limit("Client-Cert-Chain exceeds maxChainLength")
+        parseByteSequenceItem() match {
+          case Left(error) => return Left(error)
+          case Right(item) => result += item
+        }
+        skipOptionalWhitespace()
+        if (atEnd) {
+          done = true
+        } else if (current == ',') {
+          index += 1
+          skipOptionalWhitespace()
+          if (atEnd) return invalid("Client-Cert-Chain has a trailing empty list member")
+        } else {
+          return invalid("Client-Cert-Chain members must be Structured Fields Byte Sequences")
+        }
+      }
+      Right(result.toVector)
+    }
+
+    def parseByteSequenceItem(): ParseResult[Array[Byte]] =
+      for {
+        bytes <- parseCertificateByteSequence()
+        _     <- parseParameters()
+      } yield bytes
+
+    private def parseCertificateByteSequence(): ParseResult[Array[Byte]] = {
+      if (atEnd || current != ':') return invalid("Expected a Structured Fields Byte Sequence")
+      val encoded = parseByteSequenceContents() match {
+        case Left(error)  => return Left(error)
+        case Right(value) => value
+      }
+      if (encoded.isEmpty) return invalid("Client certificate Byte Sequence must not be empty")
+      if (!validBase64Syntax(encoded)) return invalid("Client certificate Byte Sequence contains invalid Base64")
+
+      val bytes =
+        try Base64.getDecoder.decode(encoded)
+        catch {
+          case _: IllegalArgumentException => return invalid("Client certificate Byte Sequence contains invalid Base64")
+        }
+      if (bytes.length > maxCertificateBytes) {
+        limit("A client certificate exceeds maxCertificateBytes")
+      } else {
+        decodedBytes.add(bytes.length).map(_ => bytes)
+      }
+    }
+
+    private def parseParameters(): ParseResult[Unit] = {
+      while (!atEnd && current == ';') {
+        index += 1
+        skipSpaces()
+        parseParameterKey() match {
+          case Left(error) => return Left(error)
+          case Right(())   => ()
+        }
+        if (!atEnd && current == '=') {
+          index += 1
+          parseBareItem() match {
+            case Left(error) => return Left(error)
+            case Right(())   => ()
+          }
+        }
+      }
+      Right(())
+    }
+
+    private def parseParameterKey(): ParseResult[Unit] = {
+      if (atEnd || (!isLowerAlpha(current) && current != '*')) {
+        return invalid("Structured Fields parameter keys must start with a lowercase letter or asterisk")
+      }
+      index += 1
+      while (!atEnd && isParameterKeyCharacter(current)) index += 1
+      Right(())
+    }
+
+    private def parseBareItem(): ParseResult[Unit] = {
+      if (atEnd) return invalid("Structured Fields parameter is missing its value")
+      current match {
+        case '-'                   => parseNumber()
+        case char if isDigit(char) => parseNumber()
+        case '"'                   => parseString()
+        case '*'                   => parseToken()
+        case char if isAlpha(char) => parseToken()
+        case ':'                   => parseParameterByteSequence()
+        case '?'                   => parseBoolean()
+        case _                     => invalid("Structured Fields parameter contains an invalid bare item")
+      }
+    }
+
+    private def parseNumber(): ParseResult[Unit] = {
+      if (current == '-') index += 1
+      val integerStart = index
+      while (!atEnd && isDigit(current)) index += 1
+      val integerDigits = index - integerStart
+      if (integerDigits == 0) return invalid("Structured Fields parameter contains an invalid number")
+
+      if (!atEnd && current == '.') {
+        if (integerDigits > 12) return invalid("Structured Fields parameter decimal has too many integer digits")
+        index += 1
+        val fractionalStart = index
+        while (!atEnd && isDigit(current)) index += 1
+        val fractionalDigits = index - fractionalStart
+        if (fractionalDigits >= 1 && fractionalDigits <= 3) Right(())
+        else invalid("Structured Fields parameter decimal must have one to three fractional digits")
+      } else {
+        if (integerDigits <= 15) Right(())
+        else invalid("Structured Fields parameter integer has too many digits")
+      }
+    }
+
+    private def parseString(): ParseResult[Unit] = {
+      index += 1
+      while (!atEnd) {
+        val char = current
+        index += 1
+        if (char == '"') return Right(())
+        if (char == '\\') {
+          if (atEnd || (current != '"' && current != '\\')) {
+            return invalid("Structured Fields parameter string contains an invalid escape")
+          }
+          index += 1
+        } else if (char < 0x20 || char > 0x7e) {
+          return invalid("Structured Fields parameter string must contain only visible ASCII or space")
+        }
+      }
+      invalid("Structured Fields parameter string is unterminated")
+    }
+
+    private def parseToken(): ParseResult[Unit] = {
+      index += 1
+      while (!atEnd && isStructuredTokenCharacter(current)) index += 1
+      Right(())
+    }
+
+    private def parseParameterByteSequence(): ParseResult[Unit] =
+      parseByteSequenceContents().flatMap { encoded =>
+        if (validBase64Syntax(encoded)) Right(())
+        else invalid("Structured Fields parameter Byte Sequence contains invalid Base64")
+      }
+
+    private def parseByteSequenceContents(): ParseResult[String] = {
+      index += 1
+      val start = index
+      while (!atEnd && current != ':') index += 1
+      if (atEnd) return invalid("Structured Fields Byte Sequence is missing its closing colon")
+      val encoded = input.substring(start, index)
+      index += 1
+      Right(encoded)
+    }
+
+    private def parseBoolean(): ParseResult[Unit] = {
+      index += 1
+      if (atEnd || (current != '0' && current != '1')) {
+        invalid("Structured Fields parameter contains an invalid boolean")
+      } else {
+        index += 1
+        Right(())
+      }
+    }
+
+    def skipSpacesAndRequireEnd(): ParseResult[Unit] = {
+      skipSpaces()
+      if (atEnd) Right(()) else invalid("Client-Cert must contain exactly one Structured Fields Byte Sequence")
+    }
+
+    private def validBase64Syntax(value: String): Boolean = {
+      var padding = false
+      var equals  = 0
+      var i       = 0
+      while (i < value.length) {
+        val char = value.charAt(i)
+        if (char == '=') {
+          padding = true
+          equals += 1
+          if (equals > 2) return false
+        } else if (padding || !isBase64Character(char)) {
+          return false
+        }
+        i += 1
+      }
+      val unpaddedLength = value.length - equals
+      if (equals == 0) value.length % 4 != 1
+      else value.length             % 4 == 0 && unpaddedLength % 4 == (if (equals == 1) 3 else 2)
+    }
+
+    private def isBase64Character(char: Char): Boolean =
+      (char >= 'A' && char <= 'Z') ||
+        (char >= 'a' && char <= 'z') ||
+        (char >= '0' && char <= '9') ||
+        char == '+' || char == '/'
+
+    private def skipSpaces(): Unit =
+      while (!atEnd && current == ' ') index += 1
+
+    private def skipOptionalWhitespace(): Unit = {
+      while (!atEnd && (current == ' ' || current == '\t')) index += 1
+    }
+
+    private def isLowerAlpha(char: Char): Boolean = char >= 'a' && char <= 'z'
+
+    private def isAlpha(char: Char): Boolean =
+      (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z')
+
+    private def isDigit(char: Char): Boolean = char >= '0' && char <= '9'
+
+    private def isParameterKeyCharacter(char: Char): Boolean =
+      isLowerAlpha(char) || isDigit(char) || char == '_' || char == '-' || char == '.' || char == '*'
+
+    private def isStructuredTokenCharacter(char: Char): Boolean =
+      isAlpha(char) ||
+        isDigit(char) ||
+        "!#$%&'*+-.^_`|~:/".indexOf(char) >= 0
+
+    private def atEnd: Boolean = index >= input.length
+    private def current: Char  = input.charAt(index)
+  }
+}

--- a/transport/server/play-server/src/main/scala/play/core/server/common/XForwardedClientCertHeaderParser.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/XForwardedClientCertHeaderParser.scala
@@ -1,0 +1,534 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.security.cert.CertificateException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.MessageDigest
+import java.util.Arrays
+import java.util.Base64
+import java.util.Locale
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
+
+import play.api.mvc.request.XForwardedClientCert
+
+/** Strict, bounded parsing for Envoy's text `X-Forwarded-Client-Cert` format. */
+private[common] object XForwardedClientCertHeaderParser {
+
+  /**
+   * Parser limits. `maxChainLength` counts chain certificates, excluding the leaf certificate that an XFCC `Chain`
+   * value repeats.
+   */
+  final case class Limits(
+      maxHeaderBytes: Long,
+      maxDecodedBytes: Long,
+      maxCertificateBytes: Long,
+      maxChainLength: Int
+  ) {
+    require(maxHeaderBytes >= 0, "maxHeaderBytes must not be negative")
+    require(maxDecodedBytes >= 0, "maxDecodedBytes must not be negative")
+    require(maxCertificateBytes >= 0, "maxCertificateBytes must not be negative")
+    require(maxChainLength >= 0, "maxChainLength must not be negative")
+  }
+
+  /**
+   * Parse a sanitized-single XFCC field.
+   *
+   * The returned vector is sequence-shaped so the request model can retain ordered assertions in a future policy,
+   * but this policy accepts at most one physical field containing exactly one information element.
+   */
+  def parse(headerValues: Seq[String], limits: Limits): Either[String, Vector[XForwardedClientCert]] = {
+    checkRawSize(headerValues, limits.maxHeaderBytes).flatMap { _ =>
+      headerValues match {
+        case Seq()      => Right(Vector.empty)
+        case Seq(value) => parseElement(value, limits).map(Vector(_))
+        case _          => Left("Sanitized X-Forwarded-Client-Cert must occur exactly once")
+      }
+    }
+  }
+
+  private def checkRawSize(values: Seq[String], maximum: Long): Either[String, Unit] = {
+    var total = 0L
+    val it    = values.iterator
+    while (it.hasNext) {
+      val value = it.next()
+      if (value == null) return Left("X-Forwarded-Client-Cert must not contain a null value")
+      val size = value.getBytes(StandardCharsets.UTF_8).length.toLong
+      if (size > maximum - total) return Left("X-Forwarded-Client-Cert exceeds maxHeaderBytes")
+      total += size
+    }
+    Right(())
+  }
+
+  private def parseElement(value: String, limits: Limits): Either[String, XForwardedClientCert] = {
+    val fields = new FieldParser(value).parse()
+    fields.flatMap { parsed =>
+      val decodedBytes = new DecodedByteBudget(limits.maxDecodedBytes)
+      for {
+        certificateFromCert   <- parseOptionalCert(parsed.certificate, limits, decodedBytes)
+        certificatesFromChain <- parseOptionalChain(parsed.chain, limits, decodedBytes)
+        normalized            <- normalizeCertificates(certificateFromCert, certificatesFromChain)
+        (certificate, chain) = normalized
+        _ <- verifyHash(parsed.hash, certificate)
+      } yield XForwardedClientCert(
+        parsed.by.toVector,
+        parsed.hash,
+        certificate,
+        chain,
+        parsed.subject,
+        parsed.uris.toVector,
+        parsed.dnsNames.toVector
+      )
+    }
+  }
+
+  private def parseOptionalCert(
+      encoded: Option[String],
+      limits: Limits,
+      decodedBytes: DecodedByteBudget
+  ): Either[String, Option[X509Certificate]] = encoded match {
+    case None        => Right(None)
+    case Some(value) =>
+      parsePem(value, 1L, limits, decodedBytes, "Cert").flatMap {
+        case Vector(certificate) => Right(Some(certificate))
+        case _                   => Left("XFCC Cert must contain exactly one PEM certificate")
+      }
+  }
+
+  private def parseOptionalChain(
+      encoded: Option[String],
+      limits: Limits,
+      decodedBytes: DecodedByteBudget
+  ): Either[String, Vector[X509Certificate]] = encoded match {
+    case None        => Right(Vector.empty)
+    case Some(value) =>
+      // Envoy's Chain includes the leaf, whereas Play's normalized chain does not.
+      val maximumCertificates = limits.maxChainLength.toLong + 1L
+      parsePem(value, maximumCertificates, limits, decodedBytes, "Chain").flatMap {
+        case Vector()     => Left("XFCC Chain must contain at least one PEM certificate")
+        case certificates => Right(certificates)
+      }
+  }
+
+  private def normalizeCertificates(
+      certificateFromCert: Option[X509Certificate],
+      certificatesFromChain: Vector[X509Certificate]
+  ): Either[String, (Option[X509Certificate], Vector[X509Certificate])] =
+    (certificateFromCert, certificatesFromChain) match {
+      case (None, Vector())                                         => Right(None -> Vector.empty)
+      case (Some(leaf), Vector())                                   => normalizedChain(leaf, Vector.empty)
+      case (None, chain)                                            => normalizedChain(chain.head, chain.tail)
+      case (Some(leaf), chain) if sameCertificate(leaf, chain.head) => normalizedChain(leaf, chain.tail)
+      case (Some(_), _)                                             => Left("XFCC Cert and Chain must assert the same leaf certificate")
+    }
+
+  private def normalizedChain(
+      leaf: X509Certificate,
+      chain: Vector[X509Certificate]
+  ): Either[String, (Option[X509Certificate], Vector[X509Certificate])] = {
+    val certificates = chain.iterator
+    while (certificates.hasNext) {
+      if (sameCertificate(leaf, certificates.next())) {
+        return Left("XFCC Chain must not repeat its leaf certificate")
+      }
+    }
+    Right(Some(leaf) -> chain)
+  }
+
+  private def verifyHash(hash: Option[String], certificate: Option[X509Certificate]): Either[String, Unit] =
+    (hash, certificate) match {
+      case (Some(expected), Some(leaf)) =>
+        val actual = hex(MessageDigest.getInstance("SHA-256").digest(leaf.getEncoded))
+        Either.cond(actual.equalsIgnoreCase(expected), (), "XFCC Hash does not match the asserted leaf certificate")
+      case _ => Right(())
+    }
+
+  private def sameCertificate(left: X509Certificate, right: X509Certificate): Boolean =
+    Arrays.equals(left.getEncoded, right.getEncoded)
+
+  private def hex(bytes: Array[Byte]): String = {
+    val characters = "0123456789abcdef"
+    val result     = new StringBuilder(bytes.length * 2)
+    var index      = 0
+    while (index < bytes.length) {
+      val value = bytes(index) & 0xff
+      result.append(characters.charAt(value >>> 4))
+      result.append(characters.charAt(value & 0x0f))
+      index += 1
+    }
+    result.result()
+  }
+
+  private def parsePem(
+      encoded: String,
+      maximumCertificates: Long,
+      limits: Limits,
+      decodedBytes: DecodedByteBudget,
+      fieldName: String
+  ): Either[String, Vector[X509Certificate]] =
+    strictPercentDecode(encoded).flatMap { bytes =>
+      parseDecodedPem(
+        new String(bytes, StandardCharsets.US_ASCII),
+        maximumCertificates,
+        limits,
+        decodedBytes,
+        fieldName
+      )
+    }
+
+  private def parseDecodedPem(
+      pem: String,
+      maximumCertificates: Long,
+      limits: Limits,
+      decodedBytes: DecodedByteBudget,
+      fieldName: String
+  ): Either[String, Vector[X509Certificate]] = {
+    val certificates = Vector.newBuilder[X509Certificate]
+    var count        = 0L
+    var index        = skipPemWhitespace(pem, 0)
+    if (index == pem.length) return Left(s"XFCC $fieldName must contain a PEM certificate")
+
+    while (index < pem.length) {
+      if (count >= maximumCertificates) {
+        return Left(
+          if (fieldName == "Cert") "XFCC Cert must contain exactly one PEM certificate"
+          else "XFCC Chain exceeds maxChainLength"
+        )
+      }
+      if (!pem.startsWith(BeginCertificate, index)) {
+        return Left(s"XFCC $fieldName contains data outside a PEM certificate")
+      }
+      val contentStart = index + BeginCertificate.length
+      val end          = pem.indexOf(EndCertificate, contentStart)
+      if (end < 0) return Left(s"XFCC $fieldName has an unterminated PEM certificate")
+
+      decodePemCertificate(pem.substring(contentStart, end), limits, decodedBytes) match {
+        case Left(error)        => return Left(error)
+        case Right(certificate) => certificates += certificate
+      }
+      count += 1
+      index = skipPemWhitespace(pem, end + EndCertificate.length)
+    }
+    Right(certificates.result())
+  }
+
+  private def strictPercentDecode(value: String): Either[String, Array[Byte]] = {
+    val result      = new Array[Byte](value.length)
+    var inputIndex  = 0
+    var outputIndex = 0
+    while (inputIndex < value.length) {
+      val char = value.charAt(inputIndex)
+      if (char == '%') {
+        if (inputIndex + 2 >= value.length) return Left("XFCC certificate contains an invalid percent escape")
+        val high = hexDigit(value.charAt(inputIndex + 1))
+        val low  = hexDigit(value.charAt(inputIndex + 2))
+        if (high < 0 || low < 0) return Left("XFCC certificate contains an invalid percent escape")
+        result(outputIndex) = ((high << 4) | low).toByte
+        inputIndex += 3
+      } else {
+        // In particular, '+' stays '+': this is URI percent decoding, not form decoding.
+        if (char > 0x7f) return Left("XFCC certificate PEM must contain only ASCII bytes")
+        result(outputIndex) = char.toByte
+        inputIndex += 1
+      }
+      outputIndex += 1
+    }
+    Right(Arrays.copyOf(result, outputIndex))
+  }
+
+  private def decodePemCertificate(
+      content: String,
+      limits: Limits,
+      decodedBytes: DecodedByteBudget
+  ): Either[String, X509Certificate] = {
+    val base64 = new StringBuilder(content.length)
+    var index  = 0
+    while (index < content.length) {
+      val char = content.charAt(index)
+      if (isPemWhitespace(char)) ()
+      else if (isBase64Character(char) || char == '=') base64.append(char)
+      else return Left("XFCC certificate PEM contains invalid Base64 data")
+      index += 1
+    }
+
+    val encoded = base64.result()
+    if (encoded.isEmpty || !validCanonicalBase64Syntax(encoded)) {
+      return Left("XFCC certificate PEM contains invalid Base64 data")
+    }
+    val bytes =
+      try Base64.getDecoder.decode(encoded)
+      catch {
+        case _: IllegalArgumentException => return Left("XFCC certificate PEM contains invalid Base64 data")
+      }
+
+    if (!Base64.getEncoder.encodeToString(bytes).equals(encoded)) {
+      Left("XFCC certificate PEM contains non-canonical Base64 data")
+    } else if (bytes.length.toLong > limits.maxCertificateBytes) {
+      Left("An XFCC certificate exceeds maxCertificateBytes")
+    } else {
+      decodedBytes.add(bytes.length).flatMap(_ => parseCertificate(bytes))
+    }
+  }
+
+  private def validCanonicalBase64Syntax(value: String): Boolean = {
+    if (value.length % 4 != 0) return false
+    var padding = false
+    var equals  = 0
+    var index   = 0
+    while (index < value.length) {
+      val char = value.charAt(index)
+      if (char == '=') {
+        padding = true
+        equals += 1
+        if (equals > 2) return false
+      } else if (padding || !isBase64Character(char)) {
+        return false
+      }
+      index += 1
+    }
+    true
+  }
+
+  private def isBase64Character(char: Char): Boolean =
+    (char >= 'A' && char <= 'Z') ||
+      (char >= 'a' && char <= 'z') ||
+      (char >= '0' && char <= '9') ||
+      char == '+' || char == '/'
+
+  private def parseCertificate(bytes: Array[Byte]): Either[String, X509Certificate] = {
+    val input = new ByteArrayInputStream(bytes)
+    try {
+      CertificateFactory.getInstance("X.509").generateCertificate(input) match {
+        case certificate: X509Certificate if input.available() == 0 && Arrays.equals(certificate.getEncoded, bytes) =>
+          Right(certificate)
+        case _: X509Certificate => Left("XFCC certificate is not one exact DER-encoded X.509 certificate")
+        case _                  => Left("XFCC certificate is not an X.509 certificate")
+      }
+    } catch {
+      case _: CertificateException => Left("XFCC certificate contains invalid X.509 data")
+      case NonFatal(_)             => Left("XFCC certificate could not be decoded")
+    }
+  }
+
+  private def skipPemWhitespace(value: String, start: Int): Int = {
+    var index = start
+    while (index < value.length && isPemWhitespace(value.charAt(index))) index += 1
+    index
+  }
+
+  private def isPemWhitespace(char: Char): Boolean =
+    char == ' ' || char == '\t' || char == '\r' || char == '\n'
+
+  private def hexDigit(char: Char): Int =
+    if (char >= '0' && char <= '9') char - '0'
+    else if (char >= 'a' && char <= 'f') char - 'a' + 10
+    else if (char >= 'A' && char <= 'F') char - 'A' + 10
+    else -1
+
+  private def isTokenCharacter(char: Char): Boolean =
+    (char >= 'a' && char <= 'z') ||
+      (char >= 'A' && char <= 'Z') ||
+      (char >= '0' && char <= '9') ||
+      "!#$%&'*+-.^_`|~".indexOf(char) >= 0
+
+  private def isInvalidValueCharacter(char: Char): Boolean =
+    char == '\r' || char == '\n' || char == 0x7f || (char < ' ' && char != '\t')
+
+  private val BeginCertificate = "-----BEGIN CERTIFICATE-----"
+  private val EndCertificate   = "-----END CERTIFICATE-----"
+
+  private final class DecodedByteBudget(maximum: Long) {
+    private var total = 0L
+
+    def add(size: Int): Either[String, Unit] = {
+      if (size.toLong > maximum - total) Left("XFCC certificates exceed maxDecodedBytes")
+      else {
+        total += size
+        Right(())
+      }
+    }
+  }
+
+  private final case class ParsedFields(
+      by: ArrayBuffer[String] = ArrayBuffer.empty,
+      var hash: Option[String] = None,
+      var certificate: Option[String] = None,
+      var chain: Option[String] = None,
+      var subject: Option[String] = None,
+      uris: ArrayBuffer[String] = ArrayBuffer.empty,
+      dnsNames: ArrayBuffer[String] = ArrayBuffer.empty,
+      var recognized: Boolean = false
+  )
+
+  private final case class ParsedValue(value: String, quoted: Boolean)
+
+  private final class FieldParser(input: String) {
+    private val result = ParsedFields()
+    private var index  = 0
+
+    def parse(): Either[String, ParsedFields] = {
+      skipOptionalWhitespace()
+      if (atEnd) return Left("X-Forwarded-Client-Cert must contain an information element")
+
+      var done = false
+      while (!done) {
+        val name = parseName() match {
+          case Left(error)  => return Left(error)
+          case Right(value) => value
+        }
+        skipOptionalWhitespace()
+        if (atEnd || current != '=') return Left("Every XFCC field must have a value")
+        index += 1
+        skipOptionalWhitespace()
+
+        val value = parseValue() match {
+          case Left(error)  => return Left(error)
+          case Right(value) => value
+        }
+        addField(name, value) match {
+          case Left(error) => return Left(error)
+          case Right(())   => ()
+        }
+
+        skipOptionalWhitespace()
+        if (atEnd) done = true
+        else if (current == ',') {
+          return Left("Sanitized X-Forwarded-Client-Cert must contain exactly one information element")
+        } else if (current == ';') {
+          index += 1
+          skipOptionalWhitespace()
+          if (atEnd || current == ',' || current == ';') return Left("XFCC contains an empty field")
+        } else {
+          return Left("XFCC fields must be separated by semicolons")
+        }
+      }
+
+      Either.cond(result.recognized, result, "XFCC must contain at least one recognized field")
+    }
+
+    private def parseName(): Either[String, String] = {
+      val start = index
+      while (!atEnd && isTokenCharacter(current)) index += 1
+      Either.cond(index > start, input.substring(start, index), "XFCC contains an invalid field name")
+    }
+
+    private def parseValue(): Either[String, ParsedValue] =
+      if (!atEnd && current == '"') parseQuotedValue()
+      else parseUnquotedValue()
+
+    private def parseQuotedValue(): Either[String, ParsedValue] = {
+      index += 1
+      val value = new StringBuilder
+      while (!atEnd) {
+        val char = current
+        if (char == '"') {
+          index += 1
+          return Right(ParsedValue(value.result(), quoted = true))
+        } else if (char == '\\') {
+          val backslashesStart = index
+          while (!atEnd && current == '\\') index += 1
+          val backslashCount = index - backslashesStart
+          if (!atEnd && current == '"' && backslashCount % 2 == 1) {
+            // Envoy wraps the whole field without adding another escaping layer. An odd backslash run keeps an
+            // RFC 2253-escaped quote inside the value, and the complete run must be preserved verbatim.
+            value.append("\\" * backslashCount)
+            value.append('"')
+            index += 1
+          } else {
+            value.append("\\" * backslashCount)
+          }
+        } else if (isInvalidValueCharacter(char)) {
+          return Left("XFCC values must not contain control characters")
+        } else {
+          value.append(char)
+          index += 1
+        }
+      }
+      Left("XFCC contains an unterminated quoted value")
+    }
+
+    private def parseUnquotedValue(): Either[String, ParsedValue] = {
+      val start = index
+      while (!atEnd && current != ';' && current != ',') {
+        if (current == '"' || current == '\\')
+          return Left("XFCC quotes and backslashes must be escaped in a quoted value")
+        if (isInvalidValueCharacter(current)) return Left("XFCC values must not contain control characters")
+        index += 1
+      }
+      var end = index
+      while (end > start && (input.charAt(end - 1) == ' ' || input.charAt(end - 1) == '\t')) end -= 1
+      Right(ParsedValue(input.substring(start, end), quoted = false))
+    }
+
+    private def addField(name: String, parsedValue: ParsedValue): Either[String, Unit] = {
+      val value = parsedValue.value
+      name.toLowerCase(Locale.ROOT) match {
+        case "by"  => addRepeated(result.by, value, "By")
+        case "uri" =>
+          // Envoy deliberately emits URI= when URI forwarding is enabled but no URI SAN exists.
+          result.recognized = true
+          if (value.nonEmpty) result.uris += value
+          Right(())
+        case "dns"  => addRepeated(result.dnsNames, value, "DNS")
+        case "hash" =>
+          result.recognized = true
+          if (result.hash.isDefined) Left("XFCC Hash must not occur more than once")
+          else if (value.length != 64 || !value.forall(hexDigit(_) >= 0))
+            Left("XFCC Hash must contain 64 hexadecimal digits")
+          else {
+            result.hash = Some(value)
+            Right(())
+          }
+        case "cert"    => addSingleton(value, result.certificate, "Cert", value => result.certificate = Some(value))
+        case "chain"   => addSingleton(value, result.chain, "Chain", value => result.chain = Some(value))
+        case "subject" =>
+          result.recognized = true
+          if (result.subject.isDefined) Left("XFCC Subject must not occur more than once")
+          else if (!parsedValue.quoted) Left("XFCC Subject must be double-quoted")
+          else {
+            // Envoy and Istio can intentionally emit Subject="".
+            result.subject = Some(value)
+            Right(())
+          }
+        case _ => Right(()) // Syntactically valid extension fields remain forward-compatible.
+      }
+    }
+
+    private def addRepeated(values: ArrayBuffer[String], value: String, name: String): Either[String, Unit] = {
+      result.recognized = true
+      if (value.isEmpty) Left(s"XFCC $name must not be empty")
+      else {
+        values += value
+        Right(())
+      }
+    }
+
+    private def addSingleton(
+        value: String,
+        existing: Option[String],
+        name: String,
+        set: String => Unit
+    ): Either[String, Unit] = {
+      result.recognized = true
+      if (existing.isDefined) Left(s"XFCC $name must not occur more than once")
+      else if (value.isEmpty) Left(s"XFCC $name must not be empty")
+      else {
+        set(value)
+        Right(())
+      }
+    }
+
+    private def skipOptionalWhitespace(): Unit =
+      while (!atEnd && (current == ' ' || current == '\t')) index += 1
+
+    private def atEnd: Boolean = index >= input.length
+    private def current: Char  = input.charAt(index)
+  }
+}

--- a/transport/server/play-server/src/test/scala/play/core/server/ServerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/ServerSpec.scala
@@ -32,6 +32,7 @@ class ServerSpec extends Specification {
       Headers(),
       TypedMap.empty,
       transport,
+      None,
       Scheme.Http,
       None
     )

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ClientCertificateHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ClientCertificateHeaderHandlerSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import java.io.ByteArrayInputStream
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Base64
+
+import com.google.common.net.InetAddresses
+import org.specs2.mutable.Specification
+import play.api.http.HeaderNames
+import play.api.mvc.request.ClientCertificateInfo
+import play.api.mvc.request.ClientCertificateSource
+import play.api.mvc.request.PeerEndpoint
+import play.api.mvc.request.TransportConnection
+import play.api.mvc.request.TransportTls
+import play.api.mvc.Headers
+import play.api.Configuration
+import play.core.server.common.ClientCertificateHeaderHandler.Config
+import play.core.server.common.ClientCertificateHeaderHandler.Off
+import play.core.server.common.ClientCertificateHeaderHandler.Rfc9440
+
+class ClientCertificateHeaderHandlerSpec extends Specification {
+  private val limits = ClientCertificateHeaderLimits(
+    maxHeaderBytes = 64 * 1024,
+    maxDecodedBytes = 64 * 1024,
+    maxCertificateBytes = 16 * 1024,
+    maxChainLength = 8
+  )
+
+  private val leafBase64 =
+    "MIIBqDCCAU6gAwIBAgIBBzAKBggqhkjOPQQDAjA6MRswGQYDVQQKDBJMZXQncyBB" +
+      "dXRoZW50aWNhdGUxGzAZBgNVBAMMEkxBIEludGVybWVkaWF0ZSBDQTAeFw0yMDAx" +
+      "MTQyMjU1MzNaFw0yMTAxMjMyMjU1MzNaMA0xCzAJBgNVBAMMAkJDMFkwEwYHKoZI" +
+      "zj0CAQYIKoZIzj0DAQcDQgAE8YnXXfaUgmnMtOXU/IncWalRhebrXmckC8vdgJ1p" +
+      "5Be5F/3YC8OthxM4+k1M6aEAEFcGzkJiNy6J84y7uzo9M6NyMHAwCQYDVR0TBAIw" +
+      "ADAfBgNVHSMEGDAWgBRm3WjLa38lbEYCuiCPct0ZaSED2DAOBgNVHQ8BAf8EBAMC" +
+      "BsAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwHQYDVR0RAQH/BBMwEYEPYmRjQGV4YW1w" +
+      "bGUuY29tMAoGCCqGSM49BAMCA0gAMEUCIBHda/r1vaL6G3VliL4/Di6YK0Q6bMje" +
+      "SkC3dFCOOB8TAiEAx/kHSB4urmiZ0NX5r5XarmPk0wmuydBVoU4hBVZ1yhk="
+
+  private val leaf = certificate(leafBase64)
+
+  "ClientCertificateHeaderHandler" should {
+    "ignore forwarded certificate fields when handling is off" in {
+      val handler = new ClientCertificateHeaderHandler(Config(Off, Nil, limits))
+
+      handler.clientCertificate(transport("127.0.0.1", Seq(leaf)), headers(HeaderNames.CLIENT_CERT -> ":bad:")) must
+        beSome[ClientCertificateInfo].like {
+          case info =>
+            info.certificate must_== leaf
+            info.source must_== ClientCertificateSource.DirectTransport
+        }
+    }
+
+    "ignore forwarded certificate fields from an untrusted direct peer" in {
+      val handler = rfcHandler("192.0.2.0/24")
+
+      handler.clientCertificate(transport("127.0.0.1", Seq(leaf)), headers(HeaderNames.CLIENT_CERT -> ":bad:")) must
+        beSome[ClientCertificateInfo].like {
+          case info => info.source must_== ClientCertificateSource.DirectTransport
+        }
+    }
+
+    "not mistake a trusted proxy certificate for the original client when fields are absent" in {
+      val handler = rfcHandler("127.0.0.1")
+
+      handler.clientCertificate(transport("127.0.0.1", Seq(leaf)), Headers()) must beNone
+    }
+
+    "select a trusted RFC 9440 client certificate" in {
+      val handler = rfcHandler("127.0.0.1")
+
+      handler.clientCertificate(
+        transport("127.0.0.1"),
+        headers(HeaderNames.CLIENT_CERT -> s":$leafBase64:")
+      ) must beSome[ClientCertificateInfo].like {
+        case info =>
+          (info.certificate.getEncoded must beEqualTo(leaf.getEncoded))
+            .and(info.source must_== ClientCertificateSource.Rfc9440)
+      }
+    }
+
+    "validate configuration eagerly" in {
+      Config(Some(config("play.http.forwarded.clientCertificates.mode" -> "rfc9440"))).mode must_== Rfc9440
+      Config(Some(config("play.http.forwarded.clientCertificates.mode" -> "unknown"))) must throwA[Exception]
+      Config(Some(config("play.http.forwarded.clientCertificates.trustedProxies" -> Seq("127.0.0.1/999")))) must
+        throwA[Exception]
+      Config(Some(config("play.http.forwarded.clientCertificates.limits.maxChainLength" -> -1))) must
+        throwA[Exception]
+    }
+  }
+
+  private def rfcHandler(trustedProxy: String): ClientCertificateHeaderHandler =
+    new ClientCertificateHeaderHandler(Config(Rfc9440, List(Subnet(trustedProxy)), limits))
+
+  private def transport(address: String, certificates: Seq[X509Certificate] = Seq.empty): TransportConnection =
+    TransportConnection(
+      PeerEndpoint(InetAddresses.forString(address), Some(443)),
+      Option.when(certificates.nonEmpty)(TransportTls(certificates))
+    )
+
+  private def headers(values: (String, String)*): Headers = new Headers(values)
+
+  private def certificate(base64: String): X509Certificate =
+    CertificateFactory
+      .getInstance("X.509")
+      .generateCertificate(new ByteArrayInputStream(Base64.getDecoder.decode(base64)))
+      .asInstanceOf[X509Certificate]
+
+  private def config(values: (String, Any)*): Configuration =
+    Configuration.from(values.toMap).withFallback(Configuration.reference)
+}

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ClientCertificateHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ClientCertificateHeaderHandlerSpec.scala
@@ -22,6 +22,7 @@ import play.api.Configuration
 import play.core.server.common.ClientCertificateHeaderHandler.Config
 import play.core.server.common.ClientCertificateHeaderHandler.Off
 import play.core.server.common.ClientCertificateHeaderHandler.Rfc9440
+import play.core.server.common.ClientCertificateHeaderHandler.XForwardedClientCertMode
 
 class ClientCertificateHeaderHandlerSpec extends Specification {
   private val limits = ClientCertificateHeaderLimits(
@@ -54,6 +55,12 @@ class ClientCertificateHeaderHandlerSpec extends Specification {
             info.certificate must_== leaf
             info.source must_== ClientCertificateSource.DirectTransport
         }
+      handler
+        .clientCertificates(
+          transport("127.0.0.1", Seq(leaf)),
+          headers(HeaderNames.X_FORWARDED_CLIENT_CERT -> "bad")
+        )
+        .xForwardedClientCertificates must beEmpty
     }
 
     "ignore forwarded certificate fields from an untrusted direct peer" in {
@@ -84,18 +91,87 @@ class ClientCertificateHeaderHandlerSpec extends Specification {
       }
     }
 
+    "retain a trusted metadata-only XFCC assertion without inventing an effective certificate" in {
+      val handler  = xfccHandler("127.0.0.1")
+      val selected = handler.clientCertificates(
+        transport("127.0.0.1", Seq(leaf)),
+        headers(
+          HeaderNames.X_FORWARDED_CLIENT_CERT ->
+            s"Hash=${"a" * 64};Subject=\"\";URI=spiffe://example.test/workload;DNS=client.example.test"
+        )
+      )
+
+      selected.clientCertificate must beNone
+      selected.xForwardedClientCertificates must beLike {
+        case Vector(assertion) =>
+          (assertion.hash must beSome("a" * 64))
+            .and(assertion.subject must beSome(""))
+            .and(assertion.uris must_== Vector("spiffe://example.test/workload"))
+            .and(assertion.dnsNames must_== Vector("client.example.test"))
+      }
+    }
+
+    "select a trusted XFCC certificate as the effective client certificate" in {
+      val handler  = xfccHandler("127.0.0.1")
+      val selected = handler.clientCertificates(
+        transport("127.0.0.1"),
+        headers(HeaderNames.X_FORWARDED_CLIENT_CERT -> s"Cert=${percentEncode(pem(leafBase64))}")
+      )
+
+      selected.clientCertificate must beSome[ClientCertificateInfo].like {
+        case info =>
+          (info.certificate.getEncoded.toVector must_== leaf.getEncoded.toVector)
+            .and(info.chain must beEmpty)
+            .and(info.source must_== ClientCertificateSource.XForwardedClientCert)
+      }
+      selected.xForwardedClientCertificates must haveSize(1)
+    }
+
+    "ignore malformed XFCC from an untrusted direct peer" in {
+      val handler  = xfccHandler("192.0.2.0/24")
+      val selected = handler.clientCertificates(
+        transport("127.0.0.1", Seq(leaf)),
+        headers(HeaderNames.X_FORWARDED_CLIENT_CERT -> "not-valid-xfcc")
+      )
+
+      selected.clientCertificate must beSome[ClientCertificateInfo].like {
+        case info => info.source must_== ClientCertificateSource.DirectTransport
+      }
+      selected.xForwardedClientCertificates must beEmpty
+    }
+
+    "not mistake a trusted proxy certificate for an absent XFCC assertion" in {
+      val selected = xfccHandler("127.0.0.1").clientCertificates(
+        transport("127.0.0.1", Seq(leaf)),
+        Headers()
+      )
+
+      selected.clientCertificate must beNone
+      selected.xForwardedClientCertificates must beEmpty
+    }
+
     "validate configuration eagerly" in {
       Config(Some(config("play.http.forwarded.clientCertificates.mode" -> "rfc9440"))).mode must_== Rfc9440
-      Config(Some(config("play.http.forwarded.clientCertificates.mode" -> "unknown"))) must throwA[Exception]
+      Config(Some(config("play.http.forwarded.clientCertificates.mode" -> "x-forwarded-client-cert"))).mode must_==
+        XForwardedClientCertMode
+      Config(Some(config("play.http.forwarded.clientCertificates.mode" -> "unknown"))) must
+        throwA[Exception]
       Config(Some(config("play.http.forwarded.clientCertificates.trustedProxies" -> Seq("127.0.0.1/999")))) must
         throwA[Exception]
       Config(Some(config("play.http.forwarded.clientCertificates.limits.maxChainLength" -> -1))) must
+        throwA[Exception]
+      Config(Some(config("play.http.forwarded.clientCertificates.xForwardedClientCert.policy" -> "append"))) must
+        throwA[Exception]
+      Config(Some(config("play.http.forwarded.clientCertificates.xForwardedClientCert.format" -> "json"))) must
         throwA[Exception]
     }
   }
 
   private def rfcHandler(trustedProxy: String): ClientCertificateHeaderHandler =
     new ClientCertificateHeaderHandler(Config(Rfc9440, List(Subnet(trustedProxy)), limits))
+
+  private def xfccHandler(trustedProxy: String): ClientCertificateHeaderHandler =
+    new ClientCertificateHeaderHandler(Config(XForwardedClientCertMode, List(Subnet(trustedProxy)), limits))
 
   private def transport(address: String, certificates: Seq[X509Certificate] = Seq.empty): TransportConnection =
     TransportConnection(
@@ -105,6 +181,28 @@ class ClientCertificateHeaderHandlerSpec extends Specification {
 
   private def headers(values: (String, String)*): Headers = new Headers(values)
 
+  private def pem(base64: String): String =
+    s"-----BEGIN CERTIFICATE-----\n$base64\n-----END CERTIFICATE-----\n"
+
+  private def percentEncode(value: String): String = {
+    val result = new StringBuilder(value.length * 3)
+    val hex    = "0123456789ABCDEF"
+    value.getBytes(java.nio.charset.StandardCharsets.US_ASCII).foreach { byte =>
+      val unsigned = byte & 0xff
+      if (
+        (unsigned >= 'a' && unsigned <= 'z') ||
+        (unsigned >= 'A' && unsigned <= 'Z') ||
+        (unsigned >= '0' && unsigned <= '9') ||
+        unsigned == '-' || unsigned == '.' || unsigned == '_' || unsigned == '~'
+      ) result.append(unsigned.toChar)
+      else {
+        result.append('%')
+        result.append(hex.charAt(unsigned >>> 4))
+        result.append(hex.charAt(unsigned & 0x0f))
+      }
+    }
+    result.result()
+  }
   private def certificate(base64: String): X509Certificate =
     CertificateFactory
       .getInstance("X.509")

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ClientCertificateHeaderHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ClientCertificateHeaderHandlerSpec.scala
@@ -43,7 +43,21 @@ class ClientCertificateHeaderHandlerSpec extends Specification {
       "bGUuY29tMAoGCCqGSM49BAMCA0gAMEUCIBHda/r1vaL6G3VliL4/Di6YK0Q6bMje" +
       "SkC3dFCOOB8TAiEAx/kHSB4urmiZ0NX5r5XarmPk0wmuydBVoU4hBVZ1yhk="
 
-  private val leaf = certificate(leafBase64)
+  private val intermediateBase64 =
+    "MIIB5jCCAYugAwIBAgIBFjAKBggqhkjOPQQDAjBWMQswCQYDVQQGEwJVUzEbMBkG" +
+      "A1UECgwSTGV0J3MgQXV0aGVudGljYXRlMSowKAYDVQQDDCFMZXQncyBBdXRoZW50" +
+      "aWNhdGUgUm9vdCBBdXRob3JpdHkwHhcNMjAwMTE0MjEzMjMwWhcNMzAwMTExMjEz" +
+      "MjMwWjA6MRswGQYDVQQKDBJMZXQncyBBdXRoZW50aWNhdGUxGzAZBgNVBAMMEkxB" +
+      "IEludGVybWVkaWF0ZSBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJf+aA54" +
+      "RC5pyLAR5yfXVYmNpgd+CGUTDp2KOGhc0gK91zxhHesEYkdXkpS2UN8Kati+yHtW" +
+      "CV3kkhCngGyv7RqjZjBkMB0GA1UdDgQWBBRm3WjLa38lbEYCuiCPct0ZaSED2DAf" +
+      "BgNVHSMEGDAWgBTEA2Q6eecKu9g9yb5glbkhhVINGDASBgNVHRMBAf8ECDAGAQH/" +
+      "AgEAMA4GA1UdDwEB/wQEAwIBhjAKBggqhkjOPQQDAgNJADBGAiEA5pLvaFwRRkxo" +
+      "mIAtDIwg9D7gC1xzxBl4r28EzmSO1pcCIQCJUShpSXO9HDIQMUgH69fNDEMHXD3R" +
+      "RX5gP7kuu2KGMg=="
+
+  private val leaf         = certificate(leafBase64)
+  private val intermediate = certificate(intermediateBase64)
 
   "ClientCertificateHeaderHandler" should {
     "ignore forwarded certificate fields when handling is off" in {
@@ -83,12 +97,60 @@ class ClientCertificateHeaderHandlerSpec extends Specification {
 
       handler.clientCertificate(
         transport("127.0.0.1"),
-        headers(HeaderNames.CLIENT_CERT -> s":$leafBase64:")
+        headers(HeaderNames.CLIENT_CERT -> byteSequence(leafBase64))
       ) must beSome[ClientCertificateInfo].like {
         case info =>
           (info.certificate.getEncoded must beEqualTo(leaf.getEncoded))
             .and(info.source must_== ClientCertificateSource.Rfc9440)
       }
+    }
+
+    "preserve valid forwarded certificate metadata when constructing an error request" in {
+      val selected = rfcHandler("127.0.0.1").clientCertificatesForErrorRequest(
+        transport("127.0.0.1", Seq(intermediate)),
+        headers(HeaderNames.CLIENT_CERT -> byteSequence(leafBase64)),
+        new IllegalArgumentException("invalid request target")
+      )
+
+      selected.clientCertificate must beSome[ClientCertificateInfo].like {
+        case info =>
+          (info.certificate.getEncoded must beEqualTo(leaf.getEncoded))
+            .and(info.source must_== ClientCertificateSource.Rfc9440)
+      }
+    }
+
+    "omit effective certificate metadata after a forwarding error instead of selecting the proxy certificate" in {
+      val handler         = xfccHandler("127.0.0.1")
+      val directTransport = transport("127.0.0.1", Seq(leaf))
+      val requestHeaders  = headers(HeaderNames.X_FORWARDED_CLIENT_CERT -> "not-valid-xfcc")
+      val requestFailure  = scala.util.Try(handler.clientCertificates(directTransport, requestHeaders)).failed.get
+      val selected        =
+        handler.clientCertificatesForErrorRequest(directTransport, requestHeaders, requestFailure)
+
+      selected.clientCertificate must beNone
+      selected.xForwardedClientCertificates must beEmpty
+    }
+
+    "not repeat certificate selection after it failed during normal request conversion" in {
+      val handler         = xfccHandler("127.0.0.1")
+      val directTransport = transport("127.0.0.1", Seq(intermediate))
+      val requestFailure  = scala.util
+        .Try(
+          handler.clientCertificates(
+            directTransport,
+            headers(HeaderNames.X_FORWARDED_CLIENT_CERT -> "not-valid-xfcc")
+          )
+        )
+        .failed
+        .get
+
+      val selected = handler.clientCertificatesForErrorRequest(
+        directTransport,
+        headers(HeaderNames.X_FORWARDED_CLIENT_CERT -> s"Cert=${percentEncode(pem(leafBase64))}"),
+        requestFailure
+      )
+
+      selected must_== ClientCertificateHeaderHandler.Selection.empty
     }
 
     "retain a trusted metadata-only XFCC assertion without inventing an effective certificate" in {
@@ -181,6 +243,8 @@ class ClientCertificateHeaderHandlerSpec extends Specification {
 
   private def headers(values: (String, String)*): Headers = new Headers(values)
 
+  private def byteSequence(base64: String): String = s":$base64:"
+
   private def pem(base64: String): String =
     s"-----BEGIN CERTIFICATE-----\n$base64\n-----END CERTIFICATE-----\n"
 
@@ -203,6 +267,7 @@ class ClientCertificateHeaderHandlerSpec extends Specification {
     }
     result.result()
   }
+
   private def certificate(base64: String): X509Certificate =
     CertificateFactory
       .getInstance("X.509")

--- a/transport/server/play-server/src/test/scala/play/core/server/common/Rfc9440ClientCertificateParserSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/Rfc9440ClientCertificateParserSpec.scala
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Base64
+
+import org.specs2.mutable.Specification
+import play.api.http.HeaderNames
+import play.api.mvc.request.ClientCertificateInfo
+import play.api.mvc.request.ClientCertificateSource
+import play.api.mvc.Headers
+
+class Rfc9440ClientCertificateParserSpec extends Specification {
+  private val limits = ClientCertificateHeaderLimits(
+    maxHeaderBytes = 64 * 1024,
+    maxDecodedBytes = 64 * 1024,
+    maxCertificateBytes = 16 * 1024,
+    maxChainLength = 8
+  )
+
+  private val leafBase64 =
+    "MIIBqDCCAU6gAwIBAgIBBzAKBggqhkjOPQQDAjA6MRswGQYDVQQKDBJMZXQncyBB" +
+      "dXRoZW50aWNhdGUxGzAZBgNVBAMMEkxBIEludGVybWVkaWF0ZSBDQTAeFw0yMDAx" +
+      "MTQyMjU1MzNaFw0yMTAxMjMyMjU1MzNaMA0xCzAJBgNVBAMMAkJDMFkwEwYHKoZI" +
+      "zj0CAQYIKoZIzj0DAQcDQgAE8YnXXfaUgmnMtOXU/IncWalRhebrXmckC8vdgJ1p" +
+      "5Be5F/3YC8OthxM4+k1M6aEAEFcGzkJiNy6J84y7uzo9M6NyMHAwCQYDVR0TBAIw" +
+      "ADAfBgNVHSMEGDAWgBRm3WjLa38lbEYCuiCPct0ZaSED2DAOBgNVHQ8BAf8EBAMC" +
+      "BsAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwHQYDVR0RAQH/BBMwEYEPYmRjQGV4YW1w" +
+      "bGUuY29tMAoGCCqGSM49BAMCA0gAMEUCIBHda/r1vaL6G3VliL4/Di6YK0Q6bMje" +
+      "SkC3dFCOOB8TAiEAx/kHSB4urmiZ0NX5r5XarmPk0wmuydBVoU4hBVZ1yhk="
+
+  private val intermediateBase64 =
+    "MIIB5jCCAYugAwIBAgIBFjAKBggqhkjOPQQDAjBWMQswCQYDVQQGEwJVUzEbMBkG" +
+      "A1UECgwSTGV0J3MgQXV0aGVudGljYXRlMSowKAYDVQQDDCFMZXQncyBBdXRoZW50" +
+      "aWNhdGUgUm9vdCBBdXRob3JpdHkwHhcNMjAwMTE0MjEzMjMwWhcNMzAwMTExMjEz" +
+      "MjMwWjA6MRswGQYDVQQKDBJMZXQncyBBdXRoZW50aWNhdGUxGzAZBgNVBAMMEkxB" +
+      "IEludGVybWVkaWF0ZSBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJf+aA54" +
+      "RC5pyLAR5yfXVYmNpgd+CGUTDp2KOGhc0gK91zxhHesEYkdXkpS2UN8Kati+yHtW" +
+      "CV3kkhCngGyv7RqjZjBkMB0GA1UdDgQWBBRm3WjLa38lbEYCuiCPct0ZaSED2DAf" +
+      "BgNVHSMEGDAWgBTEA2Q6eecKu9g9yb5glbkhhVINGDASBgNVHRMBAf8ECDAGAQH/" +
+      "AgEAMA4GA1UdDwEB/wQEAwIBhjAKBggqhkjOPQQDAgNJADBGAiEA5pLvaFwRRkxo" +
+      "mIAtDIwg9D7gC1xzxBl4r28EzmSO1pcCIQCJUShpSXO9HDIQMUgH69fNDEMHXD3R" +
+      "RX5gP7kuu2KGMg=="
+
+  private val rootBase64 =
+    "MIICBjCCAaygAwIBAgIJAKS0yiqKtlhoMAoGCCqGSM49BAMCMFYxCzAJBgNVBAYT" +
+      "AlVTMRswGQYDVQQKDBJMZXQncyBBdXRoZW50aWNhdGUxKjAoBgNVBAMMIUxldCdz" +
+      "IEF1dGhlbnRpY2F0ZSBSb290IEF1dGhvcml0eTAeFw0yMDAxMTQyMTI1NDVaFw00" +
+      "MDAxMDkyMTI1NDVaMFYxCzAJBgNVBAYTAlVTMRswGQYDVQQKDBJMZXQncyBBdXRo" +
+      "ZW50aWNhdGUxKjAoBgNVBAMMIUxldCdzIEF1dGhlbnRpY2F0ZSBSb290IEF1dGhv" +
+      "cml0eTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFoaHU+Z5bPKmGzlYXtCf+E6" +
+      "HYj62fORaHDOrt+yyh3H/rTcs7ynFfGn+gyFsrSP3Ez88rajv+U2NfD0o0uZ4Pmj" +
+      "YzBhMB0GA1UdDgQWBBTEA2Q6eecKu9g9yb5glbkhhVINGDAfBgNVHSMEGDAWgBTE" +
+      "A2Q6eecKu9g9yb5glbkhhVINGDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE" +
+      "AwIBhjAKBggqhkjOPQQDAgNIADBFAiEAmAeg1ycKHriqHnaD4M/UDBpQRpkmdcRF" +
+      "YGMg1Qyrkx4CIB4ivz3wQcQkGhcsUZ1SOImd/lq1Q0FLf09rGfLQPWDc"
+
+  private val leaf         = certificate(leafBase64)
+  private val intermediate = certificate(intermediateBase64)
+  private val root         = certificate(rootBase64)
+
+  "Rfc9440ClientCertificateParser" should {
+    "parse the RFC 9440 Appendix A leaf certificate" in {
+      parse(headers(HeaderNames.CLIENT_CERT -> byteSequence(leafBase64))) must beRight.like {
+        case Some(info) =>
+          (info.certificate.getEncoded must beEqualTo(leaf.getEncoded))
+            .and(info.chain must beEmpty)
+            .and(info.source must_== ClientCertificateSource.Rfc9440)
+      }
+    }
+
+    "accept an unpadded RFC 8941 Byte Sequence" in {
+      val unpadded = leafBase64.reverse.dropWhile(_ == '=').reverse
+
+      parse(headers(HeaderNames.CLIENT_CERT -> byteSequence(unpadded))) must beRight(beSome[ClientCertificateInfo])
+    }
+
+    "accept and ignore valid Structured Fields parameters" in {
+      val leafItem =
+        s" ${byteSequence(leafBase64)};flag;disabled=?0;count=-42;ratio=1.25;" +
+          "label=\"client\";kind=spiffe/client;data=:AQI:;flag=?0 "
+
+      parse(headers(HeaderNames.CLIENT_CERT -> leafItem)) must beRight.like {
+        case Some(info) =>
+          (info.certificate.getEncoded must beEqualTo(leaf.getEncoded))
+            .and(info.chain must beEmpty)
+      }
+    }
+
+    "preserve certificate chain order across repeated fields" in {
+      val requestHeaders = new Headers(
+        Seq(
+          HeaderNames.CLIENT_CERT       -> byteSequence(leafBase64),
+          HeaderNames.CLIENT_CERT_CHAIN -> s"${byteSequence(intermediateBase64)};role=intermediate",
+          HeaderNames.CLIENT_CERT_CHAIN -> s"\t${byteSequence(rootBase64)};role=root"
+        )
+      )
+
+      parse(requestHeaders) must beRight.like {
+        case Some(info) =>
+          info.chain.map(_.getEncoded) must contain(exactly(intermediate.getEncoded, root.getEncoded).inOrder)
+      }
+    }
+
+    "accept an explicit empty Structured Fields chain list" in {
+      Seq("", "   ").forall { chainValue =>
+        parse(
+          headers(
+            HeaderNames.CLIENT_CERT       -> byteSequence(leafBase64),
+            HeaderNames.CLIENT_CERT_CHAIN -> chainValue
+          )
+        ).exists(_.exists(_.chain.isEmpty))
+      } must beTrue
+    }
+
+    "ignore a chain with an empty member while retaining a valid leaf" in {
+      val chainItem     = byteSequence(intermediateBase64)
+      val invalidChains = Seq(
+        Seq("", chainItem),
+        Seq(chainItem, ""),
+        Seq("", "")
+      )
+
+      invalidChains.forall { chainValues =>
+        val requestHeaders = new Headers(
+          Seq(HeaderNames.CLIENT_CERT -> byteSequence(leafBase64)) ++
+            chainValues.map(HeaderNames.CLIENT_CERT_CHAIN -> _)
+        )
+        parse(requestHeaders).exists(_.exists(info => info.certificate == leaf && info.chain.isEmpty))
+      } must beTrue
+    }
+
+    "ignore duplicate singleton leaf fields" in {
+      val requestHeaders = new Headers(Seq.empty) {
+        override def getAll(name: String): Seq[String] =
+          if (name.equalsIgnoreCase(HeaderNames.CLIENT_CERT)) {
+            Vector(byteSequence(leafBase64), byteSequence(leafBase64))
+          } else Vector.empty
+      }
+
+      parse(requestHeaders) must beRight(beNone)
+    }
+
+    "ignore a leaf with malformed Structured Fields parameters or singleton tab whitespace" in {
+      val leafItem     = byteSequence(leafBase64)
+      val invalidItems = Seq(
+        s"\t$leafItem",
+        s"$leafItem\t",
+        s"$leafItem;Foo",
+        s"$leafItem;",
+        s"$leafItem;\tfoo",
+        s"$leafItem;foo =1",
+        s"$leafItem;foo= 1",
+        s"$leafItem;foo=-",
+        s"$leafItem;foo=1.",
+        s"$leafItem;foo=\"bad\\escape\"",
+        s"$leafItem;foo=:A:",
+        s"$leafItem;foo=?2"
+      )
+
+      invalidItems.forall { item =>
+        parse(headers(HeaderNames.CLIENT_CERT -> item)).contains(None)
+      } must beTrue
+    }
+
+    "ignore a chain with a tab before its first Structured Fields member" in {
+      parse(
+        headers(
+          HeaderNames.CLIENT_CERT       -> byteSequence(leafBase64),
+          HeaderNames.CLIENT_CERT_CHAIN -> s"\t${byteSequence(intermediateBase64)}"
+        )
+      ) must beRight.like {
+        case Some(info) => info.chain must beEmpty
+      }
+    }
+
+    "ignore a chain that repeats the leaf certificate" in {
+      parse(
+        headers(
+          HeaderNames.CLIENT_CERT       -> byteSequence(leafBase64),
+          HeaderNames.CLIENT_CERT_CHAIN -> byteSequence(leafBase64)
+        )
+      ) must beRight.like {
+        case Some(info) => info.chain must beEmpty
+      }
+    }
+
+    "ignore a chain without a leaf" in {
+      parse(headers(HeaderNames.CLIENT_CERT_CHAIN -> byteSequence(intermediateBase64))) must beRight(beNone)
+    }
+
+    "ignore a leaf with malformed Base64 or non-certificate DER" in {
+      parse(headers(HeaderNames.CLIENT_CERT -> ":not base64:")) must beRight(beNone)
+      parse(
+        headers(HeaderNames.CLIENT_CERT -> byteSequence(Base64.getEncoder.encodeToString(Array[Byte](1, 2, 3))))
+      ) must beRight(beNone)
+    }
+
+    "ignore malformed certificate data in the chain while retaining a valid leaf" in {
+      parse(
+        headers(
+          HeaderNames.CLIENT_CERT       -> byteSequence(leafBase64),
+          HeaderNames.CLIENT_CERT_CHAIN -> byteSequence(Base64.getEncoder.encodeToString(Array[Byte](1, 2, 3)))
+        )
+      ) must beRight.like {
+        case Some(info) =>
+          (info.certificate must_== leaf)
+            .and(info.chain must beEmpty)
+      }
+    }
+
+    "enforce header, decoded-byte, certificate, and chain limits" in {
+      val leafHeader = headers(HeaderNames.CLIENT_CERT -> byteSequence(leafBase64))
+
+      parse(leafHeader, limits.copy(maxHeaderBytes = 1)) must beLeft
+      parse(leafHeader, limits.copy(maxDecodedBytes = 1)) must beLeft
+      parse(leafHeader, limits.copy(maxCertificateBytes = 1)) must beLeft
+      parse(
+        headers(
+          HeaderNames.CLIENT_CERT       -> byteSequence(leafBase64),
+          HeaderNames.CLIENT_CERT_CHAIN -> byteSequence(intermediateBase64)
+        ),
+        limits.copy(maxChainLength = 0)
+      ) must beLeft
+      parse(
+        headers(HeaderNames.CLIENT_CERT_CHAIN -> byteSequence(intermediateBase64)),
+        limits.copy(maxChainLength = 0)
+      ) must beLeft
+
+      val repeatedEmptyChain = headers(
+        HeaderNames.CLIENT_CERT_CHAIN -> "",
+        HeaderNames.CLIENT_CERT_CHAIN -> "",
+        HeaderNames.CLIENT_CERT_CHAIN -> ""
+      )
+      parse(repeatedEmptyChain, limits.copy(maxHeaderBytes = 2)) must beRight(beNone)
+      parse(repeatedEmptyChain, limits.copy(maxHeaderBytes = 1)) must beLeft
+    }
+
+    "accept exact RFC 9440 limits and reject one unit less" in {
+      val leafValue    = byteSequence(leafBase64)
+      val leafHeader   = headers(HeaderNames.CLIENT_CERT -> leafValue)
+      val rawBytes     = leafValue.getBytes(StandardCharsets.UTF_8).length.toLong
+      val decodedBytes = leaf.getEncoded.length.toLong
+
+      parse(leafHeader, limits.copy(maxHeaderBytes = rawBytes)) must beRight(beSome[ClientCertificateInfo])
+      parse(leafHeader, limits.copy(maxHeaderBytes = rawBytes - 1)) must beLeft
+
+      parse(leafHeader, limits.copy(maxDecodedBytes = decodedBytes)) must beRight(beSome[ClientCertificateInfo])
+      parse(leafHeader, limits.copy(maxDecodedBytes = decodedBytes - 1)) must beLeft
+
+      parse(leafHeader, limits.copy(maxCertificateBytes = decodedBytes)) must beRight(beSome[ClientCertificateInfo])
+      parse(leafHeader, limits.copy(maxCertificateBytes = decodedBytes - 1)) must beLeft
+
+      val twoCertificateChain = headers(
+        HeaderNames.CLIENT_CERT       -> leafValue,
+        HeaderNames.CLIENT_CERT_CHAIN -> s"${byteSequence(intermediateBase64)},${byteSequence(rootBase64)}"
+      )
+      parse(twoCertificateChain, limits.copy(maxChainLength = 2)) must beRight.like {
+        case Some(info) => info.chain must contain(exactly(intermediate, root).inOrder)
+      }
+      parse(twoCertificateChain, limits.copy(maxChainLength = 1)) must beLeft
+    }
+  }
+
+  private def parse(
+      requestHeaders: Headers,
+      parserLimits: ClientCertificateHeaderLimits = limits
+  ): Either[String, Option[ClientCertificateInfo]] =
+    Rfc9440ClientCertificateParser.parse(requestHeaders, parserLimits)
+
+  private def headers(values: (String, String)*): Headers = new Headers(values)
+
+  private def byteSequence(base64: String): String = s":$base64:"
+
+  private def certificate(base64: String): X509Certificate =
+    CertificateFactory
+      .getInstance("X.509")
+      .generateCertificate(new ByteArrayInputStream(Base64.getDecoder.decode(base64)))
+      .asInstanceOf[X509Certificate]
+}

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -55,6 +55,7 @@ class ServerResultUtilsSpec extends Specification {
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
       transport,
       None,
+      Vector.empty,
       remote,
       Scheme.Http,
       None,

--- a/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -54,6 +54,7 @@ class ServerResultUtilsSpec extends Specification {
     val remote    = RemoteInfo.fromPeer(transport.peer)
     new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
       transport,
+      None,
       remote,
       Scheme.Http,
       None,
@@ -128,6 +129,7 @@ class ServerResultUtilsSpec extends Specification {
       Headers(),
       TypedMap.empty,
       transport,
+      None,
       Scheme.Http,
       None
     )

--- a/transport/server/play-server/src/test/scala/play/core/server/common/XForwardedClientCertHeaderParserSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/XForwardedClientCertHeaderParserSpec.scala
@@ -1,0 +1,307 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.core.server.common
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.MessageDigest
+import java.util.Base64
+
+import org.specs2.mutable.Specification
+import play.api.mvc.request.XForwardedClientCert
+import play.core.server.common.XForwardedClientCertHeaderParser.Limits
+
+class XForwardedClientCertHeaderParserSpec extends Specification {
+  private val limits = Limits(
+    maxHeaderBytes = 64 * 1024,
+    maxDecodedBytes = 64 * 1024,
+    maxCertificateBytes = 16 * 1024,
+    maxChainLength = 8
+  )
+
+  private val leafBase64 =
+    "MIIBqDCCAU6gAwIBAgIBBzAKBggqhkjOPQQDAjA6MRswGQYDVQQKDBJMZXQncyBB" +
+      "dXRoZW50aWNhdGUxGzAZBgNVBAMMEkxBIEludGVybWVkaWF0ZSBDQTAeFw0yMDAx" +
+      "MTQyMjU1MzNaFw0yMTAxMjMyMjU1MzNaMA0xCzAJBgNVBAMMAkJDMFkwEwYHKoZI" +
+      "zj0CAQYIKoZIzj0DAQcDQgAE8YnXXfaUgmnMtOXU/IncWalRhebrXmckC8vdgJ1p" +
+      "5Be5F/3YC8OthxM4+k1M6aEAEFcGzkJiNy6J84y7uzo9M6NyMHAwCQYDVR0TBAIw" +
+      "ADAfBgNVHSMEGDAWgBRm3WjLa38lbEYCuiCPct0ZaSED2DAOBgNVHQ8BAf8EBAMC" +
+      "BsAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwHQYDVR0RAQH/BBMwEYEPYmRjQGV4YW1w" +
+      "bGUuY29tMAoGCCqGSM49BAMCA0gAMEUCIBHda/r1vaL6G3VliL4/Di6YK0Q6bMje" +
+      "SkC3dFCOOB8TAiEAx/kHSB4urmiZ0NX5r5XarmPk0wmuydBVoU4hBVZ1yhk="
+
+  private val intermediateBase64 =
+    "MIIB5jCCAYugAwIBAgIBFjAKBggqhkjOPQQDAjBWMQswCQYDVQQGEwJVUzEbMBkG" +
+      "A1UECgwSTGV0J3MgQXV0aGVudGljYXRlMSowKAYDVQQDDCFMZXQncyBBdXRoZW50" +
+      "aWNhdGUgUm9vdCBBdXRob3JpdHkwHhcNMjAwMTE0MjEzMjMwWhcNMzAwMTExMjEz" +
+      "MjMwWjA6MRswGQYDVQQKDBJMZXQncyBBdXRoZW50aWNhdGUxGzAZBgNVBAMMEkxB" +
+      "IEludGVybWVkaWF0ZSBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJf+aA54" +
+      "RC5pyLAR5yfXVYmNpgd+CGUTDp2KOGhc0gK91zxhHesEYkdXkpS2UN8Kati+yHtW" +
+      "CV3kkhCngGyv7RqjZjBkMB0GA1UdDgQWBBRm3WjLa38lbEYCuiCPct0ZaSED2DAf" +
+      "BgNVHSMEGDAWgBTEA2Q6eecKu9g9yb5glbkhhVINGDASBgNVHRMBAf8ECDAGAQH/" +
+      "AgEAMA4GA1UdDwEB/wQEAwIBhjAKBggqhkjOPQQDAgNJADBGAiEA5pLvaFwRRkxo" +
+      "mIAtDIwg9D7gC1xzxBl4r28EzmSO1pcCIQCJUShpSXO9HDIQMUgH69fNDEMHXD3R" +
+      "RX5gP7kuu2KGMg=="
+
+  private val leaf         = certificate(leafBase64)
+  private val intermediate = certificate(intermediateBase64)
+  private val leafHash     = sha256(leaf)
+
+  "XForwardedClientCertHeaderParser" should {
+    "return no assertions when the field is absent" in {
+      parse() must beRight(Vector.empty[XForwardedClientCert])
+    }
+
+    "parse metadata-only assertions and retain repeated fields in order" in {
+      parse(
+        s"bY=proxy-a;By=proxy-b;HASH=${leafHash.toUpperCase};" +
+          "Subject=\"CN=client, O=Example; unit=one\\\"two\\three\";" +
+          "URI=spiffe://example.test/workload;uri=https://example.test/client;" +
+          "DNS=first.example.test;dns=second.example.test;Future=accepted"
+      ) must beRight.like {
+        case Vector(assertion) =>
+          (assertion.by must_== Vector("proxy-a", "proxy-b"))
+            .and(assertion.hash must beSome(leafHash.toUpperCase))
+            .and(assertion.certificate must beNone)
+            .and(assertion.chain must beEmpty)
+            .and(assertion.subject must beSome("CN=client, O=Example; unit=one\\\"two\\three"))
+            .and(assertion.uris must_== Vector("spiffe://example.test/workload", "https://example.test/client"))
+            .and(assertion.dnsNames must_== Vector("first.example.test", "second.example.test"))
+      }
+    }
+
+    "allow an explicitly empty Subject" in {
+      parse("Subject=\"\"") must beRight.like {
+        case Vector(assertion) => assertion.subject must beSome("")
+      }
+    }
+
+    "preserve RFC 2253 Subject escapes while recognizing escaped quotes" in {
+      Seq(
+        "Subject=\"CN=Doe\\, John\""         -> "CN=Doe\\, John",
+        "Subject=\"CN=one\\+two\""           -> "CN=one\\+two",
+        "Subject=\"CN=one\\;two\""           -> "CN=one\\;two",
+        "Subject=\"CN=leading\\ space\""     -> "CN=leading\\ space",
+        "Subject=\"CN=line\\0Dbreak\""       -> "CN=line\\0Dbreak",
+        "Subject=\"CN=one\\\\two\""          -> "CN=one\\\\two",
+        ("Subject=\"CN=one" + "\\\\" + "\"") -> ("CN=one" + "\\\\"),
+        ("Subject=\"CN=one" + "\\\"" + "\"") -> ("CN=one" + "\\\"")
+      ).forall {
+        case (header, expected) =>
+          parse(header) match {
+            case Right(Vector(assertion)) => assertion.subject.contains(expected)
+            case _                        => false
+          }
+      } must beTrue
+    }
+
+    "accept Envoy's empty URI marker without inventing an identity" in {
+      Seq("URI=", "URI=\"\"").forall { header =>
+        parse(header) match {
+          case Right(Vector(assertion)) => assertion.uris.isEmpty
+          case _                        => false
+        }
+      } must beTrue
+    }
+
+    "retain equals signs in URI values" in {
+      parse("URI=\"https://example.test/client?key=value\"") must beRight.like {
+        case Vector(assertion) => assertion.uris must_== Vector("https://example.test/client?key=value")
+      }
+      parse("URI=https://example.test/client?key=value") must beRight.like {
+        case Vector(assertion) => assertion.uris must_== Vector("https://example.test/client?key=value")
+      }
+    }
+
+    "parse Cert, preserve literal plus signs, and verify its SHA-256 Hash" in {
+      // Only line endings are escaped. A form decoder would turn the '+' in this PEM into spaces and corrupt it.
+      val encodedPem = pem(leafBase64).replace("\n", "%0A")
+
+      parse(s"Hash=${leafHash.toUpperCase};Cert=\"$encodedPem\"") must beRight.like {
+        case Vector(assertion) =>
+          (assertion.certificate.map(_.getEncoded.toVector) must beSome(leaf.getEncoded.toVector))
+            .and(assertion.chain must beEmpty)
+      }
+    }
+
+    "derive the leaf from Chain and retain only the remaining chain" in {
+      val encodedChain = percentEncode(pem(leafBase64) + pem(intermediateBase64))
+
+      parse(s"Chain=$encodedChain") must beRight.like {
+        case Vector(assertion) =>
+          (assertion.certificate.map(_.getEncoded.toVector) must beSome(leaf.getEncoded.toVector))
+            .and(assertion.chain.map(_.getEncoded.toVector) must_== Vector(intermediate.getEncoded.toVector))
+      }
+    }
+
+    "accept Envoy's quoted Chain value" in {
+      val encodedChain = percentEncode(pem(leafBase64) + pem(intermediateBase64))
+
+      parse(s"""Chain="$encodedChain"""") must beRight.like {
+        case Vector(assertion) =>
+          (assertion.certificate.map(_.getEncoded.toVector) must beSome(leaf.getEncoded.toVector))
+            .and(assertion.chain.map(_.getEncoded.toVector) must_== Vector(intermediate.getEncoded.toVector))
+      }
+    }
+
+    "accept matching Cert and Chain values" in {
+      val encodedCert  = percentEncode(pem(leafBase64))
+      val encodedChain = percentEncode(pem(leafBase64) + pem(intermediateBase64))
+
+      parse(s"Cert=$encodedCert;Chain=$encodedChain") must beRight.like {
+        case Vector(assertion) =>
+          assertion.certificates.map(_.getEncoded.toVector) must_==
+            Vector(leaf.getEncoded.toVector, intermediate.getEncoded.toVector)
+      }
+    }
+
+    "reject conflicting Cert and Chain leaves" in {
+      parse(s"Cert=${percentEncode(pem(leafBase64))};Chain=${percentEncode(pem(intermediateBase64))}") must beLeft
+    }
+
+    "reject a Chain that repeats its leaf" in {
+      val repeatedLeafChain = percentEncode(pem(leafBase64) + pem(intermediateBase64) + pem(leafBase64))
+
+      parse(s"Chain=$repeatedLeafChain") must beLeft
+    }
+
+    "reject a Hash that does not match an asserted certificate while permitting Hash-only metadata" in {
+      val wrongHash = "0" * 64
+
+      parse(s"Hash=$wrongHash") must beRight
+      parse(s"Hash=$wrongHash;Cert=${percentEncode(pem(leafBase64))}") must beLeft
+    }
+
+    "reject repeated physical fields and multiple information elements" in {
+      parse("URI=spiffe://one", "URI=spiffe://two") must beLeft
+      parse("URI=spiffe://one,URI=spiffe://two") must beLeft
+      parse("Subject=\"a,b\"") must beRight
+    }
+
+    "reject duplicate singleton fields case-insensitively" in {
+      Seq(
+        s"Hash=$leafHash;hAsH=$leafHash",
+        "Subject=\"one\";subject=\"two\"",
+        s"Cert=${percentEncode(pem(leafBase64))};cert=${percentEncode(pem(leafBase64))}",
+        s"Chain=${percentEncode(pem(leafBase64))};chain=${percentEncode(pem(leafBase64))}"
+      ).forall(value => parse(value).isLeft) must beTrue
+    }
+
+    "reject malformed fields and assertions without recognized metadata" in {
+      Seq(
+        "Future=accepted",
+        "By=",
+        "DNS=",
+        "URI=spiffe://client;",
+        "Subject=unquoted",
+        "URI=\"unterminated",
+        "URI=spiffe://client;;DNS=client.example",
+        "URI spiffe://client",
+        "=value",
+        ""
+      ).forall(value => parse(value).isLeft) must beTrue
+    }
+
+    "reject malformed Hash, percent encoding, PEM, and certificate data" in {
+      val nonCertificate = percentEncode(pem(Base64.getEncoder.encodeToString(Array[Byte](1, 2, 3))))
+      Seq(
+        "Hash=abc",
+        s"Hash=${"g" * 64}",
+        "Cert=%ZZ",
+        "Cert=not-a-pem",
+        s"Cert=$nonCertificate",
+        s"Cert=${percentEncode(pem(leafBase64) + "garbage")}",
+        s"Cert=${percentEncode(pem(leafBase64) + pem(intermediateBase64))}"
+      ).forall(value => parse(value).isLeft) must beTrue
+    }
+
+    "enforce raw, decoded, per-certificate, and chain limits" in {
+      val certHeader  = s"Cert=${percentEncode(pem(leafBase64))}"
+      val chainHeader = s"Chain=${percentEncode(pem(leafBase64) + pem(intermediateBase64))}"
+
+      parseWith(limits.copy(maxHeaderBytes = 1), certHeader) must beLeft
+      parseWith(limits.copy(maxDecodedBytes = 1), certHeader) must beLeft
+      parseWith(limits.copy(maxCertificateBytes = 1), certHeader) must beLeft
+      parseWith(limits.copy(maxChainLength = 0), chainHeader) must beLeft
+      parseWith(limits.copy(maxChainLength = 0), s"Chain=${percentEncode(pem(leafBase64))}") must beRight
+    }
+
+    "accept exact XFCC limits and reject one unit less" in {
+      val certHeader       = s"Cert=${percentEncode(pem(leafBase64))}"
+      val rawBytes         = certHeader.getBytes(StandardCharsets.UTF_8).length.toLong
+      val certificateBytes = leaf.getEncoded.length.toLong
+
+      parseWith(limits.copy(maxHeaderBytes = rawBytes), certHeader) must beRight
+      parseWith(limits.copy(maxHeaderBytes = rawBytes - 1), certHeader) must beLeft
+
+      parseWith(limits.copy(maxDecodedBytes = certificateBytes), certHeader) must beRight
+      parseWith(limits.copy(maxDecodedBytes = certificateBytes - 1), certHeader) must beLeft
+
+      parseWith(limits.copy(maxCertificateBytes = certificateBytes), certHeader) must beRight
+      parseWith(limits.copy(maxCertificateBytes = certificateBytes - 1), certHeader) must beLeft
+
+      val chainHeader = s"Chain=${percentEncode(pem(leafBase64) + pem(intermediateBase64))}"
+      val chainBytes  = leaf.getEncoded.length.toLong + intermediate.getEncoded.length.toLong
+      parseWith(limits.copy(maxDecodedBytes = chainBytes, maxChainLength = 1), chainHeader) must beRight
+      parseWith(limits.copy(maxDecodedBytes = chainBytes - 1, maxChainLength = 1), chainHeader) must beLeft
+      parseWith(limits.copy(maxDecodedBytes = chainBytes, maxChainLength = 0), chainHeader) must beLeft
+    }
+
+    "scan an unusually large single assertion iteratively" in {
+      val count       = 4096
+      val value       = Vector.tabulate(count)(index => s"URI=spiffe://example.test/$index").mkString(";")
+      val largeLimits = limits.copy(maxHeaderBytes = value.length.toLong + 1)
+
+      parseWith(largeLimits, value) must beRight.like {
+        case Vector(assertion) =>
+          (assertion.uris.length must_== count).and(assertion.uris.last must_== s"spiffe://example.test/${count - 1}")
+      }
+    }
+  }
+
+  private def parse(values: String*) = XForwardedClientCertHeaderParser.parse(values, limits)
+
+  private def parseWith(limits: Limits, values: String*) =
+    XForwardedClientCertHeaderParser.parse(values, limits)
+
+  private def pem(base64: String): String =
+    s"-----BEGIN CERTIFICATE-----\n$base64\n-----END CERTIFICATE-----\n"
+
+  private def percentEncode(value: String): String = {
+    val result = new StringBuilder(value.length * 3)
+    val bytes  = value.getBytes(java.nio.charset.StandardCharsets.US_ASCII)
+    val hex    = "0123456789ABCDEF"
+    bytes.foreach { byte =>
+      val unsigned = byte & 0xff
+      if (
+        (unsigned >= 'a' && unsigned <= 'z') ||
+        (unsigned >= 'A' && unsigned <= 'Z') ||
+        (unsigned >= '0' && unsigned <= '9') ||
+        unsigned == '-' || unsigned == '.' || unsigned == '_' || unsigned == '~'
+      ) result.append(unsigned.toChar)
+      else {
+        result.append('%')
+        result.append(hex.charAt(unsigned >>> 4))
+        result.append(hex.charAt(unsigned & 0x0f))
+      }
+    }
+    result.result()
+  }
+
+  private def certificate(base64: String): X509Certificate =
+    CertificateFactory
+      .getInstance("X.509")
+      .generateCertificate(new ByteArrayInputStream(Base64.getDecoder.decode(base64)))
+      .asInstanceOf[X509Certificate]
+
+  private def sha256(certificate: X509Certificate): String =
+    MessageDigest
+      .getInstance("SHA-256")
+      .digest(certificate.getEncoded)
+      .map(byte => f"${byte & 0xff}%02x")
+      .mkString
+}


### PR DESCRIPTION
This is a follow-up to #14103. It adds source-aware client certificate metadata and opt-in support for certificates asserted by a directly connected trusted proxy.

Applications can now use one effective client-certificate API without losing the distinction between the original client certificate and TLS metadata from the connection that actually terminates at Play.

fyi, this feature is disabled by default, so existing Play applications will not be influenced by it.

## Request APIs

The Scala and Java request APIs now expose three separate views:

| API | Meaning |
| --- | --- |
| `request.transport.tls` | TLS and peer certificates observed on the connection directly terminating at Play. Behind a TLS proxy, these describe the proxy connection. |
| `request.clientCertificate` | The effective client certificate selected for application use, including its remaining chain and source. |
| `request.xForwardedClientCertificates` | Ordered metadata from an accepted `X-Forwarded-Client-Cert` assertion, including assertions that contain identities but no certificate. |

`ClientCertificateInfo` separates the leaf from the remaining leaf-to-root chain and records a `DirectTransport`, `Rfc9440`, or `XForwardedClientCert` source. Direct transport chains are normalized so a provider-repeated leaf is not exposed again in the remaining chain.

The APIs are available consistently through request headers, requests, wrappers, factories, Scala fake requests, Java request builders, and Scala/Java conversions.

## Supported forwarding modes

Forwarded certificate interpretation is disabled by default. A deployment selects exactly one protocol with:

```hocon
play.http.forwarded.clientCertificates {
  mode = "rfc9440" # off, rfc9440, or x-forwarded-client-cert
  trustedProxies = ["10.0.0.0/24", "2001:db8:1234::/48"]

  limits {
    maxHeaderBytes = 64k
    maxDecodedBytes = 64k
    maxCertificateBytes = 16k
    maxChainLength = 8
  }
}
```

This trust list is deliberately independent from `play.http.forwarded.trustedProxies`. It authorizes only the directly connected peer to assert client-certificate information.

### RFC 9440

The `rfc9440` mode implements the standardized [`Client-Cert` and `Client-Cert-Chain` fields](https://www.rfc-editor.org/rfc/rfc9440.html):

- `Client-Cert` is parsed as one RFC 8941 Byte Sequence containing exactly one DER X.509 leaf certificate.
- `Client-Cert-Chain` is parsed as an RFC 8941 List and preserves TLS chain order without repeating the leaf.
- Repeated chain field lines are combined according to HTTP field semantics.
- Valid Structured Fields parameters are accepted and ignored for forward compatibility.
- Malformed fields follow Structured Fields failure semantics. An invalid chain is ignored independently so a valid leaf can still be retained.
- Configured size and chain limits are enforced before unbounded certificate work.

### X-Forwarded-Client-Cert

The `x-forwarded-client-cert` mode supports the [Envoy-compatible text representation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html#x-forwarded-client-cert) with a deliberately narrow `sanitized-single` policy:

- exactly one physical field containing exactly one assertion is accepted;
- the directly connected proxy must replace the field, corresponding to Envoy's `SANITIZE_SET` behavior;
- `By`, `Hash`, `Cert`, `Chain`, `Subject`, `URI`, and `DNS` metadata is parsed and retained in order;
- metadata-only assertions remain available without inventing an effective certificate;
- percent-encoded PEM certificates and chains are parsed with explicit limits;
- `Hash` is checked against the asserted certificate when both are present; and
- conflicting leaves, repeated singleton keys, malformed encoding, and appended histories fail closed.

Envoy JSON XFCC, appended multi-proxy histories, and other vendor-specific encodings are intentionally outside this initial scope.

## Selection and trust behavior

- With handling off, or when the direct peer is not trusted, Play ignores forwarded certificate fields and selects a directly observed TLS client certificate when present.
- With a trusted forwarding mode, the configured protocol describes the original client. If the proxy supplies no assertion, the effective certificate is empty instead of falling back to the proxy's transport certificate.
- Direct proxy-to-Play TLS metadata always remains available through `request.transport.tls`.
- Fields belonging to an inactive mode remain available as raw headers but do not affect the typed APIs.
- Malformed trusted XFCC and configured resource-limit violations reject the request with HTTP 400. Invalid RFC 9440 fields otherwise follow the RFC's field-failure behavior.

Normal and error-request conversion use the same selection rules in Netty and Pekko HTTP. Error requests preserve independently valid certificate metadata, avoid repeating parsing that already failed, and never substitute the trusted proxy's own certificate for malformed original-client metadata.

This also fixes Pekko HTTP mutual-TLS setup by putting its `SSLEngine` into server mode before configuring client authentication. A real mutual-TLS integration test verifies direct certificate metadata on both Netty and Pekko HTTP.

## Security model

Parsing a forwarded certificate is not certificate authentication. Play does not perform PKIX path validation, validity or revocation checks, proof-of-possession verification, certificate-to-principal mapping, or authorization.

Before enabling either forwarding mode, deployments must:

- prevent clients from connecting directly to Play;
- make the trusted proxy remove incoming `Client-Cert`, `Client-Cert-Chain`, and `X-Forwarded-Client-Cert` fields on every request;
- have the proxy set only the configured representation after authenticating the client certificate;
- authenticate or strongly isolate the proxy-to-Play connection; and
- restrict `clientCertificates.trustedProxies` to proxies authoritative for these assertions.

The documentation also covers header-size configuration and cache requirements for certificate-dependent responses, including `Cache-Control: no-store` and RFC 9440 `Vary` considerations.

## Compatibility and migration

This extends the new Play request metadata model with source-aware effective certificate and XFCC assertion fields. Custom `RequestHeader` and `RequestFactory` implementations must provide and preserve the new values. Scala fake requests and Java request builders set effective certificate metadata independently from direct transport TLS metadata.

The release highlights, migration guide, and production HTTP server documentation explain:

- direct transport certificates versus the effective client certificate;
- the corresponding Scala and Java APIs;
- protocol configuration and parser limits;
- trusted and untrusted peer behavior;
- Envoy and Istio deployment requirements; and
- the boundary between certificate parsing and application authentication.

## Test coverage

The branch includes unit and integration coverage for:

- Scala and Java API invariants, conversions, defensive copies, fakes, and builders;
- RFC 9440 and RFC 8941 grammar, malformed fields, chain ordering, and exact limit boundaries;
- sanitized Envoy XFCC metadata, certificates, chains, hashes, quoting, escaping, and parser limits;
- trusted, untrusted, disabled, absent, malformed, and metadata-only inputs;
- normal and error requests through both Netty and Pekko HTTP; and
- real direct mutual TLS through both server backends.