### PR TITLE
Avoid old vararg splice syntax in scripted tests

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
@@ -4,7 +4,7 @@ import scala.sys.process.Process
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
-  .settings(common: _*)
+  .settings(common)
   .settings(
     name                                     := "asset-changes-main",
     InputKey[Unit]("verifyResourceContains") := {
@@ -121,7 +121,7 @@ lazy val root = (project in file("."))
 
 lazy val subproj = (project in file("subproj"))
   .enablePlugins(PlayScala)
-  .settings(common: _*)
+  .settings(common)
   .settings(
     name    := "asset-changes-sub",
     version := "1.1-SNAPSHOT",

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/build.sbt
@@ -2,7 +2,7 @@
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += guice,
     PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
@@ -19,7 +19,7 @@ def commonSettings: Seq[Setting[?]] = Seq(
 )
 
 lazy val `sub-project-inside` = (project in file("./modules/sub-project-inside"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 lazy val `sub-project-outside` =
   ProjectRef(file("./dev-mode-compile-and-config-error-source-sub-project-outside"), "sub-project-outside")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/build.sbt.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/build.sbt.1
@@ -5,7 +5,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += guice,
     PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
@@ -64,6 +64,6 @@ def commonSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val `sub-project-inside` = (project in file("./modules/sub-project-inside"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 lazy val `sub-project-outside` = ProjectRef(file("../dev-mode-compile-and-config-error-source-sub-project-outside"), "sub-project-outside")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/dev-mode-compile-and-config-error-source-sub-project-outside/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-compile-and-config-error-source/dev-mode-compile-and-config-error-source-sub-project-outside/build.sbt
@@ -1,7 +1,7 @@
 // Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val `sub-project-outside` = (project in file("."))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 def commonSettings: Seq[Setting[?]] = Seq(
   scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt
@@ -2,7 +2,7 @@
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += guice,
     PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
@@ -19,7 +19,7 @@ def commonSettings: Seq[Setting[?]] = Seq(
 )
 
 lazy val `sub-project-inside` = (project in file("./modules/sub-project-inside"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 lazy val `sub-project-outside` =
   ProjectRef(file("./dev-mode-runtime-error-source-sub-project-outside"), "sub-project-outside")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt.1
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/build.sbt.1
@@ -5,7 +5,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += guice,
     PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode,
@@ -45,6 +45,6 @@ def commonSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val `sub-project-inside` = (project in file("./modules/sub-project-inside"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 lazy val `sub-project-outside` = ProjectRef(file("../dev-mode-runtime-error-source-sub-project-outside"), "sub-project-outside")

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode-runtime-error-source/dev-mode-runtime-error-source-sub-project-outside/build.sbt
@@ -1,7 +1,7 @@
 // Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
 lazy val `sub-project-outside` = (project in file("."))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 def commonSettings: Seq[Setting[?]] = Seq(
   scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
@@ -3,22 +3,22 @@
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .dependsOn(playmodule, nonplaymodule)
-  .settings(common: _*)
+  .settings(common)
 
 lazy val playmodule = (project in file("playmodule"))
   .enablePlugins(PlayScala)
   .dependsOn(transitive)
-  .settings(common: _*)
+  .settings(common)
 
 // A transitive dependency of playmodule, to check that we are pulling in transitive deps
 lazy val transitive = (project in file("transitive"))
   .enablePlugins(PlayScala)
-  .settings(common: _*)
+  .settings(common)
 
 // A non play module, to check that play settings that are not defined don't cause errors
 // and are still included in compilation
 lazy val nonplaymodule = (project in file("nonplaymodule"))
-  .settings(common: _*)
+  .settings(common)
 
 def common: Seq[Setting[?]] = Seq(
   scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
@@ -72,7 +72,7 @@ TaskKey[Unit]("checkPlayCompileEverything") := {
         val path  =
           if (names.head.startsWith("${")) { // check for ${BASE} or similar (in case it changes)
             // It's an relative path, skip the first element (which usually is "${BASE}")
-            java.nio.file.Paths.get(names.drop(1).head, names.drop(2): _*).toAbsolutePath
+            java.nio.file.Paths.get(names.drop(1).head, names.drop(2) *).toAbsolutePath
           } else {
             // It's an absolute path, sbt uses them e.g. for subprojects located outside of the base project
             val id = vf.getClass.getMethod("id").invoke(vf).asInstanceOf[String]

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes-with-request-passed/build.sbt
@@ -2,7 +2,7 @@
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .dependsOn(a, c)
   .aggregate(common, a, b, c, nonplay)
 
@@ -18,25 +18,25 @@ def commonSettings: Seq[Setting[?]] = Seq(
 
 lazy val common = (project in file("common"))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     aggregateReverseRoutes := Seq(a, b, c)
   )
 
 lazy val nonplay = (project in file("nonplay"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 lazy val a: Project = (project in file("a"))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .dependsOn(nonplay, common)
 
 lazy val b: Project = (project in file("b"))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .dependsOn(common)
 
 lazy val c: Project = (project in file("c"))
   .enablePlugins(PlayJava)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .dependsOn(b)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-aggregate-reverse-routes/build.sbt
@@ -2,7 +2,7 @@
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .dependsOn(a, c)
   .aggregate(common, a, b, c, nonplay)
 
@@ -18,25 +18,25 @@ def commonSettings: Seq[Setting[?]] = Seq(
 
 lazy val common = (project in file("common"))
   .enablePlugins(PlayScala)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     aggregateReverseRoutes := Seq(a, b, c)
   )
 
 lazy val nonplay = (project in file("nonplay"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 lazy val a: Project = (project in file("a"))
   .enablePlugins(PlayScala)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .dependsOn(nonplay, common)
 
 lazy val b: Project = (project in file("b"))
   .enablePlugins(PlayScala)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .dependsOn(common)
 
 lazy val c: Project = (project in file("c"))
   .enablePlugins(PlayScala)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .dependsOn(b)


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?


# Helpful things

## Fixes

Fix warnings.

## Purpose


## Background Context


## References
 
https://docs.scala-lang.org/scala3/reference/changed-features/vararg-splices.html
