### PR TITLE
Validate application-selected WebSocket subprotocols

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -28,6 +28,8 @@ import org.specs2.execute.EventuallyResults
 import org.specs2.matcher.Matcher
 import org.specs2.specification.AroundEach
 import play.api.http.websocket._
+import play.api.http.HttpErrorHandler
+import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json
@@ -35,6 +37,8 @@ import play.api.libs.json.Reads
 import play.api.libs.streams.ActorFlow
 import play.api.libs.ws.WSClient
 import play.api.mvc.Handler
+import play.api.mvc.RequestHeader
+import play.api.mvc.Result
 import play.api.mvc.Results
 import play.api.mvc.WebSocket
 import play.api.routing.HandlerDef
@@ -654,6 +658,54 @@ trait WebSocketSpec
         }
       }
 
+      "fail the handshake when the application selects a subprotocol not proposed by the client" in {
+        val handledError = Promise[Throwable]()
+        val errorHandler = new HttpErrorHandler {
+          override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+            Future.successful(Results.Status(statusCode)(message))
+          }
+
+          override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+            handledError.trySuccess(exception)
+            Future.successful(Results.ServiceUnavailable)
+          }
+        }
+        withServer(
+          app =>
+            WebSocket.acceptWithOptions[String, String] { req =>
+              WebSocket.Accepted(
+                Flow.fromSinkAndSource(Sink.ignore, Source(Nil)),
+                Some("not-offered")
+              )
+            },
+          errorHandler = Some(errorHandler)
+        ) { (app, port) =>
+          val status    = webSocketHandshakeStatus(app, port, Some("graphql-ws, graphql-transport-ws"))
+          val exception = await(handledError.future)
+
+          (status must_== SERVICE_UNAVAILABLE)
+            .and(exception must beAnInstanceOf[IllegalArgumentException])
+            .and(
+              exception.getMessage must_==
+                "The application selected WebSocket subprotocol 'not-offered', " +
+                "but the client offered [graphql-ws, graphql-transport-ws]"
+            )
+        }
+      }
+
+      "fail the handshake when the application selects a subprotocol but the client proposed none" in {
+        withServer(app =>
+          WebSocket.acceptWithOptions[String, String] { req =>
+            WebSocket.Accepted(
+              Flow.fromSinkAndSource(Sink.ignore, Source(Nil)),
+              Some("not-offered")
+            )
+          }
+        ) { (app, port) =>
+          webSocketHandshakeStatus(app, port, None) must_== INTERNAL_SERVER_ERROR
+        }
+      }
+
       // we keep getting timeouts on this test
       // java.util.concurrent.TimeoutException: Futures timed out after [5 seconds] (Helpers.scala:186)
       "close the websocket when the wrong type of frame is received" in {
@@ -995,13 +1047,18 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   // Extend the default spec timeout for CI.
   implicit override def defaultAwaitTimeout: Timeout = 10.seconds
 
-  def withServer[A](webSocket: Application => Handler, extraConfig: Map[String, Any] = Map.empty)(
+  def withServer[A](
+      webSocket: Application => Handler,
+      extraConfig: Map[String, Any] = Map.empty,
+      errorHandler: Option[HttpErrorHandler] = None
+  )(
       block: (Application, Int) => A
   ): A = {
     val currentApp = new AtomicReference[Application]
     val config     = Configuration(ConfigFactory.parseMap(extraConfig.asJava))
-    val app        = GuiceApplicationBuilder()
-      .configure(config)
+    val builder    = GuiceApplicationBuilder().configure(config)
+    val app        = errorHandler
+      .fold(builder)(handler => builder.overrides(bind[HttpErrorHandler].to(handler)))
       .routes {
         case _ => webSocket(currentApp.get())
       }
@@ -1171,19 +1228,24 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
 
   def allowRejectingTheWebSocketWithAResult(webSocket: Application => Int => Handler) = {
     withServer(app => webSocket(app)(FORBIDDEN)) { (app, port) =>
-      val ws = app.injector.instanceOf[WSClient]
-      await(
-        ws.url(s"http://localhost:$port/stream")
-          .addHttpHeaders(
-            "Upgrade"               -> "websocket",
-            "Connection"            -> "upgrade",
-            "Sec-WebSocket-Version" -> "13",
-            "Sec-WebSocket-Key"     -> "x3JJHMbDL1EzLkh9GBhXDw==",
-            "Origin"                -> "http://example.com"
-          )
-          .get()
-      ).status must_== FORBIDDEN
+      webSocketHandshakeStatus(app, port, None) must_== FORBIDDEN
     }
+  }
+
+  def webSocketHandshakeStatus(app: Application, port: Int, subprotocol: Option[String]): Int = {
+    val ws      = app.injector.instanceOf[WSClient]
+    val headers = Seq(
+      "Upgrade"               -> "websocket",
+      "Connection"            -> "upgrade",
+      "Sec-WebSocket-Version" -> "13",
+      "Sec-WebSocket-Key"     -> "x3JJHMbDL1EzLkh9GBhXDw==",
+      "Origin"                -> "http://example.com"
+    ) ++ subprotocol.map("Sec-WebSocket-Protocol" -> _)
+    await(
+      ws.url(s"http://localhost:$port/stream")
+        .addHttpHeaders(headers*)
+        .get()
+    ).status
   }
 
   def handleNonUpgradeRequestsGracefully(webSocket: Application => Handler) = {

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -190,6 +190,13 @@ public abstract class WebSocket {
       return flow;
     }
 
+    /**
+     * Returns the WebSocket subprotocol selected by the application, if any.
+     *
+     * <p>The selected subprotocol must be one of the subprotocols offered by the client. Otherwise,
+     * Play passes the application error to its configured HTTP error handler, which returns an HTTP
+     * 500 response by default.
+     */
     public Optional<String> subprotocol() {
       return subprotocol;
     }

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -44,16 +44,32 @@ trait WebSocket extends Handler {
  * Helper utilities to generate WebSocket results.
  */
 object WebSocket {
+  private val SubprotocolHeader = "Sec-WebSocket-Protocol"
+
+  private def requestedSubprotocols(request: RequestHeader): Seq[String] = {
+    request.headers
+      .getAll(SubprotocolHeader)
+      .flatMap(_.split(",").iterator.map(_.trim).filter(_.nonEmpty))
+  }
+
   private def closeOnException(flow: Flow[Message, Message, ?]): Flow[Message, Message, ?] = {
     flow.recover { case WebSocketCloseException(close) => close }
   }
 
   private[play] def firstRequestedSubprotocol(request: RequestHeader): Option[String] = {
-    request.headers
-      .get("Sec-WebSocket-Protocol")
-      .toSeq
-      .flatMap(_.split(",").iterator.map(_.trim).filter(_.nonEmpty))
-      .headOption
+    requestedSubprotocols(request).headOption
+  }
+
+  // Validate in Play so invalid application selections fail consistently across server backends.
+  private[play] def validateSubprotocol(request: RequestHeader, selectedSubprotocol: Option[String]): Unit = {
+    selectedSubprotocol.foreach { selected =>
+      val requested = requestedSubprotocols(request)
+      if (!requested.contains(selected)) {
+        throw new IllegalArgumentException(
+          s"The application selected WebSocket subprotocol '$selected', but the client offered [${requested.mkString(", ")}]"
+        )
+      }
+    }
   }
 
   def apply(f: RequestHeader => Future[Either[Result, Flow[Message, Message, ?]]]): WebSocket = {
@@ -64,7 +80,9 @@ object WebSocket {
    * An accepted WebSocket, including the flow that handles WebSocket messages and optional handshake metadata.
    *
    * @param flow the flow that handles WebSocket messages
-   * @param subprotocol the WebSocket subprotocol selected by the application, if any
+   * @param subprotocol the WebSocket subprotocol selected by the application, if any; this must be one of the
+   *                    subprotocols offered by the client, otherwise Play passes the application error to the configured
+   *                    [[play.api.http.HttpErrorHandler]], which returns an HTTP 500 response by default
    * @param compressionEnabled whether this accepted WebSocket may negotiate compression when compression is enabled in
    *                           the server configuration; setting this to `true` does not enable compression globally
    */

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -55,6 +55,8 @@ WebSocket.Text.acceptWithOptions(request ->
 
 This is useful for protocols where the client and server need to agree on an application-level WebSocket protocol during the opening handshake. Existing `accept` and `acceptOrResult` handlers keep their previous behavior.
 
+The selected subprotocol must be one offered by the client. Selecting any other value is an application error that Play passes to the configured `HttpErrorHandler` without completing the upgrade; the default response is HTTP 500.
+
 For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Selecting-a-WebSocket-subprotocol]] and [[Java WebSocket documentation|JavaWebSockets#Selecting-a-WebSocket-subprotocol]].
 
 ### WebSocket Abnormal Closure Status

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -98,7 +98,7 @@ A client can offer one or more WebSocket subprotocols using the `Sec-WebSocket-P
 
 @[subprotocol](code/javaguide/async/JavaWebSockets.java)
 
-If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `new WebSocket.Accepted<>(flow, Optional.empty())` and use a flow that closes the WebSocket.
+If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. Selecting a subprotocol that the client did not offer is an application error. Play passes it to the configured `HttpErrorHandler` without completing the upgrade; the default response is HTTP 500. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `new WebSocket.Accepted<>(flow, Optional.empty())` and use a flow that closes the WebSocket.
 
 ## Accessing a WebSocket
 

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -100,7 +100,7 @@ A client can offer one or more WebSocket subprotocols using the `Sec-WebSocket-P
 
 @[subprotocol](code/ScalaWebSockets.scala)
 
-If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `WebSocket.Accepted(flow, None)` and use a flow that closes the WebSocket.
+If no offered subprotocol is acceptable, use `acceptOrResultWithOptions` to reject the upgrade with a normal HTTP result. Selecting a subprotocol that the client did not offer is an application error. Play passes it to the configured `HttpErrorHandler` without completing the upgrade; the default response is HTTP 500. If a specific client or protocol requires the handshake to complete without a selected subprotocol, return `WebSocket.Accepted(flow, None)` and use a flow that closes the WebSocket.
 
 ## Accessing a WebSocket
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -213,6 +213,7 @@ private[play] class PlayRequestHandler(
               val action = EssentialAction(_ => Accumulator.done(result))
               handleAction(action, requestHeader, request, tryApp)
             case Right(accepted) =>
+              WebSocket.validateSubprotocol(requestHeader, accepted.subprotocol)
               import app.materializer
               val processor =
                 WebSocketHandler.messageFlowToFrameProcessor(

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -434,23 +434,34 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
       case (action: EssentialAction, _) =>
         runAction(tryApp, request, taggedRequestHeader, requestBodySource, action, errorHandler(tryApp), true)
       case (websocket: WebSocket, Some(upgrade)) =>
-        websocket.applyWithOptions(taggedRequestHeader).fast.flatMap {
-          case Left(result) =>
-            modelConversion(tryApp).convertResult(taggedRequestHeader, result, request.protocol, errorHandler(tryApp))
-          case Right(accepted) =>
-            Future.successful(
-              WebSocketHandler
-                .handleWebSocket(
-                  upgrade,
-                  accepted.flow,
-                  wsBufferLimit,
-                  accepted.subprotocol,
-                  accepted.compressionEnabled,
-                  wsKeepAliveMode,
-                  wsKeepAliveMaxIdle
-                )
-            )
-        }
+        Future(websocket.applyWithOptions(taggedRequestHeader))
+          .flatMap(identity)
+          .fast
+          .flatMap {
+            case Left(result) =>
+              modelConversion(tryApp).convertResult(taggedRequestHeader, result, request.protocol, errorHandler(tryApp))
+            case Right(accepted) =>
+              WebSocket.validateSubprotocol(taggedRequestHeader, accepted.subprotocol)
+              Future.successful(
+                WebSocketHandler
+                  .handleWebSocket(
+                    upgrade,
+                    accepted.flow,
+                    wsBufferLimit,
+                    accepted.subprotocol,
+                    accepted.compressionEnabled,
+                    wsKeepAliveMode,
+                    wsKeepAliveMaxIdle
+                  )
+              )
+          }
+          .recoverWith {
+            case NonFatal(error) =>
+              errorHandler(tryApp).onServerError(taggedRequestHeader, error).flatMap { result =>
+                modelConversion(tryApp)
+                  .convertResult(taggedRequestHeader, result, request.protocol, errorHandler(tryApp))
+              }
+          }
 
       case (websocket: WebSocket, None) =>
         // WebSocket handler for non WebSocket request


### PR DESCRIPTION
This validates that a WebSocket subprotocol selected through `acceptWithOptions` was offered by the client.

If the application selects an unoffered subprotocol, Play now:

- does not complete the WebSocket upgrade;
- passes an `IllegalArgumentException` to the configured `HttpErrorHandler`;
- returns HTTP 500 with the default error handler.

Selecting no subprotocol remains valid. Applications that cannot accept any offered protocol should reject the upgrade explicitly through `acceptOrResultWithOptions`.

## Motivation

The previous behavior differed between server backends:

- Netty could silently omit an invalid selected subprotocol.
- Pekko HTTP rejected the invalid selection.

Performing the validation in Play gives both backends the same application-error behavior and error message.

## Changes

- Parse all values from `Sec-WebSocket-Protocol`, including multiple header lines and comma-separated values.
- Validate the selected protocol before dispatching the WebSocket upgrade.
- Route validation failures through the configured `HttpErrorHandler`.
- Document the behavior in the Java and Scala WebSocket guides and the Play release highlights.

## Testing

Shared integration tests cover both Netty and Pekko HTTP:

- selecting a protocol that was not among multiple offered protocols;
- selecting a protocol when the client offered none;
- passing the validation exception through a custom `HttpErrorHandler`;
- returning HTTP 500 with the default error handler.
