### PR TITLE
Enforce asset path boundaries

### DIFF
--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -880,9 +880,11 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: E
    * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /).
    */
   private[controllers] def resourceNameAt(path: String, file: String): Option[String] = {
-    val decodedFile  = UriEncoding.decodePath(file, "utf-8")
-    val resourceName = removeExtraSlashes(s"/$path/$decodedFile")
-    if (!fileLikeCanonicalPath(resourceName).startsWith(fileLikeCanonicalPath(path))) {
+    val decodedFile           = UriEncoding.decodePath(file, "utf-8")
+    val resourceName          = removeExtraSlashes(s"/$path/$decodedFile")
+    val canonicalPath         = fileLikeCanonicalPath(path)
+    val canonicalResourceName = fileLikeCanonicalPath(resourceName)
+    if (canonicalResourceName != canonicalPath && !canonicalResourceName.startsWith(s"$canonicalPath/")) {
       None
     } else {
       Some(resourceName)

--- a/core/play/src/test/scala/play/api/controllers/AssetsSpec.scala
+++ b/core/play/src/test/scala/play/api/controllers/AssetsSpec.scala
@@ -220,6 +220,12 @@ class AssetsSpec extends Specification {
       Assets.resourceNameAt("/a/b", "../../c/d") must beNone
     }
 
+    "not look up assets in a sibling path that shares the parent path prefix" in {
+      Assets.resourceNameAt("/public", "../public-internal/secret.txt") must beNone
+      Assets.resourceNameAt("/public", "..%2Fpublic-internal%2Fsecret.txt") must beNone
+      Assets.resourceNameAt("/public", "..%5Cpublic-internal%5Csecret.txt") must beNone
+    }
+
     "not look up assets with dot-segments that escape the parent path with a encoded separator for Windows" in {
       // %5C is "\" URL encoded
       Assets.resourceNameAt("/a/b", "..") must beNone


### PR DESCRIPTION
- require canonical classpath asset names to remain at the configured path or below it
- reject sibling paths that merely share the configured path's string prefix
- cover literal, percent-encoded Unix, and percent-encoded Windows separators

The previous prefix check accepted a path such as `/public-internal/secret.txt` when the configured asset path was `/public`, because it used a component-unaware string prefix comparison. This could expose classpath resources outside the configured asset directory.

The bug was specifically the missing directory boundary:

- /etc/passwd does not start with /public → rejected (so we were fine :wink:)
- /public-internal/secret.txt does start with the string /public → incorrectly accepted

So it enabled access to prefix-sharing classpath siblings, not unrestricted traversal.
