### PR TITLE
Make test resource loading work from JARs

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/libs/JavaWSSpec.scala
@@ -4,7 +4,6 @@
 
 package play.it.libs
 
-import java.io.File
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.nio.ByteBuffer
@@ -17,7 +16,6 @@ import scala.concurrent.Future
 import scala.language.postfixOps
 
 import org.apache.pekko.stream.javadsl
-import org.apache.pekko.stream.scaladsl.FileIO
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
@@ -57,6 +55,14 @@ trait JavaWSSpec
   implicit val ec: ExecutionContext = ee.executionContext
 
   import play.libs.ws.WSSignatureCalculator
+
+  private def resourceBytes(name: String): ByteString = {
+    val stream = Option(getClass.getResourceAsStream(name)).getOrElse {
+      throw new IllegalArgumentException(s"Resource not found: $name")
+    }
+    try ByteString.fromArray(stream.readAllBytes())
+    finally stream.close()
+  }
 
   "Web service client" title
 
@@ -159,10 +165,10 @@ trait JavaWSSpec
     }
 
     "sending a multipart form body" in withServer { ws =>
-      val file   = new File(this.getClass.getResource("/testassets/bar.txt").toURI).toPath
-      val dp     = new Http.MultipartFormData.DataPart("hello", "world")
-      val fp     = new Http.MultipartFormData.FilePart("upload", "bar.txt", "text/plain", FileIO.fromPath(file).asJava)
-      val source = org.apache.pekko.stream.javadsl.Source.from(util.Arrays.asList(dp, fp))
+      val fileBody = javadsl.Source.single(resourceBytes("/testassets/bar.txt"))
+      val dp       = new Http.MultipartFormData.DataPart("hello", "world")
+      val fp       = new Http.MultipartFormData.FilePart("upload", "bar.txt", "text/plain", fileBody)
+      val source   = org.apache.pekko.stream.javadsl.Source.from(util.Arrays.asList(dp, fp))
 
       val res  = ws.url("/post").post(source)
       val body = res.toCompletableFuture.get().asJson()
@@ -172,13 +178,13 @@ trait JavaWSSpec
     }
 
     "sending a multipart form body with escaped 'name' and 'filename' params" in withEchoServer { ws =>
-      val file = new File(this.getClass.getResource("/testassets/bar.txt").toURI).toPath
-      val dp   = new Http.MultipartFormData.DataPart("f\ni\re\"l\nd1", "world")
-      val fp   = new Http.MultipartFormData.FilePart(
+      val fileBody = javadsl.Source.single(resourceBytes("/testassets/bar.txt"))
+      val dp       = new Http.MultipartFormData.DataPart("f\ni\re\"l\nd1", "world")
+      val fp       = new Http.MultipartFormData.FilePart(
         "f\"i\rl\nef\"ie\nld\r1",
         "f\rir\"s\ntf\ril\"e\n.txt",
         "text/plain",
-        FileIO.fromPath(file).asJava
+        fileBody
       )
       val source = org.apache.pekko.stream.javadsl.Source.from(util.Arrays.asList(dp, fp))
 
@@ -192,10 +198,10 @@ trait JavaWSSpec
     }
 
     "send a multipart request body via multipartBody()" in withServer { ws =>
-      val file = new File(this.getClass.getResource("/testassets/bar.txt").toURI)
-      val dp   = new Http.MultipartFormData.DataPart("hello", "world")
-      val fp   =
-        new Http.MultipartFormData.FilePart("upload", "bar.txt", "text/plain", FileIO.fromPath(file.toPath).asJava)
+      val fileBody = javadsl.Source.single(resourceBytes("/testassets/bar.txt"))
+      val dp       = new Http.MultipartFormData.DataPart("hello", "world")
+      val fp       =
+        new Http.MultipartFormData.FilePart("upload", "bar.txt", "text/plain", fileBody)
       val source = org.apache.pekko.stream.javadsl.Source.from(util.Arrays.asList(dp, fp))
 
       val res  = ws.url("/post").setBody(multipartBody(source)).setMethod("POST").execute()

--- a/core/play-integration-test/src/test/scala/play/it/libs/ScalaWSSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/libs/ScalaWSSpec.scala
@@ -26,7 +26,6 @@ trait ScalaWSSpec
     with ServerIntegrationSpecification
     with WSBodyWritables
     with WSBodyReadables {
-  import java.io.File
   import java.nio.charset.Charset
   import java.nio.charset.StandardCharsets
   import java.nio.ByteBuffer
@@ -36,7 +35,6 @@ trait ScalaWSSpec
   import scala.concurrent.ExecutionContext.Implicits.global
   import scala.concurrent.Future
 
-  import org.apache.pekko.stream.scaladsl.FileIO
   import org.apache.pekko.stream.scaladsl.Sink
   import org.apache.pekko.stream.scaladsl.Source
   import org.apache.pekko.util.ByteString
@@ -50,6 +48,14 @@ trait ScalaWSSpec
   import play.it.tools.HttpBinApplication
   import play.shaded.ahc.org.asynchttpclient.RequestBuilderBase
   import play.shaded.ahc.org.asynchttpclient.SignatureCalculator
+
+  private def resourceBytes(name: String): ByteString = {
+    val stream = Option(getClass.getResourceAsStream(name)).getOrElse {
+      throw new IllegalArgumentException(s"Resource not found: $name")
+    }
+    try ByteString.fromArray(stream.readAllBytes())
+    finally stream.close()
+  }
 
   "Web service client" title
 
@@ -93,9 +99,9 @@ trait ScalaWSSpec
     }
 
     "send a multipart request body" in withServer { ws =>
-      val file                                                             = new File(this.getClass.getResource("/testassets/foo.txt").toURI).toPath
+      val fileBody                                                         = Source.single(resourceBytes("/testassets/foo.txt"))
       val dp                                                               = MultipartFormData.DataPart("hello", "world")
-      val fp                                                               = MultipartFormData.FilePart("upload", "foo.txt", None, FileIO.fromPath(file))
+      val fp                                                               = MultipartFormData.FilePart("upload", "foo.txt", None, fileBody)
       val source: Source[MultipartFormData.Part[Source[ByteString, ?]], ?] = Source(List(dp, fp))
       val res                                                              = ws.url("/post").post(source)
       val jsonBody                                                         = await(res).json
@@ -105,25 +111,25 @@ trait ScalaWSSpec
     }
 
     "send a multipart request body via withBody" in withServer { ws =>
-      val file   = new File(this.getClass.getResource("/testassets/foo.txt").toURI)
-      val dp     = MultipartFormData.DataPart("hello", "world")
-      val fp     = MultipartFormData.FilePart("upload", "foo.txt", None, FileIO.fromPath(file.toPath))
-      val source = Source(List(dp, fp))
-      val res    = ws.url("/post").withBody(source).withMethod("POST").execute()
-      val body   = await(res).json
+      val fileBody = Source.single(resourceBytes("/testassets/foo.txt"))
+      val dp       = MultipartFormData.DataPart("hello", "world")
+      val fp       = MultipartFormData.FilePart("upload", "foo.txt", None, fileBody)
+      val source   = Source(List(dp, fp))
+      val res      = ws.url("/post").withBody(source).withMethod("POST").execute()
+      val body     = await(res).json
 
       (body \ "form" \ "hello").toOption must beSome(JsString("world"))
       (body \ "file").toOption must beSome(JsString("This is a test asset."))
     }
 
     "send a multipart request body with escaped 'name' and 'filename' params" in withEchoServer { ws =>
-      val file = new File(this.getClass.getResource("/testassets/foo.txt").toURI)
-      val dp   = MultipartFormData.DataPart("f\ni\re\"l\nd1", "world")
-      val fp   = MultipartFormData.FilePart(
+      val fileBody = Source.single(resourceBytes("/testassets/foo.txt"))
+      val dp       = MultipartFormData.DataPart("f\ni\re\"l\nd1", "world")
+      val fp       = MultipartFormData.FilePart(
         "f\"i\rl\nef\"ie\nld\r1",
         "f\rir\"s\ntf\ril\"e\n.txt",
         None,
-        FileIO.fromPath(file.toPath)
+        fileBody
       )
       val source = Source(List(dp, fp))
       val res    = ws.url("/post").withBody(source).withMethod("POST").execute()

--- a/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/core/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -10,11 +10,10 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.net.InetAddresses;
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
 import java.net.Inet6Address;
-import java.net.URISyntaxException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,9 +21,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import org.apache.pekko.stream.javadsl.FileIO;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
 import org.junit.Test;
@@ -753,18 +752,24 @@ public class RequestBuilderTest {
   }
 
   @Test
-  public void multipartForm_bodyRaw_correctEscapedParams() throws URISyntaxException, IOException {
+  public void multipartForm_bodyRaw_correctEscapedParams() throws IOException {
     Application app = new GuiceApplicationBuilder().build();
     Play.start(app);
 
-    File file = new File(this.getClass().getResource("/testassets/foo.txt").toURI());
+    ByteString fileContents;
+    try (InputStream stream =
+        Objects.requireNonNull(
+            getClass().getResourceAsStream("/testassets/foo.txt"),
+            "Missing test resource /testassets/foo.txt")) {
+      fileContents = ByteString.fromArray(stream.readAllBytes());
+    }
     Http.MultipartFormData.Part<Source<ByteString, ?>> filePart =
         new Http.MultipartFormData.FilePart<>(
             "f\"i\rl\nef\"ie\nld\r1",
             "f\rir\"s\ntf\ril\"e\n.txt",
             "text/plain",
-            FileIO.fromPath(file.toPath()),
-            java.nio.file.Files.size(file.toPath()));
+            Source.single(fileContents),
+            fileContents.size());
 
     Http.MultipartFormData.DataPart dataPart =
         new Http.MultipartFormData.DataPart("f\ni\re\"l\nd1", "value1");

--- a/core/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/core/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -30,7 +30,7 @@ class ResourcesSpec extends Specification {
   lazy val dirSpacesRes    = createTempDir("dir spaces ", ".tmp", tmpDir)
   lazy val spacesDir       = createTempDir("spaces ", ".tmp", tmpDir)
   lazy val spacesJar       = Files.createTempFile(spacesDir.toPath, "jar-spaces", ".tmp").toFile
-  lazy val resourcesDir    = new File(app.classloader.getResource("").getPath)
+  lazy val resourcesDir    = tmpDir
   lazy val tmpResourcesDir = createTempDir("test-bundle-", ".tmp", resourcesDir)
   lazy val fileBundle      = Files.createTempFile(tmpResourcesDir.toPath, "file-", ".tmp").toFile
   lazy val dirBundle       = createTempDir("dir-", ".tmp", tmpResourcesDir)

--- a/dev-mode/play-routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
+++ b/dev-mode/play-routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
@@ -32,8 +32,18 @@ class RoutesCompilerSpec extends Specification with FileMatchers {
       }
     }
 
+    def copyResource(name: String, directory: File): File = {
+      val file   = new File(directory, name)
+      val stream = Option(this.getClass.getClassLoader.getResourceAsStream(name)).getOrElse {
+        throw new IllegalArgumentException(s"Resource not found: $name")
+      }
+      try Files.copy(stream, file.toPath)
+      finally stream.close()
+      file
+    }
+
     "generate routes classes for route definitions that pass the checks" in withTempDir { tmp =>
-      val file = new File(this.getClass.getClassLoader.getResource("generating.routes").toURI)
+      val file = copyResource("generating.routes", tmp)
       RoutesCompiler.compile(RoutesCompilerTask(file, Seq.empty, true, true, true, false), InjectedRoutesGenerator, tmp)
 
       new File(tmp, "generating/Routes.scala") must exist
@@ -44,7 +54,7 @@ class RoutesCompilerSpec extends Specification with FileMatchers {
     }
 
     "do not generate JavaScript routes when disabled in task" in withTempDir { tmp =>
-      val file = new File(this.getClass.getClassLoader.getResource("generating.routes").toURI)
+      val file = copyResource("generating.routes", tmp)
       RoutesCompiler.compile(
         RoutesCompilerTask(file, Seq.empty, true, true, false, false),
         InjectedRoutesGenerator,
@@ -54,7 +64,7 @@ class RoutesCompilerSpec extends Specification with FileMatchers {
     }
 
     "check if there are no routes using overloaded handler methods" in withTempDir { tmp =>
-      val file = new File(this.getClass.getClassLoader.getResource("duplicateHandlers.routes").toURI)
+      val file = copyResource("duplicateHandlers.routes", tmp)
       RoutesCompiler.compile(
         RoutesCompilerTask(file, Seq.empty, true, true, true, false),
         InjectedRoutesGenerator,
@@ -63,7 +73,7 @@ class RoutesCompilerSpec extends Specification with FileMatchers {
     }
 
     "check if routes with type projection are compiled" in withTempDir { tmp =>
-      val file = new File(this.getClass.getClassLoader.getResource("complexTypes.routes").toURI)
+      val file = copyResource("complexTypes.routes", tmp)
       RoutesCompiler.compile(
         RoutesCompilerTask(file, Seq.empty, true, true, true, false),
         InjectedRoutesGenerator,
@@ -72,7 +82,7 @@ class RoutesCompilerSpec extends Specification with FileMatchers {
     }
 
     "check if routes with complex names are compiled" in withTempDir { tmp =>
-      val file = new File(this.getClass.getClassLoader.getResource("complexNames.routes").toURI)
+      val file = copyResource("complexNames.routes", tmp)
       RoutesCompiler.compile(
         RoutesCompilerTask(file, Seq.empty, true, true, true, false),
         InjectedRoutesGenerator,

--- a/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/transport/client/play-ahc-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -11,7 +11,6 @@ import scala.concurrent.duration._
 import scala.concurrent.Await
 import scala.language.implicitConversions
 
-import org.apache.pekko.stream.scaladsl.FileIO
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.util.ByteString
@@ -45,6 +44,14 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
     with FutureAwaits
     with DefaultAwaitTimeout {
   sequential
+
+  private def resourceBytes(name: String): ByteString = {
+    val stream = Option(getClass.getResourceAsStream(name)).getOrElse {
+      throw new IllegalArgumentException(s"Resource not found: $name")
+    }
+    try ByteString.fromArray(stream.readAllBytes())
+    finally stream.close()
+  }
 
   "Ahc WSClient" should {
     "support several query string values for a parameter" in {
@@ -443,10 +450,10 @@ class AhcWSSpec(implicit ee: ExecutionEnv)
     override def running() = {
       {
         val wsClient = app.injector.instanceOf(classOf[play.api.libs.ws.WSClient])
-        val file     = new java.io.File(this.getClass.getResource("/testassets/foo.txt").toURI)
+        val fileBody = Source.single(resourceBytes("/testassets/foo.txt"))
         val dp       = MultipartFormData.DataPart("h\"e\rl\nl\"o\rwo\nrld", "world")
         val fp       =
-          MultipartFormData.FilePart("u\"p\rl\no\"a\rd", "f\"o\ro\n_\"b\ra\nr.txt", None, FileIO.fromPath(file.toPath))
+          MultipartFormData.FilePart("u\"p\rl\no\"a\rd", "f\"o\ro\n_\"b\ra\nr.txt", None, fileBody)
         val source         = Source(List(dp, fp))
         val futureResponse = wsClient.url(s"http://localhost:${port}/").post(source)
 


### PR DESCRIPTION
Make tests work whether their classpath resources are provided by a classes directory or an exported JAR.

## Background Context

A classpath resource is not necessarily a filesystem file. When it is loaded from a JAR, its URL uses the `jar:` scheme and its URI is opaque. Passing that URI to `File` therefore fails with `URI is not hierarchical`.

This was exposed by sbt 2, which exports project products as JARs by default. The same assumptions can also fail under sbt 1 whenever tests run with a JAR-backed classpath.

This PR:

- reads multipart test fixtures through resource streams;
- copies route fixtures into the existing managed temporary directory where the compiler API requires a real `File`; and
- gives the resource protocol tests an explicit temporary filesystem root instead of deriving one from the classpath.

There are no production API or behavior changes.

## Verification

The affected suites pass from an exported-JAR classpath, including:

- `RequestBuilderTest`;
- both `RoutesCompilerSpec` variants;
- `AhcWSSpec`;
- the Netty and Pekko HTTP Scala and Java WS specifications; and
- `ResourcesSpec`.

Using sbt 2 those tests failed before this PR.
