### PR TITLE
Reject invalid peer WebSocket close frames

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -80,6 +80,7 @@ object WebSocketClient {
   }
   case class SimpleMessage(message: Message, finalFragment: Boolean)       extends ExtendedMessage
   case class RawTextMessage(data: ByteString, finalFragment: Boolean)      extends ExtendedMessage
+  case class RawCloseMessage(data: ByteString, finalFragment: Boolean)     extends ExtendedMessage
   case class ContinuationMessage(data: ByteString, finalFragment: Boolean) extends ExtendedMessage
   case class RawWebSocketFrame(frameType: String, data: ByteString, rsv: Int, finalFragment: Boolean)
       extends ExtendedMessage
@@ -271,6 +272,8 @@ object WebSocketClient {
           new PongWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
         case SimpleMessage(CloseMessage(statusCode, reason), finalFragment) =>
           new CloseWebSocketFrame(finalFragment, 0, statusCode.getOrElse(CloseCodes.NoStatus), reason)
+        case RawCloseMessage(data, finalFragment) =>
+          new CloseWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
         case ContinuationMessage(data, finalFragment) =>
           new ContinuationWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
         case RawWebSocketFrame(frameType, data, rsv, finalFragment) =>

--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -54,6 +54,7 @@ import play.it._
 import play.it.http.websocket.WebSocketClient.CompressionMode
 import play.it.http.websocket.WebSocketClient.ContinuationMessage
 import play.it.http.websocket.WebSocketClient.ExtendedMessage
+import play.it.http.websocket.WebSocketClient.RawCloseMessage
 import play.it.http.websocket.WebSocketClient.RawTextMessage
 import play.it.http.websocket.WebSocketClient.RawWebSocketFrame
 import play.it.http.websocket.WebSocketClient.SimpleMessage
@@ -539,6 +540,16 @@ class PekkoHttpWebSocketSpec
     with PekkoHttpIntegrationSpecification
     with WebSocketCompressionSpec {
   override def backendName: String = "pekko-http backend"
+
+  "Plays WebSockets using pekko-http backend" should {
+    "reject an unnegotiated RSV1 Close frame without waiting for another Close" in {
+      val (frames, messages) =
+        sendProtocolFrames(RawWebSocketFrame("close", ByteString.empty, rsv = 4, finalFragment = true))
+
+      frames must contain(exactly(closeFrame(CloseCodes.ProtocolError)))
+      messages must beEmpty
+    }
+  }
 
   "Plays WebSockets using pekko-http backend with HTTP2 enabled" should {
     "time out after play.server.http.idleTimeout" in delayedSend(
@@ -1218,6 +1229,36 @@ trait WebSocketSpec
       "reject an oversized Close control frame" in {
         val (frames, messages) =
           sendProtocolFrames(CloseMessage(CloseCodes.Regular, "a" * 124))
+
+        frames must contain(exactly(closeFrame(CloseCodes.ProtocolError)))
+        messages must beEmpty
+      }
+
+      Seq(999, 1004, 1005, 1006, 1015, 1016, 1100, 2000, 2999, 5000).foreach { statusCode =>
+        s"reject invalid peer Close status $statusCode" in {
+          val data               = ByteString((statusCode >> 8).toByte, statusCode.toByte)
+          val (frames, messages) = sendProtocolFrames(RawCloseMessage(data, finalFragment = true))
+
+          terminateWithOptionalClose(frames, CloseCodes.ProtocolError)
+          messages must beEmpty
+        }
+      }
+
+      "reject an invalid UTF-8 Close reason" in {
+        val data = ByteString(
+          (CloseCodes.Regular >> 8).toByte,
+          CloseCodes.Regular.toByte,
+          0xc3.toByte,
+          0x28.toByte
+        )
+        val (frames, messages) = sendProtocolFrames(RawCloseMessage(data, finalFragment = true))
+
+        terminateWithOptionalClose(frames, CloseCodes.InconsistentData)
+        messages must beEmpty
+      }
+
+      "reject a one-byte Close payload" in {
+        val (frames, messages) = sendProtocolFrames(RawCloseMessage(ByteString(0x03), finalFragment = true))
 
         frames must contain(exactly(closeFrame(CloseCodes.ProtocolError)))
         messages must beEmpty
@@ -2020,6 +2061,14 @@ trait WebSocketSpecMethods extends PlaySpecification with WsTestClient with Serv
 
   def closeFrame(status: Int = 1000): Matcher[ExtendedMessage] = beLike {
     case SimpleMessage(CloseMessage(statusCode, _), _) => statusCode must beSome(status)
+  }
+
+  def terminateWithOptionalClose(frames: List[ExtendedMessage], status: Int): Unit = {
+    // Netty treats a malformed Close as an already received closing handshake and may terminate without replying.
+    frames.foreach { frame =>
+      frame must closeFrame(status)
+    }
+    frames.size must be_<=(1)
   }
 
   def closeMessage(status: Int): Matcher[Message] = beLike {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty/src/test/scala/controllers/IntegrationTest.scala
@@ -40,10 +40,10 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
       rs.endpoints.endpoints.filter(_.protocols.contains(HttpProtocol.HTTP_2_0)) must be(Nil)
     }
 
-    "all close status codes should be pushed to app" >> { implicit rs: RunningServer =>
+    "valid private-use close status codes should be pushed to app" >> { implicit rs: RunningServer =>
       var receivedCloseCode = ""
 
-      // We open two websockets, one that gets closed with status code 2000
+      // We open two websockets, one that gets closed with status code 4000
       // Another one which tells us the close status code of the mentioned connection so we can check it.
 
       new WebSocketClient(rs.endpoints.httpEndpoint.get.wsPathUrl("/websocket-feedback"))
@@ -58,18 +58,15 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
           //
           // Immediately after opening the connection we close it again.
           //
-          // According to netty, close status code 2000 is invalid:
-          // https://github.com/netty/netty/blob/netty-4.2.0.Final/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java#L286-L291
-          // That's kind of true, because it's reserved for the protocol itself, not for users: https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2
-          // However, the pekko-http backend does not care and pushes all status code down to the application,
-          // so the netty backend should do the same.
-          override def onOpen() = ws.close(2000)
+          // Status codes from 4000 through 4999 are available for private use:
+          // https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2
+          override def onOpen() = ws.close(4000)
         }
       ).connect();
 
       Thread.sleep(1000) // Give feedback-websocket time to send message to client
 
-      receivedCloseCode mustEqual "2000"
+      receivedCloseCode mustEqual "4000"
     }
 
   }

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-pekko-http/src/test/scala/controllers/IntegrationTest.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-pekko-http/src/test/scala/controllers/IntegrationTest.scala
@@ -40,10 +40,10 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
       rs.endpoints.endpoints.filter(_.protocols.contains(HttpProtocol.HTTP_2_0)) must be(Nil)
     }
 
-    "all close status codes should be pushed to app" >> { implicit rs: RunningServer =>
+    "valid private-use close status codes should be pushed to app" >> { implicit rs: RunningServer =>
       var receivedCloseCode = ""
 
-      // We open two websockets, one that gets closed with status code 2000
+      // We open two websockets, one that gets closed with status code 4000
       // Another one which tells us the close status code of the mentioned connection so we can check it.
 
       new WebSocketClient(rs.endpoints.httpEndpoint.get.wsPathUrl("/websocket-feedback"))
@@ -58,18 +58,15 @@ class IntegrationTest extends ForServer with PlaySpecification with ApplicationF
           //
           // Immediately after opening the connection we close it again.
           //
-          // According to netty, close status code 2000 is invalid:
-          // https://github.com/netty/netty/blob/netty-4.2.0.Final/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java#L286-L291
-          // That's kind of true, because it's reserved for the protocol itself, not for users: https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2
-          // However, the pekko-http backend does not care and pushes all status code down to the application,
-          // so the netty backend should do the same.
-          override def onOpen() = ws.close(2000)
+          // Status codes from 4000 through 4999 are available for private use:
+          // https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2
+          override def onOpen() = ws.close(4000)
         }
       ).connect();
 
       Thread.sleep(1000) // Give feedback-websocket time to send message to client
 
-      receivedCloseCode mustEqual "2000"
+      receivedCloseCode mustEqual "4000"
     }
 
   }

--- a/documentation/manual/releases/release31/migration31/Migration31.md
+++ b/documentation/manual/releases/release31/migration31/Migration31.md
@@ -153,10 +153,16 @@ Play now normalizes additional WebSocket Close frame edge cases in the common We
 | **Case** | **Previous behavior** | **New behavior** |
 | --- | --- | --- |
 | Play echoes an empty Close frame from the remote peer | Play could represent the echoed frame as `CloseMessage(Some(1005), "")`. | Play sends an empty Close frame, represented as `CloseMessage(None, "")`, so `1005` is not sent on the wire. |
+| Remote peer sends a reserved or invalid close status code, such as `1006`, `2000`, or `5000` | Backend behavior differed; the status could be delivered to application code or echoed to the peer. | Play rejects the frame and does not deliver it to the application. Depending on which backend detects the violation, it either sends status `1002` before closing or terminates the transport immediately. |
+| Remote peer sends a Close reason containing malformed UTF-8 | The Pekko HTTP backend could decode the reason with replacement characters and deliver it to application code. | Play rejects the frame and does not deliver it to the application. Depending on which backend detects the violation, it either sends status `1007` before closing or terminates the transport immediately. |
+| Remote peer sends a one-byte Close payload | Backend behavior differed; the Pekko HTTP backend could expose a synthetic `1002` as though the peer had sent it. | Play rejects the frame with status `1002` and does not deliver it to the application. |
 | Application code sends `CloseMessage(Some(1005), "")` | Play could pass `1005` toward the backend as a status code. | Play sends an empty Close frame, represented as `CloseMessage(None, "")`. |
 | Application code sends a reserved or invalid close status code, such as `1006` or `999` | Play sent the status code unchanged. | Play still sends the status code unchanged for compatibility, but logs a warning because the value is not valid in a Close frame. |
 | Application code sends a Close reason that cannot be encoded as UTF-8 | Play could pass the reason toward the backend unchanged. | Play logs a warning and drops the reason. |
 | Application code sends a Close reason longer than 123 UTF-8 bytes | Play could pass an invalid oversized Close frame toward the backend. | Play logs a warning and truncates the reason to the longest valid UTF-8 prefix that fits in 123 bytes. |
 | Application code sends `CloseMessage(None, "reason")` | The close reason had no valid wire encoding because Close reasons require a status code. | Play logs a warning and sends `CloseMessage(None, "")`, dropping the reason. |
+
+When Play can send an error Close in response to a malformed peer Close frame, it terminates the connection after
+sending the error and does not wait for another Close acknowledgement.
 
 Applications that create raw `CloseMessage` values should avoid sending reserved status codes such as `1005`, `1006`, and `1015`, and should keep Close reasons short enough to fit in 123 UTF-8 bytes.

--- a/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -112,8 +112,7 @@ private[server] object WebSocketHandler {
   }
 
   private def normalizeProtocolViolation(error: Throwable): Throwable = error match {
-    case corrupted: CorruptedWebSocketFrameException
-        if Option(corrupted.getMessage).forall(message => !message.startsWith("Invalid close frame getStatus code:")) =>
+    case corrupted: CorruptedWebSocketFrameException =>
       new WebSocketFlowHandler.BackendHandledProtocolViolation(corrupted)
     case other => other
   }
@@ -125,12 +124,15 @@ private[server] object WebSocketHandler {
     val reservedBits  = frame.rsv()
     val finalFragment = frame.isFinalFragment
     val messageType   = if (reservedBits != 0) {
-      MessageType.ReservedBits
+      frame match {
+        case _: CloseWebSocketFrame => MessageType.CloseWithReservedBits
+        case _                      => MessageType.ReservedBits
+      }
     } else {
       frame match {
         case _: TextWebSocketFrame         => MessageType.Text
         case _: BinaryWebSocketFrame       => MessageType.Binary
-        case close: CloseWebSocketFrame    => MessageType.Close
+        case _: CloseWebSocketFrame        => MessageType.Close
         case _: PingWebSocketFrame         => MessageType.Ping
         case _: PongWebSocketFrame         => MessageType.Pong
         case _: ContinuationWebSocketFrame => MessageType.Continuation

--- a/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
+++ b/transport/server/play-pekko-http-server/src/main/scala/org/apache/pekko/http/play/WebSocketHandler.scala
@@ -249,8 +249,12 @@ object WebSocketHandler {
 
   private def frameToRawMessage(header: FrameHeader, data: ByteString) = {
     if (header.rsv1 || header.rsv2 || header.rsv3) {
+      val messageType = header.opcode match {
+        case Protocol.Opcode.Close => MessageType.CloseWithReservedBits
+        case _                     => MessageType.ReservedBits
+      }
       RawMessage(
-        MessageType.ReservedBits,
+        messageType,
         ByteString.empty,
         header.fin
       )

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -162,6 +162,21 @@ object WebSocketFlowHandler {
           }
         }
 
+        def rejectPeerClose(close: CloseMessage): Unit = {
+          // A malformed peer Close is already the peer's contribution to closing the connection. Send at most one
+          // protocol-error Close, and do not wait for another acknowledgement.
+          if (state != Open || isClosed(remoteOut)) {
+            completeStage()
+          } else {
+            cancel(appIn)
+            if (!isClosed(appOut)) {
+              complete(appOut)
+            }
+            cancel(remoteIn)
+            emit(remoteOut, toValidCloseFrame(close), () => completeStage())
+          }
+        }
+
         def toMessage(messageType: MessageType.Type, data: ByteString): Message = {
           messageType match {
             case MessageType.Text =>
@@ -177,7 +192,13 @@ object WebSocketFlowHandler {
             case MessageType.Binary => BinaryMessage(data)
             case MessageType.Ping   => PingMessage(data)
             case MessageType.Pong   => PongMessage(data)
-            case MessageType.Close  => parseCloseMessage(data)
+            case MessageType.Close  =>
+              parsePeerCloseMessage(data) match {
+                case Right(close) => close
+                case Left(error)  =>
+                  rejectPeerClose(error)
+                  null
+              }
           }
         }
 
@@ -191,13 +212,26 @@ object WebSocketFlowHandler {
           val read = grab(remoteIn)
 
           read.messageType match {
+            case MessageType.CloseWithReservedBits =>
+              rejectPeerClose(
+                CloseMessage(CloseCodes.ProtocolError, "WebSocket frame contained unexpected reserved bits")
+              )
+              null
             case MessageType.ReservedBits =>
               serverInitiatedClose(
                 CloseMessage(CloseCodes.ProtocolError, "WebSocket frame contained unexpected reserved bits")
               )
               null
+            case MessageType.Close if !read.isFinal =>
+              rejectPeerClose(CloseMessage(CloseCodes.ProtocolError, "Control frames must not be fragmented"))
+              null
             case messageType if isControlMessage(messageType) && !read.isFinal =>
               serverInitiatedClose(CloseMessage(CloseCodes.ProtocolError, "Control frames must not be fragmented"))
+              null
+            case MessageType.Close if read.data.size > 125 =>
+              rejectPeerClose(
+                CloseMessage(CloseCodes.ProtocolError, "Control frame payload must not exceed 125 bytes")
+              )
               null
             case messageType if isControlMessage(messageType) && read.data.size > 125 =>
               serverInitiatedClose(
@@ -328,25 +362,13 @@ object WebSocketFlowHandler {
                 case _: BackendHandledProtocolViolation =>
                   completeStage()
                 case _ =>
-                  // This happens e.g. when using the Netty backend and a client sends an invalid close status code
-                  // that is not defined in https://tools.ietf.org/html/rfc6455#section-7.4
-                  val closeFromFailure = if (state == Open) {
-                    val statusCode = """(\d+)""".r
-                    ex.getMessage match {
-                      case s"Invalid close frame getStatus code: ${statusCode(code)}" => // Parse Netty error message
-                        Some(CloseMessage(code.toInt))
-                      case _ => // Don't log the whole exception to not overwhelm the logs in case failures occur often
-                        logger.warn(s"WebSocket communication problem: ${ex.getMessage}")
-                        None
-                    }
+                  if (state == Open) {
+                    // Don't log the whole exception to avoid overwhelming the logs if failures occur often.
+                    logger.warn(s"WebSocket communication problem: ${ex.getMessage}")
                   } else {
                     logger.debug("WebSocket communication problem after the WebSocket was closed", ex)
-                    None
                   }
-                  closeFromFailure match {
-                    case Some(close) => completeAfterForwardingCloseToApp(close)
-                    case None        => completeRemoteInputAbnormally()
-                  }
+                  completeRemoteInputAbnormally()
               }
             }
 
@@ -542,25 +564,35 @@ object WebSocketFlowHandler {
   )
   object MessageType extends Enumeration {
     type Type = Value
-    val Ping, Pong, Text, Binary, Continuation, Close, ReservedBits = Value
+    val Ping, Pong, Text, Binary, Continuation, Close, ReservedBits, CloseWithReservedBits = Value
   }
 
   private[server] final class BackendHandledProtocolViolation(cause: Throwable) extends RuntimeException(cause)
 
-  def parseCloseMessage(data: ByteString): CloseMessage = {
-    def invalid(reason: String) =
-      CloseMessage(Some(CloseCodes.ProtocolError), s"Peer sent illegal close frame ($reason).")
+  private def parsePeerCloseMessage(data: ByteString): Either[CloseMessage, CloseMessage] = {
+    def invalid(statusCode: Int, reason: String) =
+      Left(CloseMessage(Some(statusCode), s"Peer sent illegal close frame ($reason)."))
 
     if (data.length >= 2) {
-      val code    = ((data(0) & 0xff) << 8) | (data(1) & 0xff)
-      val message = data.drop(2).utf8String
-      CloseMessage(Some(code), message)
+      val code = ((data(0) & 0xff) << 8) | (data(1) & 0xff)
+      invalidCloseStatusCodeReason(code) match {
+        case Some(reason) =>
+          invalid(CloseCodes.ProtocolError, reason)
+        case None =>
+          decodeUtf8(data.drop(2)) match {
+            case Right(reason) => Right(CloseMessage(Some(code), reason))
+            case Left(reason)  => invalid(CloseCodes.InconsistentData, reason)
+          }
+      }
     } else if (data.length == 1) {
-      invalid("close code must be length 2 but was 1")
+      invalid(CloseCodes.ProtocolError, "close code must be length 2 but was 1")
     } else {
-      CloseMessage(CloseCodes.NoStatus)
+      Right(CloseMessage(CloseCodes.NoStatus))
     }
   }
+
+  def parseCloseMessage(data: ByteString): CloseMessage =
+    parsePeerCloseMessage(data).fold(identity, identity)
 
   private def toValidCloseFrame(close: CloseMessage): CloseMessage = {
     close.statusCode match {
@@ -591,6 +623,8 @@ object WebSocketFlowHandler {
         Some("close code 1004 is reserved")
       case code if code < 1000 || code >= 5000 =>
         Some(s"close code must be between 1000 and 4999 but was $code")
+      case code if code >= 1016 && code <= 2999 =>
+        Some(s"close code $code is reserved")
       case _ =>
         None
     }
@@ -639,6 +673,19 @@ object WebSocketFlowHandler {
 
     try {
       Right(encoder.encode(CharBuffer.wrap(value)))
+    } catch {
+      case _: CharacterCodingException => Left("close reason must be valid UTF-8")
+    }
+  }
+
+  private def decodeUtf8(value: ByteString): Either[String, String] = {
+    val decoder = StandardCharsets.UTF_8
+      .newDecoder()
+      .onMalformedInput(CodingErrorAction.REPORT)
+      .onUnmappableCharacter(CodingErrorAction.REPORT)
+
+    try {
+      Right(decoder.decode(value.asByteBuffer).toString)
     } catch {
       case _: CharacterCodingException => Left("close reason must be valid UTF-8")
     }

--- a/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
@@ -34,7 +34,7 @@ class WebSocketFlowHandlerSpec extends Specification {
         messages must contain(exactly(closeMessage(CloseCodes.ConnectionAbort)))
     }
 
-    "forward an invalid close status code reported by the backend failure" in withActorSystem { implicit materializer =>
+    "treat an unclassified backend failure as abnormal connection loss" in withActorSystem { implicit materializer =>
       val messages = runFailedRemoteInput(new RuntimeException("Invalid close frame getStatus code: 1006"))
 
       messages must contain(exactly(closeMessage(CloseCodes.ConnectionAbort)))
@@ -67,14 +67,40 @@ class WebSocketFlowHandlerSpec extends Specification {
       WebSocketFlowHandler.parseCloseMessage(ByteString.empty) must beEqualTo(CloseMessage(CloseCodes.NoStatus))
     }
 
-    "preserve a remote close frame with a reserved status code for application visibility" in {
+    "reject a remote close frame with a reserved status code" in {
       WebSocketFlowHandler.parseCloseMessage(rawCloseData(CloseCodes.ConnectionAbort)) must beEqualTo(
-        CloseMessage(CloseCodes.ConnectionAbort)
+        CloseMessage(CloseCodes.ProtocolError, "Peer sent illegal close frame (close code 1006 must not be sent).")
       )
     }
 
-    "preserve a remote close frame with an invalid status code range for application visibility" in {
-      WebSocketFlowHandler.parseCloseMessage(rawCloseData(999)) must beEqualTo(CloseMessage(999))
+    "reject a remote close frame with an invalid status code range" in {
+      WebSocketFlowHandler.parseCloseMessage(rawCloseData(999)) must beEqualTo(
+        CloseMessage(
+          CloseCodes.ProtocolError,
+          "Peer sent illegal close frame (close code must be between 1000 and 4999 but was 999)."
+        )
+      )
+    }
+
+    "reject a remote close frame with a reserved extension status code" in {
+      WebSocketFlowHandler.parseCloseMessage(rawCloseData(2000)) must beEqualTo(
+        CloseMessage(CloseCodes.ProtocolError, "Peer sent illegal close frame (close code 2000 is reserved).")
+      )
+    }
+
+    "accept valid standard and application close status code boundaries" in {
+      Seq(CloseCodes.Regular, CloseCodes.BadGateway, 3000, 4999).foreach { statusCode =>
+        WebSocketFlowHandler.parseCloseMessage(rawCloseData(statusCode)) must beEqualTo(CloseMessage(statusCode))
+      }
+      ok
+    }
+
+    "reject a remote close frame with an invalid UTF-8 reason" in {
+      val data = rawCloseData(CloseCodes.Regular) ++ ByteString(0xc3.toByte, 0x28.toByte)
+
+      WebSocketFlowHandler.parseCloseMessage(data) must beEqualTo(
+        CloseMessage(CloseCodes.InconsistentData, "Peer sent illegal close frame (close reason must be valid UTF-8).")
+      )
     }
 
     "send 1006 after remote input completes even when the application has no immediate demand" in withActorSystem {
@@ -115,6 +141,14 @@ class WebSocketFlowHandlerSpec extends Specification {
 
       Await.result(remoteOut.pull(), 5.seconds) must beSome(closeMessage(CloseCodes.Regular))
       offer(remoteIn, rawClose(CloseCodes.Regular))
+      Await.result(remoteOut.pull(), 1.second) must beNone
+    }
+
+    "not send a second close for an invalid acknowledgement" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOut) = runClosingWebSocket(5.seconds)
+
+      Await.result(remoteOut.pull(), 5.seconds) must beSome(closeMessage(CloseCodes.Regular))
+      offer(remoteIn, rawClose(CloseCodes.ConnectionAbort))
       Await.result(remoteOut.pull(), 1.second) must beNone
     }
 
@@ -324,26 +358,74 @@ class WebSocketFlowHandlerSpec extends Specification {
       remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
     }
 
+    "reject reserved bits on a Close frame without waiting for another close" in withActorSystem {
+      implicit materializer =>
+        val invalidClose = rawMessage(
+          WebSocketFlowHandler.MessageType.CloseWithReservedBits,
+          ByteString.empty,
+          isFinal = true
+        )
+        val (appMessages, remoteMessages) = runRejectedPeerClose(invalidClose)
+
+        appMessages must beEmpty
+        remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
+    }
+
+    "reject an invalid remote close without waiting for another close" in withActorSystem { implicit materializer =>
+      val (appMessages, remoteMessages) = runRejectedPeerClose(rawClose(CloseCodes.ConnectionAbort))
+
+      appMessages must beEmpty
+      remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
+    }
+
+    "reject an invalid UTF-8 close reason without waiting for another close" in withActorSystem {
+      implicit materializer =>
+        val invalidClose = rawMessage(
+          WebSocketFlowHandler.MessageType.Close,
+          rawCloseData(CloseCodes.Regular) ++ ByteString(0xc3.toByte, 0x28.toByte),
+          isFinal = true
+        )
+        val (appMessages, remoteMessages) = runRejectedPeerClose(invalidClose)
+
+        appMessages must beEmpty
+        remoteMessages must contain(exactly(closeMessage(CloseCodes.InconsistentData)))
+    }
+
+    "reject a one-byte remote close without waiting for another close" in withActorSystem { implicit materializer =>
+      val invalidClose                  = rawMessage(WebSocketFlowHandler.MessageType.Close, ByteString(0x03), isFinal = true)
+      val (appMessages, remoteMessages) = runRejectedPeerClose(invalidClose)
+
+      appMessages must beEmpty
+      remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
+    }
+
     Seq(
       WebSocketFlowHandler.MessageType.Ping,
       WebSocketFlowHandler.MessageType.Pong,
       WebSocketFlowHandler.MessageType.Close
     ).foreach { messageType =>
       s"reject a fragmented $messageType control frame" in withActorSystem { implicit materializer =>
-        val (appMessages, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(
-          rawMessage(messageType, ByteString("control"), isFinal = false),
-          rawClose(CloseCodes.ProtocolError)
-        )
+        val invalidControl                = rawMessage(messageType, ByteString("control"), isFinal = false)
+        val (appMessages, remoteMessages) =
+          if (messageType == WebSocketFlowHandler.MessageType.Close) {
+            runRejectedPeerClose(invalidControl)
+          } else {
+            runRemoteInputAndCollectAppAndRemoteMessages(invalidControl, rawClose(CloseCodes.ProtocolError))
+          }
 
         appMessages must beEmpty
         remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
       }
 
       s"reject an oversized $messageType control frame" in withActorSystem { implicit materializer =>
-        val (appMessages, remoteMessages) = runRemoteInputAndCollectAppAndRemoteMessages(
-          rawMessage(messageType, ByteString(Array.fill[Byte](126)('a'.toByte)), isFinal = true),
-          rawClose(CloseCodes.ProtocolError)
-        )
+        val invalidControl =
+          rawMessage(messageType, ByteString(Array.fill[Byte](126)('a'.toByte)), isFinal = true)
+        val (appMessages, remoteMessages) =
+          if (messageType == WebSocketFlowHandler.MessageType.Close) {
+            runRejectedPeerClose(invalidControl)
+          } else {
+            runRemoteInputAndCollectAppAndRemoteMessages(invalidControl, rawClose(CloseCodes.ProtocolError))
+          }
 
         appMessages must beEmpty
         remoteMessages must contain(exactly(closeMessage(CloseCodes.ProtocolError)))
@@ -415,6 +497,26 @@ class WebSocketFlowHandlerSpec extends Specification {
       messages: WebSocketFlowHandler.RawMessage*
   )(implicit materializer: Materializer): (Seq[Message], Seq[Message]) = {
     runRemoteInputAndCollectAppAndRemoteMessages(Source(messages.toList))
+  }
+
+  private def runRejectedPeerClose(
+      message: WebSocketFlowHandler.RawMessage
+  )(implicit materializer: Materializer): (Seq[Message], Seq[Message]) = {
+    val appFlow = Flow.fromSinkAndSourceMat(Sink.seq[Message], Source.maybe[Message])(Keep.left)
+    val flow    = protocol(closeTimeout = 30.seconds).joinMat(appFlow)(Keep.right)
+
+    val ((remoteIn, appMessages), remoteOut) =
+      Source
+        .queue[WebSocketFlowHandler.RawMessage](1, OverflowStrategy.backpressure)
+        .viaMat(flow)(Keep.both)
+        .toMat(Sink.queue[Message]())(Keep.both)
+        .run()
+
+    offer(remoteIn, message)
+    val remoteMessages = Await.result(remoteOut.pull(), 1.second).toSeq
+
+    Await.result(remoteOut.pull(), 1.second) must beNone
+    (Await.result(appMessages, 1.second), remoteMessages)
   }
 
   private def runAppClose(close: CloseMessage)(implicit materializer: Materializer): Message = {


### PR DESCRIPTION
- validate inbound WebSocket Close status codes, including the reserved `1016`-`2999` ranges
- decode Close reasons using strict UTF-8 validation
- reject one-byte Close payloads
- send `1002` for protocol errors and `1007` for malformed UTF-8 when possible
- do not expose malformed peer Close frames to application code
- terminate after sending the error Close without waiting for another acknowledgement
- preserve the Close opcode when a frame carries unexpected reserved bits, so an RSV-invalid Close terminates immediately instead of awaiting another acknowledgement (follow-up to #14142)
- normalize application-visible malformed Close handling across Netty and Pekko HTTP
- document the application-visible migration behavior

## Motivation

Backend behavior previously differed for malformed Close frames. Pekko HTTP could expose or echo invalid status codes and decode malformed UTF-8 using replacement characters. Netty could reject the frame before Play received it.

Netty's application-visible behavior was deliberate. Commit 0a155c3e67d introduced parsing of Netty's exception message so that an invalid peer status could be delivered to the application as a `CloseMessage`.

This PR intentionally replaces that legacy behavior. A malformed wire Close is a protocol violation rather than a valid application message, and parsing a Netty exception string is brittle. Suppressing the malformed message also prevents an illegal peer-sent `1006` from being confused with Play's synthetic application-visible `1006` for abnormal connection termination.

When Play can send an error Close in response, it terminates after emitting that frame. It does not wait for another acknowledgement from a peer whose Close frame was itself malformed.

PR #14142 added validation for unexpected WebSocket reserved bits. This PR preserves the Close opcode when reporting such a violation, allowing the common handler to recognize that the peer already sent a malformed Close and terminate immediately instead of waiting for another Close acknowledgement.

Application-generated invalid Close statuses retain their existing compatibility behavior and continue to be sent with a warning.

## Testing

- common WebSocket flow-handler tests covering valid and invalid status-code boundaries, malformed UTF-8, one-byte payloads, and closing-handshake behavior
- shared integration tests for Netty and Pekko HTTP, tolerating cases where Netty rejects a malformed frame before Play sees it
- common-handler coverage for immediate termination of RSV-invalid Close frames and Pekko HTTP integration coverage for the resulting `1002` response