### PR TITLE
Allow selecting individual WebSocket messages for compression

### DIFF
--- a/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/core/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -72,6 +72,17 @@ public class WebSocketSpecJavaActions {
                 false));
   }
 
+  public static WebSocket selectMessagesForCompression() {
+    return WebSocket.Text.acceptWithOptions(
+        request ->
+            new WebSocket.Accepted<>(
+                Flow.fromSinkAndSource(Sink.ignore(), Source.from(List.of("\u20ac", "123456"))),
+                context ->
+                    context.message() instanceof play.http.websocket.Message.Text
+                        && context.payloadLength() == 3
+                        && !context.isAboveCompressionThreshold()));
+  }
+
   public static WebSocket acceptText() {
     return WebSocket.Text.accept(request -> Flow.fromSinkAndSource(Sink.ignore(), emptySource()));
   }

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -181,11 +181,161 @@ trait WebSocketCompressionSpec extends WebSocketSpecMethods {
       }
     }
 
+    "allow the application to override the compression threshold for each outbound message" in {
+      val belowText            = "\u20ac"
+      val aboveText            = "123456"
+      val belowBinary          = ByteString(1, 2, 3)
+      val aboveBinary          = ByteString(1, 2, 3, 4, 5, 6)
+      val compressibleMessages = List[Message](
+        TextMessage(belowText),
+        TextMessage(aboveText),
+        BinaryMessage(belowBinary),
+        BinaryMessage(aboveBinary)
+      )
+      val outboundMessages = compressibleMessages.patch(2, Seq(PingMessage(ByteString("ping"))), 0)
+      val observedContexts = new AtomicReference(Vector.empty[(Message, Long, Boolean)])
+
+      withServer(
+        app =>
+          WebSocket.acceptWithOptions[Message, Message] { req =>
+            WebSocket.Accepted(
+              Flow.fromSinkAndSource(Sink.ignore, Source(outboundMessages)),
+              shouldCompress = context => {
+                observedContexts.synchronized {
+                  observedContexts.set(
+                    observedContexts.get() :+ (
+                      context.message,
+                      context.payloadLength,
+                      context.isAboveCompressionThreshold
+                    )
+                  )
+                }
+                context.payloadLength == 3
+              }
+            )
+          },
+        Map(
+          "play.server.websocket.compression.threshold"                              -> "5 bytes",
+          "play.server.websocket.compression.perMessageDeflate.allowServerNoContext" -> true
+        )
+      ) { (app, port) =>
+        import app.materializer
+        val frames = runWebSocket(
+          port,
+          { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+          compressionMode = CompressionMode.RequestOnly("permessage-deflate; server_no_context_takeover")
+        )
+
+        val dataFrames = frames.collect {
+          case frame @ SimpleMessage(_: TextMessage, _)     => frame
+          case frame @ SimpleMessage(_: BinaryMessage, _)   => frame
+          case frame @ RawWebSocketFrame("text", _, _, _)   => frame
+          case frame @ RawWebSocketFrame("binary", _, _, _) => frame
+        }
+
+        val framesResult = dataFrames must beLike {
+          case List(
+                RawWebSocketFrame("text", compressedText, textRsv, true),
+                SimpleMessage(TextMessage(`aboveText`), true),
+                RawWebSocketFrame("binary", compressedBinary, binaryRsv, true),
+                SimpleMessage(BinaryMessage(`aboveBinary`), true)
+              ) =>
+            (textRsv must_== 4)
+              .and(inflatePerMessageDeflate(compressedText).utf8String must_== belowText)
+              .and(binaryRsv must_== 4)
+              .and(inflatePerMessageDeflate(compressedBinary) must_== belowBinary)
+        }
+        val contextsResult = observedContexts.get() must_== compressibleMessages.map { message =>
+          val length = message match {
+            case TextMessage(data)   => ByteString(data).length.toLong
+            case BinaryMessage(data) => data.length.toLong
+            case _                   => 0L
+          }
+          (message, length, length > 5)
+        }
+
+        framesResult.and(contextsResult).and(frames must contain(pingFrame(be_==("ping"))))
+      }
+    }
+
+    "not evaluate the message compression selector when compression was not negotiated" in {
+      val evaluated = new AtomicReference(false)
+      withServer(app =>
+        WebSocket.acceptWithOptions[String, String] { req =>
+          WebSocket.Accepted(
+            Flow.fromSinkAndSource(Sink.ignore, Source.single("plain server message")),
+            shouldCompress = _ => {
+              evaluated.set(true)
+              true
+            }
+          )
+        }
+      ) { (app, port) =>
+        import app.materializer
+        val frames = runWebSocket(
+          port,
+          { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+          compressionMode = CompressionMode.Disabled
+        )
+
+        (frames.collectFirst {
+          case SimpleMessage(TextMessage(data), true) => data
+        } must beSome("plain server message")).and(evaluated.get() must beFalse)
+      }
+    }
+
+    "allow Java applications to select outbound messages for compression" in {
+      val javaWebSocket = WebSocketSpecJavaActions.selectMessagesForCompression()
+      val javaHandler   = play.core.routing.HandlerInvokerFactory.javaWebSocket
+        .createInvoker(
+          javaWebSocket,
+          HandlerDef(
+            javaWebSocket.getClass.getClassLoader,
+            "package",
+            "controller",
+            "method",
+            Nil,
+            "GET",
+            "/stream"
+          )
+        )
+        .call(javaWebSocket)
+      withServer(
+        _ => javaHandler,
+        Map(
+          "play.server.websocket.compression.threshold"                              -> "5 bytes",
+          "play.server.websocket.compression.perMessageDeflate.allowServerNoContext" -> true
+        )
+      ) { (app, port) =>
+        import app.materializer
+        val frames = runWebSocket(
+          port,
+          { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+          compressionMode = CompressionMode.RequestOnly("permessage-deflate; server_no_context_takeover")
+        )
+
+        val dataFrames = frames.collect {
+          case frame @ SimpleMessage(_: TextMessage, _)   => frame
+          case frame @ RawWebSocketFrame("text", _, _, _) => frame
+        }
+        dataFrames must beLike {
+          case List(
+                RawWebSocketFrame("text", compressedText, rsv, true),
+                SimpleMessage(TextMessage("123456"), true)
+              ) =>
+            (rsv must_== 4).and(inflatePerMessageDeflate(compressedText).utf8String must_== "\u20ac")
+        }
+      }
+    }
+
     "not negotiate compression when websocket compression is disabled" in {
       withServer(
         app =>
-          WebSocket.accept[String, String] { req =>
-            Flow.fromSinkAndSource(Sink.ignore, Source.single("plain server message"))
+          WebSocket.acceptWithOptions[String, String] { req =>
+            WebSocket.Accepted(
+              Flow.fromSinkAndSource(Sink.ignore, Source.single("plain server message")),
+              shouldCompress = _ => throw new AssertionError("compression selector must not be evaluated")
+            )
           },
         Map("play.server.websocket.compression.enabled" -> false)
       ) { (app, port) =>
@@ -213,7 +363,8 @@ trait WebSocketCompressionSpec extends WebSocketSpecMethods {
         WebSocket.acceptWithOptions[String, String] { req =>
           WebSocket.Accepted(
             Flow.fromSinkAndSource(Sink.ignore, Source.single("plain server message")),
-            compressionEnabled = false
+            compressionEnabled = false,
+            shouldCompress = _ => throw new AssertionError("compression selector must not be evaluated")
           )
         }
       ) { (app, port) =>

--- a/core/play/src/main/java/play/mvc/WebSocket.java
+++ b/core/play/src/main/java/play/mvc/WebSocket.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.util.ByteString;
 import play.api.http.websocket.CloseCodes;
@@ -148,6 +150,48 @@ public abstract class WebSocket {
   }
 
   /**
+   * Information about an outbound WebSocket message for which Play is deciding whether to use
+   * compression.
+   *
+   * @since 3.1.0
+   */
+  public static final class CompressionContext {
+    private final Supplier<Message> message;
+    private final long payloadLength;
+    private final boolean isAboveCompressionThreshold;
+
+    public CompressionContext(
+        Message message, long payloadLength, boolean isAboveCompressionThreshold) {
+      this(() -> message, payloadLength, isAboveCompressionThreshold);
+    }
+
+    public CompressionContext(
+        Supplier<Message> message, long payloadLength, boolean isAboveCompressionThreshold) {
+      this.message = F.LazySupplier.lazy(message);
+      this.payloadLength = payloadLength;
+      this.isAboveCompressionThreshold = isAboveCompressionThreshold;
+    }
+
+    /** Returns the final Play WebSocket message after applying the configured message mapper. */
+    public Message message() {
+      return message.get();
+    }
+
+    /** Returns the uncompressed payload length in bytes, after UTF-8 encoding for text messages. */
+    public long payloadLength() {
+      return payloadLength;
+    }
+
+    /** Returns whether the payload length is greater than the configured compression threshold. */
+    public boolean isAboveCompressionThreshold() {
+      return isAboveCompressionThreshold;
+    }
+  }
+
+  private static final Predicate<CompressionContext> DEFAULT_SHOULD_COMPRESS =
+      CompressionContext::isAboveCompressionThreshold;
+
+  /**
    * An accepted WebSocket, including the flow that handles WebSocket messages and optional
    * handshake metadata.
    *
@@ -158,12 +202,29 @@ public abstract class WebSocket {
     private final Flow<In, Out, ?> flow;
     private final Optional<String> subprotocol;
     private final boolean compressionEnabled;
+    private final Predicate<CompressionContext> shouldCompress;
 
     public Accepted(
-        Flow<In, Out, ?> flow, Optional<String> subprotocol, boolean compressionEnabled) {
+        Flow<In, Out, ?> flow,
+        Optional<String> subprotocol,
+        boolean compressionEnabled,
+        Predicate<CompressionContext> shouldCompress) {
       this.flow = flow;
       this.subprotocol = subprotocol;
       this.compressionEnabled = compressionEnabled;
+      this.shouldCompress = shouldCompress;
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow, Optional<String> subprotocol, boolean compressionEnabled) {
+      this(flow, subprotocol, compressionEnabled, DEFAULT_SHOULD_COMPRESS);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        Optional<String> subprotocol,
+        Predicate<CompressionContext> shouldCompress) {
+      this(flow, subprotocol, true, shouldCompress);
     }
 
     public Accepted(Flow<In, Out, ?> flow, Optional<String> subprotocol) {
@@ -178,12 +239,36 @@ public abstract class WebSocket {
       this(flow, Optional.of(subprotocol), compressionEnabled);
     }
 
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        String subprotocol,
+        boolean compressionEnabled,
+        Predicate<CompressionContext> shouldCompress) {
+      this(flow, Optional.of(subprotocol), compressionEnabled, shouldCompress);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow, String subprotocol, Predicate<CompressionContext> shouldCompress) {
+      this(flow, Optional.of(subprotocol), true, shouldCompress);
+    }
+
     public Accepted(Flow<In, Out, ?> flow) {
       this(flow, Optional.empty());
     }
 
     public Accepted(Flow<In, Out, ?> flow, boolean compressionEnabled) {
       this(flow, Optional.empty(), compressionEnabled);
+    }
+
+    public Accepted(
+        Flow<In, Out, ?> flow,
+        boolean compressionEnabled,
+        Predicate<CompressionContext> shouldCompress) {
+      this(flow, Optional.empty(), compressionEnabled, shouldCompress);
+    }
+
+    public Accepted(Flow<In, Out, ?> flow, Predicate<CompressionContext> shouldCompress) {
+      this(flow, Optional.empty(), true, shouldCompress);
     }
 
     public Flow<In, Out, ?> flow() {
@@ -207,6 +292,16 @@ public abstract class WebSocket {
      */
     public boolean compressionEnabled() {
       return compressionEnabled;
+    }
+
+    /**
+     * Returns the selector for outbound text and binary messages after compression is negotiated.
+     * Its result can override the configured compression threshold, but cannot enable compression
+     * when it is disabled globally, disabled for this accepted WebSocket, or not negotiated with
+     * the client. The selector must not block; an exception from it fails the WebSocket stream.
+     */
+    public Predicate<CompressionContext> shouldCompress() {
+      return shouldCompress;
     }
   }
 
@@ -349,7 +444,10 @@ public abstract class WebSocket {
                             accepted.flow().map(outMapper::apply));
                     return F.Either.Right(
                         new Accepted<>(
-                            flow, accepted.subprotocol(), accepted.compressionEnabled()));
+                            flow,
+                            accepted.subprotocol(),
+                            accepted.compressionEnabled(),
+                            accepted.shouldCompress()));
                   }
                 });
       }

--- a/core/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/core/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -44,7 +44,8 @@ trait WebSocket extends Handler {
  * Helper utilities to generate WebSocket results.
  */
 object WebSocket {
-  private val SubprotocolHeader = "Sec-WebSocket-Protocol"
+  private val SubprotocolHeader                                    = "Sec-WebSocket-Protocol"
+  private val defaultShouldCompress: CompressionContext => Boolean = _.isAboveCompressionThreshold
 
   private def requestedSubprotocols(request: RequestHeader): Seq[String] = {
     request.headers
@@ -77,6 +78,22 @@ object WebSocket {
   }
 
   /**
+   * Information about an outbound WebSocket message for which Play is deciding whether to use compression.
+   *
+   * @param messageValue the final Play WebSocket message after applying the configured message flow transformer
+   * @param payloadLength the uncompressed payload length in bytes, after UTF-8 encoding for text messages
+   * @param isAboveCompressionThreshold whether the payload length is greater than the configured compression threshold
+   * @since 3.1.0
+   */
+  final class CompressionContext private[play] (
+      messageValue: => Message,
+      val payloadLength: Long,
+      val isAboveCompressionThreshold: Boolean
+  ) {
+    lazy val message: Message = messageValue
+  }
+
+  /**
    * An accepted WebSocket, including the flow that handles WebSocket messages and optional handshake metadata.
    *
    * @param flow the flow that handles WebSocket messages
@@ -85,11 +102,15 @@ object WebSocket {
    *                    [[play.api.http.HttpErrorHandler]], which returns an HTTP 500 response by default
    * @param compressionEnabled whether this accepted WebSocket may negotiate compression when compression is enabled in
    *                           the server configuration; setting this to `true` does not enable compression globally
+   * @param shouldCompress selects which outbound text and binary messages to compress after compression is negotiated;
+   *                       the default follows the configured compression threshold; this function must not block and
+   *                       an exception from it fails the WebSocket stream
    */
   case class Accepted[In, Out](
       flow: Flow[In, Out, ?],
       subprotocol: Option[String] = None,
-      compressionEnabled: Boolean = true
+      compressionEnabled: Boolean = true,
+      shouldCompress: CompressionContext => Boolean = defaultShouldCompress
   )
 
   /**
@@ -270,7 +291,8 @@ object WebSocket {
           Accepted(
             closeOnException(transformer.transform(accepted.flow)),
             accepted.subprotocol,
-            accepted.compressionEnabled
+            accepted.compressionEnabled,
+            accepted.shouldCompress
           )
         })
       }

--- a/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/core/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -191,6 +191,24 @@ object HandlerInvokerFactory {
 
         def call(wsCall: => JWebSocket): Handler = new JavaHandler {
           def withComponents(handlerComponents: JavaHandlerComponents): WebSocket = {
+            def toJavaMessage(message: Message): JMessage = message match {
+              case TextMessage(text)          => new JMessage.Text(text)
+              case BinaryMessage(data)        => new JMessage.Binary(data)
+              case PingMessage(data)          => new JMessage.Ping(data)
+              case PongMessage(data)          => new JMessage.Pong(data)
+              case CloseMessage(code, reason) =>
+                new JMessage.Close(code.toJava.asInstanceOf[Optional[Integer]], reason)
+            }
+
+            def toScalaMessage(message: JMessage): Message = message match {
+              case text: JMessage.Text     => TextMessage(text.data)
+              case binary: JMessage.Binary => BinaryMessage(binary.data)
+              case ping: JMessage.Ping     => PingMessage(ping.data)
+              case pong: JMessage.Pong     => PongMessage(pong.data)
+              case close: JMessage.Close   =>
+                CloseMessage(close.code.toScala.asInstanceOf[Option[Int]], close.reason)
+            }
+
             WebSocket.acceptOrResultWithOptions[Message, Message] { request =>
               def callWebSocketAction(req: RequestHeader) =
                 wsCall.applyWithOptions(req.asJava).asScala.map { resultOrAccepted =>
@@ -201,25 +219,21 @@ object HandlerInvokerFactory {
                     Right(
                       WebSocket.Accepted(
                         Flow[Message]
-                          .map[JMessage] {
-                            case TextMessage(text)          => new JMessage.Text(text)
-                            case BinaryMessage(data)        => new JMessage.Binary(data)
-                            case PingMessage(data)          => new JMessage.Ping(data)
-                            case PongMessage(data)          => new JMessage.Pong(data)
-                            case CloseMessage(code, reason) =>
-                              new JMessage.Close(code.toJava.asInstanceOf[Optional[Integer]], reason)
-                          }
+                          .map[JMessage](toJavaMessage)
                           .via(accepted.flow().asScala)
-                          .map[Message] {
-                            case text: JMessage.Text     => TextMessage(text.data)
-                            case binary: JMessage.Binary => BinaryMessage(binary.data)
-                            case ping: JMessage.Ping     => PingMessage(ping.data)
-                            case pong: JMessage.Pong     => PongMessage(pong.data)
-                            case close: JMessage.Close   =>
-                              CloseMessage(close.code.toScala.asInstanceOf[Option[Int]], close.reason)
-                          },
+                          .map[Message](toScalaMessage),
                         accepted.subprotocol().toScala,
-                        accepted.compressionEnabled()
+                        accepted.compressionEnabled(),
+                        context =>
+                          accepted
+                            .shouldCompress()
+                            .test(
+                              new JWebSocket.CompressionContext(
+                                () => toJavaMessage(context.message),
+                                context.payloadLength,
+                                context.isAboveCompressionThreshold
+                              )
+                            )
                       )
                     )
                   }

--- a/core/play/src/test/java/play/mvc/WebSocketTest.java
+++ b/core/play/src/test/java/play/mvc/WebSocketTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.mvc;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import play.http.websocket.Message;
+
+public class WebSocketTest {
+
+  @Test
+  public void compressionContextShouldEvaluateItsMessageLazilyAndOnlyOnce() {
+    AtomicInteger evaluations = new AtomicInteger();
+    WebSocket.CompressionContext context =
+        new WebSocket.CompressionContext(
+            () -> {
+              evaluations.incrementAndGet();
+              return new Message.Text("message");
+            },
+            7,
+            true);
+
+    assertEquals(7, context.payloadLength());
+    assertEquals(true, context.isAboveCompressionThreshold());
+    assertEquals(0, evaluations.get());
+
+    assertEquals(new Message.Text("message"), context.message());
+    assertEquals(new Message.Text("message"), context.message());
+    assertEquals(1, evaluations.get());
+  }
+}

--- a/core/play/src/test/scala/play/api/mvc/WebSocketSpec.scala
+++ b/core/play/src/test/scala/play/api/mvc/WebSocketSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.mvc
+
+import org.specs2.mutable.Specification
+import play.api.http.websocket.TextMessage
+
+class WebSocketSpec extends Specification {
+
+  "WebSocket.CompressionContext" should {
+    "evaluate its message lazily and only once" in {
+      var evaluations = 0
+      val context     = new WebSocket.CompressionContext(
+        {
+          evaluations += 1
+          TextMessage("message")
+        },
+        payloadLength = 7,
+        isAboveCompressionThreshold = true
+      )
+
+      context.payloadLength must_== 7
+      context.isAboveCompressionThreshold must beTrue
+      evaluations must_== 0
+
+      context.message must_== TextMessage("message")
+      context.message must_== TextMessage("message")
+      evaluations must_== 1
+    }
+  }
+}

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -26,6 +26,8 @@ Common tuning options are available under `play.server.websocket.compression`, i
 
 Applications can also keep compression enabled globally and disable it for a single accepted WebSocket by returning `WebSocket.Accepted` with `compressionEnabled = false`.
 
+For finer control, `WebSocket.Accepted` accepts a per-message compression selector. The selector can use the final outbound message, its uncompressed payload length, and the configured threshold result to override the threshold for individual messages.
+
 For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Configuring-WebSocket-compression]] and [[Java WebSocket documentation|JavaWebSockets#Configuring-WebSocket-compression]].
 
 ### WebSocket Subprotocol Selection

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -138,6 +138,21 @@ The `play.server.websocket.compression.threshold` setting controls the minimum o
 play.server.websocket.compression.threshold = 1k
 ```
 
+An application can replace the threshold decision for an accepted WebSocket by providing a compression selector. The selector receives the final Play message, its uncompressed payload length, and the result of the configured threshold check. It can return `true` to compress a message below the threshold or `false` to send a message above it without compression:
+
+```java
+new WebSocket.Accepted<>(
+    flow,
+    context -> {
+      if (context.message() instanceof Message.Text text && text.data().contains("secret")) {
+        return false;
+      }
+      return context.isAboveCompressionThreshold();
+    });
+```
+
+The selector is called synchronously once for each outbound text or binary message, and only when `permessage-deflate` was negotiated. It must not block. Its result cannot enable compression when compression is disabled globally, disabled for the accepted WebSocket, or not negotiated with the client.
+
 Applications can also disable compression for a single accepted WebSocket by returning `new WebSocket.Accepted<>(flow, false)` from `acceptWithOptions` or `acceptOrResultWithOptions`. This lets an application keep compression enabled globally but decline it for endpoints that carry sensitive data or are expected to exchange already-compressed messages.
 
 > **Note:** WebSocket compression can increase CPU and memory usage. If messages include secrets alongside attacker-controlled data, consider whether compression is appropriate for that endpoint. Under the `play.server.websocket` config parent, the default context-takeover settings are `compression.perMessageDeflate.allowServerNoContext = false` and `compression.perMessageDeflate.preferredClientNoContext = false`. For a more conservative setup, set them to `true` so the server may accept `server_no_context_takeover` when the client requests it, and so the server requests `client_no_context_takeover` when the client supports it.

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -140,6 +140,23 @@ The `play.server.websocket.compression.threshold` setting controls the minimum o
 play.server.websocket.compression.threshold = 1k
 ```
 
+An application can replace the threshold decision for an accepted WebSocket by providing `shouldCompress`. The selector receives the final Play message, its uncompressed payload length, and the result of the configured threshold check. It can return `true` to compress a message below the threshold or `false` to send a message above it without compression:
+
+```scala
+WebSocket.acceptWithOptions[String, String] { request =>
+  WebSocket.Accepted(
+    flow,
+    shouldCompress = context =>
+      context.message match {
+        case TextMessage(text) if text.contains("secret") => false
+        case _ => context.isAboveCompressionThreshold
+      }
+  )
+}
+```
+
+The selector is called synchronously once for each outbound text or binary message, and only when `permessage-deflate` was negotiated. It must not block. Its result cannot enable compression when compression is disabled globally, disabled for the accepted WebSocket, or not negotiated with the client.
+
 Applications can also disable compression for a single accepted WebSocket by returning `WebSocket.Accepted` with `compressionEnabled = false` from `acceptWithOptions` or `acceptOrResultWithOptions`. This lets an application keep compression enabled globally but decline it for endpoints that carry sensitive data or are expected to exchange already-compressed messages.
 
 > **Note:** WebSocket compression can increase CPU and memory usage. If messages include secrets alongside attacker-controlled data, consider whether compression is appropriate for that endpoint. Under the `play.server.websocket` config parent, the default context-takeover settings are `compression.perMessageDeflate.allowServerNoContext = false` and `compression.perMessageDeflate.preferredClientNoContext = false`. For a more conservative setup, set them to `true` so the server may accept `server_no_context_takeover` when the client requests it, and so the server requests `client_no_context_takeover` when the client supports it.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -304,6 +304,7 @@ class NettyServer(
       serverHeader,
       maxContentLength,
       wsBufferLimit,
+      wsCompressionThreshold,
       wsKeepAliveMode,
       wsKeepAliveMaxIdle,
       deferBodyParsing
@@ -352,9 +353,10 @@ class NettyServer(
     wsCompressionSettings.map { settings =>
       val compressionFilterProvider = new WebSocketExtensionFilterProvider {
         override val encoderFilter: WebSocketExtensionFilter = {
-          case frame: TextWebSocketFrame   => frame.content().readableBytes().toLong <= wsCompressionThreshold
-          case frame: BinaryWebSocketFrame => frame.content().readableBytes().toLong <= wsCompressionThreshold
-          case _                           => false
+          case frame: PlayWebSocketCompressionFrame => !frame.shouldCompress
+          case frame: TextWebSocketFrame            => frame.content().readableBytes().toLong <= wsCompressionThreshold
+          case frame: BinaryWebSocketFrame          => frame.content().readableBytes().toLong <= wsCompressionThreshold
+          case _                                    => false
         }
         override val decoderFilter: WebSocketExtensionFilter = WebSocketExtensionFilter.NEVER_SKIP
       }

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -50,6 +50,7 @@ private[play] class PlayRequestHandler(
     val serverHeader: Option[String],
     val maxContentLength: Long,
     val wsBufferLimit: Int,
+    val wsCompressionThreshold: Long,
     val wsKeepAliveMode: String,
     val wsKeepAliveMaxIdle: Duration,
     val deferBodyParsingGlobal: Boolean
@@ -219,6 +220,8 @@ private[play] class PlayRequestHandler(
                 WebSocketHandler.messageFlowToFrameProcessor(
                   accepted.flow,
                   wsBufferLimit,
+                  wsCompressionThreshold,
+                  accepted.shouldCompress,
                   wsKeepAliveMode,
                   wsKeepAliveMaxIdle
                 )

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -16,9 +16,14 @@ import org.apache.pekko.util.ByteString
 import org.reactivestreams.Processor
 import play.api.http.websocket._
 import play.api.http.websocket.Message
+import play.api.mvc.WebSocket
 import play.core.server.common.WebSocketFlowHandler
 import play.core.server.common.WebSocketFlowHandler.MessageType
 import play.core.server.common.WebSocketFlowHandler.RawMessage
+
+private[server] trait PlayWebSocketCompressionFrame {
+  def shouldCompress: Boolean
+}
 
 private[server] object WebSocketHandler {
 
@@ -31,6 +36,8 @@ private[server] object WebSocketHandler {
   def messageFlowToFrameProcessor(
       flow: Flow[Message, Message, ?],
       bufferLimit: Int,
+      compressionThreshold: Long,
+      compressionSelector: WebSocket.CompressionContext => Boolean,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration
   )(
@@ -45,7 +52,7 @@ private[server] object WebSocketHandler {
         .toProcessor
         .run(),
       frameToMessage,
-      messageToFrame
+      message => messageToFrame(message, compressionThreshold, compressionSelector)
     )
 
     new Processor[WebSocketFrame, WebSocketFrame] {
@@ -90,7 +97,11 @@ private[server] object WebSocketHandler {
   /**
    * Converts Play messages to Netty frames.
    */
-  private def messageToFrame(message: Message): WebSocketFrame = {
+  private def messageToFrame(
+      message: Message,
+      compressionThreshold: Long,
+      compressionSelector: WebSocket.CompressionContext => Boolean
+  ): WebSocketFrame = {
     def byteStringToByteBuf(bytes: ByteString): ByteBuf = {
       if (bytes.isEmpty) {
         Unpooled.EMPTY_BUFFER
@@ -99,9 +110,23 @@ private[server] object WebSocketHandler {
       }
     }
 
+    def compressionContext(payloadLength: Long) =
+      new WebSocket.CompressionContext(
+        message,
+        payloadLength,
+        payloadLength > compressionThreshold
+      )
+
     message match {
-      case TextMessage(data)                      => new TextWebSocketFrame(data)
-      case BinaryMessage(data)                    => new BinaryWebSocketFrame(byteStringToByteBuf(data))
+      case TextMessage(data) =>
+        val bytes = ByteString(data)
+        new TextWebSocketFrame(true, 0, byteStringToByteBuf(bytes)) with PlayWebSocketCompressionFrame {
+          override lazy val shouldCompress: Boolean = compressionSelector(compressionContext(bytes.length.toLong))
+        }
+      case BinaryMessage(data) =>
+        new BinaryWebSocketFrame(byteStringToByteBuf(data)) with PlayWebSocketCompressionFrame {
+          override lazy val shouldCompress: Boolean = compressionSelector(compressionContext(data.length.toLong))
+        }
       case PingMessage(data)                      => new PingWebSocketFrame(byteStringToByteBuf(data))
       case PongMessage(data)                      => new PongWebSocketFrame(byteStringToByteBuf(data))
       case CloseMessage(Some(statusCode), reason) => new CloseWebSocketFrame(statusCode, reason)

--- a/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
@@ -38,6 +38,7 @@ object WebSocketHandler {
       subprotocol: Option[String],
       compressionEnabled: Boolean,
       compressionThreshold: Long,
+      compressionSelector: (() => Message, Long, Boolean) => Boolean,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration,
   ): HttpResponse = upgrade match {
@@ -46,7 +47,15 @@ object WebSocketHandler {
         messageFlowToFrameFlow(flow, bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle),
         subprotocol,
         compressionEnabled,
-        _.data.length.toLong > compressionThreshold
+        frame => {
+          val message: () => Message = frame.header.opcode match {
+            case Protocol.Opcode.Text   => () => TextMessage(frame.data.utf8String)
+            case Protocol.Opcode.Binary => () => BinaryMessage(frame.data)
+            case opcode                 => throw new IllegalArgumentException(s"Cannot compress $opcode WebSocket frame")
+          }
+          val payloadLength = frame.data.length.toLong
+          compressionSelector(message, payloadLength, payloadLength > compressionThreshold)
+        }
       )
     case other =>
       throw new IllegalArgumentException("WebSocketUpgrade is not an Pekko HTTP UpgradeToWebsocketLowLevel")

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -452,6 +452,10 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
                     accepted.subprotocol,
                     accepted.compressionEnabled,
                     wsCompressionThreshold,
+                    (message, payloadLength, isAboveCompressionThreshold) =>
+                      accepted.shouldCompress(
+                        new WebSocket.CompressionContext(message(), payloadLength, isAboveCompressionThreshold)
+                      ),
                     wsKeepAliveMode,
                     wsKeepAliveMaxIdle
                   )


### PR DESCRIPTION
This PR lets applications decide whether each outbound WebSocket text or binary message should be compressed.

`WebSocket.Accepted` now accepts a `shouldCompress` selector in both the Scala and Java APIs. The selector receives a `CompressionContext` containing:

- The final outbound Play message
- Its uncompressed payload length in bytes
- Whether it exceeds `play.server.websocket.compression.threshold`

Returning `true` or `false` overrides the configured threshold for that message.

```scala
WebSocket.Accepted(
  flow,
  shouldCompress = context =>
    context.message match {
      case TextMessage(text) if text.contains("secret") => false
      case _ => context.isAboveCompressionThreshold
    }
)
```

This allows applications to avoid compressing sensitive or already-compressed content while continuing to compress other messages on the same WebSocket connection.

## Behavior

The selector:

- Is evaluated once for each outbound text or binary message
- Is called only when `permessage-deflate` was negotiated
- Can override the configured compression threshold
- Cannot enable compression when it is disabled globally or for the accepted WebSocket
- Must not block; an exception fails the WebSocket stream

The default selector preserves the existing threshold behavior.

## Implementation

The selector is propagated through message-flow transformations and the Java-to-Scala API bridge.

Both server backends support it:

- Netty uses its WebSocket extension filter for the final outbound frame.
- Pekko HTTP passes the decision to its per-message compression API.

## Tests

Shared integration tests for both backends verify:

- Selecting compressed and uncompressed messages on one connection
- Overriding the threshold in both directions
- Text and binary messages
- UTF-8 byte-length calculation
- Control frames bypassing the selector
- The selector not being evaluated when compression is disabled or not negotiated
- Java API propagation
- Actual compressed wire payloads, not only handshake headers

Scala and Java WebSocket documentation and the Play release highlights are updated.

## References

- Play per-WebSocket compression control: #14118
- Play compression threshold: #14120
- Pekko HTTP per-message compression API: apache/pekko-http#1172
- [RFC 7692](https://www.rfc-editor.org/rfc/rfc7692)
