### PR TITLE
Support Scala 3 opaque types as route parameters

### DIFF
--- a/dev-mode/play-routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/play-routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -65,7 +65,7 @@ case route @ Route(verb, path, call, comments, modifiers) => {
       "@for(p <- pkg) {@p}",
       "@{call.packageName.map(_ + ".").getOrElse("")}@call.controller",
       "@call.method",
-      @call.parameters.filterNot(_.isEmpty).map(params => params.map("classOf[" + _.typeNameReal + "]").mkString(", ")).map("Seq(" + _ + ")").getOrElse("Nil"),
+      @call.parameters.filterNot(_.isEmpty).map(params => params.map("_root_.scala.reflect.classTag[" + _.typeNameReal + "].runtimeClass").mkString(", ")).map("Seq(" + _ + ")").getOrElse("Nil"),
       "@verb",
       this.prefix + @encodeStringConstant(path.toString),
       @encodeStringConstant(comments.map(_.comment).mkString("\n")),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala2.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala2.jar.txt
@@ -11,8 +11,8 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT
       627  2010-01-01 00:00   controllers/routes.class
       259  2010-01-01 00:00   subproj.routes
      5269  2010-01-01 00:00   subproj/Routes$$anonfun$routes$1.class
-     9706  2010-01-01 00:00   subproj/Routes.class
+    10055  2010-01-01 00:00   subproj/Routes.class
      2077  2010-01-01 00:00   subproj/RoutesPrefix$.class
      1130  2010-01-01 00:00   subproj/RoutesPrefix.class
 ---------                     -------
-    25893                     13 files
+    26242                     13 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala3.jar.txt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/expected-asset-changes-sub.asset-changes-sub-1.0-SNAPSHOT.scala3.jar.txt
@@ -13,10 +13,10 @@ Archive:  target/universal/stage/lib/com.nice.org.asset-changes-sub-1.1-SNAPSHOT
       627  2010-01-01 00:00   controllers/routes.class
       259  2010-01-01 00:00   subproj.routes
      5049  2010-01-01 00:00   subproj/Routes$$anon$1.class
-    10626  2010-01-01 00:00   subproj/Routes.class
-     5073  2010-01-01 00:00   subproj/Routes.tasty
+    10975  2010-01-01 00:00   subproj/Routes.class
+     5267  2010-01-01 00:00   subproj/Routes.tasty
      2095  2010-01-01 00:00   subproj/RoutesPrefix$.class
       535  2010-01-01 00:00   subproj/RoutesPrefix.class
       827  2010-01-01 00:00   subproj/RoutesPrefix.tasty
 ---------                     -------
-    34382                     17 files
+    34925                     17 files

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app-2.13/models/OpaqueUserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app-2.13/models/OpaqueUserId.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package models
+
+import play.api.mvc.PathBindable
+import play.api.mvc.QueryStringBindable
+
+// Scala 2 has no opaque types. This keeps the fixture cross-building; the opaque type
+// variant that this test is about lives in app-3.
+case class OpaqueUserId(id: String) extends AnyVal
+
+object OpaqueUserId {
+  implicit val pathBindable: PathBindable[OpaqueUserId] =
+    PathBindable.bindableString.transform(OpaqueUserId(_), _.id)
+
+  implicit val queryStringBindable: QueryStringBindable[OpaqueUserId] =
+    QueryStringBindable.bindableString.transform(OpaqueUserId(_), _.id)
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app-3/models/OpaqueUserId.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app-3/models/OpaqueUserId.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package models
+
+import play.api.mvc.PathBindable
+import play.api.mvc.QueryStringBindable
+
+opaque type OpaqueUserId = String
+
+object OpaqueUserId {
+  def apply(id: String): OpaqueUserId = id
+
+  extension (userId: OpaqueUserId) def id: String = userId
+
+  given pathBindable: PathBindable[OpaqueUserId] =
+    PathBindable.bindableString.transform(OpaqueUserId.apply, _.id)
+
+  given queryStringBindable: QueryStringBindable[OpaqueUserId] =
+    QueryStringBindable.bindableString.transform(OpaqueUserId.apply, _.id)
+}

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/Application.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/app/controllers/Application.scala
@@ -7,6 +7,7 @@ package controllers
 import scala.jdk.CollectionConverters._
 
 import jakarta.inject.Inject
+import models.OpaqueUserId
 import models.UserId
 import play.api.mvc._
 
@@ -24,6 +25,12 @@ class Application @Inject() (c: ControllerComponents) extends AbstractController
     Ok(userId.id)
   }
   def queryUser(userId: UserId) = Action {
+    Ok(userId.id)
+  }
+  def opaqueUser(userId: OpaqueUserId) = Action {
+    Ok(userId.id)
+  }
+  def opaqueQueryUser(userId: OpaqueUserId) = Action {
     Ok(userId.id)
   }
   def takeInt(i: Int) = Action {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/conf/routes
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/conf/routes
@@ -9,6 +9,9 @@ GET         /instance               @controllers.InstanceController.index
 GET         /users/:userId          controllers.Application.user(userId: models.UserId)
 GET         /query-user             controllers.Application.queryUser(userId: models.UserId)
 
+GET         /opaque-users/:userId   controllers.Application.opaqueUser(userId: models.OpaqueUserId)
+GET         /opaque-query-user      controllers.Application.opaqueQueryUser(userId: models.OpaqueUserId)
+
 GET         /escapes/$i<\d+>        controllers.Application.takeInt(i: Int)
 
 GET         /take-bool              controllers.Application.takeBool(b: Boolean)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/routes-compiler-injected-routes-compilation/tests/RouterSpec.scala
@@ -6,6 +6,7 @@ package test
 
 import scala.concurrent.Future
 
+import models.OpaqueUserId
 import models.UserId
 import play.api.mvc.Result
 import play.api.test._
@@ -38,6 +39,25 @@ object RouterSpec extends PlaySpecification {
       controllers.routes.Application.user(UserId("foo%bar")).url must equalTo("/users/foo%25bar")
       // & is not special for path segments
       controllers.routes.Application.user(UserId("foo&bar")).url must equalTo("/users/foo&bar")
+    }
+  }
+
+  "support an opaque type parameter" in {
+    "reverse routing" in {
+      controllers.routes.Application.opaqueUser(OpaqueUserId("foo")).url must equalTo("/opaque-users/foo")
+      controllers.routes.Application
+        .opaqueQueryUser(OpaqueUserId("foo"))
+        .url must equalTo("/opaque-query-user?userId=foo")
+    }
+    "binding from the path" in new WithApplication() {
+      override def running() = {
+        contentAsString(route(implicitApp, FakeRequest(GET, "/opaque-users/foo")).get) must equalTo("foo")
+      }
+    }
+    "binding from the query string" in new WithApplication() {
+      override def running() = {
+        contentAsString(route(implicitApp, FakeRequest(GET, "/opaque-query-user?userId=foo")).get) must equalTo("foo")
+      }
     }
   }
 


### PR DESCRIPTION
<!--- Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com> -->

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

Use `ClassTag` instead of `classOf` in generated Routers.
This allows use of Scala 3 Opaque Types in Path / Query parameters: `classOf[A]` does not compile if `A` is an opaque type, whereas `ClassTag[A]` resolves to the underlying type.

Fixes #12774

