### PR TITLE
Avoid system classloader assumptions in tests

### DIFF
--- a/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
@@ -399,7 +399,7 @@ class ConfigurationSpec extends Specification {
     }
 
     "reference values from system properties" in {
-      val configuration = Configuration.load(Environment(new File("."), ClassLoader.getSystemClassLoader, Mode.Test))
+      val configuration = Configuration.load(Environment(new File("."), getClass.getClassLoader, Mode.Test))
 
       val javaVersion       = System.getProperty("java.specification.version")
       val configJavaVersion = configuration.get[String]("test.system.property.java.spec.version")
@@ -409,7 +409,7 @@ class ConfigurationSpec extends Specification {
 
     "reference values from system properties when passing additional properties" in {
       val configuration = Configuration.load(
-        ClassLoader.getSystemClassLoader,
+        getClass.getClassLoader,
         new Properties(), // empty so that we can check that System Properties are still considered
         directSettings = Map.empty,
         allowMissingApplicationConf = true
@@ -426,7 +426,7 @@ class ConfigurationSpec extends Specification {
       userProperties.setProperty("java.specification.version", "my java version")
 
       val configuration = Configuration.load(
-        ClassLoader.getSystemClassLoader,
+        getClass.getClassLoader,
         userProperties,
         directSettings = Map.empty,
         allowMissingApplicationConf = true

--- a/core/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
@@ -21,7 +21,7 @@ class EssentialActionSpec extends PlaySpecification {
   "an EssentialAction" should {
     "use the classloader of the running application" in {
       // start fake application with its own classloader
-      val applicationClassLoader = new ClassLoader() {}
+      val applicationClassLoader = new ClassLoader(getClass.getClassLoader) {}
 
       running(_.in(Environment.simple().copy(classLoader = applicationClassLoader))) { app =>
         import app.materializer
@@ -35,23 +35,29 @@ class EssentialActionSpec extends PlaySpecification {
           (await(actionClassLoader.future) must be).equalTo(applicationClassLoader)
         }
 
-        // make sure running thread has applicationClassLoader set
-        Thread.currentThread.setContextClassLoader(applicationClassLoader)
+        val thread              = Thread.currentThread
+        val originalClassLoader = thread.getContextClassLoader
+        try {
+          // make sure running thread has applicationClassLoader set
+          thread.setContextClassLoader(applicationClassLoader)
 
-        // test with simple sync action
-        checkAction { reportCL =>
-          Action {
-            reportCL(Thread.currentThread.getContextClassLoader)
-            Ok("")
+          // test with simple sync action
+          checkAction { reportCL =>
+            Action {
+              reportCL(Thread.currentThread.getContextClassLoader)
+              Ok("")
+            }
           }
-        }
 
-        // test with async action
-        checkAction { reportCL =>
-          Action(BodyParsers.utils.maxLength(100, BodyParsers.utils.ignore(AnyContentAsEmpty: AnyContent))) { _ =>
-            reportCL(Thread.currentThread.getContextClassLoader)
-            Ok("")
+          // test with async action
+          checkAction { reportCL =>
+            Action(BodyParsers.utils.maxLength(100, BodyParsers.utils.ignore(AnyContentAsEmpty: AnyContent))) { _ =>
+              reportCL(Thread.currentThread.getContextClassLoader)
+              Ok("")
+            }
           }
+        } finally {
+          thread.setContextClassLoader(originalClassLoader)
         }
       }
     }

--- a/core/play/src/test/scala/play/api/BuiltInComponentsSpec.scala
+++ b/core/play/src/test/scala/play/api/BuiltInComponentsSpec.scala
@@ -15,7 +15,7 @@ import play.api.routing.Router
 class BuiltInComponentsSpec extends Specification {
   "BuiltinComponents" should {
     "use the Environment ClassLoader for runtime injection" in {
-      val classLoader = new URLClassLoader(Array())
+      val classLoader = new URLClassLoader(Array.empty, getClass.getClassLoader)
       val components  = new BuiltInComponents {
         override val environment: Environment                          = Environment(new File("."), classLoader, Mode.Test)
         override def configuration: Configuration                      = Configuration.load(environment)


### PR DESCRIPTION
- Load test configuration resources through the test classloader.
- Give custom application classloaders access to the test runtime.
- Restore the thread context classloader after `EssentialActionSpec`.

## Motivation

The affected tests implicitly relied on the system classloader containing the complete project test classpath. That happens with the sbt 1 classloader layout, but is not guaranteed and no longer holds with sbt 2.

Using the classloader that owns the test class provides access to the required classes and resources while preserving the distinct custom classloaders exercised by the tests.


Needed for sbt 2 migration.