### PR TITLE
Add missing registered WebSocket close codes

### DIFF
--- a/core/play/src/main/scala/play/api/http/websocket/CloseCodes.scala
+++ b/core/play/src/main/scala/play/api/http/websocket/CloseCodes.scala
@@ -9,6 +9,9 @@ package play.api.http.websocket
  *
  * RFC 6455 limits the reason in a Close frame with a status code to 123 UTF-8 bytes. Play truncates longer
  * Close reasons before sending them.
+ *
+ * See the [[https://www.iana.org/assignments/websocket/websocket.xhtml IANA WebSocket Close Code Number Registry]]
+ * for the registered close codes.
  */
 object CloseCodes {
   val Regular       = 1000
@@ -34,6 +37,21 @@ object CloseCodes {
   val TooBig                 = 1009
   val ClientRejectsExtension = 1010
   val UnexpectedCondition    = 1011
+
+  /**
+   * Indicates that the service is restarting and the client may reconnect.
+   */
+  val ServiceRestart = 1012
+
+  /**
+   * Indicates that the service is temporarily unavailable and the client may reconnect later.
+   */
+  val TryAgainLater = 1013
+
+  /**
+   * Indicates that a server acting as a gateway received an invalid response from its upstream server.
+   */
+  val BadGateway = 1014
 
   /**
    * Indicates that the connection was closed because the TLS handshake failed.

--- a/core/play/src/test/scala/play/api/http/websocket/CloseCodesSpec.scala
+++ b/core/play/src/test/scala/play/api/http/websocket/CloseCodesSpec.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.http.websocket
+
+import org.specs2.mutable.Specification
+
+class CloseCodesSpec extends Specification {
+  "CloseCodes" should {
+    "provide the registered service close codes" in {
+      (CloseCodes.ServiceRestart, CloseCodes.TryAgainLater, CloseCodes.BadGateway) must_== ((1012, 1013, 1014))
+    }
+  }
+}


### PR DESCRIPTION
Add constants for the registered WebSocket close codes that were missing from `CloseCodes`:


- `ServiceRestart` (`1012`)
- `TryAgainLater` (`1013`)
- `BadGateway` (`1014`)

The `CloseCodes` Scaladoc now also links to the IANA WebSocket Close Code Number Registry.

## Motivation

Applications currently need to use numeric literals when closing a WebSocket with these registered service-related status codes. Providing named constants makes their purpose explicit and completes the existing sequence between `UnexpectedCondition` (`1011`) and `TLSHandshakeFailure` (`1015`).

This is an additive API change and does not alter existing WebSocket behavior.

## Testing

Added `CloseCodesSpec` to verify the values of all three constants.
