### PR TITLE
Allow disabling WebSocket compression per accepted socket

### DIFF
--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -63,6 +63,15 @@ public class WebSocketSpecJavaActions {
                 Flow.fromSinkAndSource(Sink.ignore(), Source.empty()), "graphql-transport-ws"));
   }
 
+  public static WebSocket selectSubprotocolWithoutCompression() {
+    return WebSocket.Text.acceptWithOptions(
+        request ->
+            new WebSocket.Accepted<>(
+                Flow.fromSinkAndSource(Sink.ignore(), Source.single("plain server message")),
+                "graphql-transport-ws",
+                false));
+  }
+
   public static WebSocket acceptText() {
     return WebSocket.Text.accept(request -> Flow.fromSinkAndSource(Sink.ignore(), emptySource()));
   }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -127,16 +127,16 @@ trait WebSocketCompressionSpec extends WebSocketSpecMethods {
 
     "not negotiate compression when websocket compression is disabled" in {
       withServer(
-        app => WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) },
+        app =>
+          WebSocket.accept[String, String] { req =>
+            Flow.fromSinkAndSource(Sink.ignore, Source.single("plain server message"))
+          },
         Map("play.server.websocket.compression.enabled" -> false)
       ) { (app, port) =>
         import app.materializer
-        val (_, headers) = runWebSocket(
+        val (frames, headers) = runWebSocket(
           port,
-          { flow =>
-            Source.empty[ExtendedMessage].via(flow).runWith(Sink.ignore)
-            Future.successful(())
-          },
+          { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
           subprotocol = None,
           handleConnect = c => c,
           compressionMode = CompressionMode.RequestOnly()
@@ -145,6 +145,38 @@ trait WebSocketCompressionSpec extends WebSocketSpecMethods {
         headers.collectFirst {
           case (name, value) if name.equalsIgnoreCase("Sec-WebSocket-Extensions") => value
         } must beNone
+
+        frames.collectFirst {
+          case SimpleMessage(TextMessage(data), true) => data
+        } must beSome("plain server message")
+      }
+    }
+
+    "not negotiate compression when compression is disabled for the accepted WebSocket" in {
+      withServer(app =>
+        WebSocket.acceptWithOptions[String, String] { req =>
+          WebSocket.Accepted(
+            Flow.fromSinkAndSource(Sink.ignore, Source.single("plain server message")),
+            compressionEnabled = false
+          )
+        }
+      ) { (app, port) =>
+        import app.materializer
+        val (frames, headers) = runWebSocket(
+          port,
+          { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+          subprotocol = None,
+          handleConnect = c => c,
+          compressionMode = CompressionMode.RequestOnly()
+        )
+
+        headers.collectFirst {
+          case (name, value) if name.equalsIgnoreCase("Sec-WebSocket-Extensions") => value
+        } must beNone
+
+        frames.collectFirst {
+          case SimpleMessage(TextMessage(data), true) => data
+        } must beSome("plain server message")
       }
     }
 
@@ -850,6 +882,30 @@ trait WebSocketSpec
             .map { case (key, value) => (key.toLowerCase, value) }
             .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
             .head must be).equalTo("graphql-transport-ws")
+        }
+      }
+
+      "allow selecting a subprotocol while disabling compression" in {
+        withServer(_ => WebSocketSpecJavaActions.selectSubprotocolWithoutCompression()) { (app, port) =>
+          import app.materializer
+          val (frames, headers) = runWebSocket(
+            port,
+            { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+            Some("graphql-ws, graphql-transport-ws"),
+            c => c,
+            CompressionMode.RequestOnly()
+          )
+
+          (headers
+            .map { case (key, value) => (key.toLowerCase, value) }
+            .collect { case ("sec-websocket-protocol", selectedProtocol) => selectedProtocol }
+            .head must be).equalTo("graphql-transport-ws")
+          headers.collectFirst {
+            case (name, value) if name.equalsIgnoreCase("Sec-WebSocket-Extensions") => value
+          } must beNone
+          frames.collectFirst {
+            case SimpleMessage(TextMessage(data), true) => data
+          } must beSome("plain server message")
         }
       }
 

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -157,18 +157,33 @@ public abstract class WebSocket {
   public static class Accepted<In, Out> {
     private final Flow<In, Out, ?> flow;
     private final Optional<String> subprotocol;
+    private final boolean compressionEnabled;
 
-    public Accepted(Flow<In, Out, ?> flow, Optional<String> subprotocol) {
+    public Accepted(
+        Flow<In, Out, ?> flow, Optional<String> subprotocol, boolean compressionEnabled) {
       this.flow = flow;
       this.subprotocol = subprotocol;
+      this.compressionEnabled = compressionEnabled;
+    }
+
+    public Accepted(Flow<In, Out, ?> flow, Optional<String> subprotocol) {
+      this(flow, subprotocol, true);
     }
 
     public Accepted(Flow<In, Out, ?> flow, String subprotocol) {
       this(flow, Optional.of(subprotocol));
     }
 
+    public Accepted(Flow<In, Out, ?> flow, String subprotocol, boolean compressionEnabled) {
+      this(flow, Optional.of(subprotocol), compressionEnabled);
+    }
+
     public Accepted(Flow<In, Out, ?> flow) {
       this(flow, Optional.empty());
+    }
+
+    public Accepted(Flow<In, Out, ?> flow, boolean compressionEnabled) {
+      this(flow, Optional.empty(), compressionEnabled);
     }
 
     public Flow<In, Out, ?> flow() {
@@ -177,6 +192,14 @@ public abstract class WebSocket {
 
     public Optional<String> subprotocol() {
       return subprotocol;
+    }
+
+    /**
+     * Returns whether this accepted WebSocket may negotiate compression when compression is enabled
+     * in the server configuration. Returning {@code true} does not enable compression globally.
+     */
+    public boolean compressionEnabled() {
+      return compressionEnabled;
     }
   }
 
@@ -317,7 +340,9 @@ public abstract class WebSocket {
                             Flow.<Message>create().collect(inMapper),
                             play.api.libs.streams.PekkoStreams.onlyFirstCanFinishMerge(2),
                             accepted.flow().map(outMapper::apply));
-                    return F.Either.Right(new Accepted<>(flow, accepted.subprotocol()));
+                    return F.Either.Right(
+                        new Accepted<>(
+                            flow, accepted.subprotocol(), accepted.compressionEnabled()));
                   }
                 });
       }

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -65,8 +65,14 @@ object WebSocket {
    *
    * @param flow the flow that handles WebSocket messages
    * @param subprotocol the WebSocket subprotocol selected by the application, if any
+   * @param compressionEnabled whether this accepted WebSocket may negotiate compression when compression is enabled in
+   *                           the server configuration; setting this to `true` does not enable compression globally
    */
-  case class Accepted[In, Out](flow: Flow[In, Out, ?], subprotocol: Option[String] = None)
+  case class Accepted[In, Out](
+      flow: Flow[In, Out, ?],
+      subprotocol: Option[String] = None,
+      compressionEnabled: Boolean = true
+  )
 
   /**
    * Transforms WebSocket message flows into message flows of another type.
@@ -243,7 +249,11 @@ object WebSocket {
 
       override def applyWithOptions(request: RequestHeader): Future[Either[Result, Accepted[Message, Message]]] = {
         f(request).map(_.map { accepted =>
-          Accepted(closeOnException(transformer.transform(accepted.flow)), accepted.subprotocol)
+          Accepted(
+            closeOnException(transformer.transform(accepted.flow)),
+            accepted.subprotocol,
+            accepted.compressionEnabled
+          )
         })
       }
     }

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -218,7 +218,8 @@ object HandlerInvokerFactory {
                             case close: JMessage.Close   =>
                               CloseMessage(close.code.toScala.asInstanceOf[Option[Int]], close.reason)
                           },
-                        accepted.subprotocol().toScala
+                        accepted.subprotocol().toScala,
+                        accepted.compressionEnabled()
                       )
                     )
                   }

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -24,6 +24,8 @@ play.server.websocket.compression.enabled = false
 
 Common tuning options are available under `play.server.websocket.compression`, including the compression level, preferred client window size, context-takeover behavior, and the decompression allocation limit. By default, the allocation limit follows `play.server.websocket.frame.maxLength`. The Netty backend also exposes Netty-specific settings under `play.server.netty.websocket.compression.perMessageDeflate`, including `allowServerWindowSize`, `serverWindowSize`, and `memLevel`.
 
+Applications can also keep compression enabled globally and disable it for a single accepted WebSocket by returning `WebSocket.Accepted` with `compressionEnabled = false`.
+
 For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Configuring-WebSocket-compression]] and [[Java WebSocket documentation|JavaWebSockets#Configuring-WebSocket-compression]].
 
 ### WebSocket Subprotocol Selection

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -132,6 +132,8 @@ play.server.websocket.compression.enabled = false
 
 Common compression settings are available under `play.server.websocket.compression`. These settings include the compression level, the preferred client window size, context-takeover behavior, and the maximum decompression allocation. By default, `play.server.websocket.compression.maxAllocation` uses `play.server.websocket.frame.maxLength`, so the same limit applies to decompressed WebSocket messages. The Netty backend also has Netty-specific settings under `play.server.netty.websocket.compression.perMessageDeflate`, including `allowServerWindowSize`, `serverWindowSize`, and `memLevel`.
 
+Applications can also disable compression for a single accepted WebSocket by returning `new WebSocket.Accepted<>(flow, false)` from `acceptWithOptions` or `acceptOrResultWithOptions`. This lets an application keep compression enabled globally but decline it for endpoints that carry sensitive data or are expected to exchange already-compressed messages.
+
 > **Note:** WebSocket compression can increase CPU and memory usage. If messages include secrets alongside attacker-controlled data, consider whether compression is appropriate for that endpoint. Under the `play.server.websocket` config parent, the default context-takeover settings are `compression.perMessageDeflate.allowServerNoContext = false` and `compression.perMessageDeflate.preferredClientNoContext = false`. For a more conservative setup, set them to `true` so the server may accept `server_no_context_takeover` when the client requests it, and so the server requests `client_no_context_takeover` when the client supports it.
 
 ## Configuring keep-alive Frames

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -134,6 +134,8 @@ play.server.websocket.compression.enabled = false
 
 Common compression settings are available under `play.server.websocket.compression`. These settings include the compression level, the preferred client window size, context-takeover behavior, and the maximum decompression allocation. By default, `play.server.websocket.compression.maxAllocation` uses `play.server.websocket.frame.maxLength`, so the same limit applies to decompressed WebSocket messages. The Netty backend also has Netty-specific settings under `play.server.netty.websocket.compression.perMessageDeflate`, including `allowServerWindowSize`, `serverWindowSize`, and `memLevel`.
 
+Applications can also disable compression for a single accepted WebSocket by returning `WebSocket.Accepted` with `compressionEnabled = false` from `acceptWithOptions` or `acceptOrResultWithOptions`. This lets an application keep compression enabled globally but decline it for endpoints that carry sensitive data or are expected to exchange already-compressed messages.
+
 > **Note:** WebSocket compression can increase CPU and memory usage. If messages include secrets alongside attacker-controlled data, consider whether compression is appropriate for that endpoint. Under the `play.server.websocket` config parent, the default context-takeover settings are `compression.perMessageDeflate.allowServerNoContext = false` and `compression.perMessageDeflate.preferredClientNoContext = false`. For a more conservative setup, set them to `true` so the server may accept `server_no_context_takeover` when the client requests it, and so the server requests `client_no_context_takeover` when the client supports it.
 
 ## Configuring keep-alive Frames

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -312,7 +312,13 @@ class NettyServer(
             nettyPerMessageDeflateConfig.get[Int]("memLevel"),
             maxAllocation
           )
-        )
+        ) {
+          protected override def isExtensionNegotiationEnabled(
+              ctx: ChannelHandlerContext,
+              response: HttpResponse
+          ): Boolean =
+            Option(ctx.channel().attr(PlayWebSocketCompression.Enabled).get()).forall(_.booleanValue())
+        }
       )
     }
   }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -18,6 +18,7 @@ import io.netty.channel._
 import io.netty.handler.codec.http._
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory
 import io.netty.handler.codec.TooLongFrameException
+import io.netty.util.AttributeKey
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.util.ByteString
 import org.playframework.netty.http.DefaultWebSocketHttpResponse
@@ -37,6 +38,11 @@ import play.core.server.Server
 
 private object PlayRequestHandler {
   private val logger: Logger = Logger(classOf[PlayRequestHandler])
+}
+
+private[server] object PlayWebSocketCompression {
+  val Enabled: AttributeKey[java.lang.Boolean] =
+    AttributeKey.valueOf[java.lang.Boolean]("play.websocket.compressionEnabled")
 }
 
 private[play] class PlayRequestHandler(
@@ -217,8 +223,14 @@ private[play] class PlayRequestHandler(
                 )
               val factory =
                 new WebSocketServerHandshakerFactory(wsUrl, accepted.subprotocol.orNull, true, wsBufferLimit)
+              channel.attr(PlayWebSocketCompression.Enabled).set(java.lang.Boolean.valueOf(accepted.compressionEnabled))
               Future.successful(
-                new DefaultWebSocketHttpResponse(request.protocolVersion(), HttpResponseStatus.OK, processor, factory)
+                new DefaultWebSocketHttpResponse(
+                  request.protocolVersion(),
+                  HttpResponseStatus.OK,
+                  processor,
+                  factory
+                )
               )
           }
           .recoverWith {

--- a/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
@@ -36,11 +36,16 @@ object WebSocketHandler {
       flow: Flow[Message, Message, ?],
       bufferLimit: Int,
       subprotocol: Option[String],
+      compressionEnabled: Boolean,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration,
   ): HttpResponse = upgrade match {
     case lowLevel: UpgradeToWebSocketLowLevel =>
-      lowLevel.handleFrames(messageFlowToFrameFlow(flow, bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle), subprotocol)
+      lowLevel.handleFrames(
+        messageFlowToFrameFlow(flow, bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle),
+        subprotocol,
+        compressionEnabled
+      )
     case other =>
       throw new IllegalArgumentException("WebSocketUpgrade is not an Pekko HTTP UpgradeToWebsocketLowLevel")
   }

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -445,6 +445,7 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
                   accepted.flow,
                   wsBufferLimit,
                   accepted.subprotocol,
+                  accepted.compressionEnabled,
                   wsKeepAliveMode,
                   wsKeepAliveMaxIdle
                 )


### PR DESCRIPTION
- (This is now possible since latest Netty release where I provided https://github.com/netty/netty/pull/17030)

Allow applications to disable WebSocket compression for an individual accepted connection while keeping compression enabled globally.

This is useful for endpoints that exchange already-compressed payloads or messages containing secrets alongside attacker-controlled data.

Both Scala and Java applications can set `compressionEnabled = false` through `WebSocket.Accepted` when using `acceptWithOptions` or `acceptOrResultWithOptions`.

`compressionEnabled = true` only permits negotiation. Compression must also be enabled in the server configuration, and the client must offer `permessage-deflate`.

## Implementation

- Adds `compressionEnabled` to the Scala and Java `WebSocket.Accepted` APIs, defaulting to `true` for compatibility.
- Preserves the option through message-flow transformations and Java-to-Scala routing.
- Passes the option to Pekko HTTP's accepted-WebSocket compression flag.
- Uses Netty's per-response extension-negotiation hook to decline compression for the accepted connection.
- Supports selecting a WebSocket subprotocol and disabling compression at the same time.

This option controls whether compression is negotiated for the connection. Selectively compressing individual messages after negotiation is a separate concern.

## Testing

The shared WebSocket integration tests cover both the Netty and Pekko HTTP backends and verify that:

- `permessage-deflate` is not negotiated when compression is disabled for the accepted WebSocket.
- The connection remains usable and exchanges an uncompressed server message.
- Globally disabled compression also continues exchanging uncompressed messages.
- The Java API can select a subprotocol and disable compression simultaneously.

## References

- #12477
- #14075
- https://github.com/apache/pekko-http/pull/1114
- https://github.com/netty/netty/pull/17030
