### PR TITLE
 Validate WebSocket text and control frames

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -78,6 +78,7 @@ object WebSocketClient {
       SimpleMessage(message, finalFragment = true)
   }
   case class SimpleMessage(message: Message, finalFragment: Boolean)       extends ExtendedMessage
+  case class RawTextMessage(data: ByteString, finalFragment: Boolean)      extends ExtendedMessage
   case class ContinuationMessage(data: ByteString, finalFragment: Boolean) extends ExtendedMessage
   case class RawWebSocketFrame(frameType: String, data: ByteString, rsv: Int, finalFragment: Boolean)
       extends ExtendedMessage
@@ -227,7 +228,7 @@ object WebSocketClient {
           new GraphStageLogic(shape) with InHandler with OutHandler {
             def onPush(): Unit = {
               grab(in) match {
-                case close: CloseWebSocketFrame =>
+                case close: CloseWebSocketFrame if close.isFinalFragment && close.content().readableBytes() <= 125 =>
                   clientInitiatedClose.set(true)
                   push(out, close)
                 case other => push(out, other)
@@ -246,7 +247,9 @@ object WebSocketClient {
       })
 
       val messagesToFrames = Flow[ExtendedMessage].map {
-        case SimpleMessage(TextMessage(data), finalFragment)   => new TextWebSocketFrame(finalFragment, 0, data)
+        case SimpleMessage(TextMessage(data), finalFragment) => new TextWebSocketFrame(finalFragment, 0, data)
+        case RawTextMessage(data, finalFragment)             =>
+          new TextWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
         case SimpleMessage(BinaryMessage(data), finalFragment) =>
           new BinaryWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
         case SimpleMessage(PingMessage(data), finalFragment) =>

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -49,6 +49,7 @@ import play.it._
 import play.it.http.websocket.WebSocketClient.CompressionMode
 import play.it.http.websocket.WebSocketClient.ContinuationMessage
 import play.it.http.websocket.WebSocketClient.ExtendedMessage
+import play.it.http.websocket.WebSocketClient.RawTextMessage
 import play.it.http.websocket.WebSocketClient.RawWebSocketFrame
 import play.it.http.websocket.WebSocketClient.SimpleMessage
 
@@ -566,6 +567,85 @@ trait WebSocketSpec
           )
           result.map(b => b.utf8String) must_== Seq("first", "second", "third")
         }
+      }
+
+      "reject invalid UTF-8 in a text message" in {
+        val (frames, messages) = sendProtocolFrames(RawTextMessage(ByteString(0xc3.toByte, 0x28), true))
+
+        frames must contain(exactly(closeFrame(CloseCodes.InconsistentData)))
+        messages must beEmpty
+      }
+
+      "reject invalid UTF-8 split across text message fragments" in {
+        val (frames, messages) = sendProtocolFrames(
+          RawTextMessage(ByteString(0xe2.toByte), false),
+          ContinuationMessage(ByteString(0x28), true)
+        )
+
+        frames must contain(exactly(closeFrame(CloseCodes.InconsistentData)))
+        messages must beEmpty
+      }
+
+      "accept valid UTF-8 split across text message fragments" in {
+        val (_, messages) = sendProtocolFrames(
+          RawTextMessage(ByteString(0xe2.toByte, 0x82.toByte), false),
+          ContinuationMessage(ByteString(0xac.toByte), true),
+          CloseMessage(CloseCodes.Regular)
+        )
+
+        messages must_== List(TextMessage("\u20ac"), CloseMessage(CloseCodes.Regular))
+      }
+
+      "allow control frames between data message fragments" in {
+        val (frames, messages) = sendProtocolFrames(
+          SimpleMessage(TextMessage("hel"), false),
+          PingMessage(ByteString("ping")),
+          PongMessage(ByteString("pong")),
+          ContinuationMessage(ByteString("lo"), true),
+          CloseMessage(CloseCodes.Regular)
+        )
+
+        frames must contain(exactly(pongFrame(be_==("ping")), closeFrame()).inOrder)
+        messages must_== List(
+          PingMessage(ByteString("ping")),
+          PongMessage(ByteString("pong")),
+          TextMessage("hello"),
+          CloseMessage(CloseCodes.Regular)
+        )
+      }
+
+      Seq(
+        "Ping"  -> SimpleMessage(PingMessage(ByteString("control")), false),
+        "Pong"  -> SimpleMessage(PongMessage(ByteString("control")), false),
+        "Close" -> SimpleMessage(CloseMessage(CloseCodes.Regular), false)
+      ).foreach {
+        case (name, frame) =>
+          s"reject a fragmented $name control frame" in {
+            val (frames, messages) = sendProtocolFrames(
+              frame,
+              ContinuationMessage(ByteString("continuation"), true),
+              CloseMessage(CloseCodes.Regular)
+            )
+
+            frames must contain(exactly(closeFrame(CloseCodes.ProtocolError)))
+            messages must beEmpty
+          }
+      }
+
+      "reject an oversized Pong control frame" in {
+        val (frames, messages) =
+          sendProtocolFrames(PongMessage(ByteString(Array.fill[Byte](126)('a'.toByte))))
+
+        frames must contain(exactly(closeFrame(CloseCodes.ProtocolError)))
+        messages must beEmpty
+      }
+
+      "reject an oversized Close control frame" in {
+        val (frames, messages) =
+          sendProtocolFrames(CloseMessage(CloseCodes.Regular, "a" * 124))
+
+        frames must contain(exactly(closeFrame(CloseCodes.ProtocolError)))
+        messages must beEmpty
       }
 
       "close the websocket when the buffer limit is exceeded" in {
@@ -1158,6 +1238,23 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   // frame is sent, but WebSockets require that the client waits for the server to echo the close back, and
   // let the server close.
   def sendFrames(frames: ExtendedMessage*) = Source(frames.toList).concat(Source.maybe)
+
+  def sendProtocolFrames(frames: ExtendedMessage*): (List[ExtendedMessage], List[Message]) = {
+    val consumed = Promise[List[Message]]()
+    withServer(app =>
+      WebSocket.accept[Message, Message] { req =>
+        Flow.fromSinkAndSource(onFramesConsumed[Message](consumed.success(_)), Source.maybe[Message])
+      }
+    ) { (app, port) =>
+      import app.materializer
+      runWebSocket(
+        port,
+        { flow =>
+          sendFrames(frames*).via(flow).runWith(consumeFrames).zip(consumed.future)
+        }
+      )
+    }
+  }
 
   /*
    * Shared tests

--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -97,6 +97,18 @@ Java
 
 Handlers using typed APIs such as `WebSocket.accept[String, String]` still do not receive close control frames as typed messages. Use a raw `Message` flow if your application needs to inspect WebSocket close status codes directly.
 
+### Malformed WebSocket frames are rejected more strictly
+
+Play now validates incoming WebSocket text and control frames consistently across the Netty and Pekko HTTP server backends.
+
+Previously, malformed UTF-8 in a text message could be decoded with replacement characters and delivered to the application. Play now rejects the message, sends Close status `1007` to the remote peer, and does not deliver the malformed message. Valid UTF-8 remains supported when a multi-byte character is split across WebSocket fragments. This follows [RFC 6455 section 8.1](https://datatracker.ietf.org/doc/html/rfc6455#section-8.1).
+
+Play also rejects fragmented Ping, Pong, and Close control frames, and control frames with payloads larger than 125 bytes, by sending Close status `1002`. Valid control frames can still be interleaved between fragments of a data message, as required by [RFC 6455 section 5.4](https://datatracker.ietf.org/doc/html/rfc6455#section-5.4) and [section 5.5](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5).
+
+When Netty detects and closes one of these protocol violations before it reaches Play's common WebSocket handler, Play now completes the application stream without also reporting a synthetic `1006` close message. Status `1006` remains the application-visible result for abnormal transport loss where no protocol error was already handled.
+
+Applications that previously expected replacement characters or a synthetic `1006` for malformed frames should update their handling. Clients that send valid RFC 6455 frames are unaffected.
+
 ### WebSocket close messages from typed transformers and application failures are more consistent
 
 Play now preserves more application-level WebSocket close reasons as WebSocket Close frames instead of turning them into generic stream termination.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -349,8 +349,10 @@ class NettyServer(
       }
 
       // Netty HTTP decoders/encoders/etc
-      pipeline.addLast("decoder", new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize))
       pipeline.addLast("encoder", new PlayHttpResponseEncoder())
+      // The WebSocket handshaker installs its frame encoder before this HTTP encoder. Keeping the HTTP encoder before
+      // the decoder ensures decoder-generated protocol-error Close frames pass through the WebSocket encoder.
+      pipeline.addLast("decoder", new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize))
       pipeline.addLast("decompressor", new HttpContentDecompressor())
       newWebSocketCompressionHandler().foreach(pipeline.addLast("ws-compressor", _))
       if (logWire) {

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -38,7 +38,7 @@ private[server] object WebSocketHandler {
   ): Processor[WebSocketFrame, WebSocketFrame] = {
     // The reason we use a processor is that we *must* release the buffers synchronously, since Pekko streams drops
     // messages, which will mean we can't release the ByteBufs in the messages.
-    SynchronousMappedStreams.transform(
+    val processor = SynchronousMappedStreams.transform(
       WebSocketFlowHandler
         .webSocketProtocol(bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle)
         .join(flow)
@@ -47,6 +47,23 @@ private[server] object WebSocketHandler {
       frameToMessage,
       messageToFrame
     )
+
+    new Processor[WebSocketFrame, WebSocketFrame] {
+      override def onSubscribe(subscription: org.reactivestreams.Subscription): Unit =
+        processor.onSubscribe(subscription)
+      override def onNext(frame: WebSocketFrame): Unit                                              = processor.onNext(frame)
+      override def onComplete(): Unit                                                               = processor.onComplete()
+      override def onError(error: Throwable): Unit                                                  = processor.onError(normalizeProtocolViolation(error))
+      override def subscribe(subscriber: org.reactivestreams.Subscriber[? >: WebSocketFrame]): Unit =
+        processor.subscribe(subscriber)
+    }
+  }
+
+  private def normalizeProtocolViolation(error: Throwable): Throwable = error match {
+    case corrupted: CorruptedWebSocketFrameException
+        if Option(corrupted.getMessage).forall(message => !message.startsWith("Invalid close frame getStatus code:")) =>
+      new WebSocketFlowHandler.BackendHandledProtocolViolation(corrupted)
+    case other => other
   }
 
   /**

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -89,6 +89,11 @@ object WebSocketFlowHandler {
 
         var currentPartialMessage: RawMessage = null
 
+        val textDecoder = StandardCharsets.UTF_8
+          .newDecoder()
+          .onMalformedInput(CodingErrorAction.REPORT)
+          .onUnmappableCharacter(CodingErrorAction.REPORT)
+
         // For the remoteIn, we always and only pull when the appOut is available, the only exception being when appOut
         // is already closed and we're expecting a close ack from the client. This means whenever remoteIn pushes, we
         // always know we can push directly to appOut.  It does mean however that we will never respond to close or
@@ -134,7 +139,16 @@ object WebSocketFlowHandler {
 
         def toMessage(messageType: MessageType.Type, data: ByteString): Message = {
           messageType match {
-            case MessageType.Text   => TextMessage(data.utf8String)
+            case MessageType.Text =>
+              try {
+                TextMessage(textDecoder.reset().decode(data.asByteBuffer).toString)
+              } catch {
+                case _: CharacterCodingException =>
+                  serverInitiatedClose(
+                    CloseMessage(CloseCodes.InconsistentData, "Text message contained invalid UTF-8")
+                  )
+                  null
+              }
             case MessageType.Binary => BinaryMessage(data)
             case MessageType.Ping   => PingMessage(data)
             case MessageType.Pong   => PongMessage(data)
@@ -142,10 +156,24 @@ object WebSocketFlowHandler {
           }
         }
 
+        def isControlMessage(messageType: MessageType.Type): Boolean = {
+          messageType == MessageType.Ping ||
+          messageType == MessageType.Pong ||
+          messageType == MessageType.Close
+        }
+
         def consumeMessage(): Message = {
           val read = grab(remoteIn)
 
           read.messageType match {
+            case messageType if isControlMessage(messageType) && !read.isFinal =>
+              serverInitiatedClose(CloseMessage(CloseCodes.ProtocolError, "Control frames must not be fragmented"))
+              null
+            case messageType if isControlMessage(messageType) && read.data.size > 125 =>
+              serverInitiatedClose(
+                CloseMessage(CloseCodes.ProtocolError, "Control frame payload must not exceed 125 bytes")
+              )
+              null
             case MessageType.Ping if read.directAnswer =>
               // Ping the client (Part of idle handling)
               if (isAvailable(remoteOut)) {
@@ -166,6 +194,8 @@ object WebSocketFlowHandler {
                 pongToSend = PongMessage(ByteString.empty)
               }
               null
+            case MessageType.Ping | MessageType.Pong | MessageType.Close =>
+              toMessage(read.messageType, read.data)
             case MessageType.Continuation if currentPartialMessage == null =>
               serverInitiatedClose(CloseMessage(CloseCodes.ProtocolError, "Unexpected continuation frame"))
               null
@@ -243,24 +273,29 @@ object WebSocketFlowHandler {
             }
 
             override def onUpstreamFailure(ex: Throwable): Unit = {
-              // This happens e.g. when using the Netty backend and a client sends an invalid close status code
-              // that is not defined in https://tools.ietf.org/html/rfc6455#section-7.4
-              val closeFromFailure = if (state == Open) {
-                val statusCode = """(\d+)""".r
-                ex.getMessage match {
-                  case s"Invalid close frame getStatus code: ${statusCode(code)}" => // Parse Netty error message
-                    Some(CloseMessage(code.toInt))
-                  case _ => // Don't log the whole exception to not overwhelm the logs in case failures occur often
-                    logger.warn(s"WebSocket communication problem: ${ex.getMessage}")
+              ex match {
+                case _: BackendHandledProtocolViolation =>
+                  completeStage()
+                case _ =>
+                  // This happens e.g. when using the Netty backend and a client sends an invalid close status code
+                  // that is not defined in https://tools.ietf.org/html/rfc6455#section-7.4
+                  val closeFromFailure = if (state == Open) {
+                    val statusCode = """(\d+)""".r
+                    ex.getMessage match {
+                      case s"Invalid close frame getStatus code: ${statusCode(code)}" => // Parse Netty error message
+                        Some(CloseMessage(code.toInt))
+                      case _ => // Don't log the whole exception to not overwhelm the logs in case failures occur often
+                        logger.warn(s"WebSocket communication problem: ${ex.getMessage}")
+                        None
+                    }
+                  } else {
+                    logger.debug("WebSocket communication problem after the WebSocket was closed", ex)
                     None
-                }
-              } else {
-                logger.debug("WebSocket communication problem after the WebSocket was closed", ex)
-                None
-              }
-              closeFromFailure match {
-                case Some(close) => completeAfterForwardingCloseToApp(close)
-                case None        => completeRemoteInputAbnormally()
+                  }
+                  closeFromFailure match {
+                    case Some(close) => completeAfterForwardingCloseToApp(close)
+                    case None        => completeRemoteInputAbnormally()
+                  }
               }
             }
 
@@ -446,6 +481,8 @@ object WebSocketFlowHandler {
     type Type = Value
     val Ping, Pong, Text, Binary, Continuation, Close = Value
   }
+
+  private[server] final class BackendHandledProtocolViolation(cause: Throwable) extends RuntimeException(cause)
 
   def parseCloseMessage(data: ByteString): CloseMessage = {
     def invalid(reason: String) =

--- a/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
@@ -19,6 +19,9 @@ import org.specs2.mutable.Specification
 import play.api.http.websocket.CloseCodes
 import play.api.http.websocket.CloseMessage
 import play.api.http.websocket.Message
+import play.api.http.websocket.PingMessage
+import play.api.http.websocket.PongMessage
+import play.api.http.websocket.TextMessage
 
 class WebSocketFlowHandlerSpec extends Specification {
   "WebSocketFlowHandler" should {
@@ -33,6 +36,16 @@ class WebSocketFlowHandlerSpec extends Specification {
       val messages = runFailedRemoteInput(new RuntimeException("Invalid close frame getStatus code: 1006"))
 
       messages must contain(exactly(closeMessage(CloseCodes.ConnectionAbort)))
+    }
+
+    "not send 1006 for a protocol violation already handled by the backend" in withActorSystem {
+      implicit materializer =>
+        val messages =
+          runFailedRemoteInput(
+            new WebSocketFlowHandler.BackendHandledProtocolViolation(new RuntimeException("protocol violation"))
+          )
+
+        messages must beEmpty
     }
 
     "not send 1006 when the application initiated close and remote input then fails" in withActorSystem {
@@ -99,6 +112,57 @@ class WebSocketFlowHandlerSpec extends Specification {
       val (_, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(rawClose(None))
 
       remoteMessages must contain(exactly(beEqualTo(CloseMessage(None))))
+    }
+
+    Seq(
+      WebSocketFlowHandler.MessageType.Ping,
+      WebSocketFlowHandler.MessageType.Pong,
+      WebSocketFlowHandler.MessageType.Close
+    ).foreach { messageType =>
+      s"reject a fragmented $messageType control frame" in withActorSystem { implicit materializer =>
+        val (appMessages, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(
+          rawMessage(messageType, ByteString("control"), isFinal = false),
+          rawClose(CloseCodes.ProtocolError)
+        )
+
+        appMessages must beEmpty
+        remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
+      }
+
+      s"reject an oversized $messageType control frame" in withActorSystem { implicit materializer =>
+        val (appMessages, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(
+          rawMessage(messageType, ByteString(Array.fill[Byte](126)('a'.toByte)), isFinal = true),
+          rawClose(CloseCodes.ProtocolError)
+        )
+
+        appMessages must beEmpty
+        remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
+      }
+    }
+
+    "preserve fragmented data state while processing control frames" in withActorSystem { implicit materializer =>
+      val (appMessages, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(
+        rawMessage(WebSocketFlowHandler.MessageType.Text, ByteString("hel"), isFinal = false),
+        rawMessage(WebSocketFlowHandler.MessageType.Ping, ByteString("ping"), isFinal = true),
+        rawMessage(WebSocketFlowHandler.MessageType.Pong, ByteString("pong"), isFinal = true),
+        rawMessage(WebSocketFlowHandler.MessageType.Continuation, ByteString("lo"), isFinal = true),
+        rawClose(CloseCodes.Regular)
+      )
+
+      appMessages must beEqualTo(
+        Seq(
+          PingMessage(ByteString("ping")),
+          PongMessage(ByteString("pong")),
+          TextMessage("hello"),
+          CloseMessage(CloseCodes.Regular)
+        )
+      )
+      remoteMessages must beEqualTo(
+        Seq(
+          PongMessage(ByteString("ping")),
+          CloseMessage(CloseCodes.Regular)
+        )
+      )
     }
   }
 
@@ -215,11 +279,15 @@ class WebSocketFlowHandlerSpec extends Specification {
   }
 
   private def rawClose(statusCode: Option[Int]): WebSocketFlowHandler.RawMessage = {
-    WebSocketFlowHandler.RawMessage(
-      WebSocketFlowHandler.MessageType.Close,
-      statusCode.fold(ByteString.empty)(rawCloseData),
-      isFinal = true
-    )
+    rawMessage(WebSocketFlowHandler.MessageType.Close, statusCode.fold(ByteString.empty)(rawCloseData), isFinal = true)
+  }
+
+  private def rawMessage(
+      messageType: WebSocketFlowHandler.MessageType.Type,
+      data: ByteString,
+      isFinal: Boolean
+  ): WebSocketFlowHandler.RawMessage = {
+    WebSocketFlowHandler.RawMessage(messageType, data, isFinal)
   }
 
   private def rawCloseData(statusCode: Int): ByteString = {


### PR DESCRIPTION
Strengthen WebSocket protocol validation shared by the Netty and Pekko HTTP server backends.

This change:

- validates complete text messages with a strict UTF-8 decoder;
- closes the connection with `1007` when text contains malformed UTF-8;
- rejects fragmented control frames with `1002`;
- rejects control-frame payloads larger than 125 bytes with `1002`;
- preserves an open fragmented data message while processing interleaved Ping, Pong, or Close frames;
- prevents protocol violations already handled by Netty from appearing to the application as synthetic `1006` close messages.

Malformed messages and control frames are not delivered to the application.

## Motivation

RFC 6455 requires text messages to contain valid UTF-8. It also requires control frames to be final and limits their payload to 125 bytes. Control frames may be interleaved between fragments of a data message.

Previously:

- Play decoded text using `ByteString.utf8String`, which could replace malformed byte sequences instead of rejecting the message.
- control frames could incorrectly interfere with fragmented-data state;
- some Netty protocol rejections appeared to applications as misleading `1006` close messages.

## Netty handling

Netty can reject some violations in its frame decoder before they reach Play's common WebSocket handler. It sends the appropriate `1002` or `1007` Close frame itself.

Play now recognizes those backend-handled failures and completes the application stream without generating another Close frame or forwarding a synthetic `1006`. The Netty pipeline ordering is also corrected so decoder-generated protocol-error Close frames pass through the WebSocket encoder.

## Testing

Shared integration coverage for both Netty and Pekko HTTP includes:

- invalid UTF-8 in an unfragmented text message;
- invalid UTF-8 split across fragments;
- a valid multi-byte UTF-8 character split across fragments;
- fragmented Ping, Pong, and Close frames;
- oversized control frames;
- valid Ping and Pong frames interleaved with fragmented text.

Common-handler tests additionally cover all control-frame types and confirm that backend-handled violations do not produce an application-visible `1006`.

## References

- [RFC 6455, Section 5.4: Fragmentation](https://www.rfc-editor.org/rfc/rfc6455#section-5.4)
- [RFC 6455, Section 5.5: Control Frames](https://www.rfc-editor.org/rfc/rfc6455#section-5.5)
- [RFC 6455, Section 8.1: Handling Errors in UTF-8-Encoded Data](https://www.rfc-editor.org/rfc/rfc6455#section-8.1)
