### PR TITLE
Use scala.jdk.CollectionConverters instead of JavaConverters

### DIFF
--- a/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -352,7 +352,7 @@ object HttpErrorHandlerExceptions {
   private val logger: Logger = Logger(getClass)
 
   private[play] lazy val handlers: mutable.Map[String, PartialFunction[Throwable, Throwable]] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     // Use a LinkedHashMap for predictable behavior when two handlers handle the same type
     Collections.synchronizedMap(new LinkedHashMap()).asScala
   }


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes

Fix warning.

## Purpose


## Background Context


## References

https://github.com/scala/scala/blob/v2.13.18/src/library/scala/collection/JavaConverters.scala#L78-L79