### PR TITLE
Document WebSocket HTTP/2 limitation

### DIFF
--- a/documentation/manual/working/commonGuide/server/PekkoHttpServer.md
+++ b/documentation/manual/working/commonGuide/server/PekkoHttpServer.md
@@ -28,6 +28,8 @@ There are a variety of options that can be configured for the Pekko HTTP server.
 
 Play's Pekko HTTP server also supports HTTP/2. This feature is labeled "incubating" because the API may change in the future, and it has not been thoroughly tested in the wild. However, if you'd like to help Play improve please do test out HTTP/2 support and give us feedback about your experience.
 
+> **Note:** Enabling HTTP/2 does not enable WebSockets over HTTP/2. Play currently establishes WebSockets using the HTTP/1.1 Upgrade mechanism and does not support RFC 8441 Extended CONNECT.
+
 You also should [[Configure HTTPS|ConfiguringHttps]] on your server before enabling HTTP/2. In general, browsers require TLS to work with HTTP/2, and Play's Pekko HTTP server uses ALPN (a TLS extension) to negotiate the protocol with clients that support it.
 
 To add support for HTTP/2, add the `PlayPekkoHttp2Support` plugin. You can do this in an `enablePlugins` call for your project in `build.sbt`, for example:

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -8,6 +8,8 @@ Modern HTML5 compliant web browsers natively support WebSockets via a JavaScript
 
 > **Tip:** Check [caniuse.com](https://caniuse.com/#feat=websockets) to see more about which browsers supports WebSockets, known issues and more information.
 
+> **Note:** Play currently establishes WebSockets using the HTTP/1.1 Upgrade mechanism. Enabling HTTP/2 for the Pekko HTTP backend does not enable RFC 8441 WebSockets over HTTP/2.
+
 ## Handling WebSockets
 
 Until now, we were using `Action` instances to handle standard HTTP requests and send back standard HTTP responses. WebSockets are a totally different beast and can’t be handled via standard `Action`.

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -8,6 +8,8 @@ Modern HTML5 compliant web browsers natively support WebSockets via a JavaScript
 
 > **Tip:** Check [caniuse.com](https://caniuse.com/#feat=websockets) to see more about which browsers supports WebSockets, known issues and more information.
 
+> **Note:** Play currently establishes WebSockets using the HTTP/1.1 Upgrade mechanism. Enabling HTTP/2 for the Pekko HTTP backend does not enable RFC 8441 WebSockets over HTTP/2.
+
 ## Handling WebSockets
 
 Until now, we were using `Action` instances to handle standard HTTP requests and send back standard HTTP responses. WebSockets are a totally different beast and can’t be handled via standard `Action`.


### PR DESCRIPTION
Clarify that Play currently establishes WebSockets using HTTP/1.1 Upgrade.

Enabling HTTP/2 for the Pekko HTTP backend does not enable RFC 8441 WebSockets over HTTP/2.

The Pekko HTTP server documentation and both WebSocket guides are updated.