### PR TITLE
Support JAR-exported products in Play dev mode

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInternalKeys.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlayInternalKeys.scala
@@ -13,6 +13,11 @@ import sbt.Keys.*
 object PlayInternalKeys {
   type ClassLoaderCreator = (String, Array[URL], ClassLoader) => ClassLoader
 
+  val playProjectWithDisabledAssetExports = AttributeKey[ProjectRef](
+    "playProjectWithDisabledAssetExports",
+    "The project whose assets should not be exported while Play recompiles it in dev mode."
+  )
+
   val playDependencyClasspath = taskKey[Classpath](
     "The classpath containing all the jar dependencies of the project"
   )

--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -125,9 +125,41 @@ object PlaySettings {
     playDependencyClasspath := uncached((Runtime / externalDependencyClasspath).value),
     // all user classes, in this project and any other subprojects that it depends on
     playReloaderClasspath := uncached {
-      Classpaths
-        .concatDistinct(Runtime / exportedProducts, Runtime / internalDependencyClasspath)
-        .value
+      // Select the classpath dynamically so the unselected strategy does not add
+      // unnecessary product or packaging tasks to the task graph.
+      Def.taskDyn {
+        if (exportJars.value) {
+          Def.task {
+            // Play's reloader needs live classes and resources from the current
+            // project. Dependencies may remain JAR-backed because Play recompiles
+            // them before creating a fresh application classloader.
+            implicit val fc: FileConverter = fileConverter.value
+            val currentProjectDirectories  =
+              ((Compile / productDirectories).value ++
+                (Compile / resourceDirectories).value.filter(_.exists())).distinct
+            val currentProjectArtifact = toNioPath((Compile / packageBin / artifactPath).value).toAbsolutePath
+              .normalize()
+            val currentProjectPaths = (currentProjectDirectories.map(_.toPath) :+ currentProjectArtifact)
+              .map(_.toAbsolutePath.normalize())
+              .toSet
+            val dependencyProducts = (Runtime / internalDependencyClasspath).value.filterNot { entry =>
+              currentProjectPaths(toNioPath(entry.data).toAbsolutePath.normalize())
+            }
+            val currentProjectProducts = currentProjectDirectories.map { directory =>
+              Attributed.blank(toFileRef(directory))
+            }
+            currentProjectProducts ++ dependencyProducts
+          }
+        } else {
+          // Preserve the directory-backed classpath used when JAR exports are
+          // disabled, including the sbt 1 default behavior.
+          Def.task {
+            Classpaths
+              .concatDistinct(Runtime / exportedProducts, Runtime / internalDependencyClasspath)
+              .value
+          }
+        }
+      }.value
     },
     // filter out asset directories from the classpath (supports sbt-web 1.0 and 1.1)
     playReloaderClasspath ~= { _.filter(_.get(toKey(WebKeys.webModulesLib)).isEmpty) },
@@ -279,8 +311,70 @@ object PlaySettings {
           if (testAssetsDir.exists()) Seq(Attributed.blank(toFileRef(testAssetsDir))) else Nil
         }
       }.value
+    },
+    // With JAR exports, sbt-web can discover a module from both its JAR manifest
+    // and Play's separately exported asset directory.
+    Assets / WebKeys.internalWebModules ~= (_.distinct),
+    TestAssets / WebKeys.internalWebModules ~= (_.distinct),
+  ) ++ exportedAssetsSettings(Compile, Assets) ++ exportedAssetsSettings(Test, TestAssets)
+
+  /**
+   * sbt-web normally exports asset directories with project products. It skips those
+   * directories when exportJars is enabled, but Play intentionally keeps assets out of
+   * the main project JAR and publishes them in a separate assets JAR. Keep exporting
+   * the directories inside the build so dependent projects and tests can use them.
+   * These contributions are uncached because their state markers are evaluated at
+   * runtime and therefore cannot participate in sbt 2's action cache.
+   */
+  private def exportedAssetsSettings(
+      productsConfiguration: Configuration,
+      assetsConfiguration: Configuration
+  ): Seq[Setting[?]] = Def.settings(
+    productsConfiguration / exportedProducts ++= uncached {
+      exportedAssetsForDependencies(assetsConfiguration / exportedAssets).value
+    },
+    productsConfiguration / exportedProductsIfMissing ++= uncached {
+      exportedAssetsForDependencies(assetsConfiguration / exportedAssetsIfMissing).value
+    },
+    productsConfiguration / exportedProductsNoTracking ++= uncached {
+      exportedAssetsForDependencies(assetsConfiguration / exportedAssetsNoTracking).value
     }
   )
+
+  /**
+   * Exports an sbt-web asset directory as an additional classpath product when
+   * normal products are exported as JARs. Play keeps assets out of the main
+   * project JAR, so dependent projects still need this directory.
+   *
+   * The state markers suppress asset exports without evaluating the asset task.
+   * Play's marker applies only to the application being reloaded, allowing its
+   * dependencies to keep exporting assets. sbt-web's marker disables all asset
+   * exports while the reloader classpath itself is constructed.
+   */
+  private def exportedAssetsForDependencies(
+      directoryTask: ScopedTaskable[File]
+  ): Def.Initialize[Task[Classpath]] = Def.taskDyn {
+    val currentState   = state.value
+    val jarsExported   = exportJars.value
+    val exportDisabled = currentState
+      .get(playProjectWithDisabledAssetExports)
+      .contains(thisProjectRef.value)
+    if (!jarsExported || exportDisabled || currentState.get(WebKeys.disableExportedProducts).getOrElse(false)) {
+      // Do not evaluate directoryTask: producing the directory can run the asset
+      // pipeline that these state markers are intended to suppress.
+      Def.task(Nil)
+    } else {
+      Def.task {
+        implicit val fc: FileConverter = fileConverter.value
+        val directory                  = directoryTask.toTask.value
+        if (directory.exists()) {
+          Seq(Attributed.blank(toFileRef(directory)).put(toKey(webModulesLib), moduleName.value))
+        } else {
+          Nil
+        }
+      }
+    }
+  }
 
   /**
    * Settings for creating a jar that excludes externalized resources

--- a/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/sbt/PlayRun.scala
@@ -98,15 +98,16 @@ object PlayRun {
             state.put(Keys.loggerContext, loggerContext)
           case _ => state
         }
+        val reloadState = newState.put(playProjectWithDisabledAssetExports, thisProjectRef.value)
         PlayReload.compile(
-          () => PluginCompat.runTask(scope / playReload, newState).map(_._2).get,
+          () => PluginCompat.runTask(scope / playReload, reloadState).map(_._2).get,
           () =>
             PluginCompat
-              .runTask(scope / reloaderClasspath, newState.put(WebKeys.disableExportedProducts, true))
+              .runTask(scope / reloaderClasspath, reloadState.put(WebKeys.disableExportedProducts, true))
               .map(_._2)
               .get,
-          () => PluginCompat.runTask(scope / streamsManager, newState).map(_._2).get.toEither.toOption,
-          newState,
+          () => PluginCompat.runTask(scope / streamsManager, reloadState).map(_._2).get.toEither.toOption,
+          reloadState,
           scope
         )
       } finally {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
@@ -2,12 +2,22 @@
 
 import java.net.URLClassLoader
 
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.{ stagingDirectory => universalStagingDirectory }
 import com.typesafe.sbt.packager.Keys.executableScriptName
+
+@transient val unzipAssetsJar            = taskKey[Unit]("Unzip the staged assets JAR")
+@transient val checkOnClasspath          = inputKey[Unit]("Check resources on the run classpath")
+@transient val checkOnTestClasspath      = inputKey[Unit]("Check resources on the test classpath")
+@transient val checkCompiledAssets       = taskKey[Unit]("Check compiled assets")
+@transient val checkCleanedAssets        = taskKey[Unit]("Check that compiled assets were cleaned")
+@transient val checkAssetsJarOnClasspath = taskKey[Unit]("Check the staged assets JAR classpath")
+@transient val checkReloaderClasspath    = inputKey[Unit]("Check resources on the reloader classpath")
+@transient val checkInternalWebModules   = taskKey[Unit]("Check that internal web modules are unique")
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
-  .dependsOn(module)
-  .aggregate(module)
+  .dependsOn(module, runtimeModule % Runtime)
+  .aggregate(module, runtimeModule)
   .settings(
     name          := "assets-sample",
     version       := "1.0-SNAPSHOT",
@@ -20,16 +30,24 @@ lazy val root = (project in file("."))
 
 lazy val module = (project in file("module")).enablePlugins(PlayScala)
 
-TaskKey[Unit]("unzipAssetsJar") := {
+lazy val runtimeModule = (project in file("runtime-module"))
+  .settings(
+    name          := "runtime-module-sample",
+    version       := "1.0-SNAPSHOT",
+    scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
+    updateOptions := updateOptions.value.withLatestSnapshots(false)
+  )
+
+root / unzipAssetsJar := {
   IO.unzip(
-    target.value / "universal" / "stage" / "lib" / s"${organization.value}.${normalizedName.value}-${version.value}-assets.jar",
-    target.value / "assetsJar"
+    (root / Universal / universalStagingDirectory).value / "lib" / s"${(root / organization).value}.${(root / normalizedName).value}-${(root / version).value}-assets.jar",
+    (root / baseDirectory).value / "target" / "assetsJar"
   )
 }
 
-InputKey[Unit]("checkOnClasspath") := {
+root / checkOnClasspath := {
   val args                                = Def.spaceDelimited("<resource>*").parsed
-  val creator: ClassLoader => ClassLoader = play.sbt.PlayInternalKeys.playAssetsClassLoader.value
+  val creator: ClassLoader => ClassLoader = (root / play.sbt.PlayInternalKeys.playAssetsClassLoader).value
   val classloader                         = creator(null)
   args.foreach { resource =>
     if (classloader.getResource(resource) == null) {
@@ -40,10 +58,13 @@ InputKey[Unit]("checkOnClasspath") := {
   }
 }
 
-InputKey[Unit]("checkOnTestClasspath") := {
-  val args                 = Def.spaceDelimited("<resource>*").parsed
-  val classpath: Classpath = (Test / fullClasspath).value
-  val classloader          = new URLClassLoader(classpath.map(_.data.toURI.toURL).toArray)
+root / checkOnTestClasspath := {
+  val args                             = Def.spaceDelimited("<resource>*").parsed
+  val classpath: Classpath             = (root / Test / fullClasspath).value
+  implicit val fc: xsbti.FileConverter = (root / fileConverter).value
+  val classloader                      = new URLClassLoader(
+    classpath.map(entry => play.sbt.PluginCompat.toNioPath(entry.data).toUri.toURL).toArray
+  )
   args.foreach { resource =>
     if (classloader.getResource(resource) == null) {
       sys.error(s"Could not find $resource\nin test classpath: $classpath")
@@ -53,9 +74,55 @@ InputKey[Unit]("checkOnTestClasspath") := {
   }
 }
 
-TaskKey[Unit]("check-assets-jar-on-classpath") := {
-  val startScript = IO.read(target.value / "universal" / "stage" / "bin" / executableScriptName.value)
-  val assetsJar   = s"${organization.value}.${normalizedName.value}-${version.value}-assets.jar"
+root / checkReloaderClasspath := {
+  val args                             = Def.spaceDelimited("<resource>*").parsed
+  val classpath: Classpath             = (root / play.sbt.PlayInternalKeys.playReloaderClasspath).value
+  implicit val fc: xsbti.FileConverter = (root / fileConverter).value
+  val paths                            = classpath.map { entry =>
+    play.sbt.PluginCompat.toNioPath(entry.data).toAbsolutePath.normalize()
+  }
+  val ownArtifact = play.sbt.PluginCompat
+    .toNioPath((root / Compile / packageBin / artifactPath).value)
+    .toAbsolutePath
+    .normalize()
+  assert(!paths.contains(ownArtifact), s"Reloader classpath contains the current project's JAR: $ownArtifact")
+  val classloader = new URLClassLoader(paths.map(_.toUri.toURL).toArray)
+  args.foreach { resource =>
+    if (classloader.getResource(resource) == null) {
+      sys.error(s"Could not find $resource\nin reloader classpath: $classpath")
+    } else {
+      streams.value.log.info(s"Found $resource in reloader classloader")
+    }
+  }
+}
+
+root / checkInternalWebModules := {
+  val modules = (root / Assets / WebKeys.internalWebModules).value
+  assert(modules == modules.distinct, s"Found duplicate internal web modules: $modules")
+}
+
+root / checkCompiledAssets := {
+  val files = Seq(
+    (root / Assets / WebKeys.public).value / "main.css",
+    (module / Assets / WebKeys.public).value / "module.css"
+  )
+  files.foreach(file => assert(file.exists(), s"Compiled asset does not exist: $file"))
+}
+
+root / checkCleanedAssets := {
+  val files = Seq(
+    (root / Assets / WebKeys.public).value / "main.css",
+    (module / Assets / WebKeys.public).value / "module.css"
+  )
+  files.foreach(file => assert(!file.exists(), s"Compiled asset still exists: $file"))
+}
+
+root / checkAssetsJarOnClasspath := {
+  val startScript = IO.read(
+    (root / Universal / universalStagingDirectory).value / "bin" / (root / executableScriptName).value
+  )
+  val assetsJar =
+    s"${(root / organization).value}.${(root / normalizedName).value}-${(root / version).value}-assets.jar"
   if (startScript.contains(assetsJar)) {
     println(s"Found reference to $assetsJar in start script")
   } else {

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/runtime-module/src/main/resources/runtime-only.conf
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/runtime-module/src/main/resources/runtime-only.conf
@@ -1,0 +1,1 @@
+runtime-only = true

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/test
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/test
@@ -1,11 +1,14 @@
 # Check that sub project assets get compiled on reload
 > playReload
-$ exists target/web/public/main/main.css
-$ exists module/target/web/public/main/module.css
+> checkCompiledAssets
 
 # Check that they are mounted at the right place in the run classloader
 > checkOnClasspath public/main.css
 > checkOnClasspath public/lib/assets-module-sample/module.css
+> checkInternalWebModules
+
+# Check that Runtime-scoped project dependencies remain on the reloader classpath
+> checkReloaderClasspath runtime-only.conf
 
 # Check that they are on the test classpath
 > checkOnTestClasspath public/main.css
@@ -13,11 +16,11 @@ $ exists module/target/web/public/main/module.css
 
 # Clean and ensure that it really did clean
 > clean
--$ exists target/web/public/main/main.css
--$ exists module/target/web/public/main/module.css
+> checkCleanedAssets
 
 # Check that sub project assets get compiled and included in the distribution when staged
 > stage
+> checkAssetsJarOnClasspath
 > unzipAssetsJar
 $ exists target/assetsJar/public/main.css
 $ exists target/assetsJar/public/lib/assets-module-sample/module.css


### PR DESCRIPTION
## Purpose

Keep Play's development-mode reload and asset classpaths working when sbt exports project products as JARs.

## Background Context

sbt 2 enables `exportJars` by default. The exported JAR is suitable for dependent projects, but Play's reloader needs the current application's live class and resource directories so that newly compiled output is loaded directly instead of being read from the current application's exported JAR.

Play also deliberately packages web assets separately from the main project JAR. When JAR exports are enabled, sbt-web stops exporting its asset directory, which prevents dependent projects from seeing those assets in development mode and on their test classpaths.

This PR keeps the current project directory-backed in the reloader classpath while retaining the full Runtime-scoped dependency classpath. The current project's exported JAR is filtered out so stale classes cannot shadow its live class and resource directories.

Evaluating the Runtime-scoped internal classpath can still cause sbt to build the current project's cached JAR before Play filters it out. This preserves Runtime-only project dependencies and matches the existing Runtime classpath semantics. Avoiding that packaging work would require constructing a separate Runtime-only dependency delta and can be considered independently if reload measurements show a material cost.

It also exports Play's asset directories as tagged classpath products and suppresses the owning project's asset export while that project is being recompiled. The `exportJars` and state checks happen before the asset task is evaluated, avoiding unnecessary or recursive asset pipeline execution. Module names discovered from both the main JAR and the separately exported asset directory are deduplicated.

The exported-product additions are explicitly uncached because they inspect runtime state that cannot participate in sbt 2's action cache. The custom scripted assertion keys are marked `@transient` to opt them out of sbt 2's action cache.

The existing multiproject-assets scripted test now uses explicitly scoped checks that work with both filesystem and virtual classpath entries. It also verifies a Runtime-only project dependency, excludes the current project's JAR from the reloader classpath, checks unique web-module metadata, and reads native-packager's configured staging directory.

## Verification

- Compiled the sbt 1 and sbt 2 variants of `Sbt-Plugin`.
- Ran `play-sbt-plugin/multiproject-assets` with `scriptedSbt` explicitly set to sbt 1.12.15.
- Ran `play-sbt-plugin/multiproject-assets` with `scriptedSbt` explicitly set to sbt 2.0.6.
- Ran `scalafmtCheckAll` for `Sbt-Plugin`.
