### PR TITLE
Avoid PlayDocs classpath cycle when using sbt 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -236,6 +236,9 @@ lazy val PlayJavaFormsProject = PlayCrossBuiltProject("Play-Java-Forms", "web/pl
 lazy val PlayDocsProject = PlayCrossBuiltProject("Play-Docs", "dev-mode/play-docs")
   .settings(Docs.settings *)
   .settings(
+    // sbt 2 defaults exportJars to true, but this project's packageBin generates the aggregate API docs.
+    // Using that JAR as an internal classpath product creates a cycle through apiMappings.
+    exportJars := false,
     libraryDependencies ++= playDocsDependencies
   )
   .dependsOn(PlayNettyServerProject)


### PR DESCRIPTION
Preparation for sbt 2: Explicitly disable `exportJars` for the PlayDocs project.

sbt 1 defaults `exportJars` to `false`, while sbt 2 defaults it to `true`. PlayDocs has a custom `packageBin` task that generates the
aggregate API documentation. When sbt 2 uses that generated JAR as an internal classpath product, `apiMappings` introduces a task cycle and the build stops making progress while generating the documentation.

Keeping `exportJars` disabled for this project preserves the sbt 1 behavior and keeps PlayDocs on its class directories. The setting is a no-op for current sbt 1 builds, but makes this project compatible with sbt 2 without changing the setting for other projects.

Verified that the PlayDocs package JAR can be generated with sbt 2.
