### PR TITLE
Add WebSocket close handshake timeout

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
@@ -18,6 +18,8 @@ import play.api.test._
 import play.api.Application
 
 class JsonBodyParserSpec extends PlaySpecification {
+  sequential
+
   private case class Foo(a: Int, b: String)
   private implicit val fooFormat: OFormat[Foo] = Json.format[Foo]
 

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -57,7 +57,8 @@ trait WebSocketClient {
       url: URI,
       version: WebSocketVersion = WebSocketVersion.V13,
       subprotocol: Option[String] = None,
-      compressionMode: WebSocketClient.CompressionMode = WebSocketClient.CompressionMode.Disabled
+      compressionMode: WebSocketClient.CompressionMode = WebSocketClient.CompressionMode.Disabled,
+      acknowledgeServerClose: Boolean = true
   )(
       onConnect: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
   ): Future[?]
@@ -132,7 +133,13 @@ object WebSocketClient {
     /**
      * Connect to the given URI
      */
-    def connect(url: URI, version: WebSocketVersion, subprotocol: Option[String], compressionMode: CompressionMode)(
+    def connect(
+        url: URI,
+        version: WebSocketVersion,
+        subprotocol: Option[String],
+        compressionMode: CompressionMode,
+        acknowledgeServerClose: Boolean
+    )(
         onConnected: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
     ): Future[?] = {
       val normalized = url.normalize()
@@ -166,7 +173,12 @@ object WebSocketClient {
             compressionMode != CompressionMode.Disabled,
             headers
           )
-          channel.pipeline().addLast("supervisor", new WebSocketSupervisor(disconnected, handshaker, onConnected))
+          channel
+            .pipeline()
+            .addLast(
+              "supervisor",
+              new WebSocketSupervisor(disconnected, handshaker, acknowledgeServerClose, onConnected)
+            )
           handshaker.handshake(channel)
           channel.read()
         }
@@ -184,6 +196,7 @@ object WebSocketClient {
   private class WebSocketSupervisor(
       disconnected: Promise[Unit],
       handshaker: WebSocketClientHandshaker,
+      acknowledgeServerClose: Boolean,
       onConnected: (immutable.Seq[(String, String)], Flow[ExtendedMessage, ExtendedMessage, ?]) => Unit
   ) extends ChannelInboundHandlerAdapter {
     override def channelRead(ctx: ChannelHandlerContext, msg: Object): Unit = {
@@ -300,7 +313,12 @@ object WebSocketClient {
           val handleServerClose = Flow[WebSocketFrame].filter { frame =>
             if (frame.isInstanceOf[CloseWebSocketFrame] && !clientInitiatedClose.get()) {
               serverInitiatedClose.set(true)
-              true
+              if (acknowledgeServerClose) {
+                true
+              } else {
+                ReferenceCountUtil.release(frame)
+                false
+              }
             } else {
               // If we're going to drop it, we need to release it first
               ReferenceCountUtil.release(frame)

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -673,6 +673,18 @@ trait WebSocketSpec
       expectedMessages = Seq("foo")
     )
 
+    "reject a zero play.server.websocket.closeTimeout at startup" in {
+      failToStartWithInvalidCloseTimeout("0 seconds")
+    }
+
+    "reject a negative play.server.websocket.closeTimeout at startup" in {
+      failToStartWithInvalidCloseTimeout("-1 second")
+    }
+
+    "reject an infinite play.server.websocket.closeTimeout at startup" in {
+      failToStartWithInvalidCloseTimeout("infinite")
+    }
+
     "allow handling WebSockets using Pekko streams" in {
       "allow consuming messages" in allowConsumingMessages { _ => consumed =>
         WebSocket.accept[String, String] { req =>
@@ -757,6 +769,90 @@ trait WebSocketSpec
             }
           )
           result must beEmpty
+        }
+      }
+
+      "terminate after closeTimeout when the client continues sending ping and pong frames" in {
+        val consumed = Promise[List[Message]]()
+        withServer(
+          app =>
+            WebSocket.accept[Message, Message] { req =>
+              Flow.fromSinkAndSource(
+                onFramesConsumed[Message](consumed.success(_)),
+                Source.single(CloseMessage(CloseCodes.Regular))
+              )
+            },
+          Map(
+            "play.server.http.idleTimeout"                       -> "infinite",
+            "play.server.https.idleTimeout"                      -> "infinite",
+            "play.server.websocket.closeTimeout"                 -> "300 milliseconds",
+            "play.server.websocket.periodic-keep-alive-max-idle" -> "infinite"
+          )
+        ) { (app, port) =>
+          import app.materializer
+          val closeReceived = Promise[Long]()
+          val frames        = runWebSocket(
+            port,
+            { flow =>
+              Source
+                .futureSource(
+                  closeReceived.future.map { _ =>
+                    Source
+                      .tick(10.millis, 20.millis, ())
+                      .zipWithIndex
+                      .map[ExtendedMessage] {
+                        case (_, index) if index % 2 == 0 => PingMessage(ByteString("ping"))
+                        case _ => PongMessage(ByteString("pong"))
+                      }
+                  }
+                )
+                .via(flow)
+                .map { frame =>
+                  frame match {
+                    case SimpleMessage(_: CloseMessage, _) => closeReceived.trySuccess(System.nanoTime())
+                    case _                                 =>
+                  }
+                  frame
+                }
+                .runWith(consumeFrames)
+            },
+            acknowledgeServerClose = false
+          )
+          val closeHandshakeDuration = (System.nanoTime() - await(closeReceived.future)).nanos
+
+          (frames must contain(exactly(closeFrame(CloseCodes.Regular))))
+            .and(
+              await(consumed.future).exists {
+                case _: CloseMessage => true
+                case _               => false
+              } must beFalse
+            )
+            .and(closeHandshakeDuration must beLessThan(2.seconds))
+        }
+      }
+
+      "not send periodic keep-alive frames while awaiting a close acknowledgement" in {
+        withServer(
+          app =>
+            WebSocket.accept[Message, Message] { req =>
+              Flow.fromSinkAndSource(Sink.ignore, Source.single(CloseMessage(CloseCodes.Regular)))
+            },
+          Map(
+            "play.server.http.idleTimeout"                       -> "infinite",
+            "play.server.https.idleTimeout"                      -> "infinite",
+            "play.server.websocket.closeTimeout"                 -> "200 milliseconds",
+            "play.server.websocket.periodic-keep-alive-max-idle" -> "20 milliseconds",
+            "play.server.websocket.periodic-keep-alive-mode"     -> "ping"
+          )
+        ) { (app, port) =>
+          import app.materializer
+          val frames = runWebSocket(
+            port,
+            { flow => Source.maybe[ExtendedMessage].via(flow).runWith(consumeFrames) },
+            acknowledgeServerClose = false
+          )
+
+          frames must contain(exactly(closeFrame(CloseCodes.Regular)))
         }
       }
 
@@ -1601,6 +1697,19 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
   // Extend the default spec timeout for CI.
   implicit override def defaultAwaitTimeout: Timeout = 10.seconds
 
+  def failToStartWithInvalidCloseTimeout(value: String) = {
+    withServer(
+      app => WebSocket.accept[String, String] { req => Flow.fromSinkAndSource(Sink.ignore, Source.maybe[String]) },
+      Map("play.server.websocket.closeTimeout" -> value)
+    ) { (_, _) =>
+      ()
+    } must throwA[RuntimeException].like {
+      case exception =>
+        (exception.getCause must beAnInstanceOf[play.core.server.ServerStartException])
+          .and(exception.getMessage must contain("play.server.websocket.closeTimeout"))
+    }
+  }
+
   def withServer[A](
       webSocket: Application => Handler,
       extraConfig: Map[String, Any] = Map.empty,
@@ -1630,9 +1739,12 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
       port: Int,
       handler: Flow[ExtendedMessage, ExtendedMessage, ?] => Future[A],
       handleConnect: Future[?] => Future[?] = c => c,
-      compressionMode: CompressionMode = CompressionMode.Disabled
+      compressionMode: CompressionMode = CompressionMode.Disabled,
+      acknowledgeServerClose: Boolean = true
   ): A =
-    runWebSocket(port, handler, subprotocol = None, handleConnect, compressionMode) match { case (result, _) => result }
+    runWebSocket(port, handler, subprotocol = None, handleConnect, compressionMode, acknowledgeServerClose) match {
+      case (result, _) => result
+    }
 
   def runWebSocket[A](
       port: Int,
@@ -1640,6 +1752,16 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
       subprotocol: Option[String],
       handleConnect: Future[?] => Future[?],
       compressionMode: CompressionMode
+  ): (A, immutable.Seq[(String, String)]) =
+    runWebSocket(port, handler, subprotocol, handleConnect, compressionMode, acknowledgeServerClose = true)
+
+  def runWebSocket[A](
+      port: Int,
+      handler: Flow[ExtendedMessage, ExtendedMessage, ?] => Future[A],
+      subprotocol: Option[String],
+      handleConnect: Future[?] => Future[?],
+      compressionMode: CompressionMode,
+      acknowledgeServerClose: Boolean
   ): (A, immutable.Seq[(String, String)]) = {
     WebSocketClient { client =>
       val innerResult     = Promise[A]()
@@ -1649,7 +1771,8 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
           client.connect(
             URI.create("ws://localhost:" + port + "/stream"),
             subprotocol = subprotocol,
-            compressionMode = compressionMode
+            compressionMode = compressionMode,
+            acknowledgeServerClose = acknowledgeServerClose
           ) { (headers, flow) =>
             innerResult.completeWith(handler(flow))
             responseHeaders.success(headers)

--- a/documentation/manual/releases/release31/Highlights31.md
+++ b/documentation/manual/releases/release31/Highlights31.md
@@ -89,6 +89,16 @@ This is useful for applications that need to attach handshake metadata, for exam
 
 For more details, see the [[Scala WebSocket documentation|ScalaWebSockets#Setting-WebSocket-handshake-response-options]] and [[Java WebSocket documentation|JavaWebSockets#Setting-WebSocket-handshake-response-options]].
 
+### Bounded WebSocket Closing Handshakes
+
+After Play sends a WebSocket Close frame, it now waits up to three seconds for the peer's Close acknowledgement before terminating the connection. This prevents a peer that ignores the closing handshake, or continues sending Ping and Pong frames, from keeping the connection open until the HTTP idle timeout.
+
+The timeout starts when Play emits the Close frame, is not extended by subsequent traffic, and also suppresses Play's periodic WebSocket keep-alive frames while the connection is closing. It is shared by the Netty and Pekko HTTP backends and can be configured with a positive finite duration:
+
+```hocon
+play.server.websocket.closeTimeout = 3 seconds
+```
+
 ### WebSocket Abnormal Closure Status
 
 Play now reports abnormal WebSocket connection loss to raw WebSocket handlers with close status `1006`.

--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -97,6 +97,18 @@ Java
 
 Handlers using typed APIs such as `WebSocket.accept[String, String]` still do not receive close control frames as typed messages. Use a raw `Message` flow if your application needs to inspect WebSocket close status codes directly.
 
+### Server-initiated WebSocket closing handshakes now have a timeout
+
+Previously, after Play sent a WebSocket Close frame, it could keep the underlying connection open until the peer replied with its own Close frame or the transport was terminated by another mechanism, such as the HTTP idle timeout. Because traffic such as Ping and Pong frames could keep the connection active, an uncooperative peer could prevent the idle timeout from terminating it.
+
+Play now terminates the connection if the peer does not acknowledge the Close frame within three seconds. The closing-handshake deadline starts when Play emits the Close frame, is not extended by subsequent traffic, and suppresses Play's periodic WebSocket keep-alive frames while closing. Applications that require more time can configure a different positive finite duration:
+
+```hocon
+play.server.websocket.closeTimeout = 3 seconds
+```
+
+This setting applies to both the Netty and Pekko HTTP server backends and is independent of the HTTP idle timeout.
+
 ### Malformed WebSocket frames are rejected more strictly
 
 Play now validates incoming WebSocket text and control frames consistently across the Netty and Pekko HTTP server backends.

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -201,6 +201,18 @@ If clients send close status codes other than the default 1000 to your Play app,
 
 > **Note:** The pekko-http specific configs `pekko.http.server.websocket.periodic-keep-alive-max-idle` and `pekko.http.server.websocket.periodic-keep-alive-mode` do **not** affect Play. To be backend server agnostic, Play uses its own low-level WebSocket implementation and therefore handles frames itself.
 
+## Configuring the close handshake timeout
+
+After Play sends a WebSocket Close frame, it waits for the client to acknowledge the closing handshake with its own Close frame. By default, Play terminates the connection if the client does not respond within three seconds:
+
+```hocon
+play.server.websocket.closeTimeout = 3 seconds
+```
+
+The timeout starts when the Close frame is emitted and is not extended by subsequent client traffic, including Ping and Pong frames. Play also stops sending periodic keep-alive frames while awaiting the acknowledgement. The configured value must be a positive finite duration and applies to both the Netty and Pekko HTTP server backends independently of the HTTP idle timeout.
+
+Like other backend server settings, `play.server.websocket.closeTimeout` must be set through `PlayKeys.devSettings` in `build.sbt` to affect the server used by `sbt run`.
+
 ## WebSockets and Action composition
 
 Consider the following controller example that utilizes [[action composition|JavaActionsComposition]]:

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -204,3 +204,15 @@ websocat -vv --close-status-code 1000 --close-reason "bye bye" ws://127.0.0.1:90
 If clients send close status codes other than the default 1000 to your Play app, make sure they use the ones that are defined and valid according to [RFC 6455 Section 7.4.1](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1) to avoid any problems. For example web browsers usually throw exceptions when trying to use such status codes and some server implementations (e.g. Netty) fail with exceptions if they receive them (and close the connection).
 
 > **Note:** The pekko-http specific configs `pekko.http.server.websocket.periodic-keep-alive-max-idle` and `pekko.http.server.websocket.periodic-keep-alive-mode` do **not** affect Play. To be backend server agnostic, Play uses its own low-level WebSocket implementation and therefore handles frames itself.
+
+## Configuring the close handshake timeout
+
+After Play sends a WebSocket Close frame, it waits for the client to acknowledge the closing handshake with its own Close frame. By default, Play terminates the connection if the client does not respond within three seconds:
+
+```hocon
+play.server.websocket.closeTimeout = 3 seconds
+```
+
+The timeout starts when the Close frame is emitted and is not extended by subsequent client traffic, including Ping and Pong frames. Play also stops sending periodic keep-alive frames while awaiting the acknowledgement. The configured value must be a positive finite duration and applies to both the Netty and Pekko HTTP server backends independently of the HTTP idle timeout.
+
+Like other backend server settings, `play.server.websocket.closeTimeout` must be set through `PlayKeys.devSettings` in `build.sbt` to affect the server used by `sbt run`.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -88,22 +88,27 @@ class NettyServer(
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize        =
     serverConfig.getDeprecated[ConfigMemorySize]("max-header-size", "netty.maxHeaderSize").toBytes.toInt
-  private val maxContentLength         = Server.getPossiblyInfiniteBytes(serverConfig.underlying, "max-content-length")
-  private val maxChunkSize             = nettyConfig.get[Int]("maxChunkSize")
-  private val threadCount              = nettyConfig.get[Int]("eventLoopThreads")
-  private val logWire                  = nettyConfig.get[Boolean]("log.wire")
-  private val bootstrapOption          = nettyConfig.get[Config]("option")
-  private val channelOption            = nettyConfig.get[Config]("option.child")
-  private val httpsWantClientAuth      = serverConfig.get[Boolean]("https.wantClientAuth")
-  private val httpsNeedClientAuth      = serverConfig.get[Boolean]("https.needClientAuth")
-  private val httpIdleTimeout          = serverConfig.get[Duration]("http.idleTimeout")
-  private val httpsIdleTimeout         = serverConfig.get[Duration]("https.idleTimeout")
-  private val shutdownQuietPeriod      = nettyConfig.get[FiniteDuration]("shutdownQuietPeriod")
-  private val terminationDelay         = serverConfig.get[FiniteDuration]("waitBeforeTermination")
-  private val terminationTimeout       = serverConfig.getOptional[FiniteDuration]("terminationTimeout")
-  private val wsBufferLimit            = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
-  private val wsKeepAliveMode          = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
-  private val wsKeepAliveMaxIdle       = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
+  private val maxContentLength    = Server.getPossiblyInfiniteBytes(serverConfig.underlying, "max-content-length")
+  private val maxChunkSize        = nettyConfig.get[Int]("maxChunkSize")
+  private val threadCount         = nettyConfig.get[Int]("eventLoopThreads")
+  private val logWire             = nettyConfig.get[Boolean]("log.wire")
+  private val bootstrapOption     = nettyConfig.get[Config]("option")
+  private val channelOption       = nettyConfig.get[Config]("option.child")
+  private val httpsWantClientAuth = serverConfig.get[Boolean]("https.wantClientAuth")
+  private val httpsNeedClientAuth = serverConfig.get[Boolean]("https.needClientAuth")
+  private val httpIdleTimeout     = serverConfig.get[Duration]("http.idleTimeout")
+  private val httpsIdleTimeout    = serverConfig.get[Duration]("https.idleTimeout")
+  private val shutdownQuietPeriod = nettyConfig.get[FiniteDuration]("shutdownQuietPeriod")
+  private val terminationDelay    = serverConfig.get[FiniteDuration]("waitBeforeTermination")
+  private val terminationTimeout  = serverConfig.getOptional[FiniteDuration]("terminationTimeout")
+  private val wsBufferLimit       = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
+  private val wsKeepAliveMode     = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
+  private val wsKeepAliveMaxIdle  = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
+  private val wsCloseTimeout      = Server.getPositiveFiniteDuration(
+    serverConfig,
+    "websocket.closeTimeout",
+    "play.server.websocket.closeTimeout"
+  )
   private val wsCompression            = serverConfig.get[Boolean]("websocket.compression.enabled")
   private val wsCompressionConfig      = serverConfig.get[Configuration]("websocket.compression")
   private val wsCompressionThreshold   = wsCompressionConfig.get[ConfigMemorySize]("threshold").toBytes
@@ -307,6 +312,7 @@ class NettyServer(
       wsCompressionThreshold,
       wsKeepAliveMode,
       wsKeepAliveMaxIdle,
+      wsCloseTimeout,
       deferBodyParsing
     )
 

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -8,6 +8,7 @@ import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
 import scala.util.control.Exception.catching
 import scala.util.Failure
@@ -53,6 +54,7 @@ private[play] class PlayRequestHandler(
     val wsCompressionThreshold: Long,
     val wsKeepAliveMode: String,
     val wsKeepAliveMaxIdle: Duration,
+    val wsCloseTimeout: FiniteDuration,
     val deferBodyParsingGlobal: Boolean
 ) extends ChannelInboundHandlerAdapter {
   import PlayRequestHandler._
@@ -223,7 +225,8 @@ private[play] class PlayRequestHandler(
                   wsCompressionThreshold,
                   accepted.shouldCompress,
                   wsKeepAliveMode,
-                  wsKeepAliveMaxIdle
+                  wsKeepAliveMaxIdle,
+                  wsCloseTimeout
                 )
               val factory =
                 new PlayWebSocketServerHandshakerFactory(

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -4,7 +4,7 @@
 
 package play.core.server.netty
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
@@ -42,12 +42,33 @@ private[server] object WebSocketHandler {
       wsKeepAliveMaxIdle: Duration
   )(
       implicit mat: Materializer
+  ): Processor[WebSocketFrame, WebSocketFrame] =
+    messageFlowToFrameProcessor(
+      flow,
+      bufferLimit,
+      compressionThreshold,
+      compressionSelector,
+      wsKeepAliveMode,
+      wsKeepAliveMaxIdle,
+      3.seconds
+    )
+
+  def messageFlowToFrameProcessor(
+      flow: Flow[Message, Message, ?],
+      bufferLimit: Int,
+      compressionThreshold: Long,
+      compressionSelector: WebSocket.CompressionContext => Boolean,
+      wsKeepAliveMode: String,
+      wsKeepAliveMaxIdle: Duration,
+      wsCloseTimeout: FiniteDuration
+  )(
+      implicit mat: Materializer
   ): Processor[WebSocketFrame, WebSocketFrame] = {
     // The reason we use a processor is that we *must* release the buffers synchronously, since Pekko streams drops
     // messages, which will mean we can't release the ByteBufs in the messages.
     val processor = SynchronousMappedStreams.transform(
       WebSocketFlowHandler
-        .webSocketProtocol(bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle)
+        .webSocketProtocol(bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle, wsCloseTimeout)
         .join(flow)
         .toProcessor
         .run(),

--- a/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
@@ -4,7 +4,7 @@
 
 package org.apache.pekko.http.play
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 import org.apache.pekko.http.impl.engine.ws._
 import org.apache.pekko.http.scaladsl.model.ws.WebSocketUpgrade
@@ -41,10 +41,35 @@ object WebSocketHandler {
       compressionSelector: (() => Message, Long, Boolean) => Boolean,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration,
+  ): HttpResponse =
+    handleWebSocket(
+      upgrade,
+      flow,
+      bufferLimit,
+      subprotocol,
+      compressionEnabled,
+      compressionThreshold,
+      compressionSelector,
+      wsKeepAliveMode,
+      wsKeepAliveMaxIdle,
+      3.seconds
+    )
+
+  def handleWebSocket(
+      upgrade: WebSocketUpgrade,
+      flow: Flow[Message, Message, ?],
+      bufferLimit: Int,
+      subprotocol: Option[String],
+      compressionEnabled: Boolean,
+      compressionThreshold: Long,
+      compressionSelector: (() => Message, Long, Boolean) => Boolean,
+      wsKeepAliveMode: String,
+      wsKeepAliveMaxIdle: Duration,
+      wsCloseTimeout: FiniteDuration,
   ): HttpResponse = upgrade match {
     case lowLevel: UpgradeToWebSocketLowLevel =>
       lowLevel.handleFrames(
-        messageFlowToFrameFlow(flow, bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle),
+        messageFlowToFrameFlow(flow, bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle, wsCloseTimeout),
         subprotocol,
         compressionEnabled,
         frame => {
@@ -82,6 +107,15 @@ object WebSocketHandler {
       bufferLimit: Int,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration
+  ): Flow[FrameEvent, FrameEvent, ?] =
+    messageFlowToFrameFlow(flow, bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle, 3.seconds)
+
+  def messageFlowToFrameFlow(
+      flow: Flow[Message, Message, ?],
+      bufferLimit: Int,
+      wsKeepAliveMode: String,
+      wsKeepAliveMaxIdle: Duration,
+      wsCloseTimeout: FiniteDuration
   ): Flow[FrameEvent, FrameEvent, ?] = {
     // Each of the stages here transforms frames to an Either[Message, ?], where Message is a close message indicating
     // some sort of protocol failure. The handleProtocolFailures function then ensures that these messages skip the
@@ -90,7 +124,9 @@ object WebSocketHandler {
       .via(aggregateFrames(bufferLimit))
       .via(
         handleProtocolFailures(
-          WebSocketFlowHandler.webSocketProtocol(bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle).join(flow)
+          WebSocketFlowHandler
+            .webSocketProtocol(bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle, wsCloseTimeout)
+            .join(flow)
         )
       )
       .map(messageToFrameEvent)

--- a/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/play/core/server/PekkoHttpServer.scala
@@ -113,9 +113,14 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
   private val httpsWantClientAuth                      = serverConfig.get[Boolean]("https.wantClientAuth")
   private val illegalResponseHeaderValueProcessingMode =
     pekkoServerConfig.get[String]("illegal-response-header-value-processing-mode")
-  private val wsBufferLimit          = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
-  private val wsKeepAliveMode        = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
-  private val wsKeepAliveMaxIdle     = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
+  private val wsBufferLimit      = serverConfig.get[ConfigMemorySize]("websocket.frame.maxLength").toBytes.toInt
+  private val wsKeepAliveMode    = serverConfig.get[String]("websocket.periodic-keep-alive-mode")
+  private val wsKeepAliveMaxIdle = serverConfig.get[Duration]("websocket.periodic-keep-alive-max-idle")
+  private val wsCloseTimeout     = Server.getPositiveFiniteDuration(
+    serverConfig,
+    "websocket.closeTimeout",
+    "play.server.websocket.closeTimeout"
+  )
   private val wsCompressionConfig    = serverConfig.get[Configuration]("websocket.compression")
   private val wsCompressionThreshold = wsCompressionConfig.get[ConfigMemorySize]("threshold").toBytes
 
@@ -459,7 +464,8 @@ class PekkoHttpServer(context: PekkoHttpServer.Context) extends Server {
                       new WebSocket.CompressionContext(message(), payloadLength, isAboveCompressionThreshold)
                     ),
                   wsKeepAliveMode,
-                  wsKeepAliveMaxIdle
+                  wsKeepAliveMaxIdle,
+                  wsCloseTimeout
                 )
               Future.successful(response.withHeaders(response.headers ++ handshakeHeaders))
           }

--- a/transport/server/play-server/src/main/resources/reference.conf
+++ b/transport/server/play-server/src/main/resources/reference.conf
@@ -91,6 +91,38 @@ play {
     pidfile.path = ${?pidfile.path}
 
     websocket {
+      # Maximum time to wait for the peer's Close frame after Play sends one.
+      # Incoming traffic does not extend this timeout. The connection is
+      # terminated when the timeout expires. This must be a positive finite
+      # duration.
+      closeTimeout = 3 seconds
+
+      # Maximum allowable frame payload length. Setting this value to your application's
+      # requirement may reduce denial of service attacks using long data frames.
+      # For compressed WebSocket frames, this also limits the decompression buffer
+      # used before Play handles the frame. WebSocket Close frames, on the other hand,
+      # are control frames and are still limited by RFC 6455 to 125 bytes. If a Close
+      # frame includes a status code, the status code uses 2 bytes, leaving at most
+      # 123 UTF-8 bytes for the close reason. Play truncates longer close reasons
+      # before sending them.
+      frame.maxLength = 64k
+      frame.maxLength = ${?websocket.frame.maxLength}
+
+      # Periodic keep alive may be implemented using by sending Ping frames
+      # upon which the other side is expected to reply with a Pong frame,
+      # or by sending a Pong frame, which serves as unidirectional heartbeat.
+      # Valid values:
+      #   ping - default, for bi-directional ping/pong keep-alive heartbeating
+      #   pong - for uni-directional pong keep-alive heartbeating
+      periodic-keep-alive-mode = ping
+
+      # Interval for sending periodic keep-alives
+      # If a client does not send a frame within this idle time, the server will sent the the keep-alive frame.
+      # The frame sent will be the one configured in play.server.websocket.periodic-keep-alive-mode
+      # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
+      # The value `infinite` means that *no* keep-alive heartbeat will be sent, as: "the allowed idle time is infinite"
+      periodic-keep-alive-max-idle = infinite
+
       compression {
         # Whether WebSocket compression support should be enabled.
         # WebSocket compression is negotiated during the WebSocket handshake and is
@@ -128,32 +160,6 @@ play {
           preferredClientNoContext = false
         }
       }
-
-      # Maximum allowable frame payload length. Setting this value to your application's
-      # requirement may reduce denial of service attacks using long data frames.
-      # For compressed WebSocket frames, this also limits the decompression buffer
-      # used before Play handles the frame. WebSocket Close frames, on the other hand,
-      # are control frames and are still limited by RFC 6455 to 125 bytes. If a Close
-      # frame includes a status code, the status code uses 2 bytes, leaving at most
-      # 123 UTF-8 bytes for the close reason. Play truncates longer close reasons
-      # before sending them.
-      frame.maxLength = 64k
-      frame.maxLength = ${?websocket.frame.maxLength}
-
-      # Periodic keep alive may be implemented using by sending Ping frames
-      # upon which the other side is expected to reply with a Pong frame,
-      # or by sending a Pong frame, which serves as unidirectional heartbeat.
-      # Valid values:
-      #   ping - default, for bi-directional ping/pong keep-alive heartbeating
-      #   pong - for uni-directional pong keep-alive heartbeating
-      periodic-keep-alive-mode = ping
-
-      # Interval for sending periodic keep-alives
-      # If a client does not send a frame within this idle time, the server will sent the the keep-alive frame.
-      # The frame sent will be the one configured in play.server.websocket.periodic-keep-alive-mode
-      # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
-      # The value `infinite` means that *no* keep-alive heartbeat will be sent, as: "the allowed idle time is infinite"
-      periodic-keep-alive-max-idle = infinite
     }
 
     debug {

--- a/transport/server/play-server/src/main/scala/play/core/server/Server.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/Server.scala
@@ -7,6 +7,7 @@ package play.core.server
 import java.net.URI
 import java.util.function.{ Function => JFunction }
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
 import scala.language.postfixOps
@@ -219,6 +220,18 @@ object Server {
     Configuration(config).getDeprecated[String](path, deprecatedPath) match {
       case "infinite" => Long.MaxValue
       case _          => config.getBytes(if (config.hasPath(deprecatedPath)) deprecatedPath else path)
+    }
+  }
+
+  private[server] def getPositiveFiniteDuration(
+      config: Configuration,
+      path: String,
+      displayPath: String
+  ): FiniteDuration = {
+    config.get[Duration](path) match {
+      case duration: FiniteDuration if duration > Duration.Zero => duration
+      case duration                                             =>
+        throw ServerStartException(s"$displayPath must be a positive finite duration, but was $duration")
     }
   }
 

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -29,7 +29,8 @@ object WebSocketFlowHandler {
   @deprecated("Please specify the keep-alive mode (ping or pong) and max-idle time", "2.8.19")
   def webSocketProtocol(
       bufferLimit: Int
-  ): BidiFlow[RawMessage, Message, Message, Message, NotUsed] = webSocketProtocol(bufferLimit, "ping", Duration.Inf)
+  ): BidiFlow[RawMessage, Message, Message, Message, NotUsed] =
+    webSocketProtocol(bufferLimit, "ping", Duration.Inf, 3.seconds)
 
   /**
    * Implements the WebSocket protocol, including correctly handling the closing of the WebSocket, as well as
@@ -39,6 +40,18 @@ object WebSocketFlowHandler {
       bufferLimit: Int,
       wsKeepAliveMode: String,
       wsKeepAliveMaxIdle: Duration
+  ): BidiFlow[RawMessage, Message, Message, Message, NotUsed] =
+    webSocketProtocol(bufferLimit, wsKeepAliveMode, wsKeepAliveMaxIdle, 3.seconds)
+
+  /**
+   * Implements the WebSocket protocol, including correctly handling the closing of the WebSocket, as well as
+   * other control frames like ping/pong.
+   */
+  def webSocketProtocol(
+      bufferLimit: Int,
+      wsKeepAliveMode: String,
+      wsKeepAliveMaxIdle: Duration,
+      wsCloseTimeout: FiniteDuration
   ): BidiFlow[RawMessage, Message, Message, Message, NotUsed] = {
 
     /** The layer that transparently injects (if enabled) keepAlive Ping or Pong messages when client is idle */
@@ -79,7 +92,7 @@ object WebSocketFlowHandler {
       override def shape: BidiShape[RawMessage, Message, Message, Message] =
         new BidiShape(remoteIn, appOut, appIn, remoteOut)
 
-      override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+      override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
         var state: State           = Open
         var pingToSend: Message    = null
         var pongToSend: Message    = null
@@ -123,6 +136,7 @@ object WebSocketFlowHandler {
             if (isAvailable(remoteOut)) {
               state = ServerInitiatedClose
               push(remoteOut, closeToSend)
+              scheduleOnce(CloseHandshakeTimeout, wsCloseTimeout)
               // If appOut is closed, then we may need to do our own pull so that we can get the ack
               if (isClosed(appOut) && !isClosed(remoteIn) && !hasBeenPulled(remoteIn)) {
                 pull(remoteIn)
@@ -176,22 +190,26 @@ object WebSocketFlowHandler {
               null
             case MessageType.Ping if read.directAnswer =>
               // Ping the client (Part of idle handling)
-              if (isAvailable(remoteOut)) {
-                // Send immediately
-                push(remoteOut, PingMessage(ByteString.empty))
-              } else {
-                // Store to send later
-                pingToSend = PingMessage(ByteString.empty)
+              if (state == Open) {
+                if (isAvailable(remoteOut)) {
+                  // Send immediately
+                  push(remoteOut, PingMessage(ByteString.empty))
+                } else {
+                  // Store to send later
+                  pingToSend = PingMessage(ByteString.empty)
+                }
               }
               null
             case MessageType.Pong if read.directAnswer =>
               // Pong the client (Part of idle handling)
-              if (isAvailable(remoteOut)) {
-                // Send immediately
-                push(remoteOut, PongMessage(ByteString.empty))
-              } else {
-                // Store to send later
-                pongToSend = PongMessage(ByteString.empty)
+              if (state == Open) {
+                if (isAvailable(remoteOut)) {
+                  // Send immediately
+                  push(remoteOut, PongMessage(ByteString.empty))
+                } else {
+                  // Store to send later
+                  pongToSend = PongMessage(ByteString.empty)
+                }
               }
               null
             case MessageType.Ping | MessageType.Pong | MessageType.Close =>
@@ -457,6 +475,12 @@ object WebSocketFlowHandler {
             }
           }
         )
+
+        protected override def onTimer(timerKey: Any): Unit = {
+          if (timerKey == CloseHandshakeTimeout && state == ServerInitiatedClose) {
+            completeStage()
+          }
+        }
       }
     })
     periodicKeepAlive.atop(messageHandling)
@@ -467,6 +491,7 @@ object WebSocketFlowHandler {
   private case class ServerInitiatingClose(message: CloseMessage) extends State
   private case object ServerInitiatedClose                        extends State
   private case class ClientInitiatedClose(message: CloseMessage)  extends State
+  private case object CloseHandshakeTimeout
 
   private val logger = Logger("play.core.server.common.WebSocketFlowHandler")
 

--- a/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
@@ -12,6 +12,8 @@ import scala.concurrent.Promise
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl._
 import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.OverflowStrategy
+import org.apache.pekko.stream.QueueOfferResult
 import org.apache.pekko.util.ByteString
 import org.apache.pekko.Done
 import org.specs2.matcher.Matcher
@@ -108,6 +110,64 @@ class WebSocketFlowHandlerSpec extends Specification {
       message must beEqualTo(CloseMessage(None))
     }
 
+    "complete when the peer acknowledges an application close" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOut) = runClosingWebSocket(5.seconds)
+
+      Await.result(remoteOut.pull(), 5.seconds) must beSome(closeMessage(CloseCodes.Regular))
+      offer(remoteIn, rawClose(CloseCodes.Regular))
+      Await.result(remoteOut.pull(), 1.second) must beNone
+    }
+
+    "complete when the peer does not acknowledge an application close before the timeout" in withActorSystem {
+      implicit materializer =>
+        val (remoteIn, remoteOut) = runClosingWebSocket(100.millis)
+
+        Await.result(remoteOut.pull(), 5.seconds) must beSome(closeMessage(CloseCodes.Regular))
+        Await.result(remoteOut.pull(), 5.seconds) must beNone
+        remoteIn.complete()
+        ok
+    }
+
+    "start the close timeout only after emitting the close frame" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOut) = runClosingWebSocket(100.millis)
+
+      Thread.sleep(250)
+      Await.result(remoteOut.pull(), 5.seconds) must beSome(closeMessage(CloseCodes.Regular))
+      Await.result(remoteOut.pull(), 5.seconds) must beNone
+      remoteIn.complete()
+      ok
+    }
+
+    "complete when the transport terminates while awaiting a close acknowledgement" in withActorSystem {
+      implicit materializer =>
+        val (remoteIn, remoteOut) = runClosingWebSocket(5.seconds)
+
+        Await.result(remoteOut.pull(), 5.seconds) must beSome(closeMessage(CloseCodes.Regular))
+        remoteIn.complete()
+        Await.result(remoteOut.pull(), 1.second) must beNone
+    }
+
+    "not let client ping or pong frames extend the close timeout" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOut) = runClosingWebSocket(1.second)
+
+      Await.result(remoteOut.pull(), 5.seconds) must beSome(closeMessage(CloseCodes.Regular))
+      offer(remoteIn, rawMessage(WebSocketFlowHandler.MessageType.Ping, ByteString("ping"), isFinal = true))
+      offer(remoteIn, rawMessage(WebSocketFlowHandler.MessageType.Pong, ByteString("pong"), isFinal = true))
+      Await.result(remoteOut.pull(), 5.seconds) must beNone
+      remoteIn.complete()
+      ok
+    }
+
+    "not send periodic keep-alive frames after emitting a close frame" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOut) =
+        runClosingWebSocket(1.second, wsKeepAliveMode = "ping", wsKeepAliveMaxIdle = 20.millis)
+
+      Await.result(remoteOut.pull(), 5.seconds) must beSome(closeMessage(CloseCodes.Regular))
+      Await.result(remoteOut.pull(), 5.seconds) must beNone
+      remoteIn.complete()
+      ok
+    }
+
     "echo an empty remote close frame without serializing 1005" in withActorSystem { implicit materializer =>
       val (_, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(rawClose(None))
 
@@ -194,7 +254,7 @@ class WebSocketFlowHandlerSpec extends Specification {
       appIn: Source[Message, ?] = Source.maybe[Message]
   )(implicit materializer: Materializer): (Seq[Message], Seq[Message]) = {
     val appFlow = Flow.fromSinkAndSourceMat(Sink.seq[Message], appIn)(Keep.left)
-    val flow    = protocol.joinMat(appFlow)(Keep.right)
+    val flow    = protocol().joinMat(appFlow)(Keep.right)
 
     val (appMessages, remoteMessages) = remoteIn.viaMat(flow)(Keep.right).toMat(Sink.seq[Message])(Keep.both).run()
 
@@ -212,7 +272,7 @@ class WebSocketFlowHandlerSpec extends Specification {
       Sink.seq[Message],
       Source.single(close)
     )(Keep.left)
-    val flow = protocol.joinMat(appFlow)(Keep.right)
+    val flow = protocol().joinMat(appFlow)(Keep.right)
 
     val ((remoteIn, appMessages), remoteMessage) =
       Source
@@ -236,7 +296,7 @@ class WebSocketFlowHandlerSpec extends Specification {
       Sink.seq[Message],
       Source.single(CloseMessage(CloseCodes.Regular))
     )(Keep.left)
-    val flow      = protocol.joinMat(appFlow)(Keep.right)
+    val flow      = protocol().joinMat(appFlow)(Keep.right)
     val closeSent = Promise[Message]()
 
     val ((remoteIn, appMessages), remoteOutDone) =
@@ -252,11 +312,41 @@ class WebSocketFlowHandlerSpec extends Specification {
     Await.result(appMessages, 5.seconds)
   }
 
+  private def runClosingWebSocket(
+      closeTimeout: FiniteDuration,
+      wsKeepAliveMode: String = "ping",
+      wsKeepAliveMaxIdle: Duration = Duration.Inf
+  )(implicit materializer: Materializer): (
+      SourceQueueWithComplete[WebSocketFlowHandler.RawMessage],
+      SinkQueueWithCancel[
+        Message
+      ]
+  ) = {
+    val appFlow = Flow.fromSinkAndSource(
+      Sink.ignore,
+      Source.single[Message](CloseMessage(CloseCodes.Regular))
+    )
+    val flow = protocol(closeTimeout, wsKeepAliveMode, wsKeepAliveMaxIdle).join(appFlow)
+
+    Source
+      .queue[WebSocketFlowHandler.RawMessage](16, OverflowStrategy.backpressure)
+      .via(flow)
+      .toMat(Sink.queue[Message]())(Keep.both)
+      .run()
+  }
+
+  private def offer(
+      queue: SourceQueueWithComplete[WebSocketFlowHandler.RawMessage],
+      message: WebSocketFlowHandler.RawMessage
+  ): Unit = {
+    Await.result(queue.offer(message), 5.seconds) must_== QueueOfferResult.Enqueued
+  }
+
   private def runCompletedRemoteInputWithoutInitialAppDemand()(
       implicit materializer: Materializer
   ): Seq[Message] = {
     val appFlow = Flow.fromSinkAndSourceMat(Sink.asPublisher[Message](fanout = false), Source.maybe[Message])(Keep.left)
-    val flow    = protocol.joinMat(appFlow)(Keep.right)
+    val flow    = protocol().joinMat(appFlow)(Keep.right)
 
     val (appPublisher, remoteOutDone) =
       Source.empty[WebSocketFlowHandler.RawMessage].viaMat(flow)(Keep.right).toMat(Sink.ignore)(Keep.both).run()
@@ -267,11 +357,16 @@ class WebSocketFlowHandlerSpec extends Specification {
     Await.result(appMessages, 5.seconds)
   }
 
-  private def protocol =
+  private def protocol(
+      closeTimeout: FiniteDuration = 3.seconds,
+      wsKeepAliveMode: String = "ping",
+      wsKeepAliveMaxIdle: Duration = Duration.Inf
+  ) =
     WebSocketFlowHandler.webSocketProtocol(
       bufferLimit = 65536,
-      wsKeepAliveMode = "ping",
-      wsKeepAliveMaxIdle = Duration.Inf
+      wsKeepAliveMode = wsKeepAliveMode,
+      wsKeepAliveMaxIdle = wsKeepAliveMaxIdle,
+      wsCloseTimeout = closeTimeout
     )
 
   private def rawClose(statusCode: Int): WebSocketFlowHandler.RawMessage = {


### PR DESCRIPTION
Adds a configurable timeout for server-initiated WebSocket closing handshakes:

```hocon
play.server.websocket.closeTimeout = 3 seconds
```

The setting is shared by the Netty and Pekko HTTP backends and must be a positive finite duration.

## Behavior

After Play emits a WebSocket Close frame, it waits for the peer to acknowledge the closing handshake with its own Close frame.

The timeout:

- starts only after Play emits the Close frame;
- is not extended by subsequent client traffic, including Ping and Pong frames;
- terminates the connection if the peer does not acknowledge in time;
- is bypassed when the peer acknowledges or the transport terminates first;
- suppresses Play's periodic WebSocket keep-alive frames while closing;
- is independent of the HTTP idle timeout.

This prevents an unresponsive client from keeping a closing WebSocket connection open until a broader transport timeout expires.

Invalid values such as zero, negative durations, and `infinite` now fail during server startup with a configuration error.

## Implementation

The closing-handshake state and timer are implemented in the common `WebSocketFlowHandler`, giving both server backends the same behavior. The configured duration is propagated through the Netty and Pekko HTTP WebSocket handlers.

## Testing

Tests cover:

- successful peer acknowledgement;
- an unresponsive peer and timeout expiry;
- transport termination while awaiting acknowledgement;
- starting the timer only after the Close frame is emitted;
- Ping and Pong traffic not extending the timeout;
- suppression of periodic keep-alive frames while closing;
- startup rejection of zero, negative, and infinite values;
- end-to-end timeout behavior with both Netty and Pekko HTTP.
