### PR TITLE
Fix warning in NettyServer.scala

### DIFF
--- a/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -424,7 +424,7 @@ class NettyServer(
       // The WebSocket handshaker installs its frame encoder before this HTTP encoder. Keeping the HTTP encoder before
       // the decoder ensures decoder-generated protocol-error Close frames pass through the WebSocket encoder.
       pipeline.addLast("decoder", new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize))
-      pipeline.addLast("decompressor", new HttpContentDecompressor())
+      pipeline.addLast("decompressor", new HttpContentDecompressor(0))
       newWebSocketCompressionHandler().foreach(pipeline.addLast("ws-compressor", _))
       if (logWire) {
         pipeline.addLast("logging", new LoggingHandler(LogLevel.DEBUG))


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist


* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes

Fix warning.

## Purpose


## Background Context

```
[warn] /home/runner/work/playframework/playframework/transport/server/play-netty-server/src/main/scala/play/core/server/NettyServer.scala:427:40: constructor HttpContentDecompressor in class HttpContentDecompressor is deprecated
[warn]       pipeline.addLast("decompressor", new HttpContentDecompressor())
[warn]                                        ^
```

## References

- https://github.com/netty/netty/blob/netty-4.2.16.Final/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java#L47-L64
- https://github.com/netty/netty/commit/fa97ee929d81130d23e658a0758ca09e53be2cf3#diff-2e33eaddd20ffe54e6c4e266fc9cf90ac5f8715ec82a7bcef5d45dbcfdee4996R51
