### PR TITLE
Fix exhaustive warnings

### DIFF
--- a/core/play/src/main/scala/play/api/http/AcceptEncoding.scala
+++ b/core/play/src/main/scala/play/api/http/AcceptEncoding.scala
@@ -165,7 +165,7 @@ object AcceptEncoding {
           logger.debug(s"Unable to parse part of Accept-Encoding header '${next.source}'")
         }
         encs
-      case AcceptEncodingParser.NoSuccess(err, _) =>
+      case AcceptEncodingParser.NoSuccess.I(err, _) =>
         logger.debug(s"Unable to parse Accept-Encoding header '$acceptEncoding': $err")
         Seq.empty
     }

--- a/core/play/src/main/scala/play/api/http/MediaRange.scala
+++ b/core/play/src/main/scala/play/api/http/MediaRange.scala
@@ -89,7 +89,7 @@ object MediaType {
           }
           Some(mt)
         }
-        case MediaRangeParser.NoSuccess(err, next) => {
+        case MediaRangeParser.NoSuccess.I(err, next) => {
           logger.debug(s"Unable to parse media type '${next.source}'")
           None
         }
@@ -125,7 +125,7 @@ object MediaRange {
             logger.debug(s"Unable to parse part of media range header '${next.source}'")
           }
           mrs.sorted
-        case MediaRangeParser.NoSuccess(err, _) =>
+        case MediaRangeParser.NoSuccess.I(err, _) =>
           logger.debug(s"Unable to parse media range header '$mediaRanges': $err")
           Seq.empty
       }

--- a/core/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/core/play/src/main/scala/play/api/i18n/Messages.scala
@@ -157,8 +157,8 @@ object Messages extends MessagesImplicits {
 
     def parse: Either[PlayException.ExceptionSource, Seq[Message]] = {
       parser(new CharSequenceReader(messageSource.read + "\n")) match {
-        case Success(messages, _)   => Right(messages)
-        case NoSuccess(message, in) =>
+        case Success(messages, _)     => Right(messages)
+        case NoSuccess.I(message, in) =>
           Left(
             new PlayException.ExceptionSource("Configuration error", message) {
               def line()       = in.pos.line


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes

Fix warnings.

## Purpose

Use `NoSuccess.I.unapply` instead of `NoSuccess.unapply`

## Background Context


## References

- https://github.com/scala/scala-parser-combinators/pull/496