### PR TITLE
Handle oversized byte ranges safely

### DIFF
--- a/core/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/core/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -159,18 +159,20 @@ private[mvc] object Range {
 
   def apply(entityLength: Option[Long], range: String): Option[Range] = range match {
     case RangePattern(first, last) =>
-      val firstByte = asOptionLong(first)
-      val lastByte  = asOptionLong(last)
-
-      if ((firstByte ++ lastByte).isEmpty) return None // unsatisfiable range
-
-      entityLength
-        .map(entityLen => WithEntityLengthRange(entityLen, firstByte, lastByte))
-        .orElse(Some(WithoutEntityLengthRange(firstByte, lastByte)))
+      for {
+        firstByte <- asOptionLong(first)
+        lastByte  <- asOptionLong(last)
+        if (firstByte ++ lastByte).nonEmpty
+      } yield {
+        entityLength
+          .map(entityLen => WithEntityLengthRange(entityLen, firstByte, lastByte))
+          .getOrElse(WithoutEntityLengthRange(firstByte, lastByte))
+      }
     case _ => None // unsatisfiable range
   }
 
-  private def asOptionLong(string: String) = if (string.isEmpty) None else Some(string.toLong)
+  private def asOptionLong(string: String): Option[Option[Long]] =
+    if (string.isEmpty) Some(None) else string.toLongOption.map(Some(_))
 }
 
 private[mvc] trait RangeSet {

--- a/core/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -126,6 +126,14 @@ class RangeSpec extends Specification {
     "When range header is empty" in {
       Range(entityLength = Some(100), range = "") must beNone
     }
+
+    "When the first byte exceeds Long.MaxValue" in {
+      Range(entityLength = Some(100), range = "9223372036854775808-0") must beNone
+    }
+
+    "When the last byte exceeds Long.MaxValue" in {
+      Range(entityLength = Some(100), range = "0-9223372036854775808") must beNone
+    }
   }
 
   "Ordering ranges" in {
@@ -301,6 +309,11 @@ class RangeSetSpec extends Specification {
       val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=0-0,200-210"))
       rangeSet.entityLength must beSome(120)
       rangeSet must beAnInstanceOf[UnsatisfiableRangeSet]
+    }
+    "When a byte position exceeds Long.MaxValue" in {
+      Seq("bytes=9223372036854775808-0", "bytes=0-9223372036854775808").map { header =>
+        RangeSet(entityLength = Some(120), rangeHeader = Some(header))
+      } must contain(beAnInstanceOf[UnsatisfiableRangeSet]).forall
     }
   }
 


### PR DESCRIPTION
Treat byte positions that do not fit in a `Long` as unsatisfiable ranges instead of allowing `String.toLong` to throw.

### Motivation

The range syntax accepts an arbitrary number of decimal digits. A request such as `Range: bytes=9223372036854775808-0` therefore reached `String.toLong` and raised `NumberFormatException`, turning malformed client input into a 500 response.

### Changes

- Distinguish an omitted range bound from a bound that cannot be represented as a `Long`.
- Preserve the existing handling of open-ended and suffix ranges.
- Add regression coverage for oversized first and last byte positions at both the range and range-set levels.