### PR TITLE
Add a WebSocket compression threshold

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -130,6 +130,57 @@ trait WebSocketCompressionSpec extends WebSocketSpecMethods {
       }
     }
 
+    "compress only outbound messages above the configured threshold" in {
+      val exactText        = "12345"
+      val utf8Text         = "\u20ac\u20ac"
+      val exactBinary      = ByteString(1, 2, 3, 4, 5)
+      val overBinary       = ByteString(1, 2, 3, 4, 5, 6)
+      val outboundMessages = List[Message](
+        TextMessage(exactText),
+        TextMessage(utf8Text),
+        BinaryMessage(exactBinary),
+        BinaryMessage(overBinary)
+      )
+
+      withServer(
+        app =>
+          WebSocket.accept[Message, Message] { req =>
+            Flow.fromSinkAndSource(Sink.ignore, Source(outboundMessages))
+          },
+        Map(
+          "play.server.websocket.compression.threshold"                              -> "5 bytes",
+          "play.server.websocket.compression.perMessageDeflate.allowServerNoContext" -> true
+        )
+      ) { (app, port) =>
+        import app.materializer
+        val frames = runWebSocket(
+          port,
+          { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+          compressionMode = CompressionMode.RequestOnly("permessage-deflate; server_no_context_takeover")
+        )
+
+        val dataFrames = frames.collect {
+          case frame @ SimpleMessage(_: TextMessage, _)     => frame
+          case frame @ SimpleMessage(_: BinaryMessage, _)   => frame
+          case frame @ RawWebSocketFrame("text", _, _, _)   => frame
+          case frame @ RawWebSocketFrame("binary", _, _, _) => frame
+        }
+
+        dataFrames must beLike {
+          case List(
+                SimpleMessage(TextMessage(`exactText`), true),
+                RawWebSocketFrame("text", compressedText, textRsv, true),
+                SimpleMessage(BinaryMessage(`exactBinary`), true),
+                RawWebSocketFrame("binary", compressedBinary, binaryRsv, true)
+              ) =>
+            (textRsv must_== 4)
+              .and(inflatePerMessageDeflate(compressedText).utf8String must_== utf8Text)
+              .and(binaryRsv must_== 4)
+              .and(inflatePerMessageDeflate(compressedBinary) must_== overBinary)
+        }
+      }
+    }
+
     "not negotiate compression when websocket compression is disabled" in {
       withServer(
         app =>

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -22,7 +22,7 @@ Compression is enabled by default and is negotiated during the WebSocket handsha
 play.server.websocket.compression.enabled = false
 ```
 
-Common tuning options are available under `play.server.websocket.compression`, including the compression level, preferred client window size, context-takeover behavior, and the decompression allocation limit. By default, the allocation limit follows `play.server.websocket.frame.maxLength`. The Netty backend also exposes Netty-specific settings under `play.server.netty.websocket.compression.perMessageDeflate`, including `allowServerWindowSize`, `serverWindowSize`, and `memLevel`.
+Common tuning options are available under `play.server.websocket.compression`, including an outbound message-size threshold, the compression level, preferred client window size, context-takeover behavior, and the decompression allocation limit. By default, the allocation limit follows `play.server.websocket.frame.maxLength`. The Netty backend also exposes Netty-specific settings under `play.server.netty.websocket.compression.perMessageDeflate`, including `allowServerWindowSize`, `serverWindowSize`, and `memLevel`.
 
 Applications can also keep compression enabled globally and disable it for a single accepted WebSocket by returning `WebSocket.Accepted` with `compressionEnabled = false`.
 

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -132,6 +132,12 @@ play.server.websocket.compression.enabled = false
 
 Common compression settings are available under `play.server.websocket.compression`. These settings include the compression level, the preferred client window size, context-takeover behavior, and the maximum decompression allocation. By default, `play.server.websocket.compression.maxAllocation` uses `play.server.websocket.frame.maxLength`, so the same limit applies to decompressed WebSocket messages. The Netty backend also has Netty-specific settings under `play.server.netty.websocket.compression.perMessageDeflate`, including `allowServerWindowSize`, `serverWindowSize`, and `memLevel`.
 
+The `play.server.websocket.compression.threshold` setting controls the minimum outbound message size that is compressed. The size is measured from the uncompressed payload in bytes, after UTF-8 encoding for text messages. Messages whose payload size is equal to or below the threshold are sent without compression. For example, to compress only messages larger than 1 KiB:
+
+```hocon
+play.server.websocket.compression.threshold = 1k
+```
+
 Applications can also disable compression for a single accepted WebSocket by returning `new WebSocket.Accepted<>(flow, false)` from `acceptWithOptions` or `acceptOrResultWithOptions`. This lets an application keep compression enabled globally but decline it for endpoints that carry sensitive data or are expected to exchange already-compressed messages.
 
 > **Note:** WebSocket compression can increase CPU and memory usage. If messages include secrets alongside attacker-controlled data, consider whether compression is appropriate for that endpoint. Under the `play.server.websocket` config parent, the default context-takeover settings are `compression.perMessageDeflate.allowServerNoContext = false` and `compression.perMessageDeflate.preferredClientNoContext = false`. For a more conservative setup, set them to `true` so the server may accept `server_no_context_takeover` when the client requests it, and so the server requests `client_no_context_takeover` when the client supports it.

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -134,6 +134,12 @@ play.server.websocket.compression.enabled = false
 
 Common compression settings are available under `play.server.websocket.compression`. These settings include the compression level, the preferred client window size, context-takeover behavior, and the maximum decompression allocation. By default, `play.server.websocket.compression.maxAllocation` uses `play.server.websocket.frame.maxLength`, so the same limit applies to decompressed WebSocket messages. The Netty backend also has Netty-specific settings under `play.server.netty.websocket.compression.perMessageDeflate`, including `allowServerWindowSize`, `serverWindowSize`, and `memLevel`.
 
+The `play.server.websocket.compression.threshold` setting controls the minimum outbound message size that is compressed. The size is measured from the uncompressed payload in bytes, after UTF-8 encoding for text messages. Messages whose payload size is equal to or below the threshold are sent without compression. For example, to compress only messages larger than 1 KiB:
+
+```hocon
+play.server.websocket.compression.threshold = 1k
+```
+
 Applications can also disable compression for a single accepted WebSocket by returning `WebSocket.Accepted` with `compressionEnabled = false` from `acceptWithOptions` or `acceptOrResultWithOptions`. This lets an application keep compression enabled globally but decline it for endpoints that carry sensitive data or are expected to exchange already-compressed messages.
 
 > **Note:** WebSocket compression can increase CPU and memory usage. If messages include secrets alongside attacker-controlled data, consider whether compression is appropriate for that endpoint. Under the `play.server.websocket` config parent, the default context-takeover settings are `compression.perMessageDeflate.allowServerNoContext = false` and `compression.perMessageDeflate.preferredClientNoContext = false`. For a more conservative setup, set them to `true` so the server may accept `server_no_context_takeover` when the client requests it, and so the server requests `client_no_context_takeover` when the client supports it.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -36,7 +36,11 @@ import io.netty.channel.uring.IoUringServerSocketChannel
 import io.netty.handler.codec.compression.ZlibCodecFactory
 import io.netty.handler.codec.http._
 import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilterProvider
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.handler.ssl.SslHandler
@@ -102,6 +106,7 @@ class NettyServer(
   private val wsKeepAliveMaxIdle       = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
   private val wsCompression            = serverConfig.get[Boolean]("websocket.compression.enabled")
   private val wsCompressionConfig      = serverConfig.get[Configuration]("websocket.compression")
+  private val wsCompressionThreshold   = wsCompressionConfig.get[ConfigMemorySize]("threshold").toBytes
   private val nettyWsCompressionConfig = nettyConfig.get[Configuration]("websocket.compression")
   private val wsCompressionSettings    =
     if (!wsCompression) {
@@ -345,6 +350,15 @@ class NettyServer(
 
   private def newWebSocketCompressionHandler(): Option[ChannelHandler] = {
     wsCompressionSettings.map { settings =>
+      val compressionFilterProvider = new WebSocketExtensionFilterProvider {
+        override val encoderFilter: WebSocketExtensionFilter = {
+          case frame: TextWebSocketFrame   => frame.content().readableBytes().toLong <= wsCompressionThreshold
+          case frame: BinaryWebSocketFrame => frame.content().readableBytes().toLong <= wsCompressionThreshold
+          case _                           => false
+        }
+        override val decoderFilter: WebSocketExtensionFilter = WebSocketExtensionFilter.NEVER_SKIP
+      }
+
       new WebSocketServerExtensionHandler(
         new PerMessageDeflateServerExtensionHandshaker(
           settings.compressionLevel,
@@ -354,6 +368,7 @@ class NettyServer(
           settings.preferredClientNoContext,
           settings.serverWindowSize,
           settings.memLevel,
+          compressionFilterProvider,
           settings.maxAllocation
         )
       ) {

--- a/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
@@ -37,6 +37,7 @@ object WebSocketHandler {
       bufferLimit: Int,
       subprotocol: Option[String],
       compressionEnabled: Boolean,
+      compressionThreshold: Long,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration,
   ): HttpResponse = upgrade match {
@@ -44,7 +45,8 @@ object WebSocketHandler {
       lowLevel.handleFrames(
         messageFlowToFrameFlow(flow, bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle),
         subprotocol,
-        compressionEnabled
+        compressionEnabled,
+        _.data.length.toLong > compressionThreshold
       )
     case other =>
       throw new IllegalArgumentException("WebSocketUpgrade is not an Pekko HTTP UpgradeToWebsocketLowLevel")

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -113,10 +113,11 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
   private val httpsWantClientAuth                      = serverConfig.get[Boolean]("https.wantClientAuth")
   private val illegalResponseHeaderValueProcessingMode =
     pekkoServerConfig.get[String]("illegal-response-header-value-processing-mode")
-  private val wsBufferLimit       = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
-  private val wsKeepAliveMode     = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
-  private val wsKeepAliveMaxIdle  = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
-  private val wsCompressionConfig = serverConfig.get[Configuration]("websocket.compression")
+  private val wsBufferLimit          = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
+  private val wsKeepAliveMode        = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
+  private val wsKeepAliveMaxIdle     = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
+  private val wsCompressionConfig    = serverConfig.get[Configuration]("websocket.compression")
+  private val wsCompressionThreshold = wsCompressionConfig.get[ConfigMemorySize]("threshold").toBytes
 
   private val http2Enabled: Boolean = pekkoServerConfig.getOptional[Boolean]("http2.enabled").getOrElse(false)
 
@@ -450,6 +451,7 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
                     wsBufferLimit,
                     accepted.subprotocol,
                     accepted.compressionEnabled,
+                    wsCompressionThreshold,
                     wsKeepAliveMode,
                     wsKeepAliveMaxIdle
                   )

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -98,6 +98,11 @@ play {
         # extension.
         enabled = true
 
+        # Outbound text and binary messages are compressed only when their
+        # uncompressed payload size is greater than this threshold. Text message
+        # sizes are measured after UTF-8 encoding.
+        threshold = 0
+
         # Maximum size of the WebSocket decompression buffer. If this value is
         # exceeded while inflating a compressed WebSocket message, the server
         # closes the connection. By default this follows Play's WebSocket frame


### PR DESCRIPTION
> [!WARNING]
> - ~~Does not work yet; depends on https://github.com/apache/pekko-http/pull/1172~~

Adds a configurable threshold for outbound WebSocket compression:

```hocon
play.server.websocket.compression.threshold = 0
```

Outbound text and binary messages are compressed only when their uncompressed payload size is greater than the configured threshold.

This applies consistently to both the Netty and Pekko HTTP server backends.

## Behavior

- The threshold uses HOCON byte-size syntax, such as `512 bytes`, `1 KiB`, or `64 KiB`.
- Text message sizes are measured after UTF-8 encoding.
- Binary message sizes use the binary payload length.
- The comparison is strict: `payloadLength > threshold`.
- Compression must still be enabled globally, enabled for the accepted WebSocket, and negotiated with the client.
- Control frames are never compressed.
- The default threshold is `0`, preserving compression for every non-empty message.
- Empty messages are sent uncompressed at the default threshold, avoiding unnecessary compression overhead.

## Implementation

For Netty, Play installs a `WebSocketExtensionFilterProvider` that skips compression for text and binary frames whose payload does not exceed the threshold. Netty retains the initial decision across continuation frames.

For Pekko HTTP, Play uses the per-message compression selector introduced by 
- apache/pekko-http#1172.

Both backends therefore make the compression decision before applying `permessage-deflate`, while leaving negotiation and context-takeover behavior unchanged.

## Configuration

The setting is backend-independent and is documented under:

```hocon
play.server.websocket.compression.threshold
```

It is documented in the shared server `reference.conf`, the Java and Scala WebSocket documentation, and the Play 3.1 release highlights.

## Testing

The shared WebSocket compression integration tests run against both server backends and cover:

- Messages exactly at the configured threshold
- Messages above the configured threshold
- UTF-8 text payload sizes
- Binary payload sizes
- Raw RSV1 frame state
- Manual inflation and byte-level payload verification

## Dependency

This PR depends on apache/pekko-http#1172 for selective compression support in the Pekko HTTP backend.

## References

- apache/pekko-http#1172
- playframework/playframework#12477
