### PR TITLE
Keep one inbound WebSocket message in flight under application backpressure

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -21,6 +21,7 @@ import org.apache.pekko.actor.Actor
 import org.apache.pekko.actor.Props
 import org.apache.pekko.actor.Status
 import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko.stream.OverflowStrategy
 import org.apache.pekko.util.ByteString
 import org.apache.pekko.util.Timeout
 import org.specs2.execute.AsResult
@@ -608,6 +609,90 @@ trait PingWebSocketSpec
             closeFrame()
           )
         )
+      }
+    }
+
+    "respond to pings before the application requests a message" in {
+      val appMessages = Promise[SinkQueueWithCancel[Message]]()
+
+      withServer(app =>
+        WebSocket.accept[Message, Message] { req =>
+          Flow
+            .fromSinkAndSourceMat(Sink.queue[Message](), Source.maybe[Message])(Keep.left)
+            .mapMaterializedValue { queue =>
+              appMessages.success(queue)
+              queue
+            }
+        }
+      ) { (app, port) =>
+        import app.materializer
+        val (pong, appPing, close) = runWebSocket(
+          port,
+          { flow =>
+            val (clientIn, clientOut) =
+              Source
+                .queue[ExtendedMessage](1, OverflowStrategy.backpressure)
+                .via(flow)
+                .toMat(Sink.queue[ExtendedMessage]())(Keep.both)
+                .run()
+
+            for {
+              appQueue <- appMessages.future
+              _        <- clientIn.offer(PingMessage(ByteString("hello")))
+              pong     <- clientOut.pull()
+              appPing  <- appQueue.pull()
+              appClose = appQueue.pull()
+              _     <- clientIn.offer(CloseMessage(CloseCodes.Regular))
+              close <- clientOut.pull()
+              _     <- appClose
+              _     <- clientOut.pull()
+            } yield (pong, appPing, close)
+          }
+        )
+
+        (pong must beSome(pongFrame(be_==("hello"))))
+          .and(appPing must beSome(beEqualTo(PingMessage(ByteString("hello")))))
+          .and(close must beSome(closeFrame()))
+      }
+    }
+
+    "acknowledge a close before the application requests a message" in {
+      val appMessages = Promise[SinkQueueWithCancel[Message]]()
+
+      withServer(app =>
+        WebSocket.accept[Message, Message] { req =>
+          Flow
+            .fromSinkAndSourceMat(Sink.queue[Message](), Source.maybe[Message])(Keep.left)
+            .mapMaterializedValue { queue =>
+              appMessages.success(queue)
+              queue
+            }
+        }
+      ) { (app, port) =>
+        import app.materializer
+        val (remoteClose, appClose) = runWebSocket(
+          port,
+          { flow =>
+            val (clientIn, clientOut) =
+              Source
+                .queue[ExtendedMessage](1, OverflowStrategy.backpressure)
+                .via(flow)
+                .toMat(Sink.queue[ExtendedMessage]())(Keep.both)
+                .run()
+
+            for {
+              appQueue    <- appMessages.future
+              _           <- clientIn.offer(CloseMessage(CloseCodes.GoingAway))
+              remoteClose <- clientOut.pull()
+              appClose    <- appQueue.pull()
+              _           <- clientOut.pull()
+              _           <- appQueue.pull()
+            } yield (remoteClose, appClose)
+          }
+        )
+
+        (remoteClose must beSome(closeFrame(CloseCodes.GoingAway)))
+          .and(appClose must beSome(closeMessage(CloseCodes.GoingAway)))
       }
     }
 

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -107,10 +107,11 @@ object WebSocketFlowHandler {
           .onMalformedInput(CodingErrorAction.REPORT)
           .onUnmappableCharacter(CodingErrorAction.REPORT)
 
-        // For the remoteIn, we always and only pull when the appOut is available, the only exception being when appOut
-        // is already closed and we're expecting a close ack from the client. This means whenever remoteIn pushes, we
-        // always know we can push directly to appOut.  It does mean however that we will never respond to close or
-        // pings if appOut never pulls.
+        // For remoteIn, pull only when appOut has demand, except when appOut is closed and awaiting a close
+        // acknowledgment. This guarantees appOut is available whenever a remote message needs to be pushed to it.
+        // The one-element application-side buffer below supplies demand for one application-visible message
+        // independently of the application, allowing a peer control message to be processed while the application
+        // is applying backpressure. Once that slot is occupied, further frames wait until the application pulls.
 
         // For the remoteOut, we have a few buffers - a server or client initiated close buffer, a server message, and a pong
         // message.  Multiple ping messages could arrive at any time, according to the WebSocket spec, we only need to
@@ -483,7 +484,12 @@ object WebSocketFlowHandler {
         }
       }
     })
-    periodicKeepAlive.atop(messageHandling)
+    val applicationInputBuffer = BidiFlow.fromFlows(
+      Flow[Message].buffer(1, OverflowStrategy.backpressure),
+      Flow[Message]
+    )
+
+    periodicKeepAlive.atop(messageHandling).atop(applicationInputBuffer)
   }
 
   private sealed trait State

--- a/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
@@ -168,6 +168,72 @@ class WebSocketFlowHandlerSpec extends Specification {
       ok
     }
 
+    "answer a peer ping while the application applies backpressure" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOut, appMessages, appOut) = runBackpressuredWebSocket()
+      val payload                                    = ByteString("ping")
+
+      offer(remoteIn, rawMessage(WebSocketFlowHandler.MessageType.Ping, payload, isFinal = true))
+
+      Await.result(remoteOut.pull(), 1.second) must beSome(beEqualTo(PongMessage(payload)))
+      Await.result(appMessages.pull(), 1.second) must beSome(beEqualTo(PingMessage(payload)))
+
+      appOut.complete()
+      Await.result(remoteOut.pull(), 1.second) must beSome(closeMessage(CloseCodes.Regular))
+      offer(remoteIn, rawClose(CloseCodes.Regular))
+      Await.result(remoteOut.pull(), 1.second) must beNone
+    }
+
+    "consume a peer pong while the application applies backpressure" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOut, appMessages, _) = runBackpressuredWebSocket()
+      val payload                               = ByteString("pong")
+
+      offer(remoteIn, rawMessage(WebSocketFlowHandler.MessageType.Pong, payload, isFinal = true))
+      Await.result(remoteIn.offer(rawClose(CloseCodes.Regular)), 1.second) must_== QueueOfferResult.Enqueued
+
+      Await.result(appMessages.pull(), 1.second) must beSome(beEqualTo(PongMessage(payload)))
+      val appClose = appMessages.pull()
+      Await.result(remoteOut.pull(), 1.second) must beSome(closeMessage(CloseCodes.Regular))
+      Await.result(appClose, 1.second) must beSome(closeMessage(CloseCodes.Regular))
+      Await.result(remoteOut.pull(), 1.second) must beNone
+      Await.result(appMessages.pull(), 1.second) must beNone
+    }
+
+    "acknowledge a peer close while the application applies backpressure" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOut, appMessages, _) = runBackpressuredWebSocket()
+
+      offer(remoteIn, rawClose(CloseCodes.GoingAway))
+
+      Await.result(remoteOut.pull(), 1.second) must beSome(closeMessage(CloseCodes.GoingAway))
+      Await.result(remoteOut.pull(), 1.second) must beNone
+      Await.result(appMessages.pull(), 1.second) must beSome(closeMessage(CloseCodes.GoingAway))
+      Await.result(appMessages.pull(), 1.second) must beNone
+    }
+
+    "preserve a buffered application message before reporting abnormal closure" in withActorSystem {
+      implicit materializer =>
+        val (remoteIn, remoteOut, appMessages, _) = runBackpressuredWebSocket()
+
+        offer(remoteIn, rawMessage(WebSocketFlowHandler.MessageType.Text, ByteString("message"), isFinal = true))
+        remoteIn.complete()
+
+        Await.result(appMessages.pull(), 1.second) must beSome(beEqualTo(TextMessage("message")))
+        Await.result(appMessages.pull(), 1.second) must beSome(closeMessage(CloseCodes.ConnectionAbort))
+        Await.result(appMessages.pull(), 1.second) must beNone
+        Await.result(remoteOut.pull(), 1.second) must beNone
+    }
+
+    "preserve a buffered application message before a backend-handled protocol failure" in withActorSystem {
+      implicit materializer =>
+        val (remoteIn, remoteOut, appMessages, _) = runBackpressuredWebSocket()
+
+        offer(remoteIn, rawMessage(WebSocketFlowHandler.MessageType.Text, ByteString("message"), isFinal = true))
+        remoteIn.fail(new WebSocketFlowHandler.BackendHandledProtocolViolation(new RuntimeException("invalid frame")))
+
+        Await.result(appMessages.pull(), 1.second) must beSome(beEqualTo(TextMessage("message")))
+        Await.result(appMessages.pull(), 1.second) must beNone
+        Await.result(remoteOut.pull(), 1.second) must beNone
+    }
+
     "echo an empty remote close frame without serializing 1005" in withActorSystem { implicit materializer =>
       val (_, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(rawClose(None))
 
@@ -333,6 +399,28 @@ class WebSocketFlowHandlerSpec extends Specification {
       .via(flow)
       .toMat(Sink.queue[Message]())(Keep.both)
       .run()
+  }
+
+  private def runBackpressuredWebSocket()(implicit materializer: Materializer): (
+      SourceQueueWithComplete[WebSocketFlowHandler.RawMessage],
+      SinkQueueWithCancel[Message],
+      SinkQueueWithCancel[Message],
+      SourceQueueWithComplete[Message]
+  ) = {
+    val appFlow = Flow.fromSinkAndSourceMat(
+      Sink.queue[Message](),
+      Source.queue[Message](1, OverflowStrategy.backpressure)
+    )(Keep.both)
+    val flow = protocol().joinMat(appFlow)(Keep.right)
+
+    val ((remoteIn, (appMessages, appOut)), remoteOut) =
+      Source
+        .queue[WebSocketFlowHandler.RawMessage](1, OverflowStrategy.backpressure)
+        .viaMat(flow)(Keep.both)
+        .toMat(Sink.queue[Message]())(Keep.both)
+        .run()
+
+    (remoteIn, remoteOut, appMessages, appOut)
   }
 
   private def offer(


### PR DESCRIPTION
Keep one application-visible inbound WebSocket message in flight independently of application demand.

When that message is a peer Ping, Pong, or Close message, it can reach Play's shared WebSocket protocol handler even when the application has not requested its next message. Play can therefore respond to a Ping or acknowledge a Close while retaining the application-visible message until the application pulls.

The buffer is:

- bounded to one message;
- FIFO and order-preserving;
- fused into the existing stream without an asynchronous boundary;
- shared by the Netty and Pekko HTTP backends.

## Motivation

`WebSocketFlowHandler` previously pulled remote input only when its application-facing output had demand. If an application materialized its WebSocket flow but did not immediately request a message, Play could not process the next peer control message.

The one-element buffer supplies enough demand to process one application-visible message without introducing an unbounded queue or materially weakening application backpressure.

## Scope

This deliberately provides one-message lookahead rather than unconditional control-frame liveness. Once the buffer contains a message, application backpressure applies again and further frames wait until the application pulls.

A larger buffer would only move that boundary while increasing per-connection memory use.

## Testing

Added shared protocol-handler tests covering:

- replying to Ping while the application is backpressured;
- consuming Pong while the application is backpressured;
- acknowledging Close while the application is backpressured;
- preserving a buffered message before abnormal termination;
- preserving a buffered message before a backend-handled protocol failure.

Added integration coverage verifying the Ping and Close behavior with both the
Netty and Pekko HTTP backends.

- Depends on #14129.