### PR TITLE
Fix versioned asset lookup for JAR-backed resources

### DIFF
--- a/core/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/core/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -10,9 +10,11 @@ import java.nio.charset.StandardCharsets
 
 import com.google.common.io.CharStreams
 import com.typesafe.config.ConfigFactory
+import controllers.Assets
 import controllers.AssetsComponents
 import play.api._
 import play.api.libs.ws._
+import play.api.mvc.ResponseHeader
 import play.api.routing.Router
 import play.api.test._
 import play.core.server.Server
@@ -346,10 +348,16 @@ trait AssetsSpec extends PlaySpecification with WsTestClient with ServerIntegrat
     }
 
     "return asset when modified since" in withServer() { client =>
-      val result = await(
+      // sbt 2 exports test resources in reproducible JARs whose timestamps default to 2010. The previous fixed 2012
+      // date therefore made the asset appear unmodified and produced a 304. Derive an earlier date from the actual
+      // resource timestamp so this test remains independent of how the build tool timestamps packaged resources.
+      val Some(lastModified)       = await(client.url("/foo.txt").get()).header(LAST_MODIFIED)
+      val Some(parsedLastModified) = Assets.parseModifiedDate(lastModified)
+      val earlier                  = ResponseHeader.httpDateFormat.format(parsedLastModified.toInstant.minusSeconds(1))
+      val result                   = await(
         client
           .url("/foo.txt")
-          .addHttpHeaders(IF_MODIFIED_SINCE -> "Tue, 13 Mar 2012 13:08:36 GMT")
+          .addHttpHeaders(IF_MODIFIED_SINCE -> earlier)
           .get()
       )
 

--- a/core/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/core/play/src/main/scala/play/api/controllers/Assets.scala
@@ -798,9 +798,9 @@ class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata, env: E
     // otherwise we can't.
     val requestedDigest = f.getName.takeWhile(_ != '-')
     if (!requestedDigest.isEmpty) {
-      val bareFile     = new File(f.getParent, f.getName.drop(requestedDigest.length + 1)).getPath.replace('\\', '/')
-      val bareFullPath = path + "/" + bareFile
-      blocking(digest(bareFullPath)) match {
+      val bareFile         = new File(f.getParent, f.getName.drop(requestedDigest.length + 1)).getPath.replace('\\', '/')
+      val bareResourceName = resourceNameAt(path, bareFile)
+      blocking(bareResourceName.flatMap(digest)) match {
         case Some(`requestedDigest`) => assetAt(path, bareFile, aggressiveCaching = true)
         case _                       => assetAt(path, file.name, aggressiveCaching = false)
       }


### PR DESCRIPTION
Normalize the bare resource name before looking up the digest of a versioned asset.

When the supplied asset name starts with a slash, concatenating it with the configured asset path produces a resource name containing a double slash. Directory-backed class loaders tolerate this, but JAR resource lookups do not. The digest is therefore missed and the fingerprinted file is served as an ordinary asset, with the wrong ETag and caching behavior.

Use `resourceNameAt` for the digest lookup so it receives the same path normalization and boundary validation as the subsequent asset lookup.

Also derive the `If-Modified-Since` test value from the resource's actual `Last-Modified` value. This avoids depending on a fixed date, which fails when reproducible JARs use an earlier normalized timestamp.
