### PR TITLE
Stabilize native-packager paths in scripted tests

### DIFF
--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/asset-changes-in-subprojects/build.sbt
@@ -6,6 +6,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(common)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     name                                     := "asset-changes-main",
     InputKey[Unit]("verifyResourceContains") := {
       val args                         = Def.spaceDelimited("<path> <status> <words> ...").parsed

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/assets-pipeline/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/assets-pipeline/build.sbt
@@ -12,6 +12,7 @@ val transform = taskKey[Pipeline.Stage]("transformer")
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     name          := "assets-pipeline",
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service-with-routes-file/build.sbt
@@ -4,6 +4,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayService)
   .enablePlugins(RoutesCompiler)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),
     update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/basic-service/build.sbt
@@ -3,6 +3,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(PlayService)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),
     update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/disabled-assets-jar/build.sbt
@@ -7,6 +7,7 @@ import com.typesafe.sbt.packager.Keys.executableScriptName
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     name          := "assets-sample",
     version       := "1.0-SNAPSHOT",
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
@@ -3,6 +3,7 @@
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     name          := "dist-no-documentation-sample",
     version       := "1.0-SNAPSHOT",
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -1,8 +1,11 @@
 // Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.{ stagingDirectory => universalStagingDirectory }
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     name          := "dist-sample",
     version       := "1.0-SNAPSHOT",
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
@@ -17,7 +20,7 @@ val checkStartScript = InputKey[Unit]("checkStartScript")
 
 checkStartScript := {
   val args                                            = Def.spaceDelimited().parsed
-  val startScript                                     = target.value / "universal/stage/bin/dist-sample"
+  val startScript                                     = (Universal / universalStagingDirectory).value / "bin/dist-sample"
   def startScriptError(contents: String, msg: String) = {
     println("Error in start script, dumping contents:")
     println(contents)

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-false/build.sbt
@@ -7,6 +7,7 @@ version := "1.0-SNAPSHOT"
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),
     update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/evolutions-auto-apply-true/build.sbt
@@ -7,6 +7,7 @@ version := "1.0-SNAPSHOT"
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),
     update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/http-backend-netty-channel-options/build.sbt
@@ -9,6 +9,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayNettyServer)
   .disablePlugins(PlayPekkoHttpServer)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),
     update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/pekko-fork-join-pool/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/pekko-fork-join-pool/build.sbt
@@ -7,6 +7,7 @@ version := "1.0-SNAPSHOT"
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),
     update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-downing/build.sbt
@@ -5,11 +5,14 @@ import java.util.concurrent.TimeUnit
 import sbt._
 import sbt.Keys.libraryDependencies
 
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.{ stagingDirectory => universalStagingDirectory }
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
   .disablePlugins(PlayLayoutPlugin)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),
     update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),
@@ -19,7 +22,7 @@ lazy val root = (project in file("."))
     PlayKeys.playInteractionMode                    := play.sbt.StaticPlayNonBlockingInteractionMode,
     commands += ScriptedTools.assertProcessIsStopped,
     InputKey[Unit]("awaitPidfileDeletion") := {
-      val pidFile = target.value / "universal" / "stage" / "RUNNING_PID"
+      val pidFile = (Universal / universalStagingDirectory).value / "RUNNING_PID"
       // Use a polling loop of at most 30sec. Without it, the `scripted-test` moves on
       // before the application has finished to shut down
       val secs = 30

--- a/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
+++ b/dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/shutdown-happy-path/build.sbt
@@ -8,11 +8,14 @@ import scala.concurrent.Future
 import sbt._
 import sbt.Keys.libraryDependencies
 
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.{ stagingDirectory => universalStagingDirectory }
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   // disable PlayLayoutPlugin because the `test` file used by `sbt-scripted` collides with the `test/` Play expects.
   .disablePlugins(PlayLayoutPlugin)
   .settings(
+    ScriptedTools.stableUniversalStagingDirectory,
     scalaVersion  := ScriptedTools.scalaVersionFromJavaProperties(),
     updateOptions := updateOptions.value.withLatestSnapshots(false),
     update / evictionWarningOptions ~= (_.withWarnTransitiveEvictions(false).withWarnDirectEvictions(false)),
@@ -22,7 +25,7 @@ lazy val root = (project in file("."))
     PlayKeys.playInteractionMode                    := play.sbt.StaticPlayNonBlockingInteractionMode,
     commands += ScriptedTools.assertProcessIsStopped,
     InputKey[Unit]("awaitPidfileDeletion") := {
-      val pidFile = target.value / "universal" / "stage" / "RUNNING_PID"
+      val pidFile = (Universal / universalStagingDirectory).value / "RUNNING_PID"
       // Use a polling loop of at most 30sec. Without it, the `scripted-test` moves on
       // before the application has finished to shut down
       val secs = 30

--- a/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
+++ b/dev-mode/sbt-scripted-tools/src/main/scala/play/sbt/scriptedtools/ScriptedTools.scala
@@ -19,7 +19,10 @@ import scala.sys.process.Process
 import sbt._
 import sbt.Keys._
 
-import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.{
+  stagingDirectory => universalStagingDirectory,
+  _
+}
 import play.sbt.routes.RoutesCompiler.autoImport._
 import play.sbt.run.PlayRun
 import play.sbt.PluginCompat._
@@ -33,6 +36,13 @@ object ScriptedTools extends AutoPlugin {
     // If this is a scheduled GitHub Action
     // https://docs.github.com/en/actions/learn-github-actions/environment-variables
     resolvers += Resolver.ApacheMavenSnapshotsRepo
+  )
+
+  def stableUniversalStagingDirectory: Seq[Def.Setting[?]] = Seq(
+    // sbt 2's target is configuration-specific, but these fixtures assert the stable sbt 1 path.
+    Universal / universalStagingDirectory := baseDirectory.value / "target" / "universal" / "stage",
+    // The pinned directory is outside sbt 2's normal target tree, so clean it explicitly.
+    cleanFiles += (Universal / universalStagingDirectory).value
   )
 
   def scalaVersionFromJavaProperties() =


### PR DESCRIPTION
## Purpose

Keep scripted-test staging paths stable across sbt 1 and sbt 2.

## Background Context

sbt 2 gives native-packager tasks configuration-specific target directories. Several Play scripted fixtures expect staged applications under the sbt 1 location, `target/universal/stage`, either directly in their test scripts or from helper tasks in their builds.

This PR adds a shared scripted-test setting that pins the Universal staging directory to that established location and registers it for cleaning. It resolves the path from each fixture's `baseDirectory` because sbt 2's `target` points into its configuration-specific output tree. The pinned path consequently sits outside sbt 2's normal target tree, so the shared setting also adds it to `cleanFiles`.

Fixture tasks now read the configured native-packager key instead of reconstructing its path from sbt's `target` setting.

The setting is applied only to scripted fixtures; it does not change the native-packager staging layout of Play applications.

## Verification

- Compiled both variants of `Sbt-Scripted-Tools`.
- Ran `play-sbt-plugin/basic-service` with sbt 1.12.15.
- Ran `play-sbt-plugin/basic-service` with sbt 2.0.6.