### PR TITLE
Honor SSLEngineProvider in Pekko HTTP

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/SSLEngineProviderSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/SSLEngineProviderSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.it.http
+
+import java.util.concurrent.atomic.AtomicInteger
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+
+import play.api.mvc.Results
+import play.api.test.ApplicationFactories
+import play.api.test.PlaySpecification
+import play.api.test.ServerEndpointRecipe
+import play.core.server.SelfSigned
+import play.it.test.EndpointIntegrationSpecification
+import play.it.test.NettyServerEndpointRecipes
+import play.it.test.OkHttpEndpointSupport
+import play.it.test.PekkoHttpServerEndpointRecipes
+import play.server.api.SSLEngineProvider
+
+object RecordingSSLEngineProvider {
+  private val providersCreated = new AtomicInteger
+  private val enginesCreated   = new AtomicInteger
+
+  def reset(): Unit = {
+    providersCreated.set(0)
+    enginesCreated.set(0)
+  }
+
+  def recordProviderCreated(): Unit = providersCreated.incrementAndGet()
+  def recordEngineCreated(): Unit   = enginesCreated.incrementAndGet()
+
+  def providerCount: Int = providersCreated.get()
+  def engineCount: Int   = enginesCreated.get()
+}
+
+final class RecordingSSLEngineProvider extends SSLEngineProvider {
+  RecordingSSLEngineProvider.recordProviderCreated()
+
+  override def createSSLEngine: SSLEngine = {
+    RecordingSSLEngineProvider.recordEngineCreated()
+    sslContext.createSSLEngine()
+  }
+
+  override def sslContext: SSLContext = SelfSigned.sslContext
+}
+
+class SSLEngineProviderSpec
+    extends PlaySpecification
+    with EndpointIntegrationSpecification
+    with OkHttpEndpointSupport
+    with ApplicationFactories {
+
+  sequential
+
+  private val endpoints: Seq[ServerEndpointRecipe] = Seq(
+    NettyServerEndpointRecipes.Netty11Encrypted,
+    PekkoHttpServerEndpointRecipes.PekkoHttp11Encrypted
+  ).map(
+    _.withExtraServerConfiguration(
+      Map("play.server.https.engineProvider" -> classOf[RecordingSSLEngineProvider].getName)
+    )
+  )
+
+  private val application = withAction { Action =>
+    Action(Results.Ok)
+  }
+
+  "Play HTTPS servers" should {
+    endpoints.map { endpointRecipe =>
+      s"create each engine with the configured provider for ${endpointRecipe.description}" in {
+        RecordingSSLEngineProvider.reset()
+
+        ServerEndpointRecipe.withEndpoint(endpointRecipe, application) { endpoint =>
+          withOkHttpEndpoint(endpoint) { okEndpoint =>
+            val responseCodes = (1 to 2).map { _ =>
+              val response = okEndpoint.configuredCall("/")(_.header("Connection", "close"))
+              try response.code
+              finally response.close()
+            }
+
+            (responseCodes must contain(exactly(200, 200)))
+              .and(RecordingSSLEngineProvider.providerCount must_== 1)
+              .and(RecordingSSLEngineProvider.engineCount must be_>=(2))
+          }
+        }
+      }
+    }.last
+  }
+}

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -256,8 +256,10 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
   }
 
   // Lazy since it will only be required when HTTPS is bound.
-  private lazy val sslContext: SSLContext =
-    ServerSSLEngine.createSSLEngineProvider(context.config, applicationProvider).sslContext()
+  private lazy val sslEngineProvider =
+    ServerSSLEngine.createSSLEngineProvider(context.config, applicationProvider)
+
+  private lazy val sslContext: SSLContext = sslEngineProvider.sslContext()
 
   private val httpServerBinding = context.config.port.map(port =>
     createServerBinding(
@@ -271,7 +273,7 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
     val connectionContext =
       try {
         ConnectionContext.httpsServer(() => {
-          val engine = sslContext.createSSLEngine()
+          val engine = sslEngineProvider.createSSLEngine()
           engine.setUseClientMode(false)
           createClientAuth() match {
             case Some(auth) if auth == TLSClientAuth.need =>


### PR DESCRIPTION
Make the Pekko HTTP server create TLS engines through the configured `play.server.SSLEngineProvider`, matching Netty and the public provider contract.

Pekko HTTP previously retained only the provider's `SSLContext` and created each connection engine with:

```
sslContext.createSSLEngine()
```

This bypassed custom behavior implemented in `SSLEngineProvider.createSSLEngine()`.

The server now:

* lazily creates one `SSLEngineProvider` per server;
* obtains each connection's engine through `createSSLEngine()`;
* derives the exposed `SSLContext` from that same provider instance;
* sets server mode before applying Play's `wantClientAuth` or `needClientAuth` configuration.

## Background Context

Netty already invokes `SSLEngineProvider.createSSLEngine()` for each HTTPS connection. Pekko HTTP therefore behaved differently for providers that customize individual engines, including protocol, cipher-suite, ALPN, or client-authentication settings.

This is a regression from [8dee793fc7](https://github.com/playframework/playframework/commit/8dee793fc763e5de73444a1396a5a69efd6c74e4), which replaced Akka HTTP's delegating `SSLContext` adapter with the context exposed directly by the provider.

Custom Pekko providers whose `createSSLEngine()` behavior was previously ignored will now have that behavior applied. This is the intended restoration of the existing API contract.

## Tests

Added a real HTTPS integration specification shared by Netty and Pekko HTTP.
For each backend it verifies that:

* HTTPS requests succeed with a custom provider;
* two separate TLS connections invoke `createSSLEngine()` at least twice;
* the provider is instantiated only once per server.

The new specification fails against the previous Pekko implementation with zero provider-created engines.