### PR TITLE
Use URLs for configuration origins without filenames

### DIFF
--- a/core/play-configuration/src/main/scala/play/api/Configuration.scala
+++ b/core/play-configuration/src/main/scala/play/api/Configuration.scala
@@ -153,8 +153,8 @@ object Configuration {
         This is necessary to keep the Exception serializable, because ConfigOrigin is not serializable.
          */
         val originLine       = o.lineNumber: java.lang.Integer
-        val originSourceName = o.filename
         val originUrlOpt     = Option(o.url)
+        val originSourceName = Option(o.filename).orElse(originUrlOpt.map(_.toString)).orNull
         new PlayException.ExceptionSource("Configuration error", message, e.orNull) {
           def line              = originLine
           def position: Integer = null

--- a/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/core/play-configuration/src/test/scala/play/api/ConfigurationSpec.scala
@@ -22,6 +22,7 @@ import scala.util.control.NonFatal
 
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigOriginFactory
 import org.specs2.execute.FailureException
 import org.specs2.mutable.Specification
 
@@ -356,6 +357,17 @@ class ConfigurationSpec extends Specification {
       cl.findResource("reference.conf") must_== url
       cl.getResource("reference.conf") must_== url
       cl.getResources("reference.conf").asScala.toList must_== List(url)
+    }
+
+    "use the URL as the source name when an origin has no filename" in {
+      val url    = new URL("jar:file:/tmp/application.jar!/application.conf")
+      val origin = ConfigOriginFactory.newURL(url)
+
+      origin.filename must_== null
+      Configuration
+        .configError("Invalid configuration", Some(origin))
+        .asInstanceOf[PlayException.ExceptionSource]
+        .sourceName must_== url.toString
     }
 
     "direct settings should have precedence over system properties when reading config.resource and config.file" in {


### PR DESCRIPTION
## Purpose

Preserve useful source information when reporting errors from configuration loaded through a URL without a filename.

## Background Context

Typesafe Config origins can provide both a filename and a URL, but a filename is not guaranteed. In particular, a resource loaded from a JAR can have a `jar:` URL while `ConfigOrigin.filename()` is `null`.

Play previously copied only the filename into `PlayException.ExceptionSource`. As a result, the error retained the configuration input and line number but had no source name for error pages and other diagnostics.

This PR continues to prefer the filename when one exists and otherwise uses the origin URL as the source name. The values are still copied out of `ConfigOrigin` so the resulting exception remains serializable.

## Verification

- Added a regression test using a JAR URL with no origin filename.
