### PR TITLE
Preserve WebSocket Pong responses under backpressure

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -1200,6 +1200,17 @@ trait WebSocketSpec
         )
       }
 
+      "respond to every Ping in a burst" in {
+        val payloads = (1 to 10).map(index => ByteString(s"ping-$index")).toList
+        val pings    = payloads.map(payload => SimpleMessage(PingMessage(payload), finalFragment = true))
+        val close    = SimpleMessage(CloseMessage(CloseCodes.Regular), finalFragment = true)
+
+        val (frames, messages) = sendProtocolFrames((pings :+ close)*)
+
+        frames.collect { case SimpleMessage(PongMessage(data), _) => data } must_== payloads
+        messages.collect { case PingMessage(data) => data } must_== payloads
+      }
+
       Seq(
         "Ping"  -> SimpleMessage(PingMessage(ByteString("control")), false),
         "Pong"  -> SimpleMessage(PongMessage(ByteString("control")), false),

--- a/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/transport/server/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -123,9 +123,9 @@ object WebSocketFlowHandler {
         // independently of the application, allowing a peer control message to be processed while the application
         // is applying backpressure. Once that slot is occupied, further frames wait until the application pulls.
 
-        // For the remoteOut, we have a few buffers - a server or client initiated close buffer, a server message, and a pong
-        // message.  Multiple ping messages could arrive at any time, according to the WebSocket spec, we only need to
-        // respond to the most recent one, so pong messages just overwrite each other.
+        // For remoteOut, we have a few buffers: a server or client initiated close buffer, a server message, a Pong,
+        // and a keep-alive Ping. While a Pong is pending, remoteIn is backpressured until remoteOut accepts it. This
+        // preserves the response to each peer Ping while keeping the buffer bounded to one Pong.
 
         // There can only ever be one server message to send, since we only ever pull if there's none to send.
 
@@ -135,7 +135,14 @@ object WebSocketFlowHandler {
         // server initiated close.  Note that no additional server messages can be received once the state has gone into
         // server initiated close, since this is either triggered by the appIn closing, or, when appOut cancels, we
         // cancel appIn. So server messages cannot starve server initiated close from being sent.
-        // The lowest priority is pong messages.
+        // Pong messages follow server messages, and keep-alive Ping messages have the lowest priority.
+
+        def pullRemoteInIfReady(): Unit = {
+          val canPull = state != Open || (isAvailable(appOut) && pongToSend == null)
+          if (canPull && !isClosed(remoteIn) && !hasBeenPulled(remoteIn)) {
+            pull(remoteIn)
+          }
+        }
 
         def serverInitiatedClose(close: CloseMessage) = {
           val closeToSend = toValidCloseFrame(close)
@@ -149,8 +156,8 @@ object WebSocketFlowHandler {
               push(remoteOut, closeToSend)
               scheduleOnce(CloseHandshakeTimeout, wsCloseTimeout)
               // If appOut is closed, then we may need to do our own pull so that we can get the ack
-              if (isClosed(appOut) && !isClosed(remoteIn) && !hasBeenPulled(remoteIn)) {
-                pull(remoteIn)
+              if (isClosed(appOut)) {
+                pullRemoteInIfReady()
               }
             } else {
               state = ServerInitiatingClose(closeToSend)
@@ -334,11 +341,8 @@ object WebSocketFlowHandler {
           appOut,
           new OutHandler {
             override def onPull(): Unit = {
-              // We always pull from the remote in when the app pulls, even if closing, since if we get a message from
-              // the client and we're still open, we still want to send it.
-              if (!hasBeenPulled(remoteIn)) {
-                pull(remoteIn)
-              }
+              // A pending Pong must reach the peer before another inbound message can be accepted.
+              pullRemoteInIfReady()
             }
 
             override def onDownstreamFinish(cause: Throwable): Unit = {
@@ -391,22 +395,23 @@ object WebSocketFlowHandler {
                           push(appOut, other)
                         } else {
                           // appIn is closed, we're ignoring the message and it's not going to pull, so we need to pull
-                          pull(remoteIn)
+                          pullRemoteInIfReady()
                         }
                     }
                   case Open =>
                     message match {
                       case ping @ PingMessage(data) =>
-                        // Forward down to app
-                        push(appOut, ping)
                         // Return to client
+                        val pong = PongMessage(data)
                         if (isAvailable(remoteOut)) {
                           // Send immediately
-                          push(remoteOut, PongMessage(data))
+                          push(remoteOut, pong)
                         } else {
                           // Store to send later
-                          pongToSend = PongMessage(data)
+                          pongToSend = pong
                         }
+                        // Forward down to app after recording the Pong so synchronous demand cannot pull another Ping.
+                        push(appOut, ping)
 
                       case close: CloseMessage =>
                         // Forward down to app
@@ -434,9 +439,7 @@ object WebSocketFlowHandler {
                     }
                 }
               } else {
-                if (!isClosed(remoteIn)) {
-                  pull(remoteIn)
-                }
+                pullRemoteInIfReady()
               }
             }
           }
@@ -514,8 +517,10 @@ object WebSocketFlowHandler {
                     messageToSend = null
                   } else if (pongToSend != null) {
                     // We have a pong to send
-                    push(remoteOut, pongToSend)
+                    val pong = pongToSend
                     pongToSend = null
+                    push(remoteOut, pong)
+                    pullRemoteInIfReady()
                   } else if (pingToSend != null) {
                     // We have a ping to send
                     push(remoteOut, pingToSend)

--- a/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
+++ b/transport/server/play-server/src/test/scala/play/core/server/common/WebSocketFlowHandlerSpec.scala
@@ -16,6 +16,7 @@ import org.apache.pekko.stream.OverflowStrategy
 import org.apache.pekko.stream.QueueOfferResult
 import org.apache.pekko.util.ByteString
 import org.apache.pekko.Done
+import org.reactivestreams.Publisher
 import org.specs2.matcher.Matcher
 import org.specs2.mutable.Specification
 import play.api.http.websocket.CloseCodes
@@ -210,6 +211,31 @@ class WebSocketFlowHandlerSpec extends Specification {
 
       Await.result(remoteOut.pull(), 1.second) must beSome(beEqualTo(PongMessage(payload)))
       Await.result(appMessages.pull(), 1.second) must beSome(beEqualTo(PingMessage(payload)))
+
+      appOut.complete()
+      Await.result(remoteOut.pull(), 1.second) must beSome(closeMessage(CloseCodes.Regular))
+      offer(remoteIn, rawClose(CloseCodes.Regular))
+      Await.result(remoteOut.pull(), 1.second) must beNone
+    }
+
+    "backpressure peer pings until each pong is emitted" in withActorSystem { implicit materializer =>
+      val (remoteIn, remoteOutPublisher, appMessages, appOut) = runUnsubscribedRemoteOutWebSocket()
+      val firstPayload                                        = ByteString("first")
+      val secondPayload                                       = ByteString("second")
+
+      val firstAppMessage = appMessages.pull()
+      offer(remoteIn, rawMessage(WebSocketFlowHandler.MessageType.Ping, firstPayload, isFinal = true))
+      Await.result(firstAppMessage, 1.second) must beSome(beEqualTo(PingMessage(firstPayload)))
+
+      val secondAppMessage = appMessages.pull()
+      offer(remoteIn, rawMessage(WebSocketFlowHandler.MessageType.Ping, secondPayload, isFinal = true))
+      Thread.sleep(200)
+      secondAppMessage.isCompleted must beFalse
+
+      val remoteOut = Source.fromPublisher(remoteOutPublisher).runWith(Sink.queue[Message]())
+      Await.result(remoteOut.pull(), 1.second) must beSome(beEqualTo(PongMessage(firstPayload)))
+      Await.result(secondAppMessage, 1.second) must beSome(beEqualTo(PingMessage(secondPayload)))
+      Await.result(remoteOut.pull(), 1.second) must beSome(beEqualTo(PongMessage(secondPayload)))
 
       appOut.complete()
       Await.result(remoteOut.pull(), 1.second) must beSome(closeMessage(CloseCodes.Regular))
@@ -604,6 +630,28 @@ class WebSocketFlowHandlerSpec extends Specification {
         .queue[WebSocketFlowHandler.RawMessage](1, OverflowStrategy.backpressure)
         .viaMat(flow)(Keep.both)
         .toMat(Sink.queue[Message]())(Keep.both)
+        .run()
+
+    (remoteIn, remoteOut, appMessages, appOut)
+  }
+
+  private def runUnsubscribedRemoteOutWebSocket()(implicit materializer: Materializer): (
+      SourceQueueWithComplete[WebSocketFlowHandler.RawMessage],
+      Publisher[Message],
+      SinkQueueWithCancel[Message],
+      SourceQueueWithComplete[Message]
+  ) = {
+    val appFlow = Flow.fromSinkAndSourceMat(
+      Sink.queue[Message](),
+      Source.queue[Message](1, OverflowStrategy.backpressure)
+    )(Keep.both)
+    val flow = protocol().joinMat(appFlow)(Keep.right)
+
+    val ((remoteIn, (appMessages, appOut)), remoteOut) =
+      Source
+        .queue[WebSocketFlowHandler.RawMessage](1, OverflowStrategy.backpressure)
+        .viaMat(flow)(Keep.both)
+        .toMat(Sink.asPublisher(fanout = false))(Keep.both)
         .run()
 
     (remoteIn, remoteOut, appMessages, appOut)


### PR DESCRIPTION
Preserve every automatic WebSocket Pong response when the outbound transport applies backpressure.

## Motivation

`WebSocketFlowHandler` keeps one pending Pong while waiting for outbound demand. Previously, receiving another Ping replaced that pending Pong, losing its payload.

RFC 6455 permits answering only the most recently processed Ping when earlier Pong responses have not yet been sent, so the previous behavior was compliant. However, it caused Pekko HTTP to fail Autobahn case 2.10, which sends ten Pings and expects ten corresponding Pongs. Netty happened to drain its outbound path quickly enough to pass the same case.

## Changes

- Stop pulling inbound frames while an automatic Pong is pending.
- Resume inbound processing after the transport accepts that Pong.
- Route all remote-input pulls through one helper so the pending-Pong and closing-state checks remain consistent.
- Keep buffering bounded to the existing single pending Pong.

There is no additional unbounded buffering or meaningful memory increase. A Pong payload is limited to 125 bytes.

## Backpressure tradeoff

While a Pong is pending and the outbound transport is stalled, subsequent peer frames remain backpressured. This includes a peer Close frame, which is processed after the pending Pong is accepted.

In that situation Play could not send the Close acknowledgement while the outbound transport was stalled anyway. Locally initiated closing continues to bypass the open-state pending-Pong gate.

## Tests

- Added a stage-level test with explicit outbound backpressure.
- Added a shared integration test that sends ten distinct Ping payloads and verifies all ten Pong payloads in order.