### PR TITLE
Reject unexpected WebSocket reserved bits

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -273,6 +273,17 @@ object WebSocketClient {
           new CloseWebSocketFrame(finalFragment, 0, statusCode.getOrElse(CloseCodes.NoStatus), reason)
         case ContinuationMessage(data, finalFragment) =>
           new ContinuationWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
+        case RawWebSocketFrame(frameType, data, rsv, finalFragment) =>
+          lazy val content = Unpooled.wrappedBuffer(data.asByteBuffer)
+          frameType match {
+            case "text"         => new TextWebSocketFrame(finalFragment, rsv, content)
+            case "binary"       => new BinaryWebSocketFrame(finalFragment, rsv, content)
+            case "continuation" => new ContinuationWebSocketFrame(finalFragment, rsv, content)
+            case "ping"         => new PingWebSocketFrame(finalFragment, rsv, content)
+            case "pong"         => new PongWebSocketFrame(finalFragment, rsv, content)
+            case "close"        => new CloseWebSocketFrame(finalFragment, rsv, content)
+            case other          => throw new IllegalArgumentException(s"Unsupported WebSocket frame type: $other")
+          }
       }
 
       val framesToMessages = Flow[WebSocketFrame].map { frame =>

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -1132,6 +1132,25 @@ trait WebSocketSpec
         messages must beEmpty
       }
 
+      Seq(
+        ("RSV1 text", RawWebSocketFrame("text", ByteString("text"), rsv = 4, finalFragment = true)),
+        ("RSV2 text", RawWebSocketFrame("text", ByteString("text"), rsv = 2, finalFragment = true)),
+        ("RSV3 text", RawWebSocketFrame("text", ByteString("text"), rsv = 1, finalFragment = true)),
+        ("combined RSV text", RawWebSocketFrame("text", ByteString("text"), rsv = 7, finalFragment = true)),
+        ("RSV1 binary", RawWebSocketFrame("binary", ByteString("binary"), rsv = 4, finalFragment = true)),
+        ("combined RSV binary", RawWebSocketFrame("binary", ByteString("binary"), rsv = 7, finalFragment = true)),
+        ("combined RSV Ping", RawWebSocketFrame("ping", ByteString("ping"), rsv = 6, finalFragment = true)),
+        ("RSV2 Pong", RawWebSocketFrame("pong", ByteString("pong"), rsv = 2, finalFragment = true))
+      ).foreach {
+        case (name, frame) =>
+          s"reject an unnegotiated $name frame" in {
+            val (frames, messages) = sendProtocolFrames(frame)
+
+            frames must contain(exactly(closeFrame(CloseCodes.ProtocolError)))
+            messages must beEmpty
+          }
+      }
+
       "reject invalid UTF-8 split across text message fragments" in {
         val (frames, messages) = sendProtocolFrames(
           RawTextMessage(ByteString(0xe2.toByte), false),

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -122,21 +122,34 @@ private[server] object WebSocketHandler {
    * Converts Netty frames to Play RawMessages.
    */
   private def frameToMessage(frame: WebSocketFrame): RawMessage = {
-    val builder = ByteString.newBuilder
-    frame.content().readBytes(builder.asOutputStream, frame.content().readableBytes())
-    val bytes = builder.result()
-    ReferenceCountUtil.release(frame)
-
-    val messageType = frame match {
-      case _: TextWebSocketFrame         => MessageType.Text
-      case _: BinaryWebSocketFrame       => MessageType.Binary
-      case close: CloseWebSocketFrame    => MessageType.Close
-      case _: PingWebSocketFrame         => MessageType.Ping
-      case _: PongWebSocketFrame         => MessageType.Pong
-      case _: ContinuationWebSocketFrame => MessageType.Continuation
+    val reservedBits  = frame.rsv()
+    val finalFragment = frame.isFinalFragment
+    val messageType   = if (reservedBits != 0) {
+      MessageType.ReservedBits
+    } else {
+      frame match {
+        case _: TextWebSocketFrame         => MessageType.Text
+        case _: BinaryWebSocketFrame       => MessageType.Binary
+        case close: CloseWebSocketFrame    => MessageType.Close
+        case _: PingWebSocketFrame         => MessageType.Ping
+        case _: PongWebSocketFrame         => MessageType.Pong
+        case _: ContinuationWebSocketFrame => MessageType.Continuation
+      }
     }
+    val data =
+      try {
+        if (reservedBits != 0) {
+          ByteString.empty
+        } else {
+          val builder = ByteString.newBuilder
+          frame.content().readBytes(builder.asOutputStream, frame.content().readableBytes())
+          builder.result()
+        }
+      } finally {
+        ReferenceCountUtil.release(frame)
+      }
 
-    RawMessage(messageType, bytes, frame.isFinalFragment)
+    RawMessage(messageType, data, finalFragment)
   }
 
   /**

--- a/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
@@ -248,8 +248,16 @@ object WebSocketHandler {
   }
 
   private def frameToRawMessage(header: FrameHeader, data: ByteString) = {
-    val unmasked = FrameEventParser.mask(data, header.mask)
-    RawMessage(frameOpCodeToMessageType(header.opcode), unmasked, header.fin)
+    if (header.rsv1 || header.rsv2 || header.rsv3) {
+      RawMessage(
+        MessageType.ReservedBits,
+        ByteString.empty,
+        header.fin
+      )
+    } else {
+      val unmasked = FrameEventParser.mask(data, header.mask)
+      RawMessage(frameOpCodeToMessageType(header.opcode), unmasked, header.fin)
+    }
   }
 
   /**

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -191,6 +191,11 @@ object WebSocketFlowHandler {
           val read = grab(remoteIn)
 
           read.messageType match {
+            case MessageType.ReservedBits =>
+              serverInitiatedClose(
+                CloseMessage(CloseCodes.ProtocolError, "WebSocket frame contained unexpected reserved bits")
+              )
+              null
             case messageType if isControlMessage(messageType) && !read.isFinal =>
               serverInitiatedClose(CloseMessage(CloseCodes.ProtocolError, "Control frames must not be fragmented"))
               null
@@ -537,7 +542,7 @@ object WebSocketFlowHandler {
   )
   object MessageType extends Enumeration {
     type Type = Value
-    val Ping, Pong, Text, Binary, Continuation, Close = Value
+    val Ping, Pong, Text, Binary, Continuation, Close, ReservedBits = Value
   }
 
   private[server] final class BackendHandledProtocolViolation(cause: Throwable) extends RuntimeException(cause)

--- a/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
@@ -310,6 +310,20 @@ class WebSocketFlowHandlerSpec extends Specification {
       remoteMessages must contain(exactly(beEqualTo(CloseMessage(None))))
     }
 
+    "reject reserved bits reported by a frame adapter" in withActorSystem { implicit materializer =>
+      val (appMessages, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(
+        rawMessage(
+          WebSocketFlowHandler.MessageType.ReservedBits,
+          ByteString.empty,
+          isFinal = true
+        ),
+        rawClose(CloseCodes.ProtocolError)
+      )
+
+      appMessages must beEmpty
+      remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
+    }
+
     Seq(
       WebSocketFlowHandler.MessageType.Ping,
       WebSocketFlowHandler.MessageType.Pong,


### PR DESCRIPTION
- reject WebSocket frames containing reserved bits that were not consumed by a negotiated extension
- apply the validation consistently to the Netty and Pekko HTTP backends
- close the connection with status `1002` without delivering the malformed frame to the application
- cover RSV1, RSV2, RSV3, combined bits, text, binary, Ping, and Pong frames

## Motivation

Both backends permit extensions during frame decoding so that negotiated `permessage-deflate` frames can be processed. After extension processing, any remaining RSV bits are protocol violations under RFC 6455.

## Testing

- shared WebSocket integration tests for Netty and Pekko HTTP
- common WebSocket flow-handler tests
