### PR TITLE
Keep externalized resources out of Play's sans-externalized application JAR when it is packaged by either sbt 1 or sbt 2.

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -302,9 +302,15 @@ object PlaySettings {
       val packageBinMappings = (packageBin / mappings).value
       val externalized       = playExternalizedResources.value.map(_._1).toSet
       val copied             = copyResources.value
-      val toExclude          = copied.collect {
-        case (source, dest) if externalized(toFileRef(source)) => toFileRef(dest)
-      }.toSet
+      val toExclude          = copied
+        .filter { case (source, _) => externalized(toFileRef(source)) }
+        .flatMap {
+          case (source, dest) =>
+            // sbt 1 package mappings refer to the copied resource, while sbt 2
+            // mappings retain the original source. Exclude either representation.
+            Seq(toFileRef(source), toFileRef(dest))
+        }
+        .toSet
       packageBinMappings.filterNot {
         case (file, _) => toExclude(file)
       }


### PR DESCRIPTION
## Background Context

Play derives the sans-externalized JAR from `packageBin` mappings. It uses `copyResources` to identify resources that must instead be placed beside the application during packaging.

With sbt 1, the package mapping normally points to the copied resource in the classes directory. With sbt 2, the mapping can retain the original resource source. The existing filter removed only the copied destination, allowing the original source mapping to remain in the sans-externalized JAR.

This PR excludes both the source and destination of each matching `copyResources` entry. Only the representation present in `packageBin / mappings` is removed, preserving the existing sbt 1 behavior while supporting sbt 2.

The existing `assets-pipeline` and `asset-changes-in-subprojects` fixtures compare the complete contents of the generated `-sans-externalized.jar` files, including the absence of externalized configuration resources.

## Verification

- Compiled the sbt 1 and sbt 2 variants of `Sbt-Plugin`.
- Ran `assets-pipeline` and `asset-changes-in-subprojects` with sbt 1.12.15 on this branch.
- Ran both fixtures with sbt 2.0.6 together with the separate scripted fixture-portability changes from `sbt2-scripted`.
- Ran `scalafmtCheckAll` for `Sbt-Plugin`.
