### PR TITLE
Confine external assets to their root

### DIFF
--- a/core/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/core/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -16,10 +16,14 @@ import play.api.mvc._
 
 /**
  * Controller that serves static resources from an external folder.
- * It useful in development mode if you want to serve static assets that shouldn't be part of the build process.
+ * It is useful in development mode if you want to serve static assets that shouldn't be part of the build process.
  *
  * Note that this controller IS NOT intended to be used in production mode and can lead to security issues.
  * Therefore it is automatically disabled in production mode.
+ *
+ * Requested paths are normalized lexically and must remain within the configured root. Symbolic links are not
+ * resolved by this containment check, so a link below the root may point outside it. This is intentional to support
+ * linked development assets; the configured asset tree must therefore be trusted.
  *
  * All assets are served with max-age=3600 cache directive.
  *
@@ -47,17 +51,25 @@ class ExternalAssets @Inject() (environment: Environment)(implicit ec: Execution
       case Mode.Prod => Future.successful(NotFound)
       case _         =>
         Future {
-          val fileToServe = rootPath match {
-            case AbsolutePath(_) => new File(rootPath, file)
-            case _               => new File(environment.getFile(rootPath), file)
+          val root = rootPath match {
+            case AbsolutePath(_) => new File(rootPath)
+            case _               => environment.getFile(rootPath)
           }
 
-          if (fileToServe.exists) {
-            Ok.sendFile(fileToServe, inline = true).withHeaders(CACHE_CONTROL -> "max-age=3600")
-          } else {
-            NotFound
+          ExternalAssets.resolveFile(root, file).filter(_.exists) match {
+            case Some(fileToServe) =>
+              Ok.sendFile(fileToServe, inline = true).withHeaders(CACHE_CONTROL -> "max-age=3600")
+            case None => NotFound
           }
         }
     }
+  }
+}
+
+private[controllers] object ExternalAssets {
+  private[controllers] def resolveFile(root: File, file: String): Option[File] = {
+    val normalizedRoot = root.toPath.toAbsolutePath.normalize
+    val resolvedFile   = normalizedRoot.resolve(file).normalize
+    Option.when(resolvedFile.startsWith(normalizedRoot))(resolvedFile.toFile)
   }
 }

--- a/core/play/src/test/scala/play/api/controllers/ExternalAssetsSpec.scala
+++ b/core/play/src/test/scala/play/api/controllers/ExternalAssetsSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package controllers
+
+import java.nio.file.FileSystemException
+import java.nio.file.Files
+
+import org.specs2.execute.AsResult
+import org.specs2.execute.Result
+import org.specs2.execute.Skipped
+import org.specs2.mutable.Specification
+
+class ExternalAssetsSpec extends Specification {
+  "ExternalAssets.resolveFile" should {
+    val root = new java.io.File("target/external-assets-root").toPath.toAbsolutePath.normalize
+
+    "accept normalized paths within the configured root" in {
+      ExternalAssets.resolveFile(root.toFile, "nested/../asset.txt") must beSome(root.resolve("asset.txt").toFile)
+    }
+
+    "reject paths outside the configured root" in {
+      ExternalAssets.resolveFile(root.toFile, "../secret.txt") must beNone
+      ExternalAssets.resolveFile(root.toFile, "../external-assets-root-private/secret.txt") must beNone
+      ExternalAssets.resolveFile(root.toFile, root.resolveSibling("secret.txt").toString) must beNone
+    }
+
+    "allow a path below the root to traverse a symbolic link" in {
+      val parent  = Files.createTempDirectory("external-assets-spec")
+      val root    = Files.createDirectory(parent.resolve("root"))
+      val outside = Files.createDirectory(parent.resolve("outside"))
+      val asset   = Files.writeString(outside.resolve("asset.txt"), "linked asset")
+      val link    = root.resolve("link")
+
+      val result: Result =
+        try {
+          Files.createSymbolicLink(link, outside)
+          val resolved = ExternalAssets.resolveFile(root.toFile, "link/asset.txt")
+
+          AsResult(
+            (resolved must beSome(link.resolve("asset.txt").toFile))
+              .and(resolved.map(_.toPath.toRealPath()) must beSome(asset.toRealPath()))
+          )
+        } catch {
+          case _: UnsupportedOperationException => Skipped("Symbolic links are not supported by this file system")
+          case _: FileSystemException           => Skipped("Symbolic links cannot be created in this environment")
+        } finally {
+          Files.deleteIfExists(link)
+          Files.deleteIfExists(asset)
+          Files.deleteIfExists(outside)
+          Files.deleteIfExists(root)
+          Files.deleteIfExists(parent)
+        }
+
+      result
+    }
+  }
+}


### PR DESCRIPTION
- normalize requested external-asset paths and require component-aware lexical containment within the configured root
- reject parent traversal, absolute paths, and sibling paths with a shared string prefix
- preserve symlink-based development workflows by intentionally not resolving links for containment
- document the lexical and symlink behavior in the controller Scaladoc

## Why

`ExternalAssets` is disabled in production, but a reachable development or test server could previously serve any existing file addressable through `..` traversal. The controller now confines URL-supplied paths without changing its established symlink-following behavior.