### PR TITLE
Resolve sbt virtual source paths through FileConverter

### DIFF
--- a/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/dev-mode/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -32,23 +32,34 @@ import xsbti.FileConverter
 import xsbti.Position
 import xsbti.Problem
 import xsbti.Severity
+import xsbti.VirtualFileRef
 
 object PlayReload {
-  def taskFailureHandler(
-      incomplete: Incomplete,
-      streams: Option[Streams],
-      state: State,
-      scope: Scope
-  ): PlayException = {
+  private[sbt] def mapPosition(
+      position: Position,
+      mappers: Seq[Position => Option[Position]]
+  )(implicit fileConverter: FileConverter): Position = {
+    def legacySourceFile(sourcePath: String) = {
+      val virtualRootEnd = sourcePath.indexOf('}')
+      val relativePath   =
+        if (sourcePath.startsWith("${") && virtualRootEnd >= 0) {
+          sourcePath.substring(virtualRootEnd + 1).stripPrefix("/").stripPrefix("\\")
+        } else {
+          sourcePath
+        }
+      new File(relativePath).getAbsoluteFile
+    }
 
-    def convertSbtVirtualFile(sourcePath: String) =
-      new File(if (sourcePath.startsWith("${")) { // check for ${BASE} or similar (in case it changes)
-        // Like: ${BASE}/app/controllers/MyController.scala
-        sourcePath.substring(sourcePath.indexOf("}") + 2)
-      } else {
-        // A file outside of the base project folder or using sbt <1.4
-        sourcePath
-      }).getAbsoluteFile
+    def convertSbtVirtualFile(sourcePath: String) = {
+      try {
+        val converted             = fileConverter.toPath(VirtualFileRef.of(sourcePath))
+        val unresolvedVirtualRoot =
+          sourcePath.startsWith("${") && converted.getNameCount > 0 && converted.getName(0).toString.startsWith("${")
+        if (unresolvedVirtualRoot) legacySourceFile(sourcePath) else converted.toFile.getAbsoluteFile
+      } catch {
+        case NonFatal(_) => legacySourceFile(sourcePath)
+      }
+    }
 
     // Stolen from https://github.com/sbt/sbt/blob/v1.4.8/main/src/main/scala/sbt/Defaults.scala#L466-L515
     // Slightly modified because fileConverter settings do not exist pre sbt 1.4 yet
@@ -81,7 +92,7 @@ object PlayReload {
 
     // Stolen from https://github.com/sbt/sbt/blob/v1.4.8/main/src/main/scala/sbt/Defaults.scala#L2299-L2316
     // Slightly modified because reportAbsolutePath and fileConverter settings do not exist pre sbt 1.4 yet
-    def foldMappers(mappers: Seq[Position => Option[Position]]) =
+    val foldMappers =
       mappers.foldRight { (p: Position) => toAbsoluteSource(p) } { // Fallback if sourcePositionMappers is empty
         (mapper, previousPosition) =>
           { (p: Position) =>
@@ -89,6 +100,17 @@ object PlayReload {
             mapper(toAbsoluteSource(p)).getOrElse(previousPosition(p))
           }
       }
+
+    foldMappers(position)
+  }
+
+  def taskFailureHandler(
+      incomplete: Incomplete,
+      streams: Option[Streams],
+      state: State,
+      scope: Scope
+  ): PlayException = {
+    implicit val fileConverter: FileConverter = Project.extract(state).get(scope / Keys.fileConverter)
 
     Incomplete
       .allExceptions(incomplete)
@@ -114,7 +136,7 @@ object PlayReload {
                     override def category(): String           = problem.category()
                     override def severity(): Severity         = problem.severity()
                     override def message(): String            = problem.message()
-                    override def position(): Position         = foldMappers(mappers)(problem.position())
+                    override def position(): Position         = mapPosition(problem.position(), mappers)
                     override def rendered(): Optional[String] = problem.rendered()
                   }
                 )

--- a/dev-mode/sbt-plugin/src/test/scala/play/sbt/run/PlayReloadSpec.scala
+++ b/dev-mode/sbt-plugin/src/test/scala/play/sbt/run/PlayReloadSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.sbt.run
+
+import java.io.File
+import java.nio.file.Paths
+import java.util.Optional
+
+import sbt.internal.inc.MappedFileConverter
+
+import org.specs2.mutable.Specification
+import xsbti.FileConverter
+import xsbti.Position
+
+class PlayReloadSpec extends Specification {
+  "PlayReload.mapPosition" should {
+    "resolve virtual source paths through the file converter" in {
+      val base                                  = Paths.get("target", "base").toAbsolutePath
+      val out                                   = Paths.get("target", "out").toAbsolutePath
+      implicit val fileConverter: FileConverter = MappedFileConverter(Map("BASE" -> base, "OUT" -> out), true)
+
+      val mapped = PlayReload.mapPosition(position("${OUT}/routes/main/router/Routes.scala"), Nil)
+
+      mapped.sourceFile().get().toPath must_== out.resolve("routes/main/router/Routes.scala")
+      mapped.sourcePath().get() must_== out.resolve("routes/main/router/Routes.scala").toString
+    }
+
+    "retain the working-directory fallback for an unknown virtual root" in {
+      val base                                  = Paths.get("target", "base").toAbsolutePath
+      implicit val fileConverter: FileConverter = MappedFileConverter(Map("BASE" -> base), true)
+
+      val mapped   = PlayReload.mapPosition(position("${UNKNOWN}/app/controllers/HomeController.scala"), Nil)
+      val expected = Paths
+        .get("app", "controllers", "HomeController.scala")
+        .toAbsolutePath
+
+      mapped.sourceFile().get().toPath must_== expected
+      mapped.sourcePath().get() must_== expected.toString
+    }
+  }
+
+  private def position(path: String): Position = new Position {
+    override def line(): Optional[Integer]        = Optional.empty()
+    override def lineContent(): String            = ""
+    override def offset(): Optional[Integer]      = Optional.empty()
+    override def pointer(): Optional[Integer]     = Optional.empty()
+    override def pointerSpace(): Optional[String] = Optional.empty()
+    override def sourcePath(): Optional[String]   = Optional.of(path)
+    override def sourceFile(): Optional[File]     = Optional.empty()
+  }
+}


### PR DESCRIPTION
## Purpose

Map compiler source positions back to their real filesystem paths when sbt represents them as virtual file references.

## Background Context

sbt can report source paths using IDs such as `${BASE}/...` and `${OUT}/...`. Play previously handled these IDs by removing the leading placeholder and resolving the remainder against the working directory. That loses the root associated with the placeholder and is especially incorrect for generated sources below `${OUT}`.

sbt exposes the build's `FileConverter` for exactly this conversion. This PR uses it to resolve the `VirtualFileRef` before applying Play's configured source position mappers. A mapped converter can return an unresolved virtual ID for an unknown root instead of throwing, so Play detects that result and retains its former working-directory fallback in either case.

`taskFailureHandler` obtains the converter from the scoped build state, preserving its existing public method signature.

The mapping is exposed within the `play.sbt` package so scripted test tooling can reuse the same production conversion in a follow-up PR.

## Verification

- Added a regression test for a source below a mapped `${OUT}` root using sbt's real `MappedFileConverter`.
- Added coverage for the legacy fallback when the converter does not know a virtual root.
- Ran `PlayReloadSpec` against both sbt-plugin Scala variants.