### PR TITLE
Harden server request error handling

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/RequestHeadersSpec.scala
@@ -643,6 +643,9 @@ trait RequestHeadersSpec extends PlaySpecification with ServerIntegrationSpecifi
         )
 
         response.status must_== BAD_REQUEST
+        val responseBody = response.body.left.toOption.get
+        responseBody must contain("Invalid forwarded client certificate")
+        responseBody must not contain "XFCC certificate contains an invalid percent escape"
       }
     }
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -104,8 +104,9 @@ private[server] class NettyModelConversion(
         try {
           decoder.parameters().asScala.view.mapValues(_.asScala.toList).toMap
         } catch {
-          case iae: IllegalArgumentException if iae.getMessage.startsWith("invalid hex byte") => throw iae
-          case NonFatal(e)                                                                    =>
+          case iae: IllegalArgumentException if Option(iae.getMessage).exists(_.startsWith("invalid hex byte")) =>
+            throw iae
+          case NonFatal(e) =>
             logger.warn("Failed to parse query string; returning empty map.", e)
             Map.empty
         }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -28,6 +28,7 @@ import play.api.mvc.request.RequestAttrKey
 import play.api.Application
 import play.api.Logger
 import play.api.Mode
+import play.core.server.common.ClientCertificateHeaderHandler.InvalidClientCertificateHeaderException
 import play.core.server.common.ReloadCache
 import play.core.server.common.ServerDebugInfo
 import play.core.server.common.ServerResultUtils
@@ -146,7 +147,15 @@ private[play] class PlayRequestHandler(
     }
 
     val (requestHeader, handler): (RequestHeader, Handler) = tryRequest match {
-      case Failure(exception: IllegalArgumentException) if exception.getMessage.startsWith("invalid hex byte") =>
+      case Failure(exception: InvalidClientCertificateHeaderException) =>
+        logger.debug("Rejected invalid forwarded client certificate metadata.", exception)
+        clientError(
+          Status.BAD_REQUEST,
+          "Invalid forwarded client certificate",
+          requestFailure = Some(exception)
+        )
+      case Failure(exception: IllegalArgumentException)
+          if Option(exception.getMessage).exists(_.startsWith("invalid hex byte")) =>
         clientError(
           Status.BAD_REQUEST,
           exception.getMessage,

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -52,6 +52,7 @@ import play.api.mvc._
 import play.api.mvc.pekkohttp.PekkoHttpHandler
 import play.api.mvc.request.RequestAttrKey
 import play.api.routing.Router
+import play.core.server.common.ClientCertificateHeaderHandler.InvalidClientCertificateHeaderException
 import play.core.server.common.ReloadCache
 import play.core.server.common.ServerDebugInfo
 import play.core.server.common.ServerResultUtils
@@ -374,6 +375,9 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
     }
 
     val (taggedRequestHeader, handler): (RequestHeader, Handler) = convertedRequestHeader match {
+      case Failure(exception: InvalidClientCertificateHeaderException) =>
+        logger.debug("Rejected invalid forwarded client certificate metadata.", exception)
+        clientError(Status.BAD_REQUEST, "Invalid forwarded client certificate", exception)
       case Failure(exception) =>
         clientError(Status.BAD_REQUEST, exception.getMessage, exception)
       case Success(untagged) =>


### PR DESCRIPTION
- make Netty's invalid-query classification safe for exceptions with a null message
- return a stable, generic response for invalid forwarded client-certificate metadata on both server backends
- retain the detailed certificate parsing failure in debug logs
- verify that Netty and Pekko HTTP no longer expose the parser detail in their client response

## Why

Calling `startsWith` directly on `Throwable.getMessage` could itself throw when an exception has no message. Separately, forwarded client-certificate parse details were passed to the application's client error handler and commonly rendered in the response. These changes make both failure paths robust while keeping useful diagnostics available to operators.